### PR TITLE
fix(lint): treat Astro Image component like img in useAnchorContent

### DIFF
--- a/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
@@ -212,7 +212,7 @@ fn has_accessible_content(html_child_list: &HtmlElementList) -> bool {
             let tag_text = element.name().ok().and_then(|n| n.token_text_trimmed());
 
             match tag_text.as_ref().map(|t| t.as_ref()) {
-                Some(name) if name.eq_ignore_ascii_case("img") => {
+                Some(name) if name.eq_ignore_ascii_case("img") || name == "Image" => {
                     html_self_closing_element_has_non_empty_attribute(element, "alt")
                 }
                 Some(name)

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro
@@ -20,3 +20,6 @@
 <!-- Accessible via aria-label or title alone -->
 <a aria-label="Navigate to dashboard"></a>
 <a title="Go to settings page"></a>
+
+<!-- Astro Image component with alt attribute should be treated like img -->
+<a><Image src={profileImg} alt="profile picture" /></a>


### PR DESCRIPTION
🤖 **AI Disclosure**: This PR was authored by an AI agent (OpenClaw) on behalf of @kbo4sho. Happy to address feedback.

## Summary

Fixes #9210

The `useAnchorContent` rule was throwing a false positive when using Astro's built-in `<Image>` component inside anchor tags, even when the component had a valid `alt` attribute.

This PR adds recognition for the Astro `Image` component (from `astro:assets`) and treats it the same as the native `<img>` element - checking for the `alt` attribute as valid accessible content.

## Changes

- Updated the pattern match in `has_accessible_content` to recognize both `img` (case-insensitive) and `Image` (exact match for Astro component)
- Added test case for `<Image>` component with `alt` attribute in valid.astro

## Test Plan

Added a test case demonstrating that `<a><Image src={profileImg} alt="profile picture" /></a>` should be considered valid accessible content, just like `<a><img alt="description" /></a>`.

The fix is minimal and follows the existing pattern for other image-like elements in the codebase.