### PR TITLE
docs: fix 'instaiated' typo in no-invalid-builtin-instantiation

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_builtin_instantiation.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_builtin_instantiation.rs
@@ -42,7 +42,7 @@ declare_lint_rule! {
     /// - WeakRef
     /// - WeakSet
     ///
-    /// Conversely, the following builtins cannot be instaiated with `new`:
+    /// Conversely, the following builtins cannot be instantiated with `new`:
     ///
     /// - BigInt
     /// - Symbol


### PR DESCRIPTION
## Summary

Quick fix for I typo on https://biomejs.dev/linter/rules/no-invalid-builtin-instantiation.

## Docs

> Conversely, the following builtins cannot be **instaiated** with `new`:

