### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,5 +16,18 @@
       "Bash(cargo biome-cli-dev:*)",
       "Bash(cargo biome-cli:*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook, alongside existing `permissions.allow` and `permissions.deny` entries.

Closes #9551

---

_Disclosure: I am the author and maintainer of `block-no-verify`._