### PR TITLE
feat(parse/css): add support for vue's `v-bind()` function

### DIFF
--- a/.changeset/vue-v-bind-css-parser.md
+++ b/.changeset/vue-v-bind-css-parser.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8692](https://github.com/biomejs/biome/issues/8692): Biome now accepts Vue's `v-bind()` function in CSS when Vue CSS modules parsing is enabled.

--- a/crates/biome_cli/tests/cases/handle_vue_files.rs
+++ b/crates/biome_cli/tests/cases/handle_vue_files.rs
@@ -522,6 +522,50 @@ schema + sure()
 }
 
 #[test]
+fn parse_vue_css_v_bind_function() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{ "html": { "formatter": {"enabled": true}, "linter": {"enabled": true}, "experimentalFullSupportEnabled": true } }"#
+            .as_bytes(),
+    );
+
+    let vue_file_path = Utf8Path::new("file.vue");
+    fs.insert(
+        vue_file_path.into(),
+        r#"<template>
+  <div class="red"></div>
+</template>
+
+<style>
+.red {
+  color: v-bind(color);
+}
+</style>
+"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--write", "--unsafe", vue_file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "parse_vue_css_v_bind_function",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn full_support_ts() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/parse_vue_css_v_bind_function.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/parse_vue_css_v_bind_function.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "formatter": { "enabled": true },
+    "linter": { "enabled": true },
+    "experimentalFullSupportEnabled": true
+  }
+}
+```
+
+## `file.vue`
+
+```vue
+<template>
+	<div class="red"></div>
+</template>
+
+<style>
+.red {
+	color: v-bind(color);
+}
+</style>
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_css_analyze/src/keywords.rs
+++ b/crates/biome_css_analyze/src/keywords.rs
@@ -768,6 +768,7 @@ pub const FUNCTION_KEYWORDS: &[&str] = &[
     "translatez",
     "type",
     "url",
+    "v-bind", // Vue.js specific
     "var",
     "view",
     "xywh",

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.css
@@ -13,6 +13,7 @@ a { color: light-dark(#777, #000); }
 a { offset-path: xywh(20px 30% 150% 200%); }
 a { animation-timing-function: linear(0, 0.25, 1); }
 a { height: calc-size(0px); }
+a { width: v-bind(color); }
 @font-face {
 	src: url('/fonts/Obviously.woff2?v=1') format('woff2') tech('variations');
 }

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.css.snap
@@ -19,10 +19,11 @@ a { color: light-dark(#777, #000); }
 a { offset-path: xywh(20px 30% 150% 200%); }
 a { animation-timing-function: linear(0, 0.25, 1); }
 a { height: calc-size(0px); }
+a { width: v-bind(color); }
 @font-face {
 	src: url('/fonts/Obviously.woff2?v=1') format('woff2') tech('variations');
 }
 
 ```
 
-_Note: The parser emitted 3 diagnostics which are not shown here._
+_Note: The parser emitted 4 diagnostics which are not shown here._

--- a/crates/biome_css_parser/src/syntax/css_modules.rs
+++ b/crates/biome_css_parser/src/syntax/css_modules.rs
@@ -35,6 +35,13 @@ pub(crate) fn slotted_or_deep_not_allowed(p: &CssParser, range: TextRange) -> Pa
     .with_hint("These are valid pseudo selectors only when defined inside SFC vue files.")
 }
 
+/// This function generates a parsing diagnostic for the usage of the
+/// `v-bind()` function in CSS, which is a non-standard CSS feature.
+pub(crate) fn v_bind_not_allowed(p: &CssParser, range: TextRange) -> ParseDiagnostic {
+    p.err_builder("`v-bind()` is not a standard CSS function.", range)
+        .with_hint("This is valid only when defined inside SFC vue files.")
+}
+
 pub(crate) fn expected_any_css_module_scope(p: &CssParser, range: TextRange) -> ParseDiagnostic {
     expect_one_of(&["global", "local"], range).into_diagnostic(p)
 }

--- a/crates/biome_css_parser/src/syntax/mod.rs
+++ b/crates/biome_css_parser/src/syntax/mod.rs
@@ -42,7 +42,7 @@ pub(crate) enum CssSyntaxFeatures {
     /// Enable support for CSS Modules syntax.
     CssModules,
 
-    /// Enable support for CSS Modules syntax plus parsing of pseudo selectors fo `:slotted` and `:deep`
+    /// Enable support for CSS Modules syntax plus parsing of pseudo selectors for `:slotted`, `:deep`, and the `v-bind()` function.
     CssModulesWithVue,
 }
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/function/options.json
+++ b/crates/biome_css_parser/tests/css_test_suite/error/function/options.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "css": {
+    "parser": {
+      "cssModules": false
+    }
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/function/v_bind_disabled.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/function/v_bind_disabled.css
@@ -1,0 +1,3 @@
+.red {
+  color: v-bind(color);
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/function/v_bind_disabled.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/function/v_bind_disabled.css.snap
@@ -1,0 +1,145 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+.red {
+  color: v-bind(color);
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    rules: CssRuleList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@0..1 "." [] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1..5 "red" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@5..6 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@6..14 "color" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@14..16 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@16..22 "v-bind" [] [],
+                                                    },
+                                                    L_PAREN@22..23 "(" [] [],
+                                                    CssParameterList [
+                                                        CssParameter {
+                                                            any_css_expression: CssListOfComponentValuesExpression {
+                                                                css_component_value_list: CssComponentValueList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@23..28 "color" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        },
+                                                    ],
+                                                    R_PAREN@28..29 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@29..30 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@30..32 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@32..33 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..33
+  0: (empty)
+  1: CSS_RULE_LIST@0..32
+    0: CSS_QUALIFIED_RULE@0..32
+      0: CSS_SELECTOR_LIST@0..5
+        0: CSS_COMPOUND_SELECTOR@0..5
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@0..5
+            0: CSS_CLASS_SELECTOR@0..5
+              0: DOT@0..1 "." [] []
+              1: CSS_CUSTOM_IDENTIFIER@1..5
+                0: IDENT@1..5 "red" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@5..32
+        0: L_CURLY@5..6 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@6..30
+          0: CSS_DECLARATION_WITH_SEMICOLON@6..30
+            0: CSS_DECLARATION@6..29
+              0: CSS_BOGUS_PROPERTY@6..29
+                0: CSS_IDENTIFIER@6..14
+                  0: IDENT@6..14 "color" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@14..16 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@16..29
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@16..29
+                    0: CSS_IDENTIFIER@16..22
+                      0: IDENT@16..22 "v-bind" [] []
+                    1: L_PAREN@22..23 "(" [] []
+                    2: CSS_PARAMETER_LIST@23..28
+                      0: CSS_PARAMETER@23..28
+                        0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@23..28
+                          0: CSS_COMPONENT_VALUE_LIST@23..28
+                            0: CSS_IDENTIFIER@23..28
+                              0: IDENT@23..28 "color" [] []
+                    3: R_PAREN@28..29 ")" [] []
+              1: (empty)
+            1: SEMICOLON@29..30 ";" [] []
+        2: R_CURLY@30..32 "}" [Newline("\n")] []
+  2: EOF@32..33 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+v_bind_disabled.css:2:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × `v-bind()` is not a standard CSS function.
+  
+    1 │ .red {
+  > 2 │   color: v-bind(color);
+      │          ^^^^^^^^^^^^^
+    3 │ }
+    4 │ 
+  
+  i This is valid only when defined inside SFC vue files.
+  
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Adds support for Vue's `v-bind()` function in CSS.

Generated by gpt-5.2-codex

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #8692

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
