### PR TITLE
docs(lint): useNamingConvention - object/type member

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -408,29 +408,29 @@ declare_lint_rule! {
     ///   - `importAlias`: default imports and aliases of named imports
     ///   - `exportAlias`: aliases of re-exported names
     ///   - `variable`: const, let, using, and var declarations
-    ///   - `const`
-    ///   - `let`
-    ///   - `var`
-    ///   - `using`
+    ///     - `const`
+    ///     - `let`
+    ///     - `var`
+    ///     - `using`
     ///   - `functionParameter`
     ///   - `catchParameter`
     ///   - `indexParameter`: parameters of index signatures
     ///   - `typeParameter`: generic type parameter
     ///   - `classMember`: class properties, parameter properties, methods, getters, and setters
-    ///   - `classProperty`: class properties, including parameter properties
-    ///   - `classMethod`
-    ///   - `classGetter`
-    ///   - `classSetter`
-    ///   - `objectLiteralMember`: literal object properties, methods, getters, and setters
-    ///   - `objectLiteralProperty`
-    ///   - `objectLiteralMethod`
-    ///   - `objectLiteralGetter`
-    ///   - `objectLiteralSetter`
+    ///     - `classProperty`: class properties, including parameter properties
+    ///     - `classMethod`
+    ///     - `classGetter`
+    ///     - `classSetter`
+    ///   - `objectLiteralMember`: literal object properties, methods, getters, and setters (you might want to duplicate the convention for `typeMember`)
+    ///     - `objectLiteralProperty`
+    ///     - `objectLiteralMethod`
+    ///     - `objectLiteralGetter`
+    ///     - `objectLiteralSetter`
     ///   - `typeMember`: properties, methods, getters, and setters declared in type aliases and interfaces
-    ///   - `typeProperty`
-    ///   - `typeMethod`
-    ///   - `typeGetter`
-    ///   - `typeSetter`
+    ///     - `typeProperty`
+    ///     - `typeMethod`
+    ///     - `typeGetter`
+    ///     - `typeSetter`
     /// - `modifiers`: an array of modifiers among:
     ///   - `abstract`: applies to class members and classes
     ///   - `private`: applies to class members


### PR DESCRIPTION

## Summary

I got confused, that to use a convention on object properties, i have to set the same convention on both `objectLiteralMember` and `typeMember`. Updated label makes it clearer (via https://github.com/biomejs/biome/discussions/8974#discussioncomment-15736996)


Also, I noticed that many kinds are "supersets" of other (`objectLiteral*` under `objectLiteralMember`), so I added indentation to make the list easier to understand. I am not sure, if I got this right - if they are supersets indeed.

