### PR TITLE
feat(cli): add format errors to GitLab reporter

### DIFF
--- a/.changeset/ten-bags-ring.md
+++ b/.changeset/ten-bags-ring.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+The GitLab reporter now outputs format errors.

--- a/crates/biome_cli/src/reporter/gitlab.rs
+++ b/crates/biome_cli/src/reporter/gitlab.rs
@@ -3,6 +3,7 @@ use biome_console::fmt::{Display, Formatter};
 use biome_console::{Console, ConsoleExt, markup};
 use biome_diagnostics::display::SourceFile;
 use biome_diagnostics::{Error, PrintDescription, Resource, Severity};
+use biome_rowan::{TextRange, TextSize};
 use camino::{Utf8Path, Utf8PathBuf};
 use path_absolutize::Absolutize;
 use serde::Serialize;
@@ -204,7 +205,9 @@ impl<'a> GitLabDiagnostic<'a> {
         fingerprint: u64,
     ) -> Option<Self> {
         let location = diagnostic.location();
-        let span = location.span?;
+        let span = location
+            .span
+            .unwrap_or(TextRange::new(TextSize::from(1), TextSize::from(1)));
         let source_code = location.source_code?;
         let description = PrintDescription(diagnostic).to_string();
         let begin = match SourceFile::new(source_code).location(span.start()) {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
@@ -402,6 +402,18 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
+    "description": "Formatter would have printed the following content:",
+    "check_name": "format",
+    "fingerprint": "15136662709985741127",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 1
+      }
+    }
+  },
+  {
     "description": "This variable implicitly has the any type.",
     "check_name": "lint/suspicious/noImplicitAnyLet",
     "fingerprint": "1339939023879653211",
@@ -758,6 +770,18 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
       "path": "main.ts",
       "lines": {
         "begin": 11
+      }
+    }
+  },
+  {
+    "description": "Formatter would have printed the following content:",
+    "check_name": "format",
+    "fingerprint": "8454297847249184653",
+    "severity": "critical",
+    "location": {
+      "path": "main.ts",
+      "lines": {
+        "begin": 1
       }
     }
   }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
@@ -402,6 +402,18 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
+    "description": "File content differs from formatting output",
+    "check_name": "format",
+    "fingerprint": "15136662709985741127",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 1
+      }
+    }
+  },
+  {
     "description": "This variable implicitly has the any type.",
     "check_name": "lint/suspicious/noImplicitAnyLet",
     "fingerprint": "1339939023879653211",
@@ -758,6 +770,18 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
       "path": "main.ts",
       "lines": {
         "begin": 11
+      }
+    }
+  },
+  {
+    "description": "File content differs from formatting output",
+    "check_name": "format",
+    "fingerprint": "8454297847249184653",
+    "severity": "critical",
+    "location": {
+      "path": "main.ts",
+      "lines": {
+        "begin": 1
       }
     }
   }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_format_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_format_command.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `index.ts`
 
@@ -64,5 +64,30 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-[]
+[
+  {
+    "description": "Formatter would have printed the following content:",
+    "check_name": "format",
+    "fingerprint": "15136662709985741127",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 1
+      }
+    }
+  },
+  {
+    "description": "Formatter would have printed the following content:",
+    "check_name": "format",
+    "fingerprint": "8454297847249184653",
+    "severity": "critical",
+    "location": {
+      "path": "main.ts",
+      "lines": {
+        "begin": 1
+      }
+    }
+  }
+]
 ```


### PR DESCRIPTION
## Summary

This PR adds formatting errors to the GitLab reporter output. I noticed that `biome ci --reporter=gitlab` would output an empty list of issues when only formatting errors were present in a project, but still exit with a non-zero exit code and fail the pipeline.

I checked the GitHub reporter and noticed that it does output formatting errors, dug around a bit and found this part of its code:

https://github.com/biomejs/biome/blob/96f3e778a38aa5f48e67eb44b545cba6330dc192/crates/biome_diagnostics/src/display_github.rs#L19-L22

So I just applied the same thing to the GitLab reporter.

## Test Plan

Introduced a formatting error in a sample project and verified the output of `biome check --reporter=gitlab`.

Without the reporter:

```shell
❯ bunx biome check
src/main.tsx format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Formatter would have printed the following content:

    29 29 │   createRoot(document.getElementById('root')!).render(
    30 30 │     <StrictMode>
    31    │ - ······<QueryClientProvider·client={queryClient}>
       31 │ + ····<QueryClientProvider·client={queryClient}>
    32 32 │         <RouterProvider router={router} />
    33 33 │       </QueryClientProvider>


Checked 96 files in 1360ms. No fixes applied.
Found 1 error.
check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Some errors were emitted while running checks.
```

With reporter, before this PR:

```shell
❯ bunx biome check --reporter=gitlab
[]
check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Some errors were emitted while running checks.

```

With reporter, after this PR:

```shell
❯ cargo run --manifest-path ~/projects/biome/Cargo.toml -p biome_cli check --reporter=gitlab
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
     Running `/Users/me/projects/biome/target/debug/biome check --reporter=gitlab`
[
  {
    "description": "Formatter would have printed the following content:",
    "check_name": "format",
    "fingerprint": "1427705328477204594",
    "severity": "critical",
    "location": {
      "path": "src/main.tsx",
      "lines": {
        "begin": 1
      }
    }
  }
]
check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Some errors were emitted while running checks.

```

This matches the GitHub reporter output:

```shell
❯ bunx biome check --reporter=github
::error title=format,file=src/main.tsx,line=1,endLine=1,col=2,endColumn=2::Formatter would have printed the following content:
check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  × Some errors were emitted while running checks.

```

## Docs

n/a
