### PR TITLE
fix(lint): detect array index in all positions of template strings

### DIFF
--- a/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
@@ -124,6 +124,41 @@ pub struct NoArrayIndexKeyState {
     binding_origin: TextRange,
 }
 
+
+/// Collect all identifiers from an expression (template strings, binary expressions, etc.)
+fn collect_identifiers_from_expression(expression: &AnyJsExpression) -> Vec<JsReferenceIdentifier> {
+    let mut identifiers = Vec::new();
+    
+    match expression {
+        AnyJsExpression::JsIdentifierExpression(ident_expr) => {
+            if let Ok(name) = ident_expr.name() {
+                identifiers.push(name);
+            }
+        }
+        AnyJsExpression::JsTemplateExpression(template_expr) => {
+            for element in template_expr.elements() {
+                if let AnyJsTemplateElement::JsTemplateElement(template_element) = element {
+                    if let Some(expr) = template_element.expression().ok() {
+                        // Recursively collect from nested expressions
+                        identifiers.extend(collect_identifiers_from_expression(&expr));
+                    }
+                }
+            }
+        }
+        AnyJsExpression::JsBinaryExpression(binary_expr) => {
+            if let Ok(left) = binary_expr.left() {
+                identifiers.extend(collect_identifiers_from_expression(&left));
+            }
+            if let Ok(right) = binary_expr.right() {
+                identifiers.extend(collect_identifiers_from_expression(&right));
+            }
+        }
+        _ => {}
+    }
+    
+    identifiers
+}
+
 impl Rule for NoArrayIndexKey {
     type Query = Semantic<NoArrayIndexKeyQuery>;
     type State = NoArrayIndexKeyState;
@@ -142,35 +177,57 @@ impl Rule for NoArrayIndexKey {
 
         let mut capture_array_index = None;
 
-        match reference {
-            AnyJsExpression::JsIdentifierExpression(identifier_expression) => {
-                capture_array_index = Some(identifier_expression.name().ok()?);
-            }
-            AnyJsExpression::JsTemplateExpression(template_expression) => {
-                let template_elements = template_expression.elements();
-                for element in template_elements {
-                    if let AnyJsTemplateElement::JsTemplateElement(template_element) = element {
-                        let cap_index_value = template_element
-                            .expression()
-                            .ok()?
-                            .as_js_identifier_expression()?
-                            .name()
-                            .ok();
-                        capture_array_index = cap_index_value;
-                    }
-                }
-            }
-            AnyJsExpression::JsBinaryExpression(binary_expression) => {
-                let _ = cap_array_index_value(&binary_expression, &mut capture_array_index);
-            }
-            _ => {}
-        };
+        // Collect all identifiers from the expression (fixes #8812)
+        // We need to check ALL identifiers, not just the last one in templates/binary expressions
+        let identifiers = collect_identifiers_from_expression(&reference);
+        
+        // Check each identifier to see if any is an array index parameter
+        for identifier in identifiers {
+            let parameter = match model
+                .binding(&identifier)
+                .and_then(|declaration| declaration.syntax().parent())
+                .and_then(JsFormalParameter::cast)
+            {
+                Some(param) => param,
+                None => continue,
+            };
+            
+            let function = match parameter
+                .parent::<JsParameterList>()
+                .and_then(|list| list.parent::<JsParameters>())
+                .and_then(|parameters| parameters.parent::<AnyJsFunction>())
+            {
+                Some(func) => func,
+                None => continue,
+            };
+            
+            let call_expression = match function
+                .parent::<JsCallArgumentList>()
+                .and_then(|arguments| arguments.parent::<JsCallArguments>())
+                .and_then(|arguments| arguments.parent::<JsCallExpression>())
+            {
+                Some(call) => call,
+                None => continue,
+            };
 
+            // Check if the caller is an array method and the parameter is the array index of that method
+            let is_array_method_index = match is_array_method_index(&parameter, &call_expression) {
+                Some(true) => true,
+                _ => continue,
+            };
+
+            if !is_array_method_index {
+                continue;
+            }
+            
+            // Found an array index! Set it and break
+            capture_array_index = Some(identifier);
+            break;
+        }
+        
         let reference = capture_array_index?;
-
-        // Given the reference identifier retrieved from the key property,
-        // find the declaration and ensure it resolves to the parameter of a function,
-        // and navigate up to the closest call expression
+        
+        // Re-validate to get the parameter for the diagnostic
         let parameter = model
             .binding(&reference)
             .and_then(|declaration| declaration.syntax().parent())
@@ -183,10 +240,8 @@ impl Rule for NoArrayIndexKey {
             .parent::<JsCallArgumentList>()
             .and_then(|arguments| arguments.parent::<JsCallArguments>())
             .and_then(|arguments| arguments.parent::<JsCallExpression>())?;
-
-        // Check if the caller is an array method and the parameter is the array index of that method
+        
         let is_array_method_index = is_array_method_index(&parameter, &call_expression)?;
-
         if !is_array_method_index {
             return None;
         }

--- a/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noArrayIndexKey/invalid.jsx
@@ -132,3 +132,11 @@ function Component10() {
         </HoC>
     );
 }
+// Edge case: index comes first in template string (issue #8812)
+function Component11() {
+    return (
+        <HoC>
+            {({ things }) => things.map((item, index) => <Component key={`${index}-${item}`} />)}
+        </HoC>
+    );
+}


### PR DESCRIPTION
🤖 **AI Disclosure**: This PR was authored by an AI agent (OpenClaw) on behalf of @kbo4sho. Happy to address feedback.

## Summary

Fixes #8812

The `noArrayIndexKey` rule was only checking the last identifier in template strings and binary expressions, causing false negatives when the array index appeared in any position other than last.

### Before
```jsx
// ✓ Correctly caught (index is last)
<Component key={`${item}-${index}`} />

// ✗ Missed (index is first) - BUG
<Component key={`${index}-${item}`} />
```

### After
Both cases are now correctly detected.

## Changes

- Added `collect_identifiers_from_expression()` helper function that recursively collects all identifiers from template strings and binary expressions
- Modified the rule logic to check **all** identifiers in the expression, not just the last one
- Added test case for the edge case where index appears first in the template string

## Technical Details

The original code iterated through template elements and kept reassigning `capture_array_index`, which meant only the last identifier was retained. The fix collects all identifiers into a Vec, then checks each one to see if any is an array index parameter.

This also handles nested expressions properly through recursion.

## Test Plan

Added test case:
```jsx
// Edge case: index comes first in template string (issue #8812)
function Component11() {
    return (
        <HoC>
            {({ things }) => things.map((item, index) => <Component key={`${index}-${item}`} />)}
        </HoC>
    );
}
```

This now correctly triggers the lint rule.