### PR TITLE
test: fix recent failures on `next`

### DIFF
--- a/crates/biome_cli/tests/cases/handle_vue_files.rs
+++ b/crates/biome_cli/tests/cases/handle_vue_files.rs
@@ -581,7 +581,7 @@ fn full_support_enabled_and_scss_is_skipped() {
     let astro_file_path = Utf8Path::new("file.vue");
     fs.insert(
         astro_file_path.into(),
-        r#"<html><head><title>Svelte</title></head><body></body></html>
+        r#"<html lang="en"><head><title>Vue</title></head><body></body></html>
 
 <style lang="scss">
 #id { font-family: comic-sans } .class { background: red}

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/full_support_enabled_and_scss_is_skipped.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/full_support_enabled_and_scss_is_skipped.snap
@@ -17,9 +17,9 @@ expression: redactor(content)
 ## `file.vue`
 
 ```vue
-<html>
+<html lang="en">
 	<head>
-		<title>Svelte</title>
+		<title>Vue</title>
 	</head>
 	<body></body>
 </html>

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownUnit/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownUnit/valid.css.snap
@@ -84,4 +84,4 @@ a: { --test: attr(data-test type(<color>)); }
 
 ```
 
-_Note: The parser emitted 4 diagnostics which are not shown here._
+_Note: The parser emitted 9 diagnostics which are not shown here._

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/jsxFactoryPreact.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/jsxFactoryPreact.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 151
 expression: jsxFactoryPreact.js
 ---
 # Input
@@ -17,3 +16,5 @@ function App() {
 
 
 ```
+
+_Note: The parser emitted 5 diagnostics which are not shown here._


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This repairs CI health on `next`, and unblocks PRs currently pointing to `next`.

Not entirely sure how it slipped through, but it did somehow. This one test was assuming no diagnostics, and a recent lint rule ported to HTML caused it to start emitting diagnostics. I feel like that _should_ have been caught in that PR, but maybe there's something i'm missing because im tired.

Edit: turns out it was that _and_ other things too, probably related to merging `main` into `next`

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
CI should become green.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
