### PR TITLE
fix(css-formatter): prefer breaking declaration values at top-level commas

### DIFF
--- a/.changeset/curvy-wasps-mix.md
+++ b/.changeset/curvy-wasps-mix.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8636](https://github.com/biomejs/biome/issues/8636): Biome's CSS formatter now breaks comma-separated declaration values at top-level commas when wrapping.

--- a/crates/biome_css_formatter/tests/specs/css/issue_8636.css
+++ b/crates/biome_css_formatter/tests/specs/css/issue_8636.css
@@ -1,0 +1,8 @@
+:root {
+	--popover-shadow:
+		0px 2px 4px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06)),
+		0px 8px 16px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06));
+	--popover-shadow-inline: 0px 2px 4px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06)), 0px 8px 16px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06));
+}
+
+

--- a/crates/biome_css_formatter/tests/specs/css/issue_8636.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/issue_8636.css.snap
@@ -1,0 +1,46 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 211
+info: css/issue_8636.css
+---
+# Input
+
+```css
+:root {
+	--popover-shadow:
+		0px 2px 4px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06)),
+		0px 8px 16px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06));
+	--popover-shadow-inline: 0px 2px 4px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06)), 0px 8px 16px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06));
+}
+
+
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+-----
+
+```css
+:root {
+	--popover-shadow:
+		0px 2px 4px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06)),
+		0px 8px 16px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06));
+	--popover-shadow-inline:
+		0px 2px 4px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06)),
+		0px 8px 16px 0px var(--special-shadow-blue90-6, rgba(0, 0, 0, 0.06));
+}
+```
+
+


### PR DESCRIPTION
## Summary

Closes #8636.

Fixed wrapping of comma-separated declaration values so Biome prefers breaking at top-level commas (Prettier-like), instead of wrapping inside a comma-group.

## Repro

- [Biome Playground repro](https://biomejs.dev/playground/?code=OgByAG8AbwB0ACAAewAKAAkALQAtAHAAbwBwAG8AdgBlAHIALQBzAGgAYQBkAG8AdwA6AAoACQAJADAAcAB4ACAAMgBwAHgAIAA0AHAAeAAgADAAcAB4ACAAdgBhAHIAKAAtAC0AcwBwAGUAYwBpAGEAbAAtAHMAaABhAGQAbwB3AC0AYgBsAHUAZQA5ADAALQA2ACwAIAByAGcAYgBhACgAMAAsACAAMAAsACAAMAAsACAAMAAuADAANgApACkALAAKAAkACQAwAHAAeAAgADgAcAB4ACAAMQA2AHAAeAAgADAAcAB4ACAAdgBhAHIAKAAtAC0AcwBwAGUAYwBpAGEAbAAtAHMAaABhAGQAbwB3AC0AYgBsAHUAZQA5ADAALQA2ACwAIAByAGcAYgBhACgAMAAsACAAMAAsACAAMAAsACAAMAAuADAANgApACkAOwAKAH0A&language=css)

## What changed

- In `ValueListLayout::Fill`, declaration values with top-level commas are now formatted as “comma-groups” so wrapping prefers the comma boundary.
- Added regression coverage for `--popover-shadow` (multiline and single-line input variants).

## Tests

- `just format`
- `just lint`
- `just test`

## AI assistance disclosure

This PR was written with AI assistance (Cursor + GPT). The implementation and refactors were reviewed and adjusted manually.