### PR TITLE
fix(lint): regression of the `noUnknownPseudoElement` rule

### DIFF
--- a/.changeset/tame-pants-pay.md
+++ b/.changeset/tame-pants-pay.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9081](https://github.com/biomejs/biome/issues/9081): The `noUnknownPseudoElement` rule no longer reports false positives for any known pseudo elements in CSS modules. This was a regression introduced in v2.4.0.

--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_pseudo_element.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_pseudo_element.rs
@@ -161,11 +161,8 @@ fn should_not_trigger(
     let lowercase = pseudo_element_name.to_ascii_lowercase_cow();
     let lowercase = &lowercase.as_ref();
 
-    if file_source.is_css_modules() {
-        return ["global", "local"].contains(lowercase);
-    }
-
-    !vender_prefix(pseudo_element_name).is_empty()
+    (file_source.is_css_modules() && ["global", "local"].contains(lowercase))
+        || !vender_prefix(pseudo_element_name).is_empty()
         || is_pseudo_elements(lowercase)
         || should_ignore(pseudo_element_name, options)
 }

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoElement/valid.module.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoElement/valid.module.css
@@ -1,0 +1,11 @@
+/* should not generate diagnostics */
+
+/* CSS modules specific */
+:global(.foo),
+:local(.foo) {}
+
+/* https://github.com/biomejs/biome/issues/9081 */
+* {
+	&::after,
+	&::before {}
+}

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoElement/valid.module.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoElement/valid.module.css.snap
@@ -1,0 +1,19 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: valid.module.css
+---
+# Input
+```css
+/* should not generate diagnostics */
+
+/* CSS modules specific */
+:global(.foo),
+:local(.foo) {}
+
+/* https://github.com/biomejs/biome/issues/9081 */
+* {
+	&::after,
+	&::before {}
+}
+
+```


### PR DESCRIPTION
## Summary

Fixes #9081

There was a regression that the rule don't accept any pseudo elements anymore **except** `:global` and `:local` in CSS modules.

## Test Plan

Added snapshot tests

## Docs

N/A