### PR TITLE
chore(github): update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_formatter_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_formatter_bug.yml
@@ -18,8 +18,7 @@ body:
       label: Environment information
       description: Run the command `biome rage --formatter` and paste its output here. Please review it, in case there are sensitive information you don't want to share.
       value: |
-        <details><summary>Details</summary>
-        <p>
+        <details>
         
         ```bash
 
@@ -27,7 +26,6 @@ body:
         
         ```
         
-        </p>
         </details>
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/02_lint_bug.yml
+++ b/.github/ISSUE_TEMPLATE/02_lint_bug.yml
@@ -18,8 +18,7 @@ body:
       label: Environment information
       description: Run the command `biome rage --linter` and paste its output here. Please review it, in case there are sensitive information you don't want to share.
       value: |
-        <details><summary>Details</summary>
-        <p>
+        <details>
         
         ```bash
 
@@ -27,7 +26,6 @@ body:
         
         ```
         
-        </p>
         </details>
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/03_bug.yml
+++ b/.github/ISSUE_TEMPLATE/03_bug.yml
@@ -18,8 +18,7 @@ body:
       label: Environment information
       description: Run the command `biome rage` and paste its output here. Please review it, in case there are sensitive information you don't want to share.
       value: |
-        <details><summary>Details</summary>
-        <p>
+        <details>
         
         ```bash
 
@@ -27,7 +26,6 @@ body:
         
         ```
         
-        </p>
         </details>
     validations:
       required: true


### PR DESCRIPTION
## Summary
The "environment information" sections are now wrapped in collapsible blocks so that issues are more readable/require less scrolling.

<details><summary>In issue creation</summary>
<p>

<img width="789" height="518" alt="image" src="https://github.com/user-attachments/assets/97d4aad2-9605-42d9-a246-e5b2fefca991" />

</p>
</details> 
<details><summary>Example issue without collapsible block</summary>
<p>

<img width="1282" height="1205" alt="image" src="https://github.com/user-attachments/assets/3a8ddd27-a23e-4fe3-b710-82f5a181e5b5" />
<img width="872" height="1264" alt="image" src="https://github.com/user-attachments/assets/a9e2a0cb-7e06-4771-a0ae-8ffed5a1ed7d" />
<img width="880" height="1268" alt="image" src="https://github.com/user-attachments/assets/5fc22df2-e03a-4d57-a04f-12d10bd58d37" />
<img width="883" height="1260" alt="image" src="https://github.com/user-attachments/assets/197d0ab1-6bd5-4f3e-80d9-49f943baced3" />
<img width="920" height="1268" alt="image" src="https://github.com/user-attachments/assets/d1506b80-5cdc-4f66-9252-b826c8679f0d" />

</p>
</details> 
<details><summary>Example issue with collapsible block</summary>
<p>

<img width="1253" height="1176" alt="image" src="https://github.com/user-attachments/assets/0749257f-b52a-410e-8f9e-e358287b060b" />

</p>
</details> 

The "environment information" section can be fairly massive (especially the output of `biome rage --linter`), requiring a ton of scrolling to get to the actual issue report. Using a collapsible block means it can be hidden until someone needs to view it.

## Test Plan
N/A

## Docs
N/A