### PR TITLE
fix(parse/html/vue): reject whitespace before vue directive arguments

### DIFF
--- a/.changeset/dry-cooks-start.md
+++ b/.changeset/dry-cooks-start.md
@@ -1,0 +1,10 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8174](https://github.com/biomejs/biome/issues/8174), where the HTML parser would parse 2 directives as a single directive because it would not reject whitespace in Vue directives. This would cause the formatter to erroneously merge the 2 directives into one, resulting in broken code.
+
+```diff
+- <Component v-else:property="123" />
++ <Component v-else :property="123" />
+```

--- a/crates/biome_html_formatter/tests/specs/html/vue/issue-8174.vue
+++ b/crates/biome_html_formatter/tests/specs/html/vue/issue-8174.vue
@@ -1,0 +1,2 @@
+<Component v-if="operation" :property="123" />
+<Component v-else :property="123" />

--- a/crates/biome_html_formatter/tests/specs/html/vue/issue-8174.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/vue/issue-8174.vue.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: vue/issue-8174.vue
+---
+# Input
+
+```vue
+<Component v-if="operation" :property="123" />
+<Component v-else :property="123" />
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+Self close void elements: never
+-----
+
+```vue
+<Component v-if="operation" :property="123"/>
+<Component v-else :property="123"/>
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/issue-8174.vue
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/issue-8174.vue
@@ -1,0 +1,2 @@
+<Component v-if="operation" :property="123" />
+<Component v-else :property="123" />

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/issue-8174.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/issue-8174.vue.snap
@@ -1,0 +1,151 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```vue
+<Component v-if="operation" :property="123" />
+<Component v-else :property="123" />
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlSelfClosingElement {
+            l_angle_token: L_ANGLE@0..1 "<" [] [],
+            name: HtmlTagName {
+                value_token: HTML_LITERAL@1..11 "Component" [] [Whitespace(" ")],
+            },
+            attributes: HtmlAttributeList [
+                VueDirective {
+                    name_token: VUE_IDENT@11..15 "v-if" [] [],
+                    arg: missing (optional),
+                    modifiers: VueModifierList [],
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@15..16 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@16..28 "\"operation\"" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+                VueVBindShorthandDirective {
+                    arg: VueDirectiveArgument {
+                        colon_token: COLON@28..29 ":" [] [],
+                        arg: VueStaticArgument {
+                            name_token: HTML_LITERAL@29..37 "property" [] [],
+                        },
+                    },
+                    modifiers: VueModifierList [],
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@37..38 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@38..44 "\"123\"" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            ],
+            slash_token: SLASH@44..45 "/" [] [],
+            r_angle_token: R_ANGLE@45..46 ">" [] [],
+        },
+        HtmlSelfClosingElement {
+            l_angle_token: L_ANGLE@46..48 "<" [Newline("\n")] [],
+            name: HtmlTagName {
+                value_token: HTML_LITERAL@48..58 "Component" [] [Whitespace(" ")],
+            },
+            attributes: HtmlAttributeList [
+                VueDirective {
+                    name_token: VUE_IDENT@58..65 "v-else" [] [Whitespace(" ")],
+                    arg: missing (optional),
+                    modifiers: VueModifierList [],
+                    initializer: missing (optional),
+                },
+                VueVBindShorthandDirective {
+                    arg: VueDirectiveArgument {
+                        colon_token: COLON@65..66 ":" [] [],
+                        arg: VueStaticArgument {
+                            name_token: HTML_LITERAL@66..74 "property" [] [],
+                        },
+                    },
+                    modifiers: VueModifierList [],
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@74..75 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@75..81 "\"123\"" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            ],
+            slash_token: SLASH@81..82 "/" [] [],
+            r_angle_token: R_ANGLE@82..83 ">" [] [],
+        },
+    ],
+    eof_token: EOF@83..84 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..84
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..83
+    0: HTML_SELF_CLOSING_ELEMENT@0..46
+      0: L_ANGLE@0..1 "<" [] []
+      1: HTML_TAG_NAME@1..11
+        0: HTML_LITERAL@1..11 "Component" [] [Whitespace(" ")]
+      2: HTML_ATTRIBUTE_LIST@11..44
+        0: VUE_DIRECTIVE@11..28
+          0: VUE_IDENT@11..15 "v-if" [] []
+          1: (empty)
+          2: VUE_MODIFIER_LIST@15..15
+          3: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@15..28
+            0: EQ@15..16 "=" [] []
+            1: HTML_STRING@16..28
+              0: HTML_STRING_LITERAL@16..28 "\"operation\"" [] [Whitespace(" ")]
+        1: VUE_V_BIND_SHORTHAND_DIRECTIVE@28..44
+          0: VUE_DIRECTIVE_ARGUMENT@28..37
+            0: COLON@28..29 ":" [] []
+            1: VUE_STATIC_ARGUMENT@29..37
+              0: HTML_LITERAL@29..37 "property" [] []
+          1: VUE_MODIFIER_LIST@37..37
+          2: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@37..44
+            0: EQ@37..38 "=" [] []
+            1: HTML_STRING@38..44
+              0: HTML_STRING_LITERAL@38..44 "\"123\"" [] [Whitespace(" ")]
+      3: SLASH@44..45 "/" [] []
+      4: R_ANGLE@45..46 ">" [] []
+    1: HTML_SELF_CLOSING_ELEMENT@46..83
+      0: L_ANGLE@46..48 "<" [Newline("\n")] []
+      1: HTML_TAG_NAME@48..58
+        0: HTML_LITERAL@48..58 "Component" [] [Whitespace(" ")]
+      2: HTML_ATTRIBUTE_LIST@58..81
+        0: VUE_DIRECTIVE@58..65
+          0: VUE_IDENT@58..65 "v-else" [] [Whitespace(" ")]
+          1: (empty)
+          2: VUE_MODIFIER_LIST@65..65
+          3: (empty)
+        1: VUE_V_BIND_SHORTHAND_DIRECTIVE@65..81
+          0: VUE_DIRECTIVE_ARGUMENT@65..74
+            0: COLON@65..66 ":" [] []
+            1: VUE_STATIC_ARGUMENT@66..74
+              0: HTML_LITERAL@66..74 "property" [] []
+          1: VUE_MODIFIER_LIST@74..74
+          2: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@74..81
+            0: EQ@74..75 "=" [] []
+            1: HTML_STRING@75..81
+              0: HTML_STRING_LITERAL@75..81 "\"123\"" [] [Whitespace(" ")]
+      3: SLASH@81..82 "/" [] []
+      4: R_ANGLE@82..83 ">" [] []
+  4: EOF@83..84 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This makes the parser reject trivia between `v-foo` and `:` in vue directives.

It does this by inspecting `p.source().trivia_list` to check for trivia.

It was suggested to use relexing for this use case, but I chose not to for a couple reasons.
1. I don't want to actually change what these tokens are lexed as.
2. The token source skips over whitespace tokens, so I would probably end up just having to do something like this anyway.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #8174

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
