### PR TITLE
fix(linter): add `export {}` when noUnusedImports removes last import in TypeScript

### DIFF
--- a/.changeset/no-unused-imports-ambient-module.md
+++ b/.changeset/no-unused-imports-ambient-module.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#4888](https://github.com/biomejs/biome/issues/4888).
+[noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports/) now adds `export {}` when removing the last import in a TypeScript file to prevent it from becoming an ambient module. This does not apply to embedded scripts in Vue, Svelte, or Astro files, which are already in a module context.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4888.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4888.ts
@@ -1,0 +1,13 @@
+// Removing the last import should add `export {}` to preserve module context
+
+import {foo as _foo} from "foo";
+
+function foo():number {
+  return 0;
+}
+
+declare module "react" {
+  interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
+    fetchpriority?: "high" | "low" | "auto";
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4888.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4888.ts.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_4888.ts
+---
+# Input
+```ts
+// Removing the last import should add `export {}` to preserve module context
+
+import {foo as _foo} from "foo";
+
+function foo():number {
+  return 0;
+}
+
+declare module "react" {
+  interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
+    fetchpriority?: "high" | "low" | "auto";
+  }
+}
+
+```
+
+# Diagnostics
+```
+issue_4888.ts:3:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    1 │ // Removing the last import should add `export {}` to preserve module context
+    2 │ 
+  > 3 │ import {foo as _foo} from "foo";
+      │        ^^^^^^^^^^^^^
+    4 │ 
+    5 │ function foo():number {
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Unsafe fix: Remove the unused imports.
+  
+     1  1 │   // Removing the last import should add `export {}` to preserve module context
+     2  2 │   
+     3    │ - import·{foo·as·_foo}·from·"foo";
+        3 │ + export·{}//·Removing·the·last·import·should·add·`export·{}`·to·preserve·module·context
+        4 │ + 
+     4  5 │   
+     5  6 │   function foo():number {
+  
+
+```


### PR DESCRIPTION
> **AI disclosure:** This PR was authored with the assistance of Claude (Anthropic). Claude helped explore the codebase, analyze the issue, implement the fix, write tests, and prepare the PR.

## Summary

Fixes [#4888](https://github.com/biomejs/biome/issues/4888). When [`noUnusedImports`](https://biomejs.dev/linter/rules/no-unused-imports/) removes the last import statement in a TypeScript file that has no other exports, the file becomes an ambient module (global scope). This fix replaces the removed import with `export {}` to preserve module context.

This does not apply to embedded scripts in Vue, Svelte, or Astro files, which are already in a module context.

## Test Plan

- Added `issue_4888.ts` test case with a TS file containing only one unused import and a `declare module` block
- Verified the fix generates `export {}` instead of just removing the import
- All 23 existing `noUnusedImports` tests continue to pass

## Docs

No documentation changes needed — the rule's existing documentation covers the behavior.