### PR TITLE
fix(linter): `useExhaustiveDependencies` proper rest parameters handling, fixes #8967

### DIFF
--- a/.changeset/four-cougars-fail.md
+++ b/.changeset/four-cougars-fail.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8967](https://github.com/biomejs/biome/issues/8967). [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) no longer reports false positives for variables destructured from a rest pattern.

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8967.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8967.js
@@ -1,0 +1,19 @@
+/* should not generate diagnostics */
+
+import { useEffect } from "react";
+
+// Issue #8967: Rest pattern destructuring should not cause false positives
+function Component(props) {
+    const { data, ...restProps } = props;
+    const { prop1 } = restProps;
+
+    useEffect(() => {
+        console.log(prop1);
+    }, [prop1]);
+
+    useEffect(() => {
+        console.log(restProps.prop1);
+    }, [restProps.prop1]);
+
+    return null;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8967.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue8967.js.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 152
+expression: issue8967.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+
+import { useEffect } from "react";
+
+// Issue #8967: Rest pattern destructuring should not cause false positives
+function Component(props) {
+    const { data, ...restProps } = props;
+    const { prop1 } = restProps;
+
+    useEffect(() => {
+        console.log(prop1);
+    }, [prop1]);
+
+    useEffect(() => {
+        console.log(restProps.prop1);
+    }, [restProps.prop1]);
+
+    return null;
+}
+
+```


### PR DESCRIPTION


<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixed [#8967](https://github.com/biomejs/biome/issues/8967). [useExhaustiveDependencies](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) no longer reports false positives for variables destructured from a rest pattern.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Test is included.

<!-- What demonstrates that your implementation is correct? -->

## Docs

Changeset is included.

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
