### PR TITLE
ci: attest build provenance for CLI binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   actions: write
+  attestations: write
   contents: write
+  id-token: write
   pull-requests: write
 
 env:
@@ -176,6 +178,11 @@ jobs:
           mkdir dist
           cp target/${{ matrix.target }}/release/biome ./dist/biome-${{ matrix.code-target }}
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: ./dist/biome-*
+
       # Upload the CLI binary as a build artifact
       - name: Upload CLI artifact
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -228,6 +235,11 @@ jobs:
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome ./dist/biome-${{ matrix.code-target }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: ./dist/biome-*
 
       # Upload the CLI binary as a build artifact
       - name: Upload CLI artifact

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -64,6 +64,10 @@ jobs:
 
     name: Package ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
 
     needs: check
     if: needs.check.outputs.version_changed == 'true' || needs.check.outputs.nightly == 'true'
@@ -117,6 +121,11 @@ jobs:
           mkdir dist
           cp target/${{ matrix.target }}/release/biome ./dist/biome-${{ matrix.code-target }}
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: ./dist/biome-*
+
       # Upload the CLI binary as a build artifact
       - name: Upload CLI artifact
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -139,6 +148,10 @@ jobs:
 
     name: Package ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
 
     needs: check
     if: needs.check.outputs.version_changed == 'true' || needs.check.outputs.nightly == 'true'
@@ -171,6 +184,11 @@ jobs:
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome ./dist/biome-${{ matrix.code-target }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: ./dist/biome-*
 
       # Upload the CLI binary as a build artifact
       - name: Upload CLI artifact


### PR DESCRIPTION
## Summary

Generates a build provenance for CLI binaries in a release, using the [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) action. Users now can verify the binaries using gh CLI to ensure they're really built on GitHub Actions. It's similar to npm's provenance feature, but for CLI binaries.

ref: https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations

## Test Plan

Fingers crossed on the next release

## Docs

N/A
