### PR TITLE
feat(yaml_parser): lex YAML properties

### DIFF
--- a/crates/biome_yaml_parser/src/lexer/mod.rs
+++ b/crates/biome_yaml_parser/src/lexer/mod.rs
@@ -63,11 +63,15 @@ impl<'src> YamlLexer<'src> {
             c if is_space(c) => self.consume_whitespace_token().into(),
             b'#' => self.consume_comment().into(),
             b'.' if self.is_at_doc_end() => self.consume_doc_end(),
-            current if maybe_at_mapping_start(current, self.peek_byte()) => {
-                self.consume_potential_mapping_start(current)
-            }
-            // ':', '?', '-' can be a valid plain token start
-            b'?' | b':' => self.consume_mapping_key(current),
+            b'!' | b'&' => self.consume_block_properties(),
+            current if maybe_at_mapping_start(current, self.peek_byte()) => self
+                .consume_potential_mapping_start(
+                    current,
+                    LinkedList::new(),
+                    self.current_coordinate,
+                ),
+            // '?', '-' can be a valid plain token start
+            b'?' => self.consume_explicit_mapping_key(current),
             b'-' => self.consume_sequence_entry(),
             b'|' | b'>' => self.consume_block_scalar(current),
             _ => self.consume_unexpected_token().into(),
@@ -97,11 +101,10 @@ impl<'src> YamlLexer<'src> {
         }
     }
 
