### PR TITLE
fix(lint): fix useComponentExportOnlyModules false positive with TanStack Router

### DIFF
--- a/.changeset/fix-component-export-tanstack-router.md
+++ b/.changeset/fix-component-export-tanstack-router.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8628](https://github.com/biomejs/biome/issues/8628): [`useComponentExportOnlyModules`](https://biomejs.dev/linter/rules/use-component-export-only-modules/) now allows components referenced as object property values in exported expressions. This fixes false positives for TanStack Router patterns.
+
+```jsx
+export const Route = createFileRoute('/')({
+  component: HomeComponent,
+})
+
+function HomeComponent() { ... } // no longer reported as "should be exported"
+```

--- a/crates/biome_js_analyze/tests/specs/style/useComponentExportOnlyModules/valid_component_referenced_in_export.jsx
+++ b/crates/biome_js_analyze/tests/specs/style/useComponentExportOnlyModules/valid_component_referenced_in_export.jsx
@@ -1,0 +1,12 @@
+/* should not generate diagnostics */
+
+// TanStack Router pattern - component referenced in exported object
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/')({
+  component: HomeComponent,
+})
+
+function HomeComponent() {
+  return <div>Home</div>
+}

--- a/crates/biome_js_analyze/tests/specs/style/useComponentExportOnlyModules/valid_component_referenced_in_export.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useComponentExportOnlyModules/valid_component_referenced_in_export.jsx.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid_component_referenced_in_export.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+
+// TanStack Router pattern - component referenced in exported object
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/')({
+  component: HomeComponent,
+})
+
+function HomeComponent() {
+  return <div>Home</div>
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useComponentExportOnlyModules/valid_component_shorthand_in_export.jsx
+++ b/crates/biome_js_analyze/tests/specs/style/useComponentExportOnlyModules/valid_component_shorthand_in_export.jsx
@@ -1,0 +1,10 @@
+/* should not generate diagnostics */
+
+// Shorthand property pattern - component referenced via shorthand syntax
+export const config = {
+  HomeComponent,
+}
+
+function HomeComponent() {
+  return <div>Home</div>
+}

--- a/crates/biome_js_analyze/tests/specs/style/useComponentExportOnlyModules/valid_component_shorthand_in_export.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useComponentExportOnlyModules/valid_component_shorthand_in_export.jsx.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid_component_shorthand_in_export.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+
+// Shorthand property pattern - component referenced via shorthand syntax
+export const config = {
+  HomeComponent,
+}
+
+function HomeComponent() {
+  return <div>Home</div>
+}
+
+```


### PR DESCRIPTION
## Summary

Fixes #8628

Components referenced as object property values in exported expressions are now exempt from the "should be exported" diagnostic.

This handles patterns like TanStack Router where components are passed via configuration objects:

```jsx
export const Route = createFileRoute('/')({
  component: HomeComponent,  // HomeComponent is referenced here
})

function HomeComponent() { ... }  // no longer reported as "should be exported"
```

The fix only exempts components referenced in object literals (like `{ component: X }`), not direct function call arguments (like `hoge(X)`), because the latter might be non-standard HOCs that could break Fast Refresh.

## Test plan

- Added test case for TanStack Router pattern
- Added test case for shorthand property syntax (`{ HomeComponent }`)
- Verified existing tests still pass

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.