### PR TITLE
fix(linter): prevent useConsistentCurlyBraces from suggesting invalid JSX text conversion

### DIFF
--- a/.changeset/fix-curly-braces-opening-brace.md
+++ b/.changeset/fix-curly-braces-opening-brace.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8011](https://github.com/biomejs/biome/issues/8011): [`useConsistentCurlyBraces`](https://biomejs.dev/linter/rules/use-consistent-curly-braces/) no longer suggests removing curly braces from JSX expression children containing characters that would cause parsing issues or semantic changes when converted to plain JSX text (`{`, `}`, `<`, `>`, `&`).

--- a/crates/biome_js_analyze/src/lint/style/use_consistent_curly_braces.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_curly_braces.rs
@@ -410,7 +410,17 @@ fn contains_only_spaces(literal: &JsStringLiteralExpression) -> bool {
         .is_ok_and(|text| text.bytes().all(|b| b == b' '))
 }
 
-const FORBIDDEN_CHARS: [char; 4] = ['>', '"', '\'', '}'];
+/// Characters that would cause parsing issues or semantic changes if a JSX expression
+/// child is converted to plain JSX text. When a string literal contains any of these,
+/// we must NOT suggest removing the curly braces.
+///
+/// - `{` `}` - would be parsed as expression delimiters
+/// - `<` `>` - would be parsed as tag delimiters
+/// - `&` - would be parsed as HTML entity start
+/// - `"` `'` - included for consistency, though mainly relevant in attribute contexts
+///
+/// See: https://github.com/biomejs/biome/issues/8011
+const FORBIDDEN_CHARS: [char; 7] = ['{', '}', '<', '>', '&', '"', '\''];
 
 fn contains_forbidden_chars(str_literal: &JsStringLiteralExpression) -> bool {
     str_literal.inner_string_text().is_ok_and(|text| {

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx
@@ -28,6 +28,22 @@ let baz = 4;
 
 <Foo>{'Invalid closing tag }'}</Foo>
 
+<Foo>Invalid opening tag {'{'}</Foo>
+
+<Foo>{'Invalid opening tag {'}</Foo>
+
+<Foo>{'start {{'}</Foo>
+
+<Foo>{'}} end'}</Foo>
+
+<Foo>{'<script>'}</Foo>
+
+<Foo>{'a < b'}</Foo>
+
+<Foo>{'&amp;'}</Foo>
+
+<Foo>{'Tom & Jerry'}</Foo>
+
 <Foo>Jupiter {">"} Venus</Foo>
 
 <Foo>Jupiter {'>'} Venus</Foo>

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx.snap
@@ -34,6 +34,22 @@ let baz = 4;
 
 <Foo>{'Invalid closing tag }'}</Foo>
 
+<Foo>Invalid opening tag {'{'}</Foo>
+
+<Foo>{'Invalid opening tag {'}</Foo>
+
+<Foo>{'start {{'}</Foo>
+
+<Foo>{'}} end'}</Foo>
+
+<Foo>{'<script>'}</Foo>
+
+<Foo>{'a < b'}</Foo>
+
+<Foo>{'&amp;'}</Foo>
+
+<Foo>{'Tom & Jerry'}</Foo>
+
 <Foo>Jupiter {">"} Venus</Foo>
 
 <Foo>Jupiter {'>'} Venus</Foo>


### PR DESCRIPTION
## Summary

This PR fixes #8011 where `useConsistentCurlyBraces` would suggest removing curly braces from JSX expression children containing characters that would cause parsing issues or semantic changes when converted to plain JSX text.

## Changes

Added forbidden characters check to `FORBIDDEN_CHARS` in `use_consistent_curly_braces.rs` with detailed doc comments explaining the rationale.

**Characters that cause issues when converted from JSX expression to plain JSX text:**
- `{` `}` - would be parsed as expression delimiters
- `<` `>` - would be parsed as tag delimiters  
- `&` - would be parsed as HTML entity start
- `"` `'` - included for consistency

**Scope**: This guard applies only to JSX children (not attributes), because attribute strings have different parsing rules where these characters are safe.

Before this fix:
```jsx
// Input
<Foo>{"start {{"}</Foo>
<Foo>{"<script>"}</Foo>
<Foo>{"Tom & Jerry"}</Foo>

// After unsafe fix (invalid/different JSX!)
<Foo>start {{</Foo>      // syntax error - { starts expression
<Foo><script></Foo>      // becomes an actual script tag!
<Foo>Tom & Jerry</Foo>   // & might be interpreted as entity start
```

After this fix, the rule correctly leaves these strings alone.

## Test Plan

- Added test cases for `{`, `<`, `&` in `valid.jsx`
- Ran `cargo test -p biome_js_analyze use_consistent_curly_braces` - all tests pass

## AI Assistance Disclosure

This PR was written with assistance from Claude Code.