### PR TITLE
fix(cli): json reporter escaping

### DIFF
--- a/.changeset/fix-json-reporter-escaped-quotes.md
+++ b/.changeset/fix-json-reporter-escaped-quotes.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed JSON reporter escaping of special characters in diagnostic messages. The JSON reporter now properly escapes double quotes, backslashes, and control characters in error messages and advice text, preventing invalid JSON output when diagnostics contain these characters.

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -11,6 +11,18 @@ use biome_json_factory::make::*;
 use biome_json_syntax::{AnyJsonMemberName, AnyJsonValue, JsonRoot, JsonSyntaxKind, T};
 use camino::{Utf8Path, Utf8PathBuf};
 
+/// Escapes special characters in a string for safe JSON output
+fn json_escape(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+        .replace('\x08', "\\b")
+        .replace('\x0C', "\\f")
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct JsonReporterVisitor {
     summary: TraversalSummary,
@@ -134,7 +146,9 @@ fn suggestion_to_json(suggestion: &JsonSuggestion) -> AnyJsonValue {
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("text"))),
             token(T![:]),
-            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&suggestion.text))),
+            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&json_escape(
+                &suggestion.text,
+            )))),
         ),
     ];
     let separators = vec![token(T![,]); members.len() - 1];
@@ -164,7 +178,9 @@ fn report_to_json(report: &JsonReport) -> AnyJsonValue {
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("message"))),
             token(T![:]),
-            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&report.message))),
+            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&json_escape(
+                &report.message,
+            )))),
         ),
     ];
 

--- a/crates/biome_cli/tests/cases/reporter_json.rs
+++ b/crates/biome_cli/tests/cases/reporter_json.rs
@@ -25,6 +25,8 @@ debugger
 let f;
 		let f;"#;
 
+const MAIN_WITH_QUOTES: &str = r#"function NaN() {}"#;
+
 #[test]
 fn reports_diagnostics_json_check_command() {
     let fs = MemoryFileSystem::default();
@@ -200,6 +202,31 @@ fn reports_diagnostics_json_check_command_file() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "reports_diagnostics_json_check_command_file",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn reports_diagnostics_json_with_escaped_quotes() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new("quotes.ts");
+    fs.insert(file_path.into(), MAIN_WITH_QUOTES.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--reporter=json-pretty", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "reports_diagnostics_json_with_escaped_quotes",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_with_escaped_quotes.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_with_escaped_quotes.snap
@@ -1,0 +1,81 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `quotes.ts`
+
+```ts
+function NaN() {}
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+The --json option is unstable/experimental and its output might change between patches/minor releases.
+```
+
+```block
+{
+	"summary": {
+		"changed": 0,
+		"unchanged": 1,
+		"matches": 0,
+		"duration": "<TIME>",
+		"errors": 2,
+		"warnings": 1,
+		"infos": 0,
+		"skipped": 0,
+		"suggestedFixesSkipped": 0,
+		"diagnosticsNotPrinted": 0,
+		"scannerDuration": "<TIME>"
+	},
+	"diagnostics": [
+		{
+			"severity": "warning",
+			"message": "This function NaN is unused.",
+			"category": "lint/correctness/noUnusedVariables",
+			"location": {
+				"path": "quotes.ts",
+				"start": { "line": 1, "column": 10 },
+				"end": { "line": 1, "column": 13 }
+			},
+			"advices": []
+		},
+		{
+			"severity": "error",
+			"message": "Do not shadow the global \"NaN\" property.",
+			"category": "lint/suspicious/noShadowRestrictedNames",
+			"location": {
+				"path": "quotes.ts",
+				"start": { "line": 1, "column": 10 },
+				"end": { "line": 1, "column": 13 }
+			},
+			"advices": []
+		},
+		{
+			"severity": "error",
+			"message": "Formatter would have printed the following content:",
+			"category": "format",
+			"location": {
+				"path": "quotes.ts",
+				"start": { "line": 0, "column": 0 },
+				"end": { "line": 0, "column": 0 }
+			},
+			"advices": []
+		}
+	],
+	"command": "check"
+}
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Bug found when I was testing the JSON reporter in the ecosystem CI

I generated the code with AI. The escaping uses the same code of checklist reporter.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a test

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
