### PR TITLE
fix(linter): `useExhaustiveDependencies` properly handles aliased destructured object keys when using `stableResult` configuration

### DIFF
--- a/.changeset/rich-parrots-learn.md
+++ b/.changeset/rich-parrots-learn.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed #8499: `useExhaustiveDependencies` properly handles aliased destructured object keys when using `stableResult` configuration.

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8499.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8499.options.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"correctness": {
+				"useExhaustiveDependencies": {
+					"level": "error",
+					"options": {
+						"hooks": [
+							{
+								"name": "useStable",
+								"stableResult": [
+									"stable"
+								]
+							}
+						]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8499.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8499.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+declare function useStable(): { stable: string };
+
+export function SuccessComp() {
+    const { stable } = useStable();
+
+    useEffect(() => {
+        console.log(stable);
+    }, []);
+
+    return null;
+}
+
+export function FailedComp() {
+    const { stable: alias } = useStable();
+
+    // This error is a false positive as the value is still stable
+    useEffect(() => {
+        console.log(alias);
+    }, []);
+
+    return null;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8499.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8499.ts.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 152
+expression: issue8499.ts
+---
+# Input
+```ts
+import { useEffect } from "react";
+
+declare function useStable(): { stable: string };
+
+export function SuccessComp() {
+    const { stable } = useStable();
+
+    useEffect(() => {
+        console.log(stable);
+    }, []);
+
+    return null;
+}
+
+export function FailedComp() {
+    const { stable: alias } = useStable();
+
+    // This error is a false positive as the value is still stable
+    useEffect(() => {
+        console.log(alias);
+    }, []);
+
+    return null;
+}
+
+```


### PR DESCRIPTION

<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #8499: `useExhaustiveDependencies` properly handles aliased destructured object keys when using `stableResult` configuration.

## Test Plan

Test is included.

<!-- What demonstrates that your implementation is correct? -->

## Docs

Changeset is included.

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
