### PR TITLE
fix(lint): exclude GitHub Actions expressions from noTemplateCurlyInString

### DIFF
--- a/.changeset/swift-actions-sleep.md
+++ b/.changeset/swift-actions-sleep.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+[`noTemplateCurlyInString`](https://biomejs.dev/linter/rules/no-template-curly-in-string/) no longer reports GitHub Actions expressions like `"${{ inputs.abc }}"` as errors. These use double curly braces (`${{ }}`) which are distinct from JavaScript template literal placeholders (`${}`).

--- a/crates/biome_js_analyze/tests/specs/suspicious/noTemplateCurlyInString/valid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noTemplateCurlyInString/valid.js
@@ -13,3 +13,15 @@ let a = '${';
 let a = '$}';
 let a = '{foo}';
 let a = '{foo: "bar"}';
+
+// GitHub Actions expressions (double curly braces)
+let a = "${{ inputs.abc }}";
+let a = '${{ github.event.action }}';
+let a = "environment: ${{ inputs.environment }}";
+let a = "${{ secrets.MY_SECRET }}";
+
+// GitHub Actions expressions with nested braces
+let a = "${{ fromJSON('{\"key\": \"value\"}') }}";
+let a = "${{ toJSON(github) }}";
+let a = "${{ format('{0} {1}', foo, bar) }}";
+let a = "${{ contains(github.event.head_commit.message, '[skip ci]') }}";

--- a/crates/biome_js_analyze/tests/specs/suspicious/noTemplateCurlyInString/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noTemplateCurlyInString/valid.js.snap
@@ -19,4 +19,16 @@ let a = '${';
 let a = '$}';
 let a = '{foo}';
 let a = '{foo: "bar"}';
+
+// GitHub Actions expressions (double curly braces)
+let a = "${{ inputs.abc }}";
+let a = '${{ github.event.action }}';
+let a = "environment: ${{ inputs.environment }}";
+let a = "${{ secrets.MY_SECRET }}";
+
+// GitHub Actions expressions with nested braces
+let a = "${{ fromJSON('{\"key\": \"value\"}') }}";
+let a = "${{ toJSON(github) }}";
+let a = "${{ format('{0} {1}', foo, bar) }}";
+let a = "${{ contains(github.event.head_commit.message, '[skip ci]') }}";
 ```


### PR DESCRIPTION
This is completely generated with Claude by prompting it to resolve our use case of requiring the valid case of `"${{ inputs.abc }}"`. We use https://github.com/ArmaanT/cdkactions to programatically generate our GitHub workflows and Biome warns us consistently about this.

## Summary

GitHub Actions uses `${{ ... }}` syntax (double curly braces) which was incorrectly flagged as a template literal placeholder. This fix detects and skips patterns that have double opening braces followed by double closing braces, as these are GitHub Actions expressions, not JavaScript template literal mistakes.

## Test Plan

Snapshot testing is implemented to account for the new cases.

