### PR TITLE
fix(linter): allow `() => undefined` in noUselessUndefined

### DIFF
--- a/.changeset/fix-no-useless-undefined-arrow-function.md
+++ b/.changeset/fix-no-useless-undefined-arrow-function.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6577](https://github.com/biomejs/biome/issues/6577): [`noUselessUndefined`](https://biomejs.dev/linter/rules/no-useless-undefined/) no longer reports `() => undefined` in arrow function expression bodies. Previously, the rule would flag this pattern and suggest replacing it with `() => {}`, which conflicts with the `noEmptyBlockStatements` rule.

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefined/invalid.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefined/invalid.json
@@ -6,7 +6,6 @@
 
 	"function foo() {return undefined;}",
 
-	"const foo = () => undefined;",
 	"const foo = () => {return undefined;};",
 
 	"function foo() {return undefined;}",

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefined/invalid.json.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefined/invalid.json.snap
@@ -119,30 +119,6 @@ invalid.json:1:24 lint/nursery/noUselessUndefined  FIXABLE  ━━━━━━�
 
 # Input
 ```cjs
-const foo = () => undefined;
-```
-
-# Diagnostics
-```
-invalid.json:1:19 lint/nursery/noUselessUndefined  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Don't use unnecessary undefined.
-  
-  > 1 │ const foo = () => undefined;
-      │                   ^^^^^^^^^
-  
-  i undefined is the default value for new variables, parameters, return statements, etc… so specifying it doesn't make any difference.
-  
-  i Safe fix: Remove the undefined.
-  
-  - const·foo·=·()·=>·undefined;
-  + const·foo·=·()·=>·{};
-  
-
-```
-
-# Input
-```cjs
 const foo = () => {return undefined;};
 ```
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefined/valid.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefined/valid.json
@@ -1,6 +1,7 @@
 [
 	"function foo() {return;}",
 	"const foo = () => {};",
+	"const foo = () => undefined;",
 	"let foo;",
 	"var foo;",
 	"const foo = undefined;",

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefined/valid.json.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessUndefined/valid.json.snap
@@ -14,6 +14,11 @@ const foo = () => {};
 
 # Input
 ```cjs
+const foo = () => undefined;
+```
+
+# Input
+```cjs
 let foo;
 ```
 


### PR DESCRIPTION
## Summary

Fixes #6577

This PR allows arrow function expressions with `undefined` body (`() => undefined`) in the `noUselessUndefined` rule.

### Problem

Previously, `() => undefined` was flagged as a useless undefined, and the autofix suggested replacing it with `() => {}`. However, this empty block would then trigger the `noEmptyBlockStatements` rule, creating a conflict between two rules.

### Solution

Per the discussion in the issue, the consensus (from @Conaclos) was to make an exception for `() => undefined` since there's no good alternative:

> I think we could make an exception for `() => undefined`. In other cases of the rules the action can simply remove `undefined`, while here it is not the case, we have to turn it into `{}`. And to avoid triggering `noEmptyBlock` this should even be `{ return; }`, `{ ; }`, or `{ /* undefined value */ }` that look hacky.

### Changes

- Removed `JsArrowFunctionExpression` handling from the rule
- `() => undefined` is no longer flagged
- `() => { return undefined; }` is still flagged (via `JsReturnStatement` handling)
- Updated tests and documentation

### Test Plan

- Moved `"const foo = () => undefined;"` from invalid.json to valid.json
- All existing tests pass

---

This PR was authored with the assistance of Claude Code.