### PR TITLE
feat(provenance): add core data structures and traits

### DIFF
--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -20,6 +20,7 @@ pub mod javascript;
 pub mod json;
 pub mod max_size;
 mod overrides;
+pub mod provenance;
 pub mod vcs;
 
 use crate::analyzer::assist::{Actions, AssistConfiguration, Source, assist_configuration};

--- a/crates/biome_configuration/src/provenance/entry.rs
+++ b/crates/biome_configuration/src/provenance/entry.rs
@@ -1,0 +1,64 @@
+use super::{FieldQuery, ProvenanceSource};
+use biome_json_syntax::AnyJsonValue;
+use biome_rowan::AstPtr;
+
+/// A single record of a field being set
+#[derive(Debug, Clone)]
+pub struct ProvenanceEntry {
+    /// Path to the field that was set
+    pub field_query: FieldQuery,
+
+    /// Where this value came from
+    pub source: ProvenanceSource,
+
+    /// Pointer to the JSON value node in the parsed tree
+    /// AstPtr is thread-safe (Send + Sync) and can be resolved later
+    /// by calling workspace.get_parse() to retrieve the JsonRoot
+    pub value_ptr: AstPtr<AnyJsonValue>,
+
+    /// Merge order: lower = earlier, higher = later (wins)
+    pub merge_order: u64,
+}
+
+impl ProvenanceEntry {
+    /// Create a new provenance entry
+    pub fn new(
+        field_query: FieldQuery,
+        source: ProvenanceSource,
+        value_ptr: AstPtr<AnyJsonValue>,
+        merge_order: u64,
+    ) -> Self {
+        Self {
+            field_query,
+            source,
+            value_ptr,
+            merge_order,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provenance::FieldQuery;
+
+    #[test]
+    fn test_provenance_entry_creation() {
+        let _query = FieldQuery::new();
+        let _source = ProvenanceSource::default();
+
+        // We can't create a real AstPtr without parsing JSON,
+        // but we can test the structure compiles
+        // This test mainly ensures the types are correct
+
+        // Just verify the types work together
+        fn _type_check(
+            query: FieldQuery,
+            source: ProvenanceSource,
+            ptr: AstPtr<AnyJsonValue>,
+            order: u64,
+        ) -> ProvenanceEntry {
+            ProvenanceEntry::new(query, source, ptr, order)
+        }
+    }
+}

--- a/crates/biome_configuration/src/provenance/field_query.rs
+++ b/crates/biome_configuration/src/provenance/field_query.rs
@@ -1,0 +1,152 @@
+use biome_json_syntax::JsonMemberName;
+use biome_rowan::AstPtr;
+
+/// A segment in a configuration field query
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldQuerySegment {
+    /// A named field: stores a pointer to the JsonMemberName node
+    /// AstPtr is thread-safe (Send + Sync) and only 8 bytes
+    Field(AstPtr<JsonMemberName>),
+
+    /// An array index: [2]
+    Index(usize),
+}
+
+/// Represents a captured field path during configuration deserialization
+/// Examples: "formatter.indentWidth", "extends[2]", "overrides[1].includes[0]"
+///
+/// **Important**: This structure is used ONLY during the capture phase when we have
+/// access to the JsonRoot and can create proper AstPtr references. User queries
+/// (from CLI/LSP) remain as strings and are processed using the QueryVisitor pattern.
+///
+/// Thread-safe structure using AstPtr (Send + Sync) for minimal memory usage.
+/// Field names are resolved on-demand using JsonRoot when displaying or comparing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldQuery {
+    pub(crate) segments: Vec<FieldQuerySegment>,
+}
+
+impl FieldQuery {
+    /// Create a new empty field query
+    pub fn new() -> Self {
+        Self {
+            segments: Vec::new(),
+        }
+    }
+
+    /// Create a field query from segments
+    pub fn from_segments(segments: Vec<FieldQuerySegment>) -> Self {
+        Self { segments }
+    }
+
+    /// Add a field segment
+    pub fn push_field(&mut self, ptr: AstPtr<JsonMemberName>) {
+        self.segments.push(FieldQuerySegment::Field(ptr));
+    }
+
+    /// Add an index segment
+    pub fn push_index(&mut self, index: usize) {
+        self.segments.push(FieldQuerySegment::Index(index));
+    }
+
+    /// Remove the last segment
+    pub fn pop(&mut self) -> Option<FieldQuerySegment> {
+        self.segments.pop()
+    }
+
+    /// Get the segments
+    pub fn segments(&self) -> &[FieldQuerySegment] {
+        &self.segments
+    }
+
+    /// Check if this query starts with another query (for prefix matching during capture)
+    pub fn starts_with(&self, prefix: &FieldQuery) -> bool {
+        if prefix.segments.len() > self.segments.len() {
+            return false;
+        }
+        self.segments[..prefix.segments.len()] == prefix.segments
+    }
+
+    /// Check if the query is empty
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    /// Get the length of the query (number of segments)
+    pub fn len(&self) -> usize {
+        self.segments.len()
+    }
+}
+
+impl Default for FieldQuery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_field_query_new() {
+        let query = FieldQuery::new();
+        assert!(query.is_empty());
+        assert_eq!(query.len(), 0);
+    }
+
+    #[test]
+    fn test_field_query_push_index() {
+        let mut query = FieldQuery::new();
+        query.push_index(0);
+        query.push_index(1);
+
+        assert_eq!(query.len(), 2);
+        assert!(!query.is_empty());
+
+        match &query.segments[0] {
+            FieldQuerySegment::Index(idx) => assert_eq!(*idx, 0),
+            _ => panic!("Expected index segment"),
+        }
+
+        match &query.segments[1] {
+            FieldQuerySegment::Index(idx) => assert_eq!(*idx, 1),
+            _ => panic!("Expected index segment"),
+        }
+    }
+
+    #[test]
+    fn test_field_query_pop() {
+        let mut query = FieldQuery::new();
+        query.push_index(0);
+        query.push_index(1);
+
+        let popped = query.pop();
+        assert!(popped.is_some());
+        assert_eq!(query.len(), 1);
+
+        let popped = query.pop();
+        assert!(popped.is_some());
+        assert_eq!(query.len(), 0);
+
+        let popped = query.pop();
+        assert!(popped.is_none());
+    }
+
+    #[test]
+    fn test_field_query_starts_with() {
+        let mut prefix = FieldQuery::new();
+        prefix.push_index(0);
+
+        let mut full = FieldQuery::new();
+        full.push_index(0);
+        full.push_index(1);
+
+        assert!(full.starts_with(&prefix));
+        assert!(!prefix.starts_with(&full));
+
+        let empty = FieldQuery::new();
+        assert!(full.starts_with(&empty));
+        assert!(prefix.starts_with(&empty));
+    }
+}

