### PR TITLE
chore: upgrade CVE'ed crates, remove unmaintaned crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,15 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_rgb"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a730095eb14ee842a0f1e68504b85c8d4a19b1ef2ac2a9b4debf0ed982f9b08a"
-dependencies = [
- "rgb",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,7 +1688,6 @@ dependencies = [
 name = "biome_test_utils"
 version = "0.0.0"
 dependencies = [
- "ansi_rgb",
  "biome_analyze",
  "biome_configuration",
  "biome_console",
@@ -1720,6 +1710,7 @@ dependencies = [
  "camino",
  "countme",
  "json_comments",
+ "owo-colors 4.2.3",
  "serde_json",
  "similar",
  "ureq",
@@ -1998,7 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a59e5c2bac9ccb280150ef4b58e07e4169d8c5c6ce0f70170e3c0b7c7b6124"
 dependencies = [
  "bpaf_derive",
- "owo-colors",
+ "owo-colors 3.5.0",
  "supports-color",
 ]
 
@@ -2058,9 +2049,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"
@@ -3912,9 +3903,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -3997,6 +3988,12 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "papaya"
@@ -4515,15 +4512,6 @@ checksum = "145bb27393fe455dd64d6cbc8d059adfa392590a45eadf079c01b11857e7b010"
 dependencies = [
  "hashbrown 0.15.5",
  "memchr",
-]
-
-[[package]]
-name = "rgb"
-version = "0.8.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -5210,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -5221,22 +5209,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/crates/biome_configuration/Cargo.toml
+++ b/crates/biome_configuration/Cargo.toml
@@ -49,7 +49,7 @@ schemars                   = { workspace = true, optional = true }
 serde                      = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-criterion    = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion    = { package = "codspeed-criterion-compat", version = "*" }
 insta        = { workspace = true }
 tests_macros = { workspace = true }
 

--- a/crates/biome_css_analyze/Cargo.toml
+++ b/crates/biome_css_analyze/Cargo.toml
@@ -43,7 +43,7 @@ biome_fs            = { workspace = true }
 biome_plugin_loader = { workspace = true }
 biome_test_utils    = { path = "../biome_test_utils" }
 camino              = { workspace = true }
-criterion           = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion           = { package = "codspeed-criterion-compat", version = "*" }
 insta               = { workspace = true, features = ["glob"] }
 tests_macros        = { path = "../tests_macros" }
 

--- a/crates/biome_css_formatter/Cargo.toml
+++ b/crates/biome_css_formatter/Cargo.toml
@@ -40,7 +40,7 @@ biome_service        = { path = "../biome_service" }
 biome_test_utils     = { path = "../biome_test_utils" }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }
-criterion            = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion            = { package = "codspeed-criterion-compat", version = "*" }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }
 tests_macros         = { path = "../tests_macros" }

--- a/crates/biome_css_parser/Cargo.toml
+++ b/crates/biome_css_parser/Cargo.toml
@@ -32,7 +32,7 @@ biome_fs            = { path = "../biome_fs" }
 biome_service       = { path = "../biome_service" }
 biome_test_utils    = { path = "../biome_test_utils" }
 camino              = { workspace = true }
-criterion           = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion           = { package = "codspeed-criterion-compat", version = "*" }
 insta               = { workspace = true }
 quickcheck          = { workspace = true }
 quickcheck_macros   = { workspace = true }

--- a/crates/biome_graphql_formatter/Cargo.toml
+++ b/crates/biome_graphql_formatter/Cargo.toml
@@ -38,7 +38,7 @@ biome_service        = { path = "../biome_service" }
 biome_test_utils     = { path = "../biome_test_utils" }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }
-criterion            = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion            = { package = "codspeed-criterion-compat", version = "*" }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }
 tests_macros         = { path = "../tests_macros" }

--- a/crates/biome_graphql_parser/Cargo.toml
+++ b/crates/biome_graphql_parser/Cargo.toml
@@ -30,7 +30,7 @@ unicode-bom           = { workspace = true }
 
 [dev-dependencies]
 biome_test_utils  = { workspace = true }
-criterion         = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion         = { package = "codspeed-criterion-compat", version = "*" }
 insta             = { workspace = true }
 quickcheck        = { workspace = true }
 quickcheck_macros = { workspace = true }

--- a/crates/biome_html_formatter/Cargo.toml
+++ b/crates/biome_html_formatter/Cargo.toml
@@ -37,7 +37,7 @@ biome_service        = { workspace = true }
 biome_test_utils     = { path = "../biome_test_utils" }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }
-criterion            = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion            = { package = "codspeed-criterion-compat", version = "*" }
 tests_macros         = { workspace = true }
 
 [target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dev-dependencies]

--- a/crates/biome_html_parser/Cargo.toml
+++ b/crates/biome_html_parser/Cargo.toml
@@ -28,7 +28,7 @@ tracing             = { workspace = true }
 [dev-dependencies]
 biome_test_utils  = { workspace = true }
 camino            = { workspace = true }
