### PR TITLE
feat(parse/html/svelte): new svelte syntax for comments inside tags

### DIFF
--- a/.changeset/chatty-jeans-shine.md
+++ b/.changeset/chatty-jeans-shine.md
@@ -1,0 +1,18 @@
+---
+"@biomejs/biome": patch
+---
+
+Added parsing support for Svelte's new [comments-in-tags](https://github.com/sveltejs/svelte/pull/17671) feature.
+
+The HTML parser will now accept JS style comments in tags in Svelte files.
+```svelte
+<button
+  // single-line comment
+  onclick={doTheThing}
+>click me</button>
+
+<div
+  /* block comment */
+  class="foo"
+>text</div>
+```

--- a/crates/biome_html_formatter/src/verbatim.rs
+++ b/crates/biome_html_formatter/src/verbatim.rs
@@ -6,7 +6,7 @@ use biome_formatter::format_element::tag::VerbatimKind;
 use biome_formatter::formatter::Formatter;
 use biome_formatter::prelude::{
     Tag, empty_line, expand_parent, format_with, hard_line_break, line_suffix,
-    should_nestle_adjacent_doc_comments, soft_line_break_or_space, space, text,
+    should_nestle_adjacent_doc_comments, space, text,
 };
 
 use biome_formatter::{
@@ -274,17 +274,15 @@ fn format_leading_comments_impl(
             }
 
             CommentKind::Line => {
-                // TODO: review logic here
+                // `//` line comments always require a hard line break after them because
+                // everything after `//` to end-of-line is part of the comment. Using
+                // `soft_line_break_or_space` would collapse the comment with the next
+                // attribute onto a single line, turning the `>` into part of the comment.
                 match comment.lines_after() {
                     0 => {}
-                    1 => {
-                        if comment.lines_before() == 0 {
-                            biome_formatter::write!(f, [soft_line_break_or_space()])?;
-                        } else {
-                            biome_formatter::write!(f, [hard_line_break()])?;
-                        }
+                    _ => {
+                        biome_formatter::write!(f, [hard_line_break()])?;
                     }
-                    _ => biome_formatter::write!(f, [empty_line()])?,
                 }
             }
         }

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments-in-component-tags.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments-in-component-tags.svelte
@@ -1,0 +1,15 @@
+<Component
+/* block comment */
+prop="value"
+/>
+<Component
+// line comment
+prop="value"
+/>
+<Component /* inline block comment */ prop="value" />
+<Component // inline line comment
+prop="value" />
+<Component.Member
+/* block comment */
+prop="value"
+/>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments-in-component-tags.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments-in-component-tags.svelte.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/comments-in-component-tags.svelte
+---
+
+# Input
+
+```svelte
+<Component
+/* block comment */
+prop="value"
+/>
+<Component
+// line comment
+prop="value"
+/>
+<Component /* inline block comment */ prop="value" />
+<Component // inline line comment
+prop="value" />
+<Component.Member
+/* block comment */
+prop="value"
+/>
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+Self close void elements: never
+Trailing newline: true
+-----
+
+```svelte
+<Component
+	/* block comment */
+	prop="value"
+/>
+<Component
+	// line comment
+	prop="value"
+/>
+<Component /* inline block comment */ prop="value" />
+<Component
+	// inline line comment
+	prop="value"
+/>
+<Component.Member
+	/* block comment */
+	prop="value"
+/>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments-in-tags.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments-in-tags.svelte
@@ -1,0 +1,58 @@
+<!-- Block comments between attributes (already working) -->
+<div    /* block comment */     class="foo"    /* block comment */     >text</div>
+<div    /* block comment */     class="foo"  data-foo="info"   /* block comment */   data-bar="info"  >text</div>
+
+<!-- Single-line comment between attributes — was producing invalid syntax before this fix -->
+<div    // comment
+class="foo"
+>text</div>
+
+<!-- // comment as the first attribute (no preceding node) -->
+<div
+// first comment
+class="foo"
+>text</div>
+
+<!-- // comment as the last attribute before > -->
+<div
+class="foo"
+// last comment
+>text</div>
+
+<!-- Multiple consecutive // comments -->
+<div
+// first line comment
+// second line comment
+class="foo"
+>text</div>
+
+<!-- // comment before a Svelte directive attribute -->
+<div
+// comment before directive
+on:click={handler}
+>text</div>
+
+<!-- biome-ignore suppression comment on an attribute -->
+<div
+// biome-ignore format: reason
+class   =   "foo"
+data-bar   =   "baz"
+>text</div>
+
+<!-- // comment on a self-closing Svelte component -->
+<Component
+// comment
+prop="value"
+/>
+
+<!-- /* block comment */ on a self-closing Svelte component -->
+<Component
+/* block comment */
+prop="value"
+/>
+
+<!-- // biome-ignore suppression comment on a component attribute -->
+<Component
+// biome-ignore format: reason
+prop="value"   data-bar="baz"
+/>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments-in-tags.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments-in-tags.svelte.snap
@@ -1,0 +1,175 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/comments-in-tags.svelte
+---
+
+# Input
+
+```svelte
+<!-- Block comments between attributes (already working) -->
+<div    /* block comment */     class="foo"    /* block comment */     >text</div>
+<div    /* block comment */     class="foo"  data-foo="info"   /* block comment */   data-bar="info"  >text</div>
+
+<!-- Single-line comment between attributes — was producing invalid syntax before this fix -->
+<div    // comment
+class="foo"
+>text</div>
+
+<!-- // comment as the first attribute (no preceding node) -->
+<div
+// first comment
+class="foo"
+>text</div>
+
+<!-- // comment as the last attribute before > -->
+<div
+class="foo"
+// last comment
+>text</div>
+
+<!-- Multiple consecutive // comments -->
+<div
+// first line comment
+// second line comment
+class="foo"
+>text</div>
+
+<!-- // comment before a Svelte directive attribute -->
+<div
+// comment before directive
+on:click={handler}
+>text</div>
+
+<!-- biome-ignore suppression comment on an attribute -->
+<div
+// biome-ignore format: reason
+class   =   "foo"
+data-bar   =   "baz"
+>text</div>
+
+<!-- // comment on a self-closing Svelte component -->
+<Component
+// comment
+prop="value"
+/>
+
+<!-- /* block comment */ on a self-closing Svelte component -->
+<Component
+/* block comment */
+prop="value"
+/>
+
+<!-- // biome-ignore suppression comment on a component attribute -->
+<Component
+// biome-ignore format: reason
+prop="value"   data-bar="baz"
+/>
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+Self close void elements: never
+Trailing newline: true
+-----
+
+```svelte
+<!-- Block comments between attributes (already working) -->
+<div /* block comment */ class="foo"/* block comment */>text</div>
+<div
+	/* block comment */ class="foo"
+	data-foo="info"
+	/* block comment */ data-bar="info"
+>
+	text
+</div>
+
+<!-- Single-line comment between attributes — was producing invalid syntax before this fix -->
+<div
+	// comment
+	class="foo"
+>
+	text
+</div>
+
+<!-- // comment as the first attribute (no preceding node) -->
+<div
+	// first comment
+	class="foo"
+>
+	text
+</div>
+
+<!-- // comment as the last attribute before > -->
+<div
+	class="foo"
+	// last comment
+>
+	text
+</div>
+
+<!-- Multiple consecutive // comments -->
+<div
+	// first line comment
+	// second line comment
+	class="foo"
+>
+	text
+</div>
+
+<!-- // comment before a Svelte directive attribute -->
+<div
+	// comment before directive
+	on:click={handler}
+>
+	text
+</div>
+
+<!-- biome-ignore suppression comment on an attribute -->
+<div
+	// biome-ignore format: reason
+	class   =   "foo"
+	data-bar="baz"
+>
+	text
+</div>
+
+<!-- // comment on a self-closing Svelte component -->
+<Component
+	// comment
+	prop="value"
+/>
+
+<!-- /* block comment */ on a self-closing Svelte component -->
+<Component
+	/* block comment */
+	prop="value"
+/>
+
+<!-- // biome-ignore suppression comment on a component attribute -->
+<Component
+	// biome-ignore format: reason
+	prop="value"
+	data-bar="baz"
+/>
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+   11: <!-- Single-line comment between attributes — was producing invalid syntax before this fix -->
+```

--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -175,14 +175,24 @@ impl<'src> HtmlLexer<'src> {
 
     /// Consume a token in the [HtmlLexContext::InsideTagWithDirectives] context.
     /// This context is used for Vue files with Vue-specific directives.
-    fn consume_token_inside_tag_directives(&mut self, current: u8) -> HtmlSyntaxKind {
+    /// When `svelte` is `true`, also handles `//` and `/* */` as JS-style comments.
+    fn consume_token_inside_tag_directives(&mut self, current: u8, svelte: bool) -> HtmlSyntaxKind {
         let dispatched = lookup_byte(current);
 
         match dispatched {
             WHS => self.consume_newline_or_whitespaces(),
             LSS => self.consume_l_angle(),
             MOR => self.consume_byte(T![>]),
-            SLH => self.consume_byte(T![/]),
+            SLH => {
+                if svelte {
+                    match self.byte_at(1).map(lookup_byte) {
+                        Some(SLH) => return self.consume_js_line_comment(),
+                        Some(MUL) => return self.consume_js_block_comment(),
+                        _ => {}
+                    }
+                }
+                self.consume_byte(T![/])
+            }
             EQL => self.consume_byte(T![=]),
             EXL => self.consume_byte(T![!]),
             BEO => {
@@ -259,6 +269,21 @@ impl<'src> HtmlLexer<'src> {
         } else {
             ERROR_TOKEN
         }
+    }
+
+    /// Consume a token in the [HtmlLexContext::InsideTagSvelte] context.
+    /// This context is used for Svelte files with JS-style comment support.
+    fn consume_token_inside_tag_svelte(&mut self, current: u8) -> HtmlSyntaxKind {
+        let dispatched = lookup_byte(current);
+
+        if dispatched == SLH {
+            match self.byte_at(1).map(lookup_byte) {
+                Some(SLH) => return self.consume_js_line_comment(),
+                Some(MUL) => return self.consume_js_block_comment(),
+                _ => {}
+            }
+        }
+        self.consume_token_inside_tag(current)
     }
 
     /// Consume a token in the [HtmlLexContext::Regular] context.
@@ -538,6 +563,49 @@ impl<'src> HtmlLexer<'src> {
             self.advance_byte_or_char(char);
         }
 
+        COMMENT
+    }
+
+    /// Consumes a `//` single-line comment, returning COMMENT.
+    /// Does NOT consume the terminating newline — it must be emitted as a
+    /// separate NEWLINE trivia token to preserve leading/trailing trivia boundaries.
+    fn consume_js_line_comment(&mut self) -> HtmlSyntaxKind {
+        self.advance(2);
+        while let Some(chr) = self.current_byte() {
+            match chr {
+                b'\n' | b'\r' => break,
+                _ if chr.is_ascii() => self.advance(1),
+                _ => {
+                    let c = self.current_char_unchecked();
+                    if is_linebreak(c) {
+                        break;
+                    }
+                    self.advance(c.len_utf8());
+                }
+            }
+        }
+        COMMENT
+    }
+
+    /// Consumes a `/* */` block comment, returning COMMENT.
+    fn consume_js_block_comment(&mut self) -> HtmlSyntaxKind {
+        self.advance(2);
+        while let Some(chr) = self.current_byte() {
+            let dispatched = lookup_byte(chr);
+            match dispatched {
+                MUL if self.byte_at(1).map(lookup_byte) == Some(SLH) => {
+                    self.advance(2);
+                    return COMMENT;
+                }
+                IDT | ZER | DIG | WHS | COL | SLH | MIN | MUL => self.advance(1),
+                _ if chr.is_ascii() => self.advance(1),
+                _ => self.advance(self.current_char_unchecked().len_utf8()),
+            }
+        }
+        self.push_diagnostic(ParseDiagnostic::new(
+            "Unterminated block comment, expected `*/`",
+            self.current_start..self.text_position(),
+        ));
         COMMENT
     }
 
@@ -1271,10 +1339,13 @@ impl<'src> Lexer<'src> for HtmlLexer<'src> {
                 Some(current) => match context {
                     HtmlLexContext::Regular => self.consume_token(current),
                     HtmlLexContext::InsideTag => self.consume_token_inside_tag(current),
-                    HtmlLexContext::InsideTagWithDirectives => {
-                        self.consume_token_inside_tag_directives(current)
+                    HtmlLexContext::InsideTagWithDirectives { svelte } => {
+                        self.consume_token_inside_tag_directives(current, svelte)
                     }
                     HtmlLexContext::InsideTagAstro => self.consume_token_inside_tag_astro(current),
+                    HtmlLexContext::InsideTagSvelte => {
+                        self.consume_token_inside_tag_svelte(current)
+                    }
                     HtmlLexContext::VueDirectiveArgument => {
                         self.consume_token_vue_directive_argument()
                     }
@@ -1436,6 +1507,11 @@ fn is_astro_directive_keyword_bytes(bytes: &[u8]) -> bool {
 
 fn is_vue_directive_prefix_bytes(bytes: &[u8]) -> bool {
     bytes.starts_with(b"v-")
+}
+
+/// Check if a char is a linebreak (for JS-style comments in Svelte)
+fn is_linebreak(chr: char) -> bool {
+    matches!(chr, '\n' | '\r' | '\u{2028}' | '\u{2029}')
 }
 
 /// Identifiers can contain letters, numbers and `_`

--- a/crates/biome_html_parser/src/lexer/tests.rs
+++ b/crates/biome_html_parser/src/lexer/tests.rs
@@ -409,3 +409,89 @@ fn svelte_keywords() {
         WHITESPACE: 2,
     )
 }
+
+#[test]
+fn svelte_line_comment_inside_tag() {
+    assert_lex! {
+        HtmlLexContext::InsideTagSvelte,
+        "// comment\n",
+        COMMENT: 10,
+        NEWLINE: 1,
+    }
+}
+
+#[test]
+fn svelte_line_comment_without_newline() {
+    assert_lex! {
+        HtmlLexContext::InsideTagSvelte,
+        "// comment",
+        COMMENT: 10,
+    }
+}
+
+#[test]
+fn svelte_block_comment_single_line() {
+    assert_lex! {
+        HtmlLexContext::InsideTagSvelte,
+        "/* comment */",
+        COMMENT: 13,
+    }
+}
+
+#[test]
+fn svelte_block_comment_multiline() {
+    assert_lex! {
+        HtmlLexContext::InsideTagSvelte,
+        "/* line1\nline2 */",
+        COMMENT: 17,
+    }
+}
+
+#[test]
+fn plain_slash_inside_tag_not_a_comment() {
+    assert_lex! {
+        HtmlLexContext::InsideTag,
+        "/",
+        SLASH: 1,
+    }
+}
+
+#[test]
+fn plain_double_slash_inside_tag_not_a_comment() {
+    assert_lex! {
+        HtmlLexContext::InsideTag,
+        "//",
+        SLASH: 1,
+        SLASH: 1,
+    }
+}
+
+#[test]
+fn plain_slash_asterisk_inside_tag_not_a_comment() {
+    assert_lex! {
+        HtmlLexContext::InsideTag,
+        "/*",
+        SLASH: 1,
+        HTML_LITERAL: 1,
+    }
+}
+
+#[test]
+fn svelte_slash_remains_slash_in_svelte_context() {
+    assert_lex! {
+        HtmlLexContext::InsideTagSvelte,
+        "/",
+        SLASH: 1,
+    }
+}
+
+#[test]
+fn svelte_slash_after_comment() {
+    assert_lex! {
+        HtmlLexContext::InsideTagSvelte,
+        "// comment\n/",
+        COMMENT: 10,
+        NEWLINE: 1,
+        SLASH: 1,
+    }
+}

--- a/crates/biome_html_parser/src/parser.rs
+++ b/crates/biome_html_parser/src/parser.rs
@@ -116,6 +116,7 @@ pub struct HtmlParseOptions {
     pub(crate) frontmatter: bool,
     pub(crate) text_expression: Option<TextExpressionKind>,
     pub(crate) vue: bool,
+    pub(crate) svelte: bool,
     pub(crate) is_html: bool,
 }
 
@@ -152,6 +153,11 @@ impl HtmlParseOptions {
         self
     }
 
+    pub fn with_svelte(mut self) -> Self {
+        self.svelte = true;
+        self
+    }
+
     pub fn is_html(&self) -> bool {
         self.is_html
     }
@@ -178,7 +184,7 @@ impl From<&HtmlFileSource> for HtmlParseOptions {
                 options = options.with_double_text_expression().with_vue();
             }
             HtmlVariant::Svelte => {
-                options = options.with_single_text_expression();
+                options = options.with_single_text_expression().with_svelte();
             }
         }
 

--- a/crates/biome_html_parser/src/syntax/svelte.rs
+++ b/crates/biome_html_parser/src/syntax/svelte.rs
@@ -1,5 +1,5 @@
 use crate::parser::HtmlParser;
-use crate::syntax::HtmlSyntaxFeatures::Svelte;
+use crate::syntax::HtmlSyntaxFeatures::{SingleTextExpressions, Svelte};
 use crate::syntax::parse_error::{
     expected_child_or_block, expected_expression, expected_name, expected_svelte_closing_block,
     expected_svelte_property, expected_text_expression, expected_valid_directive,
@@ -341,7 +341,7 @@ fn parse_each_opening_block(p: &mut HtmlParser, parent_marker: Marker) -> (Parse
 
 /// Parses a spread attribute or a single text expression.
 pub(crate) fn parse_svelte_spread_or_expression(p: &mut HtmlParser) -> ParsedSyntax {
-    if !Svelte.is_supported(p) {
+    if !SingleTextExpressions.is_supported(p) {
         return Absent;
     }
 
@@ -363,12 +363,12 @@ pub(crate) fn parse_svelte_spread_or_expression(p: &mut HtmlParser) -> ParsedSyn
             .parse_element(p)
             .or_add_diagnostic(p, expected_expression);
 
-        p.expect_with_context(T!['}'], HtmlLexContext::InsideTag);
+        p.expect_with_context(T!['}'], HtmlLexContext::InsideTagSvelte);
         Present(m.complete(p, HTML_SPREAD_ATTRIBUTE))
     } else {
         p.rewind(checkpoint);
         m.abandon(p);
-        parse_single_text_expression(p, HtmlLexContext::InsideTag)
+        parse_single_text_expression(p, HtmlLexContext::InsideTagSvelte)
     }
 }
 
@@ -880,7 +880,7 @@ pub(crate) fn parse_attach_attribute(p: &mut HtmlParser) -> ParsedSyntax {
 
     parse_single_text_expression_content(p).or_add_diagnostic(p, expected_text_expression);
 
-    p.expect_with_context(T!['}'], HtmlLexContext::InsideTag);
+    p.expect_with_context(T!['}'], HtmlLexContext::InsideTagSvelte);
 
     Present(m.complete(p, SVELTE_ATTACH_ATTRIBUTE))
 }
@@ -958,7 +958,7 @@ fn parse_svelte_name(p: &mut HtmlParser) -> ParsedSyntax {
 
 fn parse_binding_literal(p: &mut HtmlParser) -> ParsedSyntax {
     let m = p.start();
-    p.bump_with_context(HTML_LITERAL, HtmlLexContext::InsideTag);
+    p.bump_with_context(HTML_LITERAL, HtmlLexContext::InsideTagSvelte);
     Present(m.complete(p, SVELTE_LITERAL))
 }
 

--- a/crates/biome_html_parser/src/syntax/vue.rs
+++ b/crates/biome_html_parser/src/syntax/vue.rs
@@ -21,7 +21,10 @@ pub(crate) fn parse_vue_directive(p: &mut HtmlParser) -> ParsedSyntax {
 
     let pos = p.source().position();
     // FIXME: Ideally, the lexer would just lex IDENT directly
-    p.bump_remap_with_context(IDENT, HtmlLexContext::InsideTagWithDirectives);
+    p.bump_remap_with_context(
+        IDENT,
+        HtmlLexContext::InsideTagWithDirectives { svelte: false },
+    );
     if p.at(T![:]) {
         // is there any trivia after the directive name and before the colon?
         if let Some(last_trivia) = p.source().trivia_list.last()
@@ -71,7 +74,10 @@ pub(crate) fn parse_vue_v_on_shorthand_directive(p: &mut HtmlParser) -> ParsedSy
     let m = p.start();
 
     let pos = p.source().position();
-    p.bump_with_context(T![@], HtmlLexContext::InsideTagWithDirectives);
+    p.bump_with_context(
+        T![@],
+        HtmlLexContext::InsideTagWithDirectives { svelte: false },
+    );
     // is there any trivia after the @ and before argument?
     if let Some(last_trivia) = p.source().trivia_list.last()
         && pos < last_trivia.text_range().start()
@@ -100,7 +106,10 @@ pub(crate) fn parse_vue_v_slot_shorthand_directive(p: &mut HtmlParser) -> Parsed
     let m = p.start();
 
     let pos = p.source().position();
-    p.bump_with_context(T![#], HtmlLexContext::InsideTagWithDirectives);
+    p.bump_with_context(
+        T![#],
+        HtmlLexContext::InsideTagWithDirectives { svelte: false },
+    );
     // is there any trivia after the hash and before argument?
     if let Some(last_trivia) = p.source().trivia_list.last()
         && pos < last_trivia.text_range().start()
@@ -129,7 +138,10 @@ fn parse_vue_directive_argument(p: &mut HtmlParser) -> ParsedSyntax {
     let m = p.start();
 
     let pos = p.source().position();
-    p.bump_with_context(T![:], HtmlLexContext::InsideTagWithDirectives);
+    p.bump_with_context(
+        T![:],
+        HtmlLexContext::InsideTagWithDirectives { svelte: false },
+    );
     // is there any trivia after the colon and before argument?
     if let Some(last_trivia) = p.source().trivia_list.last()
         && pos < last_trivia.text_range().start()
@@ -149,7 +161,10 @@ fn parse_vue_directive_argument(p: &mut HtmlParser) -> ParsedSyntax {
 fn parse_vue_static_argument(p: &mut HtmlParser) -> ParsedSyntax {
     let m = p.start();
 
-    p.expect_with_context(HTML_LITERAL, HtmlLexContext::InsideTagWithDirectives);
+    p.expect_with_context(
+        HTML_LITERAL,
+        HtmlLexContext::InsideTagWithDirectives { svelte: false },
+    );
 
     Present(m.complete(p, VUE_STATIC_ARGUMENT))
 }
@@ -162,8 +177,14 @@ fn parse_vue_dynamic_argument(p: &mut HtmlParser) -> ParsedSyntax {
     let m = p.start();
 
     p.bump_with_context(T!['['], HtmlLexContext::VueDirectiveArgument);
-    p.expect_with_context(HTML_LITERAL, HtmlLexContext::InsideTagWithDirectives);
-    p.expect_with_context(T![']'], HtmlLexContext::InsideTagWithDirectives);
+    p.expect_with_context(
+        HTML_LITERAL,
+        HtmlLexContext::InsideTagWithDirectives { svelte: false },
+    );
+    p.expect_with_context(
+        T![']'],
+        HtmlLexContext::InsideTagWithDirectives { svelte: false },
+    );
 
     Present(m.complete(p, VUE_DYNAMIC_ARGUMENT))
 }
@@ -206,12 +227,21 @@ fn parse_vue_modifier(p: &mut HtmlParser) -> ParsedSyntax {
 
     let m = p.start();
 
-    p.bump_with_context(T![.], HtmlLexContext::InsideTagWithDirectives);
+    p.bump_with_context(
+        T![.],
+        HtmlLexContext::InsideTagWithDirectives { svelte: false },
+    );
     if p.at(T![:]) {
         // `:` is actually a valid modifier, for example `@keydown.:`
-        p.bump_remap_with_context(HTML_LITERAL, HtmlLexContext::InsideTagWithDirectives);
+        p.bump_remap_with_context(
+            HTML_LITERAL,
+            HtmlLexContext::InsideTagWithDirectives { svelte: false },
+        );
     } else {
-        p.expect_with_context(HTML_LITERAL, HtmlLexContext::InsideTagWithDirectives);
+        p.expect_with_context(
+            HTML_LITERAL,
+            HtmlLexContext::InsideTagWithDirectives { svelte: false },
+        );
     }
 
     Present(m.complete(p, VUE_MODIFIER))

--- a/crates/biome_html_parser/src/token_source.rs
+++ b/crates/biome_html_parser/src/token_source.rs
@@ -27,9 +27,13 @@ pub(crate) enum HtmlLexContext {
     Regular,
     /// When the lexer is inside a tag, special characters are lexed as tag tokens.
     InsideTag,
-    /// Like [InsideTag], but with Vue-specific tokens enabled.
-    /// This enables parsing of Component directives (v-bind, :, @, #, etc.)
-    InsideTagWithDirectives,
+    /// Like [InsideTag], but with Vue-style directive tokens enabled (`.`, `:`, `@`, `#`, etc.).
+    /// When `svelte` is `true`, also recognizes `//` and `/* */` as JS-style comments (for Svelte
+    /// component names which need both member-expression `.` support and comment support).
+    InsideTagWithDirectives { svelte: bool },
+    /// Like [InsideTag], but with Svelte-specific tokens enabled.
+    /// This enables parsing of JS-style `//` and `/* */` comments as trivia.
+    InsideTagSvelte,
     /// Like [InsideTag], but with Astro-specific tokens enabled.
     /// This enables parsing of Astro directives (client:, set:, class:, is:, server:)
     InsideTagAstro,

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/unterminated_js_multiline_comment.svelte
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/unterminated_js_multiline_comment.svelte
@@ -1,0 +1,4 @@
+<div
+  /* block comment
+  class="foo"
+>text</div>

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/unterminated_js_multiline_comment.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/unterminated_js_multiline_comment.svelte.snap
@@ -1,0 +1,94 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```svelte
+<div
+  /* block comment
+  class="foo"
+>text</div>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..1 "<" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@1..4 "div" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: missing (required),
+            },
+            children: HtmlElementList [],
+            closing_element: missing (required),
+        },
+    ],
+    eof_token: EOF@4..50 "" [Newline("\n"), Whitespace("  "), Comments("/* block comment\n  cl ...")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..50
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..4
+    0: HTML_ELEMENT@0..4
+      0: HTML_OPENING_ELEMENT@0..4
+        0: L_ANGLE@0..1 "<" [] []
+        1: HTML_TAG_NAME@1..4
+          0: HTML_LITERAL@1..4 "div" [] []
+        2: HTML_ATTRIBUTE_LIST@4..4
+        3: (empty)
+      1: HTML_ELEMENT_LIST@4..4
+      2: (empty)
+  4: EOF@4..50 "" [Newline("\n"), Whitespace("  "), Comments("/* block comment\n  cl ...")] []
+
+```
+
+## Diagnostics
+
+```
+unterminated_js_multiline_comment.svelte:2:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unterminated block comment, expected `*/`
+  
+    1 │ <div
+  > 2 │   /* block comment
+      │   ^^^^^^^^^^^^^^^^
+  > 3 │   class="foo"
+  > 4 │ >text</div>
+  > 5 │ 
+      │ 
+  
+unterminated_js_multiline_comment.svelte:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `>` but instead the file ends
+  
+    3 │   class="foo"
+    4 │ >text</div>
+  > 5 │ 
+      │ 
+  
+  i the file ends here
+  
+    3 │   class="foo"
+    4 │ >text</div>
+  > 5 │ 
+      │ 
+  
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_component_tags.svelte
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_component_tags.svelte
@@ -1,0 +1,15 @@
+<Component
+/* block comment */
+prop="value"
+/>
+<Component
+// line comment
+prop="value"
+/>
+<Component /* inline block comment */ prop="value" />
+<Component // inline line comment
+prop="value" />
+<Component.Member
+/* block comment */
+prop="value"
+/>

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_component_tags.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_component_tags.svelte.snap
@@ -1,0 +1,236 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```svelte
+<Component
+/* block comment */
+prop="value"
+/>
+<Component
+// line comment
+prop="value"
+/>
+<Component /* inline block comment */ prop="value" />
+<Component // inline line comment
+prop="value" />
+<Component.Member
+/* block comment */
+prop="value"
+/>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlSelfClosingElement {
+            l_angle_token: L_ANGLE@0..1 "<" [] [],
+            name: HtmlComponentName {
+                value_token: HTML_LITERAL@1..10 "Component" [] [],
+            },
+            attributes: HtmlAttributeList [
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@10..35 "prop" [Newline("\n"), Comments("/* block comment */"), Newline("\n")] [],
+                    },
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@35..36 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@36..43 "\"value\"" [] [],
+                        },
+                    },
+                },
+            ],
+            slash_token: SLASH@43..45 "/" [Newline("\n")] [],
+            r_angle_token: R_ANGLE@45..46 ">" [] [],
+        },
+        HtmlSelfClosingElement {
+            l_angle_token: L_ANGLE@46..48 "<" [Newline("\n")] [],
+            name: HtmlComponentName {
+                value_token: HTML_LITERAL@48..57 "Component" [] [],
+            },
+            attributes: HtmlAttributeList [
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@57..78 "prop" [Newline("\n"), Comments("// line comment"), Newline("\n")] [],
+                    },
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@78..79 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@79..86 "\"value\"" [] [],
+                        },
+                    },
+                },
+            ],
+            slash_token: SLASH@86..88 "/" [Newline("\n")] [],
+            r_angle_token: R_ANGLE@88..89 ">" [] [],
+        },
+        HtmlSelfClosingElement {
+            l_angle_token: L_ANGLE@89..91 "<" [Newline("\n")] [],
+            name: HtmlComponentName {
+                value_token: HTML_LITERAL@91..128 "Component" [] [Whitespace(" "), Comments("/* inline block comme ..."), Whitespace(" ")],
+            },
+            attributes: HtmlAttributeList [
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@128..132 "prop" [] [],
+                    },
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@132..133 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@133..141 "\"value\"" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            ],
+            slash_token: SLASH@141..142 "/" [] [],
+            r_angle_token: R_ANGLE@142..143 ">" [] [],
+        },
+        HtmlSelfClosingElement {
+            l_angle_token: L_ANGLE@143..145 "<" [Newline("\n")] [],
+            name: HtmlComponentName {
+                value_token: HTML_LITERAL@145..177 "Component" [] [Whitespace(" "), Comments("// inline line comment")],
+            },
+            attributes: HtmlAttributeList [
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@177..182 "prop" [Newline("\n")] [],
+                    },
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@182..183 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@183..191 "\"value\"" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            ],
+            slash_token: SLASH@191..192 "/" [] [],
+            r_angle_token: R_ANGLE@192..193 ">" [] [],
+        },
+        HtmlSelfClosingElement {
+            l_angle_token: L_ANGLE@193..195 "<" [Newline("\n")] [],
+            name: HtmlMemberName {
+                object: HtmlComponentName {
+                    value_token: HTML_LITERAL@195..204 "Component" [] [],
+                },
+                dot_token: DOT@204..205 "." [] [],
+                member: HtmlTagName {
+                    value_token: HTML_LITERAL@205..211 "Member" [] [],
+                },
+            },
+            attributes: HtmlAttributeList [
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@211..236 "prop" [Newline("\n"), Comments("/* block comment */"), Newline("\n")] [],
+                    },
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@236..237 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@237..244 "\"value\"" [] [],
+                        },
+                    },
+                },
+            ],
+            slash_token: SLASH@244..246 "/" [Newline("\n")] [],
+            r_angle_token: R_ANGLE@246..247 ">" [] [],
+        },
+    ],
+    eof_token: EOF@247..248 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..248
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..247
+    0: HTML_SELF_CLOSING_ELEMENT@0..46
+      0: L_ANGLE@0..1 "<" [] []
+      1: HTML_COMPONENT_NAME@1..10
+        0: HTML_LITERAL@1..10 "Component" [] []
+      2: HTML_ATTRIBUTE_LIST@10..43
+        0: HTML_ATTRIBUTE@10..43
+          0: HTML_ATTRIBUTE_NAME@10..35
+            0: HTML_LITERAL@10..35 "prop" [Newline("\n"), Comments("/* block comment */"), Newline("\n")] []
+          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@35..43
+            0: EQ@35..36 "=" [] []
+            1: HTML_STRING@36..43
+              0: HTML_STRING_LITERAL@36..43 "\"value\"" [] []
+      3: SLASH@43..45 "/" [Newline("\n")] []
+      4: R_ANGLE@45..46 ">" [] []
+    1: HTML_SELF_CLOSING_ELEMENT@46..89
+      0: L_ANGLE@46..48 "<" [Newline("\n")] []
+      1: HTML_COMPONENT_NAME@48..57
+        0: HTML_LITERAL@48..57 "Component" [] []
+      2: HTML_ATTRIBUTE_LIST@57..86
+        0: HTML_ATTRIBUTE@57..86
+          0: HTML_ATTRIBUTE_NAME@57..78
+            0: HTML_LITERAL@57..78 "prop" [Newline("\n"), Comments("// line comment"), Newline("\n")] []
+          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@78..86
+            0: EQ@78..79 "=" [] []
+            1: HTML_STRING@79..86
+              0: HTML_STRING_LITERAL@79..86 "\"value\"" [] []
+      3: SLASH@86..88 "/" [Newline("\n")] []
+      4: R_ANGLE@88..89 ">" [] []
+    2: HTML_SELF_CLOSING_ELEMENT@89..143
+      0: L_ANGLE@89..91 "<" [Newline("\n")] []
+      1: HTML_COMPONENT_NAME@91..128
+        0: HTML_LITERAL@91..128 "Component" [] [Whitespace(" "), Comments("/* inline block comme ..."), Whitespace(" ")]
+      2: HTML_ATTRIBUTE_LIST@128..141
+        0: HTML_ATTRIBUTE@128..141
+          0: HTML_ATTRIBUTE_NAME@128..132
+            0: HTML_LITERAL@128..132 "prop" [] []
+          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@132..141
+            0: EQ@132..133 "=" [] []
+            1: HTML_STRING@133..141
+              0: HTML_STRING_LITERAL@133..141 "\"value\"" [] [Whitespace(" ")]
+      3: SLASH@141..142 "/" [] []
+      4: R_ANGLE@142..143 ">" [] []
+    3: HTML_SELF_CLOSING_ELEMENT@143..193
+      0: L_ANGLE@143..145 "<" [Newline("\n")] []
+      1: HTML_COMPONENT_NAME@145..177
+        0: HTML_LITERAL@145..177 "Component" [] [Whitespace(" "), Comments("// inline line comment")]
+      2: HTML_ATTRIBUTE_LIST@177..191
+        0: HTML_ATTRIBUTE@177..191
+          0: HTML_ATTRIBUTE_NAME@177..182
+            0: HTML_LITERAL@177..182 "prop" [Newline("\n")] []
+          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@182..191
+            0: EQ@182..183 "=" [] []
+            1: HTML_STRING@183..191
+              0: HTML_STRING_LITERAL@183..191 "\"value\"" [] [Whitespace(" ")]
+      3: SLASH@191..192 "/" [] []
+      4: R_ANGLE@192..193 ">" [] []
+    4: HTML_SELF_CLOSING_ELEMENT@193..247
+      0: L_ANGLE@193..195 "<" [Newline("\n")] []
+      1: HTML_MEMBER_NAME@195..211
+        0: HTML_COMPONENT_NAME@195..204
+          0: HTML_LITERAL@195..204 "Component" [] []
+        1: DOT@204..205 "." [] []
+        2: HTML_TAG_NAME@205..211
+          0: HTML_LITERAL@205..211 "Member" [] []
+      2: HTML_ATTRIBUTE_LIST@211..244
+        0: HTML_ATTRIBUTE@211..244
+          0: HTML_ATTRIBUTE_NAME@211..236
+            0: HTML_LITERAL@211..236 "prop" [Newline("\n"), Comments("/* block comment */"), Newline("\n")] []
+          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@236..244
+            0: EQ@236..237 "=" [] []
+            1: HTML_STRING@237..244
+              0: HTML_STRING_LITERAL@237..244 "\"value\"" [] []
+      3: SLASH@244..246 "/" [Newline("\n")] []
+      4: R_ANGLE@246..247 ">" [] []
+  4: EOF@247..248 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_tag.svelte
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_tag.svelte
@@ -1,0 +1,33 @@
+<button
+  // single-line comment
+  onclick={doTheThing}
+>click me</button>
+
+<div
+  /* block comment */
+  class="foo"
+>text</div>
+
+<input
+  /* multi-line
+     block comment */
+  type="text"
+/>
+
+<span
+  // comment before attr
+  data-test="value"
+  /* comment between attrs */
+  id="my-span"
+>content</span>
+
+
+<button
+  // single-line comment
+  onclick={doTheThing}
+  // comment after attr
+  {type}
+  // comment after shorthand
+>click me</button>
+
+<div /* block comment */ class="foo" /* block comment */>text</div>

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_tag.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_tag.svelte.snap
@@ -1,0 +1,438 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```svelte
+<button
+  // single-line comment
+  onclick={doTheThing}
+>click me</button>
+
+<div
+  /* block comment */
+  class="foo"
+>text</div>
+
+<input
+  /* multi-line
+     block comment */
+  type="text"
+/>
+
+<span
+  // comment before attr
+  data-test="value"
+  /* comment between attrs */
+  id="my-span"
+>content</span>
+
+
+<button
+  // single-line comment
+  onclick={doTheThing}
+  // comment after attr
+  {type}
+  // comment after shorthand
+>click me</button>
+
+<div /* block comment */ class="foo" /* block comment */>text</div>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..1 "<" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@1..7 "button" [] [],
+                },
+                attributes: HtmlAttributeList [
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@7..42 "onclick" [Newline("\n"), Whitespace("  "), Comments("// single-line comment"), Newline("\n"), Whitespace("  ")] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@42..43 "=" [] [],
+                            value: HtmlAttributeSingleTextExpression {
+                                l_curly_token: L_CURLY@43..44 "{" [] [],
+                                expression: HtmlTextExpression {
+                                    html_literal_token: HTML_LITERAL@44..54 "doTheThing" [] [],
+                                },
+                                r_curly_token: R_CURLY@54..55 "}" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@55..57 ">" [Newline("\n")] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@57..65 "click me" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@65..66 "<" [] [],
+                slash_token: SLASH@66..67 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@67..73 "button" [] [],
+                },
+                r_angle_token: R_ANGLE@73..74 ">" [] [],
+            },
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@74..77 "<" [Newline("\n"), Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@77..80 "div" [] [],
+                },
+                attributes: HtmlAttributeList [
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@80..110 "class" [Newline("\n"), Whitespace("  "), Comments("/* block comment */"), Newline("\n"), Whitespace("  ")] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@110..111 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@111..116 "\"foo\"" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@116..118 ">" [Newline("\n")] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@118..122 "text" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@122..123 "<" [] [],
+                slash_token: SLASH@123..124 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@124..127 "div" [] [],
+                },
+                r_angle_token: R_ANGLE@127..128 ">" [] [],
+            },
+        },
+        HtmlSelfClosingElement {
+            l_angle_token: L_ANGLE@128..131 "<" [Newline("\n"), Newline("\n")] [],
+            name: HtmlTagName {
+                value_token: HTML_LITERAL@131..136 "input" [] [],
+            },
+            attributes: HtmlAttributeList [
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@136..181 "type" [Newline("\n"), Whitespace("  "), Comments("/* multi-line\n     bl ..."), Newline("\n"), Whitespace("  ")] [],
+                    },
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@181..182 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@182..188 "\"text\"" [] [],
+                        },
+                    },
+                },
+            ],
+            slash_token: SLASH@188..190 "/" [Newline("\n")] [],
+            r_angle_token: R_ANGLE@190..191 ">" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@191..194 "<" [Newline("\n"), Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@194..198 "span" [] [],
+                },
+                attributes: HtmlAttributeList [
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@198..235 "data-test" [Newline("\n"), Whitespace("  "), Comments("// comment before attr"), Newline("\n"), Whitespace("  ")] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@235..236 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@236..243 "\"value\"" [] [],
+                            },
+                        },
+                    },
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@243..278 "id" [Newline("\n"), Whitespace("  "), Comments("/* comment between at ..."), Newline("\n"), Whitespace("  ")] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@278..279 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@279..288 "\"my-span\"" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@288..290 ">" [Newline("\n")] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@290..297 "content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@297..298 "<" [] [],
+                slash_token: SLASH@298..299 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@299..303 "span" [] [],
+                },
+                r_angle_token: R_ANGLE@303..304 ">" [] [],
+            },
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@304..308 "<" [Newline("\n"), Newline("\n"), Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@308..314 "button" [] [],
+                },
+                attributes: HtmlAttributeList [
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@314..349 "onclick" [Newline("\n"), Whitespace("  "), Comments("// single-line comment"), Newline("\n"), Whitespace("  ")] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@349..350 "=" [] [],
+                            value: HtmlAttributeSingleTextExpression {
+                                l_curly_token: L_CURLY@350..351 "{" [] [],
+                                expression: HtmlTextExpression {
+                                    html_literal_token: HTML_LITERAL@351..361 "doTheThing" [] [],
+                                },
+                                r_curly_token: R_CURLY@361..362 "}" [] [],
+                            },
+                        },
+                    },
+                    HtmlAttributeSingleTextExpression {
+                        l_curly_token: L_CURLY@362..390 "{" [Newline("\n"), Whitespace("  "), Comments("// comment after attr"), Newline("\n"), Whitespace("  ")] [],
+                        expression: HtmlTextExpression {
+                            html_literal_token: HTML_LITERAL@390..394 "type" [] [],
+                        },
+                        r_curly_token: R_CURLY@394..395 "}" [] [],
+                    },
+                ],
+                r_angle_token: R_ANGLE@395..426 ">" [Newline("\n"), Whitespace("  "), Comments("// comment after shor ..."), Newline("\n")] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@426..434 "click me" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@434..435 "<" [] [],
+                slash_token: SLASH@435..436 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@436..442 "button" [] [],
+                },
+                r_angle_token: R_ANGLE@442..443 ">" [] [],
+            },
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@443..446 "<" [Newline("\n"), Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@446..470 "div" [] [Whitespace(" "), Comments("/* block comment */"), Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@470..475 "class" [] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@475..476 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@476..501 "\"foo\"" [] [Whitespace(" "), Comments("/* block comment */")],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@501..502 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@502..506 "text" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@506..507 "<" [] [],
+                slash_token: SLASH@507..508 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@508..511 "div" [] [],
+                },
+                r_angle_token: R_ANGLE@511..512 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@512..513 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..513
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..512
+    0: HTML_ELEMENT@0..74
+      0: HTML_OPENING_ELEMENT@0..57
+        0: L_ANGLE@0..1 "<" [] []
+        1: HTML_TAG_NAME@1..7
+          0: HTML_LITERAL@1..7 "button" [] []
+        2: HTML_ATTRIBUTE_LIST@7..55
+          0: HTML_ATTRIBUTE@7..55
+            0: HTML_ATTRIBUTE_NAME@7..42
+              0: HTML_LITERAL@7..42 "onclick" [Newline("\n"), Whitespace("  "), Comments("// single-line comment"), Newline("\n"), Whitespace("  ")] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@42..55
+              0: EQ@42..43 "=" [] []
+              1: HTML_ATTRIBUTE_SINGLE_TEXT_EXPRESSION@43..55
+                0: L_CURLY@43..44 "{" [] []
+                1: HTML_TEXT_EXPRESSION@44..54
+                  0: HTML_LITERAL@44..54 "doTheThing" [] []
+                2: R_CURLY@54..55 "}" [] []
+        3: R_ANGLE@55..57 ">" [Newline("\n")] []
+      1: HTML_ELEMENT_LIST@57..65
+        0: HTML_CONTENT@57..65
+          0: HTML_LITERAL@57..65 "click me" [] []
+      2: HTML_CLOSING_ELEMENT@65..74
+        0: L_ANGLE@65..66 "<" [] []
+        1: SLASH@66..67 "/" [] []
+        2: HTML_TAG_NAME@67..73
+          0: HTML_LITERAL@67..73 "button" [] []
+        3: R_ANGLE@73..74 ">" [] []
+    1: HTML_ELEMENT@74..128
+      0: HTML_OPENING_ELEMENT@74..118
+        0: L_ANGLE@74..77 "<" [Newline("\n"), Newline("\n")] []
+        1: HTML_TAG_NAME@77..80
+          0: HTML_LITERAL@77..80 "div" [] []
+        2: HTML_ATTRIBUTE_LIST@80..116
+          0: HTML_ATTRIBUTE@80..116
+            0: HTML_ATTRIBUTE_NAME@80..110
+              0: HTML_LITERAL@80..110 "class" [Newline("\n"), Whitespace("  "), Comments("/* block comment */"), Newline("\n"), Whitespace("  ")] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@110..116
+              0: EQ@110..111 "=" [] []
+              1: HTML_STRING@111..116
+                0: HTML_STRING_LITERAL@111..116 "\"foo\"" [] []
+        3: R_ANGLE@116..118 ">" [Newline("\n")] []
+      1: HTML_ELEMENT_LIST@118..122
+        0: HTML_CONTENT@118..122
+          0: HTML_LITERAL@118..122 "text" [] []
+      2: HTML_CLOSING_ELEMENT@122..128
+        0: L_ANGLE@122..123 "<" [] []
+        1: SLASH@123..124 "/" [] []
+        2: HTML_TAG_NAME@124..127
+          0: HTML_LITERAL@124..127 "div" [] []
+        3: R_ANGLE@127..128 ">" [] []
+    2: HTML_SELF_CLOSING_ELEMENT@128..191
+      0: L_ANGLE@128..131 "<" [Newline("\n"), Newline("\n")] []
+      1: HTML_TAG_NAME@131..136
+        0: HTML_LITERAL@131..136 "input" [] []
+      2: HTML_ATTRIBUTE_LIST@136..188
+        0: HTML_ATTRIBUTE@136..188
+          0: HTML_ATTRIBUTE_NAME@136..181
+            0: HTML_LITERAL@136..181 "type" [Newline("\n"), Whitespace("  "), Comments("/* multi-line\n     bl ..."), Newline("\n"), Whitespace("  ")] []
+          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@181..188
+            0: EQ@181..182 "=" [] []
+            1: HTML_STRING@182..188
+              0: HTML_STRING_LITERAL@182..188 "\"text\"" [] []
+      3: SLASH@188..190 "/" [Newline("\n")] []
+      4: R_ANGLE@190..191 ">" [] []
+    3: HTML_ELEMENT@191..304
+      0: HTML_OPENING_ELEMENT@191..290
+        0: L_ANGLE@191..194 "<" [Newline("\n"), Newline("\n")] []
+        1: HTML_TAG_NAME@194..198
+          0: HTML_LITERAL@194..198 "span" [] []
+        2: HTML_ATTRIBUTE_LIST@198..288
+          0: HTML_ATTRIBUTE@198..243
+            0: HTML_ATTRIBUTE_NAME@198..235
+              0: HTML_LITERAL@198..235 "data-test" [Newline("\n"), Whitespace("  "), Comments("// comment before attr"), Newline("\n"), Whitespace("  ")] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@235..243
+              0: EQ@235..236 "=" [] []
+              1: HTML_STRING@236..243
+                0: HTML_STRING_LITERAL@236..243 "\"value\"" [] []
+          1: HTML_ATTRIBUTE@243..288
+            0: HTML_ATTRIBUTE_NAME@243..278
+              0: HTML_LITERAL@243..278 "id" [Newline("\n"), Whitespace("  "), Comments("/* comment between at ..."), Newline("\n"), Whitespace("  ")] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@278..288
+              0: EQ@278..279 "=" [] []
+              1: HTML_STRING@279..288
+                0: HTML_STRING_LITERAL@279..288 "\"my-span\"" [] []
+        3: R_ANGLE@288..290 ">" [Newline("\n")] []
+      1: HTML_ELEMENT_LIST@290..297
+        0: HTML_CONTENT@290..297
+          0: HTML_LITERAL@290..297 "content" [] []
+      2: HTML_CLOSING_ELEMENT@297..304
+        0: L_ANGLE@297..298 "<" [] []
+        1: SLASH@298..299 "/" [] []
+        2: HTML_TAG_NAME@299..303
+          0: HTML_LITERAL@299..303 "span" [] []
+        3: R_ANGLE@303..304 ">" [] []
+    4: HTML_ELEMENT@304..443
+      0: HTML_OPENING_ELEMENT@304..426
+        0: L_ANGLE@304..308 "<" [Newline("\n"), Newline("\n"), Newline("\n")] []
+        1: HTML_TAG_NAME@308..314
+          0: HTML_LITERAL@308..314 "button" [] []
+        2: HTML_ATTRIBUTE_LIST@314..395
+          0: HTML_ATTRIBUTE@314..362
+            0: HTML_ATTRIBUTE_NAME@314..349
+              0: HTML_LITERAL@314..349 "onclick" [Newline("\n"), Whitespace("  "), Comments("// single-line comment"), Newline("\n"), Whitespace("  ")] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@349..362
+              0: EQ@349..350 "=" [] []
+              1: HTML_ATTRIBUTE_SINGLE_TEXT_EXPRESSION@350..362
+                0: L_CURLY@350..351 "{" [] []
+                1: HTML_TEXT_EXPRESSION@351..361
+                  0: HTML_LITERAL@351..361 "doTheThing" [] []
+                2: R_CURLY@361..362 "}" [] []
+          1: HTML_ATTRIBUTE_SINGLE_TEXT_EXPRESSION@362..395
+            0: L_CURLY@362..390 "{" [Newline("\n"), Whitespace("  "), Comments("// comment after attr"), Newline("\n"), Whitespace("  ")] []
+            1: HTML_TEXT_EXPRESSION@390..394
+              0: HTML_LITERAL@390..394 "type" [] []
+            2: R_CURLY@394..395 "}" [] []
+        3: R_ANGLE@395..426 ">" [Newline("\n"), Whitespace("  "), Comments("// comment after shor ..."), Newline("\n")] []
+      1: HTML_ELEMENT_LIST@426..434
+        0: HTML_CONTENT@426..434
+          0: HTML_LITERAL@426..434 "click me" [] []
+      2: HTML_CLOSING_ELEMENT@434..443
+        0: L_ANGLE@434..435 "<" [] []
+        1: SLASH@435..436 "/" [] []
+        2: HTML_TAG_NAME@436..442
+          0: HTML_LITERAL@436..442 "button" [] []
+        3: R_ANGLE@442..443 ">" [] []
+    5: HTML_ELEMENT@443..512
+      0: HTML_OPENING_ELEMENT@443..502
+        0: L_ANGLE@443..446 "<" [Newline("\n"), Newline("\n")] []
+        1: HTML_TAG_NAME@446..470
+          0: HTML_LITERAL@446..470 "div" [] [Whitespace(" "), Comments("/* block comment */"), Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@470..501
+          0: HTML_ATTRIBUTE@470..501
+            0: HTML_ATTRIBUTE_NAME@470..475
+              0: HTML_LITERAL@470..475 "class" [] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@475..501
+              0: EQ@475..476 "=" [] []
+              1: HTML_STRING@476..501
+                0: HTML_STRING_LITERAL@476..501 "\"foo\"" [] [Whitespace(" "), Comments("/* block comment */")]
+        3: R_ANGLE@501..502 ">" [] []
+      1: HTML_ELEMENT_LIST@502..506
+        0: HTML_CONTENT@502..506
+          0: HTML_LITERAL@502..506 "text" [] []
+      2: HTML_CLOSING_ELEMENT@506..512
+        0: L_ANGLE@506..507 "<" [] []
+        1: SLASH@507..508 "/" [] []
+        2: HTML_TAG_NAME@508..511
+          0: HTML_LITERAL@508..511 "div" [] []
+        3: R_ANGLE@511..512 ">" [] []
+  4: EOF@512..513 "" [Newline("\n")] []
+
+```