--- a/crates/biome_configuration/src/provenance/mod.rs
+++ b/crates/biome_configuration/src/provenance/mod.rs
@@ -1,0 +1,14 @@
+//! Configuration provenance tracking
+//!
+//! This module provides types and utilities for tracking where each configuration
+//! value comes from (base config, extends, overrides, editorconfig, CLI args).
+
+mod entry;
+mod field_query;
+mod override_metadata;
+mod source;
+
+pub use entry::ProvenanceEntry;
+pub use field_query::{FieldQuery, FieldQuerySegment};
+pub use override_metadata::{GlobMatcher, OverrideProvenanceMetadata};
+pub use source::ProvenanceSource;

--- a/crates/biome_configuration/src/provenance/override_metadata.rs
+++ b/crates/biome_configuration/src/provenance/override_metadata.rs
@@ -1,0 +1,130 @@
+use super::ProvenanceSource;
+use biome_glob::Glob;
+use camino::Utf8Path;
+use std::str::FromStr;
+
+/// Metadata about an override pattern for lazy evaluation
+/// Stored in ProvenanceIndex to enable file-specific queries
+#[derive(Debug, Clone)]
+pub struct OverrideProvenanceMetadata {
+    /// Source of this override (which config file)
+    pub source: ProvenanceSource,
+
+    /// The index of this override in the overrides array
+    /// Used by QueryVisitor to match entries like "overrides[N].field"
+    pub index: usize,
+
+    /// The compiled glob patterns for matching files
+    pub matchers: Vec<GlobMatcher>,
+
+    /// Merge order: when this override was encountered during config loading
+    pub merge_order: u64,
+}
+
+impl OverrideProvenanceMetadata {
+    /// Create new override metadata
+    pub fn new(
+        source: ProvenanceSource,
+        index: usize,
+        matchers: Vec<GlobMatcher>,
+        merge_order: u64,
+    ) -> Self {
+        Self {
+            source,
+            index,
+            matchers,
+            merge_order,
+        }
+    }
+
+    /// Check if this override applies to the given file path
+    pub fn matches_file(&self, path: &Utf8Path) -> bool {
+        self.matchers.iter().any(|m| m.matches(path))
+    }
+}
+
+/// A glob matcher for file paths
+#[derive(Debug, Clone)]
+pub struct GlobMatcher {
+    glob: Glob,
+}
+
+impl GlobMatcher {
+    /// Create a new glob matcher
+    pub fn new(glob: Glob) -> Self {
+        Self { glob }
+    }
+
+    /// Check if the glob matches the given path
+    pub fn matches(&self, path: &Utf8Path) -> bool {
+        self.glob.is_match(path)
+    }
+
+    /// Get the underlying glob
+    pub fn glob(&self) -> &Glob {
+        &self.glob
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+
+    #[test]
+    fn test_override_metadata_creation() {
+        let source = ProvenanceSource::default();
+        let matchers = vec![];
+
+        let metadata = OverrideProvenanceMetadata::new(source, 0, matchers, 1);
+
+        assert_eq!(metadata.index, 0);
+        assert_eq!(metadata.merge_order, 1);
+    }
+
+    #[test]
+    fn test_glob_matcher_basic() {
+        // Test basic glob pattern matching
+        let glob = Glob::from_str("*.test.js").expect("valid glob");
+        let matcher = GlobMatcher::new(glob);
+
+        let test_file = Utf8PathBuf::from("example.test.js");
+        let normal_file = Utf8PathBuf::from("example.js");
+
+        assert!(matcher.matches(&test_file));
+        assert!(!matcher.matches(&normal_file));
+    }
+
+    #[test]
+    fn test_override_metadata_matches_file() {
+        let glob = Glob::from_str("*.test.js").expect("valid glob");
+        let matchers = vec![GlobMatcher::new(glob)];
+
+        let source = ProvenanceSource::default();
+        let metadata = OverrideProvenanceMetadata::new(source, 0, matchers, 1);
+
+        let test_file = Utf8PathBuf::from("example.test.js");
+        let normal_file = Utf8PathBuf::from("example.js");
+
+        assert!(metadata.matches_file(&test_file));
+        assert!(!metadata.matches_file(&normal_file));
+    }
+
+    #[test]
+    fn test_override_metadata_multiple_patterns() {
+        let glob1 = Glob::from_str("*.test.js").expect("valid glob");
+        let glob2 = Glob::from_str("*.spec.ts").expect("valid glob");
+        let matchers = vec![GlobMatcher::new(glob1), GlobMatcher::new(glob2)];
+
+        let source = ProvenanceSource::default();
+        let metadata = OverrideProvenanceMetadata::new(source, 0, matchers, 1);
+
+        let test_js = Utf8PathBuf::from("example.test.js");
+        let spec_ts = Utf8PathBuf::from("example.spec.ts");
+        let normal = Utf8PathBuf::from("example.js");
+
+        assert!(metadata.matches_file(&test_js));
+        assert!(metadata.matches_file(&spec_ts));
+        assert!(!metadata.matches_file(&normal));
+    }
+}

--- a/crates/biome_configuration/src/provenance/source.rs
+++ b/crates/biome_configuration/src/provenance/source.rs
@@ -1,0 +1,170 @@
+use camino::{Utf8Path, Utf8PathBuf};
+
+/// Identifies which source set a configuration value
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProvenanceSource {
+    /// The base/root configuration file being loaded
+    BaseConfig {
+        /// Absolute path to the config file
+        path: Utf8PathBuf,
+    },
+
+    /// An extended configuration from the 'extends' array
+    ExtendedConfig {
+        /// The file that set this value
+        path: Utf8PathBuf,
+
+        /// How we got here (for nested extends)
+        /// Example: ["main.json", "react.json", "react-base.json"]
+        /// The last entry is the file that actually set the value
+        resolution_path: Vec<Utf8PathBuf>,
+    },
+
+    /// An .editorconfig file
+    EditorConfig {
+        /// Path to the .editorconfig file
+        path: Utf8PathBuf,
+    },
+
+    /// An override pattern from the 'overrides' array
+    Override {
+        /// Which configuration file contained this override
+        config_source: Box<ProvenanceSource>,
+
+        /// The index of this override in the overrides array
+        index: usize,
+
+        /// The glob patterns (for display purposes)
+        includes: Vec<String>,
+    },
+
+    /// CLI argument (--indent-width=4)
+    CliArgument {
+        /// The argument string for reference
+        argument: String,
+    },
+
+    /// Default/fallback value (not explicitly configured)
+    Default,
+}
+
+impl ProvenanceSource {
+    /// Get the config file path for this source
+    /// This is the actual configuration file containing the value
+    pub fn config_path(&self) -> Option<&Utf8Path> {
+        match self {
+            Self::BaseConfig { path } => Some(path),
+            Self::ExtendedConfig { path, .. } => Some(path),
+            Self::EditorConfig { path } => Some(path),
+            Self::Override { config_source, .. } => config_source.config_path(),
+            Self::CliArgument { .. } | Self::Default => None,
+        }
+    }
+
+    /// Create a BaseConfig source
+    pub fn base_config(path: Utf8PathBuf) -> Self {
+        Self::BaseConfig { path }
+    }
+
+    /// Create an ExtendedConfig source
+    pub fn extended_config(path: Utf8PathBuf, resolution_path: Vec<Utf8PathBuf>) -> Self {
+        Self::ExtendedConfig {
+            path,
+            resolution_path,
+        }
+    }
+
+    /// Create an EditorConfig source
+    pub fn editor_config(path: Utf8PathBuf) -> Self {
+        Self::EditorConfig { path }
+    }
+
+    /// Create an Override source
+    pub fn override_source(
+        config_source: ProvenanceSource,
+        index: usize,
+        includes: Vec<String>,
+    ) -> Self {
+        Self::Override {
+            config_source: Box::new(config_source),
+            index,
+            includes,
+        }
+    }
+
+    /// Create a CliArgument source
+    pub fn cli_argument(argument: String) -> Self {
+        Self::CliArgument { argument }
+    }
+
+    /// Create a Default source
+    pub fn default() -> Self {
+        Self::Default
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_base_config_source() {
+        let path = Utf8PathBuf::from("/project/biome.json");
+        let source = ProvenanceSource::base_config(path.clone());
+
+        assert_eq!(source.config_path(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn test_extended_config_source() {
+        let path = Utf8PathBuf::from("/project/base.json");
+        let resolution = vec![
+            Utf8PathBuf::from("/project/biome.json"),
+            Utf8PathBuf::from("/project/base.json"),
+        ];
+        let source = ProvenanceSource::extended_config(path.clone(), resolution);
+
+        assert_eq!(source.config_path(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn test_override_source() {
+        let base_path = Utf8PathBuf::from("/project/biome.json");
+        let base_source = ProvenanceSource::base_config(base_path.clone());
+
+        let override_source =
+            ProvenanceSource::override_source(base_source, 0, vec!["*.test.js".to_string()]);
+
+        // Override should return the base config path
+        assert_eq!(override_source.config_path(), Some(base_path.as_path()));
+    }
+
+    #[test]
+    fn test_cli_argument_source() {
+        let source = ProvenanceSource::cli_argument("--indent-width=4".to_string());
+        assert_eq!(source.config_path(), None);
+    }
+
+    #[test]
+    fn test_default_source() {
+        let source = ProvenanceSource::default();
+        assert_eq!(source.config_path(), None);
+    }
+
+    #[test]
+    fn test_nested_override_path() {
+        let base_path = Utf8PathBuf::from("/project/biome.json");
+        let extended_path = Utf8PathBuf::from("/project/base.json");
+
+        let extended_source = ProvenanceSource::extended_config(
+            extended_path.clone(),
+            vec![base_path.clone(), extended_path.clone()],
+        );
+
+        let override_source =
+            ProvenanceSource::override_source(extended_source, 0, vec!["*.ts".to_string()]);
+
+        // Should traverse through Override -> ExtendedConfig to get the path
+        assert_eq!(override_source.config_path(), Some(extended_path.as_path()));
+    }
+}


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR starts a feature that will allow for debugging configuration files, and discover which configuration changed a certain default. 

This work is going to be shipped using stacked PRs using graphite (first time).

All PRs are going to be merged into `feat/config-debugging`. That branch, at the moment, contains some MD files that I used to generate a plan using AI.

This PR starts by creating the necessary traints for tracking the changed properties, using a trait called `Provenance`

Code is generated with AI and reviewed by me.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

N/A

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
