### PR TITLE
fix(js_analyze): typo in noPositiveTabindex's action suggestion

### DIFF
--- a/.changeset/lemon-pens-prove.md
+++ b/.changeset/lemon-pens-prove.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed typo in [noPositiveTabindex](https://biomejs.dev/linter/rules/no-positive-tabindex/)'s quick fix text.

--- a/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
@@ -191,7 +191,7 @@ impl Rule for NoPositiveTabindex {
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
-            markup! { "Replace the "<Emphasis>"tableIndex"</Emphasis>" prop value with 0." }
+            markup! { "Replace the "<Emphasis>"tabIndex"</Emphasis>" prop value with 0." }
                 .to_owned(),
             mutation,
         ))

--- a/crates/biome_js_analyze/tests/specs/a11y/noPositiveTabindex/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noPositiveTabindex/invalid.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.jsx
-snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -36,7 +35,7 @@ invalid.jsx:2:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
      1  1 │   <>
      2    │ - → <div·tabIndex={1}·/>
@@ -63,7 +62,7 @@ invalid.jsx:3:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
      1  1 │   <>
      2  2 │   	<div tabIndex={1} />
@@ -91,7 +90,7 @@ invalid.jsx:4:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
      2  2 │   	<div tabIndex={1} />
      3  3 │   	<div tabIndex={"1"} />
@@ -119,7 +118,7 @@ invalid.jsx:5:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
      3  3 │   	<div tabIndex={"1"} />
      4  4 │   	<div tabIndex={'5'} />
@@ -147,7 +146,7 @@ invalid.jsx:6:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
      4  4 │   	<div tabIndex={'5'} />
      5  5 │   	<div tabIndex="1" />
@@ -175,7 +174,7 @@ invalid.jsx:7:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
      5  5 │   	<div tabIndex="1" />
      6  6 │   	<div tabIndex={1}>foo</div>
@@ -203,7 +202,7 @@ invalid.jsx:8:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
      6  6 │   	<div tabIndex={1}>foo</div>
      7  7 │   	<div tabIndex={"1"}>foo</div>
@@ -231,7 +230,7 @@ invalid.jsx:9:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
      7  7 │   	<div tabIndex={"1"}>foo</div>
      8  8 │   	<div tabIndex={'5'}>foo</div>
@@ -259,7 +258,7 @@ invalid.jsx:11:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━�
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
      9  9 │   	<div tabIndex={+5}>foo</div>
     10 10 │   	<div tabIndex={+0o5}>foo</div>

--- a/crates/biome_js_analyze/tests/specs/a11y/noPositiveTabindex/reactCreateElementInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noPositiveTabindex/reactCreateElementInvalid.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: reactCreateElementInvalid.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -27,7 +26,7 @@ reactCreateElementInvalid.js:1:40 lint/a11y/noPositiveTabindex  FIXABLE  ━━�
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
     1   │ - React.createElement("div",·{·tabIndex:·'1'·})
       1 │ + React.createElement("div",·{·tabIndex:·"0"·})
@@ -52,7 +51,7 @@ reactCreateElementInvalid.js:2:40 lint/a11y/noPositiveTabindex  FIXABLE  ━━�
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
     1 1 │   React.createElement("div", { tabIndex: '1' })
     2   │ - React.createElement("div",·{·tabIndex:·1·})
@@ -79,7 +78,7 @@ reactCreateElementInvalid.js:3:40 lint/a11y/noPositiveTabindex  FIXABLE  ━━�
   
   i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
   
-  i Unsafe fix: Replace the tableIndex prop value with 0.
+  i Unsafe fix: Replace the tabIndex prop value with 0.
   
     1 1 │   React.createElement("div", { tabIndex: '1' })
     2 2 │   React.createElement("div", { tabIndex: 1 })


### PR DESCRIPTION
## Summary

Fix typo (`tableIndex` -> `tabIndex`) in [noPositiveTabindex](https://biomejs.dev/linter/rules/no-positive-tabindex/)'s action text

## Test Plan

Unit tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
