### PR TITLE
fix(lint): avoid false positive for JSX in non-rendered arrays

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -128,6 +128,11 @@ fn handle_collections(
     options: &UseJsxKeyInIterableOptions,
 ) -> Vec<TextRange> {
     let is_inside_jsx = node.parent::<JsxExpressionChild>().is_some();
+    // Only check for keys when the array is inside JSX context (used for rendering)
+    // Arrays outside JSX context (e.g., const arr = [<Hello />]) don't need keys
+    if !is_inside_jsx {
+        return vec![];
+    }
     node.elements()
         .iter()
         .filter_map(|node| {

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx
@@ -1,11 +1,5 @@
 import React from "react";
 
-[<Hello />, <Hello />, <Hello />];
-
-[...[<Hello />, <Hello />], <Hello />];
-
-[<Hello />, xyz ? <Hello />: <Hello />, <Hello />];
-
 data.map(x => <Hello>{x}</Hello>);
 
 data.map(x => <>{x}</>);
@@ -18,11 +12,12 @@ Array.from([1, 2, 3], (x) => {
 	return <Hello>{x}</Hello>
 });
 
-[React.createElement("h1"), React.createElement("h1"), React.createElement("h1")];
-
 data.map(c => React.createElement("h1"));
 
 React.Children.map(c => React.cloneElement(c));
+
+// Standalone arrays (not inside JSX) should not trigger the rule
+// These cases are now handled in valid.jsx
 
 (<h1>{data.map(x => <h1>{x}</h1>)}</h1>)
 

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
@@ -108,6 +108,25 @@ const Valid = [<>
 	<p>Test 3</p>
 </>]
 
+// Arrays outside JSX context should not require keys
+const components = [<Hello />, <Hello />, <Hello />];
+
+const routes = [<Route path="/" />, <Route path="/about" />];
+
+export const menuItems = [<MenuItem />, <MenuItem />];
+
+let items = [<Item />];
+
+var config = [<ConfigItem />, <ConfigItem />];
+
+// Standalone array literals (not inside JSX) should not require keys
+[<Hello />, <Hello />, <Hello />];
+
+[...[<Hello />, <Hello />], <Hello />];
+
+[<Hello />, xyz ? <Hello />: <Hello />, <Hello />];
+
+[React.createElement("h1"), React.createElement("h1"), React.createElement("h1")];
 
 // should not generate diagnostics
 import { component$ } from "@builder.io/qwik";


### PR DESCRIPTION
# Fix useJsxKeyInIterable False Positives for Non-Rendered Arrays

## Problem

The `useJsxKeyInIterable` rule currently fires for JSX elements inside array literals even when those arrays are NOT used for rendering. For example:

```jsx
// Currently triggers the rule (false positive)
const components = [<Hello />, <Hello />];
const routes = [<Route path="/" />, <Route path="/about" />];
```
These arrays are just storing JSX elements, not rendering them directly, so keys are not required.
## Root Cause

In [`use_jsx_key_in_iterable.rs`](crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs), the `handle_collections` function checks if an array is inside JSX (`is_inside_jsx`), but the `handle_potential_react_component` function reports JSX elements regardless of this flag for arrays.

```353:367:crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
if is_inside_jsx {
    // Reports when inside JSX (correct)
} else {
    // Also reports when NOT inside JSX (bug)
}
```

## Solution

Modify `handle_collections` to only report diagnostics when the array is inside a JSX context (`is_inside_jsx = true`). Arrays outside JSX context should not trigger the rule since they are not being rendered.