### PR TITLE
fix(noUnknownAttribute): add `closedby` as a valid attribute for `<dialog>`

### DIFF
--- a/.changeset/fix-closedby-dialog-attribute.md
+++ b/.changeset/fix-closedby-dialog-attribute.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9141](https://github.com/biomejs/biome/issues/9141): The `noUnknownAttribute` rule no longer reports `closedby` as an unknown attribute on `<dialog>` elements.

--- a/crates/biome_js_analyze/src/lint/nursery/no_unknown_attribute.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unknown_attribute.rs
@@ -114,6 +114,7 @@ const ATTRIBUTE_TAGS_MAP: &[(&str, &[&str])] = &[
     ("autoPictureInPicture", &["video"]),
     ("charset", &["meta"]),
     ("checked", &["input"]),
+    ("closedby", &["dialog"]),
     ("controls", &["audio", "video"]),
     ("controlsList", &["audio", "video"]),
     (

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnknownAttribute/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnknownAttribute/invalid.jsx
@@ -42,6 +42,7 @@
 	<div data-xml-anything="invalid" />
 	<div data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />
 	<div abbr="abbr" />
+	<div closedby="any" />
 	<div webkitDirectory="" />
 	<div webkitdirectory="" />
 	<div

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnknownAttribute/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnknownAttribute/invalid.jsx.snap
@@ -48,6 +48,7 @@ expression: invalid.jsx
 	<div data-xml-anything="invalid" />
 	<div data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />
 	<div abbr="abbr" />
+	<div closedby="any" />
 	<div webkitDirectory="" />
 	<div webkitdirectory="" />
 	<div
@@ -847,7 +848,7 @@ invalid.jsx:43:48 lint/nursery/noUnknownAttribute ━━━━━━━━━━
   > 43 │ 	<div data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />
        │ 	                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     44 │ 	<div abbr="abbr" />
-    45 │ 	<div webkitDirectory="" />
+    45 │ 	<div closedby="any" />
   
   i This property is not recognized as a valid HTML/DOM attribute or React prop.
   
@@ -867,8 +868,8 @@ invalid.jsx:44:7 lint/nursery/noUnknownAttribute ━━━━━━━━━━�
     43 │ 	<div data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />
   > 44 │ 	<div abbr="abbr" />
        │ 	     ^^^^^^^^^^^
-    45 │ 	<div webkitDirectory="" />
-    46 │ 	<div webkitdirectory="" />
+    45 │ 	<div closedby="any" />
+    46 │ 	<div webkitDirectory="" />
   
   i This attribute is restricted and cannot be used on this HTML element
   
@@ -882,18 +883,18 @@ invalid.jsx:44:7 lint/nursery/noUnknownAttribute ━━━━━━━━━━�
 ```
 invalid.jsx:45:7 lint/nursery/noUnknownAttribute ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Property 'webkitDirectory' is not valid on a <div> element.
+  i Property 'closedby' is not valid on a <div> element.
   
     43 │ 	<div data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />
     44 │ 	<div abbr="abbr" />
-  > 45 │ 	<div webkitDirectory="" />
-       │ 	     ^^^^^^^^^^^^^^^^^^
-    46 │ 	<div webkitdirectory="" />
-    47 │ 	<div
+  > 45 │ 	<div closedby="any" />
+       │ 	     ^^^^^^^^^^^^^^
+    46 │ 	<div webkitDirectory="" />
+    47 │ 	<div webkitdirectory="" />
   
   i This attribute is restricted and cannot be used on this HTML element
   
-  i This attribute is only allowed on: input
+  i This attribute is only allowed on: dialog
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
@@ -906,11 +907,11 @@ invalid.jsx:46:7 lint/nursery/noUnknownAttribute ━━━━━━━━━━�
   i Property 'webkitDirectory' is not valid on a <div> element.
   
     44 │ 	<div abbr="abbr" />
-    45 │ 	<div webkitDirectory="" />
-  > 46 │ 	<div webkitdirectory="" />
+    45 │ 	<div closedby="any" />
+  > 46 │ 	<div webkitDirectory="" />
        │ 	     ^^^^^^^^^^^^^^^^^^
-    47 │ 	<div
-    48 │ 		className="App"
+    47 │ 	<div webkitdirectory="" />
+    48 │ 	<div
   
   i This attribute is restricted and cannot be used on this HTML element
   
@@ -922,16 +923,37 @@ invalid.jsx:46:7 lint/nursery/noUnknownAttribute ━━━━━━━━━━�
 ```
 
 ```
-invalid.jsx:49:3 lint/nursery/noUnknownAttribute ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.jsx:47:7 lint/nursery/noUnknownAttribute ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Property 'webkitDirectory' is not valid on a <div> element.
+  
+    45 │ 	<div closedby="any" />
+    46 │ 	<div webkitDirectory="" />
+  > 47 │ 	<div webkitdirectory="" />
+       │ 	     ^^^^^^^^^^^^^^^^^^
+    48 │ 	<div
+    49 │ 		className="App"
+  
+  i This attribute is restricted and cannot be used on this HTML element
+  
+  i This attribute is only allowed on: input
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.jsx:50:3 lint/nursery/noUnknownAttribute ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The property 'data-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash:c' is not a valid DOM attribute.
   
-    47 │ 	<div
-    48 │ 		className="App"
-  > 49 │ 		data-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash:c="customValue"
+    48 │ 	<div
+    49 │ 		className="App"
+  > 50 │ 		data-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash:c="customValue"
        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    50 │ 	>
-    51 │ 		Hello, world!
+    51 │ 	>
+    52 │ 		Hello, world!
   
   i This property is not recognized as a valid HTML/DOM attribute or React prop.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnknownAttribute/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnknownAttribute/valid.jsx
@@ -152,7 +152,7 @@
 	<hr align="top" />
 	<applet align="top" />
 	<marker fill="#000" />
-	<dialog onClose={handler} open id="dialog" returnValue="something" onCancel={handler2} />
+	<dialog closedby="any" onClose={handler} open id="dialog" returnValue="something" onCancel={handler2} />
 
 	<table align="top">
 		<caption align="top">Table Caption</caption>

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnknownAttribute/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnknownAttribute/valid.jsx.snap
@@ -158,7 +158,7 @@ expression: valid.jsx
 	<hr align="top" />
 	<applet align="top" />
 	<marker fill="#000" />
-	<dialog onClose={handler} open id="dialog" returnValue="something" onCancel={handler2} />
+	<dialog closedby="any" onClose={handler} open id="dialog" returnValue="something" onCancel={handler2} />
 
 	<table align="top">
 		<caption align="top">Table Caption</caption>


### PR DESCRIPTION
#### IA Usage

I made a final check before sending this PR, `invalid.jsx.snap`, `valid.jsx.snap` and `fix-closedby-dialog-attribute.md` files where updated/added by Claude, the core changes to fix the issue were manually made.

## Summary

Fixes #9141 

## Test Plan

Updated `invalid.jsx` and `valid.jsx` files