### PR TITLE
fix(linter): CSS noUselessEscapeInString now recognizes hex unicode escapes

### DIFF
--- a/.changeset/fix-css-unicode-escape.md
+++ b/.changeset/fix-css-unicode-escape.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9385](https://github.com/biomejs/biome/issues/9385): the CSS [`noUselessEscapeInString`](https://biomejs.dev/linter/rules/no-useless-escape-in-string/) rule now correctly recognizes CSS unicode escapes (`\` followed by 1-6 hex digits). Previously, the rule used JavaScript escape rules and only treated `\0`-`\7` as meaningful, causing valid CSS hex escapes like `\e7bb` or `\e644` (used in icon fonts) to be incorrectly flagged and removed by the auto-fix.

--- a/crates/biome_css_analyze/src/lint/suspicious/no_useless_escape_in_string.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_useless_escape_in_string.rs
@@ -19,7 +19,7 @@ declare_lint_rule! {
     ///
     /// ```css,expect_diagnostic
     /// a::after {
-    ///   content: "\a"
+    ///   content: "\z"
     /// }
     /// ```
     ///
@@ -39,7 +39,7 @@ declare_lint_rule! {
     ///
     /// ```css
     /// a::after {
-    ///   content: "\n"
+    ///   content: "\e7bb"
     /// }
     /// ```
     ///
@@ -98,6 +98,13 @@ impl Rule for NoUselessEscapeInString {
 }
 
 /// Returns the index in `str` of the first useless escape.
+///
+/// CSS escape sequences differ from JavaScript:
+/// - `\` followed by 1-6 hex digits (`0-9`, `a-f`, `A-F`) is a CSS unicode escape.
+/// - `\` followed by a newline or carriage return is a line continuation.
+/// - `\` followed by `\` is an escaped backslash.
+/// - `\` followed by the matching quote character is an escaped quote.
+/// - `\` followed by any other character is an identity escape (useless in strings).
 fn next_useless_escape(str: &str, quote: u8) -> Option<usize> {
     let mut it = str.bytes().enumerate();
     while let Some((i, c)) = it.next() {
@@ -105,28 +112,26 @@ fn next_useless_escape(str: &str, quote: u8) -> Option<usize> {
             && let Some((_, c)) = it.next()
         {
             match c {
-                // Meaningful escaped character
-                b'^'
-                | b'\r'
-                | b'\n'
-                | b'0'..=b'7'
-                | b'\\'
-                | b'b'
-                | b'f'
-                | b'n'
-                | b'r'
-                | b't'
-                | b'u'
-                | b'v'
-                | b'x' => {}
-                // Preserve escaping of Unicode characters U+2028 and U+2029
-                0xE2 => {
-                    if !(matches!(it.next(), Some((_, 0x80)))
-                        && matches!(it.next(), Some((_, 0xA8 | 0xA9))))
-                    {
-                        return Some(i);
+                // CSS unicode escape: \ followed by 1-6 hex digits
+                b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F' => {
+                    // Skip the remaining hex digits (up to 5 more, since 1 already consumed)
+                    for _ in 0..5 {
+                        match it.clone().next() {
+                            Some((_, b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')) => {
+                                it.next();
+                            }
+                            _ => break,
+                        }
+                    }
+                    // CSS also consumes a single trailing whitespace after hex escape
+                    if let Some((_, b' ' | b'\t')) = it.clone().next() {
+                        it.next();
                     }
                 }
+                // Line continuation: \ followed by newline or carriage return
+                b'\r' | b'\n' => {}
+                // Escaped backslash
+                b'\\' => {}
                 _ => {
                     // The quote can be escaped
                     if c != quote {

--- a/crates/biome_css_analyze/tests/specs/suspicious/noUselessEscapeInString/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noUselessEscapeInString/invalid.css
@@ -1,5 +1,5 @@
 .a::after {
-    content: /*before*/ "useless \a" /*after*/
+    content: /*before*/ "useless \z" /*after*/
 }
 .b::after {
     content: "useless \'"

--- a/crates/biome_css_analyze/tests/specs/suspicious/noUselessEscapeInString/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noUselessEscapeInString/invalid.css.snap
@@ -5,7 +5,7 @@ expression: invalid.css
 # Input
 ```css
 .a::after {
-    content: /*before*/ "useless \a" /*after*/
+    content: /*before*/ "useless \z" /*after*/
 }
 .b::after {
     content: "useless \'"
@@ -19,7 +19,7 @@ invalid.css:2:35 lint/suspicious/noUselessEscapeInString  FIXABLE  ━━━━�
   ! The character doesn't need to be escaped.
   
     1 │ .a::after {
-  > 2 │     content: /*before*/ "useless \a" /*after*/
+  > 2 │     content: /*before*/ "useless \z" /*after*/
       │                                   ^
     3 │ }
     4 │ .b::after {
@@ -28,7 +28,7 @@ invalid.css:2:35 lint/suspicious/noUselessEscapeInString  FIXABLE  ━━━━�
   
   i Safe fix: Unescape the character.
   
-    2 │ ····content:·/*before*/·"useless·\a"·/*after*/
+    2 │ ····content:·/*before*/·"useless·\z"·/*after*/
       │                                  -            
 
 ```

--- a/crates/biome_css_analyze/tests/specs/suspicious/noUselessEscapeInString/valid.css
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noUselessEscapeInString/valid.css
@@ -2,6 +2,23 @@
 .a::after {
     content: "\""
 }
+/* CSS hex escapes: \ followed by 1-6 hex digits */
 .b::after {
-    content: "\t"
+    content: "\e7bb"
+}
+.c::after {
+    content: "\e644"
+}
+.d::after {
+    content: "\a"
+}
+.e::after {
+    content: "\abcdef"
+}
+.f::after {
+    content: "\0"
+}
+/* Backslash and newline continuation */
+.g::after {
+    content: "\\"
 }

--- a/crates/biome_css_analyze/tests/specs/suspicious/noUselessEscapeInString/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noUselessEscapeInString/valid.css.snap
@@ -8,7 +8,26 @@ expression: valid.css
 .a::after {
     content: "\""
 }
+/* CSS hex escapes: \ followed by 1-6 hex digits */
 .b::after {
-    content: "\t"
+    content: "\e7bb"
+}
+.c::after {
+    content: "\e644"
+}
+.d::after {
+    content: "\a"
+}
+.e::after {
+    content: "\abcdef"
+}
+.f::after {
+    content: "\0"
+}
+/* Backslash and newline continuation */
+.g::after {
+    content: "\\"
 }
 ```
+
+_Note: The parser emitted 4 diagnostics which are not shown here._


### PR DESCRIPTION
## Summary

- Fixed the CSS `noUselessEscapeInString` rule to correctly handle CSS unicode escapes (`\` followed by 1-6 hex digits).
- The rule was previously using JavaScript escape semantics (only `\0`-`\7` octal escapes), causing valid CSS hex escapes like `\e7bb` and `\e644` to be incorrectly flagged and removed by the auto-fix.
- This broke icon font rendering when users applied auto-fix, as the unicode code points were stripped.

## Root Cause

The `next_useless_escape` function in the CSS version of the rule was copied from the JavaScript version without adapting it to CSS escape syntax. In CSS:
- `\` followed by 1-6 hex digits (`0-9`, `a-f`, `A-F`) is a valid unicode escape (e.g., `\e7bb` = U+E7BB)
- `\` followed by a newline is a line continuation
- `\` followed by `\\` is an escaped backslash
- `\` followed by the matching quote is an escaped quote
- Everything else is a useless identity escape

The old code only recognized `\0`-`\7` as valid (JavaScript octal escapes), and included JS-specific sequences like `\b`, `\f`, `\n` (the letter), `\t`, `\u`, `\v`, `\x` as meaningful - none of which are special CSS escape sequences.

## Before/After

**Before (broken):**
```css
/* Input */
.icon-file:before {
  content: "\e7bb";
}

/* After auto-fix - WRONG, breaks icon font! */
.icon-file:before {
  content: "e7bb";
}
```

**After (fixed):**
```css
/* Input - no longer flagged, no auto-fix applied */
.icon-file:before {
  content: "\e7bb";
}
```

## Test plan

- [x] Updated invalid test case: changed `\a` to `\z` since `\a` is now correctly recognized as a hex escape (U+000A)
- [x] Added valid test cases for CSS hex escapes: `\e7bb`, `\e644`, `\a`, `\abcdef`, `\0`, `\\`
- [x] All snapshot tests pass (`cargo test -p biome_css_analyze -- no_useless_escape_in_string`)
- [x] Ran `just gen-rules` for code generation

Closes #9385.

> This PR was authored with the assistance of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)