### PR TITLE
fix(core): idempotence formatting html-ish files

### DIFF
--- a/.changeset/fix-indent-script-idempotent.md
+++ b/.changeset/fix-indent-script-idempotent.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9117](https://github.com/biomejs/biome/issues/9117): `biome check --write` no longer falsely reports Svelte and Vue files as changed when `html.formatter.indentScriptAndStyle` is enabled and the files are already correctly formatted.

--- a/crates/biome_cli/tests/cases/indent_script_and_style.rs
+++ b/crates/biome_cli/tests/cases/indent_script_and_style.rs
@@ -105,6 +105,82 @@ fn indent_vue_by_config() {
     ));
 }
 
+// A properly formatted biome.json with indentScriptAndStyle enabled.
+// Uses tab indentation (Biome's default) so it won't be reformatted.
+const BIOME_CONFIG_INDENT_FORMATTED: &str =
+    "{\n\t\"html\": {\n\t\t\"formatter\": {\n\t\t\t\"indentScriptAndStyle\": true\n\t\t}\n\t}\n}\n";
+
+// An already-formatted Svelte file with indentScriptAndStyle indentation applied.
+// Running `check --write` on this should NOT report any changes.
+const SVELTE_FILE_ALREADY_FORMATTED: &str =
+    "<script lang=\"ts\">\n\tconst line1 = \"fail\";\n\tconsole.log(line1);\n</script>\n";
+
+#[test]
+fn check_write_svelte_indent_is_idempotent() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svelte_file_path = Utf8Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_FILE_ALREADY_FORMATTED.as_bytes(),
+    );
+    let biome_config = Utf8Path::new("biome.json");
+    fs.insert(
+        biome_config.into(),
+        BIOME_CONFIG_INDENT_FORMATTED.as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--write"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "check_write_svelte_indent_is_idempotent",
+        fs,
+        console,
+        result,
+    ));
+}
+
+// Same test for Vue
+const VUE_FILE_ALREADY_FORMATTED: &str = "<script>\n\tconst line1 = \"fail\";\n\tconsole.log(line1);\n</script>\n<template></template>\n";
+
+#[test]
+fn check_write_vue_indent_is_idempotent() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let vue_file_path = Utf8Path::new("file.vue");
+    fs.insert(vue_file_path.into(), VUE_FILE_ALREADY_FORMATTED.as_bytes());
+    let biome_config = Utf8Path::new("biome.json");
+    fs.insert(
+        biome_config.into(),
+        BIOME_CONFIG_INDENT_FORMATTED.as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--write"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "check_write_vue_indent_is_idempotent",
+        fs,
+        console,
+        result,
+    ));
+}
+
 const SVELTE_FILE_UNFORMATTED: &str = r#"<script>
 import {    something } from "file.svelte";
 statement ( ) ;

