### PR TITLE
reproduce deprecation in next branch

### DIFF
--- a/crates/biome_html_formatter/src/html/any/attribute_initializer.rs
+++ b/crates/biome_html_formatter/src/html/any/attribute_initializer.rs
@@ -1,32 +1,15 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
-use biome_formatter::FormatRuleWithOptions;
 use biome_html_syntax::AnyHtmlAttributeInitializer;
 #[derive(Debug, Clone, Default)]
-pub(crate) struct FormatAnyHtmlAttributeInitializer {
-    compact: bool,
-}
-
+pub(crate) struct FormatAnyHtmlAttributeInitializer;
 impl FormatRule<AnyHtmlAttributeInitializer> for FormatAnyHtmlAttributeInitializer {
     type Context = HtmlFormatContext;
     fn fmt(&self, node: &AnyHtmlAttributeInitializer, f: &mut HtmlFormatter) -> FormatResult<()> {
         match node {
-            AnyHtmlAttributeInitializer::HtmlSingleTextExpression(node) => {
-                node.format().with_options(self.compact).fmt(f)
-            }
-            AnyHtmlAttributeInitializer::HtmlString(node) => {
-                node.format().with_options(self.compact).fmt(f)
-            }
+            AnyHtmlAttributeInitializer::HtmlSingleTextExpression(node) => node.format().fmt(f),
+            AnyHtmlAttributeInitializer::HtmlString(node) => node.format().fmt(f),
         }
-    }
-}
-
-impl FormatRuleWithOptions<AnyHtmlAttributeInitializer> for FormatAnyHtmlAttributeInitializer {
-    type Options = bool;
-
-    fn with_options(mut self, options: Self::Options) -> Self {
-        self.compact = options;
-        self
     }
 }

--- a/crates/biome_html_formatter/src/svelte/any/binding_property.rs
+++ b/crates/biome_html_formatter/src/svelte/any/binding_property.rs
@@ -1,33 +1,15 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
-use biome_formatter::FormatRuleWithOptions;
 use biome_html_syntax::AnySvelteBindingProperty;
 #[derive(Debug, Clone, Default)]
-pub(crate) struct FormatAnySvelteBindingProperty {
-    /// Whether it should be formatted in compact mode. In compact mode, all tokens and children
-    /// are removed
-    pub compact: bool,
-}
+pub(crate) struct FormatAnySvelteBindingProperty;
 impl FormatRule<AnySvelteBindingProperty> for FormatAnySvelteBindingProperty {
     type Context = HtmlFormatContext;
     fn fmt(&self, node: &AnySvelteBindingProperty, f: &mut HtmlFormatter) -> FormatResult<()> {
         match node {
-            AnySvelteBindingProperty::SvelteLiteral(node) => {
-                node.format().with_options(self.compact).fmt(f)
-            }
-            AnySvelteBindingProperty::SvelteName(node) => {
-                node.format().with_options(self.compact).fmt(f)
-            }
+            AnySvelteBindingProperty::SvelteLiteral(node) => node.format().fmt(f),
+            AnySvelteBindingProperty::SvelteName(node) => node.format().fmt(f),
         }
-    }
-}
-
-impl FormatRuleWithOptions<AnySvelteBindingProperty> for FormatAnySvelteBindingProperty {
-    type Options = bool;
-
-    fn with_options(mut self, options: Self::Options) -> Self {
-        self.compact = options;
-        self
     }
 }


### PR DESCRIPTION
I noticed something (perhaps updated html grammar) is missing in the `next` branch or vice versa. Just a heads up in case we have a bug in the next release.

I get these diff when running `just gen-formatter` in `next` branch.