### PR TITLE
chore(parser): increase size of SyntaxKindSet bitfield

### DIFF
--- a/crates/biome_rowan/src/ast/mod.rs
+++ b/crates/biome_rowan/src/ast/mod.rs
@@ -31,7 +31,7 @@ pub use mutation::{AstNodeExt, AstNodeListExt, AstSeparatedListExt};
 /// bitfield here being twice as large as it needs to cover all nodes as well
 /// as all token kinds
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct SyntaxKindSet<L: Language>([u128; 4], PhantomData<L>);
+pub struct SyntaxKindSet<L: Language>([u128; 5], PhantomData<L>);
 
 impl<L> SyntaxKindSet<L>
 where
@@ -50,7 +50,7 @@ where
     /// ```compile_fail
     /// # use biome_rowan::{SyntaxKindSet, RawSyntaxKind, raw_language::RawLanguage};
     /// const EXAMPLE: SyntaxKindSet<RawLanguage> =
-    ///     SyntaxKindSet::<RawLanguage>::from_raw(RawSyntaxKind(512));
+    ///     SyntaxKindSet::<RawLanguage>::from_raw(RawSyntaxKind(640));
     /// # println!("{EXAMPLE:?}"); // The constant must be used to be evaluated
     /// ```
     pub const fn from_raw(kind: RawSyntaxKind) -> Self {
@@ -60,7 +60,7 @@ where
         let shift = kind % u128::BITS as u16;
         let mask = 1 << shift;
 
-        let mut bits = [0; 4];
+        let mut bits = [0; 5];
         bits[index] = mask;
 
         Self(bits, PhantomData)
@@ -74,6 +74,7 @@ where
                 self.0[1] | other.0[1],
                 self.0[2] | other.0[2],
                 self.0[3] | other.0[3],
+                self.0[4] | other.0[4],
             ],
             PhantomData,
         )


### PR DESCRIPTION
## Summary

I am currently working on issue #6725 to add support for the new CSS `if` feature and while doing so had to add new syntax kinds. In doing so though I realized that adding them will go over a current limit of how many syntax kinds are able to be supported by the parser.  Currently there are about [507 existing CSS kinds](https://github.com/biomejs/biome/blob/main/crates/biome_css_syntax/src/generated/kind.rs#L7-L520) and the limit is [512](https://github.com/biomejs/biome/blob/main/crates/biome_rowan/src/ast/mod.rs#L53). I wanted to split this out as it's own PR though, separate from the feature work since this is a deeper change to the parser and think it deserves more scrutiny. This PR just adds another u128 to the `SyntaxKindSet` struct array to increase the max syntax kinds to 640. 

## Test Plan

Full test suite of the repo passes

## Docs

n/a

## AI Assistance Disclosure

Claude Code was used to help locate where in the codebase the change needed to happen while working on the CSS `if` feature. The issue was originally surfaced by [this check](https://github.com/biomejs/biome/blob/main/crates/biome_rowan/src/ast/mod.rs#L53) failing though.