### PR TITLE
fix(useAwait): treat yield* as async operation in async generators

### DIFF
--- a/.changeset/use-await-yield-star.md
+++ b/.changeset/use-await-yield-star.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8645](https://github.com/biomejs/biome/issues/8645).
+[useAwait](https://biomejs.dev/linter/rules/use-await/) no longer reports `async` generator functions that use `yield*`, since `yield*` in an async generator delegates to an `AsyncIterable` and requires the `async` modifier.

--- a/crates/biome_js_analyze/tests/specs/suspicious/useAwait/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useAwait/invalid.js
@@ -88,3 +88,8 @@ class Sample {
 		return true;
 	}
 }
+
+async function* yieldWithoutStar() {
+	yield 1;
+	yield 2;
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/useAwait/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useAwait/invalid.js.snap
@@ -95,6 +95,11 @@ class Sample {
 	}
 }
 
+async function* yieldWithoutStar() {
+	yield 1;
+	yield 2;
+}
+
 ```
 
 # Diagnostics
@@ -584,6 +589,38 @@ invalid.js:86:2 lint/suspicious/useAwait ━━━━━━━━━━━━━
        │ 	^
     90 │ }
     91 │ 
+  
+  i Async functions without await expressions may not need to be declared async.
+  
+
+```
+
+```
+invalid.js:92:1 lint/suspicious/useAwait ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This async function lacks an await expression.
+  
+    90 │ }
+    91 │ 
+  > 92 │ async function* yieldWithoutStar() {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 93 │ 	yield 1;
+  > 94 │ 	yield 2;
+  > 95 │ }
+       │ ^
+    96 │ 
+  
+  i Remove this async modifier, or add an await expression in the function.
+  
+    90 │ }
+    91 │ 
+  > 92 │ async function* yieldWithoutStar() {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 93 │ 	yield 1;
+  > 94 │ 	yield 2;
+  > 95 │ }
+       │ ^
+    96 │ 
   
   i Async functions without await expressions may not need to be declared async.
   

--- a/crates/biome_js_analyze/tests/specs/suspicious/useAwait/valid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useAwait/valid.js
@@ -67,3 +67,12 @@ async function awaitExpressionWithForOf () {
 	return sum;
 };
 
+async function* yieldStarAsyncIterable() {
+	yield* otherAsyncGenerator();
+}
+
+async function* yieldStarWithAwait() {
+	const data = await fetch('/data');
+	yield* processData(data);
+}
+

--- a/crates/biome_js_analyze/tests/specs/suspicious/useAwait/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useAwait/valid.js.snap
@@ -73,5 +73,14 @@ async function awaitExpressionWithForOf () {
 	return sum;
 };
 
+async function* yieldStarAsyncIterable() {
+	yield* otherAsyncGenerator();
+}
+
+async function* yieldStarWithAwait() {
+	const data = await fetch('/data');
+	yield* processData(data);
+}
+
 
 ```


### PR DESCRIPTION
## Summary

Fixes #8645.

`yield*` in an `async` generator function delegates to an `AsyncIterable`, which requires the `async` modifier. The `useAwait` rule was incorrectly flagging these functions as missing `await`.

This PR adds `yield*` (i.e. `JsYieldExpression` with a `star_token`) to the set of expressions recognized as async operations by the `MissingAwaitVisitor`, alongside `await` and `for await...of`.

### Changes

- **`use_await.rs`**: Added a check for `JsYieldExpression` with `star_token()` in the visitor's `WalkEvent::Enter` branch
- **`valid.js`**: Added test cases for `async function*` with `yield*`
- **`invalid.js`**: Added test case for `async function*` with plain `yield` (should still be flagged)
- Updated snapshots

## Test plan

- `cargo test -p biome_js_analyze -- use_await` — all 4 tests pass
- Valid: `async function* yieldStarAsyncIterable() { yield* otherAsyncGenerator(); }` — no diagnostic
- Invalid: `async function* yieldWithoutStar() { yield 1; }` — correctly flagged