### PR TITLE
fix(lint): `lint/suspicous/noRedeclare` should not report redeclarations for `infer` type in conditional types

### DIFF
--- a/.changeset/breezy-groups-hope.md
+++ b/.changeset/breezy-groups-hope.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7809](https://github.com/biomejs/biome/issues/7809): [`noRedeclare`](https://biomejs.dev/linter/rules/no-redeclare/) no longer reports redeclarations for `infer` type in conditional types.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
@@ -171,11 +171,14 @@ fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<
                 //   A parameter can override a previous parameter.
                 // - when both are type parameter in different declarations.
                 //   A type parameter can be redeclared if they are in different declarations.
+                // - when both are infer types.
+                //   An infer type can be redeclared in the same conditional type.
                 if !(first_decl.is_mergeable(&decl)
                     || first_decl.is_parameter_like() && decl.is_parameter_like()
                     || first_decl.is_type_parameter()
                         && decl.is_type_parameter()
-                        && first_decl.syntax().parent() != decl.syntax().parent())
+                        && first_decl.syntax().parent() != decl.syntax().parent()
+                    || first_decl.is_infer_type() && decl.is_infer_type())
                 {
                     redeclarations.push(Redeclaration {
                         name: name.text().into(),

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-conditional-type.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-conditional-type.ts
@@ -1,3 +1,9 @@
 /* should not generate diagnostics */
 // Issue https://github.com/biomejs/biome/issues/2659
 type Test<T> = T extends Array<infer U> ? true : false
+
+type TestMultipleInfer<T extends readonly string[]> = T[number] extends
+  | `-${infer Base}`
+  | infer Base
+  ? Base
+  : never

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-conditional-type.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/valid-conditional-type.ts.snap
@@ -7,4 +7,11 @@ expression: valid-conditional-type.ts
 /* should not generate diagnostics */
 // Issue https://github.com/biomejs/biome/issues/2659
 type Test<T> = T extends Array<infer U> ? true : false
+
+type TestMultipleInfer<T extends readonly string[]> = T[number] extends
+  | `-${infer Base}`
+  | infer Base
+  ? Base
+  : never
+
 ```

--- a/crates/biome_js_syntax/src/binding_ext.rs
+++ b/crates/biome_js_syntax/src/binding_ext.rs
@@ -199,6 +199,11 @@ impl AnyJsBindingDeclaration {
         matches!(self, Self::TsTypeParameter(_))
     }
 
+    /// Returns `true` if `self` is an infer type.
+    pub const fn is_infer_type(&self) -> bool {
+        matches!(self, Self::TsInferType(_))
+    }
+
     /// Returns the export statement if this declaration is directly exported.
     pub fn export(&self) -> Option<JsExport> {
         let maybe_export = match self {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
- Fixes #7809 

Currently, `lint/suspicous/noRedeclare` wrongly reports redeclarations for `infer` type in conditional types. So, I added checking if the declaration is `infer` type or not, and fixed not to report multiple usage of them.

This is my first contribution to this project. Please let me know if there's anything I should do.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
I added a new test to `valid-conditional-type.ts` that demonstarates multiple `infer` declarations in conditional types.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
