### PR TITLE
fix(core): detect JSX reference identifiers in Astro/Vue/Svelte templates

### DIFF
--- a/.changeset/curly-games-follow.md
+++ b/.changeset/curly-games-follow.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9432](https://github.com/biomejs/biome/issues/9432): Values referenced as a JSX element in Astro/Vue/Svelte templates are now correctly detected; `noUnusedImports` and `useImportType` rules no longer reports these values as false positives.

--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -1055,6 +1055,54 @@ let {
 }
 
 #[test]
+fn use_import_type_not_triggered_for_components_in_template() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{ "html": { "linter": {"enabled": true}, "experimentalFullSupportEnabled": true } }"#
+            .as_bytes(),
+    );
+
+    let file = Utf8Path::new("file.astro");
+    fs.insert(
+        file.into(),
+        r#"---
+import type { ComponentProps } from "astro/types";
+
+import Badge from "@/components/mdx-components/Badge.astro";
+
+interface Props {
+	badge?: ComponentProps<typeof Badge>;
+}
+
+const { badge } = Astro.props;
+---
+
+{badge && <Badge text={badge.text} variant={badge.variant} />}
+"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", "--only=useImportType", file.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "use_import_type_not_triggered_for_components_in_template",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn no_useless_lone_block_statements_is_not_triggered() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/use_import_type_not_triggered_for_components_in_template.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/use_import_type_not_triggered_for_components_in_template.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "linter": { "enabled": true },
+    "experimentalFullSupportEnabled": true
+  }
+}
+```
+
+## `file.astro`
+
+```astro
+---
+import type { ComponentProps } from "astro/types";
+
+import Badge from "@/components/mdx-components/Badge.astro";
+
+interface Props {
+	badge?: ComponentProps<typeof Badge>;
+}
+
+const { badge } = Astro.props;
+---
+
+{badge && <Badge text={badge.text} variant={badge.variant} />}
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_service/src/workspace/document/services/embedded_value_references.rs
+++ b/crates/biome_service/src/workspace/document/services/embedded_value_references.rs
@@ -3,6 +3,7 @@ use biome_html_syntax::{
 };
 use biome_js_syntax::{
     AnyJsIdentifierUsage, AnyJsRoot, JsReferenceIdentifier, JsStaticMemberExpression,
+    JsxReferenceIdentifier,
 };
 use biome_rowan::{AstNode, TextRange, TokenText, WalkEvent};
 use rustc_hash::FxHashMap;
@@ -41,7 +42,9 @@ impl EmbeddedValueReferencesBuilder {
         for event in preorder {
             match event {
                 WalkEvent::Enter(node) => {
-                    if let Some(reference) = JsReferenceIdentifier::cast_ref(&node) {
+                    if let Some(reference) = JsxReferenceIdentifier::cast_ref(&node) {
+                        self.visit_jsx_reference_identifier(reference);
+                    } else if let Some(reference) = JsReferenceIdentifier::cast_ref(&node) {
                         self.visit_reference_identifier(reference);
                     } else if let Some(member) = JsStaticMemberExpression::cast_ref(&node) {
                         self.visit_static_member_expression(member);
@@ -140,6 +143,15 @@ impl EmbeddedValueReferencesBuilder {
                 }
             }
         }
+    }
+
+    fn visit_jsx_reference_identifier(&mut self, reference: JsxReferenceIdentifier) -> Option<()> {
+        let name_token = reference.value_token().ok()?;
+        self.references.insert(
+            name_token.text_trimmed_range(),
+            name_token.token_text_trimmed(),
+        );
+        Some(())
     }
 
     fn visit_reference_identifier(&mut self, reference: JsReferenceIdentifier) -> Option<()> {


### PR DESCRIPTION
## Summary

Closes #9432 

Added a branch to handle `JsxReferenceIdentifier` as well in the `visit_non_source_snippet` function to correctly detect usages of the value in embedded JSX snippets in Astro/Vue/Svelete templates.

## Test Plan

Added a snapshot test.

## Docs

N/A
