### PR TITLE
fix: resolve plugin paths relative to config file when using extends

### DIFF
--- a/.changeset/quiet-worms-sip.md
+++ b/.changeset/quiet-worms-sip.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8360](https://github.com/biomejs/biome/issues/8360): GritQL plugins defined in child configurations with `extends: "//"` now work correctly.

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/plugins_in_child_config_with_extends_root.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/plugins_in_child_config_with_extends_root.snap
@@ -1,0 +1,88 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 432
+expression: redactor(content)
+---
+## `packages/mobile/biome.json`
+
+```json
+{
+  "extends": "//",
+  "plugins": ["./biome-plugins/no-object-assign.grit"],
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}
+```
+
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "enabled": true
+  }
+}
+```
+
+## `packages/mobile/biome-plugins/no-object-assign.grit`
+
+```grit
+`$fn($args)` where {
+    $fn <: `Object.assign`,
+    register_diagnostic(
+        span = $fn,
+        message = "Prefer object spread instead of Object.assign()",
+        severity = "warn"
+    )
+}
+```
+
+## `packages/mobile/src/file.js`
+
+```js
+const merged = Object.assign({}, a, b);
+
+```
+
+# Emitted Messages
+
+```block
+packages/mobile/src/file.js:1:16 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Prefer object spread instead of Object.assign()
+  
+  > 1 │ const merged = Object.assign({}, a, b);
+      │                ^^^^^^^^^^^^^
+    2 │ 
+  
+
+```
+
+```block
+packages/mobile/src/file.js:1:7 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable merged is unused.
+  
+  > 1 │ const merged = Object.assign({}, a, b);
+      │       ^^^^^^
+    2 │ 
+  
+  i Unused variables are often the result of an incomplete refactoring, typos, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend merged with an underscore.
+  
+    1   │ - const·merged·=·Object.assign({},·a,·b);
+      1 │ + const·_merged·=·Object.assign({},·a,·b);
+    2 2 │   
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 2 warnings.
+```

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1006,7 +1006,6 @@ impl Workspace for WorkspaceServer {
         let mut diagnostics: Vec<biome_diagnostics::serde::Diagnostic> = vec![];
         let workspace_directory = workspace_directory.map(|p| p.to_path_buf());
         let is_root = configuration.is_root();
-        let extends_root = configuration.extends_root();
         let mut settings = if !is_root {
             if !self.projects.is_project_registered(project_key) {
                 return Err(WorkspaceError::no_project());
@@ -1034,14 +1033,8 @@ impl Workspace for WorkspaceServer {
                 .collect(),
         )?;
 
-        let loading_directory = if extends_root {
-            self.projects.get_project_path(project_key)
-        } else {
-            workspace_directory.clone()
-        };
-
         let plugin_diagnostics = self.load_plugins(
-            &loading_directory.clone().unwrap_or_default(),
+            &workspace_directory.clone().unwrap_or_default(),
             &settings.as_all_plugins(),
         );
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #8360

When using `extends: "//"` to extend from a parent `biome.json`, GritQL plugins defined in the child configuration didn't execute against files in that package.

## Test Plan

- Added regression test `plugins_in_child_config_with_extends_root`
- All 68 biome_service tests pass
- All 14 monorepo tests pass
- All 2 plugin-related CLI tests pass

## AI Disclosure

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

This PR was written with assistance from Claude (Cursor).