### PR TITLE
fix(noInvalidUseBeforeDeclaration): ignore valid use before declarations

### DIFF
--- a/.changeset/bright-tires-report.md
+++ b/.changeset/bright-tires-report.md
@@ -1,0 +1,14 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8148](https://github.com/biomejs/biome/issues/8148). [`noInvalidUseBeforeDeclaration`](https://biomejs.dev/linter/rules/no-invalid-use-before-declaration/) no longer reports some valid use before declarations.
+
+The following code is no longer reported as invalid:
+
+```ts
+class classA {
+	C = C;
+}
+const C = 0;
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noInvalidUseBeforeDeclaration/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noInvalidUseBeforeDeclaration/valid.js
@@ -13,6 +13,14 @@ function h() { Y; }; const Y = 0;
 function useClassInFunction() {
 	const instance = new Class();
 }
+
 class Class {
 	static SINGLETON = new Class();
 }
+
+class classA {
+	C = C;
+  prop = new classB();
+}
+class classB {}
+const C = 0;

--- a/crates/biome_js_analyze/tests/specs/correctness/noInvalidUseBeforeDeclaration/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noInvalidUseBeforeDeclaration/valid.js.snap
@@ -19,8 +19,16 @@ function h() { Y; }; const Y = 0;
 function useClassInFunction() {
 	const instance = new Class();
 }
+
 class Class {
 	static SINGLETON = new Class();
 }
+
+class classA {
+	C = C;
+  prop = new classB();
+}
+class classB {}
+const C = 0;
 
 ```


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/8148

The bug was caused by the fact that `JsClassDeclaration` is not part of `AnyJsControlFlowRoot`.
I introduced a new node union `AnyJsVariableScope` that corresponds to `AnyJsControlFlowRoot` with `JsClassDeclaration` added.

I wonder if we could replace `JsStaticInitializationBlockClassMember` by `JsClassDeclaration` in `AnyJsControlFlowRoot`.

## Test Plan

I added a test.

## Docs

I added a changset.
