### PR TITLE
feat(config): make options optional for rule with a fix

### DIFF
--- a/.changeset/modern-frogs-roll.md
+++ b/.changeset/modern-frogs-roll.md
@@ -1,0 +1,24 @@
+---
+"@biomejs/biome": minor
+---
+
+Rule's `options` is now optional in the Biome configuration files for rules with a `fix` kind.
+
+Previously, configuring a rule's `fix` required `options` to be set.
+Now, `options` is optional.
+The following configuration is now valid:
+
+```json
+{
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUnusedImports": {
+          "level": "on",
+          "fix": "safe"
+        }
+      }
+    }
+  }
+}
+```

--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -487,7 +487,7 @@ fn migrate_eslint_rule(
                         biome_config::RuleWithFixOptions {
                             level: severity.into(),
                             fix: None,
-                            options: *Box::new((*rule_options).into()),
+                            options: Some(*Box::new((*rule_options).into())),
                         },
                     ));
                 }
@@ -534,7 +534,7 @@ fn migrate_eslint_rule(
                             biome_config::RuleWithFixOptions {
                                 level: severity.into(),
                                 fix: None,
-                                options: *Box::new((*rule_options).into()),
+                                options: Some(*Box::new((*rule_options).into())),
                             },
                         ));
                 }
@@ -551,7 +551,7 @@ fn migrate_eslint_rule(
                             biome_config::RuleWithFixOptions {
                                 level: severity.into(),
                                 fix: None,
-                                options: rule_options.into(),
+                                options: Some(rule_options.into()),
                             },
                         ));
                 }
@@ -567,7 +567,7 @@ fn migrate_eslint_rule(
                         biome_config::RuleWithFixOptions {
                             level: severity.into(),
                             fix: None,
-                            options: rule_options.into(),
+                            options: Some(rule_options.into()),
                         },
                     ));
                 }
@@ -602,7 +602,7 @@ fn migrate_eslint_rule(
                             biome_config::RuleWithFixOptions {
                                 level: severity.into(),
                                 fix: None,
-                                options: options.into(),
+                                options: Some(options.into()),
                             },
                         ));
                 }

--- a/crates/biome_cli/tests/cases/config_extends.rs
+++ b/crates/biome_cli/tests/cases/config_extends.rs
@@ -550,3 +550,68 @@ fn extends_config_merge_overrides() {
         result,
     ));
 }
