### PR TITLE
fix(cli): disable colors when GitHub Actions auto-enables github reporter

### DIFF
--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -719,9 +719,19 @@ impl BiomeCommand {
                 {
                     return Some(&ColorsArg::Off);
                 }
-                // We want force colors in CI, to give e better UX experience
+                // We want force colors in CI, to give a better UX experience
                 // Unless users explicitly set the colors flag
                 if matches!(self, Self::Ci { .. }) && cli_options.colors.is_none() {
+                    // When running in GitHub Actions, the github reporter is
+                    // auto-enabled. Disable colors so that ::error/::warning
+                    // workflow commands aren't wrapped in ANSI escape codes.
+                    if !cfg!(debug_assertions)
+                        && std::env::var("GITHUB_ACTIONS")
+                            .ok()
+                            .is_some_and(|v| v == "true")
+                    {
+                        return Some(&ColorsArg::Off);
+                    }
                     return Some(&ColorsArg::Force);
                 }
                 // Normal behaviors


### PR DESCRIPTION
## Summary

Fixes #9189

When `biome ci` runs in GitHub Actions, the `github` reporter is auto-enabled (via `GITHUB_ACTIONS=true` detection). However, the `get_color()` method in `commands/mod.rs` forces colors on for all CI runs, causing ANSI escape codes (`ESC[0m`) to wrap `::error`/`::warning` workflow command lines. This breaks GitHub's ability to parse them as [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands).

The existing code already disables colors when `--reporter=github` is explicitly passed, but the auto-detection path was not handled.

## Changes

- In `get_color()`, check for `GITHUB_ACTIONS=true` before forcing colors on in CI mode
- Uses `cfg!(debug_assertions)` guard consistent with the detection in `ci.rs`
- Makes auto-detected GitHub Actions behave identically to `--reporter=default --reporter=github`

## Test plan

- `biome ci` in GitHub Actions should now produce clean `::error`/`::warning` lines without ANSI wrapping
- `biome ci` outside GitHub Actions still gets forced colors (unchanged)
- `biome ci --colors=force` in GitHub Actions still forces colors (user override respected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)