### PR TITLE
perf(noImportCycles): exclude `node_modules` from cycle detection

### DIFF
--- a/.changeset/some-badgers-move.md
+++ b/.changeset/some-badgers-move.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved performance for [`noImportCycles`](https://biomejs.dev/linter/rules/no-import-cycles/) by explicitly excluding node_modules from the cycle detection. The performance improvement is directly proportional to how big your dependency tree is.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_import_cycles.rs
@@ -179,6 +179,12 @@ impl Rule for NoImportCycles {
         }
 
         let resolved_path = resolved_path.as_path()?;
+
+        // Don't check for cycles through node_modules imports.
+        if is_node_modules_path(resolved_path) {
+            return None;
+        }
+
         let imports = ctx.module_info_for_path(resolved_path)?;
 
         find_cycle(ctx, resolved_path, imports)
@@ -252,6 +258,11 @@ fn find_cycle(
                 continue;
             };
 
+            // Skip node_modules paths — we don't traverse into dependencies.
+            if is_node_modules_path(path) {
+                continue;
+            }
+
             if !seen.insert(resolved_path.clone()) {
                 continue;
             }
@@ -294,4 +305,9 @@ fn find_cycle(
     }
 
     None
+}
+
+/// Returns `true` if the given path is inside a `node_modules` directory.
+fn is_node_modules_path(path: &Utf8Path) -> bool {
+    path.components().any(|c| c.as_str() == "node_modules")
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Any given project is going to have a pretty chunky `node_modules`. I think it makes sense to explicitly forbid noImportCycles from going into the project's dependencies. My logic here is that is that dependencies don't import packages from user code, so it should be ok to skip evaluating for cycles once we get to a dependency.

Users could get this behavior by excluding it with `!!node_modules/`, but that means the scanner would never touch those files, and types wouldn't get resolved from their dependencies.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
