### PR TITLE
fix(parse/html): fix panic caused by malformed tag `<12`

### DIFF
--- a/.changeset/fix-html-parser-digit-tag-start.md
+++ b/.changeset/fix-html-parser-digit-tag-start.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8363](https://github.com/biomejs/biome/issues/8363): HTML parser no longer crashes when encountering a `<` character followed by a digit in text content (e.g., `<12 months`). The parser now correctly emits an "Unescaped `<` bracket character" error instead of treating `<12` as a tag name and crashing.

--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -219,7 +219,7 @@ impl<'src> HtmlLexer<'src> {
                 // https://html.spec.whatwg.org/multipage/syntax.html#start-tags
                 if self
                     .peek_byte()
-                    .is_some_and(|b| is_tag_name_byte(b) || b == b'!' || b == b'/' || b == b'>')
+                    .is_some_and(|b| is_tag_start_byte(b) || b == b'!' || b == b'/' || b == b'>')
                 {
                     self.consume_l_angle()
                 } else {
@@ -1236,6 +1236,12 @@ fn is_tag_name_byte(byte: u8) -> bool {
     // However, Prettier considers them to be valid characters in tag names, so we allow them to remain compatible.
 
     byte.is_ascii_alphanumeric() || byte == b'-' || byte == b':' || byte == b'.'
+}
+
+fn is_tag_start_byte(byte: u8) -> bool {
+    // Tag names must start with an ASCII letter (not a digit)
+    // https://html.spec.whatwg.org/#valid-custom-element-name
+    byte.is_ascii_alphabetic()
 }
 
 fn is_attribute_name_byte(byte: u8) -> bool {

--- a/crates/biome_html_parser/tests/html_specs/error/element/tag-name-starts-with-digit.html
+++ b/crates/biome_html_parser/tests/html_specs/error/element/tag-name-starts-with-digit.html
@@ -1,0 +1,1 @@
+<div>Target <12 months</div>

--- a/crates/biome_html_parser/tests/html_specs/error/element/tag-name-starts-with-digit.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/tag-name-starts-with-digit.html.snap
@@ -1,0 +1,100 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```html
+<div>Target <12 months</div>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..1 "<" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@1..4 "div" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@4..5 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@5..12 "Target" [] [Whitespace(" ")],
+                },
+                HtmlContent {
+                    value_token: HTML_LITERAL@12..13 "<" [] [],
+                },
+                HtmlContent {
+                    value_token: HTML_LITERAL@13..22 "12 months" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@22..23 "<" [] [],
+                slash_token: SLASH@23..24 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@24..27 "div" [] [],
+                },
+                r_angle_token: R_ANGLE@27..28 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@28..29 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..29
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..28
+    0: HTML_ELEMENT@0..28
+      0: HTML_OPENING_ELEMENT@0..5
+        0: L_ANGLE@0..1 "<" [] []
+        1: HTML_TAG_NAME@1..4
+          0: HTML_LITERAL@1..4 "div" [] []
+        2: HTML_ATTRIBUTE_LIST@4..4
+        3: R_ANGLE@4..5 ">" [] []
+      1: HTML_ELEMENT_LIST@5..22
+        0: HTML_CONTENT@5..12
+          0: HTML_LITERAL@5..12 "Target" [] [Whitespace(" ")]
+        1: HTML_CONTENT@12..13
+          0: HTML_LITERAL@12..13 "<" [] []
+        2: HTML_CONTENT@13..22
+          0: HTML_LITERAL@13..22 "12 months" [] []
+      2: HTML_CLOSING_ELEMENT@22..28
+        0: L_ANGLE@22..23 "<" [] []
+        1: SLASH@23..24 "/" [] []
+        2: HTML_TAG_NAME@24..27
+          0: HTML_LITERAL@24..27 "div" [] []
+        3: R_ANGLE@27..28 ">" [] []
+  4: EOF@28..29 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+tag-name-starts-with-digit.html:1:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unescaped `<` bracket character. Expected a tag or escaped character.
+  
+  > 1 │ <div>Target <12 months</div>
+      │             ^
+    2 │ 
+  
+  i Replace this character with `&lt;` to escape it.
+  
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR fixes a crash in the HTML parser caused by trying to parse `<1` as a tag. Now we correctly emit an error for this case.

generated by glm-4.7

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #8363

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
