### PR TITLE
docs(organizeImports): fix note about import merging

### DIFF
--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -512,28 +512,25 @@ declare_source_rule! {
     /// ```ts,ignore
     /// import type { T1 } from "package";
     /// import type { T2 } from "package";
-    /// import { type T3, V1 } from "package";
     /// import * as ns from "package";
     /// import D1 from "package";
     /// import D2 from "package";
     /// import { A } from "package";
     /// import { B } from "package";
+    /// import { type T3 } from "package";
     /// ```
     ///
     /// is merged as follows:
     ///
     /// ```ts,ignore
     /// import type { T1, T2 } from "package";
-    /// import { type T3, V1 } from "package";
     /// import D1, * as ns from "package";
-    /// import D2, { A, B } from "package";
+    /// import D2, { A, B, type T3 } from "package";
     /// ```
     ///
-    /// You may want to merge the first two imports.
-    /// To allow this, you have to enable the linter rule [`useImportType`](https://biomejs.dev/linter/rules/use-import-type/)
+    /// You may want to merge the first and the last imports.
+    /// To do this, you have to enable the linter rule [`useImportType`](https://biomejs.dev/linter/rules/use-import-type/)
     /// and to set its option `style` to `inlineType`.
-    /// Also you may want to [make the code fix of the rule safe](https://biomejs.dev/linter/#configure-the-code-fix) to automatically
-    /// apply it when you run `biome check --write` or [apply safe fixes on save in your editor](https://biomejs.dev/reference/vscode/#code-fixing).
     ///
     /// With the following configuration...
     ///
@@ -544,7 +541,7 @@ declare_source_rule! {
     ///     "rules": {
     ///       "style": {
     ///         "useImportType": {
-    ///           "fix": "safe",
+    ///           "level": "on",
     ///           "options": { "style": "inlineType" }
     ///         }
     ///       }
@@ -560,9 +557,8 @@ declare_source_rule! {
     /// The previous imports are merged as follows:
     ///
     /// ```ts,ignore
-    /// import { type T1, type T2, type T3, V1 } from "package";
     /// import D1, * as ns from "package";
-    /// import D2, { A, B } from "package";
+    /// import D2, { A, B, type T1, type T2, type T3 } from "package";
     /// ```
     ///
     /// Note that if you set `style` to `separatedType` you will get the following merge:


### PR DESCRIPTION
## Summary

Follow-up of #8811

I made some errors:
- The code fix of `useImportType` is not unsafe
- I missed the last mixed import that changes how imports are merged
- I forgot to set `level` on the linter rule

## Test Plan

I [tested it on the playground](https://biomejs.dev/playground/?files.main.tsx=aQBtAHAAbwByAHQAIAB0AHkAcABlACAAewAgAFQAMQAgAH0AIABmAHIAbwBtACAAIgBwAGEAYwBrAGEAZwBlACIAOwAKAGkAbQBwAG8AcgB0ACAAdAB5AHAAZQAgAHsAIABUADIAIAB9ACAAZgByAG8AbQAgACIAcABhAGMAawBhAGcAZQAiADsACgBpAG0AcABvAHIAdAAgACoAIABhAHMAIABuAHMAIABmAHIAbwBtACAAIgBwAGEAYwBrAGEAZwBlACIAOwAKAGkAbQBwAG8AcgB0ACAARAAxACAAZgByAG8AbQAgACIAcABhAGMAawBhAGcAZQAiADsACgBpAG0AcABvAHIAdAAgAEQAMgAgAGYAcgBvAG0AIAAiAHAAYQBjAGsAYQBnAGUAIgA7AAoAaQBtAHAAbwByAHQAIAB7ACAAQQAgAH0AIABmAHIAbwBtACAAIgBwAGEAYwBrAGEAZwBlACIAOwAKAGkAbQBwAG8AcgB0ACAAewAgAEIAIAB9ACAAZgByAG8AbQAgACIAcABhAGMAawBhAGcAZQAiADsACgBpAG0AcABvAHIAdAAgAHsAIAB0AHkAcABlACAAVAAzACAAfQAgAGYAcgBvAG0AIAAiAHAAYQBjAGsAYQBnAGUAIgA7AA%3D%3D&files.biome.json=ewAKACAAIAAgACIAbABpAG4AdABlAHIAIgA6ACAAewAKACAAIAAgACAAIAAiAGUAbgBhAGIAbABlAGQAIgA6ACAAdAByAHUAZQAsAAoAIAAgACAAIAAgACIAcgB1AGwAZQBzACIAOgAgAHsACgAgACAAIAAgACAAIAAgACIAcwB0AHkAbABlACIAOgAgAHsACgAgACAAIAAgACAAIAAgACAAIAAiAHUAcwBlAEkAbQBwAG8AcgB0AFQAeQBwAGUAIgA6ACAAewAKACAAIAAgACAAIAAgACAAIAAgACAAIAAiAGwAZQB2AGUAbAAiADoAIAAiAG8AbgAiACwACgAgACAAIAAgACAAIAAgACAAIAAgACAAIgBvAHAAdABpAG8AbgBzACIAOgAgAHsAIAAiAHMAdAB5AGwAZQAiADoAIAAiAGkAbgBsAGkAbgBlAFQAeQBwAGUAIgAgAH0ACgAgACAAIAAgACAAIAAgACAAIAB9AAoAIAAgACAAIAAgACAAIAB9AAoAIAAgACAAIAAgAH0ACgAgACAAIAB9ACwACgAgACAAIAAiAGEAcwBzAGkAcwB0ACIAOgAgAHsACgAgACAAIAAgACAAIgBlAG4AYQBiAGwAZQBkACIAOgAgAHQAcgB1AGUALAAKACAAIAAgACAAIAAiAGEAYwB0AGkAbwBuAHMAIgA6ACAAewAgACIAcwBvAHUAcgBjAGUAIgA6ACAAewAgACIAbwByAGcAYQBuAGkAegBlAEkAbQBwAG8AcgB0AHMAIgA6ACAAIgBvAG4AIgAgAH0AIAB9AAoAIAAgACAAfQAKAH0A).

## Docs

No changelog needed.
