### PR TITLE
chore(doc): update formatter contributing doc

### DIFF
--- a/crates/biome_formatter/CONTRIBUTING.md
+++ b/crates/biome_formatter/CONTRIBUTING.md
@@ -330,7 +330,7 @@ To use non-default options, create `tests/specs/html/options.json`:
 
 ### "Undefined node" errors during codegen
 
-If you get an error like `Undefined node: AnyHtmlBlock`, it's likely that there's a bug in the grammar. Please refer to [the parser contributing guide](../crates/biome_parser/CONTRIBUTING.md) to troubleshoot.
+If you get an error like `Undefined node: AnyHtmlBlock`, it's likely that there's a bug in the grammar. Please refer to [the parser contributing guide](../biome_parser/CONTRIBUTING.md) to troubleshoot.
 
 ### Generated code references wrong paths
 


### PR DESCRIPTION
I was working on https://github.com/biomejs/biome/pull/8962 and confused by the organization of the contributing doc. It hasn't been updated for a while.

The PR fixes and improves the readability to better reflect how the codegen actually works (for easier debugging if something is missing or has error) and what we need to implement manually.

Disclosure: I used AI to help putting up the improvement but I manually go through each step carefully to make sure it's readable.