### PR TITLE
fix(cli): skip deleted files in --changed and --staged

### DIFF
--- a/.changeset/fix-changed-deleted-file.md
+++ b/.changeset/fix-changed-deleted-file.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fix `--changed` and `--staged` flags throwing "No such file or directory" error when a file has been deleted or renamed in the working directory. The CLI now filters out files that no longer exist before processing.

--- a/crates/biome_cli/src/changed.rs
+++ b/crates/biome_cli/src/changed.rs
@@ -1,6 +1,7 @@
 use crate::CliDiagnostic;
 use biome_configuration::Configuration;
 use biome_fs::FileSystem;
+use camino::Utf8Path;
 use std::ffi::OsString;
 
 pub(crate) fn get_changed_files(
@@ -26,7 +27,12 @@ pub(crate) fn get_changed_files(
 
     let changed_files = fs.get_changed_files(base)?;
 
-    let filtered_changed_files = changed_files.iter().map(OsString::from).collect::<Vec<_>>();
+    // Filter out files that no longer exist (e.g., deleted or renamed in the working directory)
+    let filtered_changed_files = changed_files
+        .iter()
+        .filter(|file| fs.path_is_file(Utf8Path::new(file)))
+        .map(OsString::from)
+        .collect::<Vec<_>>();
 
     Ok(filtered_changed_files)
 }
@@ -34,7 +40,12 @@ pub(crate) fn get_changed_files(
 pub(crate) fn get_staged_files(fs: &dyn FileSystem) -> Result<Vec<OsString>, CliDiagnostic> {
     let staged_files = fs.get_staged_files()?;
 
-    let filtered_staged_files = staged_files.iter().map(OsString::from).collect::<Vec<_>>();
+    // Filter out files that no longer exist (e.g., deleted or renamed in the working directory)
+    let filtered_staged_files = staged_files
+        .iter()
+        .filter(|file| fs.path_is_file(Utf8Path::new(file)))
+        .map(OsString::from)
+        .collect::<Vec<_>>();
 
     Ok(filtered_staged_files)
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_skip_nonexistent_changed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_skip_nonexistent_changed_files.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `exists.js`
+
+```js
+console.log('exists');
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_skip_nonexistent_staged_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_skip_nonexistent_staged_files.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `exists.js`
+
+```js
+console.log('exists');
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```


### PR DESCRIPTION
## Summary

Fix `--changed` and `--staged` flags throwing "No such file or directory" error when a file has been deleted or renamed in the working directory but the change hasn't been committed yet.

The issue occurs because:
1. `git diff --name-only base...HEAD` returns files that exist in HEAD
2. If a file is deleted/renamed in the working directory (uncommitted), it no longer exists on disk
3. The CLI tries to read the non-existent file and throws an error

## Solution

Filter out files that no longer exist in the working directory before processing them. This is done in `get_changed_files` and `get_staged_files` functions using `fs.path_exists()`.

## Test plan

Manual testing:
1. `git checkout main`
2. `echo "const a=1" > test.ts`
3. `git add test.ts && git commit -m "add test.ts"`
4. `git checkout -b test`
5. `echo "const a=2" > test.ts`
6. `git add test.ts && git commit -m "modify test.ts"`
7. `mv test.ts test2.ts`
8. `biome check --changed` - should no longer throw error

Closes #4952