### PR TITLE
fix(noUnknownProperty): remove explicit ignore for `composes`

### DIFF
--- a/.changeset/social-groups-beg.md
+++ b/.changeset/social-groups-beg.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+The [noUnknownProperty](https://biomejs.dev/linter/rules/no-unknown-property/) now only ignores `composes` property when `cssModules` is enabled in parser settings

--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_property.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_property.rs
@@ -79,9 +79,6 @@ impl Rule for NoUnknownProperty {
         let property_name = node.name().ok()?.to_trimmed_text();
         let property_name_lower = property_name.to_ascii_lowercase_cow();
         if !property_name_lower.starts_with("--")
-            // Ignore `composes` property.
-            // See https://github.com/css-modules/css-modules/blob/master/docs/composition.md for more details.
-            && property_name_lower != "composes"
             && !is_known_properties(&property_name_lower)
             && !vendor_prefixed(&property_name_lower)
         {

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/invalid.css
@@ -5,3 +5,14 @@ a {
 a {
   my-property: 1;
 }
+
+/* Composition is only valid when css-modules is enabled */
+.classA {
+  color: green;
+  background: red;
+}
+
+.classB {
+  composes: classA;
+  color: yellow;
+}

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/invalid.css.snap
@@ -13,6 +13,17 @@ a {
   my-property: 1;
 }
 
+/* Composition is only valid when css-modules is enabled */
+.classA {
+  color: green;
+  background: red;
+}
+
+.classB {
+  composes: classA;
+  color: yellow;
+}
+
 ```
 
 # Diagnostics
@@ -44,6 +55,24 @@ invalid.css:6:3 lint/correctness/noUnknownProperty ━━━━━━━━━�
       │   ^^^^^^^^^^^
     7 │ }
     8 │ 
+  
+  i See CSS Specifications and browser specific properties for more details.
+  
+  i To resolve this issue, replace the unknown property with a valid CSS property.
+  
+
+```
+
+```
+invalid.css:16:3 lint/correctness/noUnknownProperty ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unknown property is not allowed.
+  
+    15 │ .classB {
+  > 16 │   composes: classA;
+       │   ^^^^^^^^
+    17 │   color: yellow;
+    18 │ }
   
   i See CSS Specifications and browser specific properties for more details.
   

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/valid.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/valid.css
@@ -57,17 +57,6 @@ a {
   --custom-property: 10px;
 }
 
-/* Composition */
-.classA {
-  color: green;
-  background: red;
-}
-
-.classB {
-  composes: classA;
-  color: yellow;
-}
-
 /* View Transition navigation property (should not be flagged) */
 view-transition {
   navigation: auto;

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/valid.css.snap
@@ -63,17 +63,6 @@ a {
   --custom-property: 10px;
 }
 
-/* Composition */
-.classA {
-  color: green;
-  background: red;
-}
-
-.classB {
-  composes: classA;
-  color: yellow;
-}
-
 /* View Transition navigation property (should not be flagged) */
 view-transition {
   navigation: auto;

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/validCssModulesComposition.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/validCssModulesComposition.css
@@ -1,0 +1,11 @@
+/* should not generate diagnostics */
+/* Composition */
+.classA {
+  color: green;
+  background: red;
+}
+
+.classB {
+  composes: classA;
+  color: yellow;
+}

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/validCssModulesComposition.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/validCssModulesComposition.css.snap
@@ -1,0 +1,19 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: validCssModulesComposition.css
+---
+# Input
+```css
+/* should not generate diagnostics */
+/* Composition */
+.classA {
+  color: green;
+  background: red;
+}
+
+.classB {
+  composes: classA;
+  color: yellow;
+}
+
+```

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/validCssModulesComposition.options.json
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/validCssModulesComposition.options.json
@@ -1,0 +1,7 @@
+{
+  "css": {
+    "parser": {
+      "cssModules": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Was working on another change in `noUnknownProperty`, noticed that `composes` property is already skipped with `cssModules` enabled in parser config

The query is `Ast<CssGenericProperty>`, and when `cssModules` is enabled this property is parsed as `CssComposesProperty`, excluding it from the query

I think there is no need to allow `composes` property when css modules parsing is disabled

Prior PR when the check was added: https://github.com/biomejs/biome/pull/3217

## Test Plan

Added separate test cases with and without `cssModules` enabled

## Docs

Not sure if any is required, but if so, please tell me and I'll update the website

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
