### PR TITLE
chore: enable more rustc lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,20 @@ members  = ["crates/*", "xtask/codegen", "xtask/coverage", "xtask/rules_check"]
 resolver = "2"
 
 [workspace.lints.rust]
-absolute_paths_not_starting_with_crate = "warn"
-dead_code                              = "warn"
-trivial_numeric_casts                  = "warn"
-unused_import_braces                   = "warn"
-unused_lifetimes                       = "warn"
-unused_macro_rules                     = "warn"
+# https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+ambiguous-negative-literals    = "warn"
+dead_code                      = "warn"
+explicit-outlives-requirements = "warn"
+impl-trait-overcaptures        = "warn"
+impl-trait-redundant-captures  = "warn"
+missing-unsafe-on-extern       = "warn"
+redundant-lifetimes            = "warn"
+trivial_numeric_casts          = "warn"
+unit-bindings                  = "warn"
+unsafe-attr-outside-unsafe     = "warn"
+unused_import_braces           = "warn"
+unused_lifetimes               = "warn"
+unused_macro_rules             = "warn"
 
 [workspace.lints.clippy]
 allow_attributes        = "deny"


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

- Removed `absolute_paths_not_starting_with_crate` because it is not relevant for edition above 2015.
- Warn more rustc lints

## Test Plan

CI must pass.

## Docs

No change
