### PR TITLE
fix(console): escape backquotes in MDX context

### DIFF
--- a/crates/biome_console/src/write/html.rs
+++ b/crates/biome_console/src/write/html.rs
@@ -119,6 +119,7 @@ impl<W: io::Write> HtmlAdapter<W> {
                 b'_' => self.0.write_all(b"&#95;")?,
                 b'\\' => self.0.write_all(b"&#92;")?,
                 b'~' => self.0.write_all(b"\\~")?,
+                b'`' => self.0.write_all(b"&#96;")?,
                 _ => return Ok(false),
             }
         }


### PR DESCRIPTION
## Summary

Fixes https://github.com/biomejs/website/issues/1391

Backquotes (<code>&#96;</code>) were needed to be escaped in MDX, otherwise it may cause invisible backquotes or broken markups.

## Test Plan

Used the updated biome_console crate in the website repository to see if it works on my machine.

<img width="765" height="457" alt="image" src="https://github.com/user-attachments/assets/f6b1145d-4906-495e-a384-acb6670b7137" />


## Docs

N/A
