### PR TITLE
fix(lint): code action for `noRedundantUseStrict` no longer produces syntactically invalid nodes

### DIFF
--- a/.changeset/lazy-dancers-begin.md
+++ b/.changeset/lazy-dancers-begin.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9180](https://github.com/biomejs/biome/issues/9180): fixed a panic caused by an interaction between `noRedundantUseStrict` and the formatter

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -32,6 +32,7 @@ mod overrides_linter;
 mod overrides_max_file_size;
 mod overrides_organize_imports;
 mod protected_files;
+mod regression_tests;
 mod reporter_checkstyle;
 mod reporter_github;
 mod reporter_gitlab;

--- a/crates/biome_cli/tests/cases/regression_tests.rs
+++ b/crates/biome_cli/tests/cases/regression_tests.rs
@@ -1,0 +1,71 @@
+use bpaf::Args;
+use camino::Utf8Path;
+
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+
+use crate::run_cli;
+use crate::snap_test::{SnapshotPayload, assert_cli_snapshot};
+
+/// Regression test for https://github.com/biomejs/biome/issues/9180
+///
+/// This issue was caused by noRedundantUseStrict's fix replacing the directive with a directive that was syntactically blank.
+/// When fixes are applied, they also get formatted by our formatter. The formatter would try to format the
+/// directive, but it expects the directive to have quotes, and since it was syntactically blank, it would panic
+/// when trying to trim the quotes off.
+///
+/// Our unit tests didn't pick it up because linter unit tests don't include the formatting step.
+///
+/// This issue was fixed by changing the rule's fix to remove the node and transfer the trivia to the next token.
+#[test]
+fn issue_9180() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let js_file = Utf8Path::new("test.js");
+    fs.insert(
+        js_file.into(),
+        "// foo\n'use strict';\r\nconsole.log('test');\n".as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--write", js_file.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "issue_9180",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn issue_9180_2() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let js_file = Utf8Path::new("test.js");
+    fs.insert(js_file.into(), "// foo\n'use strict';\n".as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--write", js_file.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "issue_9180_2",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_regression_tests/issue_9180.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_regression_tests/issue_9180.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `test.js`
+
+```js
+// foo
+
+console.log("test");
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_regression_tests/issue_9180_2.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_regression_tests/issue_9180_2.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `test.js`
+
+```js
+// foo
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
@@ -2,10 +2,8 @@ use crate::JsRuleAction;
 use biome_analyze::{Ast, FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_factory::make::js_directive;
 use biome_js_syntax::{
     AnyJsClass, JsDirective, JsDirectiveList, JsFileSource, JsFunctionBody, JsModule, JsScript,
-    JsSyntaxKind, JsSyntaxToken,
 };
 use biome_rule_options::no_redundant_use_strict::NoRedundantUseStrictOptions;
 
@@ -191,17 +189,7 @@ impl Rule for NoRedundantUseStrict {
     fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsRuleAction> {
         let node = ctx.query();
         let mut mutation = ctx.root().begin();
-        let value_token = node.value_token().ok()?;
-        let new_node = js_directive(JsSyntaxToken::new_detached(
-            JsSyntaxKind::JSX_TEXT_LITERAL,
-            "",
-            [],
-            [],
-        ))
-        .build()
-        .with_leading_trivia_pieces(value_token.leading_trivia().pieces())?;
-
-        mutation.replace_node_discard_trivia(node.clone(), new_node);
+        mutation.remove_node_keep_trivia(node.clone());
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalid-with-trivia.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalid-with-trivia.js.snap
@@ -31,7 +31,18 @@ invalid-with-trivia.js:5:1 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━
   
   i Safe fix: Remove the redundant use strict directive.
   
-    5 │ "use·strict"·//·comment
-      │ -----------------------
+    1   │ - ///·<reference·types="node"·/>
+    2   │ - //·comment
+    3   │ - //·comment
+    4   │ - //·comment
+    5   │ - "use·strict"·//·comment
+      1 │ + ///·<reference·types="node"·/>
+      2 │ + //·comment
+      3 │ + //·comment
+      4 │ + //·comment
+      5 │ + ·//·comment
+    6 6 │   
+    7 7 │   let foo = "foo"
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalid.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalid.cjs.snap
@@ -42,8 +42,13 @@ invalid.cjs:2:1 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━━�
   
   i Safe fix: Remove the redundant use strict directive.
   
-    2 │ "use·strict";
-      │ -------------
+     1  1 │   "use strict";
+     2    │ - "use·strict";
+     3  2 │   
+        3 │ + 
+     4  4 │   function test() {
+     5  5 │   	"use strict";
+  
 
 ```
 
@@ -67,8 +72,15 @@ invalid.cjs:5:2 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━━�
   
   i Safe fix: Remove the redundant use strict directive.
   
-    5 │ → "use·strict";
-      │   -------------
+     3  3 │   
+     4  4 │   function test() {
+     5    │ - → "use·strict";
+     6    │ - → function·inner_a()·{
+        5 │ + → 
+        6 │ + → function·inner_a()·{
+     7  7 │   		"use strict"; // redundant directive
+     8  8 │   	}
+  
 
 ```
 
@@ -93,8 +105,15 @@ invalid.cjs:7:3 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━━�
   
   i Safe fix: Remove the redundant use strict directive.
   
-    7 │ → → "use·strict";·//·redundant·directive
-      │     ------------------------------------
+     5  5 │   	"use strict";
+     6  6 │   	function inner_a() {
+     7    │ - → → "use·strict";·//·redundant·directive
+     8    │ - → }
+        7 │ + → → ·//·redundant·directive
+        8 │ + → }
+     9  9 │   	function inner_b() {
+    10 10 │   		function inner_inner() {
+  
 
 ```
 
@@ -119,7 +138,14 @@ invalid.cjs:11:4 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━━�
   
   i Safe fix: Remove the redundant use strict directive.
   
-    11 │ → → → "use·strict";·//·additional·redundant·directive
-       │       -----------------------------------------------
+     9  9 │   	function inner_b() {
+    10 10 │   		function inner_inner() {
+    11    │ - → → → "use·strict";·//·additional·redundant·directive
+    12    │ - → → }
+       11 │ + → → → ·//·additional·redundant·directive
+       12 │ + → → }
+    13 13 │   	}
+    14 14 │   }
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalid.js.snap
@@ -43,8 +43,13 @@ invalid.js:2:1 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━━━
   
   i Safe fix: Remove the redundant use strict directive.
   
-    2 │ "use·strict";·//·Associated·comment
-      │ -----------------------------------
+     1    │ - //·js·module
+     2    │ - "use·strict";·//·Associated·comment
+        1 │ + //·js·module
+        2 │ + ·//·Associated·comment
+     3  3 │   
+     4  4 │   function foo() {
+  
 
 ```
 
@@ -63,8 +68,13 @@ invalid.js:5:2 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━━━
   
   i Safe fix: Remove the redundant use strict directive.
   
-    5 │ → "use·strict";
-      │   -------------
+     3  3 │   
+     4  4 │   function foo() {
+     5    │ - → "use·strict";
+        5 │ + → 
+     6  6 │   }
+     7  7 │   
+  
 
 ```
 
@@ -84,8 +94,15 @@ invalid.js:11:3 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━━�
   
   i Safe fix: Remove the redundant use strict directive.
   
-    11 │ → → "use·strict";
-       │     -------------
+     9  9 │   	// All code here is evaluated in strict mode
+    10 10 │   	test() {
+    11    │ - → → "use·strict";
+    12    │ - → }
+       11 │ + → → 
+       12 │ + → }
+    13 13 │   }
+    14 14 │   
+  
 
 ```
 
@@ -105,7 +122,14 @@ invalid.js:18:3 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━━�
   
   i Safe fix: Remove the redundant use strict directive.
   
-    18 │ → → "use·strict";
-       │     -------------
+    16 16 │   	// All code here is evaluated in strict mode
+    17 17 │   	test() {
+    18    │ - → → "use·strict";
+    19    │ - → }
+       18 │ + → → 
+       19 │ + → }
+    20 20 │   };
+    21 21 │   
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalid.ts.snap
@@ -26,7 +26,11 @@ invalid.ts:2:2 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━━━
   
   i Safe fix: Remove the redundant use strict directive.
   
-    2 │ → "use·strict";
-      │   -------------
+    1 1 │   function test(): void {
+    2   │ - → "use·strict";
+      2 │ + → 
+    3 3 │   }
+    4 4 │   
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalidClass.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalidClass.cjs.snap
@@ -45,8 +45,15 @@ invalidClass.cjs:3:3 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━
   
   i Safe fix: Remove the redundant use strict directive.
   
-    3 │ → → "use·strict";
-      │     -------------
+     1  1 │   class C1 {
+     2  2 │   	test() {
+     3    │ - → → "use·strict";
+     4    │ - → }
+        3 │ + → → 
+        4 │ + → }
+     5  5 │   }
+     6  6 │   
+  
 
 ```
 
@@ -77,7 +84,14 @@ invalidClass.cjs:9:3 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━━
   
   i Safe fix: Remove the redundant use strict directive.
   
-    9 │ → → "use·strict";
-      │     -------------
+     7  7 │   const C2 = class {
+     8  8 │   	test() {
+     9    │ - → → "use·strict";
+    10    │ - → }
+        9 │ + → → 
+       10 │ + → }
+    11 11 │   };
+    12 12 │   
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalidFunction.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalidFunction.cjs.snap
@@ -34,7 +34,12 @@ invalidFunction.cjs:3:2 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━
   
   i Safe fix: Remove the redundant use strict directive.
   
-    3 │ → "use·strict";
-      │   -------------
+    1 1 │   function test() {
+    2 2 │   	"use strict";
+    3   │ - → "use·strict";
+      3 │ + → 
+    4 4 │   }
+    5 5 │   
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalidFunction.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/invalidFunction.js.snap
@@ -27,8 +27,14 @@ invalidFunction.js:2:2 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━�
   
   i Safe fix: Remove the redundant use strict directive.
   
-    2 │ → "use·strict";
-      │   -------------
+    1 1 │   function test() {
+    2   │ - → "use·strict";
+    3   │ - → "use·strict";
+      2 │ + → 
+      3 │ + → "use·strict";
+    4 4 │   }
+    5 5 │   
+  
 
 ```
 
@@ -48,7 +54,12 @@ invalidFunction.js:3:2 lint/suspicious/noRedundantUseStrict  FIXABLE  ━━━�
   
   i Safe fix: Remove the redundant use strict directive.
   
-    3 │ → "use·strict";
-      │   -------------
+    1 1 │   function test() {
+    2 2 │   	"use strict";
+    3   │ - → "use·strict";
+      3 │ + → 
+    4 4 │   }
+    5 5 │   
+  
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This one was a bit of a weird one, tbh. Copying the note I left on the tests:

```
/// This issue was caused by noRedundantUseStrict's fix replacing the directive with a directive that was syntactically blank.
/// When fixes are applied, they also get formatted by our formatter. The formatter would try to format the
/// directive, but it expects the directive to have quotes, and since it was syntactically blank, it would panic
/// when trying to trim the quotes off.
///
/// Our unit tests didn't pick it up because linter unit tests don't include the formatting step.
///
/// This issue was fixed by changing the rule's fix to remove the node and transfer the trivia to the next token.
```

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #9180 

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added cli tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
