### PR TITLE
feat(css): support :active-view-transition pseudo-class

### DIFF
--- a/crates/biome_css_analyze/src/keywords.rs
+++ b/crates/biome_css_analyze/src/keywords.rs
@@ -927,8 +927,9 @@ pub const RESOURCE_STATE_PSEUDO_CLASSES: [&str; 7] = [
     "volume-locked",
 ];
 
-pub const OTHER_PSEUDO_CLASSES: [&str; 51] = [
+pub const OTHER_PSEUDO_CLASSES: [&str; 52] = [
     "active",
+    "active-view-transition",
     "any-link",
     "autofill",
     "blank",

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoClass/valid.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoClass/valid.css
@@ -39,3 +39,5 @@ a:defined { }
 ::-webkit-scrollbar-button:hover {}
 dialog:open {}
 custom-selector:state(checked) {}
+:active-view-transition {}
+:root:active-view-transition {}


### PR DESCRIPTION
## Summary

Adds support for the `:active-view-transition` pseudo-class in the CSS linter. This pseudo-class was being incorrectly flagged by `noUnknownPseudoClass`.

## Changes

- Added `active-view-transition` to `OTHER_PSEUDO_CLASSES` array in `keywords.rs`
- Added test cases to `valid.css`

## Reference

- MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/:active-view-transition
- CSS View Transitions Level 1 spec

Fixes #8777