### PR TITLE
fix(cli): revert some of PR #7531 to re-enable logging

### DIFF
--- a/.changeset/cold-webs-vanish.md
+++ b/.changeset/cold-webs-vanish.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed a bug where logs were discarded (the kind from `--log-level=info` etc.). This is a regression introduced after an internal refactor that wasn't adequately tested. 
+Fixed a bug where logs were discarded (the kind from `--log-level=info` etc.). This is a regression introduced after an internal refactor that wasn't adequately tested.

--- a/.changeset/cold-webs-vanish.md
+++ b/.changeset/cold-webs-vanish.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed all log output being discarded (the kind from `--log-level=info` etc.)
+
+This was a bug introduced in #7531.

--- a/.changeset/cold-webs-vanish.md
+++ b/.changeset/cold-webs-vanish.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed all log output being discarded (the kind from `--log-level=info` etc.)
-
-This was a bug introduced in #7531.
+Fixed a bug where logs were discarded (the kind from `--log-level=info` etc.). This is a regression introduced after an internal refactor that wasn't adequately tested. 


### PR DESCRIPTION
PR #7531 completely disabled logging because you can't just `impl Layer` without forwarding any of the 600 million methods.

## Summary

The motivation for making this change is that I wanted to see the logs

## Test Plan

None

## Docs

The logs are already documented to be working. They just weren't working