### PR TITLE
fix(useVueValidVOn): align more with source rule, also use phf hash sets for perf

### DIFF
--- a/.changeset/evil-walls-talk.md
+++ b/.changeset/evil-walls-talk.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved [`useVueValidVOn`](https://biomejs.dev/linter/rules/use-vue-valid-v-on/) to be more closely aligned with the source rule. It will now properly allow modifiers for all possible keyboard events. It should have better performance when there are no violations of the rule as well.
+
+Now treated valid:
+```vue
+<div @keydown.arrow-down="handler"></div>
+<div @keydown.a="handler"></div>
+<div @keydown.b="handler"></div>
+<div @keydown.27="foo"></div>
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "biome_test_utils",
  "camino",
  "insta",
+ "phf",
  "schemars",
  "serde",
  "tests_macros",
@@ -4037,6 +4038,7 @@ checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ libc                         = "0.2.180"
 mimalloc                     = "0.1.48"
 papaya                       = "0.2.3"
 path-absolutize              = { version = "3.1.1", features = ["use_unix_paths_on_wasm"], optional = false }
+phf                          = { version = "0.13.1", features = ["macros"] }
 proc-macro-error2            = { version = "2.0.1", default-features = false }
 proc-macro2                  = "1.0.105"
 quickcheck                   = "1.0.3"

--- a/crates/biome_html_analyze/Cargo.toml
+++ b/crates/biome_html_analyze/Cargo.toml
@@ -22,6 +22,7 @@ biome_rowan              = { workspace = true }
 biome_rule_options       = { workspace = true }
 biome_string_case        = { workspace = true }
 biome_suppression        = { workspace = true }
+phf                      = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"] }
 

--- a/crates/biome_html_analyze/src/lint/nursery/use_vue_valid_v_on.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_vue_valid_v_on.rs
@@ -5,7 +5,7 @@ use biome_console::markup;
 use biome_html_syntax::{AnyVueDirective, VueModifierList};
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_vue_valid_v_on::UseVueValidVOnOptions;
-use std::{collections::HashSet, sync::LazyLock};
+use phf::phf_set;
 
 declare_lint_rule! {
     /// Enforce valid `v-on` directives with proper arguments, modifiers, and handlers.
@@ -38,14 +38,6 @@ declare_lint_rule! {
         sources: &[RuleSource::EslintVueJs("valid-v-on").same()],
     }
 }
-
-static VALID_MODIFIERS_LIST: &[&str] = &[
-    "stop", "prevent", "capture", "self", "ctrl", "shift", "alt", "meta", "native", "once", "left",
-    "right", "middle", "passive", "esc", "tab", "enter", "space", "up", "down", "delete", "exact",
-];
-
-static VALID_MODIFIERS: LazyLock<HashSet<&'static str>> =
-    LazyLock::new(|| VALID_MODIFIERS_LIST.iter().copied().collect());
 
 pub enum ViolationKind {
     MissingEventName,
@@ -121,29 +113,32 @@ impl Rule for UseVueValidVOn {
             .note(markup! {
                     "Provide an event name after the colon, e.g. v-on:click=\"handler\"."
             }),
-            ViolationKind::InvalidModifier(invalid_range) => RuleDiagnostic::new(
-                rule_category!(),
-                invalid_range,
-                markup! {
-                    "Invalid v-on modifier."
-                },
-            )
-            .note(markup! {
-                    "Remove or correct the invalid modifier."
-            })
-            .footer_list(
-                markup! {
-                        "Allowed modifiers:"
-                },
-                VALID_MODIFIERS_LIST.iter().copied().chain(
-                    ctx.options()
-                        .modifiers
-                        .as_deref()
-                        .unwrap_or(&[])
-                        .iter()
-                        .map(|s| s.as_str()),
-                ),
-            ),
+            ViolationKind::InvalidModifier(invalid_range) => {
+                let mut allowed_modifiers = VALID_MODIFIERS
+                    .iter()
+                    .map(|modifier| (*modifier).to_string())
+                    .collect::<Vec<_>>();
+                if let Some(extra) = ctx.options().modifiers.as_ref() {
+                    allowed_modifiers.extend(extra.iter().cloned());
+                }
+
+                RuleDiagnostic::new(
+                    rule_category!(),
+                    invalid_range,
+                    markup! {
+                        "Invalid v-on modifier."
+                    },
+                )
+                .note(markup! {
+                        "Remove or correct the invalid modifier."
+                })
+                .footer_list(
+                    markup! {
+                            "Allowed modifiers:"
+                    },
+                    allowed_modifiers,
+                )
+            }
             ViolationKind::MissingHandler => RuleDiagnostic::new(
                 rule_category!(),
                 ctx.query().range(),
@@ -165,7 +160,18 @@ fn find_invalid_modifiers(
     for modifier in modifiers {
         if let Ok(modifier_token) = modifier.modifier_token() {
             let modifier_text = modifier_token.text();
+            if modifier_text.len() == 1 {
+                // allow single character modifiers (e.g. key codes)
+                continue;
+            }
             if VALID_MODIFIERS.contains(modifier_text) {
+                continue;
+            }
+            if VALID_KEY_ALIASES_LIST.contains(modifier_text) {
+                continue;
+            }
+            if modifier_text.chars().all(|c| c.is_ascii_digit()) {
+                // allow numeric key codes
                 continue;
             }
             if let Some(additional) = additional_allowed_modifiers
@@ -178,3 +184,294 @@ fn find_invalid_modifiers(
     }
     None
 }
+
+static VALID_MODIFIERS: phf::Set<&'static str> = phf_set! {
+    "stop", "prevent", "capture", "self", "ctrl", "shift", "alt", "meta", "native", "once", "left",
+    "right", "middle", "passive", "esc", "tab", "enter", "space", "up", "down", "delete", "exact",
+};
+
+/// See: https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/utils/key-aliases.json
+static VALID_KEY_ALIASES_LIST: phf::Set<&'static str> = phf_set! {
+    "a-v-r-input",
+    "a-v-r-power",
+    "accept",
+    "again",
+    "all-candidates",
+    "alphanumeric",
+    "alt",
+    "alt-graph",
+    "app-switch",
+    "arrow-down",
+    "arrow-left",
+    "arrow-right",
+    "arrow-up",
+    "attn",
+    "audio-balance-left",
+    "audio-balance-right",
+    "audio-bass-boost-down",
+    "audio-bass-boost-toggle",
+    "audio-bass-boost-up",
+    "audio-fader-front",
+    "audio-fader-rear",
+    "audio-surround-mode-next",
+    "audio-treble-down",
+    "audio-treble-up",
+    "audio-volume-down",
+    "audio-volume-mute",
+    "audio-volume-up",
+    "backspace",
+    "brightness-down",
+    "brightness-up",
+    "browser-back",
+    "browser-favorites",
+    "browser-forward",
+    "browser-home",
+    "browser-refresh",
+    "browser-search",
+    "browser-stop",
+    "call",
+    "camera",
+    "camera-focus",
+    "cancel",
+    "caps-lock",
+    "channel-down",
+    "channel-up",
+    "clear",
+    "close",
+    "closed-caption-toggle",
+    "code-input",
+    "color-f0-red",
+    "color-f1-green",
+    "color-f2-yellow",
+    "color-f3-blue",
+    "color-f4-grey",
+    "color-f5-brown",
+    "compose",
+    "context-menu",
+    "control",
+    "convert",
+    "copy",
+    "cr-sel",
+    "cut",
+    "d-v-r",
+    "dead",
+    "delete",
+    "dimmer",
+    "display-swap",
+    "eisu",
+    "eject",
+    "end",
+    "end-call",
+    "enter",
+    "erase-eof",
+    "escape",
+    "ex-sel",
+    "execute",
+    "exit",
+    "f1",
+    "f10",
+    "f11",
+    "f12",
+    "f2",
+    "f3",
+    "f4",
+    "f5",
+    "f6",
+    "f7",
+    "f8",
+    "f9",
+    "favorite-clear0",
+    "favorite-clear1",
+    "favorite-clear2",
+    "favorite-clear3",
+    "favorite-recall0",
+    "favorite-recall1",
+    "favorite-recall2",
+    "favorite-recall3",
+    "favorite-store0",
+    "favorite-store1",
+    "favorite-store2",
+    "favorite-store3",
+    "final-mode",
+    "find",
+    "fn",
+    "fn-lock",
+    "go-back",
+    "go-home",
+    "group-first",
+    "group-last",
+    "group-next",
+    "group-previous",
+    "guide",
+    "guide-next-day",
+    "guide-previous-day",
+    "hangul-mode",
+    "hanja-mode",
+    "hankaku",
+    "headset-hook",
+    "help",
+    "hibernate",
+    "hiragana",
+    "hiragana-katakana",
+    "home",
+    "hyper",
+    "info",
+    "insert",
+    "instant-replay",
+    "junja-mode",
+    "kana-mode",
+    "kanji-mode",
+    "katakana",
+    "key11",
+    "key12",
+    "last-number-redial",
+    "launch-application1",
+    "launch-application2",
+    "launch-calendar",
+    "launch-contacts",
+    "launch-mail",
+    "launch-media-player",
+    "launch-music-player",
+    "launch-phone",
+    "launch-screen-saver",
+    "launch-spreadsheet",
+    "launch-web-browser",
+    "launch-web-cam",
+    "launch-word-processor",
+    "link",
+    "list-program",
+    "live-content",
+    "lock",
+    "log-off",
+    "mail-forward",
+    "mail-reply",
+    "mail-send",
+    "manner-mode",
+    "media-apps",
+    "media-close",
+    "media-fast-forward",
+    "media-last",
+    "media-next-track",
+    "media-pause",
+    "media-play",
+    "media-play-pause",
+    "media-previous-track",
+    "media-record",
+    "media-rewind",
+    "media-skip-backward",
+    "media-skip-forward",
+    "media-step-backward",
+    "media-step-forward",
+    "media-stop",
+    "media-top-menu",
+    "media-track-next",
+    "media-track-previous",
+    "meta",
+    "microphone-toggle",
+    "microphone-volume-down",
+    "microphone-volume-mute",
+    "microphone-volume-up",
+    "mode-change",
+    "navigate-in",
+    "navigate-next",
+    "navigate-out",
+    "navigate-previous",
+    "new",
+    "next-candidate",
+    "next-favorite-channel",
+    "next-user-profile",
+    "non-convert",
+    "notification",
+    "num-lock",
+    "on-demand",
+    "open",
+    "page-down",
+    "page-up",
+    "pairing",
+    "paste",
+    "pause",
+    "pin-p-down",
+    "pin-p-move",
+    "pin-p-toggle",
+    "pin-p-up",
+    "play-speed-down",
+    "play-speed-reset",
+    "play-speed-up",
+    "power",
+    "previous-candidate",
+    "print",
+    "print-screen",
+    "process",
+    "random-toggle",
+    "rc-low-battery",
+    "record-speed-next",
+    "redo",
+    "rf-bypass",
+    "romaji",
+    "s-t-b-input",
+    "s-t-b-power",
+    "save",
+    "scan-channels-toggle",
+    "screen-mode-next",
+    "scroll-lock",
+    "select",
+    "settings",
+    "shift",
+    "single-candidate",
+    "soft1",
+    "soft2",
+    "soft3",
+    "soft4",
+    "speech-correction-list",
+    "speech-input-toggle",
+    "spell-check",
+    "split-screen-toggle",
+    "standby",
+    "subtitle",
+    "super",
+    "symbol",
+    "symbol-lock",
+    "t-v",
+    "t-v-antenna-cable",
+    "t-v-audio-description",
+    "t-v-audio-description-mix-down",
+    "t-v-audio-description-mix-up",
+    "t-v-contents-menu",
+    "t-v-data-service",
+    "t-v-input",
+    "t-v-input-component1",
+    "t-v-input-component2",
+    "t-v-input-composite1",
+    "t-v-input-composite2",
+    "t-v-input-h-d-m-i1",
+    "t-v-input-h-d-m-i2",
+    "t-v-input-h-d-m-i3",
+    "t-v-input-h-d-m-i4",
+    "t-v-input-v-g-a1",
+    "t-v-media-context",
+    "t-v-network",
+    "t-v-number-entry",
+    "t-v-power",
+    "t-v-radio-service",
+    "t-v-satellite",
+    "t-v-satellite-b-s",
+    "t-v-satellite-c-s",
+    "t-v-satellite-toggle",
+    "t-v-terrestrial-analog",
+    "t-v-terrestrial-digital",
+    "t-v-timer",
+    "t-v3-d-mode",
+    "tab",
+    "teletext",
+    "undo",
+    "unidentified",
+    "video-mode-next",
+    "voice-dial",
+    "wake-up",
+    "wink",
+    "zenkaku",
+    "zenkaku-hankaku",
+    "zoom-in",
+    "zoom-out",
+    "zoom-toggle",
+};

--- a/crates/biome_html_analyze/tests/specs/nursery/useVueValidVOn/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/useVueValidVOn/invalid.vue.snap
@@ -133,28 +133,28 @@ invalid.vue:17:18 lint/nursery/useVueValidVOn ━━━━━━━━━━━�
   
   i Allowed modifiers:
   
-  - stop
-  - prevent
-  - capture
-  - self
-  - ctrl
-  - shift
-  - alt
-  - meta
+  - delete
   - native
-  - once
+  - capture
+  - down
+  - self
+  - meta
   - left
-  - right
-  - middle
-  - passive
-  - esc
-  - tab
+  - stop
   - enter
   - space
   - up
-  - down
-  - delete
+  - once
+  - middle
+  - ctrl
+  - alt
+  - tab
   - exact
+  - passive
+  - prevent
+  - esc
+  - right
+  - shift
   
 
 ```
@@ -176,28 +176,28 @@ invalid.vue:20:15 lint/nursery/useVueValidVOn ━━━━━━━━━━━�
   
   i Allowed modifiers:
   
-  - stop
-  - prevent
-  - capture
-  - self
-  - ctrl
-  - shift
-  - alt
-  - meta
+  - delete
   - native
-  - once
+  - capture
+  - down
+  - self
+  - meta
   - left
-  - right
-  - middle
-  - passive
-  - esc
-  - tab
+  - stop
   - enter
   - space
   - up
-  - down
-  - delete
+  - once
+  - middle
+  - ctrl
+  - alt
+  - tab
   - exact
+  - passive
+  - prevent
+  - esc
+  - right
+  - shift
   
 
 ```
@@ -219,28 +219,28 @@ invalid.vue:23:17 lint/nursery/useVueValidVOn ━━━━━━━━━━━�
   
   i Allowed modifiers:
   
-  - stop
-  - prevent
-  - capture
-  - self
-  - ctrl
-  - shift
-  - alt
-  - meta
+  - delete
   - native
-  - once
+  - capture
+  - down
+  - self
+  - meta
   - left
-  - right
-  - middle
-  - passive
-  - esc
-  - tab
+  - stop
   - enter
   - space
   - up
-  - down
-  - delete
+  - once
+  - middle
+  - ctrl
+  - alt
+  - tab
   - exact
+  - passive
+  - prevent
+  - esc
+  - right
+  - shift
   
 
 ```
@@ -262,28 +262,28 @@ invalid.vue:26:18 lint/nursery/useVueValidVOn ━━━━━━━━━━━�
   
   i Allowed modifiers:
   
-  - stop
-  - prevent
-  - capture
-  - self
-  - ctrl
-  - shift
-  - alt
-  - meta
+  - delete
   - native
-  - once
+  - capture
+  - down
+  - self
+  - meta
   - left
-  - right
-  - middle
-  - passive
-  - esc
-  - tab
+  - stop
   - enter
   - space
   - up
-  - down
-  - delete
+  - once
+  - middle
+  - ctrl
+  - alt
+  - tab
   - exact
+  - passive
+  - prevent
+  - esc
+  - right
+  - shift
   
 
 ```
@@ -305,28 +305,28 @@ invalid.vue:29:18 lint/nursery/useVueValidVOn ━━━━━━━━━━━�
   
   i Allowed modifiers:
   
-  - stop
-  - prevent
-  - capture
-  - self
-  - ctrl
-  - shift
-  - alt
-  - meta
+  - delete
   - native
-  - once
+  - capture
+  - down
+  - self
+  - meta
   - left
-  - right
-  - middle
-  - passive
-  - esc
-  - tab
+  - stop
   - enter
   - space
   - up
-  - down
-  - delete
+  - once
+  - middle
+  - ctrl
+  - alt
+  - tab
   - exact
+  - passive
+  - prevent
+  - esc
+  - right
+  - shift
   
 
 ```
@@ -348,28 +348,28 @@ invalid.vue:32:22 lint/nursery/useVueValidVOn ━━━━━━━━━━━�
   
   i Allowed modifiers:
   
-  - stop
-  - prevent
-  - capture
-  - self
-  - ctrl
-  - shift
-  - alt
-  - meta
+  - delete
   - native
-  - once
+  - capture
+  - down
+  - self
+  - meta
   - left
-  - right
-  - middle
-  - passive
-  - esc
-  - tab
+  - stop
   - enter
   - space
   - up
-  - down
-  - delete
+  - once
+  - middle
+  - ctrl
+  - alt
+  - tab
   - exact
+  - passive
+  - prevent
+  - esc
+  - right
+  - shift
   
 
 ```

--- a/crates/biome_html_analyze/tests/specs/nursery/useVueValidVOn/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/nursery/useVueValidVOn/valid.vue
@@ -35,6 +35,11 @@
   <div @keydown.down="handler"></div>
   <div @keydown.left="handler"></div>
   <div @keydown.right="handler"></div>
+  <div @keydown.arrow-down="handler"></div>
+  <div @keydown.a="handler"></div>
+  <div @keydown.b="handler"></div>
+  <div @keydown.a.b.c="handler"></div>
+  <div @keydown.27="foo"></div>
 
   <!-- Combined modifiers -->
   <div @click.stop.prevent="foo"></div>

--- a/crates/biome_html_analyze/tests/specs/nursery/useVueValidVOn/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/useVueValidVOn/valid.vue.snap
@@ -41,6 +41,11 @@ expression: valid.vue
   <div @keydown.down="handler"></div>
   <div @keydown.left="handler"></div>
   <div @keydown.right="handler"></div>
+  <div @keydown.arrow-down="handler"></div>
+  <div @keydown.a="handler"></div>
+  <div @keydown.b="handler"></div>
+  <div @keydown.a.b.c="handler"></div>
+  <div @keydown.27="foo"></div>
 
   <!-- Combined modifiers -->
   <div @click.stop.prevent="foo"></div>
@@ -59,4 +64,5 @@ expression: valid.vue
   <!-- Native modifier (Vue 2 compatibility) -->
   <div @click.native="handler"></div>
 </template>
+
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
When I originally implemented this rule, I didn't notice that the rule flags takes keyboard events into account. Additionally, this replaces `LazyLock<HashSet<_>>` with a `phf::Set` to avoid the startup time initialization of the hashset. This should be a performance improvement, but I haven't measured it.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
It doesn't fix this, but it was prompted by #8765.

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
updated tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
