### PR TITLE
feat(lint): add `allowedPatterns` option to `noSecrets` rule

### DIFF
--- a/crates/biome_js_analyze/tests/specs/security/noSecrets/allowed_patterns.js
+++ b/crates/biome_js_analyze/tests/specs/security/noSecrets/allowed_patterns.js
@@ -1,0 +1,11 @@
+/* should not generate diagnostics for allowed patterns */
+
+// Stripe checkout session IDs - these are not secrets
+const checkoutSession = "cs_test_a1XjM2B3cD4eF5gH6iJ7kL8m";
+const liveCheckoutSession = "cs_live_a1XjM2B3cD4eF5gH6iJ7kL8m";
+const publishableKey = "pk_test_a1B2c3D4e5F6g7H8i9J0kLmN";
+
+/* should still detect actual secrets */
+
+// AWS key should still be detected
+const awsKey = "AKIA1234567890EXAMPLE";

--- a/crates/biome_js_analyze/tests/specs/security/noSecrets/allowed_patterns.options.json
+++ b/crates/biome_js_analyze/tests/specs/security/noSecrets/allowed_patterns.options.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+    "linter": {
+        "enabled": true,
+        "rules": {
+            "security": {
+                "noSecrets": {
+                    "level": "error",
+                    "options": {
+                        "allowedPatterns": ["cs_live_", "cs_test_", "pk_test_"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/biome_rule_options/src/no_secrets.rs
+++ b/crates/biome_rule_options/src/no_secrets.rs
@@ -7,4 +7,8 @@ pub struct NoSecretsOptions {
     /// Set entropy threshold (default is 41).
     #[serde(skip_serializing_if = "Option::<_>::is_none")]
     pub entropy_threshold: Option<u16>,
+    /// A list of strings that are not considered secrets.
+    /// Strings that contain any of the provided patterns will be ignored.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub allowed_patterns: Vec<String>,
 }


### PR DESCRIPTION
## Summary

- Added a new `allowedPatterns` option to the `noSecrets` lint rule that allows users to specify substring patterns to ignore during secret detection.
- This reduces false positives for known non-secret identifiers like Stripe's `cs_live_`, `cs_test_`, `pk_live_`, and `pk_test_` prefixes.
- Updated the diagnostic message to mention `allowedPatterns` as a false-positive mitigation option.

## Example configuration

```json
{
  "linter": {
    "rules": {
      "security": {
        "noSecrets": {
          "level": "error",
          "options": {
            "allowedPatterns": ["cs_live_", "cs_test_", "pk_live_", "pk_test_"]
          }
        }
      }
    }
  }
}
```

## AI assistance disclosure

This PR was written primarily by Claude Code.

## Test plan

- [ ] `cargo check -p biome_rule_options` passes
- [ ] `cargo check -p biome_js_analyze` passes
- [ ] `cargo test -p biome_js_analyze -- security::no_secrets` passes (snapshot tests need `cargo insta accept` for the new test fixture)
- [ ] Strings containing any of the configured `allowedPatterns` substrings are not flagged
- [ ] Strings not matching any allowed pattern are still correctly detected (e.g. AWS keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)