### PR TITLE
feat(useNumericSeparators): add options for minimum digits and group length

### DIFF
--- a/.changeset/use-numeric-separators-options.md
+++ b/.changeset/use-numeric-separators-options.md
@@ -1,0 +1,29 @@
+---
+"@biomejs/biome": minor
+---
+
+Added configurable options to the [`useNumericSeparators`](https://biomejs.dev/linter/rules/use-numeric-separators/) rule. Users can now customize the minimum number of digits required before adding separators and the group length for each type of numeric literal (`binary`, `octal`, `decimal`, `hexadecimal`).
+
+```json
+{
+    "linter": {
+        "rules": {
+            "style": {
+                "useNumericSeparators": {
+                    "level": "error",
+                    "options": {
+                        "decimal": {
+                            "minimumDigits": 7,
+                            "groupLength": 3
+                        },
+                        "hexadecimal": {
+                            "minimumDigits": 4,
+                            "groupLength": 2
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```

--- a/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
@@ -601,6 +601,11 @@ impl Deserializable for Rules {
                                 result.insert(Rule::UnicornFilenameCase(conf));
                             }
                         }
+                        "unicorn/numeric-separators-style" => {
+                            if let Some(conf) = RuleConf::deserialize(ctx, &value, name) {
+                                result.insert(Rule::UnicornNumericSeparatorsStyle(conf));
+                            }
+                        }
                         // Other rules
                         rule_name => {
                             if let Some(conf) = RuleConf::<()>::deserialize(ctx, &value, name) {
@@ -795,6 +800,7 @@ pub(crate) enum Rule {
     TypeScriptNamingConvention(RuleConf<Box<eslint_typescript::NamingConventionSelection>>),
     TypeScriptNoShadow(RuleConf<eslint_typescript::NoShadowOptions>),
     UnicornFilenameCase(RuleConf<eslint_unicorn::FilenameCaseOptions>),
+    UnicornNumericSeparatorsStyle(RuleConf<eslint_unicorn::NumericSeparatorsStyleOptions>),
     // If you add new variants, don't forget to update [Rules::deserialize].
 }
 impl Rule {
@@ -822,6 +828,9 @@ impl Rule {
             }
             Self::TypeScriptNoShadow(_) => Cow::Borrowed("@typescript-eslint/no-shadow"),
             Self::UnicornFilenameCase(_) => Cow::Borrowed("unicorn/filename-case"),
+            Self::UnicornNumericSeparatorsStyle(_) => {
+                Cow::Borrowed("unicorn/numeric-separators-style")
+            }
         }
     }
 }

--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -866,6 +866,21 @@ fn migrate_eslint_rule(
                 results.add(&name, RuleMigrationResult::Migrated);
             }
         }
