### PR TITLE
fix(analyze/types): reduce created types when flattening a static member access on a union type

### DIFF
--- a/.changeset/union-static-member-resolution.md
+++ b/.changeset/union-static-member-resolution.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8527](https://github.com/biomejs/biome/issues/8527): Improved type inference where analyzing code with repeated object property access and assignments (e.g. `node = node.parent`, a pattern common when traversing trees in a while loop) could hit an internal type limit. Biome now handles these cases without exceeding the type limit.

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_static_member_on_union.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_static_member_on_union.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_js_type_info/tests/utils.rs
+expression: content
+---
+## Input
+
+```ts
+interface Node {
+	parentNode: Node | null;
+}
+
+declare let parentNode: Node | null;
+
+parentNode.parentNode;
+
+```
+
+## Result
+
+```
+Global TypeId(0) | Global TypeId(1) | Global TypeId(2)
+```
+
+## Registered types
+
+```
+Thin TypeId(0) => Global TypeId(3) | Global TypeId(1)
+
+Global TypeId(0) => instanceof unresolved reference "Node" (scope ID: 0)
+
+Global TypeId(1) => null
+
+Global TypeId(2) => Global TypeId(0) | Global TypeId(1)
+
+Global TypeId(3) => interface "Node" {
+  extends: []
+  type_args: []
+  members: ["parentNode": Global TypeId(2)]
+}
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The root cause was that during type flattening, when a static member was accessed on a union type eg. `node.parentNode` (see the snapshot test to get a better idea of what I'm talking about), it would continuously create new types over and over. As a result, it would hit the type limit, and emit the diagnostic.

I have no idea if this is the "correct" fix, since I'm not super familiar with this area of the codebase. I used AI quite heavily here to do the initial instrumentation, draft the fix, and write the test.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #8527

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
I created a test that showed the behavior on `main`, and then switched to this branch to make sure the snapshot output changed.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
