### PR TITLE
fix(format/html): fix double emitting comments sometimes

### DIFF
--- a/.changeset/fuzzy-comments-double-print.md
+++ b/.changeset/fuzzy-comments-double-print.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8803](https://github.com/biomejs/biome/issues/8803): Prevented HTML comments from being printed twice when text content and leading comment formatting overlap.

--- a/crates/biome_html_formatter/tests/quick_test.rs
+++ b/crates/biome_html_formatter/tests/quick_test.rs
@@ -13,15 +13,40 @@ mod language {
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
-    let src = r#"<div>hello    world</div>"#;
-    let source_type = HtmlFileSource::html();
+    //     let src = r#"
+    // <span>foo</span>
+    // <!-- biome-ignore format: reason -->
+    // foo bar baz boof
+    // quick brown fox
+    // "#;
+    let src = r#"
+{#snippet ff.call()}
+    {page.value}
+    {second.value}
+    <div>
+        <span></span>
+    </div>
+{/snippet}
+"#;
+    let source_type = HtmlFileSource::astro();
     let tree = parse_html(src, HtmlParseOptions::from(&source_type));
     let options = HtmlFormatOptions::new(source_type)
-        .with_indent_style(IndentStyle::Tab)
+        .with_indent_style(IndentStyle::Space)
         .with_line_width(LineWidth::try_from(80).unwrap())
         .with_attribute_position(AttributePosition::Auto);
 
     let doc = format_node(options.clone(), &tree.syntax(), false).unwrap();
     let result = doc.print().unwrap();
+
+    println!("{}", doc.into_document());
     eprintln!("{}", result.as_code());
+
+    CheckReformat::new(
+        &tree.syntax(),
+        result.as_code(),
+        "testing",
+        &language::HtmlTestFormatLanguage::new(source_type),
+        HtmlFormatLanguage::new(options),
+    )
+    .check_reformat();
 }

--- a/crates/biome_html_formatter/tests/quick_test.rs
+++ b/crates/biome_html_formatter/tests/quick_test.rs
@@ -13,40 +13,15 @@ mod language {
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
-    //     let src = r#"
-    // <span>foo</span>
-    // <!-- biome-ignore format: reason -->
-    // foo bar baz boof
-    // quick brown fox
-    // "#;
-    let src = r#"
-{#snippet ff.call()}
-    {page.value}
-    {second.value}
-    <div>
-        <span></span>
-    </div>
-{/snippet}
-"#;
-    let source_type = HtmlFileSource::astro();
+    let src = r#"<div>hello    world</div>"#;
+    let source_type = HtmlFileSource::html();
     let tree = parse_html(src, HtmlParseOptions::from(&source_type));
     let options = HtmlFormatOptions::new(source_type)
-        .with_indent_style(IndentStyle::Space)
+        .with_indent_style(IndentStyle::Tab)
         .with_line_width(LineWidth::try_from(80).unwrap())
         .with_attribute_position(AttributePosition::Auto);
 
     let doc = format_node(options.clone(), &tree.syntax(), false).unwrap();
     let result = doc.print().unwrap();
-
-    println!("{}", doc.into_document());
     eprintln!("{}", result.as_code());
-
-    CheckReformat::new(
-        &tree.syntax(),
-        result.as_code(),
-        "testing",
-        &language::HtmlTestFormatLanguage::new(source_type),
-        HtmlFormatLanguage::new(options),
-    )
-    .check_reformat();
 }

--- a/crates/biome_html_formatter/tests/specs/html/comments/comment-at-end-of-text.html
+++ b/crates/biome_html_formatter/tests/specs/html/comments/comment-at-end-of-text.html
@@ -1,0 +1,3 @@
+<div>
+    text content<!-- comment at end -->
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/comments/comment-at-end-of-text.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/comments/comment-at-end-of-text.html.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: comments/comment-at-end-of-text.html
+---
+# Input
+
+```html
+<div>
+    text content<!-- comment at end -->
+</div>
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+Self close void elements: never
+Trailing newline: true
+-----
+
+```html
+<div>text content<!-- comment at end --></div>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/comments/comment-between-inline-elements.html
+++ b/crates/biome_html_formatter/tests/specs/html/comments/comment-between-inline-elements.html
@@ -1,0 +1,3 @@
+<p>
+    <span>text1</span><!-- comment --><span>text2</span>
+</p>

--- a/crates/biome_html_formatter/tests/specs/html/comments/comment-between-inline-elements.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/comments/comment-between-inline-elements.html.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: comments/comment-between-inline-elements.html
+---
+# Input
+
+```html
+<p>
+    <span>text1</span><!-- comment --><span>text2</span>
+</p>
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+Self close void elements: never
+Trailing newline: true
+-----
+
+```html
+<p><span>text1</span<!-- comment -->><span>text2</span></p>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/comments/entities-with-comment.html
+++ b/crates/biome_html_formatter/tests/specs/html/comments/entities-with-comment.html
@@ -1,0 +1,3 @@
+<div>
+    &nbsp;<!-- comment -->&thinsp;
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/comments/entity-comment-text.html
+++ b/crates/biome_html_formatter/tests/specs/html/comments/entity-comment-text.html
@@ -1,0 +1,3 @@
+<div>
+    &thinsp;<!-- comment -->text
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/comments/multiline-comment-in-text.html
+++ b/crates/biome_html_formatter/tests/specs/html/comments/multiline-comment-in-text.html
@@ -1,0 +1,6 @@
+<div>
+    text<!--
+    multi-line
+    comment
+    -->more text
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/comments/multiple-comments-in-text.html
+++ b/crates/biome_html_formatter/tests/specs/html/comments/multiple-comments-in-text.html
@@ -1,0 +1,3 @@
+<div>
+    text1<!-- comment1 -->text2<!-- comment2 -->text3
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/comments/multiple-entities-and-comments.html
+++ b/crates/biome_html_formatter/tests/specs/html/comments/multiple-entities-and-comments.html
@@ -1,0 +1,3 @@
+<div>
+    &nbsp;<!-- c1 -->&thinsp;<!-- c2 -->&mdash;<!-- c3 -->text
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/entity-comment-expression.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/entity-comment-expression.svelte
@@ -1,0 +1,4 @@
+<div>
+    &thinsp;<!--
+    -->{ expression }
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/entity-comment-expression.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/entity-comment-expression.svelte.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/entity-comment-expression.svelte
+---
+# Input
+
+```svelte
+<div>
+    &thinsp;<!--
+    -->{ expression }
+</div>
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+Self close void elements: never
+Trailing newline: true
+-----
+
+```svelte
+<div>
+	&thinsp;<!--
+    -->{expression}
+</div>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/vue/comment-before-interpolation.vue
+++ b/crates/biome_html_formatter/tests/specs/html/vue/comment-before-interpolation.vue
@@ -1,0 +1,6 @@
+<template>
+<div>
+    &thinsp;<!--
+    -->{{ 123 }}
+</div>
+</template>

--- a/crates/biome_html_formatter/tests/specs/html/vue/comment-before-interpolation.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/vue/comment-before-interpolation.vue.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: vue/comment-before-interpolation.vue
+---
+# Input
+
+```vue
+<template>
+<div>
+    &thinsp;<!--
+    -->{{ 123 }}
+</div>
+</template>
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+Self close void elements: never
+Trailing newline: true
+-----
+
+```vue
+<template>
+	<div>
+		&thinsp;<!--
+    -->{{ 123 }}
+	</div>
+</template>
+
+```

--- a/crates/biome_html_formatter/tests/specs/prettier/html/interpolation/example.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/html/interpolation/example.html.snap
@@ -49,7 +49,7 @@ x => {
 -  vero est error {{ preserve invalid interpolation }} reprehenderit voluptates
 -  minus {{console.log( short_interpolation )}} nemo.
 -</div>
-+<!--interpolations in html should be treated as normal text--> <div>Fuga magnam facilis. Voluptatem quaerat porro.{{
++<!--interpolations in html should be treated as normal text--><div>Fuga magnam facilis. Voluptatem quaerat porro.{{
 +
 +
 +x => {
@@ -80,7 +80,7 @@ x => {
 # Output
 
 ```html
-<!--interpolations in html should be treated as normal text--> <div>Fuga magnam facilis. Voluptatem quaerat porro.{{
+<!--interpolations in html should be treated as normal text--><div>Fuga magnam facilis. Voluptatem quaerat porro.{{
 
 
 x => {
@@ -177,6 +177,6 @@ example.html:26:35 parse ━━━━━━━━━━━━━━━━━━�
 
 # Lines exceeding max width of 80 characters
 ```
-    1: <!--interpolations in html should be treated as normal text--> <div>Fuga magnam facilis. Voluptatem quaerat porro.{{
+    1: <!--interpolations in html should be treated as normal text--><div>Fuga magnam facilis. Voluptatem quaerat porro.{{
    26: }} reprehenderit voluptates minus {{console.log(  short_interpolation )}} nemo.</div>
 ```

--- a/packages/prettier-compare/src/languages.ts
+++ b/packages/prettier-compare/src/languages.ts
@@ -105,6 +105,11 @@ export const LANGUAGES: Record<string, LanguageConfig> = {
 		prettierParser: "astro",
 		displayName: "Astro",
 	},
+	vue: {
+		biomeFilePath: "file.vue",
+		prettierParser: "vue",
+		displayName: "Vue",
+	},
 };
 
 /**


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Prettier's parser fundamentally treats comments differently than we do. It treats comments as actual nodes in the markup, but we treat them as trivia. To match this behavior more closely, we try to split children of an element into an iter of `HtmlChild` so we can iterate over the children easier.

This PR fixes a case where that wasn't happening correctly. Now we prefer the comment we get as an `HtmlChild`, and skip formatting it as trivia.

Generated by opus 4.5

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #8803

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added snapshots.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
