### PR TITLE
fix(diagnostic): include config path and CWD in ConfigurationOutsideProject

### DIFF
--- a/.changeset/brave-eagles-swim.md
+++ b/.changeset/brave-eagles-swim.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9463](https://github.com/biomejs/biome/issues/9463): the "Biome found a configuration file outside of the current working directory" diagnostic now includes the configuration file path and the working directory, giving users actionable information to debug the issue.

--- a/crates/biome_cli/src/runner/mod.rs
+++ b/crates/biome_cli/src/runner/mod.rs
@@ -387,8 +387,15 @@ pub(crate) trait CommandRunner {
             &root_configuration_dir
         };
         if !loaded_location.is_in_project() {
+            let config_path_str = directory_path
+                .as_ref()
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "<unknown>".to_string());
             console.log(markup! {
-                {PrintDiagnostic::simple(&ConfigurationOutsideProject)}
+                {PrintDiagnostic::simple(&ConfigurationOutsideProject {
+                    config_path: config_path_str,
+                    working_directory: working_dir.to_string(),
+                })}
             })
         }
 

--- a/crates/biome_cli/src/runner/mod.rs
+++ b/crates/biome_cli/src/runner/mod.rs
@@ -392,8 +392,7 @@ pub(crate) trait CommandRunner {
         if !loaded_location.is_in_project() {
             let config_file_path = config_file_path
                 .as_ref()
-                .map(|p| p.to_string())
-                .unwrap_or("<unknown>".to_string());
+                .map_or_else(|| "<unknown>".to_string(), |p| p.to_string());
             console.log(markup! {
                 {PrintDiagnostic::simple(&ConfigurationOutsideProject {
                     config_path: config_file_path,

--- a/crates/biome_cli/src/runner/mod.rs
+++ b/crates/biome_cli/src/runner/mod.rs
@@ -362,6 +362,9 @@ pub(crate) trait CommandRunner {
             mut loaded_location,
         } = loaded_configuration;
 
+        // Save the config file path for diagnostics before merge_configuration consumes it
+        let config_file_path = file_path.clone();
+
         // Merge the FS configuration with the CLI arguments
         let configuration = self.merge_configuration(
             configuration,
@@ -387,7 +390,7 @@ pub(crate) trait CommandRunner {
             &root_configuration_dir
         };
         if !loaded_location.is_in_project() {
-            let config_path_str = directory_path
+            let config_path_str = config_file_path
                 .as_ref()
                 .map(|p| p.to_string())
                 .unwrap_or_else(|| "<unknown>".to_string());

--- a/crates/biome_cli/src/runner/mod.rs
+++ b/crates/biome_cli/src/runner/mod.rs
@@ -390,13 +390,13 @@ pub(crate) trait CommandRunner {
             &root_configuration_dir
         };
         if !loaded_location.is_in_project() {
-            let config_path_str = config_file_path
+            let config_file_path = config_file_path
                 .as_ref()
                 .map(|p| p.to_string())
-                .unwrap_or_else(|| "<unknown>".to_string());
+                .unwrap_or("<unknown>".to_string());
             console.log(markup! {
                 {PrintDiagnostic::simple(&ConfigurationOutsideProject {
-                    config_path: config_path_str,
+                    config_path: config_file_path,
                     working_directory: working_dir.to_string(),
                 })}
             })

--- a/crates/biome_cli/tests/snapshots/main_cases_configuration/can_read_configuration_from_user_home.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_configuration/can_read_configuration_from_user_home.snap
@@ -36,7 +36,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 project ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Biome found a configuration file outside of the current working directory. If the configuration enables the scanner, Biome might scan the whole file system. This behaviour will be fixed in the next major version.
+  i Biome found the configuration file <CONFIG_DIR>/biome.json outside of the current working directory . If the configuration enables the scanner, Biome might scan the whole file system. This behaviour will be fixed in the next major version.
   
 
 ```

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -974,8 +974,7 @@ impl Session {
             let config_path = loaded_configuration
                 .file_path
                 .as_ref()
-                .map(|p| p.to_string())
-                .unwrap_or_else(|| "<unknown>".to_string());
+                .map_or_else(|| "<unknown>".to_string(), |p| p.to_string());
             let working_directory = match &base_path {
                 ConfigurationPathHint::FromLsp(path)
                 | ConfigurationPathHint::FromWorkspace(path) => path.to_string(),

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -978,9 +978,19 @@ impl Session {
                 .unwrap_or_else(|| "<unknown>".to_string());
             let working_directory = match &base_path {
                 ConfigurationPathHint::FromLsp(path)
-                | ConfigurationPathHint::FromWorkspace(path)
-                | ConfigurationPathHint::FromUser(path)
-                | ConfigurationPathHint::FromUserExternal(path) => path.to_string(),
+                | ConfigurationPathHint::FromWorkspace(path) => path.to_string(),
+                ConfigurationPathHint::FromUser(path) => {
+                    let fs = self.workspace.fs();
+                    if fs.path_is_file(path) {
+                        path.parent()
+                            .map_or("<unknown>".to_string(), |p| p.to_string())
+                    } else {
+                        path.to_string()
+                    }
+                }
+                ConfigurationPathHint::FromUserExternal(_) => self
+                    .base_path()
+                    .map_or("<unknown>".to_string(), |p| p.to_string()),
                 ConfigurationPathHint::None => "<unknown>".to_string(),
             };
             let message = PrintDescription(&ConfigurationOutsideProject {

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -971,7 +971,23 @@ impl Session {
             }
         };
         if !loaded_configuration.loaded_location.is_in_project() {
-            let message = PrintDescription(&ConfigurationOutsideProject).to_string();
+            let config_path = loaded_configuration
+                .file_path
+                .as_ref()
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "<unknown>".to_string());
+            let working_directory = match &base_path {
+                ConfigurationPathHint::FromLsp(path)
+                | ConfigurationPathHint::FromWorkspace(path)
+                | ConfigurationPathHint::FromUser(path)
+                | ConfigurationPathHint::FromUserExternal(path) => path.to_string(),
+                ConfigurationPathHint::None => "<unknown>".to_string(),
+            };
+            let message = PrintDescription(&ConfigurationOutsideProject {
+                config_path,
+                working_directory,
+            })
+            .to_string();
             self.client.log_message(MessageType::INFO, message).await;
         }
 

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -696,13 +696,19 @@ pub struct WatchError {
     pub reason: String,
 }
 
-#[derive(Debug, Default, Diagnostic, Serialize, Deserialize)]
+#[derive(Debug, Diagnostic, Serialize, Deserialize)]
 #[diagnostic(
     category = "project",
     severity = Hint,
-    message = "Biome found a configuration file outside of the current working directory. If the configuration enables the scanner, Biome might scan the whole file system. This behaviour will be fixed in the next major version.",
+    message(
+        message("Biome found the configuration file "{self.config_path}" outside of the current working directory "{self.working_directory}". If the configuration enables the scanner, Biome might scan the whole file system. This behaviour will be fixed in the next major version."),
+        description = "Biome found the configuration file {config_path} outside of the current working directory {working_directory}. If the configuration enables the scanner, Biome might scan the whole file system. This behaviour will be fixed in the next major version."
+    ),
 )]
-pub struct ConfigurationOutsideProject;
+pub struct ConfigurationOutsideProject {
+    pub config_path: String,
+    pub working_directory: String,
+}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
## Summary

The "Biome found a configuration file outside of the current working directory" diagnostic now includes the actual configuration file path and working directory. Previously the message had no dynamic content, leaving users with no actionable information to debug the issue.

Before:
> Biome found a configuration file outside of the current working directory.

After:
> Biome found the configuration file "/home/user/.config/biome.json" outside of the current working directory "/home/user/project".

Both CLI and LSP code paths are updated.

Fixes #9463

## Test Plan

- `cargo check -p biome_lsp -p biome_cli` passes
- Diagnostic struct now takes `config_path` and `working_directory` fields

## AI Assistance

This PR was written with AI assistance (Claude Code).