### PR TITLE
fix(linter): `useUniqueElementIds` should ignore SVG elements

### DIFF
--- a/.changeset/fix-use-unique-element-ids-svg-context.md
+++ b/.changeset/fix-use-unique-element-ids-svg-context.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+The `useUniqueElementIds` rule now ignores elements inside an SVG context. SVG elements use `id` attributes for local references (gradients, patterns, clip-paths) and don't need globally unique IDs. The rule walks up the JSX tree to detect `<svg>` ancestors and skips the check when found. HTML elements outside SVG contexts continue to be flagged as expected.
+
+Closes #6206

--- a/crates/biome_js_analyze/src/lint/correctness/use_unique_element_ids.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_unique_element_ids.rs
@@ -4,7 +4,7 @@ use biome_diagnostics::Severity;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsxAttributeValue, JsCallExpression, JsPropertyObjectMember, JsxAttribute,
-    jsx_ext::AnyJsxElement,
+    JsxElement, jsx_ext::AnyJsxElement,
 };
 use biome_rowan::{AstNode, TokenText, declare_node_union};
 use biome_rule_options::use_unique_element_ids::UseUniqueElementIdsOptions;
@@ -42,6 +42,24 @@ declare_lint_rule! {
     /// ```jsx
     /// const id = useId();
     /// React.createElement("div", { id });
+    /// ```
+    ///
+    /// SVG elements are allowed to use static `id` attributes since they have
+    /// local scope within the SVG context:
+    ///
+    /// ```jsx
+    /// function Icon() {
+    ///   return (
+    ///     <svg>
+    ///       <defs>
+    ///         <linearGradient id="gradient1">
+    ///           <stop offset="0%" stopColor="red" />
+    ///         </linearGradient>
+    ///       </defs>
+    ///       <rect id="rect1" fill="url(#gradient1)" />
+    ///     </svg>
+    ///   );
+    /// }
     /// ```
     ///
     /// ## Options
@@ -103,6 +121,19 @@ impl UseUniqueElementIdsQuery {
         }
     }
 
