### PR TITLE
refactor(parse/html): use token_set! instead of matches! for svelte keywords and directives helpers

### DIFF
--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -4,13 +4,7 @@ use crate::token_source::{
     HtmlEmbeddedLanguage, HtmlLexContext, HtmlReLexContext, RestrictedExpressionStopAt,
     TextExpressionKind,
 };
-use biome_html_syntax::HtmlSyntaxKind::{
-    ANIMATE_KW, AS_KW, ATTACH_KW, AWAIT_KW, BIND_KW, CATCH_KW, CLASS_KW, CLIENT_KW, COMMENT,
-    CONST_KW, DEBUG_KW, DEFINE_KW, DOCTYPE_KW, EACH_KW, ELSE_KW, EOF, ERROR_TOKEN, HTML_KW,
-    HTML_LITERAL, HTML_STRING_LITERAL, IDENT, IF_KW, IN_KW, IS_KW, KEY_KW, NEWLINE, OUT_KW,
-    RENDER_KW, SERVER_KW, SET_KW, SNIPPET_KW, STYLE_KW, THEN_KW, TOMBSTONE, TRANSITION_KW,
-    UNICODE_BOM, USE_KW, WHITESPACE,
-};
+use biome_html_syntax::HtmlSyntaxKind::*;
 use biome_html_syntax::{HtmlSyntaxKind, T, TextLen, TextSize};
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{Lexer, LexerCheckpoint, LexerWithCheckpoint, ReLexer, TokenFlags};

--- a/crates/biome_html_parser/src/syntax/svelte.rs
+++ b/crates/biome_html_parser/src/syntax/svelte.rs
@@ -9,24 +9,7 @@ use crate::syntax::{
     parse_single_text_expression_content,
 };
 use crate::token_source::{HtmlLexContext, HtmlReLexContext, RestrictedExpressionStopAt};
-use biome_html_syntax::HtmlSyntaxKind::{
-    EOF, HTML_BOGUS_ELEMENT, HTML_ELEMENT_LIST, HTML_LITERAL, HTML_SPREAD_ATTRIBUTE, IDENT,
-    SVELTE_ANIMATE_DIRECTIVE, SVELTE_ATTACH_ATTRIBUTE, SVELTE_AWAIT_BLOCK,
-    SVELTE_AWAIT_CATCH_BLOCK, SVELTE_AWAIT_CATCH_CLAUSE, SVELTE_AWAIT_CLAUSES_LIST,
-    SVELTE_AWAIT_CLOSING_BLOCK, SVELTE_AWAIT_OPENING_BLOCK, SVELTE_AWAIT_THEN_BLOCK,
-    SVELTE_AWAIT_THEN_CLAUSE, SVELTE_BIND_DIRECTIVE, SVELTE_BINDING_ASSIGNMENT_BINDING_LIST,
-    SVELTE_BINDING_LIST, SVELTE_BOGUS_BLOCK, SVELTE_CLASS_DIRECTIVE, SVELTE_CONST_BLOCK,
-    SVELTE_CURLY_DESTRUCTURED_NAME, SVELTE_DEBUG_BLOCK, SVELTE_DIRECTIVE_MODIFIER,
-    SVELTE_DIRECTIVE_MODIFIER_LIST, SVELTE_DIRECTIVE_VALUE, SVELTE_EACH_AS_KEYED_ITEM,
-    SVELTE_EACH_BLOCK, SVELTE_EACH_CLOSING_BLOCK, SVELTE_EACH_INDEX, SVELTE_EACH_KEY,
-    SVELTE_EACH_KEYED_ITEM, SVELTE_EACH_OPENING_BLOCK, SVELTE_ELSE_CLAUSE, SVELTE_ELSE_IF_CLAUSE,
-    SVELTE_ELSE_IF_CLAUSE_LIST, SVELTE_HTML_BLOCK, SVELTE_IF_BLOCK, SVELTE_IF_CLOSING_BLOCK,
-    SVELTE_IF_OPENING_BLOCK, SVELTE_IN_DIRECTIVE, SVELTE_KEY_BLOCK, SVELTE_KEY_CLOSING_BLOCK,
-    SVELTE_KEY_OPENING_BLOCK, SVELTE_LITERAL, SVELTE_NAME, SVELTE_OUT_DIRECTIVE,
-    SVELTE_RENDER_BLOCK, SVELTE_REST_BINDING, SVELTE_SNIPPET_BLOCK, SVELTE_SNIPPET_CLOSING_BLOCK,
-    SVELTE_SNIPPET_OPENING_BLOCK, SVELTE_SQUARE_DESTRUCTURED_NAME, SVELTE_STYLE_DIRECTIVE,
-    SVELTE_TRANSITION_DIRECTIVE, SVELTE_USE_DIRECTIVE,
-};
+use biome_html_syntax::HtmlSyntaxKind::*;
 use biome_html_syntax::{HtmlSyntaxKind, T};
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
 use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
@@ -1244,43 +1227,45 @@ impl ParseNodeList for ModifiersList {
 
 // #region Check functions
 
+const SVELTE_KEYWORDS: TokenSet<HtmlSyntaxKind> = token_set!(
+    T![if],
+    T![else],
+    T![each],
+    T![debug],
+    T![const],
+    T![attach],
+    T![render],
+    T![key],
+    T![as],
+    T![await],
+    T![catch],
+    T![then],
+    T![snippet],
+    T![class],
+    T![in],
+    T![out],
+    T![transition],
+    T![animate],
+    T![bind]
+);
+
+const SVELTE_DIRECTIVE_KEYWORDS: TokenSet<HtmlSyntaxKind> = token_set!(
+    T![bind],
+    T![transition],
+    T![in],
+    T![out],
+    T![class],
+    T![style],
+    T![use],
+    T![animate]
+);
+
 pub(crate) fn is_at_svelte_keyword(p: &HtmlParser) -> bool {
-    matches!(
-        p.cur(),
-        T![if]
-            | T![else]
-            | T![each]
-            | T![debug]
-            | T![const]
-            | T![attach]
-            | T![render]
-            | T![key]
-            | T![as]
-            | T![await]
-            | T![catch]
-            | T![then]
-            | T![snippet]
-            | T![class]
-            | T![in]
-            | T![out]
-            | T![transition]
-            | T![animate]
-            | T![bind]
-    )
+    p.at_ts(SVELTE_KEYWORDS)
 }
 
 fn is_at_svelte_directive_keyword(token: HtmlSyntaxKind) -> bool {
-    matches!(
-        token,
-        T![bind]
-            | T![transition]
-            | T![in]
-            | T![out]
-            | T![class]
-            | T![style]
-            | T![use]
-            | T![animate]
-    )
+    SVELTE_DIRECTIVE_KEYWORDS.contains(token)
 }
 
 fn is_at_else_opening_block(p: &mut HtmlParser) -> bool {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
I noticed this when working on #9128. No changeset because no change in behavior, except maybe performance.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
CI should remain green

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
