### PR TITLE
fix(js): detect array index in any position within template strings and binary expressions

### DIFF
--- a/.changeset/fix-no-array-index-key-template-order.md
+++ b/.changeset/fix-no-array-index-key-template-order.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8812](https://github.com/biomejs/biome/issues/8812): [`noArrayIndexKey`](https://biomejs.dev/linter/rules/no-array-index-key/) now correctly detects array index usage in template strings regardless of position. Previously, a key like `` `${index}-${item}` `` was not flagged while `` `${item}-${index}` `` was.

--- a/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx
@@ -132,3 +132,19 @@ function Component10() {
         </HoC>
     );
 }
+
+// index appears before item in template string (issue #8812)
+function Component11() {
+    const arr = [1,2,3];
+    return arr.map((item, index) => {
+        return <div key={`${index}-${item}`}>{item}</div>;
+    })
+}
+
+// index appears before item in binary expression
+function Component12() {
+    const arr = [1,2,3];
+    return arr.map((item, index) => {
+        return <div key={index + "-" + item}>{item}</div>;
+    })
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.jsx
-snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -138,6 +137,22 @@ function Component10() {
             {({ things }) => things.map((_, index) => <Component key={"test" + index + "test"} />)}
         </HoC>
     );
+}
+
+// index appears before item in template string (issue #8812)
+function Component11() {
+    const arr = [1,2,3];
+    return arr.map((item, index) => {
+        return <div key={`${index}-${item}`}>{item}</div>;
+    })
+}
+
+// index appears before item in binary expression
+function Component12() {
+    const arr = [1,2,3];
+    return arr.map((item, index) => {
+        return <div key={index + "-" + item}>{item}</div>;
+    })
 }
 ```
 
@@ -928,6 +943,62 @@ invalid.jsx:131:80 lint/suspicious/noArrayIndexKey ━━━━━━━━━�
         │                                             ^^^^^
     132 │         </HoC>
     133 │     );
+  
+  i The order of the items may change, and this also affects performances and component state.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:140:29 lint/suspicious/noArrayIndexKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Avoid using the index of an array as key property in an element.
+  
+    138 │     const arr = [1,2,3];
+    139 │     return arr.map((item, index) => {
+  > 140 │         return <div key={`${index}-${item}`}>{item}</div>;
+        │                             ^^^^^
+    141 │     })
+    142 │ }
+  
+  i This is the source of the key value.
+  
+    137 │ function Component11() {
+    138 │     const arr = [1,2,3];
+  > 139 │     return arr.map((item, index) => {
+        │                           ^^^^^
+    140 │         return <div key={`${index}-${item}`}>{item}</div>;
+    141 │     })
+  
+  i The order of the items may change, and this also affects performances and component state.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:148:26 lint/suspicious/noArrayIndexKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Avoid using the index of an array as key property in an element.
+  
+    146 │     const arr = [1,2,3];
+    147 │     return arr.map((item, index) => {
+  > 148 │         return <div key={index + "-" + item}>{item}</div>;
+        │                          ^^^^^
+    149 │     })
+    150 │ }
+  
+  i This is the source of the key value.
+  
+    145 │ function Component12() {
+    146 │     const arr = [1,2,3];
+  > 147 │     return arr.map((item, index) => {
+        │                           ^^^^^
+    148 │         return <div key={index + "-" + item}>{item}</div>;
+    149 │     })
   
   i The order of the items may change, and this also affects performances and component state.
   


### PR DESCRIPTION
## Summary

- Fixed false negative in `noArrayIndexKey` rule when array index appears before other values in template strings or binary expressions
- The rule now correctly checks ALL identifiers in template strings and binary expressions, not just the last one

Fixes #8812

## Test plan

- [x] Added test cases for `key={\`${index}-${item}\`}` and `key={index + "-" + item}` to invalid.jsx
- [x] Updated documentation with additional invalid example
- [x] Tests pass locally with `cargo test -p biome_js_analyze no_array_index_key`

## AI Disclosure

This PR was written primarily by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)