### PR TITLE
fix(service): don't duplicate snippet's trivia when updating snippets

### DIFF
--- a/crates/biome_cli/tests/cases/handle_vue_files.rs
+++ b/crates/biome_cli/tests/cases/handle_vue_files.rs
@@ -1363,3 +1363,40 @@ fn fails_for_ts_grammar_when_lang_is_not_ts() {
         result,
     ));
 }
+
+#[test]
+fn lint_vue_should_not_add_extra_newlines_in_embedded_snippet() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{ "html": { "linter": {"enabled": true}, "experimentalFullSupportEnabled": true } }"#
+            .as_bytes(),
+    );
+
+    let file = Utf8Path::new("file.vue");
+    fs.insert(
+        file.into(),
+        r#"<script>
+import { computed } from "vue";
+</script>"#
+            .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", "--write", file.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "lint_vue_should_not_add_extra_newlines_in_embedded_snippet",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_should_not_add_extra_newlines_in_embedded_snippet.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_should_not_add_extra_newlines_in_embedded_snippet.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "linter": { "enabled": true },
+    "experimentalFullSupportEnabled": true
+  }
+}
+```
+
+## `file.vue`
+
+```vue
+<script>
+import { computed } from "vue";
+</script>
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -1333,7 +1333,7 @@ pub(crate) fn update_snippets(
             let new_token = ident(&format!(
                 "{}{}{}",
                 leading_trivia,
-                snippet.new_code.as_str(),
+                snippet.new_code.trim(), // trim to avoid duplicating trivia
                 trailing_trivia
             ));
             mutation.replace_token(value_token, new_token);


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
`update_snippets` was duplicating snippets trivia. The root cause was `read_leading_trivia` grabs the trivia from the original snippet. It then concatenated the leading trivia on the snippet's new code, which also contained leading whitespace. The result was duplicated whitespace. The same thing was happening to the trailing trivia as well.

No changeset since this is a regression from the current `main`, and it hasn't been released yet.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Fixes #9050

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
