### PR TITLE
fix(parse/css/tailwind): make `@custom-variant` accept selector lists

### DIFF
--- a/.changeset/stale-windows-strive.md
+++ b/.changeset/stale-windows-strive.md
@@ -1,0 +1,9 @@
+---
+"@biomejs/biome": patch
+---
+
+The CSS parser, with `tailwindDirectives` enabled, will now accept lists of selectors in `@custom-variant` shorthand syntax.
+
+```css
+@custom-variant cell (th:has(&), td:has(&));
+```

--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -2424,7 +2424,7 @@ pub fn tw_custom_variant_at_rule(
 }
 pub fn tw_custom_variant_shorthand(
     l_paren_token: SyntaxToken,
-    selector: AnyCssSelector,
+    selector: CssSelectorList,
     r_paren_token: SyntaxToken,
     semicolon_token: SyntaxToken,
 ) -> TwCustomVariantShorthand {

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -4985,7 +4985,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 }
                 slots.next_slot();
                 if let Some(element) = &current_element
-                    && AnyCssSelector::can_cast(element.kind())
+                    && CssSelectorList::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_css_parser/src/syntax/at_rule/tailwind.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/tailwind.rs
@@ -3,14 +3,12 @@ use crate::parser::CssParser;
 use crate::syntax::block::{
     parse_declaration_block, parse_declaration_or_rule_list_block, parse_rule_block,
 };
-use crate::syntax::parse_error::{
-    expected_identifier, expected_selector, expected_string, expected_tw_source,
-};
-use crate::syntax::selector::parse_selector;
+use crate::syntax::parse_error::{expected_identifier, expected_string, expected_tw_source};
+use crate::syntax::selector::SelectorList;
 use crate::syntax::{is_at_identifier, parse_identifier, parse_regular_identifier, parse_string};
 use biome_css_syntax::CssSyntaxKind::{self, *};
 use biome_css_syntax::T;
-use biome_parser::parse_lists::ParseNodeList;
+use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
 use biome_parser::parse_recovery::ParseRecoveryTokenSet;
 use biome_parser::parsed_syntax::ParsedSyntax;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