-criterion         = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion         = { package = "codspeed-criterion-compat", version = "*" }
 insta             = { workspace = true }
 quickcheck        = { workspace = true }
 quickcheck_macros = { workspace = true }

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -62,7 +62,7 @@ biome_js_parser     = { path = "../biome_js_parser", features = ["tests"] }
 biome_plugin_loader = { workspace = true }
 biome_service       = { workspace = true }
 biome_test_utils    = { path = "../biome_test_utils" }
-criterion           = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion           = { package = "codspeed-criterion-compat", version = "*" }
 insta               = { workspace = true, features = ["glob"] }
 tests_macros        = { path = "../tests_macros" }
 

--- a/crates/biome_js_formatter/Cargo.toml
+++ b/crates/biome_js_formatter/Cargo.toml
@@ -49,7 +49,7 @@ biome_parser         = { path = "../biome_parser" }
 biome_service        = { path = "../biome_service" }
 biome_test_utils     = { path = "../biome_test_utils" }
 countme              = { workspace = true, features = ["enable"] }
-criterion            = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion            = { package = "codspeed-criterion-compat", version = "*" }
 quickcheck           = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -44,7 +44,7 @@ biome_fs            = { workspace = true }
 biome_service       = { workspace = true }
 biome_test_utils    = { workspace = true }
 camino              = { workspace = true }
-criterion           = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion           = { package = "codspeed-criterion-compat", version = "*" }
 insta               = { workspace = true }
 quickcheck          = { workspace = true }
 quickcheck_macros   = { workspace = true }

--- a/crates/biome_json_analyze/Cargo.toml
+++ b/crates/biome_json_analyze/Cargo.toml
@@ -35,7 +35,7 @@ rustc-hash           = { workspace = true }
 biome_configuration = { workspace = true }
 biome_json_parser   = { path = "../biome_json_parser" }
 biome_test_utils    = { path = "../biome_test_utils" }
-criterion           = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion           = { package = "codspeed-criterion-compat", version = "*" }
 insta               = { workspace = true, features = ["glob"] }
 tests_macros        = { path = "../tests_macros" }
 

--- a/crates/biome_json_formatter/Cargo.toml
+++ b/crates/biome_json_formatter/Cargo.toml
@@ -42,7 +42,7 @@ biome_parser         = { path = "../biome_parser" }
 biome_service        = { path = "../biome_service" }
 biome_test_utils     = { path = "../biome_test_utils" }
 countme              = { workspace = true, features = ["enable"] }
-criterion            = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion            = { package = "codspeed-criterion-compat", version = "*" }
 serde_json           = { workspace = true }
 tests_macros         = { path = "../tests_macros" }
 

--- a/crates/biome_json_parser/Cargo.toml
+++ b/crates/biome_json_parser/Cargo.toml
@@ -32,7 +32,7 @@ unicode-bom         = { workspace = true }
 
 [dev-dependencies]
 biome_test_utils  = { workspace = true }
-criterion         = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion         = { package = "codspeed-criterion-compat", version = "*" }
 insta             = { workspace = true }
 quickcheck        = { workspace = true }
 quickcheck_macros = { workspace = true }

--- a/crates/biome_tailwind_parser/Cargo.toml
+++ b/crates/biome_tailwind_parser/Cargo.toml
@@ -28,7 +28,7 @@ tracing                = { workspace = true }
 [dev-dependencies]
 biome_test_utils  = { workspace = true }
 camino            = { workspace = true }
-criterion         = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+criterion         = { package = "codspeed-criterion-compat", version = "*" }
 insta             = { workspace = true }
 quickcheck        = { workspace = true }
 quickcheck_macros = { workspace = true }

--- a/crates/biome_test_utils/Cargo.toml
+++ b/crates/biome_test_utils/Cargo.toml
@@ -14,7 +14,6 @@ publish              = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ansi_rgb             = "0.2.0"
 biome_analyze        = { workspace = true }
 biome_configuration  = { workspace = true }
 biome_console        = { workspace = true }
@@ -37,6 +36,7 @@ biome_string_case    = { workspace = true }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }
 json_comments        = "0.2.2"
+owo-colors           = { version = "4.2.3" }
 serde_json           = { workspace = true }
 similar              = { workspace = true }
 ureq                 = { workspace = true }

--- a/crates/biome_test_utils/src/bench_case.rs
+++ b/crates/biome_test_utils/src/bench_case.rs
@@ -1,5 +1,6 @@
-use ansi_rgb::{Foreground, red};
 use camino::{Utf8Path, Utf8PathBuf};
+use owo_colors::OwoColorize;
+use owo_colors::colors::*;
 use std::env;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::PathBuf;
@@ -71,7 +72,7 @@ impl BenchCase {
             });
 
         content.map(|code| {
-            println!("[{}] - using [{}]", filename.clone().fg(red()), path);
+            println!("[{}] - using [{}]", filename.clone().fg::<Red>(), path);
             Self {
                 id: filename.clone(),
                 code,


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

We had some CVEs and some unmaintained crates in our tree. This PR updates `bytes` and `time`, which had CVEs, updates the codespeed crate, which contained unmaintained crates, uses `owo-colors` to replace `ansi_rgb`, which contained unmaintained crates 

> [!IMPORTANT]
> We need this PR merged, or we can't do any release

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

CI should stay green

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