--- a/packages/prettier-compare/package.json
+++ b/packages/prettier-compare/package.json
@@ -14,7 +14,7 @@
     "@opentui/react": "^0.1.75",
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
-    "prettier-plugin-svelte": "^3.4.1",
+    "prettier-plugin-svelte": "^3.5.0",
     "react": "^19.2.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1
       prettier-plugin-svelte:
-        specifier: ^3.4.1
-        version: 3.4.1(prettier@3.8.1)(svelte@5.46.4)
+        specifier: ^3.5.0
+        version: 3.5.0(prettier@3.8.1)(svelte@5.46.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1789,8 +1789,8 @@ packages:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
     engines: {node: ^14.15.0 || >=16.0.0}
 
-  prettier-plugin-svelte@3.4.1:
-    resolution: {integrity: sha512-xL49LCloMoZRvSwa6IEdN2GV6cq2IqpYGstYtMT+5wmml1/dClEoI0MZR78MiVPpu6BdQFfN0/y73yO6+br5Pg==}
+  prettier-plugin-svelte@3.5.0:
+    resolution: {integrity: sha512-2lLO/7EupnjO/95t+XZesXs8Bf3nYLIDfCo270h5QWbj/vjLqmrQ1LiRk9LPggxSDsnVYfehamZNf+rgQYApZg==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
@@ -3850,7 +3850,7 @@ snapshots:
       prettier: 3.8.1
       sass-formatter: 0.7.9
 
-  prettier-plugin-svelte@3.4.1(prettier@3.8.1)(svelte@5.46.4):
+  prettier-plugin-svelte@3.5.0(prettier@3.8.1)(svelte@5.46.4):
     dependencies:
       prettier: 3.8.1
       svelte: 5.46.4


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
In https://github.com/sveltejs/svelte/pull/17671, Svelte just added support for comments inside HTML tags. This PR updates our HTML parser to accept this syntax, and properly treat these comments as trivia.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
