### PR TITLE
fix(linter): handle re-ordered index in template string for noArrayIndexKey

### DIFF
--- a/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
@@ -48,6 +48,12 @@ declare_lint_rule! {
     ///
     /// ```jsx,expect_diagnostic
     /// something.forEach((Element, index) => {
+    ///     <Component key={`${index}-test-key`} >foo</Component>
+    /// });
+    /// ```
+    ///
+    /// ```jsx,expect_diagnostic
+    /// something.forEach((Element, index) => {
     ///     <Component key={"test" + index} >foo</Component>
     /// });
     /// ```
@@ -140,33 +146,58 @@ impl Rule for NoArrayIndexKey {
         let model = ctx.model();
         let reference = node.as_js_expression()?;
 
-        let mut capture_array_index = None;
+        let mut candidate_references: Vec<JsReferenceIdentifier> = Vec::new();
 
         match reference {
             AnyJsExpression::JsIdentifierExpression(identifier_expression) => {
-                capture_array_index = Some(identifier_expression.name().ok()?);
+                if let Ok(name) = identifier_expression.name() {
+                    candidate_references.push(name);
+                }
             }
             AnyJsExpression::JsTemplateExpression(template_expression) => {
                 let template_elements = template_expression.elements();
                 for element in template_elements {
                     if let AnyJsTemplateElement::JsTemplateElement(template_element) = element {
-                        let cap_index_value = template_element
+                        if let Some(name) = template_element
                             .expression()
-                            .ok()?
-                            .as_js_identifier_expression()?
-                            .name()
-                            .ok();
-                        capture_array_index = cap_index_value;
+                            .ok()
+                            .and_then(|expr| expr.as_js_identifier_expression().cloned())
+                            .and_then(|ident| ident.name().ok())
+                        {
+                            candidate_references.push(name);
+                        }
                     }
                 }
             }
             AnyJsExpression::JsBinaryExpression(binary_expression) => {
+                let mut capture_array_index = None;
                 let _ = cap_array_index_value(&binary_expression, &mut capture_array_index);
+                if let Some(reference) = capture_array_index {
+                    candidate_references.push(reference);
+                }
             }
             _ => {}
         };
 
-        let reference = capture_array_index?;
+        // Find the first candidate that resolves to an array index parameter
+        let reference = candidate_references.into_iter().find(|candidate| {
+            model
+                .binding(candidate)
+                .and_then(|declaration| declaration.syntax().parent())
+                .and_then(JsFormalParameter::cast)
+                .and_then(|param| {
+                    let function = param
+                        .parent::<JsParameterList>()
+                        .and_then(|list| list.parent::<JsParameters>())
+                        .and_then(|parameters| parameters.parent::<AnyJsFunction>())?;
+                    let call_expr = function
+                        .parent::<JsCallArgumentList>()
+                        .and_then(|arguments| arguments.parent::<JsCallArguments>())
+                        .and_then(|arguments| arguments.parent::<JsCallExpression>())?;
+                    is_array_method_index(&param, &call_expr)
+                })
+                .unwrap_or(false)
+        })?;
 
         // Given the reference identifier retrieved from the key property,
         // find the declaration and ensure it resolves to the parameter of a function,

--- a/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx
@@ -132,3 +132,10 @@ function Component10() {
         </HoC>
     );
 }
+function Component11() {
+    return (
+        <HoC>
+            {({ things }) => things.map((item, index) => <Component key={`${index}-${item}`} />)}
+        </HoC>
+    );
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx.snap
@@ -138,6 +138,14 @@ function Component10() {
         </HoC>
     );
 }
+function Component11() {
+    return (
+        <HoC>
+            {({ things }) => things.map((item, index) => <Component key={`${index}-${item}`} />)}
+        </HoC>
+    );
+}
+
 ```
 
 # Diagnostics
@@ -927,6 +935,34 @@ invalid.jsx:131:80 lint/suspicious/noArrayIndexKey ━━━━━━━━━�
         │                                             ^^^^^
     132 │         </HoC>
     133 │     );
+  
+  i The order of the items may change, and this also affects performances and component state.
+  
+  i Check the React documentation. 
+  
+
+```
+
+```
+invalid.jsx:138:77 lint/suspicious/noArrayIndexKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Avoid using the index of an array as key property in an element.
+  
+    136 │     return (
+    137 │         <HoC>
+  > 138 │             {({ things }) => things.map((item, index) => <Component key={`${index}-${item}`} />)}
+        │                                                                             ^^^^^
+    139 │         </HoC>
+    140 │     );
+  
+  i This is the source of the key value.
+  
+    136 │     return (
+    137 │         <HoC>
+  > 138 │             {({ things }) => things.map((item, index) => <Component key={`${index}-${item}`} />)}
+        │                                                ^^^^^
+    139 │         </HoC>
+    140 │     );
   
   i The order of the items may change, and this also affects performances and component state.
   


### PR DESCRIPTION
## Summary

Fixes #8812

The `noArrayIndexKey` rule had a false negative when the array index appeared before other interpolations in a template literal. For example:

```jsx
// ✅ Was correctly detected
<div key={`${item}-${index}`} />

// ❌ Was NOT detected (false negative)
<div key={`${index}-${item}`} />
```

### Root cause

The template expression handler iterated over all template elements but kept overwriting `capture_array_index` with each one. Only the **last** interpolation was checked. When `index` appeared first, it was overwritten by `item`, which doesn't resolve to an array index parameter.

### Fix

Instead of keeping only the last identifier, collect **all** identifier expressions from template elements and check each one against the array index parameter binding. The first match is used.

## Test Plan

- Added test case for `${index}-${item}` ordering in `invalid.jsx`
- All existing tests pass
- Snapshot updated