### PR TITLE
fix(linter): fix useExhaustiveDependencies false positive with arrow function params

### DIFF
--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8883.tsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8883.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+// Test: Arrow function with parameter without parentheses, using props directly
+const TestDirect = props => {
+  useEffect(() => console.log(props.msg), [props.msg]);
+};
+
+// Test: Arrow function with parameter without parentheses, destructuring in body
+const TestDestructure = props => {
+  const { msg } = props;
+  useEffect(() => console.log(msg), [msg]);
+};

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8883.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8883.tsx.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 152
+expression: issue8883.tsx
+---
+# Input
+```tsx
+import { useEffect } from 'react';
+
+// Test: Arrow function with parameter without parentheses, using props directly
+const TestDirect = props => {
+  useEffect(() => console.log(props.msg), [props.msg]);
+};
+
+// Test: Arrow function with parameter without parentheses, destructuring in body
+const TestDestructure = props => {
+  const { msg } = props;
+  useEffect(() => console.log(msg), [msg]);
+};
+
+```


### PR DESCRIPTION
## Summary

Fixes false positive in `useExhaustiveDependencies` rule when props are destructured in function body or accessed directly with arrow function params without parentheses.

## Problem

The rule incorrectly flagged hook dependencies as "unnecessary" when:
1. Arrow functions used parameters without parentheses (e.g., `props =>`)
2. Props were accessed via destructuring in function body (e.g., `const { msg } = props`)

Example that was incorrectly flagged:
```tsx
const Component: React.FC<Props> = props => {
  const { msg } = props
  useEffect(() => console.log(msg), [msg]); // ❌ false positive: "msg" is unnecessary
};
```

## Root Cause

The bug was in the `is_stable_expression` function. It had a "self-reference" check that returned `true` (stable) when an identifier's ancestors included its declaration node.

For arrow functions with parameters without parentheses (`props =>`), the binding's declaration is the entire `JsArrowFunctionExpression`. Since the arrow function is an ancestor of any identifier used inside it, the check incorrectly returned `true` for parameter usages in the body.

## Solution

Modified the self-reference check to exclude arrow function parameters, formal parameters, and rest parameters from being considered "stable self-references":

```rust
if is_ancestor
    && !matches!(
        decl,
        AnyJsBindingDeclaration::JsArrowFunctionExpression(_)
            | AnyJsBindingDeclaration::JsFormalParameter(_)
            | AnyJsBindingDeclaration::JsRestParameter(_)
    )
{
    return true;
}
```

## Test plan

- [x] Added test case covering all scenarios from the issue
- [x] All existing `useExhaustiveDependencies` tests pass (53 tests)
- [x] All `biome_js_analyze` tests pass (1990 tests)

## AI Disclosure

This PR was written primarily by Claude Code (AI assistant).

Fixes #8883

🤖 Generated with [Claude Code](https://claude.ai/code)