### PR TITLE
fix(linter): `useExhaustiveDependencies` revert object method call behavior change, fixes #8958

### DIFF
--- a/.changeset/dry-spies-go.md
+++ b/.changeset/dry-spies-go.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Reverted a behavior change in [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) that was accidentally included as part of the [#8802](https://github.com/biomejs/biome/issues/8802) fix. The change made method calls on objects (e.g., `props.data.forEach(...)`) report only the object (`props.data`) as a missing dependency instead of the full member expression. This behavior change will be reconsidered separately.

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8802.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8802.ts
@@ -13,19 +13,8 @@ const WeekdayValues: (keyof Days)[] = ["mon", "tue", "wed", "thu", "fri"];
 // "day" doesn't exist outside the memoized function.
 // Biome should report "props.value" as a missing dependency,
 // NOT "props.value[day]" since "day" is a callback-scoped variable.
-function Component1(props: { value: Days }) {
+function Component(props: { value: Days }) {
     useMemo(() => {
         return WeekdayValues.filter((day) => props.value[day]);
-    }, []);
-}
-
-// Example with forEach and index
-// Biome should report "props.data" as missing dependency,
-// NOT "props.data.forEach" to follow eslint React plugin behavior.
-function Component2(props: { data: number[] }) {
-    useMemo(() => {
-        props.data.forEach((value, index) => {
-            console.log(value, index);
-        });
     }, []);
 }

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8802.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8802.ts.snap
@@ -20,20 +20,9 @@ const WeekdayValues: (keyof Days)[] = ["mon", "tue", "wed", "thu", "fri"];
 // "day" doesn't exist outside the memoized function.
 // Biome should report "props.value" as a missing dependency,
 // NOT "props.value[day]" since "day" is a callback-scoped variable.
-function Component1(props: { value: Days }) {
+function Component(props: { value: Days }) {
     useMemo(() => {
         return WeekdayValues.filter((day) => props.value[day]);
-    }, []);
-}
-
-// Example with forEach and index
-// Biome should report "props.data" as missing dependency,
-// NOT "props.data.forEach" to follow eslint React plugin behavior.
-function Component2(props: { data: number[] }) {
-    useMemo(() => {
-        props.data.forEach((value, index) => {
-            console.log(value, index);
-        });
     }, []);
 }
 
@@ -46,7 +35,7 @@ issue8802.ts:17:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
   × This hook does not specify its dependency on props.value.
   
     15 │ // NOT "props.value[day]" since "day" is a callback-scoped variable.
-    16 │ function Component1(props: { value: Days }) {
+    16 │ function Component(props: { value: Days }) {
   > 17 │     useMemo(() => {
        │     ^^^^^^^
     18 │         return WeekdayValues.filter((day) => props.value[day]);
@@ -54,7 +43,7 @@ issue8802.ts:17:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
   
   i This dependency is being used here, but is not specified in the hook dependency list.
   
-    16 │ function Component1(props: { value: Days }) {
+    16 │ function Component(props: { value: Days }) {
     17 │     useMemo(() => {
   > 18 │         return WeekdayValues.filter((day) => props.value[day]);
        │                                              ^^^^^^^^^^^
@@ -71,39 +60,5 @@ issue8802.ts:17:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
   
     19 │ ····},·[props.value]);
        │         +++++++++++   
-
-```
-
-```
-issue8802.ts:26:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × This hook does not specify its dependency on props.data.
-  
-    24 │ // NOT "props.data.forEach" to follow eslint React plugin behavior.
-    25 │ function Component2(props: { data: number[] }) {
-  > 26 │     useMemo(() => {
-       │     ^^^^^^^
-    27 │         props.data.forEach((value, index) => {
-    28 │             console.log(value, index);
-  
-  i This dependency is being used here, but is not specified in the hook dependency list.
-  
-    25 │ function Component2(props: { data: number[] }) {
-    26 │     useMemo(() => {
-  > 27 │         props.data.forEach((value, index) => {
-       │         ^^^^^^^^^^
-    28 │             console.log(value, index);
-    29 │         });
-  
-  i React relies on hook dependencies to determine when to re-compute Effects.
-    Failing to specify dependencies can result in Effects not updating correctly when state changes.
-    These "stale closures" are a common source of surprising bugs.
-  
-  i Either include it or remove the dependency array.
-  
-  i Unsafe fix: Add the missing dependency to the list.
-  
-    30 │ ····},·[props.data]);
-       │         ++++++++++   
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Reverted a behavior change in [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) that was accidentally included as part of the [#8802](https://github.com/biomejs/biome/issues/8802) fix. The change made method calls on objects (e.g., `props.data.forEach(...)`) report only the object (`props.data`) as a missing dependency instead of the full member expression. This behavior change will be reconsidered separately.

Closes https://github.com/biomejs/biome/issues/8958

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Test was updated.

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