+
+#[test]
+fn extends_config_rule_options_merge() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let shared = Utf8Path::new("shared.json");
+    fs.insert(
+        shared.into(),
+        r#"{
+            "linter": {
+                "enabled": true,
+                "rules": {
+                    "correctness": {
+                        "noUnusedVariables": {
+                            "level": "on",
+                            "options": {
+                                "ignoreRestSiblings": false
+                            }
+                        }
+                    }
+                }
+            }
+        }"#,
+    );
+
+    let biome_json = Utf8Path::new("biome.json");
+    fs.insert(
+        biome_json.into(),
+        r#"{
+            "extends": ["shared.json"],
+            "linter": {
+                "enabled": true,
+                "rules": {
+                    "correctness": {
+                        "noUnusedVariables": {
+                            "level": "on",
+                            "fix": "safe"
+                        }
+                    }
+                }
+            }
+        }"#,
+    );
+
+    let test_file = Utf8Path::new("test.js");
+    fs.insert(
+        test_file.into(),
+        "const { a, ...rest } = { a: 1, b: 2}; export { rest }",
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", test_file.as_str()].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "extends_config_rule_options_merge",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_rule_options_merge.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_rule_options_merge.snap
@@ -1,0 +1,70 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "extends": ["shared.json"],
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "correctness": {
+        "noUnusedVariables": {
+          "level": "on",
+          "fix": "safe"
+        }
+      }
+    }
+  }
+}
+```
+
+## `shared.json`
+
+```json
+{
+            "linter": {
+                "enabled": true,
+                "rules": {
+                    "correctness": {
+                        "noUnusedVariables": {
+                            "level": "on",
+                            "options": {
+                                "ignoreRestSiblings": false
+                            }
+                        }
+                    }
+                }
+            }
+        }
+```
+
+## `test.js`
+
+```js
+const { a, ...rest } = { a: 1, b: 2}; export { rest }
+```
+
+# Emitted Messages
+
+```block
+test.js:1:9 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable a is unused.
+  
+  > 1 │ const { a, ...rest } = { a: 1, b: 2}; export { rest }
+      │         ^
+  
+  i Unused variables are often the result of an incomplete refactoring, typos, or other sources of bugs.
+  
+  i You can use the ignoreRestSiblings option to ignore unused variables in an object destructuring with a spread.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 warning.
+```

--- a/crates/biome_configuration/src/analyzer/mod.rs
+++ b/crates/biome_configuration/src/analyzer/mod.rs
@@ -165,9 +165,10 @@ impl<T: Clone + Default + 'static> RuleFixConfiguration<T> {
     pub fn get_options(&self) -> Option<RuleOptions> {
         match self {
             Self::Plain(_) => None,
-            Self::WithOptions(options) => {
-                Some(RuleOptions::new(options.options.clone(), options.fix))
-            }
+            Self::WithOptions(options) => Some(RuleOptions::new(
+                options.options.clone().unwrap_or_default(),
+                options.fix,
+            )),
         }
     }
 }
@@ -403,14 +404,16 @@ pub struct RuleWithFixOptions<T: Default> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fix: Option<FixKind>,
     /// Rule's options
-    pub options: T,
+    pub options: Option<T>,
 }
 
 impl<T: Default> Merge for RuleWithFixOptions<T> {
     fn merge_with(&mut self, other: Self) {
         self.level = other.level;
         self.fix = other.fix.or(self.fix);
-        self.options = other.options;
+        if other.options.is_some() {
+            self.options = other.options;
+        }
     }
 }
 

--- a/crates/biome_configuration/tests/valid/optional_options.json
+++ b/crates/biome_configuration/tests/valid/optional_options.json
@@ -1,0 +1,12 @@
+{
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUnusedImports": {
+          "level": "on",
+          "fix": "safe"
+        }
+      }
+    }
+  }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3708,7 +3708,7 @@ export interface RuleWithFixOptions_for_NoAccessKeyOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoAccessKeyOptions;
+	options?: NoAccessKeyOptions;
 }
 export interface RuleWithFixOptions_for_NoAriaHiddenOnFocusableOptions {
 	/**
@@ -3722,7 +3722,7 @@ export interface RuleWithFixOptions_for_NoAriaHiddenOnFocusableOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoAriaHiddenOnFocusableOptions;
+	options?: NoAriaHiddenOnFocusableOptions;
 }
 export interface RuleWithFixOptions_for_NoAriaUnsupportedElementsOptions {
 	/**
@@ -3736,7 +3736,7 @@ export interface RuleWithFixOptions_for_NoAriaUnsupportedElementsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoAriaUnsupportedElementsOptions;
+	options?: NoAriaUnsupportedElementsOptions;
 }
 export interface RuleWithFixOptions_for_NoAutofocusOptions {
 	/**
@@ -3750,7 +3750,7 @@ export interface RuleWithFixOptions_for_NoAutofocusOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoAutofocusOptions;
+	options?: NoAutofocusOptions;
 }
 export interface RuleWithFixOptions_for_NoDistractingElementsOptions {
 	/**
@@ -3764,7 +3764,7 @@ export interface RuleWithFixOptions_for_NoDistractingElementsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoDistractingElementsOptions;
+	options?: NoDistractingElementsOptions;
 }
 export interface RuleWithFixOptions_for_NoHeaderScopeOptions {
 	/**
@@ -3778,7 +3778,7 @@ export interface RuleWithFixOptions_for_NoHeaderScopeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoHeaderScopeOptions;
+	options?: NoHeaderScopeOptions;
 }
 export interface RuleWithFixOptions_for_NoInteractiveElementToNoninteractiveRoleOptions {
 	/**
@@ -3792,7 +3792,7 @@ export interface RuleWithFixOptions_for_NoInteractiveElementToNoninteractiveRole
 	/**
 	 * Rule's options
 	 */
-	options: NoInteractiveElementToNoninteractiveRoleOptions;
+	options?: NoInteractiveElementToNoninteractiveRoleOptions;
 }
 export interface RuleWithOptions_for_NoLabelWithoutControlOptions {
 	/**
@@ -3826,7 +3826,7 @@ export interface RuleWithFixOptions_for_NoNoninteractiveElementToInteractiveRole
 	/**
 	 * Rule's options
 	 */
-	options: NoNoninteractiveElementToInteractiveRoleOptions;
+	options?: NoNoninteractiveElementToInteractiveRoleOptions;
 }
 export interface RuleWithFixOptions_for_NoNoninteractiveTabindexOptions {
 	/**
@@ -3840,7 +3840,7 @@ export interface RuleWithFixOptions_for_NoNoninteractiveTabindexOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoNoninteractiveTabindexOptions;
+	options?: NoNoninteractiveTabindexOptions;
 }
 export interface RuleWithFixOptions_for_NoPositiveTabindexOptions {
 	/**
@@ -3854,7 +3854,7 @@ export interface RuleWithFixOptions_for_NoPositiveTabindexOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoPositiveTabindexOptions;
+	options?: NoPositiveTabindexOptions;
 }
 export interface RuleWithOptions_for_NoRedundantAltOptions {
 	/**
@@ -3878,7 +3878,7 @@ export interface RuleWithFixOptions_for_NoRedundantRolesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoRedundantRolesOptions;
+	options?: NoRedundantRolesOptions;
 }
 export interface RuleWithOptions_for_NoStaticElementInteractionsOptions {
 	/**
@@ -3922,7 +3922,7 @@ export interface RuleWithFixOptions_for_UseAnchorContentOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseAnchorContentOptions;
+	options?: UseAnchorContentOptions;
 }
 export interface RuleWithFixOptions_for_UseAriaActivedescendantWithTabindexOptions {
 	/**
@@ -3936,7 +3936,7 @@ export interface RuleWithFixOptions_for_UseAriaActivedescendantWithTabindexOptio
 	/**
 	 * Rule's options
 	 */
-	options: UseAriaActivedescendantWithTabindexOptions;
+	options?: UseAriaActivedescendantWithTabindexOptions;
 }
 export interface RuleWithOptions_for_UseAriaPropsForRoleOptions {
 	/**
@@ -4080,7 +4080,7 @@ export interface RuleWithFixOptions_for_UseValidAriaPropsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseValidAriaPropsOptions;
+	options?: UseValidAriaPropsOptions;
 }
 export interface RuleWithFixOptions_for_UseValidAriaRoleOptions {
 	/**
@@ -4094,7 +4094,7 @@ export interface RuleWithFixOptions_for_UseValidAriaRoleOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseValidAriaRoleOptions;
+	options?: UseValidAriaRoleOptions;
 }
 export interface RuleWithOptions_for_UseValidAriaValuesOptions {
 	/**
@@ -4138,7 +4138,7 @@ export interface RuleWithFixOptions_for_NoAdjacentSpacesInRegexOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoAdjacentSpacesInRegexOptions;
+	options?: NoAdjacentSpacesInRegexOptions;
 }
 export interface RuleWithOptions_for_NoArgumentsOptions {
 	/**
@@ -4162,7 +4162,7 @@ export interface RuleWithFixOptions_for_NoBannedTypesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoBannedTypesOptions;
+	options?: NoBannedTypesOptions;
 }
 export interface RuleWithOptions_for_NoCommaOperatorOptions {
 	/**
@@ -4226,7 +4226,7 @@ export interface RuleWithFixOptions_for_NoExtraBooleanCastOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoExtraBooleanCastOptions;
+	options?: NoExtraBooleanCastOptions;
 }
 export interface RuleWithFixOptions_for_NoFlatMapIdentityOptions {
 	/**
@@ -4240,7 +4240,7 @@ export interface RuleWithFixOptions_for_NoFlatMapIdentityOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoFlatMapIdentityOptions;
+	options?: NoFlatMapIdentityOptions;
 }
 export interface RuleWithOptions_for_NoForEachOptions {
 	/**
@@ -4264,7 +4264,7 @@ export interface RuleWithFixOptions_for_NoImplicitCoercionsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoImplicitCoercionsOptions;
+	options?: NoImplicitCoercionsOptions;
 }
 export interface RuleWithFixOptions_for_NoImportantStylesOptions {
 	/**
@@ -4278,7 +4278,7 @@ export interface RuleWithFixOptions_for_NoImportantStylesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoImportantStylesOptions;
+	options?: NoImportantStylesOptions;
 }
 export interface RuleWithOptions_for_NoStaticOnlyClassOptions {
 	/**
@@ -4302,7 +4302,7 @@ export interface RuleWithFixOptions_for_NoThisInStaticOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoThisInStaticOptions;
+	options?: NoThisInStaticOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessCatchOptions {
 	/**
@@ -4316,7 +4316,7 @@ export interface RuleWithFixOptions_for_NoUselessCatchOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessCatchOptions;
+	options?: NoUselessCatchOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessConstructorOptions {
 	/**
@@ -4330,7 +4330,7 @@ export interface RuleWithFixOptions_for_NoUselessConstructorOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessConstructorOptions;
+	options?: NoUselessConstructorOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessContinueOptions {
 	/**
@@ -4344,7 +4344,7 @@ export interface RuleWithFixOptions_for_NoUselessContinueOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessContinueOptions;
+	options?: NoUselessContinueOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessEmptyExportOptions {
 	/**
@@ -4358,7 +4358,7 @@ export interface RuleWithFixOptions_for_NoUselessEmptyExportOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessEmptyExportOptions;
+	options?: NoUselessEmptyExportOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessEscapeInRegexOptions {
 	/**
@@ -4372,7 +4372,7 @@ export interface RuleWithFixOptions_for_NoUselessEscapeInRegexOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessEscapeInRegexOptions;
+	options?: NoUselessEscapeInRegexOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessFragmentsOptions {
 	/**
@@ -4386,7 +4386,7 @@ export interface RuleWithFixOptions_for_NoUselessFragmentsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessFragmentsOptions;
+	options?: NoUselessFragmentsOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessLabelOptions {
 	/**
@@ -4400,7 +4400,7 @@ export interface RuleWithFixOptions_for_NoUselessLabelOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessLabelOptions;
+	options?: NoUselessLabelOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessLoneBlockStatementsOptions {
 	/**
@@ -4414,7 +4414,7 @@ export interface RuleWithFixOptions_for_NoUselessLoneBlockStatementsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessLoneBlockStatementsOptions;
+	options?: NoUselessLoneBlockStatementsOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessRenameOptions {
 	/**
@@ -4428,7 +4428,7 @@ export interface RuleWithFixOptions_for_NoUselessRenameOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessRenameOptions;
+	options?: NoUselessRenameOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessStringConcatOptions {
 	/**
@@ -4442,7 +4442,7 @@ export interface RuleWithFixOptions_for_NoUselessStringConcatOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessStringConcatOptions;
+	options?: NoUselessStringConcatOptions;
 }
 export interface RuleWithOptions_for_NoUselessStringRawOptions {
 	/**
@@ -4466,7 +4466,7 @@ export interface RuleWithFixOptions_for_NoUselessSwitchCaseOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessSwitchCaseOptions;
+	options?: NoUselessSwitchCaseOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessTernaryOptions {
 	/**
@@ -4480,7 +4480,7 @@ export interface RuleWithFixOptions_for_NoUselessTernaryOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessTernaryOptions;
+	options?: NoUselessTernaryOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessThisAliasOptions {
 	/**
@@ -4494,7 +4494,7 @@ export interface RuleWithFixOptions_for_NoUselessThisAliasOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessThisAliasOptions;
+	options?: NoUselessThisAliasOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessTypeConstraintOptions {
 	/**
@@ -4508,7 +4508,7 @@ export interface RuleWithFixOptions_for_NoUselessTypeConstraintOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessTypeConstraintOptions;
+	options?: NoUselessTypeConstraintOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessUndefinedInitializationOptions {
 	/**
@@ -4522,7 +4522,7 @@ export interface RuleWithFixOptions_for_NoUselessUndefinedInitializationOptions 
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessUndefinedInitializationOptions;
+	options?: NoUselessUndefinedInitializationOptions;
 }
 export interface RuleWithOptions_for_NoVoidOptions {
 	/**
@@ -4546,7 +4546,7 @@ export interface RuleWithFixOptions_for_UseArrowFunctionOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseArrowFunctionOptions;
+	options?: UseArrowFunctionOptions;
 }
 export interface RuleWithFixOptions_for_UseDateNowOptions {
 	/**
@@ -4560,7 +4560,7 @@ export interface RuleWithFixOptions_for_UseDateNowOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseDateNowOptions;
+	options?: UseDateNowOptions;
 }
 export interface RuleWithFixOptions_for_UseFlatMapOptions {
 	/**
@@ -4574,7 +4574,7 @@ export interface RuleWithFixOptions_for_UseFlatMapOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseFlatMapOptions;
+	options?: UseFlatMapOptions;
 }
 export interface RuleWithFixOptions_for_UseIndexOfOptions {
 	/**
@@ -4588,7 +4588,7 @@ export interface RuleWithFixOptions_for_UseIndexOfOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseIndexOfOptions;
+	options?: UseIndexOfOptions;
 }
 export interface RuleWithFixOptions_for_UseLiteralKeysOptions {
 	/**
@@ -4602,7 +4602,7 @@ export interface RuleWithFixOptions_for_UseLiteralKeysOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseLiteralKeysOptions;
+	options?: UseLiteralKeysOptions;
 }
 export interface RuleWithFixOptions_for_UseNumericLiteralsOptions {
 	/**
@@ -4616,7 +4616,7 @@ export interface RuleWithFixOptions_for_UseNumericLiteralsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseNumericLiteralsOptions;
+	options?: UseNumericLiteralsOptions;
 }
 export interface RuleWithFixOptions_for_UseOptionalChainOptions {
 	/**
@@ -4630,7 +4630,7 @@ export interface RuleWithFixOptions_for_UseOptionalChainOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseOptionalChainOptions;
+	options?: UseOptionalChainOptions;
 }
 export interface RuleWithFixOptions_for_UseRegexLiteralsOptions {
 	/**
@@ -4644,7 +4644,7 @@ export interface RuleWithFixOptions_for_UseRegexLiteralsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseRegexLiteralsOptions;
+	options?: UseRegexLiteralsOptions;
 }
 export interface RuleWithFixOptions_for_UseSimpleNumberKeysOptions {
 	/**
@@ -4658,7 +4658,7 @@ export interface RuleWithFixOptions_for_UseSimpleNumberKeysOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseSimpleNumberKeysOptions;
+	options?: UseSimpleNumberKeysOptions;
 }
 export interface RuleWithFixOptions_for_UseSimplifiedLogicExpressionOptions {
 	/**
@@ -4672,7 +4672,7 @@ export interface RuleWithFixOptions_for_UseSimplifiedLogicExpressionOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseSimplifiedLogicExpressionOptions;
+	options?: UseSimplifiedLogicExpressionOptions;
 }
 export interface RuleWithFixOptions_for_UseWhileOptions {
 	/**
@@ -4686,7 +4686,7 @@ export interface RuleWithFixOptions_for_UseWhileOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseWhileOptions;
+	options?: UseWhileOptions;
 }
 export interface RuleWithOptions_for_NoChildrenPropOptions {
 	/**
@@ -4710,7 +4710,7 @@ export interface RuleWithFixOptions_for_NoConstAssignOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoConstAssignOptions;
+	options?: NoConstAssignOptions;
 }
 export interface RuleWithOptions_for_NoConstantConditionOptions {
 	/**
@@ -4734,7 +4734,7 @@ export interface RuleWithFixOptions_for_NoConstantMathMinMaxClampOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoConstantMathMinMaxClampOptions;
+	options?: NoConstantMathMinMaxClampOptions;
 }
 export interface RuleWithOptions_for_NoConstructorReturnOptions {
 	/**
@@ -4778,7 +4778,7 @@ export interface RuleWithFixOptions_for_NoGlobalDirnameFilenameOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoGlobalDirnameFilenameOptions;
+	options?: NoGlobalDirnameFilenameOptions;
 }
 export interface RuleWithOptions_for_NoGlobalObjectCallsOptions {
 	/**
@@ -4812,7 +4812,7 @@ export interface RuleWithFixOptions_for_NoInvalidBuiltinInstantiationOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoInvalidBuiltinInstantiationOptions;
+	options?: NoInvalidBuiltinInstantiationOptions;
 }
 export interface RuleWithOptions_for_NoInvalidConstructorSuperOptions {
 	/**
@@ -4906,7 +4906,7 @@ export interface RuleWithFixOptions_for_NoNonoctalDecimalEscapeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoNonoctalDecimalEscapeOptions;
+	options?: NoNonoctalDecimalEscapeOptions;
 }
 export interface RuleWithOptions_for_NoPrecisionLossOptions {
 	/**
@@ -4940,7 +4940,7 @@ export interface RuleWithFixOptions_for_NoProcessGlobalOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoProcessGlobalOptions;
+	options?: NoProcessGlobalOptions;
 }
 export interface RuleWithOptions_for_NoQwikUseVisibleTaskOptions {
 	/**
@@ -5024,7 +5024,7 @@ export interface RuleWithFixOptions_for_NoStringCaseMismatchOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoStringCaseMismatchOptions;
+	options?: NoStringCaseMismatchOptions;
 }
 export interface RuleWithFixOptions_for_NoSwitchDeclarationsOptions {
 	/**
@@ -5038,7 +5038,7 @@ export interface RuleWithFixOptions_for_NoSwitchDeclarationsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoSwitchDeclarationsOptions;
+	options?: NoSwitchDeclarationsOptions;
 }
 export interface RuleWithOptions_for_NoUndeclaredDependenciesOptions {
 	/**
@@ -5192,7 +5192,7 @@ export interface RuleWithFixOptions_for_NoUnusedFunctionParametersOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUnusedFunctionParametersOptions;
+	options?: NoUnusedFunctionParametersOptions;
 }
 export interface RuleWithFixOptions_for_NoUnusedImportsOptions {
 	/**
@@ -5206,7 +5206,7 @@ export interface RuleWithFixOptions_for_NoUnusedImportsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUnusedImportsOptions;
+	options?: NoUnusedImportsOptions;
 }
 export interface RuleWithFixOptions_for_NoUnusedLabelsOptions {
 	/**
@@ -5220,7 +5220,7 @@ export interface RuleWithFixOptions_for_NoUnusedLabelsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUnusedLabelsOptions;
+	options?: NoUnusedLabelsOptions;
 }
 export interface RuleWithFixOptions_for_NoUnusedPrivateClassMembersOptions {
 	/**
@@ -5234,7 +5234,7 @@ export interface RuleWithFixOptions_for_NoUnusedPrivateClassMembersOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUnusedPrivateClassMembersOptions;
+	options?: NoUnusedPrivateClassMembersOptions;
 }
 export interface RuleWithFixOptions_for_NoUnusedVariablesOptions {
 	/**
@@ -5248,7 +5248,7 @@ export interface RuleWithFixOptions_for_NoUnusedVariablesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUnusedVariablesOptions;
+	options?: NoUnusedVariablesOptions;
 }
 export interface RuleWithFixOptions_for_NoVoidElementsWithChildrenOptions {
 	/**
@@ -5262,7 +5262,7 @@ export interface RuleWithFixOptions_for_NoVoidElementsWithChildrenOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoVoidElementsWithChildrenOptions;
+	options?: NoVoidElementsWithChildrenOptions;
 }
 export interface RuleWithOptions_for_NoVoidTypeReturnOptions {
 	/**
@@ -5286,7 +5286,7 @@ export interface RuleWithFixOptions_for_UseExhaustiveDependenciesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseExhaustiveDependenciesOptions;
+	options?: UseExhaustiveDependenciesOptions;
 }
 export interface RuleWithFixOptions_for_UseGraphqlNamedOperationsOptions {
 	/**
@@ -5300,7 +5300,7 @@ export interface RuleWithFixOptions_for_UseGraphqlNamedOperationsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseGraphqlNamedOperationsOptions;
+	options?: UseGraphqlNamedOperationsOptions;
 }
 export interface RuleWithOptions_for_UseHookAtTopLevelOptions {
 	/**
@@ -5334,7 +5334,7 @@ export interface RuleWithFixOptions_for_UseImportExtensionsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseImportExtensionsOptions;
+	options?: UseImportExtensionsOptions;
 }
 export interface RuleWithFixOptions_for_UseIsNanOptions {
 	/**
@@ -5348,7 +5348,7 @@ export interface RuleWithFixOptions_for_UseIsNanOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseIsNanOptions;
+	options?: UseIsNanOptions;
 }
 export interface RuleWithFixOptions_for_UseJsonImportAttributesOptions {
 	/**
@@ -5362,7 +5362,7 @@ export interface RuleWithFixOptions_for_UseJsonImportAttributesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseJsonImportAttributesOptions;
+	options?: UseJsonImportAttributesOptions;
 }
 export interface RuleWithOptions_for_UseJsxKeyInIterableOptions {
 	/**
@@ -5386,7 +5386,7 @@ export interface RuleWithFixOptions_for_UseParseIntRadixOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseParseIntRadixOptions;
+	options?: UseParseIntRadixOptions;
 }
 export interface RuleWithOptions_for_UseQwikClasslistOptions {
 	/**
@@ -5410,7 +5410,7 @@ export interface RuleWithFixOptions_for_UseSingleJsDocAsteriskOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseSingleJsDocAsteriskOptions;
+	options?: UseSingleJsDocAsteriskOptions;
 }
 export interface RuleWithOptions_for_UseUniqueElementIdsOptions {
 	/**
@@ -5444,7 +5444,7 @@ export interface RuleWithFixOptions_for_UseValidTypeofOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseValidTypeofOptions;
+	options?: UseValidTypeofOptions;
 }
 export interface RuleWithOptions_for_UseYieldOptions {
 	/**
@@ -5498,7 +5498,7 @@ export interface RuleWithFixOptions_for_NoFloatingPromisesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoFloatingPromisesOptions;
+	options?: NoFloatingPromisesOptions;
 }
 export interface RuleWithOptions_for_NoImportCyclesOptions {
 	/**
@@ -5532,7 +5532,7 @@ export interface RuleWithFixOptions_for_NoMisusedPromisesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoMisusedPromisesOptions;
+	options?: NoMisusedPromisesOptions;
 }
 export interface RuleWithOptions_for_NoNextAsyncClientComponentOptions {
 	/**
@@ -5556,7 +5556,7 @@ export interface RuleWithFixOptions_for_NoReactForwardRefOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoReactForwardRefOptions;
+	options?: NoReactForwardRefOptions;
 }
 export interface RuleWithOptions_for_NoShadowOptions {
 	/**
@@ -5610,7 +5610,7 @@ export interface RuleWithFixOptions_for_NoUselessCatchBindingOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessCatchBindingOptions;
+	options?: NoUselessCatchBindingOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessUndefinedOptions {
 	/**
@@ -5624,7 +5624,7 @@ export interface RuleWithFixOptions_for_NoUselessUndefinedOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessUndefinedOptions;
+	options?: NoUselessUndefinedOptions;
 }
 export interface RuleWithFixOptions_for_NoVueDataObjectDeclarationOptions {
 	/**
@@ -5638,7 +5638,7 @@ export interface RuleWithFixOptions_for_NoVueDataObjectDeclarationOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoVueDataObjectDeclarationOptions;
+	options?: NoVueDataObjectDeclarationOptions;
 }
 export interface RuleWithOptions_for_NoVueDuplicateKeysOptions {
 	/**
@@ -5682,7 +5682,7 @@ export interface RuleWithFixOptions_for_UseConsistentArrowReturnOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseConsistentArrowReturnOptions;
+	options?: UseConsistentArrowReturnOptions;
 }
 export interface RuleWithOptions_for_UseDeprecatedDateOptions {
 	/**
@@ -5706,7 +5706,7 @@ export interface RuleWithFixOptions_for_UseExhaustiveSwitchCasesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseExhaustiveSwitchCasesOptions;
+	options?: UseExhaustiveSwitchCasesOptions;
 }
 export interface RuleWithOptions_for_UseExplicitTypeOptions {
 	/**
@@ -5760,7 +5760,7 @@ export interface RuleWithFixOptions_for_UseSortedClassesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseSortedClassesOptions;
+	options?: UseSortedClassesOptions;
 }
 export interface RuleWithFixOptions_for_UseVueDefineMacrosOrderOptions {
 	/**
@@ -5774,7 +5774,7 @@ export interface RuleWithFixOptions_for_UseVueDefineMacrosOrderOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseVueDefineMacrosOrderOptions;
+	options?: UseVueDefineMacrosOrderOptions;
 }
 export interface RuleWithOptions_for_UseVueMultiWordComponentNamesOptions {
 	/**
@@ -5828,7 +5828,7 @@ export interface RuleWithFixOptions_for_NoDeleteOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoDeleteOptions;
+	options?: NoDeleteOptions;
 }
 export interface RuleWithOptions_for_NoDynamicNamespaceImportAccessOptions {
 	/**
@@ -5892,7 +5892,7 @@ export interface RuleWithFixOptions_for_UseGoogleFontPreconnectOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseGoogleFontPreconnectOptions;
+	options?: UseGoogleFontPreconnectOptions;
 }
 export interface RuleWithOptions_for_UseSolidForComponentOptions {
 	/**
@@ -5926,7 +5926,7 @@ export interface RuleWithFixOptions_for_NoBlankTargetOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoBlankTargetOptions;
+	options?: NoBlankTargetOptions;
 }
 export interface RuleWithOptions_for_NoDangerouslySetInnerHtmlOptions {
 	/**
@@ -6050,7 +6050,7 @@ export interface RuleWithFixOptions_for_NoImplicitBooleanOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoImplicitBooleanOptions;
+	options?: NoImplicitBooleanOptions;
 }
 export interface RuleWithFixOptions_for_NoInferrableTypesOptions {
 	/**
@@ -6064,7 +6064,7 @@ export interface RuleWithFixOptions_for_NoInferrableTypesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoInferrableTypesOptions;
+	options?: NoInferrableTypesOptions;
 }
 export interface RuleWithOptions_for_NoMagicNumbersOptions {
 	/**
@@ -6098,7 +6098,7 @@ export interface RuleWithFixOptions_for_NoNegationElseOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoNegationElseOptions;
+	options?: NoNegationElseOptions;
 }
 export interface RuleWithOptions_for_NoNestedTernaryOptions {
 	/**
@@ -6122,7 +6122,7 @@ export interface RuleWithFixOptions_for_NoNonNullAssertionOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoNonNullAssertionOptions;
+	options?: NoNonNullAssertionOptions;
 }
 export interface RuleWithOptions_for_NoParameterAssignOptions {
 	/**
@@ -6186,7 +6186,7 @@ export interface RuleWithFixOptions_for_NoRestrictedTypesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoRestrictedTypesOptions;
+	options?: NoRestrictedTypesOptions;
 }
 export interface RuleWithFixOptions_for_NoShoutyConstantsOptions {
 	/**
@@ -6200,7 +6200,7 @@ export interface RuleWithFixOptions_for_NoShoutyConstantsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoShoutyConstantsOptions;
+	options?: NoShoutyConstantsOptions;
 }
 export interface RuleWithFixOptions_for_NoSubstrOptions {
 	/**
@@ -6214,7 +6214,7 @@ export interface RuleWithFixOptions_for_NoSubstrOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoSubstrOptions;
+	options?: NoSubstrOptions;
 }
 export interface RuleWithFixOptions_for_NoUnusedTemplateLiteralOptions {
 	/**
@@ -6228,7 +6228,7 @@ export interface RuleWithFixOptions_for_NoUnusedTemplateLiteralOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUnusedTemplateLiteralOptions;
+	options?: NoUnusedTemplateLiteralOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessElseOptions {
 	/**
@@ -6242,7 +6242,7 @@ export interface RuleWithFixOptions_for_NoUselessElseOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessElseOptions;
+	options?: NoUselessElseOptions;
 }
 export interface RuleWithOptions_for_NoValueAtRuleOptions {
 	/**
@@ -6266,7 +6266,7 @@ export interface RuleWithFixOptions_for_NoYodaExpressionOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoYodaExpressionOptions;
+	options?: NoYodaExpressionOptions;
 }
 export interface RuleWithFixOptions_for_UseArrayLiteralsOptions {
 	/**
@@ -6280,7 +6280,7 @@ export interface RuleWithFixOptions_for_UseArrayLiteralsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseArrayLiteralsOptions;
+	options?: UseArrayLiteralsOptions;
 }
 export interface RuleWithFixOptions_for_UseAsConstAssertionOptions {
 	/**
@@ -6294,7 +6294,7 @@ export interface RuleWithFixOptions_for_UseAsConstAssertionOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseAsConstAssertionOptions;
+	options?: UseAsConstAssertionOptions;
 }
 export interface RuleWithFixOptions_for_UseAtIndexOptions {
 	/**
@@ -6308,7 +6308,7 @@ export interface RuleWithFixOptions_for_UseAtIndexOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseAtIndexOptions;
+	options?: UseAtIndexOptions;
 }
 export interface RuleWithFixOptions_for_UseBlockStatementsOptions {
 	/**
@@ -6322,7 +6322,7 @@ export interface RuleWithFixOptions_for_UseBlockStatementsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseBlockStatementsOptions;
+	options?: UseBlockStatementsOptions;
 }
 export interface RuleWithFixOptions_for_UseCollapsedElseIfOptions {
 	/**
@@ -6336,7 +6336,7 @@ export interface RuleWithFixOptions_for_UseCollapsedElseIfOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseCollapsedElseIfOptions;
+	options?: UseCollapsedElseIfOptions;
 }
 export interface RuleWithFixOptions_for_UseCollapsedIfOptions {
 	/**
@@ -6350,7 +6350,7 @@ export interface RuleWithFixOptions_for_UseCollapsedIfOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseCollapsedIfOptions;
+	options?: UseCollapsedIfOptions;
 }
 export interface RuleWithOptions_for_UseComponentExportOnlyModulesOptions {
 	/**
@@ -6374,7 +6374,7 @@ export interface RuleWithFixOptions_for_UseConsistentArrayTypeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseConsistentArrayTypeOptions;
+	options?: UseConsistentArrayTypeOptions;
 }
 export interface RuleWithFixOptions_for_UseConsistentBuiltinInstantiationOptions {
 	/**
@@ -6388,7 +6388,7 @@ export interface RuleWithFixOptions_for_UseConsistentBuiltinInstantiationOptions
 	/**
 	 * Rule's options
 	 */
-	options: UseConsistentBuiltinInstantiationOptions;
+	options?: UseConsistentBuiltinInstantiationOptions;
 }
 export interface RuleWithFixOptions_for_UseConsistentCurlyBracesOptions {
 	/**
@@ -6402,7 +6402,7 @@ export interface RuleWithFixOptions_for_UseConsistentCurlyBracesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseConsistentCurlyBracesOptions;
+	options?: UseConsistentCurlyBracesOptions;
 }
 export interface RuleWithOptions_for_UseConsistentMemberAccessibilityOptions {
 	/**
@@ -6426,7 +6426,7 @@ export interface RuleWithFixOptions_for_UseConsistentObjectDefinitionsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseConsistentObjectDefinitionsOptions;
+	options?: UseConsistentObjectDefinitionsOptions;
 }
 export interface RuleWithFixOptions_for_UseConsistentTypeDefinitionsOptions {
 	/**
@@ -6440,7 +6440,7 @@ export interface RuleWithFixOptions_for_UseConsistentTypeDefinitionsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseConsistentTypeDefinitionsOptions;
+	options?: UseConsistentTypeDefinitionsOptions;
 }
 export interface RuleWithFixOptions_for_UseConstOptions {
 	/**
@@ -6454,7 +6454,7 @@ export interface RuleWithFixOptions_for_UseConstOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseConstOptions;
+	options?: UseConstOptions;
 }
 export interface RuleWithFixOptions_for_UseDefaultParameterLastOptions {
 	/**
@@ -6468,7 +6468,7 @@ export interface RuleWithFixOptions_for_UseDefaultParameterLastOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseDefaultParameterLastOptions;
+	options?: UseDefaultParameterLastOptions;
 }
 export interface RuleWithOptions_for_UseDefaultSwitchClauseOptions {
 	/**
@@ -6502,7 +6502,7 @@ export interface RuleWithFixOptions_for_UseEnumInitializersOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseEnumInitializersOptions;
+	options?: UseEnumInitializersOptions;
 }
 export interface RuleWithFixOptions_for_UseExplicitLengthCheckOptions {
 	/**
@@ -6516,7 +6516,7 @@ export interface RuleWithFixOptions_for_UseExplicitLengthCheckOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseExplicitLengthCheckOptions;
+	options?: UseExplicitLengthCheckOptions;
 }
 export interface RuleWithFixOptions_for_UseExponentiationOperatorOptions {
 	/**
@@ -6530,7 +6530,7 @@ export interface RuleWithFixOptions_for_UseExponentiationOperatorOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseExponentiationOperatorOptions;
+	options?: UseExponentiationOperatorOptions;
 }
 export interface RuleWithFixOptions_for_UseExportTypeOptions {
 	/**
@@ -6544,7 +6544,7 @@ export interface RuleWithFixOptions_for_UseExportTypeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseExportTypeOptions;
+	options?: UseExportTypeOptions;
 }
 export interface RuleWithOptions_for_UseExportsLastOptions {
 	/**
@@ -6588,7 +6588,7 @@ export interface RuleWithFixOptions_for_UseFragmentSyntaxOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseFragmentSyntaxOptions;
+	options?: UseFragmentSyntaxOptions;
 }
 export interface RuleWithOptions_for_UseGraphqlNamingConventionOptions {
 	/**
@@ -6622,7 +6622,7 @@ export interface RuleWithFixOptions_for_UseImportTypeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseImportTypeOptions;
+	options?: UseImportTypeOptions;
 }
 export interface RuleWithOptions_for_UseLiteralEnumMembersOptions {
 	/**
@@ -6646,7 +6646,7 @@ export interface RuleWithFixOptions_for_UseNamingConventionOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseNamingConventionOptions;
+	options?: UseNamingConventionOptions;
 }
 export interface RuleWithFixOptions_for_UseNodeAssertStrictOptions {
 	/**
@@ -6660,7 +6660,7 @@ export interface RuleWithFixOptions_for_UseNodeAssertStrictOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseNodeAssertStrictOptions;
+	options?: UseNodeAssertStrictOptions;
 }
 export interface RuleWithFixOptions_for_UseNodejsImportProtocolOptions {
 	/**
@@ -6674,7 +6674,7 @@ export interface RuleWithFixOptions_for_UseNodejsImportProtocolOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseNodejsImportProtocolOptions;
+	options?: UseNodejsImportProtocolOptions;
 }
 export interface RuleWithFixOptions_for_UseNumberNamespaceOptions {
 	/**
@@ -6688,7 +6688,7 @@ export interface RuleWithFixOptions_for_UseNumberNamespaceOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseNumberNamespaceOptions;
+	options?: UseNumberNamespaceOptions;
 }
 export interface RuleWithFixOptions_for_UseNumericSeparatorsOptions {
 	/**
@@ -6702,7 +6702,7 @@ export interface RuleWithFixOptions_for_UseNumericSeparatorsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseNumericSeparatorsOptions;
+	options?: UseNumericSeparatorsOptions;
 }
 export interface RuleWithFixOptions_for_UseObjectSpreadOptions {
 	/**
@@ -6716,7 +6716,7 @@ export interface RuleWithFixOptions_for_UseObjectSpreadOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseObjectSpreadOptions;
+	options?: UseObjectSpreadOptions;
 }
 export interface RuleWithOptions_for_UseReactFunctionComponentsOptions {
 	/**
@@ -6740,7 +6740,7 @@ export interface RuleWithFixOptions_for_UseReadonlyClassPropertiesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseReadonlyClassPropertiesOptions;
+	options?: UseReadonlyClassPropertiesOptions;
 }
 export interface RuleWithFixOptions_for_UseSelfClosingElementsOptions {
 	/**
@@ -6754,7 +6754,7 @@ export interface RuleWithFixOptions_for_UseSelfClosingElementsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseSelfClosingElementsOptions;
+	options?: UseSelfClosingElementsOptions;
 }
 export interface RuleWithFixOptions_for_UseShorthandAssignOptions {
 	/**
@@ -6768,7 +6768,7 @@ export interface RuleWithFixOptions_for_UseShorthandAssignOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseShorthandAssignOptions;
+	options?: UseShorthandAssignOptions;
 }
 export interface RuleWithFixOptions_for_UseShorthandFunctionTypeOptions {
 	/**
@@ -6782,7 +6782,7 @@ export interface RuleWithFixOptions_for_UseShorthandFunctionTypeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseShorthandFunctionTypeOptions;
+	options?: UseShorthandFunctionTypeOptions;
 }
 export interface RuleWithFixOptions_for_UseSingleVarDeclaratorOptions {
 	/**
@@ -6796,7 +6796,7 @@ export interface RuleWithFixOptions_for_UseSingleVarDeclaratorOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseSingleVarDeclaratorOptions;
+	options?: UseSingleVarDeclaratorOptions;
 }
 export interface RuleWithOptions_for_UseSymbolDescriptionOptions {
 	/**
@@ -6820,7 +6820,7 @@ export interface RuleWithFixOptions_for_UseTemplateOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseTemplateOptions;
+	options?: UseTemplateOptions;
 }
 export interface RuleWithFixOptions_for_UseThrowNewErrorOptions {
 	/**
@@ -6834,7 +6834,7 @@ export interface RuleWithFixOptions_for_UseThrowNewErrorOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseThrowNewErrorOptions;
+	options?: UseThrowNewErrorOptions;
 }
 export interface RuleWithOptions_for_UseThrowOnlyErrorOptions {
 	/**
@@ -6858,7 +6858,7 @@ export interface RuleWithFixOptions_for_UseTrimStartEndOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseTrimStartEndOptions;
+	options?: UseTrimStartEndOptions;
 }
 export interface RuleWithFixOptions_for_UseUnifiedTypeSignaturesOptions {
 	/**
@@ -6872,7 +6872,7 @@ export interface RuleWithFixOptions_for_UseUnifiedTypeSignaturesOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseUnifiedTypeSignaturesOptions;
+	options?: UseUnifiedTypeSignaturesOptions;
 }
 export interface RuleWithOptions_for_NoAlertOptions {
 	/**
@@ -6896,7 +6896,7 @@ export interface RuleWithFixOptions_for_NoApproximativeNumericConstantOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoApproximativeNumericConstantOptions;
+	options?: NoApproximativeNumericConstantOptions;
 }
 export interface RuleWithOptions_for_NoArrayIndexKeyOptions {
 	/**
@@ -6940,7 +6940,7 @@ export interface RuleWithFixOptions_for_NoBiomeFirstExceptionOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoBiomeFirstExceptionOptions;
+	options?: NoBiomeFirstExceptionOptions;
 }
 export interface RuleWithOptions_for_NoBitwiseOperatorsOptions {
 	/**
@@ -6984,7 +6984,7 @@ export interface RuleWithFixOptions_for_NoCommentTextOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoCommentTextOptions;
+	options?: NoCommentTextOptions;
 }
 export interface RuleWithFixOptions_for_NoCompareNegZeroOptions {
 	/**
@@ -6998,7 +6998,7 @@ export interface RuleWithFixOptions_for_NoCompareNegZeroOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoCompareNegZeroOptions;
+	options?: NoCompareNegZeroOptions;
 }
 export interface RuleWithOptions_for_NoConfusingLabelsOptions {
 	/**
@@ -7022,7 +7022,7 @@ export interface RuleWithFixOptions_for_NoConfusingVoidTypeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoConfusingVoidTypeOptions;
+	options?: NoConfusingVoidTypeOptions;
 }
 export interface RuleWithFixOptions_for_NoConsoleOptions {
 	/**
@@ -7036,7 +7036,7 @@ export interface RuleWithFixOptions_for_NoConsoleOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoConsoleOptions;
+	options?: NoConsoleOptions;
 }
 export interface RuleWithFixOptions_for_NoConstEnumOptions {
 	/**
@@ -7050,7 +7050,7 @@ export interface RuleWithFixOptions_for_NoConstEnumOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoConstEnumOptions;
+	options?: NoConstEnumOptions;
 }
 export interface RuleWithOptions_for_NoConstantBinaryExpressionsOptions {
 	/**
@@ -7084,7 +7084,7 @@ export interface RuleWithFixOptions_for_NoDebuggerOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoDebuggerOptions;
+	options?: NoDebuggerOptions;
 }
 export interface RuleWithOptions_for_NoDocumentCookieOptions {
 	/**
@@ -7118,7 +7118,7 @@ export interface RuleWithFixOptions_for_NoDoubleEqualsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoDoubleEqualsOptions;
+	options?: NoDoubleEqualsOptions;
 }
 export interface RuleWithOptions_for_NoDuplicateAtImportRulesOptions {
 	/**
@@ -7282,7 +7282,7 @@ export interface RuleWithFixOptions_for_NoEmptyInterfaceOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoEmptyInterfaceOptions;
+	options?: NoEmptyInterfaceOptions;
 }
 export interface RuleWithOptions_for_NoEvolvingTypesOptions {
 	/**
@@ -7326,7 +7326,7 @@ export interface RuleWithFixOptions_for_NoExtraNonNullAssertionOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoExtraNonNullAssertionOptions;
+	options?: NoExtraNonNullAssertionOptions;
 }
 export interface RuleWithOptions_for_NoFallthroughSwitchClauseOptions {
 	/**
@@ -7350,7 +7350,7 @@ export interface RuleWithFixOptions_for_NoFocusedTestsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoFocusedTestsOptions;
+	options?: NoFocusedTestsOptions;
 }
 export interface RuleWithOptions_for_NoFunctionAssignOptions {
 	/**
@@ -7384,7 +7384,7 @@ export interface RuleWithFixOptions_for_NoGlobalIsFiniteOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoGlobalIsFiniteOptions;
+	options?: NoGlobalIsFiniteOptions;
 }
 export interface RuleWithFixOptions_for_NoGlobalIsNanOptions {
 	/**
@@ -7398,7 +7398,7 @@ export interface RuleWithFixOptions_for_NoGlobalIsNanOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoGlobalIsNanOptions;
+	options?: NoGlobalIsNanOptions;
 }
 export interface RuleWithOptions_for_NoHeadImportInDocumentOptions {
 	/**
@@ -7472,7 +7472,7 @@ export interface RuleWithFixOptions_for_NoMisleadingCharacterClassOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoMisleadingCharacterClassOptions;
+	options?: NoMisleadingCharacterClassOptions;
 }
 export interface RuleWithOptions_for_NoMisleadingInstantiatorOptions {
 	/**
@@ -7506,7 +7506,7 @@ export interface RuleWithFixOptions_for_NoMisrefactoredShorthandAssignOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoMisrefactoredShorthandAssignOptions;
+	options?: NoMisrefactoredShorthandAssignOptions;
 }
 export interface RuleWithOptions_for_NoNonNullAssertedOptionalChainOptions {
 	/**
@@ -7530,7 +7530,7 @@ export interface RuleWithFixOptions_for_NoOctalEscapeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoOctalEscapeOptions;
+	options?: NoOctalEscapeOptions;
 }
 export interface RuleWithFixOptions_for_NoPrototypeBuiltinsOptions {
 	/**
@@ -7544,7 +7544,7 @@ export interface RuleWithFixOptions_for_NoPrototypeBuiltinsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoPrototypeBuiltinsOptions;
+	options?: NoPrototypeBuiltinsOptions;
 }
 export interface RuleWithFixOptions_for_NoQuickfixBiomeOptions {
 	/**
@@ -7558,7 +7558,7 @@ export interface RuleWithFixOptions_for_NoQuickfixBiomeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoQuickfixBiomeOptions;
+	options?: NoQuickfixBiomeOptions;
 }
 export interface RuleWithFixOptions_for_NoReactSpecificPropsOptions {
 	/**
@@ -7572,7 +7572,7 @@ export interface RuleWithFixOptions_for_NoReactSpecificPropsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoReactSpecificPropsOptions;
+	options?: NoReactSpecificPropsOptions;
 }
 export interface RuleWithOptions_for_NoRedeclareOptions {
 	/**
@@ -7596,7 +7596,7 @@ export interface RuleWithFixOptions_for_NoRedundantUseStrictOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoRedundantUseStrictOptions;
+	options?: NoRedundantUseStrictOptions;
 }
 export interface RuleWithOptions_for_NoSelfCompareOptions {
 	/**
@@ -7640,7 +7640,7 @@ export interface RuleWithFixOptions_for_NoSkippedTestsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoSkippedTestsOptions;
+	options?: NoSkippedTestsOptions;
 }
 export interface RuleWithFixOptions_for_NoSparseArrayOptions {
 	/**
@@ -7654,7 +7654,7 @@ export interface RuleWithFixOptions_for_NoSparseArrayOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoSparseArrayOptions;
+	options?: NoSparseArrayOptions;
 }
 export interface RuleWithOptions_for_NoSuspiciousSemicolonInJsxOptions {
 	/**
@@ -7698,7 +7698,7 @@ export interface RuleWithFixOptions_for_NoTsIgnoreOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoTsIgnoreOptions;
+	options?: NoTsIgnoreOptions;
 }
 export interface RuleWithOptions_for_NoUnassignedVariablesOptions {
 	/**
@@ -7742,7 +7742,7 @@ export interface RuleWithFixOptions_for_NoUnsafeNegationOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUnsafeNegationOptions;
+	options?: NoUnsafeNegationOptions;
 }
 export interface RuleWithFixOptions_for_NoUselessEscapeInStringOptions {
 	/**
@@ -7756,7 +7756,7 @@ export interface RuleWithFixOptions_for_NoUselessEscapeInStringOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoUselessEscapeInStringOptions;
+	options?: NoUselessEscapeInStringOptions;
 }
 export interface RuleWithOptions_for_NoUselessRegexBackrefsOptions {
 	/**
@@ -7780,7 +7780,7 @@ export interface RuleWithFixOptions_for_NoVarOptions {
 	/**
 	 * Rule's options
 	 */
-	options: NoVarOptions;
+	options?: NoVarOptions;
 }
 export interface RuleWithOptions_for_NoWithOptions {
 	/**
@@ -7824,7 +7824,7 @@ export interface RuleWithFixOptions_for_UseBiomeIgnoreFolderOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseBiomeIgnoreFolderOptions;
+	options?: UseBiomeIgnoreFolderOptions;
 }
 export interface RuleWithOptions_for_UseDefaultSwitchClauseLastOptions {
 	/**
@@ -7888,7 +7888,7 @@ export interface RuleWithFixOptions_for_UseIsArrayOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseIsArrayOptions;
+	options?: UseIsArrayOptions;
 }
 export interface RuleWithOptions_for_UseIterableCallbackReturnOptions {
 	/**
@@ -7912,7 +7912,7 @@ export interface RuleWithFixOptions_for_UseNamespaceKeywordOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseNamespaceKeywordOptions;
+	options?: UseNamespaceKeywordOptions;
 }
 export interface RuleWithFixOptions_for_UseNumberToFixedDigitsArgumentOptions {
 	/**
@@ -7926,7 +7926,7 @@ export interface RuleWithFixOptions_for_UseNumberToFixedDigitsArgumentOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseNumberToFixedDigitsArgumentOptions;
+	options?: UseNumberToFixedDigitsArgumentOptions;
 }
 export interface RuleWithFixOptions_for_UseStaticResponseMethodsOptions {
 	/**
@@ -7940,7 +7940,7 @@ export interface RuleWithFixOptions_for_UseStaticResponseMethodsOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseStaticResponseMethodsOptions;
+	options?: UseStaticResponseMethodsOptions;
 }
 export interface RuleWithFixOptions_for_UseStrictModeOptions {
 	/**
@@ -7954,7 +7954,7 @@ export interface RuleWithFixOptions_for_UseStrictModeOptions {
 	/**
 	 * Rule's options
 	 */
-	options: UseStrictModeOptions;
+	options?: UseStrictModeOptions;
 }
 export type ImportGroups = ImportGroup[];
 export type SortOrder = "natural" | "lexicographic";

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -5906,7 +5906,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoAccessKeyOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoAccessKeyOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -5940,7 +5943,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoAdjacentSpacesInRegexOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoAdjacentSpacesInRegexOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -5974,8 +5980,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoApproximativeNumericConstantOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoApproximativeNumericConstantOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -6010,7 +6017,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoAriaHiddenOnFocusableOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoAriaHiddenOnFocusableOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6029,8 +6039,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoAriaUnsupportedElementsOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoAriaUnsupportedElementsOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -6095,7 +6106,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoAutofocusOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoAutofocusOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6129,7 +6143,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoBannedTypesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoBannedTypesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6163,7 +6180,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoBiomeFirstExceptionOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoBiomeFirstExceptionOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6197,7 +6217,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoBlankTargetOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoBlankTargetOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6276,7 +6299,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoCommentTextOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoCommentTextOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6310,7 +6336,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoCompareNegZeroOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoCompareNegZeroOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6344,7 +6373,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoConfusingVoidTypeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoConfusingVoidTypeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6363,7 +6395,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoConsoleOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoConsoleOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6382,7 +6417,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoConstAssignOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoConstAssignOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6401,7 +6439,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoConstEnumOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoConstEnumOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6452,8 +6493,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoConstantMathMinMaxClampOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoConstantMathMinMaxClampOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -6541,7 +6583,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoDebuggerOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoDebuggerOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6575,7 +6620,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoDeleteOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoDeleteOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6624,7 +6672,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoDistractingElementsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoDistractingElementsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6688,7 +6739,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoDoubleEqualsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoDoubleEqualsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -6985,7 +7039,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoEmptyInterfaceOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoEmptyInterfaceOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7175,7 +7232,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoExtraBooleanCastOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoExtraBooleanCastOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7194,7 +7254,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoExtraNonNullAssertionOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoExtraNonNullAssertionOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7230,7 +7293,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoFlatMapIdentityOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoFlatMapIdentityOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7249,7 +7315,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoFloatingPromisesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoFloatingPromisesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7268,7 +7337,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoFocusedTestsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoFocusedTestsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7332,7 +7404,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoGlobalDirnameFilenameOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoGlobalDirnameFilenameOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7366,7 +7441,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoGlobalIsFiniteOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoGlobalIsFiniteOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7385,7 +7463,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoGlobalIsNanOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoGlobalIsNanOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7449,7 +7530,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoHeaderScopeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoHeaderScopeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7498,7 +7582,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoImplicitBooleanOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoImplicitBooleanOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7517,7 +7604,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoImplicitCoercionsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoImplicitCoercionsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7581,7 +7671,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoImportantStylesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoImportantStylesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7600,7 +7693,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoInferrableTypesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoInferrableTypesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7634,10 +7730,11 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
+					"anyOf": [
 						{
 							"$ref": "#/definitions/NoInteractiveElementToNoninteractiveRoleOptions"
-						}
+						},
+						{ "type": "null" }
 					]
 				}
 			},
@@ -7657,8 +7754,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoInvalidBuiltinInstantiationOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoInvalidBuiltinInstantiationOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -7838,8 +7936,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoMisleadingCharacterClassOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoMisleadingCharacterClassOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -7889,8 +7988,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoMisrefactoredShorthandAssignOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoMisrefactoredShorthandAssignOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -7925,7 +8025,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoMisusedPromisesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoMisusedPromisesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -7974,7 +8077,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoNegationElseOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoNegationElseOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8074,7 +8180,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoNonNullAssertionOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoNonNullAssertionOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8112,10 +8221,11 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
+					"anyOf": [
 						{
 							"$ref": "#/definitions/NoNoninteractiveElementToInteractiveRoleOptions"
-						}
+						},
+						{ "type": "null" }
 					]
 				}
 			},
@@ -8135,7 +8245,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoNoninteractiveTabindexOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoNoninteractiveTabindexOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8154,7 +8267,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoNonoctalDecimalEscapeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoNonoctalDecimalEscapeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8173,7 +8289,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoOctalEscapeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoOctalEscapeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8222,7 +8341,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoPositiveTabindexOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoPositiveTabindexOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8286,7 +8408,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoProcessGlobalOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoProcessGlobalOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8305,7 +8430,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoPrototypeBuiltinsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoPrototypeBuiltinsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8324,7 +8452,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoQuickfixBiomeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoQuickfixBiomeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8373,7 +8504,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoReactForwardRefOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoReactForwardRefOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8407,7 +8541,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoReactSpecificPropsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoReactSpecificPropsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8456,7 +8593,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoRedundantRolesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoRedundantRolesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8475,7 +8615,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoRedundantUseStrictOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoRedundantUseStrictOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8554,7 +8697,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoRestrictedTypesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoRestrictedTypesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8680,7 +8826,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoShoutyConstantsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoShoutyConstantsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8699,7 +8848,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoSkippedTestsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoSkippedTestsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8733,7 +8885,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoSparseArrayOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoSparseArrayOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8784,7 +8939,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoStringCaseMismatchOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoStringCaseMismatchOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8803,7 +8961,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoSubstrOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoSubstrOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8854,7 +9015,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoSwitchDeclarationsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoSwitchDeclarationsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8903,7 +9067,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoThisInStaticOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoThisInStaticOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -8922,7 +9089,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoTsIgnoreOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoTsIgnoreOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9215,7 +9385,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUnsafeNegationOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUnsafeNegationOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9264,8 +9437,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoUnusedFunctionParametersOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUnusedFunctionParametersOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -9285,7 +9459,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUnusedImportsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUnusedImportsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9304,7 +9481,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUnusedLabelsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUnusedLabelsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9323,8 +9503,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoUnusedPrivateClassMembersOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUnusedPrivateClassMembersOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -9344,7 +9525,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUnusedTemplateLiteralOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUnusedTemplateLiteralOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9363,7 +9547,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUnusedVariablesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUnusedVariablesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9397,7 +9584,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessCatchBindingOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessCatchBindingOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9416,7 +9606,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessCatchOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessCatchOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9435,7 +9628,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessConstructorOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessConstructorOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9454,7 +9650,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessContinueOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessContinueOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9473,7 +9672,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessElseOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessElseOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9492,7 +9694,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessEmptyExportOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessEmptyExportOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9511,7 +9716,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessEscapeInRegexOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessEscapeInRegexOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9530,7 +9738,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessEscapeInStringOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessEscapeInStringOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9549,7 +9760,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessFragmentsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessFragmentsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9568,7 +9782,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessLabelOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessLabelOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9587,8 +9804,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoUselessLoneBlockStatementsOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessLoneBlockStatementsOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -9623,7 +9841,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessRenameOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessRenameOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9642,7 +9863,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessStringConcatOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessStringConcatOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9676,7 +9900,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessSwitchCaseOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessSwitchCaseOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9695,7 +9922,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessTernaryOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessTernaryOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9714,7 +9944,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessThisAliasOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessThisAliasOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9733,7 +9966,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessTypeConstraintOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessTypeConstraintOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9752,8 +9988,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoUselessUndefinedInitializationOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessUndefinedInitializationOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -9773,7 +10010,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoUselessUndefinedOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoUselessUndefinedOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9807,7 +10047,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoVarOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoVarOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -9826,8 +10069,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoVoidElementsWithChildrenOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoVoidElementsWithChildrenOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -9877,8 +10121,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/NoVueDataObjectDeclarationOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/NoVueDataObjectDeclarationOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -9958,7 +10203,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/NoYodaExpressionOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/NoYodaExpressionOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10009,7 +10257,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseAnchorContentOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseAnchorContentOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10028,10 +10279,11 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
+					"anyOf": [
 						{
 							"$ref": "#/definitions/UseAriaActivedescendantWithTabindexOptions"
-						}
+						},
+						{ "type": "null" }
 					]
 				}
 			},
@@ -10083,7 +10335,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseArrayLiteralsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseArrayLiteralsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10102,7 +10357,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseArrowFunctionOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseArrowFunctionOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10121,7 +10379,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseAsConstAssertionOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseAsConstAssertionOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10140,7 +10401,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseAtIndexOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseAtIndexOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10174,7 +10438,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseBiomeIgnoreFolderOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseBiomeIgnoreFolderOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10193,7 +10460,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseBlockStatementsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseBlockStatementsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10227,7 +10497,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseCollapsedElseIfOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseCollapsedElseIfOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10246,7 +10519,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseCollapsedIfOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseCollapsedIfOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10282,7 +10558,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseConsistentArrayTypeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseConsistentArrayTypeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10301,7 +10580,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseConsistentArrowReturnOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseConsistentArrowReturnOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10320,8 +10602,11 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/UseConsistentBuiltinInstantiationOptions" }
+					"anyOf": [
+						{
+							"$ref": "#/definitions/UseConsistentBuiltinInstantiationOptions"
+						},
+						{ "type": "null" }
 					]
 				}
 			},
@@ -10341,7 +10626,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseConsistentCurlyBracesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseConsistentCurlyBracesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10377,8 +10665,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/UseConsistentObjectDefinitionsOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/UseConsistentObjectDefinitionsOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -10398,8 +10687,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/UseConsistentTypeDefinitionsOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/UseConsistentTypeDefinitionsOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -10419,7 +10709,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseConstOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseConstOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10438,7 +10731,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseDateNowOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseDateNowOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10457,7 +10753,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseDefaultParameterLastOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseDefaultParameterLastOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10538,7 +10837,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseEnumInitializersOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseEnumInitializersOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10572,8 +10874,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/UseExhaustiveDependenciesOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/UseExhaustiveDependenciesOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -10593,7 +10896,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseExhaustiveSwitchCasesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseExhaustiveSwitchCasesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10612,7 +10918,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseExplicitLengthCheckOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseExplicitLengthCheckOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10646,8 +10955,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/UseExponentiationOperatorOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/UseExponentiationOperatorOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -10667,7 +10977,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseExportTypeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseExportTypeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10716,7 +11029,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseFlatMapOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseFlatMapOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10765,7 +11081,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseFragmentSyntaxOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseFragmentSyntaxOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10829,7 +11148,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseGoogleFontPreconnectOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseGoogleFontPreconnectOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -10848,8 +11170,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/UseGraphqlNamedOperationsOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/UseGraphqlNamedOperationsOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -10991,7 +11314,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseImportExtensionsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseImportExtensionsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11010,7 +11336,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseImportTypeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseImportTypeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11029,7 +11358,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseIndexOfOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseIndexOfOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11048,7 +11380,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseIsArrayOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseIsArrayOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11067,7 +11402,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseIsNanOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseIsNanOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11103,7 +11441,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseJsonImportAttributesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseJsonImportAttributesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11182,7 +11523,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseLiteralKeysOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseLiteralKeysOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11231,7 +11575,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseNamespaceKeywordOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseNamespaceKeywordOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11250,7 +11597,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseNamingConventionOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseNamingConventionOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11269,7 +11619,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseNodeAssertStrictOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseNodeAssertStrictOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11288,7 +11641,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseNodejsImportProtocolOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseNodejsImportProtocolOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11307,7 +11663,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseNumberNamespaceOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseNumberNamespaceOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11326,8 +11685,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/UseNumberToFixedDigitsArgumentOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/UseNumberToFixedDigitsArgumentOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -11347,7 +11707,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseNumericLiteralsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseNumericLiteralsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11366,7 +11729,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseNumericSeparatorsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseNumericSeparatorsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11385,7 +11751,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseObjectSpreadOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseObjectSpreadOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11404,7 +11773,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseOptionalChainOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseOptionalChainOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11423,7 +11795,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseParseIntRadixOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseParseIntRadixOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11504,8 +11879,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/UseReadonlyClassPropertiesOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/UseReadonlyClassPropertiesOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -11525,7 +11901,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseRegexLiteralsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseRegexLiteralsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11544,7 +11923,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseSelfClosingElementsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseSelfClosingElementsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11578,7 +11960,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseShorthandAssignOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseShorthandAssignOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11597,7 +11982,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseShorthandFunctionTypeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseShorthandFunctionTypeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11616,7 +12004,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseSimpleNumberKeysOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseSimpleNumberKeysOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11635,8 +12026,9 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [
-						{ "$ref": "#/definitions/UseSimplifiedLogicExpressionOptions" }
+					"anyOf": [
+						{ "$ref": "#/definitions/UseSimplifiedLogicExpressionOptions" },
+						{ "type": "null" }
 					]
 				}
 			},
@@ -11656,7 +12048,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseSingleJsDocAsteriskOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseSingleJsDocAsteriskOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11675,7 +12070,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseSingleVarDeclaratorOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseSingleVarDeclaratorOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11709,7 +12107,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseSortedClassesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseSortedClassesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11728,7 +12129,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseStaticResponseMethodsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseStaticResponseMethodsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11747,7 +12151,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseStrictModeOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseStrictModeOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11781,7 +12188,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseTemplateOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseTemplateOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11800,7 +12210,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseThrowNewErrorOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseThrowNewErrorOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11849,7 +12262,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseTrimStartEndOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseTrimStartEndOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11868,7 +12284,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseUnifiedTypeSignaturesOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseUnifiedTypeSignaturesOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11917,7 +12336,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseValidAriaPropsOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseValidAriaPropsOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -11936,7 +12358,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseValidAriaRoleOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseValidAriaRoleOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -12015,7 +12440,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseValidTypeofOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseValidTypeofOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -12034,7 +12462,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseVueDefineMacrosOrderOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseVueDefineMacrosOrderOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -12070,7 +12501,10 @@
 				},
 				"options": {
 					"description": "Rule's options",
-					"allOf": [{ "$ref": "#/definitions/UseWhileOptions" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/UseWhileOptions" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary

Fixes https://github.com/biomejs/biome/issues/7943

This PR changes the way we merge rules' options.
We now track if `options` was set or not for rules with fixes.

One downside is that `RuleWithFixOptions` increases its size by one byte.
This concerns even rules with a fix and without options.
This seems reasonable because most of the rules have no fixes.

If we wished to reduce this cost to rules without options, we will need some metadata to differentiate rules with and without options - what we don't have currently.

## Alternative fix

An alternative fix could be to implement `Merge` for every Rule options such as merging a default config into an explicit one, don't override the explicitly set options.
This will require to change many options to make them properly mergeable.

See https://github.com/biomejs/biome/pull/7941

## Test Plan

I added a test for testing that the options are correctly inherited.

## Docs

I added a change set.