### PR TITLE
fix(lsp): biome project watcher

### DIFF
--- a/.changeset/brave-tires-tap.md
+++ b/.changeset/brave-tires-tap.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where the Biome Language Server would enable its project file watcher even when no project rules were enabled.
+
+Now the watching of nested configuration files and nested ignore files is delegated to the editor, if their LSP spec supports it.

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -153,6 +153,20 @@ impl LSPServer {
                                 }),
                                 kind: Some(WatchKind::all()),
                             },
+                            FileSystemWatcher {
+                                glob_pattern: GlobPattern::Relative(RelativePattern {
+                                    pattern: "**/.gitignore".to_string(),
+                                    base_uri: OneOf::Left(folder.clone()),
+                                }),
+                                kind: Some(WatchKind::all()),
+                            },
+                            FileSystemWatcher {
+                                glob_pattern: GlobPattern::Relative(RelativePattern {
+                                    pattern: "**/.ignore".to_string(),
+                                    base_uri: OneOf::Left(folder.clone()),
+                                }),
+                                kind: Some(WatchKind::all()),
+                            },
                         ]
                     })
                     .collect();
@@ -174,6 +188,15 @@ impl LSPServer {
                                 "{}/.editorconfig",
                                 base_path.as_path().as_str()
                             )),
+                            kind: Some(WatchKind::all()),
+                        },
+                        FileSystemWatcher {
+                            glob_pattern: GlobPattern::String("**/.gitignore".to_string()),
+                            kind: Some(WatchKind::all()),
+                        },
+                        FileSystemWatcher {
+                            glob_pattern: GlobPattern::String("**/.ignore".to_string()),
+
                             kind: Some(WatchKind::all()),
                         },
                     ],
@@ -354,7 +377,9 @@ impl LanguageServer for LSPServer {
                     && (ConfigName::file_names()
                         .iter()
                         .any(|file_name| watched_file.ends_with(file_name))
-                        || watched_file.ends_with(".editorconfig"))
+                        || (watched_file.ends_with(".editorconfig"))
+                        || watched_file.ends_with(".gitignore")
+                        || watched_file.ends_with(".ignore"))
                 {
                     self.session.load_extension_settings().await;
                     self.session.load_workspace_settings(true).await;

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -707,7 +707,7 @@ impl Session {
         spawn_blocking(move || {
             let result = session.workspace.scan_project(ScanProjectParams {
                 project_key,
-                watch: true,
+                watch: scan_kind.is_project(),
                 force,
                 scan_kind,
                 verbose: false,


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The Biome language server already uses the LSP to monitor nested configuration files. 

This PR adds ignore files too, and in turn enables the Biome project watcher only if `ScanKind` is `::Project`.



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Unfortunately, I couldn't create a test because we can't simulate file system changes after we created the server. However I did manual testing and I could see the diagnostics correctly updated when:
- I updated the configuration file
- I updated the ignore file

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
