### PR TITLE
chore(benchmark): upgrade to Debian 13 Trixie, Node.js 24

### DIFF
--- a/Dockerfile.benchmark
+++ b/Dockerfile.benchmark
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1@sha256:b6afd42430b15f2d2a4c5a02b919e98a525b785b1aaff16747d2f623364e39b6
-FROM rust:1.94.0-bookworm@sha256:6a544e5d08298a8cddfe9e7d3b4796e746601d933f3b40b3cccc7acdfcd66e0d
+FROM rust:1.94.0-trixie@sha256:7e322aa1b876cbb977e0df46812af6c4e8be2efbfb2ce3712c28a93ba2968726
 WORKDIR /usr/src/
 
 # https://github.com/nodesource/distributions
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && apt-get install -y nodejs
 RUN cargo install hyperfine
 
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
## Summary

Upgraded the base image of the Dockerfile for benchmarks to Debian 13 Trixie. Also upgraded Node.js installation to 24, the latest LTS.

## Test Plan

CIs should stays green

## Docs

N/A