### PR TITLE
refactor: deduplicate common code in unit test lint rules

### DIFF
--- a/crates/biome_js_analyze/src/frameworks/unit_tests.rs
+++ b/crates/biome_js_analyze/src/frameworks/unit_tests.rs
@@ -1,6 +1,14 @@
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsFunctionBody, AnyJsName, AnyJsStatement, JsCallExpression,
+    AnyJsExpression, AnyJsFunctionBody, AnyJsModuleItem, AnyJsName, AnyJsStatement,
+    JsCallExpression, JsLanguage, JsModule, JsScript, JsStatementList,
 };
+use biome_rowan::{AstNodeListIterator, declare_node_union};
+
+declare_node_union! {
+    /// A node that represents a scope containing test/describe calls:
+    /// either the top-level module/script, or a `describe(...)` call.
+    pub AnyTestScope = JsModule | JsScript | JsCallExpression
+}
 
 /// The four lifecycle hooks recognised by Jest/Vitest/similar frameworks.
 ///
@@ -160,12 +168,11 @@ pub(crate) fn is_describe_call(call: &JsCallExpression) -> bool {
     }
 }
 
-/// Returns the list of direct-child statements from the callback passed to a
-/// `describe(...)` call, or `None` if the callback is not a recognisable
-/// function literal with a block body.
-pub(crate) fn describe_body_statements(call: &JsCallExpression) -> Option<Vec<AnyJsStatement>> {
+/// Returns the `JsStatementList` from the callback body of a `describe(...)` call,
+/// or `None` if the callback is not a recognisable function literal with a block body.
+pub(crate) fn describe_body_statements(call: &JsCallExpression) -> Option<JsStatementList> {
     let args = call.arguments().ok()?;
-    let [_, callback_arg] = args.get_arguments_by_index([0, 1]);
+    let [callback_arg] = args.get_arguments_by_index([1]);
     let callback_arg = callback_arg?;
     let expr = callback_arg.as_any_js_expression()?;
 
@@ -181,14 +188,78 @@ pub(crate) fn describe_body_statements(call: &JsCallExpression) -> Option<Vec<An
         return None;
     };
 
-    Some(block.statements().into_iter().collect())
+    Some(block.statements())
+}
+
+/// An iterator over the direct-child [`JsCallExpression`] statements of a
+/// test scope — skipping anything that isn't an expression-statement call.
+///
+/// Constructed via [`get_unit_test_scope_calls`]. Zero heap allocations.
+pub(crate) struct TestScopeCallIter {
+    inner: TestScopeStmtIter,
+}
+
+enum TestScopeStmtIter {
+    /// The scope is not a valid describe block — yield nothing.
+    Empty,
+    /// JsScript or describe body — iterate a `JsStatementList`.
+    Statements(AstNodeListIterator<JsLanguage, AnyJsStatement>),
+    /// JsModule — iterate a `JsModuleItemList`, casting each item to a statement.
+    Module(AstNodeListIterator<JsLanguage, AnyJsModuleItem>),
+}
+
+impl Iterator for TestScopeCallIter {
+    type Item = JsCallExpression;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let stmt: AnyJsStatement = match &mut self.inner {
+                TestScopeStmtIter::Empty => return None,
+                TestScopeStmtIter::Statements(iter) => iter.next()?,
+                TestScopeStmtIter::Module(iter) => loop {
+                    if let AnyJsModuleItem::AnyJsStatement(s) = iter.next()? {
+                        break s;
+                    }
+                },
+            };
+            if let Some(call) = stmt
+                .as_js_expression_statement()
+                .and_then(|e| e.expression().ok())
+                .and_then(|e| e.as_js_call_expression().cloned())
+            {
+                return Some(call);
+            }
+        }
+    }
+}
+
+/// Returns an iterator over the direct-child call expression statements of
+/// a test scope, with zero heap allocations.
+pub(crate) fn get_unit_test_scope_calls(scope: &AnyTestScope) -> TestScopeCallIter {
+    let inner = match scope {
+        AnyTestScope::JsCallExpression(call) => {
+            if !is_describe_call(call) {
+                TestScopeStmtIter::Empty
+            } else {
+                match describe_body_statements(call) {
+                    Some(list) => TestScopeStmtIter::Statements(list.into_iter()),
+                    None => TestScopeStmtIter::Empty,
+                }
+            }
+        }
+        AnyTestScope::JsModule(module) => TestScopeStmtIter::Module(module.items().into_iter()),
+        AnyTestScope::JsScript(script) => {
+            TestScopeStmtIter::Statements(script.statements().into_iter())
+        }
+    };
+    TestScopeCallIter { inner }
 }
 
 #[cfg(test)]
 mod tests {
     use biome_js_parser::JsParserOptions;
     use biome_js_syntax::{JsCallExpression, JsFileSource};
-    use biome_rowan::AstNode;
+    use biome_rowan::{AstNode, AstNodeList};
 
     use super::{LifecycleHook, describe_body_statements, is_describe_call, is_unit_test};
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_identical_test_title.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_identical_test_title.rs
@@ -4,13 +4,14 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsLiteralExpression, AnyJsModuleItem, AnyJsStatement, AnyJsTemplateElement,
-    JsCallExpression, JsModule, JsScript,
+    AnyJsExpression, AnyJsLiteralExpression, AnyJsTemplateElement, JsCallExpression,
 };