+        eslint_eslint::Rule::UnicornNumericSeparatorsStyle(conf) => {
+            if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
+                let group = rules.style.get_or_insert_with(Default::default);
+                if let SeverityOrGroup::Group(group) = group {
+                    group.use_numeric_separators =
+                        Some(biome_config::RuleFixConfiguration::WithOptions(
+                            biome_config::RuleWithFixOptions {
+                                level: conf.severity().into(),
+                                fix: None,
+                                options: conf.option_or_default().into(),
+                            },
+                        ));
+                }
+            }
+        }
         eslint_eslint::Rule::UnicornFilenameCase(conf) => {
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 let group = rules.style.get_or_insert_with(Default::default);

--- a/crates/biome_cli/src/execute/migrate/eslint_unicorn.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_unicorn.rs
@@ -4,7 +4,9 @@
 /// ALso, the module includes implementation to convert rule options to Biome's rule options.
 use biome_deserialize_macros::Deserializable;
 use biome_rule_options::use_filenaming_convention;
+use biome_rule_options::use_numeric_separators;
 use smallvec::SmallVec;
+use std::num::NonZeroU8;
 
 #[derive(Clone, Debug, Default, Deserializable)]
 pub(crate) struct FilenameCaseOptions {
@@ -75,5 +77,55 @@ impl From<FilenameCases> for Option<use_filenaming_convention::FilenameCases> {
         } else {
             Some(use_filenaming_convention::FilenameCases::from_iter(cases))
         }
+    }
+}
+
+/// ESLint options for `unicorn/numeric-separators-style`.
+///
+/// Note: ESLint uses `number` for decimal literals, while Biome uses `decimal`.
+/// The `onlyIfContainsSeparator` option is not supported and is ignored.
+#[derive(Clone, Debug, Default, Deserializable)]
+pub(crate) struct NumericSeparatorsStyleOptions {
+    number: EslintNumericSeparatorTypeOptions,
+    binary: EslintNumericSeparatorTypeOptions,
+    octal: EslintNumericSeparatorTypeOptions,
+    hexadecimal: EslintNumericSeparatorTypeOptions,
+}
+
+#[derive(Clone, Debug, Default, Deserializable)]
+pub(crate) struct EslintNumericSeparatorTypeOptions {
+    minimum_digits: Option<u8>,
+    group_length: Option<NonZeroU8>,
+}
+
+impl From<EslintNumericSeparatorTypeOptions>
+    for use_numeric_separators::NumericLiteralSeparatorOptions
+{
+    fn from(val: EslintNumericSeparatorTypeOptions) -> Self {
+        Self {
+            minimum_digits: val.minimum_digits,
+            group_length: val.group_length,
+        }
+    }
+}
+
+impl From<NumericSeparatorsStyleOptions> for use_numeric_separators::UseNumericSeparatorsOptions {
+    fn from(val: NumericSeparatorsStyleOptions) -> Self {
+        Self {
+            binary: some_if_set(val.binary),
+            octal: some_if_set(val.octal),
+            decimal: some_if_set(val.number),
+            hexadecimal: some_if_set(val.hexadecimal),
+        }
+    }
+}
+
+fn some_if_set(
+    opts: EslintNumericSeparatorTypeOptions,
+) -> Option<use_numeric_separators::NumericLiteralSeparatorOptions> {
+    if opts.minimum_digits.is_some() || opts.group_length.is_some() {
+        Some(opts.into())
+    } else {
+        None
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_numeric_separators.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_numeric_separators.rs
@@ -4,7 +4,7 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_js_syntax::{JsNumberLiteralExpression, JsSyntaxToken};
 use biome_rowan::{AstNode, BatchMutationExt};
-use biome_rule_options::use_numeric_separators::UseNumericSeparatorsOptions;
+use biome_rule_options::use_numeric_separators::{ResolvedOptions, UseNumericSeparatorsOptions};
 
 use crate::JsRuleAction;
 
@@ -52,6 +52,110 @@ declare_lint_rule! {
     /// var a = 0b1100_1100;
     /// ```
     ///
+    /// ## Options
+    ///
+    /// Each numeric literal type `binary`, `octal`, `decimal`, and `hexadecimal` can be configured with its own options object. Each type accepts `minimumDigits` or `groupLength`.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "decimal": {
+    ///             "minimumDigits": 7,
+    ///             "groupLength": 3
+    ///         },
+    ///         "hexadecimal": {
+    ///             "minimumDigits": 4,
+    ///             "groupLength": 2
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### `<numeric literal type>.minimumDigits`
+    ///
+    /// Minimum number of digits required before adding separators. For example, with `minimumDigits` set to `5`, the number `1234` would not require separators, but `12345` would be expected to be formatted as `12_345`.
+    ///
+    /// Default values for `minimumDigits` vary by numeric literal type:
+    /// - `binary`: `0`
+    /// - `octal`: `0`
+    /// - `decimal`: `5`
+    /// - `hexadecimal`: `0`
+    ///
+    /// #### Invalid
+    ///
+    /// ```json,options
+    /// {
+    ///    "options": {
+    ///       "decimal": {
+    ///          "minimumDigits": 8
+    ///       }
+    ///    }
+    /// }
+    /// ```
+    ///
+    /// ```js,use_options,expect_diagnostic
+    /// 12345678;
+    /// ```
+    ///
+    /// #### Valid
+    ///
+    /// ```json,options
+    /// {
+    ///    "options": {
+    ///       "decimal": {
+    ///          "minimumDigits": 8
+    ///       }
+    ///    }
+    /// }
+    /// ```
+    ///
+    /// ```js,use_options
+    /// 1234;
+    /// 12_345_678;
+    /// ```
+    ///
+    /// ### `<numeric literal type>.groupLength`
+    ///
+    /// Number of digits between separators. For example, with `groupLength` set to `2`, the number `12345` would be expected to be formatted as `1_23_45`.
+    ///
+    /// Default values for `groupLength` vary by numeric literal type:
+    /// - `binary`: `4`
+    /// - `octal`: `4`
+    /// - `decimal`: `3`
+    /// - `hexadecimal`: `2`
+    ///
+    /// #### Invalid
+    ///
+    /// ```json,options
+    /// {
+    ///    "options": {
+    ///       "decimal": {
+    ///          "groupLength": 5
+    ///       }
+    ///    }
+    /// }
+    /// ```
+    ///
+    /// ```js,use_options,expect_diagnostic
+    /// 123_451_2345;
+    /// ```
+    ///
+    /// #### Valid
+    ///
+    /// ```json,options
+    /// {
+    ///    "options": {
+    ///       "decimal": {
+    ///          "groupLength": 5
+    ///       }
+    ///    }
+    /// }
+    /// ```
+    ///
+    /// ```js,use_options
+    /// 12345_12345;
+    /// ```
+    ///
     pub UseNumericSeparators {
         version: "2.0.0",
         name: "useNumericSeparators",
@@ -77,12 +181,12 @@ impl Rule for UseNumericSeparators {
             return None;
         }
 
-        let expected = format_numeric_literal(raw);
+        let analysis = analyze_numeric_literal(raw, ctx.options());
 
-        if raw == expected {
+        if analysis.is_formatted {
             None
         } else if raw.contains('_') {
-            if expected.contains('_') {
+            if analysis.needs_separators {
                 // Contains separators, but not in the same places as the expected value.
                 Some(State::InconsistentGrouping)
             } else {
@@ -122,7 +226,7 @@ impl Rule for UseNumericSeparators {
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
         let token = ctx.query().value_token().ok()?;
-        let num = format_numeric_literal(token.text_trimmed());
+        let num = format_numeric_literal(token.text_trimmed(), ctx.options());
 
         let new_token = JsSyntaxToken::new_detached(token.kind(), &num, [], []);
         let mut mutation = ctx.root().begin();
@@ -148,14 +252,155 @@ pub enum State {
     UnnecessaryGrouping,
 }
 
-// Options for the minimum length of a number required before adding separators and the length of digit groups between separators, respectively.
-const BINARY_OPTS: (usize, usize) = (0, 4);
-const OCTAL_OPTS: (usize, usize) = (0, 4);
-const DECIMAL_OPTS: (usize, usize) = (5, 3);
-const HEXADECIMAL_OPTS: (usize, usize) = (0, 2);
+struct NumericLiteralAnalysis {
+    is_formatted: bool,
+    needs_separators: bool,
+}
+
+struct ChunkAnalysis {
+    is_formatted: bool,
+    needs_separators: bool,
+}
+
+/// Analyzes a numeric literal without allocating the formatted representation.
+fn analyze_numeric_literal(
+    raw: &str,
+    options: &UseNumericSeparatorsOptions,
+) -> NumericLiteralAnalysis {
+    let bytes = raw.as_bytes();
+    let mut current_num_start = 0;
+
+    let mut is_formatted = true;
+    let mut needs_separators = false;
+
+    let mut is_base_10 = true;
+    let mut in_fraction = false;
+    let mut prefix_parsed = false;
+
+    let mut separator_options = options.decimal();
+
+    let mut index = 0;
+    while let Some(&byte) = bytes.get(index) {
+        match byte {
+            b'_' => {}
+            b'0' if !prefix_parsed && !in_fraction => {
+                if let Some(&next) = bytes.get(index + 1) {
+                    let opts = match next {
+                        b'b' | b'B' => Some(options.binary()),
+                        b'o' | b'O' | b'0'..=b'7' => Some(options.octal()),
+                        b'x' | b'X' => Some(options.hexadecimal()),
+                        _ => None,
+                    };
+
+                    if let Some(opts) = opts {
+                        separator_options = opts;
+                        is_base_10 = false;
+                        prefix_parsed = true;
+                        current_num_start = index + 2;
+                        index += 1;
+                    }
+                }
+            }
+            b'e' | b'E' if is_base_10 => {
+                let analysis = analyze_number_chunk(
+                    &bytes[current_num_start..index],
+                    in_fraction,
+                    &separator_options,
+                );
+                is_formatted &= analysis.is_formatted;
+                needs_separators |= analysis.needs_separators;
+                current_num_start = index + 1;
+                in_fraction = false;
+            }
+            b'.' => {
+                let analysis = analyze_number_chunk(
+                    &bytes[current_num_start..index],
+                    false,
+                    &separator_options,
+                );
+                is_formatted &= analysis.is_formatted;
+                needs_separators |= analysis.needs_separators;
+                current_num_start = index + 1;
+                in_fraction = true;
+            }
+            b'-' | b'+' => {
+                current_num_start = index + 1;
+            }
+            b if b.is_ascii_alphanumeric() => {
+                prefix_parsed = true;
+            }
+
+            _ => panic!("unexpected byte '{byte}'",),
+        }
+
+        index += 1;
+    }
+
+    let analysis =
+        analyze_number_chunk(&bytes[current_num_start..], in_fraction, &separator_options);
+    is_formatted &= analysis.is_formatted;
+    needs_separators |= analysis.needs_separators;
+
+    NumericLiteralAnalysis {
+        is_formatted,
+        needs_separators,
+    }
+}
+
+fn analyze_number_chunk(
+    raw: &[u8],
+    left_aligned: bool,
+    separator_options: &ResolvedOptions,
+) -> ChunkAnalysis {
+    let min_digits = separator_options.minimum_digits as usize;
+    let group_len = separator_options.group_length.get() as usize;
+    let digit_count = raw.iter().filter(|&&byte| byte != b'_').count();
+    let needs_separators = digit_count >= min_digits && digit_count > group_len;
+
+    let mut current_digit = 0;
+    let mut consumed_separator = false;
+    let mut is_formatted = true;
+
+    for &byte in raw {
+        let should_have_separator = needs_separators
+            && current_digit > 0
+            && if left_aligned {
+                current_digit % group_len == 0
+            } else {
+                (digit_count - current_digit) % group_len == 0
+            };
+
+        if byte == b'_' {
+            if !needs_separators || !should_have_separator || consumed_separator {
+                is_formatted = false;
+                break;
+            }
+
+            consumed_separator = true;
+            continue;
+        }
+
+        if should_have_separator && !consumed_separator {
+            is_formatted = false;
+            break;
+        }
+
+        consumed_separator = false;
+        current_digit += 1;
+    }
+
+    if is_formatted && current_digit != digit_count {
+        is_formatted = false;
+    }
+
+    ChunkAnalysis {
+        is_formatted,
+        needs_separators,
+    }
+}
 
 /// Formats all parts of a numeric literal by adding separators between groups of digits when appropriate.
-fn format_numeric_literal(raw: &str) -> String {
+fn format_numeric_literal(raw: &str, options: &UseNumericSeparatorsOptions) -> String {
     let mut bytes = raw.bytes().peekable();
     let mut result = Vec::new();
     let mut current_num = Vec::new();
@@ -164,7 +409,7 @@ fn format_numeric_literal(raw: &str) -> String {
     let mut in_fraction = false;
     let mut prefix_parsed = false;
 
-    let (mut min_digits, mut group_len) = DECIMAL_OPTS;
+    let mut separator_options = options.decimal();
 
     while let Some(b) = bytes.next() {
         match b {
@@ -172,14 +417,14 @@ fn format_numeric_literal(raw: &str) -> String {
             b'0' if !prefix_parsed && !in_fraction => {
                 if let Some(&next) = bytes.peek() {
                     let opts = match next {
-                        b'b' | b'B' => Some(BINARY_OPTS),
-                        b'o' | b'O' | b'0'..=b'7' => Some(OCTAL_OPTS),
-                        b'x' | b'X' => Some(HEXADECIMAL_OPTS),
+                        b'b' | b'B' => Some(options.binary()),
+                        b'o' | b'O' | b'0'..=b'7' => Some(options.octal()),
+                        b'x' | b'X' => Some(options.hexadecimal()),
                         _ => None,
                     };
 
                     if let Some(opts) = opts {
-                        (min_digits, group_len) = opts;
+                        separator_options = opts;
                         result.push(b);
                         // SAFETY: We already peeked and confirmed the existence of the `next` byte, so we can safely advance the iterator and push the value immediately.
                         result.push(bytes.next().unwrap());
@@ -194,20 +439,14 @@ fn format_numeric_literal(raw: &str) -> String {
                 result.extend(&insert_separators(
                     &current_num,
                     in_fraction,
-                    min_digits,
-                    group_len,
+                    &separator_options,
                 ));
                 result.push(b);
                 current_num.clear();
                 in_fraction = false;
             }
             b'.' => {
-                result.extend(insert_separators(
-                    &current_num,
-                    false,
-                    min_digits,
-                    group_len,
-                ));
+                result.extend(insert_separators(&current_num, false, &separator_options));
                 result.push(b);
                 current_num.clear();
                 in_fraction = true;
@@ -225,8 +464,7 @@ fn format_numeric_literal(raw: &str) -> String {
     result.extend(insert_separators(
         &current_num,
         in_fraction,
-        min_digits,
-        group_len,
+        &separator_options,
     ));
 
     // SAFETY: The original string is valid UTF-8 so we can be confident here that the result is valid as well.
@@ -249,9 +487,10 @@ fn format_numeric_literal(raw: &str) -> String {
 fn insert_separators(
     number: &[u8],
     left_aligned: bool,
-    min_digits: usize,
-    group_len: usize,
+    separator_options: &ResolvedOptions,
 ) -> Vec<u8> {
+    let min_digits = separator_options.minimum_digits as usize;
+    let group_len = separator_options.group_length.get() as usize;
     if number.len() < min_digits {
         // Don't insert separators if the number is shorter than the minimum number of digits required to start adding separators.
         number.to_vec()

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCombinedCustomOptions.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCombinedCustomOptions.js
@@ -1,0 +1,7 @@
+/* should generate diagnostics */
+
+let foo;
+
+// Decimal: minimumDigits: 7 and groupLength: 2, so 7+ digits must use groups of 2
+foo = 1234567; // 1_23_45_67
+foo = 1_234_567; // 1_23_45_67

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCombinedCustomOptions.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCombinedCustomOptions.js.snap
@@ -1,0 +1,65 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidCombinedCustomOptions.js
+---
+# Input
+```js
+/* should generate diagnostics */
+
+let foo;
+
+// Decimal: minimumDigits: 7 and groupLength: 2, so 7+ digits must use groups of 2
+foo = 1234567; // 1_23_45_67
+foo = 1_234_567; // 1_23_45_67
+
+```
+
+# Diagnostics
+```
+invalidCombinedCustomOptions.js:6:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  i Long numeric literal lacks separators.
+  
+    5 │ // Decimal: minimumDigits: 7 and groupLength: 2, so 7+ digits must use groups of 2
+  > 6 │ foo = 1234567; // 1_23_45_67
+      │       ^^^^^^^
+    7 │ foo = 1_234_567; // 1_23_45_67
+    8 │ 
+  
+  i Adding separators helps improve readability and clarity for long numbers.
+  
+  i Safe fix: Add numeric separators.
+  
+    4 4 │   
+    5 5 │   // Decimal: minimumDigits: 7 and groupLength: 2, so 7+ digits must use groups of 2
+    6   │ - foo·=·1234567;·//·1_23_45_67
+      6 │ + foo·=·1_23_45_67;·//·1_23_45_67
+    7 7 │   foo = 1_234_567; // 1_23_45_67
+    8 8 │   
+  
+
+```
+
+```
+invalidCombinedCustomOptions.js:7:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  i Inconsistent grouping of digits in numeric literal.
+  
+    5 │ // Decimal: minimumDigits: 7 and groupLength: 2, so 7+ digits must use groups of 2
+    6 │ foo = 1234567; // 1_23_45_67
+  > 7 │ foo = 1_234_567; // 1_23_45_67
+      │       ^^^^^^^^^
+    8 │ 
+  
+  i Numbers with inconsistently placed separators can be misleading or confusing.
+  
+  i Safe fix: Use consistent numeric separator grouping.
+  
+    5 5 │   // Decimal: minimumDigits: 7 and groupLength: 2, so 7+ digits must use groups of 2
+    6 6 │   foo = 1234567; // 1_23_45_67
+    7   │ - foo·=·1_234_567;·//·1_23_45_67
+      7 │ + foo·=·1_23_45_67;·//·1_23_45_67
+    8 8 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCombinedCustomOptions.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCombinedCustomOptions.options.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "useNumericSeparators": {
+          "level": "error",
+          "options": {
+            "decimal": {
+              "minimumDigits": 7,
+              "groupLength": 2
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCustomOptions.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCustomOptions.js
@@ -1,0 +1,19 @@
+/* should generate diagnostics */
+
+let foo;
+
+// Decimal: minimumDigits: 7, so 7+ digits without separators are invalid
+foo = 1234567; // 1_234_567
+foo = 1234567890; // 1_234_567_890
+
+// Hexadecimal: minimumDigits: 4, so 4+ digits without separators are invalid
+foo = 0xABCD; // 0xAB_CD
+foo = 0xABCDEF; // 0xAB_CD_EF
+
+// Binary: groupLength: 2, wrong grouping
+foo = 0b11001100; // 0b11_00_11_00
+foo = 0b1010_0001; // 0b10_10_00_01
+
+// Octal: groupLength: 2, wrong grouping
+foo = 0o12345670; // 0o12_34_56_70
+foo = 0o1234_5670; // 0o12_34_56_70

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCustomOptions.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCustomOptions.js.snap
@@ -1,0 +1,230 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidCustomOptions.js
+---
+# Input
+```js
+/* should generate diagnostics */
+
+let foo;
+
+// Decimal: minimumDigits: 7, so 7+ digits without separators are invalid
+foo = 1234567; // 1_234_567
+foo = 1234567890; // 1_234_567_890
+
+// Hexadecimal: minimumDigits: 4, so 4+ digits without separators are invalid
+foo = 0xABCD; // 0xAB_CD
+foo = 0xABCDEF; // 0xAB_CD_EF
+
+// Binary: groupLength: 2, wrong grouping
+foo = 0b11001100; // 0b11_00_11_00
+foo = 0b1010_0001; // 0b10_10_00_01
+
+// Octal: groupLength: 2, wrong grouping
+foo = 0o12345670; // 0o12_34_56_70
+foo = 0o1234_5670; // 0o12_34_56_70
+
+```
+
+# Diagnostics
+```
+invalidCustomOptions.js:6:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Long numeric literal lacks separators.
+  
+    5 │ // Decimal: minimumDigits: 7, so 7+ digits without separators are invalid
+  > 6 │ foo = 1234567; // 1_234_567
+      │       ^^^^^^^
+    7 │ foo = 1234567890; // 1_234_567_890
+    8 │ 
+  
+  i Adding separators helps improve readability and clarity for long numbers.
+  
+  i Safe fix: Add numeric separators.
+  
+     4  4 │   
+     5  5 │   // Decimal: minimumDigits: 7, so 7+ digits without separators are invalid
+     6    │ - foo·=·1234567;·//·1_234_567
+        6 │ + foo·=·1_234_567;·//·1_234_567
+     7  7 │   foo = 1234567890; // 1_234_567_890
+     8  8 │   
+  
+
+```
+
+```
+invalidCustomOptions.js:7:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Long numeric literal lacks separators.
+  
+    5 │ // Decimal: minimumDigits: 7, so 7+ digits without separators are invalid
+    6 │ foo = 1234567; // 1_234_567
+  > 7 │ foo = 1234567890; // 1_234_567_890
+      │       ^^^^^^^^^^
+    8 │ 
+    9 │ // Hexadecimal: minimumDigits: 4, so 4+ digits without separators are invalid
+  
+  i Adding separators helps improve readability and clarity for long numbers.
+  
+  i Safe fix: Add numeric separators.
+  
+     5  5 │   // Decimal: minimumDigits: 7, so 7+ digits without separators are invalid
+     6  6 │   foo = 1234567; // 1_234_567
+     7    │ - foo·=·1234567890;·//·1_234_567_890
+        7 │ + foo·=·1_234_567_890;·//·1_234_567_890
+     8  8 │   
+     9  9 │   // Hexadecimal: minimumDigits: 4, so 4+ digits without separators are invalid
+  
+
+```
+
+```
+invalidCustomOptions.js:10:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Long numeric literal lacks separators.
+  
+     9 │ // Hexadecimal: minimumDigits: 4, so 4+ digits without separators are invalid
+  > 10 │ foo = 0xABCD; // 0xAB_CD
+       │       ^^^^^^
+    11 │ foo = 0xABCDEF; // 0xAB_CD_EF
+    12 │ 
+  
+  i Adding separators helps improve readability and clarity for long numbers.
+  
+  i Safe fix: Add numeric separators.
+  
+     8  8 │   
+     9  9 │   // Hexadecimal: minimumDigits: 4, so 4+ digits without separators are invalid
+    10    │ - foo·=·0xABCD;·//·0xAB_CD
+       10 │ + foo·=·0xAB_CD;·//·0xAB_CD
+    11 11 │   foo = 0xABCDEF; // 0xAB_CD_EF
+    12 12 │   
+  
+
+```
+
+```
+invalidCustomOptions.js:11:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Long numeric literal lacks separators.
+  
+     9 │ // Hexadecimal: minimumDigits: 4, so 4+ digits without separators are invalid
+    10 │ foo = 0xABCD; // 0xAB_CD
+  > 11 │ foo = 0xABCDEF; // 0xAB_CD_EF
+       │       ^^^^^^^^
+    12 │ 
+    13 │ // Binary: groupLength: 2, wrong grouping
+  
+  i Adding separators helps improve readability and clarity for long numbers.
+  
+  i Safe fix: Add numeric separators.
+  
+     9  9 │   // Hexadecimal: minimumDigits: 4, so 4+ digits without separators are invalid
+    10 10 │   foo = 0xABCD; // 0xAB_CD
+    11    │ - foo·=·0xABCDEF;·//·0xAB_CD_EF
+       11 │ + foo·=·0xAB_CD_EF;·//·0xAB_CD_EF
+    12 12 │   
+    13 13 │   // Binary: groupLength: 2, wrong grouping
+  
+
+```
+
+```
+invalidCustomOptions.js:14:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Long numeric literal lacks separators.
+  
+    13 │ // Binary: groupLength: 2, wrong grouping
+  > 14 │ foo = 0b11001100; // 0b11_00_11_00
+       │       ^^^^^^^^^^
+    15 │ foo = 0b1010_0001; // 0b10_10_00_01
+    16 │ 
+  
+  i Adding separators helps improve readability and clarity for long numbers.
+  
+  i Safe fix: Add numeric separators.
+  
+    12 12 │   
+    13 13 │   // Binary: groupLength: 2, wrong grouping
+    14    │ - foo·=·0b11001100;·//·0b11_00_11_00
+       14 │ + foo·=·0b11_00_11_00;·//·0b11_00_11_00
+    15 15 │   foo = 0b1010_0001; // 0b10_10_00_01
+    16 16 │   
+  
+
+```
+
+```
+invalidCustomOptions.js:15:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Inconsistent grouping of digits in numeric literal.
+  
+    13 │ // Binary: groupLength: 2, wrong grouping
+    14 │ foo = 0b11001100; // 0b11_00_11_00
+  > 15 │ foo = 0b1010_0001; // 0b10_10_00_01
+       │       ^^^^^^^^^^^
+    16 │ 
+    17 │ // Octal: groupLength: 2, wrong grouping
+  
+  i Numbers with inconsistently placed separators can be misleading or confusing.
+  
+  i Safe fix: Use consistent numeric separator grouping.
+  
+    13 13 │   // Binary: groupLength: 2, wrong grouping
+    14 14 │   foo = 0b11001100; // 0b11_00_11_00
+    15    │ - foo·=·0b1010_0001;·//·0b10_10_00_01
+       15 │ + foo·=·0b10_10_00_01;·//·0b10_10_00_01
+    16 16 │   
+    17 17 │   // Octal: groupLength: 2, wrong grouping
+  
+
+```
+
+```
+invalidCustomOptions.js:18:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Long numeric literal lacks separators.
+  
+    17 │ // Octal: groupLength: 2, wrong grouping
+  > 18 │ foo = 0o12345670; // 0o12_34_56_70
+       │       ^^^^^^^^^^
+    19 │ foo = 0o1234_5670; // 0o12_34_56_70
+    20 │ 
+  
+  i Adding separators helps improve readability and clarity for long numbers.
+  
+  i Safe fix: Add numeric separators.
+  
+    16 16 │   
+    17 17 │   // Octal: groupLength: 2, wrong grouping
+    18    │ - foo·=·0o12345670;·//·0o12_34_56_70
+       18 │ + foo·=·0o12_34_56_70;·//·0o12_34_56_70
+    19 19 │   foo = 0o1234_5670; // 0o12_34_56_70
+    20 20 │   
+  
+
+```
+
+```
+invalidCustomOptions.js:19:7 lint/style/useNumericSeparators  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Inconsistent grouping of digits in numeric literal.
+  
+    17 │ // Octal: groupLength: 2, wrong grouping
+    18 │ foo = 0o12345670; // 0o12_34_56_70
+  > 19 │ foo = 0o1234_5670; // 0o12_34_56_70
+       │       ^^^^^^^^^^^
+    20 │ 
+  
+  i Numbers with inconsistently placed separators can be misleading or confusing.
+  
+  i Safe fix: Use consistent numeric separator grouping.
+  
+    17 17 │   // Octal: groupLength: 2, wrong grouping
+    18 18 │   foo = 0o12345670; // 0o12_34_56_70
+    19    │ - foo·=·0o1234_5670;·//·0o12_34_56_70
+       19 │ + foo·=·0o12_34_56_70;·//·0o12_34_56_70
+    20 20 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCustomOptions.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/invalidCustomOptions.options.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "useNumericSeparators": {
+          "level": "error",
+          "options": {
+            "decimal": {
+              "minimumDigits": 7
+            },
+            "hexadecimal": {
+              "minimumDigits": 4
+            },
+            "binary": {
+              "groupLength": 2
+            },
+            "octal": {
+              "groupLength": 2
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCombinedCustomOptions.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCombinedCustomOptions.js
@@ -1,0 +1,9 @@
+/* should not generate diagnostics */
+
+let foo;
+
+// Decimal: minimumDigits: 7 and groupLength: 2, so 6 digit numbers are fine
+foo = 123456;
+
+// Decimal with 7+ digits, properly grouped
+foo = 1_23_45_67;

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCombinedCustomOptions.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCombinedCustomOptions.js.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validCombinedCustomOptions.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+
+let foo;
+
+// Decimal: minimumDigits: 7 and groupLength: 2, so 6 digit numbers are fine
+foo = 123456;
+
+// Decimal with 7+ digits, properly grouped
+foo = 1_23_45_67;
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCombinedCustomOptions.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCombinedCustomOptions.options.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "useNumericSeparators": {
+          "level": "error",
+          "options": {
+            "decimal": {
+              "minimumDigits": 7,
+              "groupLength": 2
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCustomOptions.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCustomOptions.js
@@ -1,0 +1,25 @@
+/* should not generate diagnostics */
+
+let foo;
+
+// Decimal: minimumDigits: 7, so 5 and 6 digit numbers are fine
+foo = 12345;
+foo = 123456;
+
+// Hexadecimal: minimumDigits: 4, so 2 digit numbers are fine
+foo = 0xAB;
+foo = 0xA;
+
+// Binary: groupLength: 2, properly grouped
+foo = 0b11_00_11_00;
+
+// Octal: groupLength: 2, properly grouped
+foo = 0o12_34_56_70;
+
+// Decimal with 7+ digits, properly grouped
+foo = 1_234_567;
+foo = 12_345_678;
+
+// Hexadecimal with 4+ digits, properly grouped
+foo = 0xAB_CD;
+foo = 0xAB_CD_EF;

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCustomOptions.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCustomOptions.js.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validCustomOptions.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+
+let foo;
+
+// Decimal: minimumDigits: 7, so 5 and 6 digit numbers are fine
+foo = 12345;
+foo = 123456;
+
+// Hexadecimal: minimumDigits: 4, so 2 digit numbers are fine
+foo = 0xAB;
+foo = 0xA;
+
+// Binary: groupLength: 2, properly grouped
+foo = 0b11_00_11_00;
+
+// Octal: groupLength: 2, properly grouped
+foo = 0o12_34_56_70;
+
+// Decimal with 7+ digits, properly grouped
+foo = 1_234_567;
+foo = 12_345_678;
+
+// Hexadecimal with 4+ digits, properly grouped
+foo = 0xAB_CD;
+foo = 0xAB_CD_EF;
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCustomOptions.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useNumericSeparators/validCustomOptions.options.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "useNumericSeparators": {
+          "level": "error",
+          "options": {
+            "decimal": {
+              "minimumDigits": 7
+            },
+            "hexadecimal": {
+              "minimumDigits": 4
+            },
+            "binary": {
+              "groupLength": 2
+            },
+            "octal": {
+              "groupLength": 2
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_rule_options/src/use_numeric_separators.rs
+++ b/crates/biome_rule_options/src/use_numeric_separators.rs
@@ -1,6 +1,121 @@
 use biome_deserialize_macros::{Deserializable, Merge};
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU8;
+
+#[derive(Clone, Debug, Default, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct NumericLiteralSeparatorOptions {
+    /// Minimum number of digits required before adding separators.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub minimum_digits: Option<u8>,
+    /// Number of digits between separators.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub group_length: Option<NonZeroU8>,
+}
+
+impl NumericLiteralSeparatorOptions {
+    /// Returns the resolved options, using the provided defaults for any fields
+    /// that are not set.
+    pub fn resolve(
+        &self,
+        default_min_digits: u8,
+        default_group_length: NonZeroU8,
+    ) -> ResolvedOptions {
+        ResolvedOptions {
+            minimum_digits: self.minimum_digits.unwrap_or(default_min_digits),
+            group_length: self.group_length.unwrap_or(default_group_length),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResolvedOptions {
+    pub minimum_digits: u8,
+    pub group_length: NonZeroU8,
+}
+
 #[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
-pub struct UseNumericSeparatorsOptions {}
+pub struct UseNumericSeparatorsOptions {
+    /// Options for binary literals (e.g., `0b1010_0001`).
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub binary: Option<NumericLiteralSeparatorOptions>,
+    /// Options for octal literals (e.g., `0o1234_5670`).
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub octal: Option<NumericLiteralSeparatorOptions>,
+    /// Options for decimal literals (e.g., `1_234_567`).
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub decimal: Option<NumericLiteralSeparatorOptions>,
+    /// Options for hexadecimal literals (e.g., `0xAB_CD`).
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub hexadecimal: Option<NumericLiteralSeparatorOptions>,
+}
+
+impl UseNumericSeparatorsOptions {
+    pub const DEFAULT_BINARY_MIN_DIGITS: u8 = 0;
+    pub const DEFAULT_BINARY_GROUP_LENGTH: NonZeroU8 = NonZeroU8::new(4).unwrap();
+    pub const DEFAULT_OCTAL_MIN_DIGITS: u8 = 0;
+    pub const DEFAULT_OCTAL_GROUP_LENGTH: NonZeroU8 = NonZeroU8::new(4).unwrap();
+    pub const DEFAULT_DECIMAL_MIN_DIGITS: u8 = 5;
+    pub const DEFAULT_DECIMAL_GROUP_LENGTH: NonZeroU8 = NonZeroU8::new(3).unwrap();
+    pub const DEFAULT_HEXADECIMAL_MIN_DIGITS: u8 = 0;
+    pub const DEFAULT_HEXADECIMAL_GROUP_LENGTH: NonZeroU8 = NonZeroU8::new(2).unwrap();
+
+    /// Returns resolved options for binary literals.
+    pub fn binary(&self) -> ResolvedOptions {
+        match &self.binary {
+            Some(opts) => opts.resolve(
+                Self::DEFAULT_BINARY_MIN_DIGITS,
+                Self::DEFAULT_BINARY_GROUP_LENGTH,
+            ),
+            None => ResolvedOptions {
+                minimum_digits: Self::DEFAULT_BINARY_MIN_DIGITS,
+                group_length: Self::DEFAULT_BINARY_GROUP_LENGTH,
+            },
+        }
+    }
+
+    /// Returns resolved options for octal literals.
+    pub fn octal(&self) -> ResolvedOptions {
+        match &self.octal {
+            Some(opts) => opts.resolve(
+                Self::DEFAULT_OCTAL_MIN_DIGITS,
+                Self::DEFAULT_OCTAL_GROUP_LENGTH,
+            ),
+            None => ResolvedOptions {
+                minimum_digits: Self::DEFAULT_OCTAL_MIN_DIGITS,
+                group_length: Self::DEFAULT_OCTAL_GROUP_LENGTH,
+            },
+        }
+    }
+
+    /// Returns resolved options for decimal literals.
+    pub fn decimal(&self) -> ResolvedOptions {
+        match &self.decimal {
+            Some(opts) => opts.resolve(
+                Self::DEFAULT_DECIMAL_MIN_DIGITS,
+                Self::DEFAULT_DECIMAL_GROUP_LENGTH,
+            ),
+            None => ResolvedOptions {
+                minimum_digits: Self::DEFAULT_DECIMAL_MIN_DIGITS,
+                group_length: Self::DEFAULT_DECIMAL_GROUP_LENGTH,
+            },
+        }
+    }
+
+    /// Returns resolved options for hexadecimal literals.
+    pub fn hexadecimal(&self) -> ResolvedOptions {
+        match &self.hexadecimal {
+            Some(opts) => opts.resolve(
+                Self::DEFAULT_HEXADECIMAL_MIN_DIGITS,
+                Self::DEFAULT_HEXADECIMAL_GROUP_LENGTH,
+            ),
+            None => ResolvedOptions {
+                minimum_digits: Self::DEFAULT_HEXADECIMAL_MIN_DIGITS,
+                group_length: Self::DEFAULT_HEXADECIMAL_GROUP_LENGTH,
+            },
+        }
+    }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8826,7 +8826,24 @@ This does not affect other [Case].
 export type UseNodeAssertStrictOptions = {};
 export type UseNodejsImportProtocolOptions = {};
 export type UseNumberNamespaceOptions = {};
-export type UseNumericSeparatorsOptions = {};
+export interface UseNumericSeparatorsOptions {
+	/**
+	 * Options for binary literals (e.g., `0b1010_0001`).
+	 */
+	binary?: NumericLiteralSeparatorOptions;
+	/**
+	 * Options for decimal literals (e.g., `1_234_567`).
+	 */
+	decimal?: NumericLiteralSeparatorOptions;
+	/**
+	 * Options for hexadecimal literals (e.g., `0xAB_CD`).
+	 */
+	hexadecimal?: NumericLiteralSeparatorOptions;
+	/**
+	 * Options for octal literals (e.g., `0o1234_5670`).
+	 */
+	octal?: NumericLiteralSeparatorOptions;
+}
 export type UseObjectSpreadOptions = {};
 export type UseReactFunctionComponentsOptions = {};
 export interface UseReadonlyClassPropertiesOptions {
@@ -9135,6 +9152,16 @@ export interface Convention {
 	 * Declarations concerned by this convention
 	 */
 	selector?: Selector;
+}
+export interface NumericLiteralSeparatorOptions {
+	/**
+	 * Number of digits between separators.
+	 */
+	groupLength?: number;
+	/**
+	 * Minimum number of digits required before adding separators.
+	 */
+	minimumDigits?: number;
 }
 export type GroupMatcher = ImportMatcher | SourceMatcher;
 export type StableHookResult = boolean | number[] | string[];

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -6278,6 +6278,26 @@
 			"description": "Normalized Biome glob pattern that strips `./` from the pattern.",
 			"type": "string"
 		},
+		"NumericLiteralSeparatorOptions": {
+			"type": "object",
+			"properties": {
+				"groupLength": {
+					"description": "Number of digits between separators.",
+					"type": ["integer", "null"],
+					"format": "uint8",
+					"maximum": 255,
+					"minimum": 1
+				},
+				"minimumDigits": {
+					"description": "Minimum number of digits required before adding separators.",
+					"type": ["integer", "null"],
+					"format": "uint8",
+					"maximum": 255,
+					"minimum": 0
+				}
+			},
+			"additionalProperties": false
+		},
 		"Nursery": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",
@@ -15622,6 +15642,36 @@
 		},
 		"UseNumericSeparatorsOptions": {
 			"type": "object",
+			"properties": {
+				"binary": {
+					"description": "Options for binary literals (e.g., `0b1010_0001`).",
+					"anyOf": [
+						{ "$ref": "#/$defs/NumericLiteralSeparatorOptions" },
+						{ "type": "null" }
+					]
+				},
+				"decimal": {
+					"description": "Options for decimal literals (e.g., `1_234_567`).",
+					"anyOf": [
+						{ "$ref": "#/$defs/NumericLiteralSeparatorOptions" },
+						{ "type": "null" }
+					]
+				},
+				"hexadecimal": {
+					"description": "Options for hexadecimal literals (e.g., `0xAB_CD`).",
+					"anyOf": [
+						{ "$ref": "#/$defs/NumericLiteralSeparatorOptions" },
+						{ "type": "null" }
+					]
+				},
+				"octal": {
+					"description": "Options for octal literals (e.g., `0o1234_5670`).",
+					"anyOf": [
+						{ "$ref": "#/$defs/NumericLiteralSeparatorOptions" },
+						{ "type": "null" }
+					]
+				}
+			},
 			"additionalProperties": false
 		},
 		"UseObjectSpreadConfiguration": {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
I realize the way the options are documented is a little different than what we usually do. The agent came up with it, and tbh I think the more concise summary is more preferable than having valid and invalid cases for all 4 * 2 options.

Generated by opus 4.6

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
discussion: #9316

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
