### PR TITLE
refactor(markdown-parser): replace remaining magic numbers with named constants

### DIFF
--- a/crates/biome_markdown_parser/src/parser.rs
+++ b/crates/biome_markdown_parser/src/parser.rs
@@ -470,7 +470,7 @@ fn count_leading_indent(text: &str) -> usize {
     for c in text.chars() {
         match c {
             ' ' => count += 1,
-            '\t' => count += 4,
+            '\t' => count += TAB_STOP_SPACES,
             _ => break,
         }
     }

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -534,7 +534,7 @@ fn consume_indent_prefix(p: &mut MarkdownParser, indent: usize) {
         if text == " " {
             consumed += 1;
         } else if text == "\t" {
-            consumed += 4;
+            consumed += TAB_STOP_SPACES;
         } else {
             break;
         }

--- a/crates/biome_markdown_parser/src/to_html.rs
+++ b/crates/biome_markdown_parser/src/to_html.rs
@@ -1148,7 +1148,9 @@ fn render_fenced_code_block(
         indent
     });
     let container_indent = list_indent + quote_indent;
-    let fence_indent = fence_leading_indent.saturating_sub(container_indent).min(3);
+    let fence_indent = fence_leading_indent
+        .saturating_sub(container_indent)
+        .min(MAX_BLOCK_PREFIX_INDENT);
     let content_indent = container_indent + fence_indent;
 
     // Get info string (language) - process escapes


### PR DESCRIPTION
> [!NOTE]
> **AI Assistance Disclosure**: This PR was developed with assistance from Claude Code.

## Summary

Follow-up to #9228 — three hardcoded literals were missed before that PR merged.

- `count_leading_indent` in `parser.rs`: `4` → `TAB_STOP_SPACES`
- `consume_indent_prefix` in `syntax/mod.rs`: `4` → `TAB_STOP_SPACES`
- `render_fenced_code_block` in `to_html.rs`: `.min(3)` → `.min(MAX_BLOCK_PREFIX_INDENT)`

No user-facing behavior change. All 652 CommonMark conformance tests pass.

## Test Plan

- `just test-markdown-conformance` — 652/652 pass, 100% coverage
- `cargo check -p biome_markdown_parser` — compiles cleanly

## Docs

N/A — internal refactor only.