### PR TITLE
refactor(analyze/json): remove dependence on biome_configuration

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -49,7 +49,9 @@ pub use crate::rule::{
     RuleDomain, RuleGroup, RuleMeta, RuleMetadata, RuleSource, RuleSourceKind, RuleSourceWithKind,
     SuppressAction,
 };
-pub use crate::services::{FromServices, ServiceBag, ServicesDiagnostic};
+pub use crate::services::{
+    ExtendedConfigurationProvider, FromServices, ServiceBag, ServicesDiagnostic,
+};
 pub use crate::signals::{
     AnalyzerAction, AnalyzerSignal, AnalyzerTransformation, DiagnosticSignal,
 };

--- a/crates/biome_analyze/src/services.rs
+++ b/crates/biome_analyze/src/services.rs
@@ -61,3 +61,13 @@ impl FromServices for () {
         Ok(())
     }
 }
+
+/// Trait for providing information about extended configurations.
+///
+/// This allows analyzers to query configuration information without depending
+/// on the full `biome_configuration` crate, breaking circular dependencies.
+pub trait ExtendedConfigurationProvider: Send + Sync + std::fmt::Debug {
+    /// Returns `true` if any extended configuration has `files.includes`
+    /// where the first pattern is the catch-all `**`.
+    fn any_extended_starts_with_catch_all(&self) -> bool;
+}

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -40,6 +40,7 @@ pub use analyzer::{
     LinterConfiguration, RuleConfiguration, RuleFixConfiguration, RulePlainConfiguration,
     RuleWithFixOptions, RuleWithOptions, Rules, linter_configuration,
 };
+use biome_analyze::ExtendedConfigurationProvider;
 use biome_console::fmt::{Display, Formatter};
 use biome_console::{KeyValuePair, markup};
 use biome_deserialize::{
@@ -811,6 +812,17 @@ impl ConfigurationSource {
         self.source.as_ref().and_then(|source| {
             let (_, path) = source.clone();
             path.map(|p| p.as_path().to_path_buf())
+        })
+    }
+}
+
+impl ExtendedConfigurationProvider for ConfigurationSource {
+    fn any_extended_starts_with_catch_all(&self) -> bool {
+        self.extended_configurations().any(|c| {
+            c.files
+                .as_ref()
+                .and_then(|files| files.includes.as_deref())
+                .is_some_and(|globs| globs.first().is_some_and(|glob| glob.as_str() == "**"))
         })
     }
 }

--- a/crates/biome_json_analyze/Cargo.toml
+++ b/crates/biome_json_analyze/Cargo.toml
@@ -18,36 +18,31 @@ harness = false
 name    = "json_analyzer"
 
 [dependencies]
-biome_analyze       = { workspace = true }
-# biome_configuration is optional because the codegen disables it. The codegen generates the configuration schema, and it depends on this crate to to that. It's kinda like a circular dependency. A chicken and egg problem, if you will.
-biome_configuration = { workspace = true, optional = true }
-biome_console       = { workspace = true }
-biome_diagnostics   = { workspace = true }
-biome_json_factory  = { workspace = true }
-biome_json_syntax   = { workspace = true }
-biome_rowan         = { workspace = true }
-biome_rule_options  = { workspace = true }
-biome_string_case   = { workspace = true }
-biome_suppression   = { workspace = true }
-camino              = { workspace = true }
-rustc-hash          = { workspace = true }
+biome_analyze      = { workspace = true }
+biome_console      = { workspace = true }
+biome_diagnostics  = { workspace = true }
+biome_json_factory = { workspace = true }
+biome_json_syntax  = { workspace = true }
+biome_rowan        = { workspace = true }
+biome_rule_options = { workspace = true }
+biome_string_case  = { workspace = true }
+biome_suppression  = { workspace = true }
+camino             = { workspace = true }
+rustc-hash         = { workspace = true }
 
 [dev-dependencies]
-biome_json_parser = { path = "../biome_json_parser" }
-biome_test_utils  = { path = "../biome_test_utils" }
-criterion         = { package = "codspeed-criterion-compat", version = "=3.0.5" }
-insta             = { workspace = true, features = ["glob"] }
-tests_macros      = { path = "../tests_macros" }
+biome_configuration = { workspace = true }
+biome_json_parser   = { path = "../biome_json_parser" }
+biome_test_utils    = { path = "../biome_test_utils" }
+criterion           = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+insta               = { workspace = true, features = ["glob"] }
+tests_macros        = { path = "../tests_macros" }
 
 [target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dev-dependencies]
 tikv-jemallocator = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 mimalloc = { workspace = true }
