### PR TITLE
fix: resolve plugin paths from extended configs

### DIFF
--- a/.changeset/fix-extended-plugin-paths.md
+++ b/.changeset/fix-extended-plugin-paths.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed plugin paths in extended configuration files to resolve relative to the extended config location.

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -76,6 +76,19 @@ impl LoadedLocation {
     }
 }
 
+fn normalize_plugin_paths(configuration: &mut Configuration, base_dir: &Utf8Path) {
+    if let Some(plugins) = configuration.plugins.as_mut() {
+        plugins.normalize_relative_paths(base_dir);
+    }
+    if let Some(overrides) = configuration.overrides.as_mut() {
+        for pattern in overrides.0.iter_mut() {
+            if let Some(plugins) = pattern.plugins.as_mut() {
+                plugins.normalize_relative_paths(base_dir);
+            }
+        }
+    }
+}
+
 impl LoadedConfiguration {
     /// It consumes the payload, applies and extends and returns the final, extended configuration.
     pub fn try_from_payload(
@@ -111,17 +124,8 @@ impl LoadedConfiguration {
                 // still load plugins defined in other configuration files.
                 let config_dir = configuration_file_path
                     .parent()
-                    .unwrap_or(external_resolution_base_path.as_path());
-                if let Some(plugins) = partial_configuration.plugins.as_mut() {
-                    plugins.normalize_relative_paths(config_dir);
-                }
-                if let Some(overrides) = partial_configuration.overrides.as_mut() {
-                    for pattern in overrides.0.iter_mut() {
-                        if let Some(plugins) = pattern.plugins.as_mut() {
-                            plugins.normalize_relative_paths(config_dir);
-                        }
-                    }
-                }
+                    .unwrap_or(&external_resolution_base_path);
+                normalize_plugin_paths(&mut partial_configuration, config_dir);
                 partial_configuration
             }
             None => Configuration::default(),
@@ -699,7 +703,14 @@ impl ConfigurationExt for Configuration {
                     },
                     "",
                 );
-                deserialized_configurations.push(deserialized)
+                let (mut config, diagnostics) = deserialized.consume();
+                if let Some(config) = config.as_mut() {
+                    let config_dir = extend_configuration_file_path
+                        .parent()
+                        .unwrap_or(external_resolution_base_path);
+                    normalize_plugin_paths(config, config_dir);
+                }
+                deserialized_configurations.push(Deserialized::new(config, diagnostics))
             }
         }
         Ok(deserialized_configurations)
@@ -717,6 +728,7 @@ mod test {
         BiomeDiagnostic, ConfigurationPathHint, diagnostics::ConfigurationDiagnostic,
     };
     use biome_fs::MemoryFileSystem;
+    use biome_plugin_loader::PluginConfiguration;
     use camino::Utf8PathBuf;
 
     #[test]
@@ -782,6 +794,33 @@ mod test {
                 ));
             }
         }
+    }
+
+    #[test]
+    fn should_normalize_plugin_paths_in_extended_configuration() {
+        let fs = MemoryFileSystem::default();
+        fs.insert(
+            Utf8PathBuf::from("/package-a/biome-common.json"),
+            r#"{ "plugins": ["./plugins/plugin-a.grit"] }"#.to_string(),
+        );
+        fs.insert(
+            Utf8PathBuf::from("/package-b/biome.json"),
+            r#"{ "extends": ["/package-a/biome-common.json"] }"#.to_string(),
+        );
+        let path_hint = ConfigurationPathHint::FromWorkspace(Utf8PathBuf::from("/package-b"));
+
+        let loaded = load_configuration(&fs, path_hint).expect("Config loading should succeed");
+        let plugins = loaded
+            .configuration
+            .plugins
+            .expect("Plugins should be present from extended configuration");
+        let first = match &plugins[0] {
+            PluginConfiguration::Path(path) => path.as_str(),
+        };
+        let normalized = std::path::PathBuf::from(first);
+        let expected = std::path::PathBuf::from("/package-a/plugins/plugin-a.grit");
+
+        assert_eq!(normalized, expected);
     }
 }
 


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

> [!NOTE]
> (from the human) I don’t know Rust at all & all these changes were implemented via Codex with my guidance. I've built the binary and tested it locally using my monorepo as a test case (see example layout below).

## Summary
Fixes plugin path resolution for plugins listed in extended config files and adds `@`-specifier support via `package.json` resolution, while preserving legacy non‑`@` behavior.

## Context
Previously, plugin paths from extended configs were normalized only after all configs were merged, so relative plugin paths were resolved against the entry config rather than the config file where they were declared. This change normalizes plugin paths at load time so extended configs resolve their own relative plugin paths correctly.

  My use case is a PNPM monorepo with a shared tools package. `extends` resolves fine, but custom Grit plugins declared in the shared config were not resolved relative to the common/tools package.

<details>
<summary>Example layout</summary>

```
repo/
  package-a/
    package.json
    biome.json
  package-b/
    package.json
    biome.json
  package-tools/
    package.json
    biome-common.json
    plugins/
      plugin-a.grit
```

`package-a/biome.json`:
```json
{
  "extends": ["@my-scope/package-tools/biome-common.json"]
}
```

`package-b/biome.json`:
```json
{
  "extends": ["@my-scope/package-tools/biome-common.json"]
}
```

`package-tools/biome-common.json`:
```json
{
  "plugins": ["./plugins/plugin-a.grit"]
}
```

`package-tools/package.json` (PNPM workspace structure, abbreviated):
```json
{
  "name": "@my-scope/package-tools",
  "private": true
}
```

`package-a/package.json` / `package-b/package.json`:
```json
{
  "name": "@my-scope/package-a",
  "private": true
}
```
</details>

## Test Plan
- `cargo test -p biome_service should_normalize_plugin_paths_in_extended_configuration`
- `cargo test -p biome_service plugins_support_package_specifiers_via_package_json`
- `cargo test -p biome_cli --test main -- tests/
config.rs::extends_config_extends_external_plugins_without_relative_paths tests/
config.rs::extends_config_extends_plugins_with_relative_paths tests/
config.rs::extends_config_extends_plugins_only_from_base`
- `cargo test -p biome_lsp --lib`

## Docs
Not applicable.

## Future Enhancement

Note that the changes in this PR are 100% backward‑compatible with the existing plugin file resolution (the current `"extend"`-ed plugins paths are broken ATM). Any non‑`@` plugin specifiers still use the current behaviour (so a simple-path like `"plugins": ["foo.grit"]` resolves as before — relative to the entry config — only `./` or `../`-prefixes are treated as explicit relative paths to the declaring config).

We could allow a small-ish "breaking" change to allow unscoped package names to resolve via `package.json` or `node_modules`. This could be done via an explicit `./` or `../` (or sniff the file system, `package.json`, etc) to distinguish file paths from package names. The benefit here would be to make it more obvious between: a) a relative plugin `./` or `../`-prefixed path or b) a "external" package (either via workspaces or npmjs.com).