### PR TITLE
chore(parser): increase size of TokenSet

### DIFF
--- a/crates/biome_parser/src/token_set.rs
+++ b/crates/biome_parser/src/token_set.rs
@@ -85,8 +85,8 @@ mod tests {
         const TOMBSTONE: Self = Self::Kind0;
         const EOF: Self = Self::Kind383;
 
-        fn to_raw(&self) -> biome_rowan::RawSyntaxKind {
-            biome_rowan::RawSyntaxKind(*self as u16)
+        fn to_raw(&self) -> RawSyntaxKind {
+            RawSyntaxKind(*self as u16)
         }
 
         #[expect(unsafe_code)]
@@ -192,7 +192,9 @@ mod tests {
         assert!(!set.contains(TestKind::Kind0));
         assert!(!set.contains(TestKind::Kind127));
 
-        let set = token_set![TestKind::Kind0, TestKind::Kind128, TestKind::Kind383,];
+        let set = TokenSet::singleton(TestKind::Kind0)
+            .union(TokenSet::singleton(TestKind::Kind128))
+            .union(TokenSet::singleton(TestKind::Kind383));
 
         assert!(set.contains(TestKind::Kind0));
         assert!(set.contains(TestKind::Kind128));
@@ -202,14 +204,12 @@ mod tests {
         assert!(!set.contains(TestKind::Kind255));
         assert!(!set.contains(TestKind::Kind256));
 
-        let set = token_set![
-            TestKind::Kind0,
-            TestKind::Kind127,
-            TestKind::Kind128,
-            TestKind::Kind255,
-            TestKind::Kind256,
-            TestKind::Kind383,
-        ];
+        let set = TokenSet::singleton(TestKind::Kind0)
+            .union(TokenSet::singleton(TestKind::Kind127))
+            .union(TokenSet::singleton(TestKind::Kind128))
+            .union(TokenSet::singleton(TestKind::Kind255))
+            .union(TokenSet::singleton(TestKind::Kind256))
+            .union(TokenSet::singleton(TestKind::Kind383));
 
         assert!(set.contains(TestKind::Kind0));
         assert!(set.contains(TestKind::Kind127));
@@ -217,19 +217,5 @@ mod tests {
         assert!(set.contains(TestKind::Kind255));
         assert!(set.contains(TestKind::Kind256));
         assert!(set.contains(TestKind::Kind383));
-    }
-
-    #[test]
-    fn test_union() {
-        let set1 = token_set![TestKind::Kind0];
-        let set2 = token_set![TestKind::Kind128];
-        let set3 = token_set![TestKind::Kind383];
-
-        let union = set1.union(set2);
-        let union = union.union(set3);
-
-        assert!(union.contains(TestKind::Kind0));
-        assert!(union.contains(TestKind::Kind128));
-        assert!(union.contains(TestKind::Kind383));
     }
 }


### PR DESCRIPTION
## Summary

This PR is related to #7994

Similar to the other listed PR we need to increase the size of the TokenKind limit to handling growing language grammars. This issue was caught while working on the CSS `if` feature for issue #6725  in unit tests such as `ok::grit_metavariable::metavar_css` in `crates/biome_parser/src/token_set.rs` due to an "attempt to shift left with overflow" panic. This PR adds an extra item to the TokenKind array increasing the limit from 256 kinds to 384. I also broke this work out into a smaller separate PR since it seems like a deeper change with potentially more widespread impact and wanted it to be easier to review and scrutinize.

## Test Plan

- Added several unit tests to the file to test basic functionality across usage of each item in the TokenSet bitfield array.
- All other unit tests in the repo are passing.

## Docs

n/a

## AI Assistance Disclosure

Claude Code was used for basic iteration and code research but almost all of this code was written directly by me and verified with unit tests written by me as well.