@@ -133,7 +131,10 @@ fn parse_custom_variant_shorthand(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
 
     p.bump(T!['(']);
-    parse_selector(p).or_add_diagnostic(p, expected_selector);
+    let mut selector_list = SelectorList::default()
+        .with_end_kind_ts(token_set![T![')']])
+        .with_recovery_ts(token_set![T![')'], T![,], T![;]]);
+    selector_list.parse_list(p);
     p.expect(T![')']);
     p.expect(T![;]);
 

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/dark.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/dark.css.snap
@@ -25,51 +25,53 @@ CssRoot {
                 },
                 selector: TwCustomVariantShorthand {
                     l_paren_token: L_PAREN@21..22 "(" [] [],
-                    selector: CssCompoundSelector {
-                        nesting_selectors: CssNestedSelectorList [
-                            CssNestedSelector {
-                                amp_token: AMP@22..23 "&" [] [],
-                            },
-                        ],
-                        simple_selector: missing (optional),
-                        sub_selectors: CssSubSelectorList [
-                            CssPseudoClassSelector {
-                                colon_token: COLON@23..24 ":" [] [],
-                                class: CssPseudoClassFunctionSelectorList {
-                                    name: CssIdentifier {
-                                        value_token: IDENT@24..26 "is" [] [],
-                                    },
-                                    l_paren_token: L_PAREN@26..27 "(" [] [],
-                                    selectors: CssSelectorList [
-                                        CssComplexSelector {
-                                            left: CssCompoundSelector {
-                                                nesting_selectors: CssNestedSelectorList [],
-                                                simple_selector: missing (optional),
-                                                sub_selectors: CssSubSelectorList [
-                                                    CssClassSelector {
-                                                        dot_token: DOT@27..28 "." [] [],
-                                                        name: CssCustomIdentifier {
-                                                            value_token: IDENT@28..32 "dark" [] [],
-                                                        },
-                                                    },
-                                                ],
-                                            },
-                                            combinator: CSS_SPACE_LITERAL@32..33 " " [] [],
-                                            right: CssCompoundSelector {
-                                                nesting_selectors: CssNestedSelectorList [],
-                                                simple_selector: CssUniversalSelector {
-                                                    namespace: missing (optional),
-                                                    star_token: STAR@33..34 "*" [] [],
-                                                },
-                                                sub_selectors: CssSubSelectorList [],
-                                            },
-                                        },
-                                    ],
-                                    r_paren_token: R_PAREN@34..35 ")" [] [],
+                    selector: CssSelectorList [
+                        CssCompoundSelector {
+                            nesting_selectors: CssNestedSelectorList [
+                                CssNestedSelector {
+                                    amp_token: AMP@22..23 "&" [] [],
                                 },
-                            },
-                        ],
-                    },
+                            ],
+                            simple_selector: missing (optional),
+                            sub_selectors: CssSubSelectorList [
+                                CssPseudoClassSelector {
+                                    colon_token: COLON@23..24 ":" [] [],
+                                    class: CssPseudoClassFunctionSelectorList {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@24..26 "is" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@26..27 "(" [] [],
+                                        selectors: CssSelectorList [
+                                            CssComplexSelector {
+                                                left: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: missing (optional),
+                                                    sub_selectors: CssSubSelectorList [
+                                                        CssClassSelector {
+                                                            dot_token: DOT@27..28 "." [] [],
+                                                            name: CssCustomIdentifier {
+                                                                value_token: IDENT@28..32 "dark" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                combinator: CSS_SPACE_LITERAL@32..33 " " [] [],
+                                                right: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: CssUniversalSelector {
+                                                        namespace: missing (optional),
+                                                        star_token: STAR@33..34 "*" [] [],
+                                                    },
+                                                    sub_selectors: CssSubSelectorList [],
+                                                },
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@34..35 ")" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
                     r_paren_token: R_PAREN@35..36 ")" [] [],
                     semicolon_token: SEMICOLON@36..37 ";" [] [],
                 },
@@ -94,36 +96,37 @@ CssRoot {
           0: IDENT@16..21 "dark" [] [Whitespace(" ")]
         2: TW_CUSTOM_VARIANT_SHORTHAND@21..37
           0: L_PAREN@21..22 "(" [] []
-          1: CSS_COMPOUND_SELECTOR@22..35
-            0: CSS_NESTED_SELECTOR_LIST@22..23
-              0: CSS_NESTED_SELECTOR@22..23
-                0: AMP@22..23 "&" [] []
-            1: (empty)
-            2: CSS_SUB_SELECTOR_LIST@23..35
-              0: CSS_PSEUDO_CLASS_SELECTOR@23..35
-                0: COLON@23..24 ":" [] []
-                1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@24..35
-                  0: CSS_IDENTIFIER@24..26
-                    0: IDENT@24..26 "is" [] []
-                  1: L_PAREN@26..27 "(" [] []
-                  2: CSS_SELECTOR_LIST@27..34
-                    0: CSS_COMPLEX_SELECTOR@27..34
-                      0: CSS_COMPOUND_SELECTOR@27..32
-                        0: CSS_NESTED_SELECTOR_LIST@27..27
-                        1: (empty)
-                        2: CSS_SUB_SELECTOR_LIST@27..32
-                          0: CSS_CLASS_SELECTOR@27..32
-                            0: DOT@27..28 "." [] []
-                            1: CSS_CUSTOM_IDENTIFIER@28..32
-                              0: IDENT@28..32 "dark" [] []
-                      1: CSS_SPACE_LITERAL@32..33 " " [] []
-                      2: CSS_COMPOUND_SELECTOR@33..34
-                        0: CSS_NESTED_SELECTOR_LIST@33..33
-                        1: CSS_UNIVERSAL_SELECTOR@33..34
-                          0: (empty)
-                          1: STAR@33..34 "*" [] []
-                        2: CSS_SUB_SELECTOR_LIST@34..34
-                  3: R_PAREN@34..35 ")" [] []
+          1: CSS_SELECTOR_LIST@22..35
+            0: CSS_COMPOUND_SELECTOR@22..35
+              0: CSS_NESTED_SELECTOR_LIST@22..23
+                0: CSS_NESTED_SELECTOR@22..23
+                  0: AMP@22..23 "&" [] []
+              1: (empty)
+              2: CSS_SUB_SELECTOR_LIST@23..35
+                0: CSS_PSEUDO_CLASS_SELECTOR@23..35
+                  0: COLON@23..24 ":" [] []
+                  1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@24..35
+                    0: CSS_IDENTIFIER@24..26
+                      0: IDENT@24..26 "is" [] []
+                    1: L_PAREN@26..27 "(" [] []
+                    2: CSS_SELECTOR_LIST@27..34
+                      0: CSS_COMPLEX_SELECTOR@27..34
+                        0: CSS_COMPOUND_SELECTOR@27..32
+                          0: CSS_NESTED_SELECTOR_LIST@27..27
+                          1: (empty)
+                          2: CSS_SUB_SELECTOR_LIST@27..32
+                            0: CSS_CLASS_SELECTOR@27..32
+                              0: DOT@27..28 "." [] []
+                              1: CSS_CUSTOM_IDENTIFIER@28..32
+                                0: IDENT@28..32 "dark" [] []
+                        1: CSS_SPACE_LITERAL@32..33 " " [] []
+                        2: CSS_COMPOUND_SELECTOR@33..34
+                          0: CSS_NESTED_SELECTOR_LIST@33..33
+                          1: CSS_UNIVERSAL_SELECTOR@33..34
+                            0: (empty)
+                            1: STAR@33..34 "*" [] []
+                          2: CSS_SUB_SELECTOR_LIST@34..34
+                    3: R_PAREN@34..35 ")" [] []
           2: R_PAREN@35..36 ")" [] []
           3: SEMICOLON@36..37 ";" [] []
   2: EOF@37..38 "" [Newline("\n")] []

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/shorthand-multiple-selectors.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/shorthand-multiple-selectors.css
@@ -1,0 +1,3 @@
+@custom-variant foobar (.foo, .bar);
+
+@custom-variant cell (th:has(&), td:has(&));

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/shorthand-multiple-selectors.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/shorthand-multiple-selectors.css.snap
@@ -1,0 +1,248 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+@custom-variant foobar (.foo, .bar);
+
+@custom-variant cell (th:has(&), td:has(&));
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    rules: CssRuleList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: TwCustomVariantAtRule {
+                custom_variant_token: CUSTOM_VARIANT_KW@1..16 "custom-variant" [] [Whitespace(" ")],
+                name: CssIdentifier {
+                    value_token: IDENT@16..23 "foobar" [] [Whitespace(" ")],
+                },
+                selector: TwCustomVariantShorthand {
+                    l_paren_token: L_PAREN@23..24 "(" [] [],
+                    selector: CssSelectorList [
+                        CssCompoundSelector {
+                            nesting_selectors: CssNestedSelectorList [],
+                            simple_selector: missing (optional),
+                            sub_selectors: CssSubSelectorList [
+                                CssClassSelector {
+                                    dot_token: DOT@24..25 "." [] [],
+                                    name: CssCustomIdentifier {
+                                        value_token: IDENT@25..28 "foo" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                        COMMA@28..30 "," [] [Whitespace(" ")],
+                        CssCompoundSelector {
+                            nesting_selectors: CssNestedSelectorList [],
+                            simple_selector: missing (optional),
+                            sub_selectors: CssSubSelectorList [
+                                CssClassSelector {
+                                    dot_token: DOT@30..31 "." [] [],
+                                    name: CssCustomIdentifier {
+                                        value_token: IDENT@31..34 "bar" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    r_paren_token: R_PAREN@34..35 ")" [] [],
+                    semicolon_token: SEMICOLON@35..36 ";" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@36..39 "@" [Newline("\n"), Newline("\n")] [],
+            rule: TwCustomVariantAtRule {
+                custom_variant_token: CUSTOM_VARIANT_KW@39..54 "custom-variant" [] [Whitespace(" ")],
+                name: CssIdentifier {
+                    value_token: IDENT@54..59 "cell" [] [Whitespace(" ")],
+                },
+                selector: TwCustomVariantShorthand {
+                    l_paren_token: L_PAREN@59..60 "(" [] [],
+                    selector: CssSelectorList [
+                        CssCompoundSelector {
+                            nesting_selectors: CssNestedSelectorList [],
+                            simple_selector: CssTypeSelector {
+                                namespace: missing (optional),
+                                ident: CssIdentifier {
+                                    value_token: IDENT@60..62 "th" [] [],
+                                },
+                            },
+                            sub_selectors: CssSubSelectorList [
+                                CssPseudoClassSelector {
+                                    colon_token: COLON@62..63 ":" [] [],
+                                    class: CssPseudoClassFunctionRelativeSelectorList {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@63..66 "has" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@66..67 "(" [] [],
+                                        relative_selectors: CssRelativeSelectorList [
+                                            CssRelativeSelector {
+                                                combinator: missing (optional),
+                                                selector: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [
+                                                        CssNestedSelector {
+                                                            amp_token: AMP@67..68 "&" [] [],
+                                                        },
+                                                    ],
+                                                    simple_selector: missing (optional),
+                                                    sub_selectors: CssSubSelectorList [],
+                                                },
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@68..69 ")" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                        COMMA@69..71 "," [] [Whitespace(" ")],
+                        CssCompoundSelector {
+                            nesting_selectors: CssNestedSelectorList [],
+                            simple_selector: CssTypeSelector {
+                                namespace: missing (optional),
+                                ident: CssIdentifier {
+                                    value_token: IDENT@71..73 "td" [] [],
+                                },
+                            },
+                            sub_selectors: CssSubSelectorList [
+                                CssPseudoClassSelector {
+                                    colon_token: COLON@73..74 ":" [] [],
+                                    class: CssPseudoClassFunctionRelativeSelectorList {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@74..77 "has" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@77..78 "(" [] [],
+                                        relative_selectors: CssRelativeSelectorList [
+                                            CssRelativeSelector {
+                                                combinator: missing (optional),
+                                                selector: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [
+                                                        CssNestedSelector {
+                                                            amp_token: AMP@78..79 "&" [] [],
+                                                        },
+                                                    ],
+                                                    simple_selector: missing (optional),
+                                                    sub_selectors: CssSubSelectorList [],
+                                                },
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@79..80 ")" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    r_paren_token: R_PAREN@80..81 ")" [] [],
+                    semicolon_token: SEMICOLON@81..82 ";" [] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@82..83 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..83
+  0: (empty)
+  1: CSS_RULE_LIST@0..82
+    0: CSS_AT_RULE@0..36
+      0: AT@0..1 "@" [] []
+      1: TW_CUSTOM_VARIANT_AT_RULE@1..36
+        0: CUSTOM_VARIANT_KW@1..16 "custom-variant" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@16..23
+          0: IDENT@16..23 "foobar" [] [Whitespace(" ")]
+        2: TW_CUSTOM_VARIANT_SHORTHAND@23..36
+          0: L_PAREN@23..24 "(" [] []
+          1: CSS_SELECTOR_LIST@24..34
+            0: CSS_COMPOUND_SELECTOR@24..28
+              0: CSS_NESTED_SELECTOR_LIST@24..24
+              1: (empty)
+              2: CSS_SUB_SELECTOR_LIST@24..28
+                0: CSS_CLASS_SELECTOR@24..28
+                  0: DOT@24..25 "." [] []
+                  1: CSS_CUSTOM_IDENTIFIER@25..28
+                    0: IDENT@25..28 "foo" [] []
+            1: COMMA@28..30 "," [] [Whitespace(" ")]
+            2: CSS_COMPOUND_SELECTOR@30..34
+              0: CSS_NESTED_SELECTOR_LIST@30..30
+              1: (empty)
+              2: CSS_SUB_SELECTOR_LIST@30..34
+                0: CSS_CLASS_SELECTOR@30..34
+                  0: DOT@30..31 "." [] []
+                  1: CSS_CUSTOM_IDENTIFIER@31..34
+                    0: IDENT@31..34 "bar" [] []
+          2: R_PAREN@34..35 ")" [] []
+          3: SEMICOLON@35..36 ";" [] []
+    1: CSS_AT_RULE@36..82
+      0: AT@36..39 "@" [Newline("\n"), Newline("\n")] []
+      1: TW_CUSTOM_VARIANT_AT_RULE@39..82
+        0: CUSTOM_VARIANT_KW@39..54 "custom-variant" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@54..59
+          0: IDENT@54..59 "cell" [] [Whitespace(" ")]
+        2: TW_CUSTOM_VARIANT_SHORTHAND@59..82
+          0: L_PAREN@59..60 "(" [] []
+          1: CSS_SELECTOR_LIST@60..80
+            0: CSS_COMPOUND_SELECTOR@60..69
+              0: CSS_NESTED_SELECTOR_LIST@60..60
+              1: CSS_TYPE_SELECTOR@60..62
+                0: (empty)
+                1: CSS_IDENTIFIER@60..62
+                  0: IDENT@60..62 "th" [] []
+              2: CSS_SUB_SELECTOR_LIST@62..69
+                0: CSS_PSEUDO_CLASS_SELECTOR@62..69
+                  0: COLON@62..63 ":" [] []
+                  1: CSS_PSEUDO_CLASS_FUNCTION_RELATIVE_SELECTOR_LIST@63..69
+                    0: CSS_IDENTIFIER@63..66
+                      0: IDENT@63..66 "has" [] []
+                    1: L_PAREN@66..67 "(" [] []
+                    2: CSS_RELATIVE_SELECTOR_LIST@67..68
+                      0: CSS_RELATIVE_SELECTOR@67..68
+                        0: (empty)
+                        1: CSS_COMPOUND_SELECTOR@67..68
+                          0: CSS_NESTED_SELECTOR_LIST@67..68
+                            0: CSS_NESTED_SELECTOR@67..68
+                              0: AMP@67..68 "&" [] []
+                          1: (empty)
+                          2: CSS_SUB_SELECTOR_LIST@68..68
+                    3: R_PAREN@68..69 ")" [] []
+            1: COMMA@69..71 "," [] [Whitespace(" ")]
+            2: CSS_COMPOUND_SELECTOR@71..80
+              0: CSS_NESTED_SELECTOR_LIST@71..71
+              1: CSS_TYPE_SELECTOR@71..73
+                0: (empty)
+                1: CSS_IDENTIFIER@71..73
+                  0: IDENT@71..73 "td" [] []
+              2: CSS_SUB_SELECTOR_LIST@73..80
+                0: CSS_PSEUDO_CLASS_SELECTOR@73..80
+                  0: COLON@73..74 ":" [] []
+                  1: CSS_PSEUDO_CLASS_FUNCTION_RELATIVE_SELECTOR_LIST@74..80
+                    0: CSS_IDENTIFIER@74..77
+                      0: IDENT@74..77 "has" [] []
+                    1: L_PAREN@77..78 "(" [] []
+                    2: CSS_RELATIVE_SELECTOR_LIST@78..79
+                      0: CSS_RELATIVE_SELECTOR@78..79
+                        0: (empty)
+                        1: CSS_COMPOUND_SELECTOR@78..79
+                          0: CSS_NESTED_SELECTOR_LIST@78..79
+                            0: CSS_NESTED_SELECTOR@78..79
+                              0: AMP@78..79 "&" [] []
+                          1: (empty)
+                          2: CSS_SUB_SELECTOR_LIST@79..79
+                    3: R_PAREN@79..80 ")" [] []
+          2: R_PAREN@80..81 ")" [] []
+          3: SEMICOLON@81..82 ";" [] []
+  2: EOF@82..83 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/shorthand.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/shorthand.css.snap
@@ -25,64 +25,66 @@ CssRoot {
                 },
                 selector: TwCustomVariantShorthand {
                     l_paren_token: L_PAREN@31..32 "(" [] [],
-                    selector: CssCompoundSelector {
-                        nesting_selectors: CssNestedSelectorList [
-                            CssNestedSelector {
-                                amp_token: AMP@32..33 "&" [] [],
-                            },
-                        ],
-                        simple_selector: missing (optional),
-                        sub_selectors: CssSubSelectorList [
-                            CssPseudoClassSelector {
-                                colon_token: COLON@33..34 ":" [] [],
-                                class: CssPseudoClassFunctionSelectorList {
-                                    name: CssIdentifier {
-                                        value_token: IDENT@34..39 "where" [] [],
-                                    },
-                                    l_paren_token: L_PAREN@39..40 "(" [] [],
-                                    selectors: CssSelectorList [
-                                        CssComplexSelector {
-                                            left: CssCompoundSelector {
-                                                nesting_selectors: CssNestedSelectorList [],
-                                                simple_selector: missing (optional),
-                                                sub_selectors: CssSubSelectorList [
-                                                    CssAttributeSelector {
-                                                        l_brack_token: L_BRACK@40..41 "[" [] [],
-                                                        name: CssAttributeName {
-                                                            namespace: missing (optional),
-                                                            name: CssIdentifier {
-                                                                value_token: IDENT@41..51 "data-theme" [] [],
-                                                            },
-                                                        },
-                                                        matcher: CssAttributeMatcher {
-                                                            operator: EQ@51..52 "=" [] [],
-                                                            value: CssAttributeMatcherValue {
-                                                                name: CssString {
-                                                                    value_token: CSS_STRING_LITERAL@52..62 "\"midnight\"" [] [],
+                    selector: CssSelectorList [
+                        CssCompoundSelector {
+                            nesting_selectors: CssNestedSelectorList [
+                                CssNestedSelector {
+                                    amp_token: AMP@32..33 "&" [] [],
+                                },
+                            ],
+                            simple_selector: missing (optional),
+                            sub_selectors: CssSubSelectorList [
+                                CssPseudoClassSelector {
+                                    colon_token: COLON@33..34 ":" [] [],
+                                    class: CssPseudoClassFunctionSelectorList {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@34..39 "where" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@39..40 "(" [] [],
+                                        selectors: CssSelectorList [
+                                            CssComplexSelector {
+                                                left: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: missing (optional),
+                                                    sub_selectors: CssSubSelectorList [
+                                                        CssAttributeSelector {
+                                                            l_brack_token: L_BRACK@40..41 "[" [] [],
+                                                            name: CssAttributeName {
+                                                                namespace: missing (optional),
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@41..51 "data-theme" [] [],
                                                                 },
                                                             },
-                                                            modifier: missing (optional),
+                                                            matcher: CssAttributeMatcher {
+                                                                operator: EQ@51..52 "=" [] [],
+                                                                value: CssAttributeMatcherValue {
+                                                                    name: CssString {
+                                                                        value_token: CSS_STRING_LITERAL@52..62 "\"midnight\"" [] [],
+                                                                    },
+                                                                },
+                                                                modifier: missing (optional),
+                                                            },
+                                                            r_brack_token: R_BRACK@62..63 "]" [] [],
                                                         },
-                                                        r_brack_token: R_BRACK@62..63 "]" [] [],
-                                                    },
-                                                ],
-                                            },
-                                            combinator: CSS_SPACE_LITERAL@63..64 " " [] [],
-                                            right: CssCompoundSelector {
-                                                nesting_selectors: CssNestedSelectorList [],
-                                                simple_selector: CssUniversalSelector {
-                                                    namespace: missing (optional),
-                                                    star_token: STAR@64..65 "*" [] [],
+                                                    ],
                                                 },
-                                                sub_selectors: CssSubSelectorList [],
+                                                combinator: CSS_SPACE_LITERAL@63..64 " " [] [],
+                                                right: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: CssUniversalSelector {
+                                                        namespace: missing (optional),
+                                                        star_token: STAR@64..65 "*" [] [],
+                                                    },
+                                                    sub_selectors: CssSubSelectorList [],
+                                                },
                                             },
-                                        },
-                                    ],
-                                    r_paren_token: R_PAREN@65..66 ")" [] [],
+                                        ],
+                                        r_paren_token: R_PAREN@65..66 ")" [] [],
+                                    },
                                 },
-                            },
-                        ],
-                    },
+                            ],
+                        },
+                    ],
                     r_paren_token: R_PAREN@66..67 ")" [] [],
                     semicolon_token: SEMICOLON@67..68 ";" [] [],
                 },
@@ -107,45 +109,46 @@ CssRoot {
           0: IDENT@16..31 "theme-midnight" [] [Whitespace(" ")]
         2: TW_CUSTOM_VARIANT_SHORTHAND@31..68
           0: L_PAREN@31..32 "(" [] []
-          1: CSS_COMPOUND_SELECTOR@32..66
-            0: CSS_NESTED_SELECTOR_LIST@32..33
-              0: CSS_NESTED_SELECTOR@32..33
-                0: AMP@32..33 "&" [] []
-            1: (empty)
-            2: CSS_SUB_SELECTOR_LIST@33..66
-              0: CSS_PSEUDO_CLASS_SELECTOR@33..66
-                0: COLON@33..34 ":" [] []
-                1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@34..66
-                  0: CSS_IDENTIFIER@34..39
-                    0: IDENT@34..39 "where" [] []
-                  1: L_PAREN@39..40 "(" [] []
-                  2: CSS_SELECTOR_LIST@40..65
-                    0: CSS_COMPLEX_SELECTOR@40..65
-                      0: CSS_COMPOUND_SELECTOR@40..63
-                        0: CSS_NESTED_SELECTOR_LIST@40..40
-                        1: (empty)
-                        2: CSS_SUB_SELECTOR_LIST@40..63
-                          0: CSS_ATTRIBUTE_SELECTOR@40..63
-                            0: L_BRACK@40..41 "[" [] []
-                            1: CSS_ATTRIBUTE_NAME@41..51
-                              0: (empty)
-                              1: CSS_IDENTIFIER@41..51
-                                0: IDENT@41..51 "data-theme" [] []
-                            2: CSS_ATTRIBUTE_MATCHER@51..62
-                              0: EQ@51..52 "=" [] []
-                              1: CSS_ATTRIBUTE_MATCHER_VALUE@52..62
-                                0: CSS_STRING@52..62
-                                  0: CSS_STRING_LITERAL@52..62 "\"midnight\"" [] []
-                              2: (empty)
-                            3: R_BRACK@62..63 "]" [] []
-                      1: CSS_SPACE_LITERAL@63..64 " " [] []
-                      2: CSS_COMPOUND_SELECTOR@64..65
-                        0: CSS_NESTED_SELECTOR_LIST@64..64
-                        1: CSS_UNIVERSAL_SELECTOR@64..65
-                          0: (empty)
-                          1: STAR@64..65 "*" [] []
-                        2: CSS_SUB_SELECTOR_LIST@65..65
-                  3: R_PAREN@65..66 ")" [] []
+          1: CSS_SELECTOR_LIST@32..66
+            0: CSS_COMPOUND_SELECTOR@32..66
+              0: CSS_NESTED_SELECTOR_LIST@32..33
+                0: CSS_NESTED_SELECTOR@32..33
+                  0: AMP@32..33 "&" [] []
+              1: (empty)
+              2: CSS_SUB_SELECTOR_LIST@33..66
+                0: CSS_PSEUDO_CLASS_SELECTOR@33..66
+                  0: COLON@33..34 ":" [] []
+                  1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@34..66
+                    0: CSS_IDENTIFIER@34..39
+                      0: IDENT@34..39 "where" [] []
+                    1: L_PAREN@39..40 "(" [] []
+                    2: CSS_SELECTOR_LIST@40..65
+                      0: CSS_COMPLEX_SELECTOR@40..65
+                        0: CSS_COMPOUND_SELECTOR@40..63
+                          0: CSS_NESTED_SELECTOR_LIST@40..40
+                          1: (empty)
+                          2: CSS_SUB_SELECTOR_LIST@40..63
+                            0: CSS_ATTRIBUTE_SELECTOR@40..63
+                              0: L_BRACK@40..41 "[" [] []
+                              1: CSS_ATTRIBUTE_NAME@41..51
+                                0: (empty)
+                                1: CSS_IDENTIFIER@41..51
+                                  0: IDENT@41..51 "data-theme" [] []
+                              2: CSS_ATTRIBUTE_MATCHER@51..62
+                                0: EQ@51..52 "=" [] []
+                                1: CSS_ATTRIBUTE_MATCHER_VALUE@52..62
+                                  0: CSS_STRING@52..62
+                                    0: CSS_STRING_LITERAL@52..62 "\"midnight\"" [] []
+                                2: (empty)
+                              3: R_BRACK@62..63 "]" [] []
+                        1: CSS_SPACE_LITERAL@63..64 " " [] []
+                        2: CSS_COMPOUND_SELECTOR@64..65
+                          0: CSS_NESTED_SELECTOR_LIST@64..64
+                          1: CSS_UNIVERSAL_SELECTOR@64..65
+                            0: (empty)
+                            1: STAR@64..65 "*" [] []
+                          2: CSS_SUB_SELECTOR_LIST@65..65
+                    3: R_PAREN@65..66 ")" [] []
           2: R_PAREN@66..67 ")" [] []
           3: SEMICOLON@67..68 ";" [] []
   2: EOF@68..69 "" [Newline("\n")] []

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/shadcn-default.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/shadcn-default.css.snap
@@ -195,51 +195,53 @@ CssRoot {
                 },
                 selector: TwCustomVariantShorthand {
                     l_paren_token: L_PAREN@77..78 "(" [] [],
-                    selector: CssCompoundSelector {
-                        nesting_selectors: CssNestedSelectorList [
-                            CssNestedSelector {
-                                amp_token: AMP@78..79 "&" [] [],
-                            },
-                        ],
-                        simple_selector: missing (optional),
-                        sub_selectors: CssSubSelectorList [
-                            CssPseudoClassSelector {
-                                colon_token: COLON@79..80 ":" [] [],
-                                class: CssPseudoClassFunctionSelectorList {
-                                    name: CssIdentifier {
-                                        value_token: IDENT@80..82 "is" [] [],
-                                    },
-                                    l_paren_token: L_PAREN@82..83 "(" [] [],
-                                    selectors: CssSelectorList [
-                                        CssComplexSelector {
-                                            left: CssCompoundSelector {
-                                                nesting_selectors: CssNestedSelectorList [],
-                                                simple_selector: missing (optional),
-                                                sub_selectors: CssSubSelectorList [
-                                                    CssClassSelector {
-                                                        dot_token: DOT@83..84 "." [] [],
-                                                        name: CssCustomIdentifier {
-                                                            value_token: IDENT@84..88 "dark" [] [],
-                                                        },
-                                                    },
-                                                ],
-                                            },
-                                            combinator: CSS_SPACE_LITERAL@88..89 " " [] [],
-                                            right: CssCompoundSelector {
-                                                nesting_selectors: CssNestedSelectorList [],
-                                                simple_selector: CssUniversalSelector {
-                                                    namespace: missing (optional),
-                                                    star_token: STAR@89..90 "*" [] [],
-                                                },
-                                                sub_selectors: CssSubSelectorList [],
-                                            },
-                                        },
-                                    ],
-                                    r_paren_token: R_PAREN@90..91 ")" [] [],
+                    selector: CssSelectorList [
+                        CssCompoundSelector {
+                            nesting_selectors: CssNestedSelectorList [
+                                CssNestedSelector {
+                                    amp_token: AMP@78..79 "&" [] [],
                                 },
-                            },
-                        ],
-                    },
+                            ],
+                            simple_selector: missing (optional),
+                            sub_selectors: CssSubSelectorList [
+                                CssPseudoClassSelector {
+                                    colon_token: COLON@79..80 ":" [] [],
+                                    class: CssPseudoClassFunctionSelectorList {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@80..82 "is" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@82..83 "(" [] [],
+                                        selectors: CssSelectorList [
+                                            CssComplexSelector {
+                                                left: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: missing (optional),
+                                                    sub_selectors: CssSubSelectorList [
+                                                        CssClassSelector {
+                                                            dot_token: DOT@83..84 "." [] [],
+                                                            name: CssCustomIdentifier {
+                                                                value_token: IDENT@84..88 "dark" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                combinator: CSS_SPACE_LITERAL@88..89 " " [] [],
+                                                right: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: CssUniversalSelector {
+                                                        namespace: missing (optional),
+                                                        star_token: STAR@89..90 "*" [] [],
+                                                    },
+                                                    sub_selectors: CssSubSelectorList [],
+                                                },
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@90..91 ")" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
                     r_paren_token: R_PAREN@91..92 ")" [] [],
                     semicolon_token: SEMICOLON@92..93 ";" [] [],
                 },
@@ -4468,36 +4470,37 @@ CssRoot {
           0: IDENT@72..77 "dark" [] [Whitespace(" ")]
         2: TW_CUSTOM_VARIANT_SHORTHAND@77..93
           0: L_PAREN@77..78 "(" [] []
-          1: CSS_COMPOUND_SELECTOR@78..91
-            0: CSS_NESTED_SELECTOR_LIST@78..79
-              0: CSS_NESTED_SELECTOR@78..79
-                0: AMP@78..79 "&" [] []
-            1: (empty)
-            2: CSS_SUB_SELECTOR_LIST@79..91
-              0: CSS_PSEUDO_CLASS_SELECTOR@79..91
-                0: COLON@79..80 ":" [] []
-                1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@80..91
-                  0: CSS_IDENTIFIER@80..82
-                    0: IDENT@80..82 "is" [] []
-                  1: L_PAREN@82..83 "(" [] []
-                  2: CSS_SELECTOR_LIST@83..90
-                    0: CSS_COMPLEX_SELECTOR@83..90
-                      0: CSS_COMPOUND_SELECTOR@83..88
-                        0: CSS_NESTED_SELECTOR_LIST@83..83
-                        1: (empty)
-                        2: CSS_SUB_SELECTOR_LIST@83..88
-                          0: CSS_CLASS_SELECTOR@83..88
-                            0: DOT@83..84 "." [] []
-                            1: CSS_CUSTOM_IDENTIFIER@84..88
-                              0: IDENT@84..88 "dark" [] []
-                      1: CSS_SPACE_LITERAL@88..89 " " [] []
-                      2: CSS_COMPOUND_SELECTOR@89..90
-                        0: CSS_NESTED_SELECTOR_LIST@89..89
-                        1: CSS_UNIVERSAL_SELECTOR@89..90
-                          0: (empty)
-                          1: STAR@89..90 "*" [] []
-                        2: CSS_SUB_SELECTOR_LIST@90..90
-                  3: R_PAREN@90..91 ")" [] []
+          1: CSS_SELECTOR_LIST@78..91
+            0: CSS_COMPOUND_SELECTOR@78..91
+              0: CSS_NESTED_SELECTOR_LIST@78..79
+                0: CSS_NESTED_SELECTOR@78..79
+                  0: AMP@78..79 "&" [] []
+              1: (empty)
+              2: CSS_SUB_SELECTOR_LIST@79..91
+                0: CSS_PSEUDO_CLASS_SELECTOR@79..91
+                  0: COLON@79..80 ":" [] []
+                  1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@80..91
+                    0: CSS_IDENTIFIER@80..82
+                      0: IDENT@80..82 "is" [] []
+                    1: L_PAREN@82..83 "(" [] []
+                    2: CSS_SELECTOR_LIST@83..90
+                      0: CSS_COMPLEX_SELECTOR@83..90
+                        0: CSS_COMPOUND_SELECTOR@83..88
+                          0: CSS_NESTED_SELECTOR_LIST@83..83
+                          1: (empty)
+                          2: CSS_SUB_SELECTOR_LIST@83..88
+                            0: CSS_CLASS_SELECTOR@83..88
+                              0: DOT@83..84 "." [] []
+                              1: CSS_CUSTOM_IDENTIFIER@84..88
+                                0: IDENT@84..88 "dark" [] []
+                        1: CSS_SPACE_LITERAL@88..89 " " [] []
+                        2: CSS_COMPOUND_SELECTOR@89..90
+                          0: CSS_NESTED_SELECTOR_LIST@89..89
+                          1: CSS_UNIVERSAL_SELECTOR@89..90
+                            0: (empty)
+                            1: STAR@89..90 "*" [] []
+                          2: CSS_SUB_SELECTOR_LIST@90..90
+                    3: R_PAREN@90..91 ")" [] []
           2: R_PAREN@91..92 ")" [] []
           3: SEMICOLON@92..93 ";" [] []
     3: CSS_QUALIFIED_RULE@93..1262

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -7042,8 +7042,8 @@ impl TwCustomVariantShorthand {
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
-    pub fn selector(&self) -> SyntaxResult<AnyCssSelector> {
-        support::required_node(&self.syntax, 1usize)
+    pub fn selector(&self) -> CssSelectorList {
+        support::list(&self.syntax, 1usize)
     }
     pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 2usize)
@@ -7063,7 +7063,7 @@ impl Serialize for TwCustomVariantShorthand {
 #[derive(Serialize)]
 pub struct TwCustomVariantShorthandFields {
     pub l_paren_token: SyntaxResult<SyntaxToken>,
-    pub selector: SyntaxResult<AnyCssSelector>,
+    pub selector: CssSelectorList,
     pub r_paren_token: SyntaxResult<SyntaxToken>,
     pub semicolon_token: SyntaxResult<SyntaxToken>,
 }
@@ -18366,7 +18366,7 @@ impl std::fmt::Debug for TwCustomVariantShorthand {
                     "l_paren_token",
                     &support::DebugSyntaxResult(self.l_paren_token()),
                 )
-                .field("selector", &support::DebugSyntaxResult(self.selector()))
+                .field("selector", &self.selector())
                 .field(
                     "r_paren_token",
                     &support::DebugSyntaxResult(self.r_paren_token()),

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -2846,7 +2846,7 @@ impl TwCustomVariantShorthand {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_selector(self, element: AnyCssSelector) -> Self {
+    pub fn with_selector(self, element: CssSelectorList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -1930,7 +1930,7 @@ AnyTwCustomVariantSelector =
 
 TwCustomVariantShorthand =
   '('
-  selector: AnyCssSelector
+  selector: CssSelectorList
   ')'
   ';'
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This simply expands what `@custom-variant` accepts to be a selector list instead of a single selector.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
related to https://github.com/biomejs/biome/issues/7964#issuecomment-3499595259

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added tests, CI should be green

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
