### PR TITLE
feat: add the checkForEach option to useIterableCallbackReturn

### DIFF
--- a/.changeset/dirty-beans-flash.md
+++ b/.changeset/dirty-beans-flash.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Closes [#8024](https://github.com/biomejs/biome/issues/8024). Adds the `checkForEach` option to [useIterableCallbackReturn](https://biomejs.dev/linter/rules/use-iterable-callback-return/) allowing `forEach()` callbacks to be skipped from being checked for returning a value.

--- a/crates/biome_js_analyze/src/lint/suspicious/use_iterable_callback_return.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_iterable_callback_return.rs
@@ -80,6 +80,23 @@ declare_lint_rule! {
     /// ```js
     /// [].forEach(() => void null); // Void return value, which doesn't trigger the rule
     /// ```
+    ///
+    /// ## Options
+    ///
+    /// ### `checkForEach`
+    ///
+    /// Default: `true`
+    ///
+    /// When set to `false`, rule will skip reporting `forEach` callbacks that return a value.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "checkForEach": true
+    ///     }
+    /// }
+    /// ```
+    ///
     pub UseIterableCallbackReturn {
         version: "2.0.0",
         name: "useIterableCallbackReturn",
@@ -127,6 +144,10 @@ impl Rule for UseIterableCallbackReturn {
             .ok()
             .and_then(|member| member.as_js_name().cloned())
             .and_then(|name| name.value_token().ok())?;
+
+        if !ctx.options().check_for_each() && member_name.text_trimmed() == "forEach" {
+            return None;
+        }
 
         let method_config = ITERABLE_METHOD_INFOS.get(member_name.text_trimmed())?;
 

--- a/crates/biome_rule_options/src/use_iterable_callback_return.rs
+++ b/crates/biome_rule_options/src/use_iterable_callback_return.rs
@@ -3,4 +3,18 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
-pub struct UseIterableCallbackReturnOptions {}
+pub struct UseIterableCallbackReturnOptions {
+    /// When set to `false`, rule will skip reporting `forEach` callbacks that return a value.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub check_for_each: Option<bool>,
+}
+
+impl UseIterableCallbackReturnOptions {
+    pub const DEFAULT_CHECK_FOR_EACH: bool = true;
+
+    /// Returns [`Self::check_for_each`] if it is set.
+    /// Otherwise, returns [`Self::DEFAULT_CHECK_FOR_EACH`].
+    pub fn check_for_each(&self) -> bool {
+        self.check_for_each.unwrap_or(Self::DEFAULT_CHECK_FOR_EACH)
+    }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8721,7 +8721,12 @@ export interface UseGetterReturnOptions {}
 export interface UseGoogleFontDisplayOptions {}
 export interface UseGuardForInOptions {}
 export interface UseIsArrayOptions {}
-export interface UseIterableCallbackReturnOptions {}
+export interface UseIterableCallbackReturnOptions {
+	/**
+	 * When set to `false`, rule will skip reporting `forEach` callbacks that return a value.
+	 */
+	checkForEach?: boolean;
+}
 export interface UseNamespaceKeywordOptions {}
 export interface UseNumberToFixedDigitsArgumentOptions {}
 export interface UseStaticResponseMethodsOptions {}

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -14510,6 +14510,12 @@
 		},
 		"UseIterableCallbackReturnOptions": {
 			"type": "object",
+			"properties": {
+				"checkForEach": {
+					"description": "When set to `false`, rule will skip reporting `forEach` callbacks that return a value.",
+					"type": ["boolean", "null"]
+				}
+			},
 			"additionalProperties": false
 		},
 		"UseJsonImportAttributesConfiguration": {


### PR DESCRIPTION
## Summary

Adds the "checkForEach" option to the "useIterableCallbackReturn" rule.

When enabled (default behavior) .forEach() callbacks will be checked to not return anything. When disabled the callbacks will not be checked for behavior. This option exists in the eslint rule.

Rule Option:
```json
{
    "options": {
        "checkForEach": true
    }
}
```

Closes #8024

Relevant:
https://github.com/biomejs/biome/discussions/8005

## Test Plan

## Docs
