### PR TITLE
fix(html): skip unsupported <script> types instead of treating as JS (fixes #9506, #9479)

### DIFF
--- a/.changeset/fix-unsupported-script-types.md
+++ b/.changeset/fix-unsupported-script-types.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9506](https://github.com/biomejs/biome/issues/9506) and [#9479](https://github.com/biomejs/biome/issues/9479): Biome no longer reports false parse errors on `<script type="speculationrules">` and `<script type="application/ld+json">` tags. These script types contain non-JavaScript content and are now correctly skipped by the embedded language detector.

--- a/crates/biome_service/src/embed/registry.rs
+++ b/crates/biome_service/src/embed/registry.rs
@@ -40,15 +40,18 @@ static HTML_DETECTORS: [EmbedDetector; 5] = [
     // <script> → JS/TS/JSON (dynamic: depends on type/lang attributes + framework)
     //
     // A single detector handles all <script> variants via the dynamic resolver:
-    //   - <script>                          → JsScript (classic HTML)
-    //   - <script type="module">            → JsModule (ES module)
-    //   - <script lang="ts">                → Ts (Vue/Svelte)
-    //   - <script lang="tsx">               → Tsx (Vue/Svelte)
-    //   - <script lang="jsx">               → Jsx (Vue/Svelte)
-    //   - <script type="importmap">         → Json
-    //   - <script type="application/json">  → Json
-    //   - Astro <script> (no frontmatter)   → Ts
-    //   - Vue/Svelte default                → JsModule
+    //   - <script>                               → JsScript (classic HTML)
+    //   - <script type="module">                 → JsModule (ES module)
+    //   - <script lang="ts">                     → Ts (Vue/Svelte)
+    //   - <script lang="tsx">                    → Tsx (Vue/Svelte)
+    //   - <script lang="jsx">                    → Jsx (Vue/Svelte)
+    //   - <script type="importmap">              → Json
+    //   - <script type="application/json">       → Json
+    //   - Astro <script> (no frontmatter)        → Ts
+    //   - Vue/Svelte default                     → JsModule
+    //   - <script type="speculationrules">       → skipped (unsupported type)
+    //   - <script type="application/ld+json">    → skipped (unsupported type)
+    //   - <script type="text/x-handlebars-*">    → skipped (unsupported type)
     //
     // The handler dispatches on embed_match.guest to call the right parser
     // (parse JS vs parse JSON). No separate detector needed for JSON scripts.
@@ -56,7 +59,10 @@ static HTML_DETECTORS: [EmbedDetector; 5] = [
         tag: "script",
         target: EmbedTarget::Dynamic {
             resolver: resolve_script_language,
-            fallback: Some(GuestLanguage::JsScript),
+            // No fallback: the resolver handles all supported cases explicitly.
+            // Returning None means "skip this element" (e.g. unsupported type
+            // like speculationrules or application/ld+json).
+            fallback: None,
         },
     },
     // <style> → CSS (dynamic: skips SCSS via resolver returning None)

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -485,6 +485,83 @@ fn pull_diagnostics_and_actions_for_js_file() {
     insta::assert_debug_snapshot!(result)
 }
 
+/// Regression test for https://github.com/biomejs/biome/issues/9506 and
+/// https://github.com/biomejs/biome/issues/9479.
+///
+/// `<script type="speculationrules">` and `<script type="application/ld+json">`
+/// contain JSON-like content that is NOT JavaScript. Before this fix, biome's
+/// embed registry fallback would treat these as JavaScript, causing false
+/// parse errors and incorrect lint diagnostics.
+#[test]
+fn no_diagnostics_for_unsupported_script_types() {
+    // speculationrules content is JSON-like but is NOT JavaScript.
+    // application/ld+json content is JSON-LD, also not JavaScript.
+    // Both should be silently skipped by the embed detector (no JS parse errors).
+    const FILE_CONTENT: &str = r#"<!doctype html>
+<html>
+  <head>
+    <script type="speculationrules">
+      {
+        "prerender": [
+          { "source": "list", "urls": ["/next-page"] }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Test"
+      }
+    </script>
+  </head>
+</html>"#;
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from("/project/file.html"), FILE_CONTENT);
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::Project,
+            verbose: false,
+        })
+        .unwrap();
+
+    workspace
+        .open_file(OpenFileParams {
+            project_key,
+            path: BiomePath::new("/project/file.html"),
+            content: FileContent::FromServer,
+            document_file_source: None,
+            persist_node_cache: false,
+            inline_config: None,
+        })
+        .unwrap();
+
+    let result = workspace
+        .pull_diagnostics_and_actions(PullDiagnosticsAndActionsParams {
+            path: BiomePath::new("/project/file.html"),
+            only: vec![],
+            skip: vec![],
+            enabled_rules: vec![],
+            project_key,
+            categories: Default::default(),
+            inline_config: None,
+        })
+        .unwrap();
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "Expected no diagnostics for unsupported script types, got: {:#?}",
+        result.diagnostics
+    );
+}
+
 #[test]
 fn format_js_with_embedded_css() {
     const FILE_PATH: &str = "/project/file.js";


### PR DESCRIPTION
## Summary

Fixes #9506
Fixes #9479.

The embed registry's script element detector was using `fallback: Some(GuestLanguage::JsScript)` in its `EmbedTarget::Dynamic` config. When `resolve_script_language` returned `None` for types like `speculationrules` or `application/ld+json` (which are `ScriptType::Unsupported`), `EmbedTarget::resolve()` applied the `JsScript` fallback via `.or(*fallback)`, causing biome to parse non-JavaScript content as JavaScript.

---

## Root Cause

In `crates/biome_service/src/embed/registry.rs`, `HTML_DETECTORS` had:

```rust
EmbedDetector::Element {
    tag: "script",
    target: EmbedTarget::Dynamic {
        resolver: resolve_script_language,
        fallback: Some(GuestLanguage::JsScript),  // ← problem
    },
},
```

`resolve_script_language` correctly returns `None` for `ScriptType::Unsupported` types (line `if !script_type.is_javascript() { return None; }`). However, `EmbedTarget::resolve()` applies the fallback when the resolver returns `None`:

```rust
Self::Dynamic { resolver, fallback } => resolver(candidate, file_source).or(*fallback),
```

So `speculationrules` and `application/ld+json` content was being passed to the JavaScript parser, producing false parse errors and incorrect lint diagnostics.

---

## Solution

Remove the fallback (`fallback: None`). The `resolve_script_language` function already returns a correct `GuestLanguage` for every legitimate JavaScript script case — it only returns `None` for unsupported types or non-HTML file sources, both of which should mean "skip this element".

---

## Testing

- Added `no_diagnostics_for_unsupported_script_types` in `crates/biome_service/src/workspace/server.tests.rs` that reproduces the exact scenario from both issues: an HTML file containing `<script type="speculationrules">` and `<script type="application/ld+json">` blocks. The test asserts zero diagnostics are returned.
- All existing `biome_service` tests (98) and `biome_html_formatter` tests (127) pass.

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New test covers the exact failing scenario from the issues
- [x] All existing tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Read CONTRIBUTING.md and followed its requirements

---

> This PR was written primarily by Claude Code.