### PR TITLE
fix(linter): handle destructuring from `this` in noUnusedPrivateClassMembers

### DIFF
--- a/.changeset/fix-unused-private-destructuring.md
+++ b/.changeset/fix-unused-private-destructuring.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9008](https://github.com/biomejs/biome/issues/9008). The [`noUnusedPrivateClassMembers`](https://biomejs.dev/linter/rules/no-unused-private-class-members/) rule no longer reports false positives when TypeScript `private` class members are accessed via destructuring from `this`. Patterns such as `const { myVar } = this;`, `const { myVar: renamed } = this;`, and `({ myVar } = this)` are now correctly recognized as usage.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.ts
@@ -1,0 +1,58 @@
+/* should not generate diagnostics */
+
+// issue #9008 - destructuring from `this` should count as usage
+class DestructuringShorthand {
+	private myVar: string;
+
+	constructor() {
+		this.myVar = "Hello";
+	}
+
+	print() {
+		const { myVar } = this;
+		console.log(myVar);
+	}
+}
+
+class DestructuringMultiple {
+	private myVar1: string;
+	private myVar2: string;
+
+	constructor() {
+		this.myVar1 = "Hello";
+		this.myVar2 = "World";
+	}
+
+	print() {
+		const { myVar1 } = this;
+		console.log(myVar1);
+		console.log(this.myVar2);
+	}
+}
+
+class DestructuringRenamed {
+	private myVar: string;
+
+	constructor() {
+		this.myVar = "Hello";
+	}
+
+	print() {
+		const { myVar: renamed } = this;
+		console.log(renamed);
+	}
+}
+
+class DestructuringAssignmentPattern {
+	private myVar: string;
+
+	constructor() {
+		this.myVar = "Hello";
+	}
+
+	print() {
+		let myVar: string;
+		({ myVar } = this);
+		console.log(myVar);
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.ts.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+// issue #9008 - destructuring from `this` should count as usage
+class DestructuringShorthand {
+	private myVar: string;
+
+	constructor() {
+		this.myVar = "Hello";
+	}
+
+	print() {
+		const { myVar } = this;
+		console.log(myVar);
+	}
+}
+
+class DestructuringMultiple {
+	private myVar1: string;
+	private myVar2: string;
+
+	constructor() {
+		this.myVar1 = "Hello";
+		this.myVar2 = "World";
+	}
+
+	print() {
+		const { myVar1 } = this;
+		console.log(myVar1);
+		console.log(this.myVar2);
+	}
+}
+
+class DestructuringRenamed {
+	private myVar: string;
+
+	constructor() {
+		this.myVar = "Hello";
+	}
+
+	print() {
+		const { myVar: renamed } = this;
+		console.log(renamed);
+	}
+}
+
+class DestructuringAssignmentPattern {
+	private myVar: string;
+
+	constructor() {
+		this.myVar = "Hello";
+	}
+
+	print() {
+		let myVar: string;
+		({ myVar } = this);
+		console.log(myVar);
+	}
+}
+
+```


### PR DESCRIPTION
## Summary

Fixed [#9008](https://github.com/biomejs/biome/issues/9008).

The `noUnusedPrivateClassMembers` rule reported false positives when TypeScript `private` class members were accessed via object destructuring from `this`.

```ts
class MyClass {
  private myVar: string;

  constructor() {
    this.myVar = "Hello";
  }

  print() {
    const { myVar } = this; // was incorrectly flagged as unused
    console.log(myVar);
  }
}
```

## Root Cause

`traverse_members_usage` only matched `AnyJsName` nodes (used in direct member access like `this.myVar`). In destructuring patterns like `const { myVar } = this`, the property name appears as a `JsIdentifierBinding` inside a `JsObjectBindingPatternShorthandProperty`, which is not an `AnyJsName` node and was therefore never recognized as usage.

## Changes

- Added `get_destructured_names_from_this()` to extract property names from object destructuring patterns where the initializer is `this`. Handles:
  - `const { myVar } = this;` (shorthand binding pattern)
  - `const { myVar: renamed } = this;` (renamed binding pattern)
  - `({ myVar } = this)` (assignment destructuring pattern)
- Added `AnyMember::member_name()` to extract the private member name as a `String` for comparison with destructured names.
- Integrated destructuring detection into `traverse_members_usage`.

## Test Plan

Added `valid.ts` test file covering all destructuring patterns:
- `DestructuringShorthand` — `const { myVar } = this;`
- `DestructuringMultiple` — multiple private members, some accessed via destructuring
- `DestructuringRenamed` — `const { myVar: renamed } = this;`
- `DestructuringAssignmentPattern` — `({ myVar } = this);`

All 7 existing tests pass. New test passes with no diagnostics.

## AI Assistance Disclosure

This PR was written primarily by Claude Code.