### PR TITLE
fix: disable ANSI colors when GitHub reporter is auto-enabled

### DIFF
--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -719,9 +719,21 @@ impl BiomeCommand {
                 {
                     return Some(&ColorsArg::Off);
                 }
-                // We want force colors in CI, to give e better UX experience
+                // We want force colors in CI, to give a better UX experience
                 // Unless users explicitly set the colors flag
+                // However, when running inside GitHub Actions, we need to disable colors
+                // so the auto-enabled GitHub reporter output is not corrupted by ANSI escape codes
                 if matches!(self, Self::Ci { .. }) && cli_options.colors.is_none() {
+                    let is_github_actions = if cfg!(debug_assertions) {
+                        false
+                    } else {
+                        std::env::var("GITHUB_ACTIONS")
+                            .ok()
+                            .is_some_and(|value| value == "true")
+                    };
+                    if is_github_actions {
+                        return Some(&ColorsArg::Off);
+                    }
                     return Some(&ColorsArg::Force);
                 }
                 // Normal behaviors


### PR DESCRIPTION
## Summary

When `biome ci` runs in GitHub Actions, the GitHub reporter is automatically enabled via the `GITHUB_ACTIONS` environment variable (added in #9120). However, the color output was still being forced on in the `get_color()` method, causing ANSI escape sequences (`ESC[0m`) to wrap GitHub reporter output lines and break GitHub's annotation parsing.

## Fix

In the `get_color()` method, before force-enabling colors for CI, check if we're running inside GitHub Actions. If so, disable colors — matching the existing behavior when `--reporter=github` is explicitly passed.

This implements option 1 from the issue: make `biome ci` (when `GITHUB_ACTIONS=true`) behave the same as `--reporter=default --reporter=github` with respect to color output.

The `cfg!(debug_assertions)` guard is included (consistent with `ci.rs`) to avoid false positives in Biome's own CI test suite.

Closes #9189