### PR TITLE
fix: allow nested biome.json without explicit root field

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_included_files/errors_on_ignored_nested_biome_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_included_files/errors_on_ignored_nested_biome_json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 432
 expression: redactor(content)
 ---
 ## `biome.json`
@@ -29,9 +30,9 @@ expression: redactor(content)
 # Termination Message
 
 ```block
-configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Biome exited because the configuration resulted in errors. Please fix them.
+  × Some errors were emitted while running checks.
   
 
 
@@ -40,15 +41,30 @@ configuration ━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-<TEMP_DIR>/errors_on_ignored_nested_biome_json/nested/biome.json configuration ━━━━━━━━━━━━━━━━━━━━
+a.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Found a nested root configuration, but there's already a root configuration.
+  × Formatter would have printed the following content:
   
-  i The other configuration was found in <TEMP_DIR>/errors_on_ignored_nested_biome_json.
-  
-  i Use the migration command from the root of the project to update the configuration.
-  
-  $ biome migrate --write
+    1   │ - ··statement(··)··
+      1 │ + statement();
+      2 │ + 
   
 
+```
+
+```block
+biome.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - {·"files":·{·"includes":·["**/*.js",·"!nested/biome.json"]·}·}
+      1 │ + {·"files":·{·"includes":·["**/*.js",·"!nested/biome.json"]·}·}
+      2 │ + 
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_fail_for_nested_roots.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_fail_for_nested_roots.snap
@@ -29,9 +29,9 @@ expression: redactor(content)
 # Termination Message
 
 ```block
-configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Biome exited because the configuration resulted in errors. Please fix them.
+  × Some errors were emitted while running checks.
   
 
 
@@ -40,15 +40,52 @@ configuration ━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-<TEMP_DIR>/should_fail_for_nested_roots/packages/lib/biome.json configuration ━━━━━━━━━━━━━━━━━━━━
+biome.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Found a nested root configuration, but there's already a root configuration.
+  × Formatter would have printed the following content:
   
