### PR TITLE
perf(noEmptyBlockStatements): short circuit to avoid traversing descendants for comments

### DIFF
--- a/.changeset/nine-sides-wish.md
+++ b/.changeset/nine-sides-wish.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved performance of [`noEmptyBlockStatements`](https://biomejs.dev/linter/rules/no-empty-block-statements/). The rule is now smarter about short-circuiting its logic.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_empty_block_statements.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_empty_block_statements.rs
@@ -83,12 +83,17 @@ impl Rule for NoEmptyBlockStatements {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let query = ctx.query();
-        let is_empty = is_empty(query);
-        let has_comments = query.syntax().has_comments_descendants();
-        let is_constructor_with_ts_param_props_or_private =
-            is_constructor_with_ts_param_props_or_private(query);
+        if !is_empty(query) {
+            return None;
+        }
+        if is_constructor_with_ts_param_props_or_private(query) {
+            return None;
+        }
+        if query.syntax().has_comments_descendants() {
+            return None;
+        }
 
-        (is_empty && !has_comments && !is_constructor_with_ts_param_props_or_private).then_some(())
+        Some(())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
@@ -111,10 +116,10 @@ impl Rule for NoEmptyBlockStatements {
 fn is_empty(query: &Query) -> bool {
     use Query::*;
     match query {
-        JsFunctionBody(body) => body.directives().len() == 0 && body.statements().len() == 0,
-        JsBlockStatement(block) => block.statements().len() == 0,
-        JsStaticInitializationBlockClassMember(block) => block.statements().len() == 0,
-        JsSwitchStatement(statement) => statement.cases().len() == 0,
+        JsFunctionBody(body) => body.directives().is_empty() && body.statements().is_empty(),
+        JsBlockStatement(block) => block.statements().is_empty(),
+        JsStaticInitializationBlockClassMember(block) => block.statements().is_empty(),
+        JsSwitchStatement(statement) => statement.cases().is_empty(),
     }
 }
 
@@ -141,9 +146,11 @@ fn is_constructor_with_ts_param_props_or_private(query: &Query) -> bool {
         .parameters()
         .into_iter()
         .any(|param| matches!(param, Ok(AnyJsConstructorParameter::TsPropertyParameter(_))));
-    let is_private = constructor
+    if is_param_props {
+        return true;
+    }
+    constructor
         .modifiers()
         .into_iter()
-        .any(|modifier| modifier.is_private() || modifier.is_protected());
-    is_param_props || is_private
+        .any(|modifier| modifier.is_private() || modifier.is_protected())
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
It turns out the compiler wasn't optimizing this rule so that it would short circuit automatically. This manually short circuits the logic to avoid scanning of descendants for comments if the block is already known to be not empty.

Found this when stress testing on https://github.com/elastic/kibana Originally, the rule was taking 6s total to execute, but now it takes 124ms.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
CI should remain green

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