+    /// Check if this element is inside an SVG context by walking up the AST tree.
+    /// We look for `JsxElement` ancestors whose opening element is `<svg>`.
+    fn is_inside_svg(&self) -> bool {
+        self.syntax().ancestors().filter_map(JsxElement::cast).any(|element| {
+            element
+                .opening_element()
+                .ok()
+                .and_then(|opening| opening.name().ok())
+                .and_then(|name| name.as_jsx_name().cloned())
+                .is_some_and(|name| name.value_token().is_ok_and(|t| t.text_trimmed() == "svg"))
+        })
+    }
+
     fn element_name(&self, model: &SemanticModel) -> Option<TokenText> {
         match self {
             Self::AnyJsxElement(jsx) => jsx
@@ -139,6 +170,12 @@ impl Rule for UseUniqueElementIds {
         let node = ctx.query();
         let model = ctx.model();
         let options = ctx.options();
+        
+        // Skip if this element is inside an SVG context
+        if node.is_inside_svg() {
+            return None;
+        }
+        
         if let Some(name) = node.element_name(model)
             && let Some(excluded_components) = &options.excluded_components
             && excluded_components.contains(name.text())

--- a/crates/biome_js_analyze/tests/specs/correctness/useUniqueElementIds/svg.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useUniqueElementIds/svg.jsx
@@ -1,0 +1,67 @@
+// SVG elements with static id attributes should not be flagged
+function SvgWithIds() {
+	return (
+		<svg>
+			<defs>
+				<linearGradient id="gradient1">
+					<stop offset="0%" stopColor="red" />
+					<stop offset="100%" stopColor="blue" />
+				</linearGradient>
+				<pattern id="pattern1" width="10" height="10">
+					<circle cx="5" cy="5" r="3" fill="blue" />
+				</pattern>
+				<clipPath id="clip1">
+					<rect x="0" y="0" width="100" height="100" />
+				</clipPath>
+			</defs>
+			<rect id="rect1" width="100" height="100" fill="url(#gradient1)" />
+			<circle id="circle1" cx="50" cy="50" r="25" />
+		</svg>
+	);
+}
+
+// Nested SVG elements should also not be flagged
+function NestedSvg() {
+	return (
+		<div>
+			<svg>
+				<g id="group1">
+					<rect id="rect2" width="50" height="50" />
+					<svg>
+						<circle id="circle2" cx="25" cy="25" r="10" />
+					</svg>
+				</g>
+			</svg>
+		</div>
+	);
+}
+
+// HTML elements outside SVG should still be flagged (these should trigger diagnostics)
+function HtmlWithIds() {
+	return (
+		<div>
+			<div id="shouldBeFlagged1">Content</div>
+			<svg>
+				<rect id="shouldNotBeFlagged" width="50" height="50" />
+			</svg>
+			<p id="shouldBeFlagged2">More content</p>
+		</div>
+	);
+}
+
+// Mixed case: SVG elements should not be flagged, but HTML elements should
+function MixedContent() {
+	return (
+		<div id="htmlDiv">
+			<svg>
+				<defs>
+					<linearGradient id="svgGradient">
+						<stop offset="0%" />
+					</linearGradient>
+				</defs>
+				<rect id="svgRect" fill="url(#svgGradient)" />
+			</svg>
+			<span id="htmlSpan">Text</span>
+		</div>
+	);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useUniqueElementIds/svg.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useUniqueElementIds/svg.jsx.snap
@@ -1,0 +1,143 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: svg.jsx
+---
+# Input
+```jsx
+// SVG elements with static id attributes should not be flagged
+function SvgWithIds() {
+	return (
+		<svg>
+			<defs>
+				<linearGradient id="gradient1">
+					<stop offset="0%" stopColor="red" />
+					<stop offset="100%" stopColor="blue" />
+				</linearGradient>
+				<pattern id="pattern1" width="10" height="10">
+					<circle cx="5" cy="5" r="3" fill="blue" />
+				</pattern>
+				<clipPath id="clip1">
+					<rect x="0" y="0" width="100" height="100" />
+				</clipPath>
+			</defs>
+			<rect id="rect1" width="100" height="100" fill="url(#gradient1)" />
+			<circle id="circle1" cx="50" cy="50" r="25" />
+		</svg>
+	);
+}
+
+// Nested SVG elements should also not be flagged
+function NestedSvg() {
+	return (
+		<div>
+			<svg>
+				<g id="group1">
+					<rect id="rect2" width="50" height="50" />
+					<svg>
+						<circle id="circle2" cx="25" cy="25" r="10" />
+					</svg>
+				</g>
+			</svg>
+		</div>
+	);
+}
+
+// HTML elements outside SVG should still be flagged (these should trigger diagnostics)
+function HtmlWithIds() {
+	return (
+		<div>
+			<div id="shouldBeFlagged1">Content</div>
+			<svg>
+				<rect id="shouldNotBeFlagged" width="50" height="50" />
+			</svg>
+			<p id="shouldBeFlagged2">More content</p>
+		</div>
+	);
+}
+
+// Mixed case: SVG elements should not be flagged, but HTML elements should
+function MixedContent() {
+	return (
+		<div id="htmlDiv">
+			<svg>
+				<defs>
+					<linearGradient id="svgGradient">
+						<stop offset="0%" />
+					</linearGradient>
+				</defs>
+				<rect id="svgRect" fill="url(#svgGradient)" />
+			</svg>
+			<span id="htmlSpan">Text</span>
+		</div>
+	);
+}
+```
+
+# Diagnostics
+```
+svg.jsx:43:4 lint/correctness/useUniqueElementIds ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × id attribute should not be a static string literal. Generate unique IDs using useId().
+  
+    41 │ 	return (
+    42 │ 		<div>
+  > 43 │ 			<div id="shouldBeFlagged1">Content</div>
+       │ 			^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    44 │ 			<svg>
+    45 │ 				<rect id="shouldNotBeFlagged" width="50" height="50" />
+  
+  i In React, if you hardcode IDs and use the component multiple times, it can lead to duplicate IDs in the DOM. Instead, generate unique IDs using useId().
+  
+
+```
+
+```
+svg.jsx:47:4 lint/correctness/useUniqueElementIds ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × id attribute should not be a static string literal. Generate unique IDs using useId().
+  
+    45 │ 				<rect id="shouldNotBeFlagged" width="50" height="50" />
+    46 │ 			</svg>
+  > 47 │ 			<p id="shouldBeFlagged2">More content</p>
+       │ 			^^^^^^^^^^^^^^^^^^^^^^^^^
+    48 │ 		</div>
+    49 │ 	);
+  
+  i In React, if you hardcode IDs and use the component multiple times, it can lead to duplicate IDs in the DOM. Instead, generate unique IDs using useId().
+  
+
+```
+
+```
+svg.jsx:55:3 lint/correctness/useUniqueElementIds ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × id attribute should not be a static string literal. Generate unique IDs using useId().
+  
+    53 │ function MixedContent() {
+    54 │ 	return (
+  > 55 │ 		<div id="htmlDiv">
+       │ 		^^^^^^^^^^^^^^^^^^
+    56 │ 			<svg>
+    57 │ 				<defs>
+  
+  i In React, if you hardcode IDs and use the component multiple times, it can lead to duplicate IDs in the DOM. Instead, generate unique IDs using useId().
+  
+
+```
+
+```
+svg.jsx:64:4 lint/correctness/useUniqueElementIds ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × id attribute should not be a static string literal. Generate unique IDs using useId().
+  
+    62 │ 				<rect id="svgRect" fill="url(#svgGradient)" />
+    63 │ 			</svg>
+  > 64 │ 			<span id="htmlSpan">Text</span>
+       │ 			^^^^^^^^^^^^^^^^^^^^
+    65 │ 		</div>
+    66 │ 	);
+  
+  i In React, if you hardcode IDs and use the component multiple times, it can lead to duplicate IDs in the DOM. Instead, generate unique IDs using useId().
+  
+
+```


### PR DESCRIPTION
## Summary

Fixes #6206

The `useUniqueElementIds` rule now ignores elements inside an SVG context. SVG elements use `id` attributes for local references (gradients, patterns, clip-paths) and don't need globally unique IDs.

Instead of maintaining a list of SVG tag names (which was the approach in the closed PR #6213 and had issues with ambiguous tags like `a`, `script`, `style`), this fix walks up the JSX tree looking for `JsxElement` ancestors with an `<svg>` opening element. No string allocations, no constant array to maintain.

## Test Plan

Added comprehensive test file `svg.jsx` covering:
- SVG elements with static IDs (gradients, patterns, clip-paths) — not flagged ✅
- Nested SVG elements — not flagged ✅
- HTML elements outside SVG — still flagged ✅
- Mixed HTML/SVG content — correct selective flagging ✅

All 7 existing tests pass.

### Known limitation

`React.createElement` calls nested inside a `createElement('svg', ...)` parent are not covered because `createElement` calls don't produce `JsxElement` AST nodes. Could be addressed in a follow-up.

## AI Disclosure

> This PR was written primarily by an AI agent (Clawd Lee / Claude via OpenClaw).