### PR TITLE
fix(linter): treat separator role as non-interactive for hr elements

### DIFF
--- a/.changeset/fix-hr-presentation-role.md
+++ b/.changeset/fix-hr-presentation-role.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9024](https://github.com/biomejs/biome/issues/9024). The `noInteractiveElementToNoninteractiveRole` rule no longer incorrectly flags `<hr>` elements with `role="presentation"` or `role="none"`. The `separator` role (implicit role of `<hr>`) is now treated as non-interactive, matching the WAI-ARIA spec where a non-focusable separator is a static structural element.

--- a/crates/biome_aria_metadata/src/lib.rs
+++ b/crates/biome_aria_metadata/src/lib.rs
@@ -160,13 +160,19 @@ impl AriaRole {
             .find_map(|value| value.parse().ok())
     }
 
-    /// Returns `true` if the given role inherits of `AriaAbstractRole::Widget` and is not `Self::Progressbar`.
+    /// Returns `true` if the given role inherits of `AriaAbstractRole::Widget` and is not `Self::Progressbar` or `Self::Separator`.
     ///
     /// This corresponds to a role that defines a user interface widget (slider, tree control, ...)
     pub fn is_interactive(self) -> bool {
         // `progressbar` inherits of `widget`, but its value is always `readonly`.
         // So we treat it as a non-interactive role.
+        //
+        // `separator` inherits of both `structure` and `widget`, but it is only interactive
+        // when it is focusable (e.g. has `tabindex` and `aria-valuenow`).
+        // A non-focusable `separator` (such as `<hr>`) is a static structural element.
+        // See: https://www.w3.org/TR/wai-aria-1.2/#separator
         self != Self::Progressbar
+            && self != Self::Separator
             && self
                 .inherited_abstract_roles()
                 .contains(&AriaAbstractRole::Widget)

--- a/crates/biome_js_analyze/tests/specs/a11y/noInteractiveElementToNoninteractiveRole/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noInteractiveElementToNoninteractiveRole/valid.jsx
@@ -209,6 +209,8 @@
 <h5 role="button" />;
 <h6 role="button" />;
 <hr role="button" />;
+<hr role="presentation" />;
+<hr role="none" />;
 <img role="button" />;
 <li role="button" />;
 <li role="presentation" />;

--- a/crates/biome_js_analyze/tests/specs/a11y/noInteractiveElementToNoninteractiveRole/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noInteractiveElementToNoninteractiveRole/valid.jsx.snap
@@ -215,6 +215,8 @@ expression: valid.jsx
 <h5 role="button" />;
 <h6 role="button" />;
 <hr role="button" />;
+<hr role="presentation" />;
+<hr role="none" />;
 <img role="button" />;
 <li role="button" />;
 <li role="presentation" />;


### PR DESCRIPTION
## Summary

Fixes #9024.

`<hr role="presentation">` incorrectly triggers `noInteractiveElementToNoninteractiveRole` because the `separator` role (implicit role of `<hr>`) inherits from `widget`, causing it to be classified as interactive.

Per the [WAI-ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#separator), the `separator` role is only interactive when the element is focusable (e.g. has `tabindex` and `aria-valuenow`). A non-focusable `<hr>` is a static structural element.

## Changes

- Added `Separator` to the exception list in `AriaRole::is_interactive()` (same pattern as the existing `Progressbar` exception).
- Added `<hr role="presentation" />` and `<hr role="none" />` to valid test cases.
- Updated snapshot.

## Test plan

- `cargo test -p biome_js_analyze -- no_interactive_element_to_noninteractive_role` — 2 passed
- `cargo test -p biome_js_analyze -- no_noninteractive_element_to_interactive_role` — 2 passed
- `cargo test -p biome_aria_metadata` — all passed

## AI assistance disclosure

This PR was authored with AI assistance (Claude Code) for codebase exploration, analysis, and implementation.