### PR TITLE
fix(noUnknownMediaFeatureName): fix typo in prefers-reduced-transparency

### DIFF
--- a/.changeset/fix-prefers-reduced-transparency-typo.md
+++ b/.changeset/fix-prefers-reduced-transparency-typo.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fix [`noUnknownMediaFeatureName`](https://biomejs.dev/linter/rules/no-unknown-media-feature-name/) false positive for `prefers-reduced-transparency` media feature. The feature name was misspelled as `prefers-reduded-transparency` in the keywords list.

--- a/crates/biome_css_analyze/src/keywords.rs
+++ b/crates/biome_css_analyze/src/keywords.rs
@@ -5150,7 +5150,7 @@ pub const MEDIA_FEATURE_NAMES: [&str; 60] = [
     "prefers-contrast",
     "prefers-reduced-data",
     "prefers-reduced-motion",
-    "prefers-reduded-transparency",
+    "prefers-reduced-transparency",
     "resolution",
     "scan",
     "screen-spanning",

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownMediaFeatureName/valid.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownMediaFeatureName/valid.css
@@ -19,3 +19,6 @@
 
 @media (400px <= width <= 700px) {
 }
+
+@media (prefers-reduced-transparency: reduce) {
+}

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownMediaFeatureName/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownMediaFeatureName/valid.css.snap
@@ -26,4 +26,7 @@ expression: valid.css
 @media (400px <= width <= 700px) {
 }
 
+@media (prefers-reduced-transparency: reduce) {
+}
+
 ```


### PR DESCRIPTION
## Summary

Fix typo in `MEDIA_FEATURE_NAMES` array: `prefers-reduded-transparency` → `prefers-reduced-transparency`.

This fixes the false positive reported in #8029 where `@media (prefers-reduced-transparency: reduce)` was incorrectly flagged as an unknown media feature.

## Test plan

- Added test case for `prefers-reduced-transparency` in valid.css
- Verified no diagnostic is produced for the valid media query

Closes #8029