### PR TITLE
chore(just): add `just new-crate`

### DIFF
--- a/justfile
+++ b/justfile
@@ -274,3 +274,7 @@ ready:
 # Creates a new changeset for the final changelog
 new-changeset:
   pnpm changeset
+
+# Create new crate
+new-crate name:
+  cargo new crates/{{name}} --lib


### PR DESCRIPTION
The docs [CONTRIBUTING.md#crates-development](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#crates-development) and [crates/biome_formatter/CONTRIBUTING.md](https://github.com/biomejs/biome/blob/main/crates/biome_formatter/CONTRIBUTING.md) suggest contributors to use `just new-crate` to initiate a new crate but the command doesn't exist.