-
-[features]
-default       = ["configuration"]
-configuration = ["dep:biome_configuration"]
 
 [lints]
 workspace = true

--- a/crates/biome_json_analyze/benches/json_analyzer.rs
+++ b/crates/biome_json_analyze/benches/json_analyzer.rs
@@ -63,7 +63,7 @@ fn bench_analyzer(criterion: &mut Criterion) {
                         b.iter(|| {
                             let json_services = JsonAnalyzeServices {
                                 file_source,
-                                configuration_source: None,
+                                configuration_provider: None,
                             };
 
                             biome_json_analyze::analyze(

--- a/crates/biome_json_analyze/src/lint/suspicious/no_biome_first_exception.rs
+++ b/crates/biome_json_analyze/src/lint/suspicious/no_biome_first_exception.rs
@@ -86,18 +86,8 @@ impl Rule for NoBiomeFirstException {
         let root = ctx.query();
         let file_path = ctx.file_path();
 
-        // we check if and extended package starts with `**`
-        #[cfg(feature = "configuration")]
-        let extends_starts_with_catch_all = ctx.extends().is_some_and(|mut extends| {
-            extends.any(|c| {
-                c.files
-                    .as_ref()
-                    .and_then(|files| files.includes.as_deref())
-                    .is_some_and(|globs| globs.first().is_some_and(|glob| glob.as_str() == "**"))
-            })
-        });
-        #[cfg(not(feature = "configuration"))]
-        let extends_starts_with_catch_all = false;
+        // we check if an extended package starts with `**`
+        let extends_starts_with_catch_all = ctx.any_extended_starts_with_catch_all();
         // we use ends_with so it works only during testing
         if !file_path
             .file_name()

--- a/crates/biome_json_analyze/tests/spec_tests.rs
+++ b/crates/biome_json_analyze/tests/spec_tests.rs
@@ -1,7 +1,7 @@
 use biome_analyze::{AnalysisFilter, AnalyzerAction, ControlFlow, Never, RuleFilter};
 use biome_configuration::{ConfigurationSource, ExtendedConfigurations};
 use biome_diagnostics::advice::CodeSuggestionAdvice;
-use biome_json_analyze::JsonAnalyzeServices;
+use biome_json_analyze::{ExtendedConfigurationProvider, JsonAnalyzeServices};
 use biome_json_parser::{JsonParserOptions, parse_json};
 use biome_json_syntax::{JsonFileSource, JsonLanguage};
 use biome_rowan::AstNode;
@@ -168,11 +168,11 @@ pub(crate) fn analyze_and_snap(
     let options = create_analyzer_options::<JsonLanguage>(input_file, &mut diagnostics);
     let services = JsonAnalyzeServices {
         file_source,
-        configuration_source: configuration_source.map(|(config, list)| {
+        configuration_provider: configuration_source.map(|(config, list)| {
             Arc::new(ConfigurationSource {
                 source: Some((config, Some(input_file.to_path_buf()))),
                 extended_configurations: ExtendedConfigurations::from(list),
-            })
+            }) as Arc<dyn ExtendedConfigurationProvider>
         }),
     };
     let (_, errors) = biome_json_analyze::analyze(&root, filter, &options, services, |event| {

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -383,7 +383,7 @@ fn assert_lint(
                 let options = test.create_analyzer_options::<JsonLanguage>(config)?;
                 let json_services = JsonAnalyzeServices {
                     file_source,
-                    configuration_source: None,
+                    configuration_provider: None,
                 };
                 biome_json_analyze::analyze(&root, filter, &options, json_services, |signal| {
                     if let Some(mut diag) = signal.diagnostic() {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Instead of dealing with the configuration directly, we put a trait in front of it and use that as the interface to do the analysis. Technically, this could have a perf impact in the general case (because of the `dyn`), but I doubt users have enough biome config files for this to actually matter. This gets rid of the dependency cycle problem for codegen. Ideally we could do something to prevent it happening again in the future, but I'm not sure how we would go about that.

Planned and implemented by opus. 

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
https://discord.com/channels/1132231889290285117/1132602492987908166/1455632945560813732

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
ci should be green

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
