### PR TITLE
fix(parse/html/vue): don't treat `:` as special token outside of vue directives

### DIFF
--- a/.changeset/fix-vue-colon-attribute-parsing.md
+++ b/.changeset/fix-vue-colon-attribute-parsing.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9161](https://github.com/biomejs/biome/issues/9161): The Vue parser now correctly handles colon attributes like `xlink:href` and `xmlns:xlink` by parsing them as single attributes instead of splitting them into separate tokens.

--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -759,7 +759,11 @@ impl<'src> HtmlLexer<'src> {
                     }
                 }
                 IdentifierContext::Vue => {
-                    if is_attribute_name_byte_vue(byte) {
+                    if byte == b':' && is_vue_directive_prefix_bytes(&buffer[..len]) {
+                        break;
+                    }
+
+                    if is_attribute_name_byte_vue(byte) || byte == b':' {
                         if len < BUFFER_SIZE {
                             buffer[len] = byte;
                             len += 1;
@@ -1428,6 +1432,10 @@ fn is_astro_directive_keyword_bytes(bytes: &[u8]) -> bool {
         bytes,
         b"client" | b"set" | b"class" | b"is" | b"server" | b"define"
     )
+}
+
+fn is_vue_directive_prefix_bytes(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"v-")
 }
 
 /// Identifiers can contain letters, numbers and `_`

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/component_with_attributes.vue
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/component_with_attributes.vue
@@ -1,6 +1,5 @@
 <template>
   <AvatarPrimitive.Fallback
-    bind:ref
     class="something nice"
   />
 </template>

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/component_with_attributes.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/component_with_attributes.vue.snap
@@ -8,7 +8,6 @@ expression: snapshot
 ```vue
 <template>
   <AvatarPrimitive.Fallback
-    bind:ref
     class="something nice"
   />
 </template>
@@ -48,67 +47,51 @@ HtmlRoot {
                     attributes: HtmlAttributeList [
                         HtmlAttribute {
                             name: HtmlAttributeName {
-                                value_token: HTML_LITERAL@38..47 "bind" [Newline("\n"), Whitespace("    ")] [],
-                            },
-                            initializer: missing (optional),
-                        },
-                        VueVBindShorthandDirective {
-                            arg: VueDirectiveArgument {
-                                colon_token: COLON@47..48 ":" [] [],
-                                arg: VueStaticArgument {
-                                    name_token: HTML_LITERAL@48..51 "ref" [] [],
-                                },
-                            },
-                            modifiers: VueModifierList [],
-                            initializer: missing (optional),
-                        },
-                        HtmlAttribute {
-                            name: HtmlAttributeName {
-                                value_token: HTML_LITERAL@51..61 "class" [Newline("\n"), Whitespace("    ")] [],
+                                value_token: HTML_LITERAL@38..48 "class" [Newline("\n"), Whitespace("    ")] [],
                             },
                             initializer: HtmlAttributeInitializerClause {
-                                eq_token: EQ@61..62 "=" [] [],
+                                eq_token: EQ@48..49 "=" [] [],
                                 value: HtmlString {
-                                    value_token: HTML_STRING_LITERAL@62..78 "\"something nice\"" [] [],
+                                    value_token: HTML_STRING_LITERAL@49..65 "\"something nice\"" [] [],
                                 },
                             },
                         },
                     ],
-                    slash_token: SLASH@78..82 "/" [Newline("\n"), Whitespace("  ")] [],
-                    r_angle_token: R_ANGLE@82..83 ">" [] [],
+                    slash_token: SLASH@65..69 "/" [Newline("\n"), Whitespace("  ")] [],
+                    r_angle_token: R_ANGLE@69..70 ">" [] [],
                 },
             ],
             closing_element: HtmlClosingElement {
-                l_angle_token: L_ANGLE@83..85 "<" [Newline("\n")] [],
-                slash_token: SLASH@85..86 "/" [] [],
+                l_angle_token: L_ANGLE@70..72 "<" [Newline("\n")] [],
+                slash_token: SLASH@72..73 "/" [] [],
                 name: HtmlTagName {
-                    value_token: HTML_LITERAL@86..94 "template" [] [],
+                    value_token: HTML_LITERAL@73..81 "template" [] [],
                 },
-                r_angle_token: R_ANGLE@94..95 ">" [] [],
+                r_angle_token: R_ANGLE@81..82 ">" [] [],
             },
         },
     ],
-    eof_token: EOF@95..96 "" [Newline("\n")] [],
+    eof_token: EOF@82..83 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: HTML_ROOT@0..96
+0: HTML_ROOT@0..83
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..95
-    0: HTML_ELEMENT@0..95
+  3: HTML_ELEMENT_LIST@0..82
+    0: HTML_ELEMENT@0..82
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
         1: HTML_TAG_NAME@1..9
           0: HTML_LITERAL@1..9 "template" [] []
         2: HTML_ATTRIBUTE_LIST@9..9
         3: R_ANGLE@9..10 ">" [] []
-      1: HTML_ELEMENT_LIST@10..83
-        0: HTML_SELF_CLOSING_ELEMENT@10..83
+      1: HTML_ELEMENT_LIST@10..70
+        0: HTML_SELF_CLOSING_ELEMENT@10..70
           0: L_ANGLE@10..14 "<" [Newline("\n"), Whitespace("  ")] []
           1: HTML_MEMBER_NAME@14..38
             0: HTML_COMPONENT_NAME@14..29
@@ -116,33 +99,22 @@ HtmlRoot {
             1: DOT@29..30 "." [] []
             2: HTML_TAG_NAME@30..38
               0: HTML_LITERAL@30..38 "Fallback" [] []
-          2: HTML_ATTRIBUTE_LIST@38..78
-            0: HTML_ATTRIBUTE@38..47
-              0: HTML_ATTRIBUTE_NAME@38..47
-                0: HTML_LITERAL@38..47 "bind" [Newline("\n"), Whitespace("    ")] []
-              1: (empty)
-            1: VUE_V_BIND_SHORTHAND_DIRECTIVE@47..51
-              0: VUE_DIRECTIVE_ARGUMENT@47..51
-                0: COLON@47..48 ":" [] []
-                1: VUE_STATIC_ARGUMENT@48..51
-                  0: HTML_LITERAL@48..51 "ref" [] []
-              1: VUE_MODIFIER_LIST@51..51
-              2: (empty)
-            2: HTML_ATTRIBUTE@51..78
-              0: HTML_ATTRIBUTE_NAME@51..61
-                0: HTML_LITERAL@51..61 "class" [Newline("\n"), Whitespace("    ")] []
-              1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@61..78
-                0: EQ@61..62 "=" [] []
-                1: HTML_STRING@62..78
-                  0: HTML_STRING_LITERAL@62..78 "\"something nice\"" [] []
-          3: SLASH@78..82 "/" [Newline("\n"), Whitespace("  ")] []
-          4: R_ANGLE@82..83 ">" [] []
-      2: HTML_CLOSING_ELEMENT@83..95
-        0: L_ANGLE@83..85 "<" [Newline("\n")] []
-        1: SLASH@85..86 "/" [] []
-        2: HTML_TAG_NAME@86..94
-          0: HTML_LITERAL@86..94 "template" [] []
-        3: R_ANGLE@94..95 ">" [] []
-  4: EOF@95..96 "" [Newline("\n")] []
+          2: HTML_ATTRIBUTE_LIST@38..65
+            0: HTML_ATTRIBUTE@38..65
+              0: HTML_ATTRIBUTE_NAME@38..48
+                0: HTML_LITERAL@38..48 "class" [Newline("\n"), Whitespace("    ")] []
+              1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@48..65
+                0: EQ@48..49 "=" [] []
+                1: HTML_STRING@49..65
+                  0: HTML_STRING_LITERAL@49..65 "\"something nice\"" [] []
+          3: SLASH@65..69 "/" [Newline("\n"), Whitespace("  ")] []
+          4: R_ANGLE@69..70 ">" [] []
+      2: HTML_CLOSING_ELEMENT@70..82
+        0: L_ANGLE@70..72 "<" [Newline("\n")] []
+        1: SLASH@72..73 "/" [] []
+        2: HTML_TAG_NAME@73..81
+          0: HTML_LITERAL@73..81 "template" [] []
+        3: R_ANGLE@81..82 ">" [] []
+  4: EOF@82..83 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/svg_with_colon_attribute.vue
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/svg_with_colon_attribute.vue
@@ -1,0 +1,13 @@
+<svg width="200" height="150"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+
+  <defs>
+      <circle id="myCircle" cx="0" cy="0" r="30" fill="orange" />
+  </defs>
+
+  <!-- xlink:href should be parsed as a single attribute -->
+  <use xlink:href="#myCircle" x="50" y="50" />
+  <use xlink:href="#myCircle" x="150" y="100" fill="steelblue" />
+
+</svg>

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/svg_with_colon_attribute.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/svg_with_colon_attribute.vue.snap
@@ -1,0 +1,457 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```vue
+<svg width="200" height="150"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+
+  <defs>
+      <circle id="myCircle" cx="0" cy="0" r="30" fill="orange" />
+  </defs>
+
+  <!-- xlink:href should be parsed as a single attribute -->
+  <use xlink:href="#myCircle" x="50" y="50" />
+  <use xlink:href="#myCircle" x="150" y="100" fill="steelblue" />
+
+</svg>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..1 "<" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@1..5 "svg" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@5..10 "width" [] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@10..11 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@11..17 "\"200\"" [] [Whitespace(" ")],
+                            },
+                        },
+                    },
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@17..23 "height" [] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@23..24 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@24..29 "\"150\"" [] [],
+                            },
+                        },
+                    },
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@29..39 "xmlns" [Newline("\n"), Whitespace("    ")] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@39..40 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@40..68 "\"http://www.w3.org/2000/svg\"" [] [],
+                            },
+                        },
+                    },
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@68..84 "xmlns:xlink" [Newline("\n"), Whitespace("    ")] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@84..85 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@85..115 "\"http://www.w3.org/1999/xlink\"" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@115..116 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlElement {
+                    opening_element: HtmlOpeningElement {
+                        l_angle_token: L_ANGLE@116..121 "<" [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                        name: HtmlTagName {
+                            value_token: HTML_LITERAL@121..125 "defs" [] [],
+                        },
+                        attributes: HtmlAttributeList [],
+                        r_angle_token: R_ANGLE@125..126 ">" [] [],
+                    },
+                    children: HtmlElementList [
+                        HtmlSelfClosingElement {
+                            l_angle_token: L_ANGLE@126..134 "<" [Newline("\n"), Whitespace("      ")] [],
+                            name: HtmlTagName {
+                                value_token: HTML_LITERAL@134..141 "circle" [] [Whitespace(" ")],
+                            },
+                            attributes: HtmlAttributeList [
+                                HtmlAttribute {
+                                    name: HtmlAttributeName {
+                                        value_token: HTML_LITERAL@141..143 "id" [] [],
+                                    },
+                                    initializer: HtmlAttributeInitializerClause {
+                                        eq_token: EQ@143..144 "=" [] [],
+                                        value: HtmlString {
+                                            value_token: HTML_STRING_LITERAL@144..155 "\"myCircle\"" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                                HtmlAttribute {
+                                    name: HtmlAttributeName {
+                                        value_token: HTML_LITERAL@155..157 "cx" [] [],
+                                    },
+                                    initializer: HtmlAttributeInitializerClause {
+                                        eq_token: EQ@157..158 "=" [] [],
+                                        value: HtmlString {
+                                            value_token: HTML_STRING_LITERAL@158..162 "\"0\"" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                                HtmlAttribute {
+                                    name: HtmlAttributeName {
+                                        value_token: HTML_LITERAL@162..164 "cy" [] [],
+                                    },
+                                    initializer: HtmlAttributeInitializerClause {
+                                        eq_token: EQ@164..165 "=" [] [],
+                                        value: HtmlString {
+                                            value_token: HTML_STRING_LITERAL@165..169 "\"0\"" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                                HtmlAttribute {
+                                    name: HtmlAttributeName {
+                                        value_token: HTML_LITERAL@169..170 "r" [] [],
+                                    },
+                                    initializer: HtmlAttributeInitializerClause {
+                                        eq_token: EQ@170..171 "=" [] [],
+                                        value: HtmlString {
+                                            value_token: HTML_STRING_LITERAL@171..176 "\"30\"" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                                HtmlAttribute {
+                                    name: HtmlAttributeName {
+                                        value_token: HTML_LITERAL@176..180 "fill" [] [],
+                                    },
+                                    initializer: HtmlAttributeInitializerClause {
+                                        eq_token: EQ@180..181 "=" [] [],
+                                        value: HtmlString {
+                                            value_token: HTML_STRING_LITERAL@181..190 "\"orange\"" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                            ],
+                            slash_token: SLASH@190..191 "/" [] [],
+                            r_angle_token: R_ANGLE@191..192 ">" [] [],
+                        },
+                    ],
+                    closing_element: HtmlClosingElement {
+                        l_angle_token: L_ANGLE@192..196 "<" [Newline("\n"), Whitespace("  ")] [],
+                        slash_token: SLASH@196..197 "/" [] [],
+                        name: HtmlTagName {
+                            value_token: HTML_LITERAL@197..201 "defs" [] [],
+                        },
+                        r_angle_token: R_ANGLE@201..202 ">" [] [],
+                    },
+                },
+                HtmlSelfClosingElement {
+                    l_angle_token: L_ANGLE@202..268 "<" [Newline("\n"), Newline("\n"), Whitespace("  "), Comments("<!-- xlink:href shoul ..."), Newline("\n"), Whitespace("  ")] [],
+                    name: HtmlTagName {
+                        value_token: HTML_LITERAL@268..272 "use" [] [Whitespace(" ")],
+                    },
+                    attributes: HtmlAttributeList [
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@272..282 "xlink:href" [] [],
+                            },
+                            initializer: HtmlAttributeInitializerClause {
+                                eq_token: EQ@282..283 "=" [] [],
+                                value: HtmlString {
+                                    value_token: HTML_STRING_LITERAL@283..295 "\"#myCircle\"" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@295..296 "x" [] [],
+                            },
+                            initializer: HtmlAttributeInitializerClause {
+                                eq_token: EQ@296..297 "=" [] [],
+                                value: HtmlString {
+                                    value_token: HTML_STRING_LITERAL@297..302 "\"50\"" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@302..303 "y" [] [],
+                            },
+                            initializer: HtmlAttributeInitializerClause {
+                                eq_token: EQ@303..304 "=" [] [],
+                                value: HtmlString {
+                                    value_token: HTML_STRING_LITERAL@304..309 "\"50\"" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                    ],
+                    slash_token: SLASH@309..310 "/" [] [],
+                    r_angle_token: R_ANGLE@310..311 ">" [] [],
+                },
+                HtmlSelfClosingElement {
+                    l_angle_token: L_ANGLE@311..315 "<" [Newline("\n"), Whitespace("  ")] [],
+                    name: HtmlTagName {
+                        value_token: HTML_LITERAL@315..319 "use" [] [Whitespace(" ")],
+                    },
+                    attributes: HtmlAttributeList [
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@319..329 "xlink:href" [] [],
+                            },
+                            initializer: HtmlAttributeInitializerClause {
+                                eq_token: EQ@329..330 "=" [] [],
+                                value: HtmlString {
+                                    value_token: HTML_STRING_LITERAL@330..342 "\"#myCircle\"" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@342..343 "x" [] [],
+                            },
+                            initializer: HtmlAttributeInitializerClause {
+                                eq_token: EQ@343..344 "=" [] [],
+                                value: HtmlString {
+                                    value_token: HTML_STRING_LITERAL@344..350 "\"150\"" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@350..351 "y" [] [],
+                            },
+                            initializer: HtmlAttributeInitializerClause {
+                                eq_token: EQ@351..352 "=" [] [],
+                                value: HtmlString {
+                                    value_token: HTML_STRING_LITERAL@352..358 "\"100\"" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@358..362 "fill" [] [],
+                            },
+                            initializer: HtmlAttributeInitializerClause {
+                                eq_token: EQ@362..363 "=" [] [],
+                                value: HtmlString {
+                                    value_token: HTML_STRING_LITERAL@363..375 "\"steelblue\"" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                    ],
+                    slash_token: SLASH@375..376 "/" [] [],
+                    r_angle_token: R_ANGLE@376..377 ">" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@377..380 "<" [Newline("\n"), Newline("\n")] [],
+                slash_token: SLASH@380..381 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@381..384 "svg" [] [],
+                },
+                r_angle_token: R_ANGLE@384..385 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@385..386 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..386
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..385
+    0: HTML_ELEMENT@0..385
+      0: HTML_OPENING_ELEMENT@0..116
+        0: L_ANGLE@0..1 "<" [] []
+        1: HTML_TAG_NAME@1..5
+          0: HTML_LITERAL@1..5 "svg" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@5..115
+          0: HTML_ATTRIBUTE@5..17
+            0: HTML_ATTRIBUTE_NAME@5..10
+              0: HTML_LITERAL@5..10 "width" [] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@10..17
+              0: EQ@10..11 "=" [] []
+              1: HTML_STRING@11..17
+                0: HTML_STRING_LITERAL@11..17 "\"200\"" [] [Whitespace(" ")]
+          1: HTML_ATTRIBUTE@17..29
+            0: HTML_ATTRIBUTE_NAME@17..23
+              0: HTML_LITERAL@17..23 "height" [] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@23..29
+              0: EQ@23..24 "=" [] []
+              1: HTML_STRING@24..29
+                0: HTML_STRING_LITERAL@24..29 "\"150\"" [] []
+          2: HTML_ATTRIBUTE@29..68
+            0: HTML_ATTRIBUTE_NAME@29..39
+              0: HTML_LITERAL@29..39 "xmlns" [Newline("\n"), Whitespace("    ")] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@39..68
+              0: EQ@39..40 "=" [] []
+              1: HTML_STRING@40..68
+                0: HTML_STRING_LITERAL@40..68 "\"http://www.w3.org/2000/svg\"" [] []
+          3: HTML_ATTRIBUTE@68..115
+            0: HTML_ATTRIBUTE_NAME@68..84
+              0: HTML_LITERAL@68..84 "xmlns:xlink" [Newline("\n"), Whitespace("    ")] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@84..115
+              0: EQ@84..85 "=" [] []
+              1: HTML_STRING@85..115
+                0: HTML_STRING_LITERAL@85..115 "\"http://www.w3.org/1999/xlink\"" [] []
+        3: R_ANGLE@115..116 ">" [] []
+      1: HTML_ELEMENT_LIST@116..377
+        0: HTML_ELEMENT@116..202
+          0: HTML_OPENING_ELEMENT@116..126
+            0: L_ANGLE@116..121 "<" [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+            1: HTML_TAG_NAME@121..125
+              0: HTML_LITERAL@121..125 "defs" [] []
+            2: HTML_ATTRIBUTE_LIST@125..125
+            3: R_ANGLE@125..126 ">" [] []
+          1: HTML_ELEMENT_LIST@126..192
+            0: HTML_SELF_CLOSING_ELEMENT@126..192
+              0: L_ANGLE@126..134 "<" [Newline("\n"), Whitespace("      ")] []
+              1: HTML_TAG_NAME@134..141
+                0: HTML_LITERAL@134..141 "circle" [] [Whitespace(" ")]
+              2: HTML_ATTRIBUTE_LIST@141..190
+                0: HTML_ATTRIBUTE@141..155
+                  0: HTML_ATTRIBUTE_NAME@141..143
+                    0: HTML_LITERAL@141..143 "id" [] []
+                  1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@143..155
+                    0: EQ@143..144 "=" [] []
+                    1: HTML_STRING@144..155
+                      0: HTML_STRING_LITERAL@144..155 "\"myCircle\"" [] [Whitespace(" ")]
+                1: HTML_ATTRIBUTE@155..162
+                  0: HTML_ATTRIBUTE_NAME@155..157
+                    0: HTML_LITERAL@155..157 "cx" [] []
+                  1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@157..162
+                    0: EQ@157..158 "=" [] []
+                    1: HTML_STRING@158..162
+                      0: HTML_STRING_LITERAL@158..162 "\"0\"" [] [Whitespace(" ")]
+                2: HTML_ATTRIBUTE@162..169
+                  0: HTML_ATTRIBUTE_NAME@162..164
+                    0: HTML_LITERAL@162..164 "cy" [] []
+                  1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@164..169
+                    0: EQ@164..165 "=" [] []
+                    1: HTML_STRING@165..169
+                      0: HTML_STRING_LITERAL@165..169 "\"0\"" [] [Whitespace(" ")]
+                3: HTML_ATTRIBUTE@169..176
+                  0: HTML_ATTRIBUTE_NAME@169..170
+                    0: HTML_LITERAL@169..170 "r" [] []
+                  1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@170..176
+                    0: EQ@170..171 "=" [] []
+                    1: HTML_STRING@171..176
+                      0: HTML_STRING_LITERAL@171..176 "\"30\"" [] [Whitespace(" ")]
+                4: HTML_ATTRIBUTE@176..190
+                  0: HTML_ATTRIBUTE_NAME@176..180
+                    0: HTML_LITERAL@176..180 "fill" [] []
+                  1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@180..190
+                    0: EQ@180..181 "=" [] []
+                    1: HTML_STRING@181..190
+                      0: HTML_STRING_LITERAL@181..190 "\"orange\"" [] [Whitespace(" ")]
+              3: SLASH@190..191 "/" [] []
+              4: R_ANGLE@191..192 ">" [] []
+          2: HTML_CLOSING_ELEMENT@192..202
+            0: L_ANGLE@192..196 "<" [Newline("\n"), Whitespace("  ")] []
+            1: SLASH@196..197 "/" [] []
+            2: HTML_TAG_NAME@197..201
+              0: HTML_LITERAL@197..201 "defs" [] []
+            3: R_ANGLE@201..202 ">" [] []
+        1: HTML_SELF_CLOSING_ELEMENT@202..311
+          0: L_ANGLE@202..268 "<" [Newline("\n"), Newline("\n"), Whitespace("  "), Comments("<!-- xlink:href shoul ..."), Newline("\n"), Whitespace("  ")] []
+          1: HTML_TAG_NAME@268..272
+            0: HTML_LITERAL@268..272 "use" [] [Whitespace(" ")]
+          2: HTML_ATTRIBUTE_LIST@272..309
+            0: HTML_ATTRIBUTE@272..295
+              0: HTML_ATTRIBUTE_NAME@272..282
+                0: HTML_LITERAL@272..282 "xlink:href" [] []
+              1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@282..295
+                0: EQ@282..283 "=" [] []
+                1: HTML_STRING@283..295
+                  0: HTML_STRING_LITERAL@283..295 "\"#myCircle\"" [] [Whitespace(" ")]
+            1: HTML_ATTRIBUTE@295..302
+              0: HTML_ATTRIBUTE_NAME@295..296
+                0: HTML_LITERAL@295..296 "x" [] []
+              1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@296..302
+                0: EQ@296..297 "=" [] []
+                1: HTML_STRING@297..302
+                  0: HTML_STRING_LITERAL@297..302 "\"50\"" [] [Whitespace(" ")]
+            2: HTML_ATTRIBUTE@302..309
+              0: HTML_ATTRIBUTE_NAME@302..303
+                0: HTML_LITERAL@302..303 "y" [] []
+              1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@303..309
+                0: EQ@303..304 "=" [] []
+                1: HTML_STRING@304..309
+                  0: HTML_STRING_LITERAL@304..309 "\"50\"" [] [Whitespace(" ")]
+          3: SLASH@309..310 "/" [] []
+          4: R_ANGLE@310..311 ">" [] []
+        2: HTML_SELF_CLOSING_ELEMENT@311..377
+          0: L_ANGLE@311..315 "<" [Newline("\n"), Whitespace("  ")] []
+          1: HTML_TAG_NAME@315..319
+            0: HTML_LITERAL@315..319 "use" [] [Whitespace(" ")]
+          2: HTML_ATTRIBUTE_LIST@319..375
+            0: HTML_ATTRIBUTE@319..342
+              0: HTML_ATTRIBUTE_NAME@319..329
+                0: HTML_LITERAL@319..329 "xlink:href" [] []
+              1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@329..342
+                0: EQ@329..330 "=" [] []
+                1: HTML_STRING@330..342
+                  0: HTML_STRING_LITERAL@330..342 "\"#myCircle\"" [] [Whitespace(" ")]
+            1: HTML_ATTRIBUTE@342..350
+              0: HTML_ATTRIBUTE_NAME@342..343
+                0: HTML_LITERAL@342..343 "x" [] []
+              1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@343..350
+                0: EQ@343..344 "=" [] []
+                1: HTML_STRING@344..350
+                  0: HTML_STRING_LITERAL@344..350 "\"150\"" [] [Whitespace(" ")]
+            2: HTML_ATTRIBUTE@350..358
+              0: HTML_ATTRIBUTE_NAME@350..351
+                0: HTML_LITERAL@350..351 "y" [] []
+              1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@351..358
+                0: EQ@351..352 "=" [] []
+                1: HTML_STRING@352..358
+                  0: HTML_STRING_LITERAL@352..358 "\"100\"" [] [Whitespace(" ")]
+            3: HTML_ATTRIBUTE@358..375
+              0: HTML_ATTRIBUTE_NAME@358..362
+                0: HTML_LITERAL@358..362 "fill" [] []
+              1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@362..375
+                0: EQ@362..363 "=" [] []
+                1: HTML_STRING@363..375
+                  0: HTML_STRING_LITERAL@363..375 "\"steelblue\"" [] [Whitespace(" ")]
+          3: SLASH@375..376 "/" [] []
+          4: R_ANGLE@376..377 ">" [] []
+      2: HTML_CLOSING_ELEMENT@377..385
+        0: L_ANGLE@377..380 "<" [Newline("\n"), Newline("\n")] []
+        1: SLASH@380..381 "/" [] []
+        2: HTML_TAG_NAME@381..384
+          0: HTML_LITERAL@381..384 "svg" [] []
+        3: R_ANGLE@384..385 ">" [] []
+  4: EOF@385..386 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/unocss-attributify.vue
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/unocss-attributify.vue
@@ -1,0 +1,12 @@
+<template>
+	<!--
+		The `hover:bg` attribute is syntax for UnoCSS's Attributify preset: https://unocss.dev/presets/attributify
+		We need to make sure that the `hover:bg` attribute is parsed as a single attribute, and not split into two attributes `hover` and `:bg`.
+	-->
+  <button
+    type = "button"
+    hover:bg="gray-400 opacity-20"
+  >
+    +
+  </button>
+</template>

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/unocss-attributify.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/unocss-attributify.vue.snap
@@ -1,0 +1,158 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```vue
+<template>
+	<!--
+		The `hover:bg` attribute is syntax for UnoCSS's Attributify preset: https://unocss.dev/presets/attributify
+		We need to make sure that the `hover:bg` attribute is parsed as a single attribute, and not split into two attributes `hover` and `:bg`.
+	-->
+  <button
+    type = "button"
+    hover:bg="gray-400 opacity-20"
+  >
+    +
+  </button>
+</template>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..1 "<" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@1..9 "template" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@9..10 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlElement {
+                    opening_element: HtmlOpeningElement {
+                        l_angle_token: L_ANGLE@10..273 "<" [Newline("\n"), Whitespace("\t"), Comments("<!--\n\t\tThe `hover:bg` ..."), Newline("\n"), Whitespace("  ")] [],
+                        name: HtmlTagName {
+                            value_token: HTML_LITERAL@273..279 "button" [] [],
+                        },
+                        attributes: HtmlAttributeList [
+                            HtmlAttribute {
+                                name: HtmlAttributeName {
+                                    value_token: HTML_LITERAL@279..289 "type" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                                },
+                                initializer: HtmlAttributeInitializerClause {
+                                    eq_token: EQ@289..291 "=" [] [Whitespace(" ")],
+                                    value: HtmlString {
+                                        value_token: HTML_STRING_LITERAL@291..299 "\"button\"" [] [],
+                                    },
+                                },
+                            },
+                            HtmlAttribute {
+                                name: HtmlAttributeName {
+                                    value_token: HTML_LITERAL@299..312 "hover:bg" [Newline("\n"), Whitespace("    ")] [],
+                                },
+                                initializer: HtmlAttributeInitializerClause {
+                                    eq_token: EQ@312..313 "=" [] [],
+                                    value: HtmlString {
+                                        value_token: HTML_STRING_LITERAL@313..334 "\"gray-400 opacity-20\"" [] [],
+                                    },
+                                },
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@334..338 ">" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    children: HtmlElementList [
+                        HtmlContent {
+                            value_token: HTML_LITERAL@338..344 "+" [Newline("\n"), Whitespace("    ")] [],
+                        },
+                    ],
+                    closing_element: HtmlClosingElement {
+                        l_angle_token: L_ANGLE@344..348 "<" [Newline("\n"), Whitespace("  ")] [],
+                        slash_token: SLASH@348..349 "/" [] [],
+                        name: HtmlTagName {
+                            value_token: HTML_LITERAL@349..355 "button" [] [],
+                        },
+                        r_angle_token: R_ANGLE@355..356 ">" [] [],
+                    },
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@356..358 "<" [Newline("\n")] [],
+                slash_token: SLASH@358..359 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@359..367 "template" [] [],
+                },
+                r_angle_token: R_ANGLE@367..368 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@368..369 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..369
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..368
+    0: HTML_ELEMENT@0..368
+      0: HTML_OPENING_ELEMENT@0..10
+        0: L_ANGLE@0..1 "<" [] []
+        1: HTML_TAG_NAME@1..9
+          0: HTML_LITERAL@1..9 "template" [] []
+        2: HTML_ATTRIBUTE_LIST@9..9
+        3: R_ANGLE@9..10 ">" [] []
+      1: HTML_ELEMENT_LIST@10..356
+        0: HTML_ELEMENT@10..356
+          0: HTML_OPENING_ELEMENT@10..338
+            0: L_ANGLE@10..273 "<" [Newline("\n"), Whitespace("\t"), Comments("<!--\n\t\tThe `hover:bg` ..."), Newline("\n"), Whitespace("  ")] []
+            1: HTML_TAG_NAME@273..279
+              0: HTML_LITERAL@273..279 "button" [] []
+            2: HTML_ATTRIBUTE_LIST@279..334
+              0: HTML_ATTRIBUTE@279..299
+                0: HTML_ATTRIBUTE_NAME@279..289
+                  0: HTML_LITERAL@279..289 "type" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+                1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@289..299
+                  0: EQ@289..291 "=" [] [Whitespace(" ")]
+                  1: HTML_STRING@291..299
+                    0: HTML_STRING_LITERAL@291..299 "\"button\"" [] []
+              1: HTML_ATTRIBUTE@299..334
+                0: HTML_ATTRIBUTE_NAME@299..312
+                  0: HTML_LITERAL@299..312 "hover:bg" [Newline("\n"), Whitespace("    ")] []
+                1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@312..334
+                  0: EQ@312..313 "=" [] []
+                  1: HTML_STRING@313..334
+                    0: HTML_STRING_LITERAL@313..334 "\"gray-400 opacity-20\"" [] []
+            3: R_ANGLE@334..338 ">" [Newline("\n"), Whitespace("  ")] []
+          1: HTML_ELEMENT_LIST@338..344
+            0: HTML_CONTENT@338..344
+              0: HTML_LITERAL@338..344 "+" [Newline("\n"), Whitespace("    ")] []
+          2: HTML_CLOSING_ELEMENT@344..356
+            0: L_ANGLE@344..348 "<" [Newline("\n"), Whitespace("  ")] []
+            1: SLASH@348..349 "/" [] []
+            2: HTML_TAG_NAME@349..355
+              0: HTML_LITERAL@349..355 "button" [] []
+            3: R_ANGLE@355..356 ">" [] []
+      2: HTML_CLOSING_ELEMENT@356..368
+        0: L_ANGLE@356..358 "<" [Newline("\n")] []
+        1: SLASH@358..359 "/" [] []
+        2: HTML_TAG_NAME@359..367
+          0: HTML_LITERAL@359..367 "template" [] []
+        3: R_ANGLE@367..368 ">" [] []
+  4: EOF@368..369 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This makes sure we only consider colons to be special if we know we are lexing a vue directive, in vue files.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
partial fix for #9161

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added snapshots, removed some invalid svelte syntax from a vue test

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
