### PR TITLE
fix(parse/tailwind): fix lexing variants that start with numbers

### DIFF
--- a/crates/biome_tailwind_parser/src/lexer/mod.rs
+++ b/crates/biome_tailwind_parser/src/lexer/mod.rs
@@ -58,7 +58,7 @@ impl<'src> TailwindLexer<'src> {
             b'-' => self.consume_byte(T![-]),
             b'!' => self.consume_byte(T![!]),
             b'/' => self.consume_byte(T![/]),
-            _ if current.is_ascii_alphabetic() => self.consume_base(),
+            _ if current.is_ascii_alphanumeric() => self.consume_base(),
             _ => {
                 if self.position == 0
                     && let Some((bom, bom_size)) = self.consume_potential_bom(UNICODE_BOM)

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/starts-with-number.txt
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/starts-with-number.txt
@@ -1,0 +1,1 @@
+2xl:table

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/starts-with-number.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/starts-with-number.txt.snap
@@ -1,0 +1,54 @@
+---
+source: crates/biome_tailwind_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```text
+2xl:table
+
+```
+
+
+## AST
+
+```
+TwRoot {
+    bom_token: missing (optional),
+    candidates: TwCandidateList [
+        TwFullCandidate {
+            variants: TwVariantList [
+                TwStaticVariant {
+                    base_token: TW_BASE@0..3 "2xl" [] [],
+                },
+                COLON@3..4 ":" [] [],
+            ],
+            negative_token: missing (optional),
+            candidate: TwStaticCandidate {
+                base_token: TW_BASE@4..10 "table" [] [Newline("\n")],
+            },
+            excl_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@10..10 "" [] [],
+}
+```
+
+## CST
+
+```
+0: TW_ROOT@0..10
+  0: (empty)
+  1: TW_CANDIDATE_LIST@0..10
+    0: TW_FULL_CANDIDATE@0..10
+      0: TW_VARIANT_LIST@0..4
+        0: TW_STATIC_VARIANT@0..3
+          0: TW_BASE@0..3 "2xl" [] []
+        1: COLON@3..4 ":" [] []
+      1: (empty)
+      2: TW_STATIC_CANDIDATE@4..10
+        0: TW_BASE@4..10 "table" [] [Newline("\n")]
+      3: (empty)
+  2: EOF@10..10 "" [] []
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Fixes lexing for candidates that look like `2xl:text-lg`

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
