### PR TITLE
feat(parse/html/vue): parse v-slot shorthand syntax

### DIFF
--- a/.changeset/forty-falcons-pick.md
+++ b/.changeset/forty-falcons-pick.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8222](https://github.com/biomejs/biome/issues/8222): The HTML parser, with Vue directives enabled, can now parse `v-slot` shorthand syntax, e.g. `<template #foo>`.

--- a/crates/biome_html_factory/src/generated/node_factory.rs
+++ b/crates/biome_html_factory/src/generated/node_factory.rs
@@ -727,6 +727,42 @@ impl VueVOnShorthandDirectiveBuilder {
         ))
     }
 }
+pub fn vue_v_slot_shorthand_directive(
+    hash_token: SyntaxToken,
+    arg: AnyVueDirectiveArgument,
+    modifiers: VueModifierList,
+) -> VueVSlotShorthandDirectiveBuilder {
+    VueVSlotShorthandDirectiveBuilder {
+        hash_token,
+        arg,
+        modifiers,
+        initializer: None,
+    }
+}
+pub struct VueVSlotShorthandDirectiveBuilder {
+    hash_token: SyntaxToken,
+    arg: AnyVueDirectiveArgument,
+    modifiers: VueModifierList,
+    initializer: Option<HtmlAttributeInitializerClause>,
+}
+impl VueVSlotShorthandDirectiveBuilder {
+    pub fn with_initializer(mut self, initializer: HtmlAttributeInitializerClause) -> Self {
+        self.initializer = Some(initializer);
+        self
+    }
+    pub fn build(self) -> VueVSlotShorthandDirective {
+        VueVSlotShorthandDirective::unwrap_cast(SyntaxNode::new_detached(
+            HtmlSyntaxKind::VUE_V_SLOT_SHORTHAND_DIRECTIVE,
+            [
+                Some(SyntaxElement::Token(self.hash_token)),
+                Some(SyntaxElement::Node(self.arg.into_syntax())),
+                Some(SyntaxElement::Node(self.modifiers.into_syntax())),
+                self.initializer
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
+            ],
+        ))
+    }
+}
 pub fn html_attribute_list<I>(items: I) -> HtmlAttributeList
 where
     I: IntoIterator<Item = AnyHtmlAttribute>,

--- a/crates/biome_html_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_html_factory/src/generated/syntax_factory.rs
@@ -1372,6 +1372,46 @@ impl SyntaxFactory for HtmlSyntaxFactory {
                 }
                 slots.into_node(VUE_V_ON_SHORTHAND_DIRECTIVE, children)
             }
+            VUE_V_SLOT_SHORTHAND_DIRECTIVE => {
+                let mut elements = (&children).into_iter();
+                let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
+                let mut current_element = elements.next();
+                if let Some(element) = &current_element
+                    && element.kind() == T ! [#]
+                {
+                    slots.mark_present();
+                    current_element = elements.next();
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element
+                    && AnyVueDirectiveArgument::can_cast(element.kind())
+                {
+                    slots.mark_present();
+                    current_element = elements.next();
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element
+                    && VueModifierList::can_cast(element.kind())
+                {
+                    slots.mark_present();
+                    current_element = elements.next();
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element
+                    && HtmlAttributeInitializerClause::can_cast(element.kind())
+                {
+                    slots.mark_present();
+                    current_element = elements.next();
+                }
+                slots.next_slot();
+                if current_element.is_some() {
+                    return RawSyntaxNode::new(
+                        VUE_V_SLOT_SHORTHAND_DIRECTIVE.to_bogus(),
+                        children.into_iter().map(Some),
+                    );
+                }
+                slots.into_node(VUE_V_SLOT_SHORTHAND_DIRECTIVE, children)
+            }
             HTML_ATTRIBUTE_LIST => {
                 Self::make_node_list_syntax(kind, children, AnyHtmlAttribute::can_cast)
             }

--- a/crates/biome_html_formatter/src/generated.rs
+++ b/crates/biome_html_formatter/src/generated.rs
@@ -1498,6 +1498,38 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::VueVOnShorthandDirecti
         FormatOwnedWithRule :: new (self , crate :: vue :: auxiliary :: v_on_shorthand_directive :: FormatVueVOnShorthandDirective :: default ())
     }
 }
+impl FormatRule<biome_html_syntax::VueVSlotShorthandDirective>
+    for crate::vue::auxiliary::v_slot_shorthand_directive::FormatVueVSlotShorthandDirective
+{
+    type Context = HtmlFormatContext;
+    #[inline(always)]
+    fn fmt(
+        &self,
+        node: &biome_html_syntax::VueVSlotShorthandDirective,
+        f: &mut HtmlFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<biome_html_syntax::VueVSlotShorthandDirective>::fmt(self, node, f)
+    }
+}
+impl AsFormat<HtmlFormatContext> for biome_html_syntax::VueVSlotShorthandDirective {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_html_syntax::VueVSlotShorthandDirective,
+        crate::vue::auxiliary::v_slot_shorthand_directive::FormatVueVSlotShorthandDirective,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule :: new (self , crate :: vue :: auxiliary :: v_slot_shorthand_directive :: FormatVueVSlotShorthandDirective :: default ())
+    }
+}
+impl IntoFormat<HtmlFormatContext> for biome_html_syntax::VueVSlotShorthandDirective {
+    type Format = FormatOwnedWithRule<
+        biome_html_syntax::VueVSlotShorthandDirective,
+        crate::vue::auxiliary::v_slot_shorthand_directive::FormatVueVSlotShorthandDirective,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule :: new (self , crate :: vue :: auxiliary :: v_slot_shorthand_directive :: FormatVueVSlotShorthandDirective :: default ())
+    }
+}
 impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlAttributeList {
     type Format<'a> = FormatRefWithRule<
         'a,

--- a/crates/biome_html_formatter/src/vue/any/directive.rs
+++ b/crates/biome_html_formatter/src/vue/any/directive.rs
@@ -12,6 +12,7 @@ impl FormatRule<AnyVueDirective> for FormatAnyVueDirective {
             AnyVueDirective::VueDirective(node) => node.format().fmt(f),
             AnyVueDirective::VueVBindShorthandDirective(node) => node.format().fmt(f),
             AnyVueDirective::VueVOnShorthandDirective(node) => node.format().fmt(f),
+            AnyVueDirective::VueVSlotShorthandDirective(node) => node.format().fmt(f),
         }
     }
 }

