### PR TITLE
feat(biome_js_analyze): skip noEmptyBlockStatements for methods in classes implementing interfaces

### DIFF
--- a/crates/biome_js_analyze/src/lint/suspicious/no_empty_block_statements.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_empty_block_statements.rs
@@ -4,8 +4,8 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
-    AnyJsConstructorParameter, JsBlockStatement, JsConstructorClassMember, JsFunctionBody,
-    JsStaticInitializationBlockClassMember, JsSwitchStatement,
+    AnyJsClass, AnyJsConstructorParameter, JsBlockStatement, JsConstructorClassMember,
+    JsFunctionBody, JsMethodClassMember, JsStaticInitializationBlockClassMember, JsSwitchStatement,
 };
 use biome_rowan::{AstNode, AstNodeList, SyntaxNodeCast, declare_node_union};
 use biome_rule_options::no_empty_block_statements::NoEmptyBlockStatementsOptions;
@@ -87,8 +87,13 @@ impl Rule for NoEmptyBlockStatements {
         let has_comments = query.syntax().has_comments_descendants();
         let is_constructor_with_ts_param_props_or_private =
             is_constructor_with_ts_param_props_or_private(query);
+        let is_method_in_class_with_implements = is_method_in_class_with_implements(query);
 
-        (is_empty && !has_comments && !is_constructor_with_ts_param_props_or_private).then_some(())
+        (is_empty
+            && !has_comments
+            && !is_constructor_with_ts_param_props_or_private
+            && !is_method_in_class_with_implements)
+        .then_some(())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
@@ -146,4 +151,29 @@ fn is_constructor_with_ts_param_props_or_private(query: &Query) -> bool {
         .into_iter()
         .any(|modifier| modifier.is_private() || modifier.is_protected());
     is_param_props || is_private
+}
+
+/// Check if the function body belongs to a method in a class that implements an interface.
+///
+/// When a class implements an interface, it is common for methods to have empty bodies,
+/// especially in mock implementations used for testing.
+fn is_method_in_class_with_implements(query: &Query) -> bool {
+    let Query::JsFunctionBody(body) = query else {
+        return false;
+    };
+
+    // Check if the parent is a method class member
+    let Some(parent) = body.syntax().parent() else {
+        return false;
+    };
+    if JsMethodClassMember::cast(parent).is_none() {
+        return false;
+    }
+
+    // Walk up to find the enclosing class: method -> member list -> class
+    body.syntax()
+        .ancestors()
+        .find_map(AnyJsClass::cast)
+        .and_then(|class| class.implements_clause())
+        .is_some()
 }

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyBlockStatements/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyBlockStatements/invalid.ts
@@ -1,11 +1,11 @@
-function fooEmptyTs() {}
+function fooEmptyTs() { }
 
-const barEmptyTs = () => {};
+const barEmptyTs = () => { };
 
 function fooWithNestedEmptyFnBlockTs() {
   let a = 1;
 
-  function shouldFail(){}
+  function shouldFail() { }
 
   return a
 }
@@ -14,7 +14,7 @@ function fooWithNestedEmptyFnBlockTs() {
 const barWithNestedEmptyFnBlockTs = () => {
   let a = 1;
 
-  const shouldFail = () => {}
+  const shouldFail = () => { }
 
   return a
 }
@@ -26,43 +26,43 @@ if (someVarTs) {
 while (someVarTs) {
 }
 
-switch(someVarTs) {
+switch (someVarTs) {
 }
 
 const doSomething = () => null;
 try {
-    doSomething();
-} catch(ex) {
+  doSomething();
+} catch (ex) {
 
 } finally {
 
 }
 
 class FooEmptyStaticTs {
-  static {}
+  static { }
 }
 
-for(let i; i>0; i++){}
+for (let i; i > 0; i++) { }
 
 const obTs = {}
-for (const key in obTs) {}
+for (const key in obTs) { }
 
 const arTs = []
-for (const val of arTs) {}
+for (const val of arTs) { }
 
-function fooWithInternalEmptyBlocksTs(){
+function fooWithInternalEmptyBlocksTs() {
   let someOtherVar: string = '';
-  if (someOtherVar) {}
+  if (someOtherVar) { }
 
   while (someOtherVar) {
   }
 
-  switch(someOtherVar) {
+  switch (someOtherVar) {
   }
 
   try {
-      doSomething();
-  } catch(ex) {
+    doSomething();
+  } catch (ex) {
 
   } finally {
 
@@ -75,5 +75,21 @@ export class FooBar {
   ) {
     function bar() { }
     bar();
+  }
+}
+
+// Class without implements should still flag empty methods
+class NoImplements {
+  doSomething() { }
+}
+
+// Nested function inside a method of a class with implements should still flag
+interface SomeInterface {
+  run(): void;
+}
+class ImplWithNested implements SomeInterface {
+  run() {
+    function inner() { }
+    inner();
   }
 }

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyBlockStatements/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyBlockStatements/invalid.ts.snap
@@ -4,14 +4,14 @@ expression: invalid.ts
 ---
 # Input
 ```ts
-function fooEmptyTs() {}
+function fooEmptyTs() { }
 
-const barEmptyTs = () => {};
+const barEmptyTs = () => { };
 
 function fooWithNestedEmptyFnBlockTs() {
   let a = 1;
 
-  function shouldFail(){}
+  function shouldFail() { }
 
   return a
 }
@@ -20,7 +20,7 @@ function fooWithNestedEmptyFnBlockTs() {
 const barWithNestedEmptyFnBlockTs = () => {
   let a = 1;
 
-  const shouldFail = () => {}
+  const shouldFail = () => { }
 
   return a
 }
@@ -32,43 +32,43 @@ if (someVarTs) {
 while (someVarTs) {
 }
 
-switch(someVarTs) {
+switch (someVarTs) {
 }
 
 const doSomething = () => null;
 try {
-    doSomething();
-} catch(ex) {
+  doSomething();
+} catch (ex) {
 
 } finally {
 
 }
 
 class FooEmptyStaticTs {
-  static {}
+  static { }
 }
 
-for(let i; i>0; i++){}
+for (let i; i > 0; i++) { }
 
 const obTs = {}
-for (const key in obTs) {}
+for (const key in obTs) { }
 
 const arTs = []
-for (const val of arTs) {}
+for (const val of arTs) { }
 
-function fooWithInternalEmptyBlocksTs(){
+function fooWithInternalEmptyBlocksTs() {
   let someOtherVar: string = '';
-  if (someOtherVar) {}
+  if (someOtherVar) { }
 
   while (someOtherVar) {
   }
 
-  switch(someOtherVar) {
+  switch (someOtherVar) {
   }
 
   try {
-      doSomething();
-  } catch(ex) {
+    doSomething();
+  } catch (ex) {
 
   } finally {
 
@@ -84,6 +84,22 @@ export class FooBar {
   }
 }
 
+// Class without implements should still flag empty methods
+class NoImplements {
+  doSomething() { }
+}
+
+// Nested function inside a method of a class with implements should still flag
+interface SomeInterface {
+  run(): void;
+}
+class ImplWithNested implements SomeInterface {
+  run() {
+    function inner() { }
+    inner();
+  }
+}
+
 ```
 
 # Diagnostics
@@ -92,10 +108,10 @@ invalid.ts:1:23 lint/suspicious/noEmptyBlockStatements ━━━━━━━━�
 
   ! Unexpected empty block.
   
-  > 1 │ function fooEmptyTs() {}
-      │                       ^^
+  > 1 │ function fooEmptyTs() { }
+      │                       ^^^
     2 │ 
-    3 │ const barEmptyTs = () => {};
+    3 │ const barEmptyTs = () => { };
   
   i Empty blocks are usually the result of an incomplete refactoring. Remove the empty block or add a comment inside it if it is intentional.
   
@@ -107,10 +123,10 @@ invalid.ts:3:26 lint/suspicious/noEmptyBlockStatements ━━━━━━━━�
 
   ! Unexpected empty block.
   
-    1 │ function fooEmptyTs() {}
+    1 │ function fooEmptyTs() { }
     2 │ 
-  > 3 │ const barEmptyTs = () => {};
-      │                          ^^
+  > 3 │ const barEmptyTs = () => { };
+      │                          ^^^
     4 │ 
     5 │ function fooWithNestedEmptyFnBlockTs() {
   
@@ -120,14 +136,14 @@ invalid.ts:3:26 lint/suspicious/noEmptyBlockStatements ━━━━━━━━�
 ```
 
 ```
-invalid.ts:8:24 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:8:25 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Unexpected empty block.
   
      6 │   let a = 1;
      7 │ 
-   > 8 │   function shouldFail(){}
-       │                        ^^
+   > 8 │   function shouldFail() { }
+       │                         ^^^
      9 │ 
     10 │   return a
   
@@ -143,8 +159,8 @@ invalid.ts:17:28 lint/suspicious/noEmptyBlockStatements ━━━━━━━━
   
     15 │   let a = 1;
     16 │ 
-  > 17 │   const shouldFail = () => {}
-       │                            ^^
+  > 17 │   const shouldFail = () => { }
+       │                            ^^^
     18 │ 
     19 │   return a
   
@@ -183,7 +199,7 @@ invalid.ts:26:19 lint/suspicious/noEmptyBlockStatements ━━━━━━━━
   > 27 │ }
        │ ^
     28 │ 
-    29 │ switch(someVarTs) {
+    29 │ switch (someVarTs) {
   
   i Empty blocks are usually the result of an incomplete refactoring. Remove the empty block or add a comment inside it if it is intentional.
   
@@ -197,8 +213,8 @@ invalid.ts:29:1 lint/suspicious/noEmptyBlockStatements ━━━━━━━━�
   
     27 │ }
     28 │ 
-  > 29 │ switch(someVarTs) {
-       │ ^^^^^^^^^^^^^^^^^^^
+  > 29 │ switch (someVarTs) {
+       │ ^^^^^^^^^^^^^^^^^^^^
   > 30 │ }
        │ ^
     31 │ 
@@ -210,14 +226,14 @@ invalid.ts:29:1 lint/suspicious/noEmptyBlockStatements ━━━━━━━━�
 ```
 
 ```
-invalid.ts:35:13 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:35:14 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Unexpected empty block.
   
     33 │ try {
-    34 │     doSomething();
-  > 35 │ } catch(ex) {
-       │             ^
+    34 │   doSomething();
+  > 35 │ } catch (ex) {
+       │              ^
   > 36 │ 
   > 37 │ } finally {
        │ ^
@@ -234,7 +250,7 @@ invalid.ts:37:11 lint/suspicious/noEmptyBlockStatements ━━━━━━━━
 
   ! Unexpected empty block.
   
-    35 │ } catch(ex) {
+    35 │ } catch (ex) {
     36 │ 
   > 37 │ } finally {
        │           ^
@@ -255,8 +271,8 @@ invalid.ts:42:3 lint/suspicious/noEmptyBlockStatements ━━━━━━━━�
   ! Unexpected empty block.
   
     41 │ class FooEmptyStaticTs {
-  > 42 │   static {}
-       │   ^^^^^^^^^
+  > 42 │   static { }
+       │   ^^^^^^^^^^
     43 │ }
     44 │ 
   
@@ -266,14 +282,14 @@ invalid.ts:42:3 lint/suspicious/noEmptyBlockStatements ━━━━━━━━�
 ```
 
 ```
-invalid.ts:45:21 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:45:25 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Unexpected empty block.
   
     43 │ }
     44 │ 
-  > 45 │ for(let i; i>0; i++){}
-       │                     ^^
+  > 45 │ for (let i; i > 0; i++) { }
+       │                         ^^^
     46 │ 
     47 │ const obTs = {}
   
@@ -288,8 +304,8 @@ invalid.ts:48:25 lint/suspicious/noEmptyBlockStatements ━━━━━━━━
   ! Unexpected empty block.
   
     47 │ const obTs = {}
-  > 48 │ for (const key in obTs) {}
-       │                         ^^
+  > 48 │ for (const key in obTs) { }
+       │                         ^^^
     49 │ 
     50 │ const arTs = []
   
@@ -304,10 +320,10 @@ invalid.ts:51:25 lint/suspicious/noEmptyBlockStatements ━━━━━━━━
   ! Unexpected empty block.
   
     50 │ const arTs = []
-  > 51 │ for (const val of arTs) {}
-       │                         ^^
+  > 51 │ for (const val of arTs) { }
+       │                         ^^^
     52 │ 
-    53 │ function fooWithInternalEmptyBlocksTs(){
+    53 │ function fooWithInternalEmptyBlocksTs() {
   
   i Empty blocks are usually the result of an incomplete refactoring. Remove the empty block or add a comment inside it if it is intentional.
   
@@ -319,10 +335,10 @@ invalid.ts:55:21 lint/suspicious/noEmptyBlockStatements ━━━━━━━━
 
   ! Unexpected empty block.
   
-    53 │ function fooWithInternalEmptyBlocksTs(){
+    53 │ function fooWithInternalEmptyBlocksTs() {
     54 │   let someOtherVar: string = '';
-  > 55 │   if (someOtherVar) {}
-       │                     ^^
+  > 55 │   if (someOtherVar) { }
+       │                     ^^^
     56 │ 
     57 │   while (someOtherVar) {
   
@@ -336,14 +352,14 @@ invalid.ts:57:24 lint/suspicious/noEmptyBlockStatements ━━━━━━━━
 
   ! Unexpected empty block.
   
-    55 │   if (someOtherVar) {}
+    55 │   if (someOtherVar) { }
     56 │ 
   > 57 │   while (someOtherVar) {
        │                        ^
   > 58 │   }
        │   ^
     59 │ 
-    60 │   switch(someOtherVar) {
+    60 │   switch (someOtherVar) {
   
   i Empty blocks are usually the result of an incomplete refactoring. Remove the empty block or add a comment inside it if it is intentional.
   
@@ -357,8 +373,8 @@ invalid.ts:60:3 lint/suspicious/noEmptyBlockStatements ━━━━━━━━�
   
     58 │   }
     59 │ 
-  > 60 │   switch(someOtherVar) {
-       │   ^^^^^^^^^^^^^^^^^^^^^^
+  > 60 │   switch (someOtherVar) {
+       │   ^^^^^^^^^^^^^^^^^^^^^^^
   > 61 │   }
        │   ^
     62 │ 
@@ -370,14 +386,14 @@ invalid.ts:60:3 lint/suspicious/noEmptyBlockStatements ━━━━━━━━�
 ```
 
 ```
-invalid.ts:65:15 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:65:16 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Unexpected empty block.
   
     63 │   try {
-    64 │       doSomething();
-  > 65 │   } catch(ex) {
-       │               ^
+    64 │     doSomething();
+  > 65 │   } catch (ex) {
+       │                ^
   > 66 │ 
   > 67 │   } finally {
        │   ^
@@ -394,7 +410,7 @@ invalid.ts:67:13 lint/suspicious/noEmptyBlockStatements ━━━━━━━━
 
   ! Unexpected empty block.
   
-    65 │   } catch(ex) {
+    65 │   } catch (ex) {
     66 │ 
   > 67 │   } finally {
        │             ^
@@ -420,6 +436,40 @@ invalid.ts:76:20 lint/suspicious/noEmptyBlockStatements ━━━━━━━━
        │                    ^^^
     77 │     bar();
     78 │   }
+  
+  i Empty blocks are usually the result of an incomplete refactoring. Remove the empty block or add a comment inside it if it is intentional.
+  
+
+```
+
+```
+invalid.ts:83:17 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected empty block.
+  
+    81 │ // Class without implements should still flag empty methods
+    82 │ class NoImplements {
+  > 83 │   doSomething() { }
+       │                 ^^^
+    84 │ }
+    85 │ 
+  
+  i Empty blocks are usually the result of an incomplete refactoring. Remove the empty block or add a comment inside it if it is intentional.
+  
+
+```
+
+```
+invalid.ts:92:22 lint/suspicious/noEmptyBlockStatements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Unexpected empty block.
+  
+    90 │ class ImplWithNested implements SomeInterface {
+    91 │   run() {
+  > 92 │     function inner() { }
+       │                      ^^^
+    93 │     inner();
+    94 │   }
   
   i Empty blocks are usually the result of an incomplete refactoring. Remove the empty block or add a comment inside it if it is intentional.
   

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyBlockStatements/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyBlockStatements/valid.ts
@@ -77,3 +77,25 @@ export class FooBar {
 class FooBarPrivate {
   private constructor() { }
 }
+
+// Classes implementing interfaces may have empty method bodies (e.g. mock implementations)
+interface MyInterface {
+  connect(): void;
+  disconnect(): void;
+}
+
+class MyMock implements MyInterface {
+  connect() {}
+  disconnect() {}
+}
+
+// Class implementing multiple interfaces
+interface AnotherInterface {
+  start(): void;
+}
+
+class MultiMock implements MyInterface, AnotherInterface {
+  connect() {}
+  disconnect() {}
+  start() {}
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noEmptyBlockStatements/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noEmptyBlockStatements/valid.ts.snap
@@ -84,4 +84,26 @@ class FooBarPrivate {
   private constructor() { }
 }
 
+// Classes implementing interfaces may have empty method bodies (e.g. mock implementations)
+interface MyInterface {
+  connect(): void;
+  disconnect(): void;
+}
+
+class MyMock implements MyInterface {
+  connect() {}
+  disconnect() {}
+}
+
+// Class implementing multiple interfaces
+interface AnotherInterface {
+  start(): void;
+}
+
+class MultiMock implements MyInterface, AnotherInterface {
+  connect() {}
+  disconnect() {}
+  start() {}
+}
+
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

**AI Assistance Notice:** This PR was developed with the help of an AI coding assistant.

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

Fixes #9287

When a class `implements` an interface, it's common for methods to have empty bodies — especially in mock implementations used for unit testing:

```ts
interface MyInterface {
  connect(): void;
}
class MyMock implements MyInterface {
  connect() {} // ← false positive was reported here
}
```

This PR adds a helper function `is_method_in_class_with_implements()` that checks if a `JsFunctionBody` belongs to a method in a class with an `implements` clause, and skips the diagnostic in that case.

The fix is narrowly scoped — it only skips direct methods (`JsMethodClassMember`). Constructors, nested functions, methods in nested classes without `implements`, and other block types are still flagged.

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- Added **valid** test cases: class implementing single/multiple interfaces with empty method bodies
- Added **invalid** edge case tests:
  - Empty methods in classes **without** `implements` are still flagged
  - Nested functions inside methods of `implements` classes are still flagged
- All 5 snapshot tests pass: `cargo test -p biome_js_analyze -- no_empty_block_statements`

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

No documentation changes needed — this is a bug fix for an existing rule, not a new feature or option.
