### PR TITLE
fix: correctly place await after comment

### DIFF
--- a/.changeset/balanced-bananas-balloon.md
+++ b/.changeset/balanced-bananas-balloon.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7999](https://github.com/biomejs/biome/issues/7999): Correctly place `await` after leading comment in auto-fix action from `noFloatingPromises` rule.

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -292,10 +292,10 @@ impl Rule for NoFloatingPromises {
                     AnyJsExpression::JsAwaitExpression(make::js_await_expression(
                         make::token(JsSyntaxKind::AWAIT_KW)
                             .with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")]),
-                        expression.clone().trim_leading_trivia()?,
+                        expression.clone().trim_comments_and_trivia()?,
                     ));
 
-                mutation.replace_node(expression, await_expression);
+                mutation.replace_node_transfer_trivia(expression, await_expression);
                 Some(JsRuleAction::new(
                     ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js
@@ -3,3 +3,8 @@ async function returnsPromise() {
 }
 returnsPromise();
 returnsPromise().then(() => { }).finally(() => { });
+
+async function issue7999() {
+  // ✅
+  returnsPromise();
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js.snap
@@ -10,6 +10,11 @@ async function returnsPromise() {
 returnsPromise();
 returnsPromise().then(() => { }).finally(() => { });
 
+async function issue7999() {
+  // ✅
+  returnsPromise();
+}
+
 ```
 
 # Diagnostics
@@ -40,8 +45,30 @@ invalid.js:5:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━
   > 5 │ returnsPromise().then(() => { }).finally(() => { });
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     6 │ 
+    7 │ async function issue7999() {
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
+
+```
+
+```
+invalid.js:9:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+     7 │ async function issue7999() {
+     8 │   // ✅
+   > 9 │   returnsPromise();
+       │   ^^^^^^^^^^^^^^^^^
+    10 │ }
+    11 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    9 │ ··await·returnsPromise();
+      │   ++++++                 
 
 ```

--- a/crates/biome_rowan/src/ast/batch.rs
+++ b/crates/biome_rowan/src/ast/batch.rs
@@ -221,6 +221,37 @@ where
         self.replace_element_discard_trivia(prev_token.into(), next_token.into())
     }
 
+    /// Push a change to replace the "prev_node" with "next_node".
+    ///
+    /// - leading trivia of `prev_node`
+    /// - leading trivia of `next_node`
+    /// - trailing trivia of `prev_node`
+    /// - trailing trivia of `next_node`
+    pub fn replace_node_transfer_trivia<T>(&mut self, prev_node: T, next_node: T) -> Option<()>
+    where
+        T: AstNode<Language = L>,
+    {
+        let prev_node = prev_node.into_syntax();
+        let next_node = next_node.into_syntax();
+
+        let leading_trivia = chain_trivia_pieces(
+            prev_node.first_token()?.leading_trivia().pieces(),
+            next_node.first_token()?.leading_trivia().pieces(),
+        );
+
+        let trailing_trivia = chain_trivia_pieces(
+            prev_node.last_token()?.trailing_trivia().pieces(),
+            next_node.last_token()?.trailing_trivia().pieces(),
+        );
+        let new_node = next_node
+            .with_leading_trivia_pieces(leading_trivia)?
+            .with_trailing_trivia_pieces(trailing_trivia)?;
+
+        self.replace_element_discard_trivia(prev_node.into(), new_node.into());
+
+        Some(())
+    }
+
     /// Push a change to replace the "prev_token" with "next_token".
     ///
     /// - leading trivia of `prev_token`

--- a/crates/biome_rowan/src/ast/mod.rs
+++ b/crates/biome_rowan/src/ast/mod.rs
@@ -276,6 +276,15 @@ pub trait AstNode: Clone {
         Self::cast(self.into_syntax().append_trivia_pieces(trivia)?)
     }
 
+    /// Returns a new version of this node with *all* trivia stripped.
+    fn trim_comments_and_trivia(self) -> Option<Self> {
+        Self::cast(
+            self.into_syntax()
+                .with_leading_trivia_pieces([])?
+                .with_trailing_trivia_pieces([])?,
+        )
+    }
+
     /// Return a new version of this node without leading and trailing newlines and whitespaces.
     fn trim_trivia(self) -> Option<Self> {
         Self::cast(


### PR DESCRIPTION
## Summary

Fixed [#7999](https://github.com/biomejs/biome/issues/7999): Correctly place `await` after leading comment in auto-fix action from `noFloatingPromises` rule.

## Test Plan

Test case included.

## Docs

N/A