--- a/crates/biome_html_formatter/src/vue/auxiliary/mod.rs
+++ b/crates/biome_html_formatter/src/vue/auxiliary/mod.rs
@@ -7,3 +7,4 @@ pub(crate) mod modifier;
 pub(crate) mod static_argument;
 pub(crate) mod v_bind_shorthand_directive;
 pub(crate) mod v_on_shorthand_directive;
+pub(crate) mod v_slot_shorthand_directive;

--- a/crates/biome_html_formatter/src/vue/auxiliary/v_slot_shorthand_directive.rs
+++ b/crates/biome_html_formatter/src/vue/auxiliary/v_slot_shorthand_directive.rs
@@ -1,0 +1,30 @@
+use crate::prelude::*;
+use biome_formatter::write;
+use biome_html_syntax::{VueVSlotShorthandDirective, VueVSlotShorthandDirectiveFields};
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatVueVSlotShorthandDirective;
+impl FormatNodeRule<VueVSlotShorthandDirective> for FormatVueVSlotShorthandDirective {
+    fn fmt_fields(
+        &self,
+        node: &VueVSlotShorthandDirective,
+        f: &mut HtmlFormatter,
+    ) -> FormatResult<()> {
+        let VueVSlotShorthandDirectiveFields {
+            hash_token,
+            arg,
+            modifiers,
+            initializer,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                hash_token.format(),
+                arg.format(),
+                modifiers.format(),
+                initializer.format()
+            ]
+        )
+    }
+}

