### PR TITLE
fix(justfile): remove errant `run` argument from test commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -202,11 +202,11 @@ _touch file:
 
 # Run tests of all crates
 test:
-	cargo test run --no-fail-fast
+	cargo test --no-fail-fast
 
 # Run tests for the crate passed as argument e.g. just test-create biome_cli
 test-crate name:
-	cargo test run -p {{name}} --no-fail-fast
+	cargo test -p {{name}} --no-fail-fast
 
 # Run doc tests
 test-doc:


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

In commit ef5fd3aa91, the test runner was switched from cargo nextest run to cargo test, but the word run was accidentally left in the command:

Before: `cargo nextest run --no-fail-fast` (correct for nextest)
After: `cargo test run --no-fail-fast` (incorrect)
With cargo test run, the word run is interpreted as a test name filter, causing cargo to only run tests containing "run" in their name. This filters out the vast majority of tests.

```bash
# Example of the bug:
  running 0 tests
  test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out
```

```bash
# After this fix:
  running 733 tests
  test result: ok. 730 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Ran `just test` before and after the fix to confirm tests now execute properly rather than being filtered out.

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A - internal tooling fix.

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