-use biome_rowan::{AstNode, TokenText, declare_node_union};
+use biome_rowan::{AstNode, TokenText};
 use biome_rule_options::no_identical_test_title::NoIdenticalTestTitleOptions;
 
-use crate::frameworks::unit_tests::{describe_body_statements, is_describe_call, is_unit_test};
+use crate::frameworks::unit_tests::{
+    AnyTestScope, get_unit_test_scope_calls, is_describe_call, is_unit_test,
+};
 
 declare_lint_rule! {
     /// Disallow identical titles in test suites and test cases.
@@ -70,12 +71,6 @@ declare_lint_rule! {
     }
 }
 
-declare_node_union! {
-    /// A node that represents a scope containing test/describe calls:
-    /// either the top-level module/script, or a `describe(...)` call.
-    pub AnyTestScope = JsModule | JsScript | JsCallExpression
-}
-
 impl Rule for NoIdenticalTestTitle {
     type Query = Ast<AnyTestScope>;
     type State = JsCallExpression;
@@ -83,36 +78,8 @@ impl Rule for NoIdenticalTestTitle {
     type Options = NoIdenticalTestTitleOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let scope = ctx.query();
-
-        // For a JsCallExpression, only act when it is a describe block.
-        if let AnyTestScope::JsCallExpression(call) = scope {
-            if !is_describe_call(call) {
-                return vec![];
-            }
-            let Some(stmts) = describe_body_statements(call) else {
-                return vec![];
-            };
-            return check_direct_children(&stmts);
-        }
-
-        // For the top-level module or script, gather the top-level statements.
-        let stmts: Vec<AnyJsStatement> = match scope {
-            AnyTestScope::JsModule(module) => module
-                .items()
-                .into_iter()
-                .filter_map(|item| {
-                    if let AnyJsModuleItem::AnyJsStatement(stmt) = item {
-                        Some(stmt)
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            AnyTestScope::JsScript(script) => script.statements().into_iter().collect(),
-            AnyTestScope::JsCallExpression(_) => unreachable!(),
-        };
-        check_direct_children(&stmts)
+        let calls = get_unit_test_scope_calls(ctx.query());
+        check_direct_children(calls)
     }
 
     fn diagnostic(_: &RuleContext<Self>, node: &Self::State) -> Option<RuleDiagnostic> {
@@ -148,20 +115,14 @@ impl Rule for NoIdenticalTestTitle {
 ///
 /// Returns every call expression that is a duplicate (i.e. the second or later
 /// occurrence of a given title at this level).
-fn check_direct_children(statements: &[AnyJsStatement]) -> Vec<JsCallExpression> {
+fn check_direct_children(
+    calls: impl IntoIterator<Item = JsCallExpression>,
+) -> Vec<JsCallExpression> {
     let mut describe_titles: Vec<TokenText> = vec![];
     let mut test_titles: Vec<TokenText> = vec![];
     let mut duplicates: Vec<JsCallExpression> = vec![];
 
-    for stmt in statements {
-        let Some(call) = stmt
-            .as_js_expression_statement()
-            .and_then(|e| e.expression().ok())
-            .and_then(|e| e.as_js_call_expression().cloned())
-        else {
-            continue;
-        };
-
+    for call in calls {
         if is_describe_call(&call) {
             if let Some(title) = extract_call_title(&call) {
                 if describe_titles.contains(&title) {

--- a/crates/biome_js_analyze/src/lint/nursery/use_test_hooks_in_order.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_test_hooks_in_order.rs
@@ -3,11 +3,11 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{AnyJsModuleItem, AnyJsStatement, JsCallExpression, JsModule, JsScript};
-use biome_rowan::{AstNode, TextRange, declare_node_union};
+use biome_js_syntax::JsCallExpression;
+use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_test_hooks_in_order::UseTestHooksInOrderOptions;
 
-use crate::frameworks::unit_tests::{LifecycleHook, describe_body_statements, is_describe_call};
+use crate::frameworks::unit_tests::{AnyTestScope, LifecycleHook, get_unit_test_scope_calls};
 
 declare_lint_rule! {
     /// Enforce that test lifecycle hooks are declared in the order they execute.
@@ -84,13 +84,6 @@ declare_lint_rule! {
     }
 }
 
-declare_node_union! {
-    /// A node that represents a scope containing test/hook calls:
-    /// either the top-level module/script, or a `describe(...)` call.
-    pub AnyTestScope = JsModule | JsScript | JsCallExpression
-}
-
-/// A lifecycle hook that is out of order.
 pub struct HookOrderViolation {
     /// The out-of-order hook.
     pub hook: JsCallExpression,
@@ -107,36 +100,8 @@ impl Rule for UseTestHooksInOrder {
     type Options = UseTestHooksInOrderOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let scope = ctx.query();
-
-        // For a JsCallExpression, only act when it is a describe block.
-        if let AnyTestScope::JsCallExpression(call) = scope {
-            if !is_describe_call(call) {
-                return vec![];
-            }
-            let Some(stmts) = describe_body_statements(call) else {
-                return vec![];
-            };
-            return check_hooks_order(&stmts);
-        }
-
-        // For the top-level module or script, gather the top-level statements.
-        let stmts: Vec<AnyJsStatement> = match scope {
-            AnyTestScope::JsModule(module) => module
-                .items()
-                .into_iter()
-                .filter_map(|item| {
-                    if let AnyJsModuleItem::AnyJsStatement(stmt) = item {
-                        Some(stmt)
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            AnyTestScope::JsScript(script) => script.statements().into_iter().collect(),
-            AnyTestScope::JsCallExpression(_) => unreachable!(),
-        };
-        check_hooks_order(&stmts)
+        let calls = get_unit_test_scope_calls(ctx.query());
+        check_hooks_order(calls)
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
@@ -176,22 +141,12 @@ impl Rule for UseTestHooksInOrder {
 /// Only looks at the **direct children** of the current scope — does not
 /// recurse. Recursion is handled by the query firing again for each nested
 /// `describe` call.
-fn check_hooks_order(statements: &[AnyJsStatement]) -> Vec<HookOrderViolation> {
+fn check_hooks_order(calls: impl IntoIterator<Item = JsCallExpression>) -> Vec<HookOrderViolation> {
     let mut violations: Vec<HookOrderViolation> = vec![];
     // Tracks the last hook seen in the current contiguous run.
     let mut last_hook: Option<(JsCallExpression, LifecycleHook)> = None;
 
-    for stmt in statements {
-        let Some(call) = stmt
-            .as_js_expression_statement()
-            .and_then(|e| e.expression().ok())
-            .and_then(|e| e.as_js_call_expression().cloned())
-        else {
-            // A non-call statement breaks the contiguous hook run.
-            last_hook = None;
-            continue;
-        };
-
+    for call in calls {
         if let Some(hook) = LifecycleHook::from_call_expression(&call) {
             if let Some((ref prev_call, prev_hook)) = last_hook
                 && hook < prev_hook

--- a/crates/biome_js_analyze/src/lint/nursery/use_test_hooks_on_top.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_test_hooks_on_top.rs
@@ -3,12 +3,12 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{AnyJsModuleItem, AnyJsStatement, JsCallExpression, JsModule, JsScript};
-use biome_rowan::{AstNode, TextRange, declare_node_union};
+use biome_js_syntax::JsCallExpression;
+use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_test_hooks_on_top::UseTestHooksOnTopOptions;
 
 use crate::frameworks::unit_tests::{
-    LifecycleHook, describe_body_statements, is_describe_call, is_unit_test,
+    AnyTestScope, LifecycleHook, get_unit_test_scope_calls, is_unit_test,
 };
 
 declare_lint_rule! {
@@ -54,14 +54,6 @@ declare_lint_rule! {
     }
 }
 
-declare_node_union! {
-    /// A node that represents a scope containing test/hook calls:
-    /// either the top-level module/script, or a `describe(...)` call.
-    pub AnyTestScope = JsModule | JsScript | JsCallExpression
-}
-
-/// A lifecycle hook that is misplaced, together with the range of the first
-/// test case that precedes it in the same block.
 pub struct HookViolation {
     /// The misplaced hook call.
     pub hook: JsCallExpression,
@@ -76,36 +68,8 @@ impl Rule for UseTestHooksOnTop {
     type Options = UseTestHooksOnTopOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let scope = ctx.query();
-
-        // For a JsCallExpression, only act when it is a describe block.
-        if let AnyTestScope::JsCallExpression(call) = scope {
-            if !is_describe_call(call) {
-                return vec![];
-            }
-            let Some(stmts) = describe_body_statements(call) else {
-                return vec![];
-            };
-            return check_hooks_after_tests(&stmts);
-        }
-
-        // For the top-level module or script, gather the top-level statements.
-        let stmts: Vec<AnyJsStatement> = match scope {
-            AnyTestScope::JsModule(module) => module
-                .items()
-                .into_iter()
-                .filter_map(|item| {
-                    if let AnyJsModuleItem::AnyJsStatement(stmt) = item {
-                        Some(stmt)
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            AnyTestScope::JsScript(script) => script.statements().into_iter().collect(),
-            AnyTestScope::JsCallExpression(_) => unreachable!(),
-        };
-        check_hooks_after_tests(&stmts)
+        let calls = get_unit_test_scope_calls(ctx.query());
+        check_hooks_after_tests(calls)
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
@@ -138,19 +102,13 @@ impl Rule for UseTestHooksOnTop {
 /// Only looks at the **direct children** of the current scope — does not
 /// recurse. Recursion is handled by the query firing again for each nested
 /// `describe` call.
-fn check_hooks_after_tests(statements: &[AnyJsStatement]) -> Vec<HookViolation> {
+fn check_hooks_after_tests(
+    calls: impl IntoIterator<Item = JsCallExpression>,
+) -> Vec<HookViolation> {
     let mut first_test: Option<TextRange> = None;
     let mut violations: Vec<HookViolation> = vec![];
 
-    for stmt in statements {
-        let Some(call) = stmt
-            .as_js_expression_statement()
-            .and_then(|e| e.expression().ok())
-            .and_then(|e| e.as_js_call_expression().cloned())
-        else {
-            continue;
-        };
-
+    for call in calls {
         if is_unit_test(&call) {
             if first_test.is_none() {
                 first_test = Some(call.range());
@@ -163,7 +121,6 @@ fn check_hooks_after_tests(statements: &[AnyJsStatement]) -> Vec<HookViolation> 
                 first_test_range,
             });
         }
-        // describe blocks and other statements are ignored at this level.
     }
 
     violations


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The goal was to simplify the implementations of these rules, and avoid allocating `Vec`s when just iterating over unit test functions.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