--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -140,6 +140,7 @@ impl<'src> HtmlLexer<'src> {
             b'.' => self.consume_byte(T![.]),
             b'[' => self.consume_byte(T!['[']),
             b']' => self.consume_byte(T![']']),
+            b'#' => self.consume_byte(T![#]),
 
             b'\'' | b'"' => self.consume_string_literal(current),
             _ if self.current_kind == T![<] && is_tag_name_byte(current) => {

--- a/crates/biome_html_parser/src/syntax/mod.rs
+++ b/crates/biome_html_parser/src/syntax/mod.rs
@@ -12,6 +12,7 @@ use crate::syntax::svelte::{
 };
 use crate::syntax::vue::{
     parse_vue_directive, parse_vue_v_bind_shorthand_directive, parse_vue_v_on_shorthand_directive,
+    parse_vue_v_slot_shorthand_directive,
 };
 use crate::token_source::{
     HtmlEmbeddedLanguage, HtmlLexContext, HtmlReLexContext, TextExpressionKind,
@@ -369,6 +370,11 @@ fn parse_attribute(p: &mut HtmlParser) -> ParsedSyntax {
             parse_vue_v_on_shorthand_directive,
             |p, m| disabled_vue(p, m.range(p)),
         ),
+        T![#] => HtmlSyntaxFeatures::Vue.parse_exclusive_syntax(
+            p,
+            parse_vue_v_slot_shorthand_directive,
+            |p, m| disabled_vue(p, m.range(p)),
+        ),
         T!['{'] => SingleTextExpressions.parse_exclusive_syntax(
             p,
             |p| parse_single_text_expression(p, HtmlLexContext::InsideTag),
@@ -398,8 +404,14 @@ fn parse_attribute(p: &mut HtmlParser) -> ParsedSyntax {
 }
 
 fn is_at_attribute_start(p: &mut HtmlParser) -> bool {
-    p.at_ts(token_set![HTML_LITERAL, T!["{{"], T!['{'], T![:], T![@]])
-        || (SingleTextExpressions.is_supported(p) && p.at(T!["{@"]))
+    p.at_ts(token_set![
+        HTML_LITERAL,
+        T!["{{"],
+        T!['{'],
+        T![:],
+        T![@],
+        T![#],
+    ]) || (SingleTextExpressions.is_supported(p) && p.at(T!["{@"]))
 }
 
 fn parse_literal(p: &mut HtmlParser, kind: HtmlSyntaxKind) -> ParsedSyntax {

--- a/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-slot-shorthand.vue
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-slot-shorthand.vue
@@ -1,0 +1,1 @@
+<template # data-foo="bar" foo="bar"></template>

--- a/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-slot-shorthand.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-slot-shorthand.vue.snap
@@ -1,0 +1,132 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```vue
+<template # data-foo="bar" foo="bar"></template>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..1 "<" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@1..10 "template" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    VueBogusDirective {
+                        items: [
+                            HASH@10..12 "#" [] [Whitespace(" ")],
+                        ],
+                    },
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@12..20 "data-foo" [] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@20..21 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@21..27 "\"bar\"" [] [Whitespace(" ")],
+                            },
+                        },
+                    },
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@27..30 "foo" [] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@30..31 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@31..36 "\"bar\"" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@36..37 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@37..38 "<" [] [],
+                slash_token: SLASH@38..39 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@39..47 "template" [] [],
+                },
+                r_angle_token: R_ANGLE@47..48 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@48..49 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..49
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..48
+    0: HTML_ELEMENT@0..48
+      0: HTML_OPENING_ELEMENT@0..37
+        0: L_ANGLE@0..1 "<" [] []
+        1: HTML_TAG_NAME@1..10
+          0: HTML_LITERAL@1..10 "template" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@10..36
+          0: VUE_BOGUS_DIRECTIVE@10..12
+            0: HASH@10..12 "#" [] [Whitespace(" ")]
+          1: HTML_ATTRIBUTE@12..27
+            0: HTML_ATTRIBUTE_NAME@12..20
+              0: HTML_LITERAL@12..20 "data-foo" [] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@20..27
+              0: EQ@20..21 "=" [] []
+              1: HTML_STRING@21..27
+                0: HTML_STRING_LITERAL@21..27 "\"bar\"" [] [Whitespace(" ")]
+          2: HTML_ATTRIBUTE@27..36
+            0: HTML_ATTRIBUTE_NAME@27..30
+              0: HTML_LITERAL@27..30 "foo" [] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@30..36
+              0: EQ@30..31 "=" [] []
+              1: HTML_STRING@31..36
+                0: HTML_STRING_LITERAL@31..36 "\"bar\"" [] []
+        3: R_ANGLE@36..37 ">" [] []
+      1: HTML_ELEMENT_LIST@37..37
+      2: HTML_CLOSING_ELEMENT@37..48
+        0: L_ANGLE@37..38 "<" [] []
+        1: SLASH@38..39 "/" [] []
+        2: HTML_TAG_NAME@39..47
+          0: HTML_LITERAL@39..47 "template" [] []
+        3: R_ANGLE@47..48 ">" [] []
+  4: EOF@48..49 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+invalid-v-slot-shorthand.vue:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a vue directive argument but instead found ' '.
+  
+  > 1 │ <template # data-foo="bar" foo="bar"></template>
+      │            ^
+    2 │ 
+  
+  i Expected a vue directive argument here.
+  
+  > 1 │ <template # data-foo="bar" foo="bar"></template>
+      │            ^
+    2 │ 
+  
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-mixed-complex.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-mixed-complex.vue.snap
@@ -348,10 +348,12 @@ HtmlRoot {
                                     value_token: HTML_LITERAL@593..602 "template" [] [Whitespace(" ")],
                                 },
                                 attributes: HtmlAttributeList [
-                                    HtmlAttribute {
-                                        name: HtmlAttributeName {
-                                            value_token: HTML_LITERAL@602..610 "#default" [] [],
+                                    VueVSlotShorthandDirective {
+                                        hash_token: HASH@602..603 "#" [] [],
+                                        arg: VueStaticArgument {
+                                            name_token: HTML_LITERAL@603..610 "default" [] [],
                                         },
+                                        modifiers: VueModifierList [],
                                         initializer: HtmlAttributeInitializerClause {
                                             eq_token: EQ@610..611 "=" [] [],
                                             value: HtmlString {
@@ -407,10 +409,12 @@ HtmlRoot {
                                     value_token: HTML_LITERAL@675..684 "template" [] [Whitespace(" ")],
                                 },
                                 attributes: HtmlAttributeList [
-                                    HtmlAttribute {
-                                        name: HtmlAttributeName {
-                                            value_token: HTML_LITERAL@684..691 "#footer" [] [],
+                                    VueVSlotShorthandDirective {
+                                        hash_token: HASH@684..685 "#" [] [],
+                                        arg: VueStaticArgument {
+                                            name_token: HTML_LITERAL@685..691 "footer" [] [],
                                         },
+                                        modifiers: VueModifierList [],
                                         initializer: missing (optional),
                                     },
                                 ],
@@ -711,10 +715,12 @@ HtmlRoot {
                 1: HTML_TAG_NAME@593..602
                   0: HTML_LITERAL@593..602 "template" [] [Whitespace(" ")]
                 2: HTML_ATTRIBUTE_LIST@602..625
-                  0: HTML_ATTRIBUTE@602..625
-                    0: HTML_ATTRIBUTE_NAME@602..610
-                      0: HTML_LITERAL@602..610 "#default" [] []
-                    1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@610..625
+                  0: VUE_V_SLOT_SHORTHAND_DIRECTIVE@602..625
+                    0: HASH@602..603 "#" [] []
+                    1: VUE_STATIC_ARGUMENT@603..610
+                      0: HTML_LITERAL@603..610 "default" [] []
+                    2: VUE_MODIFIER_LIST@610..610
+                    3: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@610..625
                       0: EQ@610..611 "=" [] []
                       1: HTML_STRING@611..625
                         0: HTML_STRING_LITERAL@611..625 "\"{ slotProp }\"" [] []
@@ -751,10 +757,12 @@ HtmlRoot {
                 1: HTML_TAG_NAME@675..684
                   0: HTML_LITERAL@675..684 "template" [] [Whitespace(" ")]
                 2: HTML_ATTRIBUTE_LIST@684..691
-                  0: HTML_ATTRIBUTE@684..691
-                    0: HTML_ATTRIBUTE_NAME@684..691
-                      0: HTML_LITERAL@684..691 "#footer" [] []
-                    1: (empty)
+                  0: VUE_V_SLOT_SHORTHAND_DIRECTIVE@684..691
+                    0: HASH@684..685 "#" [] []
+                    1: VUE_STATIC_ARGUMENT@685..691
+                      0: HTML_LITERAL@685..691 "footer" [] []
+                    2: VUE_MODIFIER_LIST@691..691
+                    3: (empty)
                 3: R_ANGLE@691..692 ">" [] []
               1: HTML_ELEMENT_LIST@692..738
                 0: HTML_ELEMENT@692..738

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-slot-shorthand.vue
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-slot-shorthand.vue
@@ -1,0 +1,3 @@
+<template #header></template>
+<template #footer="slotProps"></template>
+<template #[dynamicSlot]></template>

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-slot-shorthand.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-slot-shorthand.vue.snap
@@ -1,0 +1,194 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```vue
+<template #header></template>
+<template #footer="slotProps"></template>
+<template #[dynamicSlot]></template>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..1 "<" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@1..10 "template" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    VueVSlotShorthandDirective {
+                        hash_token: HASH@10..11 "#" [] [],
+                        arg: VueStaticArgument {
+                            name_token: HTML_LITERAL@11..17 "header" [] [],
+                        },
+                        modifiers: VueModifierList [],
+                        initializer: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@17..18 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@18..19 "<" [] [],
+                slash_token: SLASH@19..20 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@20..28 "template" [] [],
+                },
+                r_angle_token: R_ANGLE@28..29 ">" [] [],
+            },
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@29..31 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@31..40 "template" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    VueVSlotShorthandDirective {
+                        hash_token: HASH@40..41 "#" [] [],
+                        arg: VueStaticArgument {
+                            name_token: HTML_LITERAL@41..47 "footer" [] [],
+                        },
+                        modifiers: VueModifierList [],
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@47..48 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@48..59 "\"slotProps\"" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@59..60 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@60..61 "<" [] [],
+                slash_token: SLASH@61..62 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@62..70 "template" [] [],
+                },
+                r_angle_token: R_ANGLE@70..71 ">" [] [],
+            },
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@71..73 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@73..82 "template" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    VueVSlotShorthandDirective {
+                        hash_token: HASH@82..83 "#" [] [],
+                        arg: VueDynamicArgument {
+                            l_brack_token: L_BRACKET@83..84 "[" [] [],
+                            name_token: HTML_LITERAL@84..95 "dynamicSlot" [] [],
+                            r_brack_token: R_BRACKET@95..96 "]" [] [],
+                        },
+                        modifiers: VueModifierList [],
+                        initializer: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@96..97 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@97..98 "<" [] [],
+                slash_token: SLASH@98..99 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@99..107 "template" [] [],
+                },
+                r_angle_token: R_ANGLE@107..108 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@108..109 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..109
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..108
+    0: HTML_ELEMENT@0..29
+      0: HTML_OPENING_ELEMENT@0..18
+        0: L_ANGLE@0..1 "<" [] []
+        1: HTML_TAG_NAME@1..10
+          0: HTML_LITERAL@1..10 "template" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@10..17
+          0: VUE_V_SLOT_SHORTHAND_DIRECTIVE@10..17
+            0: HASH@10..11 "#" [] []
+            1: VUE_STATIC_ARGUMENT@11..17
+              0: HTML_LITERAL@11..17 "header" [] []
+            2: VUE_MODIFIER_LIST@17..17
+            3: (empty)
+        3: R_ANGLE@17..18 ">" [] []
+      1: HTML_ELEMENT_LIST@18..18
+      2: HTML_CLOSING_ELEMENT@18..29
+        0: L_ANGLE@18..19 "<" [] []
+        1: SLASH@19..20 "/" [] []
+        2: HTML_TAG_NAME@20..28
+          0: HTML_LITERAL@20..28 "template" [] []
+        3: R_ANGLE@28..29 ">" [] []
+    1: HTML_ELEMENT@29..71
+      0: HTML_OPENING_ELEMENT@29..60
+        0: L_ANGLE@29..31 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@31..40
+          0: HTML_LITERAL@31..40 "template" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@40..59
+          0: VUE_V_SLOT_SHORTHAND_DIRECTIVE@40..59
+            0: HASH@40..41 "#" [] []
+            1: VUE_STATIC_ARGUMENT@41..47
+              0: HTML_LITERAL@41..47 "footer" [] []
+            2: VUE_MODIFIER_LIST@47..47
+            3: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@47..59
+              0: EQ@47..48 "=" [] []
+              1: HTML_STRING@48..59
+                0: HTML_STRING_LITERAL@48..59 "\"slotProps\"" [] []
+        3: R_ANGLE@59..60 ">" [] []
+      1: HTML_ELEMENT_LIST@60..60
+      2: HTML_CLOSING_ELEMENT@60..71
+        0: L_ANGLE@60..61 "<" [] []
+        1: SLASH@61..62 "/" [] []
+        2: HTML_TAG_NAME@62..70
+          0: HTML_LITERAL@62..70 "template" [] []
+        3: R_ANGLE@70..71 ">" [] []
+    2: HTML_ELEMENT@71..108
+      0: HTML_OPENING_ELEMENT@71..97
+        0: L_ANGLE@71..73 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@73..82
+          0: HTML_LITERAL@73..82 "template" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@82..96
+          0: VUE_V_SLOT_SHORTHAND_DIRECTIVE@82..96
+            0: HASH@82..83 "#" [] []
+            1: VUE_DYNAMIC_ARGUMENT@83..96
+              0: L_BRACKET@83..84 "[" [] []
+              1: HTML_LITERAL@84..95 "dynamicSlot" [] []
+              2: R_BRACKET@95..96 "]" [] []
+            2: VUE_MODIFIER_LIST@96..96
+            3: (empty)
+        3: R_ANGLE@96..97 ">" [] []
+      1: HTML_ELEMENT_LIST@97..97
+      2: HTML_CLOSING_ELEMENT@97..108
+        0: L_ANGLE@97..98 "<" [] []
+        1: SLASH@98..99 "/" [] []
+        2: HTML_TAG_NAME@99..107
+          0: HTML_LITERAL@99..107 "template" [] []
+        3: R_ANGLE@107..108 ">" [] []
+  4: EOF@108..109 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_syntax/src/generated/kind.rs
+++ b/crates/biome_html_syntax/src/generated/kind.rs
@@ -35,6 +35,7 @@ pub enum HtmlSyntaxKind {
     DOT,
     L_BRACKET,
     R_BRACKET,
+    HASH,
     NULL_KW,
     TRUE_KW,
     FALSE_KW,
@@ -99,6 +100,7 @@ pub enum HtmlSyntaxKind {
     VUE_DIRECTIVE_ARGUMENT,
     VUE_V_BIND_SHORTHAND_DIRECTIVE,
     VUE_V_ON_SHORTHAND_DIRECTIVE,
+    VUE_V_SLOT_SHORTHAND_DIRECTIVE,
     VUE_STATIC_ARGUMENT,
     VUE_DYNAMIC_ARGUMENT,
     VUE_MODIFIER_LIST,
@@ -142,6 +144,7 @@ impl HtmlSyntaxKind {
                 | DOT
                 | L_BRACKET
                 | R_BRACKET
+                | HASH
         )
     }
     pub const fn is_literal(self) -> bool {
@@ -200,6 +203,7 @@ impl HtmlSyntaxKind {
             DOT => ".",
             L_BRACKET => "[",
             R_BRACKET => "]",
+            HASH => "#",
             NULL_KW => "null",
             TRUE_KW => "true",
             FALSE_KW => "false",
@@ -221,4 +225,4 @@ impl HtmlSyntaxKind {
 }
 #[doc = r" Utility macro for creating a SyntaxKind through simple macro syntax"]
 #[macro_export]
-macro_rules ! T { [<] => { $ crate :: HtmlSyntaxKind :: L_ANGLE } ; [>] => { $ crate :: HtmlSyntaxKind :: R_ANGLE } ; [/] => { $ crate :: HtmlSyntaxKind :: SLASH } ; [=] => { $ crate :: HtmlSyntaxKind :: EQ } ; [!] => { $ crate :: HtmlSyntaxKind :: BANG } ; [-] => { $ crate :: HtmlSyntaxKind :: MINUS } ; ["<![CDATA["] => { $ crate :: HtmlSyntaxKind :: CDATA_START } ; ["]]>"] => { $ crate :: HtmlSyntaxKind :: CDATA_END } ; [---] => { $ crate :: HtmlSyntaxKind :: FENCE } ; ['{'] => { $ crate :: HtmlSyntaxKind :: L_CURLY } ; ['}'] => { $ crate :: HtmlSyntaxKind :: R_CURLY } ; ["{{"] => { $ crate :: HtmlSyntaxKind :: L_DOUBLE_CURLY } ; ["}}"] => { $ crate :: HtmlSyntaxKind :: R_DOUBLE_CURLY } ; ["{@"] => { $ crate :: HtmlSyntaxKind :: SV_CURLY_AT } ; ["{#"] => { $ crate :: HtmlSyntaxKind :: SV_CURLY_HASH } ; ["{/"] => { $ crate :: HtmlSyntaxKind :: SV_CURLY_SLASH } ; ["{:"] => { $ crate :: HtmlSyntaxKind :: SV_CURLY_COLON } ; [,] => { $ crate :: HtmlSyntaxKind :: COMMA } ; [:] => { $ crate :: HtmlSyntaxKind :: COLON } ; [@] => { $ crate :: HtmlSyntaxKind :: AT } ; [.] => { $ crate :: HtmlSyntaxKind :: DOT } ; ['['] => { $ crate :: HtmlSyntaxKind :: L_BRACKET } ; [']'] => { $ crate :: HtmlSyntaxKind :: R_BRACKET } ; [null] => { $ crate :: HtmlSyntaxKind :: NULL_KW } ; [true] => { $ crate :: HtmlSyntaxKind :: TRUE_KW } ; [false] => { $ crate :: HtmlSyntaxKind :: FALSE_KW } ; [doctype] => { $ crate :: HtmlSyntaxKind :: DOCTYPE_KW } ; [html] => { $ crate :: HtmlSyntaxKind :: HTML_KW } ; [debug] => { $ crate :: HtmlSyntaxKind :: DEBUG_KW } ; [key] => { $ crate :: HtmlSyntaxKind :: KEY_KW } ; [render] => { $ crate :: HtmlSyntaxKind :: RENDER_KW } ; [const] => { $ crate :: HtmlSyntaxKind :: CONST_KW } ; [attach] => { $ crate :: HtmlSyntaxKind :: ATTACH_KW } ; [else] => { $ crate :: HtmlSyntaxKind :: ELSE_KW } ; [if] => { $ crate :: HtmlSyntaxKind :: IF_KW } ; [ident] => { $ crate :: HtmlSyntaxKind :: IDENT } ; [EOF] => { $ crate :: HtmlSyntaxKind :: EOF } ; [UNICODE_BOM] => { $ crate :: HtmlSyntaxKind :: UNICODE_BOM } ; [#] => { $ crate :: HtmlSyntaxKind :: HASH } ; }
+macro_rules ! T { [<] => { $ crate :: HtmlSyntaxKind :: L_ANGLE } ; [>] => { $ crate :: HtmlSyntaxKind :: R_ANGLE } ; [/] => { $ crate :: HtmlSyntaxKind :: SLASH } ; [=] => { $ crate :: HtmlSyntaxKind :: EQ } ; [!] => { $ crate :: HtmlSyntaxKind :: BANG } ; [-] => { $ crate :: HtmlSyntaxKind :: MINUS } ; ["<![CDATA["] => { $ crate :: HtmlSyntaxKind :: CDATA_START } ; ["]]>"] => { $ crate :: HtmlSyntaxKind :: CDATA_END } ; [---] => { $ crate :: HtmlSyntaxKind :: FENCE } ; ['{'] => { $ crate :: HtmlSyntaxKind :: L_CURLY } ; ['}'] => { $ crate :: HtmlSyntaxKind :: R_CURLY } ; ["{{"] => { $ crate :: HtmlSyntaxKind :: L_DOUBLE_CURLY } ; ["}}"] => { $ crate :: HtmlSyntaxKind :: R_DOUBLE_CURLY } ; ["{@"] => { $ crate :: HtmlSyntaxKind :: SV_CURLY_AT } ; ["{#"] => { $ crate :: HtmlSyntaxKind :: SV_CURLY_HASH } ; ["{/"] => { $ crate :: HtmlSyntaxKind :: SV_CURLY_SLASH } ; ["{:"] => { $ crate :: HtmlSyntaxKind :: SV_CURLY_COLON } ; [,] => { $ crate :: HtmlSyntaxKind :: COMMA } ; [:] => { $ crate :: HtmlSyntaxKind :: COLON } ; [@] => { $ crate :: HtmlSyntaxKind :: AT } ; [.] => { $ crate :: HtmlSyntaxKind :: DOT } ; ['['] => { $ crate :: HtmlSyntaxKind :: L_BRACKET } ; [']'] => { $ crate :: HtmlSyntaxKind :: R_BRACKET } ; [#] => { $ crate :: HtmlSyntaxKind :: HASH } ; [null] => { $ crate :: HtmlSyntaxKind :: NULL_KW } ; [true] => { $ crate :: HtmlSyntaxKind :: TRUE_KW } ; [false] => { $ crate :: HtmlSyntaxKind :: FALSE_KW } ; [doctype] => { $ crate :: HtmlSyntaxKind :: DOCTYPE_KW } ; [html] => { $ crate :: HtmlSyntaxKind :: HTML_KW } ; [debug] => { $ crate :: HtmlSyntaxKind :: DEBUG_KW } ; [key] => { $ crate :: HtmlSyntaxKind :: KEY_KW } ; [render] => { $ crate :: HtmlSyntaxKind :: RENDER_KW } ; [const] => { $ crate :: HtmlSyntaxKind :: CONST_KW } ; [attach] => { $ crate :: HtmlSyntaxKind :: ATTACH_KW } ; [else] => { $ crate :: HtmlSyntaxKind :: ELSE_KW } ; [if] => { $ crate :: HtmlSyntaxKind :: IF_KW } ; [ident] => { $ crate :: HtmlSyntaxKind :: IDENT } ; [EOF] => { $ crate :: HtmlSyntaxKind :: EOF } ; [UNICODE_BOM] => { $ crate :: HtmlSyntaxKind :: UNICODE_BOM } ; [#] => { $ crate :: HtmlSyntaxKind :: HASH } ; }

--- a/crates/biome_html_syntax/src/generated/macros.rs
+++ b/crates/biome_html_syntax/src/generated/macros.rs
@@ -178,6 +178,11 @@ macro_rules! map_syntax_node {
                     let $pattern = unsafe { $crate::VueVOnShorthandDirective::new_unchecked(node) };
                     $body
                 }
+                $crate::HtmlSyntaxKind::VUE_V_SLOT_SHORTHAND_DIRECTIVE => {
+                    let $pattern =
+                        unsafe { $crate::VueVSlotShorthandDirective::new_unchecked(node) };
+                    $body
+                }
                 $crate::HtmlSyntaxKind::ASTRO_BOGUS_FRONTMATTER => {
                     let $pattern = unsafe { $crate::AstroBogusFrontmatter::new_unchecked(node) };
                     $body

--- a/crates/biome_html_syntax/src/generated/nodes.rs
+++ b/crates/biome_html_syntax/src/generated/nodes.rs
@@ -1839,6 +1839,56 @@ pub struct VueVOnShorthandDirectiveFields {
     pub modifiers: VueModifierList,
     pub initializer: Option<HtmlAttributeInitializerClause>,
 }
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct VueVSlotShorthandDirective {
+    pub(crate) syntax: SyntaxNode,
+}
+impl VueVSlotShorthandDirective {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self { syntax }
+    }
+    pub fn as_fields(&self) -> VueVSlotShorthandDirectiveFields {
+        VueVSlotShorthandDirectiveFields {
+            hash_token: self.hash_token(),
+            arg: self.arg(),
+            modifiers: self.modifiers(),
+            initializer: self.initializer(),
+        }
+    }
+    pub fn hash_token(&self) -> SyntaxResult<SyntaxToken> {
+        support::required_token(&self.syntax, 0usize)
+    }
+    pub fn arg(&self) -> SyntaxResult<AnyVueDirectiveArgument> {
+        support::required_node(&self.syntax, 1usize)
+    }
+    pub fn modifiers(&self) -> VueModifierList {
+        support::list(&self.syntax, 2usize)
+    }
+    pub fn initializer(&self) -> Option<HtmlAttributeInitializerClause> {
+        support::node(&self.syntax, 3usize)
+    }
+}
+impl Serialize for VueVSlotShorthandDirective {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_fields().serialize(serializer)
+    }
+}
+#[derive(Serialize)]
+pub struct VueVSlotShorthandDirectiveFields {
+    pub hash_token: SyntaxResult<SyntaxToken>,
+    pub arg: SyntaxResult<AnyVueDirectiveArgument>,
+    pub modifiers: VueModifierList,
+    pub initializer: Option<HtmlAttributeInitializerClause>,
+}
 #[derive(Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum AnyAstroFrontmatterElement {
     AstroBogusFrontmatter(AstroBogusFrontmatter),
@@ -2083,6 +2133,7 @@ pub enum AnyVueDirective {
     VueDirective(VueDirective),
     VueVBindShorthandDirective(VueVBindShorthandDirective),
     VueVOnShorthandDirective(VueVOnShorthandDirective),
+    VueVSlotShorthandDirective(VueVSlotShorthandDirective),
 }
 impl AnyVueDirective {
     pub fn as_vue_bogus_directive(&self) -> Option<&VueBogusDirective> {
@@ -2106,6 +2157,12 @@ impl AnyVueDirective {
     pub fn as_vue_v_on_shorthand_directive(&self) -> Option<&VueVOnShorthandDirective> {
         match &self {
             Self::VueVOnShorthandDirective(item) => Some(item),
+            _ => None,
+        }
+    }
+    pub fn as_vue_v_slot_shorthand_directive(&self) -> Option<&VueVSlotShorthandDirective> {
+        match &self {
+            Self::VueVSlotShorthandDirective(item) => Some(item),
             _ => None,
         }
     }
@@ -4328,6 +4385,59 @@ impl From<VueVOnShorthandDirective> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl AstNode for VueVSlotShorthandDirective {
+    type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(VUE_V_SLOT_SHORTHAND_DIRECTIVE as u16));
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == VUE_V_SLOT_SHORTHAND_DIRECTIVE
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        if Self::can_cast(syntax.kind()) {
+            Some(Self { syntax })
+        } else {
+            None
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl std::fmt::Debug for VueVSlotShorthandDirective {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        thread_local! { static DEPTH : std :: cell :: Cell < u8 > = const { std :: cell :: Cell :: new (0) } };
+        let current_depth = DEPTH.get();
+        let result = if current_depth < 16 {
+            DEPTH.set(current_depth + 1);
+            f.debug_struct("VueVSlotShorthandDirective")
+                .field("hash_token", &support::DebugSyntaxResult(self.hash_token()))
+                .field("arg", &support::DebugSyntaxResult(self.arg()))
+                .field("modifiers", &self.modifiers())
+                .field(
+                    "initializer",
+                    &support::DebugOptionalElement(self.initializer()),
+                )
+                .finish()
+        } else {
+            f.debug_struct("VueVSlotShorthandDirective").finish()
+        };
+        DEPTH.set(current_depth);
+        result
+    }
+}
+impl From<VueVSlotShorthandDirective> for SyntaxNode {
+    fn from(n: VueVSlotShorthandDirective) -> Self {
+        n.syntax
+    }
+}
+impl From<VueVSlotShorthandDirective> for SyntaxElement {
+    fn from(n: VueVSlotShorthandDirective) -> Self {
+        n.syntax.into()
+    }
+}
 impl From<AstroBogusFrontmatter> for AnyAstroFrontmatterElement {
     fn from(node: AstroBogusFrontmatter) -> Self {
         Self::AstroBogusFrontmatter(node)
@@ -4982,12 +5092,18 @@ impl From<VueVOnShorthandDirective> for AnyVueDirective {
         Self::VueVOnShorthandDirective(node)
     }
 }
+impl From<VueVSlotShorthandDirective> for AnyVueDirective {
+    fn from(node: VueVSlotShorthandDirective) -> Self {
+        Self::VueVSlotShorthandDirective(node)
+    }
+}
 impl AstNode for AnyVueDirective {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> = VueBogusDirective::KIND_SET
         .union(VueDirective::KIND_SET)
         .union(VueVBindShorthandDirective::KIND_SET)
-        .union(VueVOnShorthandDirective::KIND_SET);
+        .union(VueVOnShorthandDirective::KIND_SET)
+        .union(VueVSlotShorthandDirective::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -4995,6 +5111,7 @@ impl AstNode for AnyVueDirective {
                 | VUE_DIRECTIVE
                 | VUE_V_BIND_SHORTHAND_DIRECTIVE
                 | VUE_V_ON_SHORTHAND_DIRECTIVE
+                | VUE_V_SLOT_SHORTHAND_DIRECTIVE
         )
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
@@ -5007,6 +5124,9 @@ impl AstNode for AnyVueDirective {
             VUE_V_ON_SHORTHAND_DIRECTIVE => {
                 Self::VueVOnShorthandDirective(VueVOnShorthandDirective { syntax })
             }
+            VUE_V_SLOT_SHORTHAND_DIRECTIVE => {
+                Self::VueVSlotShorthandDirective(VueVSlotShorthandDirective { syntax })
+            }
             _ => return None,
         };
         Some(res)
@@ -5017,6 +5137,7 @@ impl AstNode for AnyVueDirective {
             Self::VueDirective(it) => it.syntax(),
             Self::VueVBindShorthandDirective(it) => it.syntax(),
             Self::VueVOnShorthandDirective(it) => it.syntax(),
+            Self::VueVSlotShorthandDirective(it) => it.syntax(),
         }
     }
     fn into_syntax(self) -> SyntaxNode {
@@ -5025,6 +5146,7 @@ impl AstNode for AnyVueDirective {
             Self::VueDirective(it) => it.into_syntax(),
             Self::VueVBindShorthandDirective(it) => it.into_syntax(),
             Self::VueVOnShorthandDirective(it) => it.into_syntax(),
+            Self::VueVSlotShorthandDirective(it) => it.into_syntax(),
         }
     }
 }
@@ -5035,6 +5157,7 @@ impl std::fmt::Debug for AnyVueDirective {
             Self::VueDirective(it) => std::fmt::Debug::fmt(it, f),
             Self::VueVBindShorthandDirective(it) => std::fmt::Debug::fmt(it, f),
             Self::VueVOnShorthandDirective(it) => std::fmt::Debug::fmt(it, f),
+            Self::VueVSlotShorthandDirective(it) => std::fmt::Debug::fmt(it, f),
         }
     }
 }
@@ -5045,6 +5168,7 @@ impl From<AnyVueDirective> for SyntaxNode {
             AnyVueDirective::VueDirective(it) => it.into_syntax(),
             AnyVueDirective::VueVBindShorthandDirective(it) => it.into_syntax(),
             AnyVueDirective::VueVOnShorthandDirective(it) => it.into_syntax(),
+            AnyVueDirective::VueVSlotShorthandDirective(it) => it.into_syntax(),
         }
     }
 }
@@ -5371,6 +5495,11 @@ impl std::fmt::Display for VueVBindShorthandDirective {
     }
 }
 impl std::fmt::Display for VueVOnShorthandDirective {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for VueVSlotShorthandDirective {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/biome_html_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_html_syntax/src/generated/nodes_mut.rs
@@ -827,3 +827,29 @@ impl VueVOnShorthandDirective {
         ))
     }
 }
+impl VueVSlotShorthandDirective {
+    pub fn with_hash_token(self, element: SyntaxToken) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(0usize..=0usize, once(Some(element.into()))),
+        )
+    }
+    pub fn with_arg(self, element: AnyVueDirectiveArgument) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
+        )
+    }
+    pub fn with_modifiers(self, element: VueModifierList) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),
+        )
+    }
+    pub fn with_initializer(self, element: Option<HtmlAttributeInitializerClause>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            3usize..=3usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
+    }
+}

--- a/xtask/codegen/html.ungram
+++ b/xtask/codegen/html.ungram
@@ -329,6 +329,7 @@ AnyVueDirective =
 	VueDirective
 	| VueVBindShorthandDirective
 	| VueVOnShorthandDirective
+	| VueVSlotShorthandDirective
 	| VueBogusDirective
 
 // <div v-bind:href="url" />
@@ -356,6 +357,14 @@ VueVBindShorthandDirective =
 //      ^^^^^^^^^^^^^^^^
 VueVOnShorthandDirective =
 	'@'
+	arg: AnyVueDirectiveArgument
+	modifiers: VueModifierList
+	initializer: HtmlAttributeInitializerClause?
+
+// <template #foo>
+//           ^^^^
+VueVSlotShorthandDirective =
+	'#'
 	arg: AnyVueDirectiveArgument
 	modifiers: VueModifierList
 	initializer: HtmlAttributeInitializerClause?

--- a/xtask/codegen/src/html_kinds_src.rs
+++ b/xtask/codegen/src/html_kinds_src.rs
@@ -25,6 +25,7 @@ pub const HTML_KINDS_SRC: KindsSrc = KindsSrc {
         (".", "DOT"),
         ("[", "L_BRACKET"),
         ("]", "R_BRACKET"),
+        ("#", "HASH"),
     ],
     keywords: &[
         "null", "true", "false", "doctype", "html", "debug", "key", "render", "const", "attach",
@@ -87,6 +88,7 @@ pub const HTML_KINDS_SRC: KindsSrc = KindsSrc {
         "VUE_DIRECTIVE_ARGUMENT",
         "VUE_V_BIND_SHORTHAND_DIRECTIVE",
         "VUE_V_ON_SHORTHAND_DIRECTIVE",
+        "VUE_V_SLOT_SHORTHAND_DIRECTIVE",
         "VUE_STATIC_ARGUMENT",
         "VUE_DYNAMIC_ARGUMENT",
         "VUE_MODIFIER_LIST",


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Lets the HTML parser handle v-slot shorthand syntax: `<template #foo>`

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #8222

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added snapshot tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