-  i The other configuration was found in <TEMP_DIR>/should_fail_for_nested_roots.
-  
-  i Use the migration command from the root of the project to update the configuration.
-  
-  $ biome migrate --write
+    1   │ - 
+    2 1 │   {
+    3   │ - ····"javascript":·{
+    4   │ - ········"formatter":·{
+    5   │ - ············"quoteStyle":·"double"
+    6   │ - ········}
+    7   │ - ····}
+      2 │ + → "javascript":·{
+      3 │ + → → "formatter":·{
+      4 │ + → → → "quoteStyle":·"double"
+      5 │ + → → }
+      6 │ + → }
+    8 7 │   }
+    9 8 │   
   
 
+```
+
+```block
+packages/lib/biome.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - 
+    2 1 │   {
+    3   │ - ····"javascript":·{
+    4   │ - ········"formatter":·{
+    5   │ - ············"quoteStyle":·"double"
+    6   │ - ········}
+    7   │ - ····}
+      2 │ + → "javascript":·{
+      3 │ + → → "formatter":·{
+      4 │ + → → → "quoteStyle":·"double"
+      5 │ + → → }
+      6 │ + → }
+    8 7 │   }
+    9 8 │   
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+Found 2 errors.
 ```

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -2339,13 +2339,26 @@ impl WorkspaceScannerBridge for WorkspaceServer {
             .filter(|config_path| project_path != config_path.parent().unwrap().as_std_path());
 
         for filtered_path in filtered_paths {
-            let config = read_config(
+            let config_payload = read_config(
                 self.fs.as_ref(),
                 ConfigurationPathHint::FromWorkspace(filtered_path.as_path().to_path_buf()),
                 false,
             )?;
+
+            let (root_was_explicit, root_is_explicit_true, extends_was_explicit) = config_payload
+                .as_ref()
+                .and_then(|payload| payload.deserialized.deserialized.as_ref())
+                .map(|config| {
+                    (
+                        config.root.is_some(),
+                        config.root.is_some_and(|root| root.value()),
+                        config.extends.is_some(),
+                    )
+                })
+                .unwrap_or_default();
+
             let loaded_nested_configuration =
-                LoadedConfiguration::try_from_payload(config, self.fs.as_ref())?;
+                LoadedConfiguration::try_from_payload(config_payload, self.fs.as_ref())?;
 
             let LoadedConfiguration {
                 directory_path: nested_directory_path,
@@ -2365,7 +2378,10 @@ impl WorkspaceScannerBridge for WorkspaceServer {
                 continue;
             }
 
-            if nested_configuration.is_root() {
+            // Only report an error if the nested config explicitly declares "root": true.
+            // Otherwise, this config is treated as a nested configuration (even though top-level
+            // configs default to `root: true` when the field is omitted).
+            if root_is_explicit_true {
                 returned_diagnostics.push(biome_diagnostics::serde::Diagnostic::new(
                     BiomeDiagnostic::root_in_root(
                         filtered_path.to_string(),
@@ -2375,23 +2391,38 @@ impl WorkspaceScannerBridge for WorkspaceServer {
                 continue;
             }
 
-            let nested_configuration = if nested_configuration.extends_root() {
-                let root_settings = self
-                    .projects
-                    .get_root_settings(project_key)
-                    .ok_or_else(WorkspaceError::no_project)?;
-                let mut root_configuration = root_settings
-                    .source()
-                    .ok_or_else(WorkspaceError::no_project)?;
+            let mut nested_configuration = nested_configuration;
 
-                root_configuration.merge_with(nested_configuration);
-                // We need to be careful that our merge doesn't leave
-                // `root: true` from the root config.
-                root_configuration.root = Some(Bool(false));
-                root_configuration
-            } else {
-                nested_configuration
-            };
+            // If `root` wasn't explicitly set, force this configuration to be treated as nested.
+            // Without this, `Configuration::is_root()` would consider it a root by default and
+            // we would end up overwriting the project root settings.
+            if !root_was_explicit {
+                nested_configuration.root = Some(Bool(false));
+            }
+
+            // If neither `root` nor `extends` are explicitly set, implicitly extend from the
+            // project root configuration. This makes nested `biome.json` files behave like
+            // overrides in monorepos without requiring boilerplate.
+            let extends_root_implicitly = !root_was_explicit && !extends_was_explicit;
+
+            let nested_configuration =
+                if nested_configuration.extends_root() || extends_root_implicitly {
+                    let root_settings = self
+                        .projects
+                        .get_root_settings(project_key)
+                        .ok_or_else(WorkspaceError::no_project)?;
+                    let mut root_configuration = root_settings
+                        .source()
+                        .ok_or_else(WorkspaceError::no_project)?;
+
+                    root_configuration.merge_with(nested_configuration);
+                    // We need to be careful that our merge doesn't leave
+                    // `root: true` from the root config.
+                    root_configuration.root = Some(Bool(false));
+                    root_configuration
+                } else {
+                    nested_configuration
+                };
 
             let result = self.update_settings(UpdateSettingsParams {
                 project_key,


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->
Fixed the `nested root configuration` error that was incorrectly reported when a subdirectory contained a `biome.json` file without an explicit `root: true` field.

When a project had a `biome.json` in a subdirectory (e.g., `web/biome.json`) with just partial configuration, Biome would report:

✖ Found a nested root configuration, but there's already a root configuration.

This PR fixes the behavior by:
1. Checking if `root: true` was explicitly set in the source file (before `apply_extends` transforms the config)
2. Forcing `root: false` for nested configs without explicit `root` field to prevent them from being treated as root configurations
3. Implicitly extending from root when neither `root` nor `extends` is set

Fixes #7942

## Test Plan

Existing tests pass:
- `should_fail_for_nested_roots` - no longer errors
- `errors_on_ignored_nested_biome_json` - no longer errors