### PR TITLE
fix(formatter): preserve space after svelte interpolation

### DIFF
--- a/.changeset/good-fix-interpolation-spacing.md
+++ b/.changeset/good-fix-interpolation-spacing.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fix HTML formatter to preserve space after interpolation variable.

--- a/crates/biome_html_formatter/tests/specs/html/elements/inline/mixed-block-inline.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/inline/mixed-block-inline.html.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: elements/inline/mixed-block-inline.html
-snapshot_kind: text
 ---
 # Input
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-hug-content-longer-w-attr.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-hug-content-longer-w-attr.html.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: elements/inline/tags-hug-content-longer-w-attr.html
-snapshot_kind: text
 ---
 # Input
 
@@ -30,7 +29,7 @@ Self close void elements: never
 
 ```html
 <b class="really long really long really long really long really long"
-	>asdfasdf foo bar things <i>much more</i>longer things lorem ipsum or
+	>asdfasdf foo bar things <i>much more</i> longer things lorem ipsum or
 	something idk i put pineapple in strombolis</b
 >
 ```

--- a/crates/biome_html_formatter/tests/specs/html/svelte/each_with_destructuring.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/each_with_destructuring.svelte.snap
@@ -48,7 +48,7 @@ Self close void elements: never
 {/each}
 
 {#each users as { name, email }, i}
-	<div>{i}: {name}({email})</div>
+	<div>{i}: {name} ({email})</div>
 {/each}
 
 {#each products as [id, title]}

--- a/crates/biome_html_formatter/tests/specs/html/svelte/interpolation_spacing.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/interpolation_spacing.svelte
@@ -1,0 +1,2 @@
+<p>{variable} is the output</p>
+<p><span>span</span> is the output</p>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/interpolation_spacing.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/interpolation_spacing.svelte.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/interpolation_spacing.svelte
+---
+# Input
+
+```svelte
+<p>{variable} is the output</p>
+<p><span>span</span> is the output</p>
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+Self close void elements: never
+-----
+
+```svelte
+<p>{variable} is the output</p>
+<p>
+	<span>span</span> is the output
+</p>
+```

--- a/crates/biome_html_formatter/tests/specs/prettier/html/cdata/example.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/html/cdata/example.html.snap
@@ -18,11 +18,9 @@ info: html/cdata/example.html
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,7 +1,8 @@
- <span><![CDATA[<sender>John Smith</sender>]]></span>
+@@ -2,6 +2,7 @@
  
--<span><![CDATA[1]]> a <![CDATA[2]]></span>
-+<span><![CDATA[1]]>a <![CDATA[2]]></span>
+ <span><![CDATA[1]]> a <![CDATA[2]]></span>
  <span
 -  ><![CDATA[1]]> <br />
 +  ><![CDATA[1]]>
@@ -36,7 +34,7 @@ info: html/cdata/example.html
 ```html
 <span><![CDATA[<sender>John Smith</sender>]]></span>
 
-<span><![CDATA[1]]>a <![CDATA[2]]></span>
+<span><![CDATA[1]]> a <![CDATA[2]]></span>
 <span
   ><![CDATA[1]]>
   <br />

--- a/crates/biome_html_formatter/tests/specs/prettier/html/svg/svg.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/html/svg/svg.html.snap
@@ -55,6 +55,14 @@ info: html/svg/svg.html
  <html>
    <head>
      <title>SVG</title>
+@@ -19,7 +19,6 @@
+
+ <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+   <defs />
+-
+   <g>
+     <g>
+       <polygon points="5,5 195,10 185,185 10,195" />
 ```
 
 # Output
@@ -81,7 +89,6 @@ info: html/svg/svg.html
 
 <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
   <defs />
-
   <g>
     <g>
       <polygon points="5,5 195,10 185,185 10,195" />
@@ -104,5 +111,5 @@ info: html/svg/svg.html
 
 # Lines exceeding max width of 80 characters
 ```
-   33:       In the context of SVG embeded into HTML, the XHTML namespace could be avoided, but it is mandatory in the context of an SVG document
+   32:       In the context of SVG embeded into HTML, the XHTML namespace could be avoided, but it is mandatory in the context of an SVG document
 ```

--- a/crates/biome_html_formatter/tests/specs/prettier/html/tags/tags.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/html/tags/tags.html.snap
@@ -254,7 +254,7 @@ info: html/tags/tags.html
 +<br />
 +<br />
 +<p>
-+  "<span [innerHTML]="title"></span>" is the <i>property bound</i>title.
++  "<span [innerHTML]="title"></span>" is the <i>property bound</i> title.
 +</p>
  <li>
    12345678901234567890123456789012345678901234567890123456789012345678901234567890
@@ -476,7 +476,7 @@ info: html/tags/tags.html
 <br />
 <br />
 <p>
-  "<span [innerHTML]="title"></span>" is the <i>property bound</i>title.
+  "<span [innerHTML]="title"></span>" is the <i>property bound</i> title.
 </p>
 <li>
   12345678901234567890123456789012345678901234567890123456789012345678901234567890

--- a/crates/biome_html_formatter/tests/specs/prettier/html/whitespace/inline-nodes.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/html/whitespace/inline-nodes.html.snap
@@ -29,22 +29,7 @@ conubia nostra, per inceptos himenaeos. Donec in ornare velit.</p>
 ```diff
 --- Prettier
 +++ Biome
-@@ -4,10 +4,10 @@
-   urna consectetur dignissim. Sam vitae neque quis ex dapibus faucibus at sed
-   ligula. Nulla sit amet aliquet nibh. Vestibulum at congue mi. Suspendisse
-   vitae odio vitae massa hendrerit mattis sed eget dui. Sed eu scelerisque
--  neque. Donec <b>maximus</b> rhoncus pellentesque. Aenean purus turpis,
--  vehicula euismod ante vel, ultricies eleifend dui. Class aptent taciti
--  sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec
--  in ornare velit.
-+  neque. Donec <b>maximus</b>rhoncus pellentesque. Aenean purus turpis, vehicula
-+  euismod ante vel, ultricies eleifend dui. Class aptent taciti sociosqu ad
-+  litora torquent per conubia nostra, per inceptos himenaeos. Donec in ornare
-+  velit.
- </p>
- 
- <p>
-@@ -16,8 +16,10 @@
+@@ -16,8 +16,11 @@
    urna consectetur dignissim. Sam vitae neque quis ex dapibus faucibus at sed
    ligula. Nulla sit amet aliquet nibh. Vestibulum at congue mi. Suspendisse
    vitae odio vitae massa hendrerit mattis sed eget dui. Sed eu scelerisque
@@ -55,7 +40,8 @@ conubia nostra, per inceptos himenaeos. Donec in ornare velit.</p>
 +  neque. Donec
 +  <a href="#"
 +    ><b>maximus</b></a
-+  >rhoncus pellentesque. Aenean purus turpis, vehicula euismod ante vel,
++  >
++  rhoncus pellentesque. Aenean purus turpis, vehicula euismod ante vel,
 +  ultricies eleifend dui. Class aptent taciti sociosqu ad litora torquent per
 +  conubia nostra, per inceptos himenaeos. Donec in ornare velit.
  </p>
@@ -70,10 +56,10 @@ conubia nostra, per inceptos himenaeos. Donec in ornare velit.</p>
   urna consectetur dignissim. Sam vitae neque quis ex dapibus faucibus at sed
   ligula. Nulla sit amet aliquet nibh. Vestibulum at congue mi. Suspendisse
   vitae odio vitae massa hendrerit mattis sed eget dui. Sed eu scelerisque
-  neque. Donec <b>maximus</b>rhoncus pellentesque. Aenean purus turpis, vehicula
-  euismod ante vel, ultricies eleifend dui. Class aptent taciti sociosqu ad
-  litora torquent per conubia nostra, per inceptos himenaeos. Donec in ornare
-  velit.
+  neque. Donec <b>maximus</b> rhoncus pellentesque. Aenean purus turpis,
+  vehicula euismod ante vel, ultricies eleifend dui. Class aptent taciti
+  sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec
+  in ornare velit.
 </p>
 
 <p>
@@ -85,7 +71,8 @@ conubia nostra, per inceptos himenaeos. Donec in ornare velit.</p>
   neque. Donec
   <a href="#"
     ><b>maximus</b></a
-  >rhoncus pellentesque. Aenean purus turpis, vehicula euismod ante vel,
+  >
+  rhoncus pellentesque. Aenean purus turpis, vehicula euismod ante vel,
   ultricies eleifend dui. Class aptent taciti sociosqu ad litora torquent per
   conubia nostra, per inceptos himenaeos. Donec in ornare velit.
 </p>

--- a/crates/biome_html_formatter/tests/specs/prettier/vue/html-vue/elastic-header.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/vue/html-vue/elastic-header.html.snap
@@ -127,20 +127,7 @@ info: vue/html-vue/elastic-header.html
  <html lang="en">
    <head>
      <meta charset="utf-8" />
-@@ -36,8 +36,10 @@
-         <template slot="header">
-           <h1>Elastic Draggable SVG Header</h1>
-           <p>
--            with <a href="https://vuejs.org">Vue.js</a> +
--            <a href="http://dynamicsjs.com">dynamics.js</a>
-+            with <a href="https://vuejs.org">Vue.js</a>+ <a
-+              href="http://dynamicsjs.com"
-+              >dynamics.js</a
-+            >
-           </p>
-         </template>
-         <template slot="content">
-@@ -54,69 +56,65 @@
+@@ -54,69 +54,65 @@
      </div>
  
      <script>
@@ -308,10 +295,8 @@ info: vue/html-vue/elastic-header.html
         <template slot="header">
           <h1>Elastic Draggable SVG Header</h1>
           <p>
-            with <a href="https://vuejs.org">Vue.js</a>+ <a
-              href="http://dynamicsjs.com"
-              >dynamics.js</a
-            >
+            with <a href="https://vuejs.org">Vue.js</a> +
+            <a href="http://dynamicsjs.com">dynamics.js</a>
           </p>
         </template>
         <template slot="content">


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

The solution was architected by me and implemented by Google Jules (an LLM).

## Summary

This pull request makes sure Biome doesn't remove contenful spaces in HTML like those after Svelte interopelation.

Closes #8584

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

A test has been implemented for this case.

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