--- a/crates/biome_cli/tests/snapshots/main_cases_indent_script_and_style/check_write_svelte_indent_is_idempotent.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_indent_script_and_style/check_write_svelte_indent_is_idempotent.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "formatter": {
+      "indentScriptAndStyle": true
+    }
+  }
+}
+```
+
+## `file.svelte`
+
+```svelte
+<script lang="ts">
+	const line1 = "fail";
+	console.log(line1);
+</script>
+
+```
+
+# Emitted Messages
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_indent_script_and_style/check_write_vue_indent_is_idempotent.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_indent_script_and_style/check_write_vue_indent_is_idempotent.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "formatter": {
+      "indentScriptAndStyle": true
+    }
+  }
+}
+```
+
+## `file.vue`
+
+```vue
+<script>
+	const line1 = "fail";
+	console.log(line1);
+</script>
+<template></template>
+
+```
+
+# Emitted Messages
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+```

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -731,19 +731,22 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
         })?;
 
         if result.is_none() {
-            return process_fix_all.finish(|| {
-                Ok(if params.should_format {
-                    Either::Left(format_node(
-                        params.settings.format_options::<CssLanguage>(
-                            params.biome_path,
-                            &params.document_file_source,
-                        ),
-                        tree.syntax(),
-                    ))
-                } else {
-                    Either::Right(tree.syntax().to_string())
-                })
-            });
+            return process_fix_all.finish(
+                || {
+                    Ok(if params.should_format {
+                        Either::Left(format_node(
+                            params.settings.format_options::<CssLanguage>(
+                                params.biome_path,
+                                &params.document_file_source,
+                            ),
+                            tree.syntax(),
+                        ))
+                    } else {
+                        Either::Right(tree.syntax().to_string())
+                    })
+                },
+                params.embeds_initial_indent,
+            );
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -596,19 +596,22 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
         })?;
 
         if result.is_none() {
-            return process_fix_all.finish(|| {
-                Ok(if params.should_format {
-                    Either::Left(format_node(
-                        params.settings.format_options::<GraphqlLanguage>(
-                            params.biome_path,
-                            &params.document_file_source,
-                        ),
-                        tree.syntax(),
-                    ))
-                } else {
-                    Either::Right(tree.syntax().to_string())
-                })
-            });
+            return process_fix_all.finish(
+                || {
+                    Ok(if params.should_format {
+                        Either::Left(format_node(
+                            params.settings.format_options::<GraphqlLanguage>(
+                                params.biome_path,
+                                &params.document_file_source,
+                            ),
+                            tree.syntax(),
+                        ))
+                    } else {
+                        Either::Right(tree.syntax().to_string())
+                    })
+                },
+                params.embeds_initial_indent,
+            );
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -1577,24 +1577,27 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
         })?;
 
         if result.is_none() {
-            return process_fix_all.finish(|| {
-                Ok(if params.should_format {
-                    Either::Left(format_node(
-                        params.settings.format_options::<HtmlLanguage>(
-                            params.biome_path,
-                            &params.document_file_source,
-                        ),
-                        tree.syntax(),
-                        // NOTE: this is important that stays false. In this instance, the formatting of embedded
-                        // nodes has already happened, because the workspace during fix_all() process the embedded nodes
-                        // first, and then the root document. This means the embedded nodes don't need to be formatted and can
-                        // be printed verbatim by the formatter.
-                        false,
-                    ))
-                } else {
-                    Either::Right(tree.syntax().to_string())
-                })
-            });
+            return process_fix_all.finish(
+                || {
+                    Ok(if params.should_format {
+                        Either::Left(format_node(
+                            params.settings.format_options::<HtmlLanguage>(
+                                params.biome_path,
+                                &params.document_file_source,
+                            ),
+                            tree.syntax(),
+                            // NOTE: this is important that stays false. In this instance, the formatting of embedded
+                            // nodes has already happened, because the workspace during fix_all() process the embedded nodes
+                            // first, and then the root document. This means the embedded nodes don't need to be formatted and can
+                            // be printed verbatim by the formatter.
+                            false,
+                        ))
+                    } else {
+                        Either::Right(tree.syntax().to_string())
+                    })
+                },
+                params.embeds_initial_indent,
+            );
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -1167,20 +1167,23 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
         })?;
 
         if result.is_none() {
-            return process_fix_all.finish(|| {
-                Ok(if params.should_format {
-                    Either::Left(format_node(
-                        params.settings.format_options::<JsLanguage>(
-                            params.biome_path,
-                            &params.document_file_source,
-                        ),
-                        tree.syntax(),
-                        false,
-                    ))
-                } else {
-                    Either::Right(tree.syntax().to_string())
-                })
-            });
+            return process_fix_all.finish(
+                || {
+                    Ok(if params.should_format {
+                        Either::Left(format_node(
+                            params.settings.format_options::<JsLanguage>(
+                                params.biome_path,
+                                &params.document_file_source,
+                            ),
+                            tree.syntax(),
+                            false,
+                        ))
+                    } else {
+                        Either::Right(tree.syntax().to_string())
+                    })
+                },
+                params.embeds_initial_indent,
+            );
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -724,19 +724,22 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
         })?;
 
         if result.is_none() {
-            return process_fix_all.finish(|| {
-                Ok(if params.should_format {
-                    Either::Left(format_node(
-                        params.settings.format_options::<JsonLanguage>(
-                            params.biome_path,
-                            &params.document_file_source,
-                        ),
-                        tree.syntax(),
-                    ))
-                } else {
-                    Either::Right(tree.syntax().to_string())
-                })
-            });
+            return process_fix_all.finish(
+                || {
+                    Ok(if params.should_format {
+                        Either::Left(format_node(
+                            params.settings.format_options::<JsonLanguage>(
+                                params.biome_path,
+                                &params.document_file_source,
+                            ),
+                            tree.syntax(),
+                        ))
+                    } else {
+                        Either::Right(tree.syntax().to_string())
+                    })
+                },
+                params.embeds_initial_indent,
+            );
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -28,7 +28,7 @@ use biome_console::fmt::Formatter;
 use biome_css_analyze::METADATA as css_metadata;
 use biome_css_syntax::{CssFileSource, CssLanguage};
 use biome_diagnostics::{Applicability, Diagnostic, DiagnosticExt, Error, Severity, category};
-use biome_formatter::{FormatContext, FormatResult, Formatted, Printed};
+use biome_formatter::{FormatContext, FormatResult, Formatted, Printed, SourceMapGeneration};
 use biome_fs::BiomePath;
 use biome_graphql_analyze::METADATA as graphql_metadata;
 use biome_graphql_syntax::{GraphqlFileSource, GraphqlLanguage};
@@ -505,6 +505,10 @@ pub struct FixAllParams<'a> {
     pub(crate) enabled_rules: &'a [AnalyzerSelector],
     pub(crate) plugins: AnalyzerPluginVec,
     pub(crate) document_services: &'a DocumentServices,
+    /// The initial indentation level to apply when printing formatted code.
+    /// Used by embedded language handlers (Svelte, Vue) to preserve
+    /// `indentScriptAndStyle` indentation during fix-all operations.
+    pub(crate) embeds_initial_indent: u16,
 }
 
 #[derive(Default)]
@@ -872,13 +876,29 @@ impl<'a> ProcessFixAll<'a> {
 
     /// Finish processing the fix all actions. Returns the result of the fix-all actions. The `format_tree`
     /// is a closure that must return the new code (formatted, if needed).
-    pub(crate) fn finish<F, C>(self, format_tree: F) -> Result<FixFileResult, WorkspaceError>
+    ///
+    /// `initial_indent` specifies the base indentation level for printing. This is used by
+    /// embedded language handlers (e.g. Svelte, Vue) to preserve `indentScriptAndStyle`
+    /// indentation when formatting during fix-all operations.
+    pub(crate) fn finish<F, C>(
+        self,
+        format_tree: F,
+        initial_indent: u16,
+    ) -> Result<FixFileResult, WorkspaceError>
     where
         F: FnOnce() -> Result<Either<FormatResult<Formatted<C>>, String>, WorkspaceError>,
         C: FormatContext,
     {
         let code = match format_tree()? {
-            Either::Left(printed) => printed?.print()?.into_code(),
+            Either::Left(printed) => {
+                if initial_indent > 0 {
+                    printed?
+                        .print_with_indent(initial_indent, SourceMapGeneration::Disabled)?
+                        .into_code()
+                } else {
+                    printed?.print()?.into_code()
+                }
+            }
             Either::Right(string) => string,
         };
         Ok(FixFileResult {

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -196,6 +196,12 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     javascript::code_actions(params)
 }
 
-fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
+fn fix_all(mut params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
+    let html_options = params
+        .settings
+        .format_options::<HtmlLanguage>(params.biome_path, &params.document_file_source);
+    if *html_options.indent_script_and_style() {
+        params.embeds_initial_indent = 1;
+    }
     javascript::fix_all(params)
 }

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -203,6 +203,12 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     javascript::code_actions(params)
 }
 
-fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
+fn fix_all(mut params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
+    let html_options = params
+        .settings
+        .format_options::<HtmlLanguage>(params.biome_path, &params.document_file_source);
+    if *html_options.indent_script_and_style() {
+        params.embeds_initial_indent = 1;
+    }
     javascript::fix_all(params)
 }

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -2249,6 +2249,7 @@ impl Workspace for WorkspaceServer {
                     enabled_rules: &enabled_rules,
                     plugins: plugins.clone(),
                     document_services: &services,
+                    embeds_initial_indent: 0,
                 })?;
 
                 actions.extend(results.actions);
@@ -2281,6 +2282,7 @@ impl Workspace for WorkspaceServer {
             enabled_rules: &enabled_rules,
             plugins: plugins.clone(),
             document_services: &services,
+            embeds_initial_indent: 0,
         })?;
 
         actions.extend(fix_result.actions);


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/9117

The issue was caused by the loss of indentation when fixing embedded snippets. The fix adds a new parameter passed to `fix_all`, which is the indentation required. It's passed when calling `fix_all` of the embeds.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
