### PR TITLE
fix(dx): deny `type Options = ()` in rules

### DIFF
--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -1,6 +1,7 @@
 //! This module is in charge of checking if the documentation and tests cases inside the Analyzer rules are correct.
 //!
 //!
+use std::any::TypeId;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Display, Formatter, Write};
 use std::str::FromStr;
@@ -69,6 +70,12 @@ pub fn check_rules() -> anyhow::Result<()> {
             let group = R::Group::NAME;
             let rule_name = R::METADATA.name;
             let rule_severity = R::METADATA.severity;
+
+            if TypeId::of::<R::Options>() == TypeId::of::<()>() {
+                self.errors.push(Errors::new(format!(
+                    "The rule '{rule_name}' uses `type Options = ()`. All lint rules must use a generated options struct (e.g., `RuleNameOptions`), even if empty. One should have been created for you if you ran the codegen when creating the rule. Create an empty options struct for this rule in biome_rule_options and update the rule to use it (e.g., `type Options = RuleNameOptions`)."
+                )));
+            }
 
             if let Some(issue_number) = R::METADATA.issue_number
                 && group != "nursery"


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #9263
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
CI should be green

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
