### PR TITLE
fix(types): fix bounds check in `split_regex_literal`

### DIFF
--- a/.changeset/khaki-vans-learn.md
+++ b/.changeset/khaki-vans-learn.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed #8563: fixed a bounds check on bogus regex literals that caused panics when doing type inference

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -2688,7 +2688,7 @@ fn split_regex_literal(token: SyntaxResult<JsSyntaxToken>) -> Option<RegexpLiter
     let literal = token.ok()?.token_text_trimmed();
     let open_index: usize = literal.find('/')? + 1;
     let close_index: usize = literal.rfind('/')?;
-    if open_index == close_index {
+    if open_index >= close_index {
         return None;
     }
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Fixes a bounds check that was allowing invalid text ranges to be constructed.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #8563

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
No changes to snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
