### PR TITLE
docs: document Markdown aside syntax for rule documentation

### DIFF
--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -1355,47 +1355,17 @@ The documentation needs to adhere to the following rules:
 
 - **Callout blocks (Asides)**
 
-  You can use Markdown asides (also known as "admonitions" or "callouts") to highlight important notes, warnings, or tips in your rule documentation.
+  You can use [Starlight asides](https://starlight.astro.build/guides/authoring-content/#asides) (also known as "admonitions" or "callouts") to highlight important notes, warnings, or tips in your rule documentation.
 
-  The following types of asides are supported:
-
-  - `:::note` - General information or supplementary details
-  - `:::tip` - Helpful suggestions or best practices
-  - `:::caution` - Important warnings about potential issues or limitations
-  - `:::danger` - Critical warnings about dangerous behavior
-
-  Example usage from the `useNodejsImportProtocol` rule:
+  Example usage:
 
   ````rust
-  /// The rule also isn't triggered if there are dependencies declared in the `package.json` that match
-  /// the name of a built-in Node.js module.
-  ///
   /// :::caution
   /// The rule doesn't support dependencies installed inside a monorepo.
   /// :::
-  ///
-  /// ## Examples
   ````
 
-  Example usage from the `noImportCycles` rule:
-
-  ````rust
-  /// :::note
-  /// This rule is computationally expensive. If you are particularly
-  /// pressed for lint time, or don't think you have an issue with dependency
-  /// cycles, you may not want this rule enabled.
-  /// :::
-  ````
-
-  You can also include a custom title for the aside:
-
-  ````rust
-  /// :::caution[Custom Title]
-  /// Your content here.
-  /// :::
-  ````
-
-  Unlike code blocks, asides are regular Markdown content and don't require any special properties or validation.
+  Supported types: `:::note`, `:::tip`, `:::caution`, `:::danger`.
 
 - **Ordering of code block properties**
 

--- a/xtask/codegen/src/generate_new_analyzer_rule.rs
+++ b/xtask/codegen/src/generate_new_analyzer_rule.rs
@@ -94,13 +94,9 @@ use biome_rule_options::{rule_name_snake_case}::{rule_name_upper_camel}Options;
     ///
     /// Try to stay consistent with the descriptions of implemented rules.
     ///
-    /// You can use Markdown asides to highlight important information:
+    /// You can use asides to highlight important information:
     /// :::note
-    /// Useful information that users should know, even when skimming content.
-    /// :::
-    ///
-    /// :::caution
-    /// Urgent info that needs immediate user attention to avoid problems.
+    /// Important information for users.
     /// :::
     ///
     /// ## Examples
@@ -178,13 +174,9 @@ use biome_rule_options::{rule_name_snake_case}::{rule_name_upper_camel}Options;
     ///
     /// Add a link to the corresponding stylelint rule (if any):
     ///
-    /// You can use Markdown asides to highlight important information:
+    /// You can use asides to highlight important information:
     /// :::note
-    /// Useful information that users should know, even when skimming content.
-    /// :::
-    ///
-    /// :::caution
-    /// Urgent info that needs immediate user attention to avoid problems.
+    /// Important information for users.
     /// :::
     ///
     /// ## Examples
@@ -265,13 +257,9 @@ use biome_rule_options::{rule_name_snake_case}::{rule_name_upper_camel}Options;
     ///
     /// Try to stay consistent with the descriptions of implemented rules.
     ///
-    /// You can use Markdown asides to highlight important information:
+    /// You can use asides to highlight important information:
     /// :::note
-    /// Useful information that users should know, even when skimming content.
-    /// :::
-    ///
-    /// :::caution
-    /// Urgent info that needs immediate user attention to avoid problems.
+    /// Important information for users.
     /// :::
     ///
     /// ## Examples
@@ -352,13 +340,9 @@ use biome_rule_options::{rule_name_snake_case}::{rule_name_upper_camel}Options;
     ///
     /// Try to stay consistent with the descriptions of implemented rules.
     ///
-    /// You can use Markdown asides to highlight important information:
+    /// You can use asides to highlight important information:
     /// :::note
-    /// Useful information that users should know, even when skimming content.
-    /// :::
-    ///
-    /// :::caution
-    /// Urgent info that needs immediate user attention to avoid problems.
+    /// Important information for users.
     /// :::
     ///
     /// ## Examples
@@ -436,13 +420,9 @@ use biome_rule_options::{rule_name_snake_case}::{rule_name_upper_camel}Options;
     ///
     /// Try to stay consistent with the descriptions of implemented rules.
     ///
-    /// You can use Markdown asides to highlight important information:
+    /// You can use asides to highlight important information:
     /// :::note
-    /// Useful information that users should know, even when skimming content.
-    /// :::
-    ///
-    /// :::caution
-    /// Urgent info that needs immediate user attention to avoid problems.
+    /// Important information for users.
     /// :::
     ///
     /// ## Examples
@@ -520,13 +500,9 @@ use biome_rule_options::{rule_name_snake_case}::{rule_name_upper_camel}Options;
     ///
     /// Try to stay consistent with the descriptions of implemented rules.
     ///
-    /// You can use Markdown asides to highlight important information:
+    /// You can use asides to highlight important information:
     /// :::note
-    /// Useful information that users should know, even when skimming content.
-    /// :::
-    ///
-    /// :::caution
-    /// Urgent info that needs immediate user attention to avoid problems.
+    /// Important information for users.
     /// :::
     ///
     /// ## Examples


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

**AI Assistance Disclosure**: This PR was developed with assistance from Claude (Cursor AI). The implementation approach and content were collaboratively developed through discussion.

## Summary

This PR adds documentation for Markdown aside syntax (also known as "admonitions" or "callouts") to help rule authors highlight important notes, warnings, or tips in their documentation.

While the `:::note`, `:::caution`, etc. syntax is already supported and used in several existing rules (e.g., `useNodejsImportProtocol`, `noImportCycles`), it was not documented in the CONTRIBUTING guide.

**Changes:**
- Added "Callout blocks (Asides)" section to `crates/biome_analyze/CONTRIBUTING.md` with examples
- Updated all rule templates in `xtask/codegen/src/generate_new_analyzer_rule.rs` to include aside syntax examples

Fixes #8402

## Test Plan

- ✅ Verified no linter errors with `just l`
- ✅ Confirmed formatting with `just f`
- ✅ Checked that existing documentation builds correctly
- ✅ Reviewed existing rules that already use this syntax (`useNodejsImportProtocol`, `noImportCycles`, `useSortedClasses`) to ensure documentation matches actual usage

## Docs

Documentation changes are included in this PR as part of the CONTRIBUTING guide updates. No website documentation PR is needed since this is internal contributor documentation.