### PR TITLE
fix(plugins): normalize relative plugin paths during config loading

### DIFF
--- a/.changeset/cruel-clouds-crash.md
+++ b/.changeset/cruel-clouds-crash.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8488](https://github.com/biomejs/biome/issues/8488): Relative plugin paths are now resolved from the configuration file directory, including when configurations are merged (e.g. `extends: "//"`).

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/plugins_from_root_config_work_in_child_config_extends_root.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/plugins_from_root_config_work_in_child_config_extends_root.snap
@@ -1,0 +1,92 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 432
+expression: redactor(content)
+---
+## `packages/mobile/biome.json`
+
+```json
+{
+  "extends": "//",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}
+```
+
+## `biome.json`
+
+```json
+{
+  "root": true,
+  "plugins": ["./biome/no-object-assign.grit"],
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}
+```
+
+## `biome/no-object-assign.grit`
+
+```grit
+`$fn($args)` where {
+    $fn <: `Object.assign`,
+    register_diagnostic(
+        span = $fn,
+        message = "Prefer object spread instead of Object.assign()",
+        severity = "warn"
+    )
+}
+```
+
+## `packages/mobile/src/file.js`
+
+```js
+const merged = Object.assign({}, a, b);
+
+```
+
+# Emitted Messages
+
+```block
+packages/mobile/src/file.js:1:16 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Prefer object spread instead of Object.assign()
+  
+  > 1 │ const merged = Object.assign({}, a, b);
+      │                ^^^^^^^^^^^^^
+    2 │ 
+  
+
+```
+
+```block
+packages/mobile/src/file.js:1:7 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable merged is unused.
+  
+  > 1 │ const merged = Object.assign({}, a, b);
+      │       ^^^^^^
+    2 │ 
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend merged with an underscore.
+  
+    1   │ - const·merged·=·Object.assign({},·a,·b);
+      1 │ + const·_merged·=·Object.assign({},·a,·b);
+    2 2 │   
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 2 warnings.
+```

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -15,7 +15,7 @@ publish              = true
 biome_analyze            = { workspace = true }
 biome_console            = { workspace = true }
 biome_css_syntax         = { workspace = true }
-biome_deserialize        = { workspace = true }
+biome_deserialize        = { workspace = true, features = ["serde"] }
 biome_deserialize_macros = { workspace = true }
 biome_diagnostics        = { workspace = true }
 biome_fs                 = { workspace = true }

--- a/crates/biome_plugin_loader/src/configuration.rs
+++ b/crates/biome_plugin_loader/src/configuration.rs
@@ -2,6 +2,8 @@ use biome_deserialize::{
     Deserializable, DeserializableType, DeserializableValue, DeserializationContext,
 };
 use biome_deserialize_macros::{Deserializable, Merge};
+use biome_fs::normalize_path;
+use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use std::{
     ops::{Deref, DerefMut},
@@ -16,6 +18,26 @@ pub struct Plugins(pub Vec<PluginConfiguration>);
 impl Plugins {
     pub fn iter(&self) -> impl Iterator<Item = &PluginConfiguration> {
         self.deref().iter()
+    }
+
+    /// Normalizes plugin paths in-place.
+    ///
+    /// For each relative path, this joins it with `base_dir` and normalizes
+    /// `.` / `..` segments (without resolving symlinks).
+    pub fn normalize_relative_paths(&mut self, base_dir: &Utf8Path) {
+        for plugin_config in self.0.iter_mut() {
+            match plugin_config {
+                PluginConfiguration::Path(plugin_path) => {
+                    let plugin_path_buf = Utf8Path::new(plugin_path.as_str());
+                    if plugin_path_buf.is_absolute() {
+                        continue;
+                    }
+
+                    let normalized = normalize_path(&base_dir.join(plugin_path_buf));
+                    *plugin_path = normalized.to_string();
+                }
+            }
+        }
     }
 }
 
@@ -67,5 +89,43 @@ impl Deserializable for PluginConfiguration {
             .map(|plugin| Self::PathWithOptions(plugin))*/
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_relative_paths_makes_paths_base_dir_relative_and_normalized() {
+        let base_dir = Utf8Path::new("base");
+        let mut plugins = Plugins(vec![
+            PluginConfiguration::Path("./biome/../biome/my-plugin.grit".into()),
+            PluginConfiguration::Path("other.grit".into()),
+        ]);
+
+        plugins.normalize_relative_paths(base_dir);
+
+        let PluginConfiguration::Path(first) = &plugins.0[0];
+        assert!(Utf8Path::new(first).starts_with(base_dir));
+        let expected_suffix = Utf8Path::new("biome").join("my-plugin.grit");
+        assert!(Utf8Path::new(first).ends_with(expected_suffix.as_path()));
+
+        let PluginConfiguration::Path(second) = &plugins.0[1];
+        assert!(Utf8Path::new(second).starts_with(base_dir));
+        assert!(Utf8Path::new(second).ends_with("other.grit"));
+    }
+
+    #[test]
+    fn normalize_relative_paths_leaves_absolute_paths_unchanged() {
+        let base_dir = Utf8Path::new("base");
+        let sep = std::path::MAIN_SEPARATOR;
+        let absolute = format!("{sep}abs{sep}my-plugin.grit");
+        let mut plugins = Plugins(vec![PluginConfiguration::Path(absolute.clone())]);
+
+        plugins.normalize_relative_paths(base_dir);
+
+        let PluginConfiguration::Path(result) = &plugins.0[0];
+        assert_eq!(result, &absolute);
     }
 }


### PR DESCRIPTION
## Summary

Fixes [#8488](https://github.com/biomejs/biome/issues/8488).

In monorepos where nested configurations use `extends: "//"`, relative plugin paths declared in the root configuration could be resolved relative to the child configuration directory, causing plugin loading to fail with "Cannot read file." This is related to the `extends: "//"` behavior discussed in [#8360](https://github.com/biomejs/biome/issues/8360).

This PR normalizes plugin paths relative to the directory of the configuration file that declares them so that merged configurations keep consistent plugin path semantics.

AI disclosure: I used AI assistance (Cursor / GPT) to explore the codebase and draft the fix and tests.

## Test Plan

- Added unit tests for plugin path normalization.
- Added a regression test covering a monorepo where root config plugins are inherited by a child config using `extends: "//"`.

Commands run:
- `cargo test -p biome_plugin_loader`
- `cargo test -p biome_cli --test main -- cases::monorepo`
- `cargo test -p biome_service`
- `cargo fmt --check`
- `cargo clippy -p biome_service -p biome_cli -p biome_plugin_loader -- -D warnings`

## Docs

No documentation changes are needed (bugfix only).
