### PR TITLE
fix(linter): prevent useConsistentArrowReturn from producing ASI-affected code

### DIFF
--- a/.changeset/fix-use-consistent-arrow-return-asi.md
+++ b/.changeset/fix-use-consistent-arrow-return-asi.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8179](https://github.com/biomejs/biome/issues/8179): [`useConsistentArrowReturn`](https://biomejs.dev/linter/rules/use-consistent-arrow-return/) autofix no longer produces semantically incorrect code when adding braces to arrow functions with multiline expressions. Previously, the fix could place a newline between `return` and the expression, triggering JavaScript's automatic semicolon insertion (ASI) and causing the function to return `undefined` instead of the intended value.

--- a/crates/biome_js_analyze/src/lint/nursery/use_consistent_arrow_return.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_consistent_arrow_return.rs
@@ -179,6 +179,11 @@ impl Rule for UseConsistentArrowReturn {
                     expr.clone()
                 };
 
+                // Remove leading trivia (newlines/whitespace) from the expression to prevent
+                // ASI issues where `return\n expr` would return undefined instead of expr.
+                // See: https://github.com/biomejs/biome/issues/8179
+                let expr_to_return = expr_to_return.trim_leading_trivia()?;
+
                 let return_statement =
                     make::js_return_statement(make::token(T![return]).with_trailing_trivia([(
                         biome_js_syntax::TriviaPieceKind::Whitespace,

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentArrowReturn/always.invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentArrowReturn/always.invalid.js
@@ -2,3 +2,12 @@ const returnsSequenceArrow = () => (a, b)
 
 const returnsAwaitArrow = async () => await fetchData()
 
+// Issue #8179: multiline expressions should not cause ASI issues
+const getSchemaRowTypes = (l) =>
+  l
+    .split("\n")
+
+const multilineChain = () =>
+  foo
+    .bar()
+    .baz()

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentArrowReturn/always.invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentArrowReturn/always.invalid.js.snap
@@ -8,6 +8,15 @@ const returnsSequenceArrow = () => (a, b)
 
 const returnsAwaitArrow = async () => await fetchData()
 
+// Issue #8179: multiline expressions should not cause ASI issues
+const getSchemaRowTypes = (l) =>
+  l
+    .split("\n")
+
+const multilineChain = () =>
+  foo
+    .bar()
+    .baz()
 
 ```
 
@@ -24,12 +33,12 @@ always.invalid.js:1:30 lint/nursery/useConsistentArrowReturn  FIXABLE  ━━━
   
   i Safe fix: Add braces to the arrow function body.
   
-    1   │ - const·returnsSequenceArrow·=·()·=>·(a,·b)
-      1 │ + const·returnsSequenceArrow·=·()·=>·{
-      2 │ + → return·a,·b;
-      3 │ + }
-    2 4 │   
-    3 5 │   const returnsAwaitArrow = async () => await fetchData()
+     1    │ - const·returnsSequenceArrow·=·()·=>·(a,·b)
+        1 │ + const·returnsSequenceArrow·=·()·=>·{
+        2 │ + → return·a,·b;
+        3 │ + }
+     2  4 │   
+     3  5 │   const returnsAwaitArrow = async () => await fetchData()
   
 
 ```
@@ -44,17 +53,79 @@ always.invalid.js:3:27 lint/nursery/useConsistentArrowReturn  FIXABLE  ━━━
   > 3 │ const returnsAwaitArrow = async () => await fetchData()
       │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ 
+    5 │ // Issue #8179: multiline expressions should not cause ASI issues
   
   i Safe fix: Add braces to the arrow function body.
   
-    1 1 │   const returnsSequenceArrow = () => (a, b)
-    2 2 │   
-    3   │ - const·returnsAwaitArrow·=·async·()·=>·await·fetchData()
-      3 │ + const·returnsAwaitArrow·=·async·()·=>·{
-      4 │ + → return·await·fetchData();
-      5 │ + }
-    4 6 │   
-    5 7 │   
+     1  1 │   const returnsSequenceArrow = () => (a, b)
+     2  2 │   
+     3    │ - const·returnsAwaitArrow·=·async·()·=>·await·fetchData()
+        3 │ + const·returnsAwaitArrow·=·async·()·=>·{
+        4 │ + → return·await·fetchData();
+        5 │ + }
+     4  6 │   
+     5  7 │   // Issue #8179: multiline expressions should not cause ASI issues
+  
+
+```
+
+```
+always.invalid.js:6:27 lint/nursery/useConsistentArrowReturn  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This arrow function body should be a block statement.
+  
+     5 │ // Issue #8179: multiline expressions should not cause ASI issues
+   > 6 │ const getSchemaRowTypes = (l) =>
+       │                           ^^^^^^
+   > 7 │   l
+   > 8 │     .split("\n")
+       │     ^^^^^^^^^^^^
+     9 │ 
+    10 │ const multilineChain = () =>
+  
+  i Safe fix: Add braces to the arrow function body.
+  
+     5  5 │   // Issue #8179: multiline expressions should not cause ASI issues
+     6  6 │   const getSchemaRowTypes = (l) =>
+     7    │ - ··l
+     8    │ - ····.split("\n")
+        7 │ + ··{
+        8 │ + → return·l
+        9 │ + ····.split("\n");
+       10 │ + }
+     9 11 │   
+    10 12 │   const multilineChain = () =>
+  
+
+```
+
+```
+always.invalid.js:10:24 lint/nursery/useConsistentArrowReturn  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This arrow function body should be a block statement.
+  
+     8 │     .split("\n")
+     9 │ 
+  > 10 │ const multilineChain = () =>
+       │                        ^^^^^
+  > 11 │   foo
+  > 12 │     .bar()
+  > 13 │     .baz()
+       │     ^^^^^^
+    14 │ 
+  
+  i Safe fix: Add braces to the arrow function body.
+  
+     9  9 │   
+    10 10 │   const multilineChain = () =>
+    11    │ - ··foo
+       11 │ + ··{
+       12 │ + → return·foo
+    12 13 │       .bar()
+    13    │ - ····.baz()
+       14 │ + ····.baz();
+       15 │ + }
+    14 16 │   
   
 
 ```


### PR DESCRIPTION
# Summary

Fixed [#8179](https://github.com/biomejs/biome/issues/8179): `useConsistentArrowReturn` autofix no longer produces semantically incorrect code when adding braces to arrow functions with multiline expressions.

## Problem

When running `biome lint --fix` with `useConsistentArrowReturn` configured with `style: "always"`, the autofix could produce code that silently changes runtime behavior:

**Input:**
```typescript
const foo = (l: string) =>
  l
    .split('\n')
```

**Before (incorrect autofix):**
```typescript
const foo = (l: string) =>
  {
  return
  l
    .split("\n");
}
```

The function now returns `undefined` instead of the split array because JavaScript's automatic semicolon insertion (ASI) inserts a semicolon after `return` when followed by a newline.

## Solution

Strip leading trivia (newlines/whitespace) from the expression before inserting it after the `return` keyword, ensuring `return` and the expression stay on the same line.

**After (correct autofix):**
```typescript
const foo = (l: string) =>
  {
  return l
    .split("\n");
}
```

## Changes

- `use_consistent_arrow_return.rs`: Added `trim_leading_trivia()` call on the expression
- Added test cases for multiline expressions

## AI Assistance Disclosure

This PR was written with assistance from Claude Code.