### PR TITLE
fix(cli): stdin regression

### DIFF
--- a/.changeset/thin-ideas-tap.md
+++ b/.changeset/thin-ideas-tap.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9095](https://github.com/biomejs/biome/issues/9095), where Biome didn't print anything in stdin mode. This was a regression caused by a recent, internal refactor.

--- a/crates/biome_cli/src/runner/mod.rs
+++ b/crates/biome_cli/src/runner/mod.rs
@@ -402,13 +402,13 @@ pub(crate) trait CommandRunner {
             open_uninitialized: true,
         })?;
 
-        let stdin = self.get_stdin(console, execution.as_ref())?;
+        let stdin = execution.get_stdin_file_path().map(Utf8PathBuf::from);
         let computed_scan_kind =
             execution.scan_kind_computer(ProjectScanComputer::new(&configuration));
 
         let scan_kind = derive_best_scan_kind(
             computed_scan_kind,
-            stdin.as_ref(),
+            stdin.as_deref(),
             &root_configuration_dir,
             &working_dir,
             &configuration,

--- a/crates/biome_cli/src/runner/scan_kind.rs
+++ b/crates/biome_cli/src/runner/scan_kind.rs
@@ -1,4 +1,3 @@
-use crate::runner::execution::Stdin;
 use biome_configuration::Configuration;
 use biome_fs::BiomePath;
 use biome_service::workspace::ScanKind;
@@ -6,21 +5,20 @@ use camino::Utf8Path;
 
 /// Returns a forced scan kind based on the given `execution`.
 fn get_forced_scan_kind(
-    stdin: Option<&Stdin>,
+    stdin_file_path: Option<&Utf8Path>,
     root_configuration_dir: &Utf8Path,
     working_dir: &Utf8Path,
     maybe_scan_kind: Option<ScanKind>,
 ) -> Option<ScanKind> {
-    if let Some(stdin) = stdin {
-        let path = stdin.as_path();
-        if path
+    if let Some(stdin_file_path) = stdin_file_path {
+        if stdin_file_path
             .parent()
             .is_some_and(|dir| dir == root_configuration_dir)
         {
             return Some(ScanKind::NoScanner);
         } else {
             return Some(ScanKind::TargetedKnownFiles {
-                target_paths: vec![BiomePath::new(working_dir.join(path))],
+                target_paths: vec![BiomePath::new(working_dir.join(stdin_file_path))],
                 descend_from_targets: false,
             });
         }
@@ -43,7 +41,7 @@ fn get_forced_scan_kind(
 /// - Otherwise, we return the requested scan kind.
 pub(crate) fn derive_best_scan_kind(
     requested_scan_kind: ScanKind,
-    stdin: Option<&Stdin>,
+    stdin: Option<&Utf8Path>,
     root_configuration_dir: &Utf8Path,
     working_dir: &Utf8Path,
     configuration: &Configuration,


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/9095

We couldn't catch the bug because in our tests, `.read` always yields the same input; however, in reality, we can read only once, and then the input is consumed. 


For now I kept the changes at a minum, I will follow up with a change to better simulate the real stdin

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Manually tested

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
