### PR TITLE
fix(lsp): filter organizeImports from fixAll code action

### DIFF
--- a/.changeset/quiet-foxes-camp.md
+++ b/.changeset/quiet-foxes-camp.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#9477](https://github.com/biomejs/biome/issues/9477): `source.fixAll.biome` no longer sorts imports when `source.organizeImports.biome` is set to "explicit" or "never" in editor settings. The organize imports action is now excluded from the fix-all pass unless explicitly requested.
+Fixed [#9477](https://github.com/biomejs/biome/issues/9477): `source.fixAll.biome` no longer sorts imports when `source.organizeImports.biome` is disabled in editor settings. The organize imports action is now excluded from the fix-all pass unless explicitly requested.

--- a/.changeset/quiet-foxes-camp.md
+++ b/.changeset/quiet-foxes-camp.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9477](https://github.com/biomejs/biome/issues/9477): `source.fixAll.biome` no longer sorts imports when `source.organizeImports.biome` is set to "explicit" or "never" in editor settings. The organize imports action is now excluded from the fix-all pass unless explicitly requested.

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -30,6 +30,8 @@ use tower_lsp_server::ls_types::{
 use tracing::{debug, info};
 
 const FIX_ALL_CATEGORY: ActionCategory = ActionCategory::Source(SourceActionKind::FixAll);
+const ORGANIZE_IMPORTS_CATEGORY: ActionCategory =
+    ActionCategory::Source(SourceActionKind::OrganizeImports);
 
 fn fix_all_kind() -> CodeActionKind {
     match FIX_ALL_CATEGORY.to_str() {
@@ -108,12 +110,16 @@ pub(crate) fn code_actions(
     }
 
     let mut has_fix_all = false;
+    let mut has_organize_imports = false;
     let mut filters = Vec::new();
     if let Some(filter) = &params.context.only {
         for kind in filter {
             let kind = kind.as_str();
             if FIX_ALL_CATEGORY.matches(kind) {
                 has_fix_all = true;
+            }
+            if ORGANIZE_IMPORTS_CATEGORY.matches(kind) {
+                has_organize_imports = true;
             }
             filters.push(kind);
         }
@@ -190,7 +196,15 @@ pub(crate) fn code_actions(
     // document if the action category "source.fixAll" was explicitly requested
     // by the language client
     let fix_all = if has_fix_all {
-        fix_all(session, &url, path, &doc.line_index, &diagnostics, None)?
+        fix_all(
+            session,
+            &url,
+            path,
+            &doc.line_index,
+            &diagnostics,
+            None,
+            has_organize_imports,
+        )?
     } else {
         None
     };
@@ -285,7 +299,12 @@ pub(crate) fn code_actions(
     Ok(Some(actions))
 }
 
-/// Generate the code action `source.fixAll.biome` for the current document
+/// Generate the code action `source.fixAll.biome` for the current document.
+///
+/// When `include_organize_imports` is `false`, the organize imports action is
+/// excluded from the fix-all pass. This prevents `source.fixAll.biome` from
+/// sorting imports when `source.organizeImports.biome` was not explicitly
+/// requested by the editor.
 #[tracing::instrument(level = "debug", skip(session, url))]
 fn fix_all(
     session: &Session,
@@ -294,6 +313,7 @@ fn fix_all(
     line_index: &LineIndex,
     diagnostics: &[lsp::Diagnostic],
     offset: Option<u32>,
+    include_organize_imports: bool,
 ) -> Result<Option<CodeActionOrCommand>, Error> {
     let Some(doc) = session.document(url) else {
         return Ok(None);
@@ -356,13 +376,21 @@ fn fix_all(
         categories = categories.with_assist();
     }
 
+    let mut skip = vec![];
+    if !include_organize_imports {
+        skip.push(AnalyzerSelector::Rule(RuleSelector::Rule(
+            "source",
+            "organizeImports",
+        )));
+    }
+
     let fixed = session.workspace.fix_file(FixFileParams {
         project_key: doc.project_key,
         path: path.clone(),
         fix_file_mode: FixFileMode::SafeFixes,
         should_format,
         only: vec![],
-        skip: vec![],
+        skip,
         enabled_rules: vec![],
         suppression_reason: None,
         rule_categories: categories.build(),

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -2571,6 +2571,92 @@ async fn pull_fix_all() -> Result<()> {
 }
 
 #[tokio::test]
+async fn fix_all_does_not_sort_imports_unless_requested() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    // Document with unsorted imports AND a lint error (comparing to -0).
+    // If fix-all respects the filter, it should fix the lint error but
+    // leave the import order unchanged.
+    server
+        .open_document("import { b } from \"b\";\nimport { a } from \"a\";\nif(a === -0) {}")
+        .await?;
+
+    // Request source.fixAll WITHOUT source.organizeImports
+    let res: CodeActionResponse = server
+        .request(
+            "textDocument/codeAction",
+            "pull_code_actions",
+            CodeActionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: uri!("document.js"),
+                },
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 2,
+                        character: 15,
+                    },
+                },
+                context: CodeActionContext {
+                    diagnostics: vec![fixable_diagnostic(2)?],
+                    only: Some(vec![CodeActionKind::new("source.fixAll")]),
+                    ..Default::default()
+                },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+        )
+        .await?
+        .context("codeAction returned None")?;
+
+    // The fix-all action should exist
+    assert_eq!(res.len(), 1);
+
+    let CodeActionOrCommand::CodeAction(action) = &res[0] else {
+        panic!("expected CodeAction");
+    };
+    assert_eq!(
+        action.kind,
+        Some(CodeActionKind::new("source.fixAll.biome"))
+    );
+
+    // The edit should fix the -0 comparison but NOT reorder imports.
+    // If imports were sorted, "a" would come before "b".
+    let edit = action.edit.as_ref().context("expected edit")?;
+    let changes = edit.changes.as_ref().context("expected changes")?;
+    let edits = changes
+        .get(&uri!("document.js"))
+        .context("expected edits for document.js")?;
+    let new_text = &edits[0].new_text;
+    assert!(
+        new_text.starts_with("import { b }"),
+        "imports should NOT be reordered when organizeImports is not requested, got: {new_text}"
+    );
+
+    server.close_document().await?;
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn change_document_remove_line() -> Result<()> {
     let factory = ServerFactory::default();
     let (service, client) = factory.create().into_inner();


### PR DESCRIPTION
## Summary

When `source.fixAll.biome` runs (e.g. on save), it includes organize imports actions even when `source.organizeImports.biome` is set to "explicit" or "never" in editor settings. This PR filters out the organize imports rule from the fix-all pass when organize imports was not explicitly requested.

The fix adds an `include_organize_imports` parameter to the `fix_all()` function. When `source.organizeImports.biome` is not in the editor's requested code actions, the organize imports rule is added to the `skip` list in `FixFileParams`, preventing it from running as part of fix-all.

Fixes #9477

## Test Plan

- `cargo check -p biome_lsp` passes
- All 43 existing `biome_lsp` tests pass (`cargo test -p biome_lsp`)

## AI Assistance

This PR was written with AI assistance (Claude Code).