-    /// Consume a known mapping key, indicated by either '?' or ':'.
-    /// '?' signifies an explicit mapping key, while ':' represents an empty one.
-    /// For example, `: abc` is a valid yaml mapping, which is equivalent
-    /// to `{null: abc}`
-    fn consume_mapping_key(&mut self, current: u8) -> LinkedList<LexToken> {
+    /// Consume an explicit mapping key, indicated by '?'.
+    /// '?' signifies an explicit mapping key, which opens a block mapping entry
+    /// at the current indentation.
+    fn consume_explicit_mapping_key(&mut self, current: u8) -> LinkedList<LexToken> {
         debug_assert!(matches!(current, b'?' | b':'));
         let indicator = if current == b'?' {
             self.consume_byte_as_token(T![?])
@@ -124,22 +127,33 @@ impl<'src> YamlLexer<'src> {
         }
     }
 
-    /// Consume and disambiguate a YAML value to determine whether it's a YAML block map or just a
-    /// YAML flow value
-    fn consume_potential_mapping_start(&mut self, current: u8) -> LinkedList<LexToken> {
+    /// Consume and disambiguate a YAML value to determine whether it opens a block
+    /// mapping entry, with or without properties, or just a standalone flow value.
+    fn consume_potential_mapping_start(
+        &mut self,
+        current: u8,
+        properties: LinkedList<LexToken>,
+        start_coordinate: TextCoordinate,
+    ) -> LinkedList<LexToken> {
         debug_assert!(maybe_at_mapping_start(current, self.peek_byte()));
 
-        let start = self.current_coordinate;
-        let mut tokens = self.consume_potential_mapping_key(current);
-        if self.scopes.last().is_none_or(|scope| scope.indent(start)) {
+        let mut tokens = properties;
+        let mut potential_mapping_keys = self.consume_potential_mapping_key(current);
+        tokens.append(&mut potential_mapping_keys);
+        if self
+            .scopes
+            .last()
+            .is_none_or(|scope| scope.indent(start_coordinate))
+        {
             if self.is_at_mapping_indicator() {
                 let indicator = self.consume_byte_as_token(T![:]);
-                tokens.push_front(LexToken::pseudo(MAPPING_START, start));
+                tokens.push_front(LexToken::pseudo(MAPPING_START, start_coordinate));
                 tokens.push_back(indicator);
-                self.scopes.push(BlockScope::new_mapping_scope(start));
+                self.scopes
+                    .push(BlockScope::new_mapping_scope(start_coordinate));
             } else {
                 // Just a normal flow value
-                tokens.push_front(LexToken::pseudo(FLOW_START, start));
+                tokens.push_front(LexToken::pseudo(FLOW_START, start_coordinate));
                 // Consume any trailing trivia remaining before closing the flow, as we must not
                 // have trailing trivia followed FLOW_END token
                 let mut trivia = self.consume_trivia(true);
@@ -306,8 +320,10 @@ impl<'src> YamlLexer<'src> {
             self.consume_double_quoted_literal().into()
         } else if current == b'\'' {
             self.consume_single_quoted_literal().into()
-        } else {
+        } else if is_start_of_plain(current, self.peek_byte(), false) {
             self.consume_plain_literal(current, false).into()
+        } else {
+            LinkedList::new()
         }
     }
 
@@ -373,6 +389,8 @@ impl<'src> YamlLexer<'src> {
                     self.consume_byte_as_token(T!['}'])
                 }
                 (b',', _) => self.consume_byte_as_token(T![,]),
+                (b'&', _) => self.consume_anchor_property(),
+                (b'!', _) => self.consume_tag_property(),
                 (current, peek) if is_start_of_plain(current, peek, true) => {
                     self.consume_plain_literal(current, true)
                 }
@@ -610,6 +628,150 @@ impl<'src> YamlLexer<'src> {
             self.advance(1);
         }
         LexToken::new(COMMENT, start, self.current_coordinate)
+    }
+
+    fn consume_block_properties(&mut self) -> LinkedList<LexToken> {
+        debug_assert!(matches!(self.current_byte(), Some(b'!' | b'&')));
+
+        let start_coordinate = self.current_coordinate;
+        let mut start_column = self.current_coordinate.column;
+        let mut properties = LinkedList::new();
+
+        // Lex all properties until we find a non-property
+        while let Some(current) = self.current_byte() {
+            match current {
+                b'&' => {
+                    start_column = start_column.min(self.current_coordinate.column);
+                    properties.push_back(self.consume_anchor_property());
+                }
+                b'!' => {
+                    start_column = start_column.min(self.current_coordinate.column);
+                    properties.push_back(self.consume_tag_property());
+                }
+                c if is_space(c) => properties.push_back(self.consume_whitespace_token()),
+                b'#' => properties.push_back(self.consume_comment()),
+                c if is_break(c) => {
+                    // Check if we would breach parent scope before consuming trivia
+                    let start = self.current_coordinate;
+                    let mut trivia = self.consume_trivia(false);
+                    if self.breach_parent_scope() {
+                        // Restore position and break
+                        self.current_coordinate = start;
+                        break;
+                    } else {
+                        properties.append(&mut trivia);
+                    }
+                }
+                _ => break,
+            }
+        }
+
+        let Some(current) = self.current_byte() else {
+            // EOF after properties, wrap in flow markers as properties for empty plain node
+            properties.push_front(LexToken::pseudo(FLOW_START, start_coordinate));
+            properties.push_back(LexToken::pseudo(FLOW_END, self.current_coordinate));
+            return properties;
+        };
+
+        // Property list terminated by a newline that breaches the enclosing block, which means an
+        // empty plain node.
+        // We only need to check for is_break here, as the lexer only stops at a line break if
+        // consuming the line break would breach the parent scope
+        if is_break(current) {
+            properties.push_front(LexToken::pseudo(FLOW_START, start_coordinate));
+            properties.push_back(LexToken::pseudo(FLOW_END, self.current_coordinate));
+            return properties;
+        }
+
+        if maybe_at_mapping_start(current, self.peek_byte())
+            && self.current_coordinate.column >= start_column
+        {
+            // properties of flow collection/scalar that could be a mapping key
+            self.consume_potential_mapping_start(current, properties, start_coordinate)
+        } else {
+            properties
+        }
+    }
+
+    fn consume_anchor_property(&mut self) -> LexToken {
+        self.assert_byte(b'&');
+        let start = self.current_coordinate;
+        self.advance(1);
+
+        while let Some(c) = self.current_byte() {
+            if is_anchor_char(c) {
+                self.advance(1);
+            } else {
+                break;
+            }
+        }
+
+        LexToken::new(ANCHOR_PROPERTY_LITERAL, start, self.current_coordinate)
+    }
+
+    /// Consumes a tag property (verbatim `!<uri>`, secondary `!!tag`, named `!handle!tag`, primary `!tag`, or non-specific `!`).
+    /// We might benefit from separating these different constructs in the grammar itself in the
+    /// future.
+    fn consume_tag_property(&mut self) -> LexToken {
+        self.assert_byte(b'!');
+        let start = self.current_coordinate;
+        self.advance(1);
+
+        match self.current_byte() {
+            // verbatim: !<uri>
+            Some(b'<') => {
+                self.advance(1);
+                while let Some(c) = self.current_byte() {
+                    if c == b'>' {
+                        self.advance(1);
+                        break;
+                    }
+                    if !is_non_blank_char(c) {
+                        break;
+                    }
+                    self.advance(1);
+                }
+            }
+            // secondary handle: !!body
+            Some(b'!') => {
+                self.advance(1);
+                while let Some(c) = self.current_byte() {
+                    if is_tag_char(c) {
+                        self.advance(1);
+                    } else {
+                        break;
+                    }
+                }
+            }
+            // primary: !body, or named handle: !handle!body
+            Some(c) if is_tag_char(c) => {
+                // named handle: !word! prefix, then body
+                if is_word_char(c) {
+                    let mut offset = 0;
+                    while let Some(b) = self.byte_at(offset) {
+                        if is_word_char(b) {
+                            offset += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    if self.byte_at(offset) == Some(b'!') {
+                        self.advance(offset + 1);
+                    }
+                }
+                while let Some(c) = self.current_byte() {
+                    if is_tag_char(c) {
+                        self.advance(1);
+                    } else {
+                        break;
+                    }
+                }
+            }
+            // non-specific: bare !
+            _ => {}
+        }
+
+        LexToken::new(TAG_PROPERTY_LITERAL, start, self.current_coordinate)
     }
 
     fn consume_unexpected_token(&mut self) -> LexToken {
@@ -950,13 +1112,15 @@ impl TextCoordinate {
     }
 }
 
-// https://yaml.org/spec/1.2.2/#rule-ns-s-block-map-implicit-key
+// https://yaml.org/spec/1.2.2/#rule-ns-l-block-map-implicit-entry
 #[inline]
 fn maybe_at_mapping_start(current: u8, peek: Option<u8>) -> bool {
     is_flow_collection_indicator(current)
         || is_start_of_plain(current, peek, false)
         || current == b'"'
         || current == b'\''
+        // empty key
+        || current == b':'
 }
 
 // https://yaml.org/spec/1.2.2/#rule-ns-plain-first
@@ -1024,4 +1188,22 @@ fn is_indicator(c: u8) -> bool {
 #[inline]
 fn is_flow_collection_indicator(c: u8) -> bool {
     c == b',' || c == b'[' || c == b']' || c == b'{' || c == b'}'
+}
+
+// https://yaml.org/spec/1.2.2/#rule-ns-anchor-char
+#[inline]
+fn is_anchor_char(c: u8) -> bool {
+    is_non_blank_char(c) && !is_flow_collection_indicator(c)
+}
+
+// https://yaml.org/spec/1.2.2/#rule-ns-word-char
+#[inline]
+fn is_word_char(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || c == b'-'
+}
+
+// https://yaml.org/spec/1.2.2/#rule-ns-tag-char
+#[inline]
+fn is_tag_char(c: u8) -> bool {
+    is_non_blank_char(c) && c != b'!' && !is_flow_collection_indicator(c)
 }

--- a/crates/biome_yaml_parser/src/lexer/tests/mod.rs
+++ b/crates/biome_yaml_parser/src/lexer/tests/mod.rs
@@ -3,6 +3,7 @@
 mod block;
 mod document;
 mod flow;
+mod property;
 
 use super::TextSize;
 use crate::lexer::YamlLexer;

--- a/crates/biome_yaml_parser/src/lexer/tests/property.rs
+++ b/crates/biome_yaml_parser/src/lexer/tests/property.rs
@@ -1,0 +1,338 @@
+use crate::assert_lex;
+
+#[test]
+fn anchor_property() {
+    assert_lex!("&anchor",
+        FLOW_START:0,
+        ANCHOR_PROPERTY_LITERAL:7,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn tag_property() {
+    assert_lex!("!tag",
+        FLOW_START:0,
+        TAG_PROPERTY_LITERAL:4,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn anchor_with_value() {
+    assert_lex!("&anchor value",
+        FLOW_START:0,
+        ANCHOR_PROPERTY_LITERAL:7,
+        WHITESPACE:1,
+        PLAIN_LITERAL:5,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn multiple_properties() {
+    assert_lex!("&anchor !tag abc",
+        FLOW_START:0,
+        ANCHOR_PROPERTY_LITERAL:7,
+        WHITESPACE:1,
+        TAG_PROPERTY_LITERAL:4,
+        WHITESPACE:1,
+        PLAIN_LITERAL:3,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn block_map_property() {
+    assert_lex!(r#"a:
+   &abc
+  !abc
+ b: c"#,
+        MAPPING_START:0,
+        PLAIN_LITERAL:1,
+        COLON:1,
+        NEWLINE:1,
+        WHITESPACE:3,
+        ANCHOR_PROPERTY_LITERAL:4,
+        NEWLINE:1,
+        WHITESPACE:2,
+        TAG_PROPERTY_LITERAL:4,
+        NEWLINE:1,
+        WHITESPACE:1,
+        MAPPING_START:0,
+        PLAIN_LITERAL:1,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        PLAIN_LITERAL:1,
+        FLOW_END:0,
+        MAPPING_END:0,
+        MAPPING_END:0
+    );
+}
+
+#[test]
+fn block_sequence_property() {
+    assert_lex!(r#"a:
+  !abc
+ - 123"#,
+        MAPPING_START:0,
+        PLAIN_LITERAL:1,
+        COLON:1,
+        NEWLINE:1,
+        WHITESPACE:2,
+        TAG_PROPERTY_LITERAL:4,
+        NEWLINE:1,
+        WHITESPACE:1,
+        SEQUENCE_START:0,
+        DASH:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        PLAIN_LITERAL:3,
+        FLOW_END:0,
+        SEQUENCE_END:0,
+        MAPPING_END:0
+    );
+}
+
+#[test]
+fn property_in_map_key() {
+    assert_lex!(r#"a:
+ !abc b: c
+ d: e"#,
+        MAPPING_START:0,
+        PLAIN_LITERAL:1,
+        COLON:1,
+        NEWLINE:1,
+        WHITESPACE:1,
+        MAPPING_START:0,
+        TAG_PROPERTY_LITERAL:4,
+        WHITESPACE:1,
+        PLAIN_LITERAL:1,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        PLAIN_LITERAL:1,
+        FLOW_END:0,
+        NEWLINE:1,
+        WHITESPACE:1,
+        PLAIN_LITERAL:1,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        PLAIN_LITERAL:1,
+        FLOW_END:0,
+        MAPPING_END:0,
+        MAPPING_END:0
+    );
+}
+
+#[test]
+fn property_in_map_key_multiline() {
+    assert_lex!(r#"a:
+  &abc
+ !abc
+ b: c
+ d: e"#,
+        MAPPING_START:0,
+        PLAIN_LITERAL:1,
+        COLON:1,
+        NEWLINE:1,
+        WHITESPACE:2,
+        MAPPING_START:0,
+        ANCHOR_PROPERTY_LITERAL:4,
+        NEWLINE:1,
+        WHITESPACE:1,
+        TAG_PROPERTY_LITERAL:4,
+        NEWLINE:1,
+        WHITESPACE:1,
+        PLAIN_LITERAL:1,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        PLAIN_LITERAL:1,
+        FLOW_END:0,
+        MAPPING_END:0,
+        NEWLINE:1,
+        WHITESPACE:1,
+        MAPPING_START:0,
+        PLAIN_LITERAL:1,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        PLAIN_LITERAL:1,
+        FLOW_END:0,
+        MAPPING_END:0,
+        MAPPING_END:0
+    );
+}
+
+#[test]
+fn property_for_empty_map_key() {
+    assert_lex!(r#"&prop : val"#,
+        MAPPING_START:0,
+        ANCHOR_PROPERTY_LITERAL:5,
+        WHITESPACE:1,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        PLAIN_LITERAL:3,
+        FLOW_END:0,
+        MAPPING_END:0,
+    );
+}
+
+#[test]
+fn named_tag_handle() {
+    assert_lex!("!e!tag",
+        FLOW_START:0,
+        TAG_PROPERTY_LITERAL:6,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn verbatim_tag() {
+    assert_lex!("!<tag:yaml.org,2002:str>",
+        FLOW_START:0,
+        TAG_PROPERTY_LITERAL:24,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn non_specific_tag() {
+    assert_lex!("!",
+        FLOW_START:0,
+        TAG_PROPERTY_LITERAL:1,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn primary_tag_non_word_start() {
+    assert_lex!("!.foo",
+        FLOW_START:0,
+        TAG_PROPERTY_LITERAL:5,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn multiple_properties_secondary_handle() {
+    assert_lex!("&anchor !!str abc",
+        FLOW_START:0,
+        ANCHOR_PROPERTY_LITERAL:7,
+        WHITESPACE:1,
+        TAG_PROPERTY_LITERAL:5,
+        WHITESPACE:1,
+        PLAIN_LITERAL:3,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn verbatim_tag_in_flow_context() {
+    assert_lex!("[!<tag:yaml.org,2002:str>, val]",
+        FLOW_START:0,
+        L_BRACK:1,
+        TAG_PROPERTY_LITERAL:24,
+        COMMA:1,
+        WHITESPACE:1,
+        PLAIN_LITERAL:3,
+        R_BRACK:1,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn empty_named_tag_handle_body() {
+    assert_lex!("!e!",
+        FLOW_START:0,
+        TAG_PROPERTY_LITERAL:3,
+        FLOW_END:0
+    );
+}
+
+#[test]
+fn anchor_in_block_map_value() {
+    assert_lex!("key: &anchor value",
+        MAPPING_START:0,
+        PLAIN_LITERAL:3,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        ANCHOR_PROPERTY_LITERAL:7,
+        WHITESPACE:1,
+        PLAIN_LITERAL:5,
+        FLOW_END:0,
+        MAPPING_END:0
+    );
+}
+
+#[test]
+fn tag_in_block_map_value() {
+    assert_lex!("key: !tag\n",
+        MAPPING_START:0,
+        PLAIN_LITERAL:3,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        TAG_PROPERTY_LITERAL:4,
+        FLOW_END:0,
+        NEWLINE:1,
+        MAPPING_END:0
+    );
+}
+
+#[test]
+fn anchor_in_block_sequence_entry() {
+    assert_lex!("- &anchor\n",
+        SEQUENCE_START:0,
+        DASH:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        ANCHOR_PROPERTY_LITERAL:7,
+        FLOW_END:0,
+        SEQUENCE_END:0,
+        NEWLINE:1
+    );
+}
+
+#[test]
+fn multi_property_in_block_map_value() {
+    assert_lex!("key: &a !tag\n",
+        MAPPING_START:0,
+        PLAIN_LITERAL:3,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        ANCHOR_PROPERTY_LITERAL:2,
+        WHITESPACE:1,
+        TAG_PROPERTY_LITERAL:4,
+        FLOW_END:0,
+        NEWLINE:1,
+        MAPPING_END:0
+    );
+}
+
+#[test]
+fn property_for_empty_map_value() {
+    assert_lex!("outer: &anchor\nnext: value",
+        MAPPING_START:0,
+        PLAIN_LITERAL:5,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        ANCHOR_PROPERTY_LITERAL:7,
+        FLOW_END:0,
+        NEWLINE:1,
+        PLAIN_LITERAL:4,
+        COLON:1,
+        WHITESPACE:1,
+        FLOW_START:0,
+        PLAIN_LITERAL:5,
+        FLOW_END:0,
+        MAPPING_END:0
+    );
+}


### PR DESCRIPTION
## Summary

Follow up of https://github.com/biomejs/biome/pull/9220. With this PR, YAML lexer can now lex yaml properties like
```
&anchor !!str
```

Having the parser consuming these tokens will be the work of a different PR

## Test Plan

Added new YAML snippets containing properties to the lexer test suite

## Docs

N/A
