### PR TITLE
refactor(formatter): memoize text width

### DIFF
--- a/.changeset/long-cars-beam.md
+++ b/.changeset/long-cars-beam.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": patch
+---
+
+Introduces a new TextWidth field on all text FormatElements that stores either the precomputed width of the text or
+indicates that it is multiline.

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -72,7 +72,7 @@ pub use buffer::{
     VecBuffer,
 };
 pub use builders::BestFitting;
-pub use format_element::{FormatElement, LINE_TERMINATORS, normalize_newlines};
+pub use format_element::{FormatElement, LINE_TERMINATORS, TextWidth, normalize_newlines};
 pub use group_id::GroupId;
 pub use source_map::{TransformSourceMap, TransformSourceMapBuilder};
 use std::num::ParseIntError;
@@ -2057,7 +2057,10 @@ pub fn format_sub_tree<L: FormatLanguage>(
     ))
 }
 
-impl<L: Language, Context> Format<Context> for SyntaxTriviaPiece<L> {
+impl<L: Language, Context> Format<Context> for SyntaxTriviaPiece<L>
+where
+    Context: FormatContext,
+{
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         let range = self.text_range();
 

--- a/crates/biome_html_formatter/src/utils/children.rs
+++ b/crates/biome_html_formatter/src/utils/children.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use biome_formatter::{
-    Buffer, Format, FormatElement, FormatResult, format_args, prelude::*, write,
+    Buffer, Format, FormatElement, FormatOptions, FormatResult, TextWidth, format_args, prelude::*,
+    write,
 };
 use biome_html_syntax::{AnyHtmlContent, AnyHtmlElement};
 use biome_rowan::{AstNode, SyntaxResult, TextLen, TextRange, TextSize, TokenText};
@@ -66,6 +67,7 @@ impl Format<HtmlFormatContext> for HtmlWord {
         f.write_element(FormatElement::LocatedTokenText {
             source_position: self.source_position,
             slice: self.text.clone(),
+            text_width: TextWidth::from_text(&self.text, f.options().indent_width()),
         })
     }
 }

--- a/crates/biome_js_formatter/src/utils/jsx.rs
+++ b/crates/biome_js_formatter/src/utils/jsx.rs
@@ -1,6 +1,8 @@
 use crate::JsCommentStyle;
 use crate::prelude::*;
-use biome_formatter::{FormatOptions, QuoteStyle, TextWidth, comments::CommentStyle, format_args, write};
+use biome_formatter::{
+    FormatOptions, QuoteStyle, TextWidth, comments::CommentStyle, format_args, write,
+};
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, AnyJsxChild, AnyJsxTag, JsComputedMemberExpression,
     JsStaticMemberExpression, JsSyntaxKind, JsxChildList, JsxExpressionChild, JsxTagExpression,

--- a/crates/biome_js_formatter/src/utils/jsx.rs
+++ b/crates/biome_js_formatter/src/utils/jsx.rs
@@ -1,6 +1,6 @@
 use crate::JsCommentStyle;
 use crate::prelude::*;
-use biome_formatter::{QuoteStyle, comments::CommentStyle, format_args, write};
+use biome_formatter::{FormatOptions, QuoteStyle, TextWidth, comments::CommentStyle, format_args, write};
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, AnyJsxChild, AnyJsxTag, JsComputedMemberExpression,
     JsStaticMemberExpression, JsSyntaxKind, JsxChildList, JsxExpressionChild, JsxTagExpression,
@@ -423,6 +423,7 @@ impl Format<JsFormatContext> for JsxWord {
         f.write_element(FormatElement::LocatedTokenText {
             source_position: self.source_position,
             slice: self.text.clone(),
+            text_width: TextWidth::from_text(&self.text, f.options().indent_width()),
         })
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Port of https://github.com/astral-sh/ruff/pull/6552

This change introduces a new TextWidth field on all text FormatElements, which stores either the precomputed width of the text or indicates that it is multiline.

## Test Plan

Green CI

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
