### PR TITLE
fix(linter): support SolidJS's `innerHTML` in `useAnchorContent`

### DIFF
--- a/.changeset/happy-hipsters-celebrate.md
+++ b/.changeset/happy-hipsters-celebrate.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [`#7730`](https://github.com/biomejs/biome/issues/7730): [`useAnchorContent`](https://biomejs.dev/linter/rules/use-anchor-content/) now recognises SolidJS's `innerHTML` the same way as React's `dangerouslySetInnerHTML`.

--- a/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
@@ -160,6 +160,7 @@ impl Rule for UseAnchorContent {
 fn has_valid_anchor_content(node: &AnyJsxElement) -> bool {
     node.find_attribute_by_name("dangerouslySetInnerHTML")
         .is_some()
+        || node.find_attribute_by_name("innerHTML").is_some()
         || node
             .find_attribute_by_name("children")
             .is_some_and(|attribute| {

--- a/crates/biome_js_analyze/tests/specs/a11y/useAnchorContent/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAnchorContent/valid.jsx
@@ -6,6 +6,7 @@
 		<a><TextWrapper aria-hidden={true} /></a>
     <a><TextWrapper aria-hidden={false} /></a>
     <a dangerouslySetInnerHTML={{ __html: "foo" }} />
+    <a innerHTML={"<i />"} />
     <a><div aria-hidden="true"></div>content</a>
     <a><span aria-hidden="false">content</span></a>
     <a>{content}</a>

--- a/crates/biome_js_analyze/tests/specs/a11y/useAnchorContent/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAnchorContent/valid.jsx.snap
@@ -12,6 +12,7 @@ expression: valid.jsx
 		<a><TextWrapper aria-hidden={true} /></a>
     <a><TextWrapper aria-hidden={false} /></a>
     <a dangerouslySetInnerHTML={{ __html: "foo" }} />
+    <a innerHTML={"<i />"} />
     <a><div aria-hidden="true"></div>content</a>
     <a><span aria-hidden="false">content</span></a>
     <a>{content}</a>


### PR DESCRIPTION
## Summary

Fixed #7730: [`useAnchorContent`](https://biomejs.dev/linter/rules/use-anchor-content/) now recognises SolidJS's `innerHTML` the same way as React's `dangerouslySetInnerHTML`.

## Test Plan

Testcase added and snapshots updated.

## Docs

Let this one be a happy surprise when things "just work" :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed the useAnchorContent linting rule to properly recognize the `innerHTML` attribute as valid anchor content, improving compatibility with SolidJS applications and aligning behavior across different frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->