### PR TITLE
docs(lint): clarify useArrowFunction rule

### DIFF
--- a/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
@@ -28,6 +28,8 @@ declare_lint_rule! {
     ///
     /// This rule proposes turning all function expressions that are not generators (`function*`) and don't use `this` into arrow functions.
     ///
+    /// This rule does not modify top-level function declarations ([discuss here](https://github.com/biomejs/biome/discussions/7108)).
+    ///
     /// ## Examples
     ///
     /// ### Invalid


### PR DESCRIPTION
## Summary

I found it confusing, that the description talks about functions **expressions**. I automatically assumed it would include top-level function as well (like eslint does), so i misread it.

Original description:
> Use arrow functions over function expressions.
> An arrow function expression is a compact alternative to a regular function expression, with an important distinction: this is not bound to the arrow function. It inherits this from its parent scope.
> This rule proposes turning all function expressions that are not generators (function*) and don’t use this into arrow functions.

via https://github.com/biomejs/biome/issues/8925#issuecomment-3829461797

