### PR TITLE
fix(useJsxKeyInIterable): ignore rule in Map constructor

### DIFF
--- a/.changeset/modern-crews-stick.md
+++ b/.changeset/modern-crews-stick.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Updated the useJsxKeyInIterable rule to not run inside Map constructors

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx
@@ -124,3 +124,7 @@ export default component$(() => {
     </div>
   );
 });
+
+new Map([
+    ["None", [<TriangleDownIcon sx={{ fontSize: "1.25rem", color: "error.main" }} />]],
+]);

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/invalid.jsx.snap
@@ -131,6 +131,10 @@ export default component$(() => {
   );
 });
 
+new Map([
+    ["None", [<TriangleDownIcon sx={{ fontSize: "1.25rem", color: "error.main" }} />]],
+]);
+
 ```
 
 _Note: The parser emitted 1 diagnostics which are not shown here._
@@ -1017,6 +1021,24 @@ invalid.jsx:123:29 lint/correctness/useJsxKeyInIterable ━━━━━━━━
         │                             ^^^
     124 │     </div>
     125 │   );
+  
+  i The order of the items may change, and having a key can help React identify which item was moved.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:129:15 lint/correctness/useJsxKeyInIterable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Missing key property for this element in iterable.
+  
+    128 │ new Map([
+  > 129 │     ["None", [<TriangleDownIcon sx={{ fontSize: "1.25rem", color: "error.main" }} />]],
+        │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    130 │ ]);
+    131 │ 
   
   i The order of the items may change, and having a key can help React identify which item was moved.
   

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx
@@ -150,3 +150,7 @@ export default component$(() => {
     </div>
   );
 });
+
+new Map([
+    ["None", <TriangleDownIcon sx={{ fontSize: "1.25rem", color: "error.main" }} />],
+]);

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.jsx.snap
@@ -156,6 +156,11 @@ export default component$(() => {
     </div>
   );
 });
+
+new Map([
+    ["None", <TriangleDownIcon sx={{ fontSize: "1.25rem", color: "error.main" }} />],
+]);
+
 ```
 
 _Note: The parser emitted 11 diagnostics which are not shown here._


### PR DESCRIPTION
## Summary
- Fixes #8572 
- Ignores the `useJsxKeyInIterable` rule for Map constructor

## Test Plan
- Adds snapshot tests for the rule