### PR TITLE
refactor(organizeImports): improve diagnostics

### DIFF
--- a/.changeset/giant-radios-pay.md
+++ b/.changeset/giant-radios-pay.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#9530](https://github.com/biomejs/biome/issues/9530). [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/) now outputs detailed diagnostics.
+Fixed [#9530](https://github.com/biomejs/biome/issues/9530). The diagnostics of [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/) are now more detailed and more precise. They are also better at localizing where the issue is.

--- a/.changeset/giant-radios-pay.md
+++ b/.changeset/giant-radios-pay.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#9530](https://github.com/biomejs/biome/issues/9530). [`organizeImports](https://biomejs.dev/assist/actions/organize-imports/) now outputs detailed diagnostics.
+Fixed [#9530](https://github.com/biomejs/biome/issues/9530). [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/) now outputs detailed diagnostics.

--- a/.changeset/giant-radios-pay.md
+++ b/.changeset/giant-radios-pay.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9530](https://github.com/biomejs/biome/issues/9530). [`organizeImports](https://biomejs.dev/assist/actions/organize-imports/) now outputs detailed diagnostics.

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
@@ -40,9 +40,15 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-src/index.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+src/index.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Some imports or exports are not organized.
+  
+  > 1 │ import { graphql, useFragment, useMutation } from "react-relay";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import { FC, memo, useCallback } from "react";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
@@ -42,15 +42,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 src/index.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Some imports or exports are not organized.
-  
-  > 1 │ import { graphql, useFragment, useMutation } from "react-relay";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import { FC, memo, useCallback } from "react";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ 
-  
-  i Sort this chunk of imports.
+  × Sort this chunk of imports.
   
   > 1 │ import { graphql, useFragment, useMutation } from "react-relay";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
@@ -42,7 +42,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 src/index.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Sort this chunk of imports.
+  × Sort these imports.
   
   > 1 │ import { graphql, useFragment, useMutation } from "react-relay";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
@@ -40,16 +40,19 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-src/index.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+src/index.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The imports and exports are not sorted.
+  × Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 1 │ import { graphql, useFragment, useMutation } from "react-relay";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import { FC, memo, useCallback } from "react";
+  > 2 │ import { FC, memo, useCallback } from "react";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     3 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·{·graphql,·useFragment,·useMutation·}·from·"react-relay";
     2   │ - import·{·FC,·memo,·useCallback·}·from·"react";

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -28,23 +28,13 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.astro:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Some imports or exports are not organized.
+  × Sort this chunk of imports.
   
     1 │ ---
   > 2 │ import { getLocale } from "astro:i18n";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   > 3 │ import { Code } from "astro:components";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ ---
-    5 │ <div></div>
-  
-  i Sort this chunk of imports.
-  
-  > 1 │ ---
-      │  ^^
-  > 2 │ import { getLocale } from "astro:i18n";
-  > 3 │ import { Code } from "astro:components";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ ---
     5 │ <div></div>
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -28,7 +28,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.astro:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Sort this chunk of imports.
+  × Sort these imports.
   
     1 │ ---
   > 2 │ import { getLocale } from "astro:i18n";

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -26,9 +26,17 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-file.astro assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.astro:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Some imports or exports are not organized.
+  
+    1 │ ---
+  > 2 │ import { getLocale } from "astro:i18n";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ import { Code } from "astro:components";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ ---
+    5 │ <div></div>
   
   i Sort this chunk of imports.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -26,17 +26,21 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-file.astro:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.astro assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The imports and exports are not sorted.
+  × Some imports or exports are not organized.
   
-    1 │ ---
+  i Sort this chunk of imports.
+  
+  > 1 │ ---
+      │  ^^
   > 2 │ import { getLocale } from "astro:i18n";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import { Code } from "astro:components";
+  > 3 │ import { Code } from "astro:components";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ ---
+    5 │ <div></div>
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   
     2   │ - import·{·getLocale·}·from·"astro:i18n";

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
@@ -28,7 +28,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.svelte:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Sort this chunk of imports.
+  × Sort these imports.
   
     1 │ <script lang="ts">
   > 2 │ import Button from "./components/Button.svelte";

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
@@ -26,17 +26,21 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-file.svelte:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.svelte assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The imports and exports are not sorted.
+  × Some imports or exports are not organized.
   
-    1 │ <script lang="ts">
+  i Sort this chunk of imports.
+  
+  > 1 │ <script lang="ts">
+      │ ^^^^^^^^^^^^^^^^^^
   > 2 │ import Button from "./components/Button.svelte";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import * as svelteUse from "svelte-use";
+  > 3 │ import * as svelteUse from "svelte-use";
+      │ ^^^^^^^^^^^^^^^^^^^^^
     4 │ </script>
+    5 │ <div></div>
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·Button·from·"./components/Button.svelte";
     2   │ - import·*·as·svelteUse·from·"svelte-use";

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
@@ -26,9 +26,17 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-file.svelte assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.svelte:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Some imports or exports are not organized.
+  
+    1 │ <script lang="ts">
+  > 2 │ import Button from "./components/Button.svelte";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ import * as svelteUse from "svelte-use";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ </script>
+    5 │ <div></div>
   
   i Sort this chunk of imports.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
@@ -28,23 +28,13 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.svelte:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Some imports or exports are not organized.
+  × Sort this chunk of imports.
   
     1 │ <script lang="ts">
   > 2 │ import Button from "./components/Button.svelte";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   > 3 │ import * as svelteUse from "svelte-use";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ </script>
-    5 │ <div></div>
-  
-  i Sort this chunk of imports.
-  
-  > 1 │ <script lang="ts">
-      │ ^^^^^^^^^^^^^^^^^^
-  > 2 │ import Button from "./components/Button.svelte";
-  > 3 │ import * as svelteUse from "svelte-use";
-      │ ^^^^^^^^^^^^^^^^^^^^^
     4 │ </script>
     5 │ <div></div>
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
@@ -28,23 +28,13 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.vue:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Some imports or exports are not organized.
+  × Sort this chunk of imports.
   
     1 │ <script setup lang="ts">
   > 2 │ import Button from "./components/Button.vue";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   > 3 │ import * as vueUse from "vue-use";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ </script>
-    5 │ <template></template>
-  
-  i Sort this chunk of imports.
-  
-  > 1 │ <script setup lang="ts">
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import Button from "./components/Button.vue";
-  > 3 │ import * as vueUse from "vue-use";
-      │ ^^^^^^^^^
     4 │ </script>
     5 │ <template></template>
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
@@ -26,17 +26,21 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-file.vue:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The imports and exports are not sorted.
+  × Some imports or exports are not organized.
   
-    1 │ <script setup lang="ts">
+  i Sort this chunk of imports.
+  
+  > 1 │ <script setup lang="ts">
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^
   > 2 │ import Button from "./components/Button.vue";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import * as vueUse from "vue-use";
+  > 3 │ import * as vueUse from "vue-use";
+      │ ^^^^^^^^^
     4 │ </script>
+    5 │ <template></template>
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·Button·from·"./components/Button.vue";
     2   │ - import·*·as·vueUse·from·"vue-use";

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
@@ -26,9 +26,17 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-file.vue assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.vue:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Some imports or exports are not organized.
+  
+    1 │ <script setup lang="ts">
+  > 2 │ import Button from "./components/Button.vue";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ import * as vueUse from "vue-use";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ </script>
+    5 │ <template></template>
   
   i Sort this chunk of imports.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
@@ -28,7 +28,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.vue:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Sort this chunk of imports.
+  × Sort these imports.
   
     1 │ <script setup lang="ts">
   > 2 │ import Button from "./components/Button.vue";

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command.snap
@@ -51,7 +51,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Sort these imports." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />
@@ -65,7 +65,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Sort these imports." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command.snap
@@ -51,7 +51,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="The imports and exports are not sorted." source="assist/source/organizeImports" />
+    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />
@@ -65,7 +65,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="The imports and exports are not sorted." source="assist/source/organizeImports" />
+    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command.snap
@@ -51,7 +51,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />
@@ -65,7 +65,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command_file.snap
@@ -12,7 +12,7 @@ expression: redactor(content)
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Sort these imports." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />
@@ -26,7 +26,7 @@ expression: redactor(content)
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Sort these imports." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command_file.snap
@@ -12,7 +12,7 @@ expression: redactor(content)
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="The imports and exports are not sorted." source="assist/source/organizeImports" />
+    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />
@@ -26,7 +26,7 @@ expression: redactor(content)
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="The imports and exports are not sorted." source="assist/source/organizeImports" />
+    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_check_command_file.snap
@@ -12,7 +12,7 @@ expression: redactor(content)
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />
@@ -26,7 +26,7 @@ expression: redactor(content)
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_ci_command.snap
@@ -51,7 +51,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="The imports and exports are not sorted." source="assist/source/organizeImports" />
+    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />
@@ -65,7 +65,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="The imports and exports are not sorted." source="assist/source/organizeImports" />
+    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_ci_command.snap
@@ -51,7 +51,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />
@@ -65,7 +65,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="0" column="0" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_checkstyle/reports_diagnostics_checkstyle_ci_command.snap
@@ -51,7 +51,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Sort these imports." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />
@@ -65,7 +65,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <error line="2" column="10" severity="warning" message="Several of these imports are unused." source="lint/correctness/noUnusedImports" />
     <error line="8" column="5" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
     <error line="9" column="7" severity="warning" message="This variable f is unused." source="lint/correctness/noUnusedVariables" />
-    <error line="1" column="1" severity="error" message="Some imports or exports are not organized." source="assist/source/organizeImports" />
+    <error line="1" column="1" severity="error" message="Sort these imports." source="assist/source/organizeImports" />
     <error line="4" column="3" severity="error" message="Using == may be unsafe if you are relying on type coercion." source="lint/suspicious/noDoubleEquals" />
     <error line="6" column="1" severity="error" message="This is an unexpected use of the debugger statement." source="lint/suspicious/noDebugger" />
     <error line="8" column="5" severity="error" message="This variable implicitly has the any type." source="lint/suspicious/noImplicitAnyLet" />

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_check_command.snap
@@ -76,7 +76,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=1,col=2,endColumn=2::Some imports or exports are not organized.
+::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=2,col=1,endColumn=33::Some imports or exports are not organized.
 ```
 
 ```block
@@ -108,7 +108,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=1,col=2,endColumn=2::Some imports or exports are not organized.
+::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=2,col=1,endColumn=33::Some imports or exports are not organized.
 ```
 
 ```block

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_check_command.snap
@@ -76,7 +76,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=2,col=1,endColumn=33::Some imports or exports are not organized.
+::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=2,col=1,endColumn=33::Sort these imports.
 ```
 
 ```block
@@ -108,7 +108,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=2,col=1,endColumn=33::Some imports or exports are not organized.
+::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=2,col=1,endColumn=33::Sort these imports.
 ```
 
 ```block

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_check_command.snap
@@ -76,7 +76,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=1,col=1,endColumn=21::The imports and exports are not sorted.
+::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=1,col=2,endColumn=2::Some imports or exports are not organized.
 ```
 
 ```block
@@ -108,7 +108,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=1,col=1,endColumn=21::The imports and exports are not sorted.
+::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=1,col=2,endColumn=2::Some imports or exports are not organized.
 ```
 
 ```block

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_ci_command.snap
@@ -76,7 +76,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=2,col=1,endColumn=33::Some imports or exports are not organized.
+::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=2,col=1,endColumn=33::Sort these imports.
 ```
 
 ```block
@@ -108,7 +108,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=2,col=1,endColumn=33::Some imports or exports are not organized.
+::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=2,col=1,endColumn=33::Sort these imports.
 ```
 
 ```block

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_ci_command.snap
@@ -76,7 +76,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=1,col=1,endColumn=21::The imports and exports are not sorted.
+::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=1,col=2,endColumn=2::Some imports or exports are not organized.
 ```
 
 ```block
@@ -108,7 +108,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=1,col=1,endColumn=21::The imports and exports are not sorted.
+::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=1,col=2,endColumn=2::Some imports or exports are not organized.
 ```
 
 ```block

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_ci_command.snap
@@ -76,7 +76,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=1,col=2,endColumn=2::Some imports or exports are not organized.
+::error title=assist/source/organizeImports,file=index.ts,line=1,endLine=2,col=1,endColumn=33::Some imports or exports are not organized.
 ```
 
 ```block
@@ -108,7 +108,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=1,col=2,endColumn=2::Some imports or exports are not organized.
+::error title=assist/source/organizeImports,file=main.ts,line=1,endLine=2,col=1,endColumn=33::Some imports or exports are not organized.
 ```
 
 ```block

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
@@ -260,7 +260,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
   {
     "description": "Some imports or exports are not organized.",
     "check_name": "assist/source/organizeImports",
-    "fingerprint": "8970064143624904929",
+    "fingerprint": "8459329872035046942",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -680,7 +680,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
   {
     "description": "Some imports or exports are not organized.",
     "check_name": "assist/source/organizeImports",
-    "fingerprint": "16289383351071945716",
+    "fingerprint": "15695086553598122883",
     "severity": "critical",
     "location": {
       "path": "main.ts",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
@@ -258,9 +258,9 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "The imports and exports are not sorted.",
+    "description": "Some imports or exports are not organized.",
     "check_name": "assist/source/organizeImports",
-    "fingerprint": "4789482553704082688",
+    "fingerprint": "8970064143624904929",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -678,9 +678,9 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "The imports and exports are not sorted.",
+    "description": "Some imports or exports are not organized.",
     "check_name": "assist/source/organizeImports",
-    "fingerprint": "71463377061397589",
+    "fingerprint": "16289383351071945716",
     "severity": "critical",
     "location": {
       "path": "main.ts",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
@@ -258,7 +258,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Some imports or exports are not organized.",
+    "description": "Sort these imports.",
     "check_name": "assist/source/organizeImports",
     "fingerprint": "8459329872035046942",
     "severity": "critical",
@@ -678,7 +678,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Some imports or exports are not organized.",
+    "description": "Sort these imports.",
     "check_name": "assist/source/organizeImports",
     "fingerprint": "15695086553598122883",
     "severity": "critical",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
@@ -258,7 +258,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Some imports or exports are not organized.",
+    "description": "Sort these imports.",
     "check_name": "assist/source/organizeImports",
     "fingerprint": "8459329872035046942",
     "severity": "critical",
@@ -678,7 +678,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Some imports or exports are not organized.",
+    "description": "Sort these imports.",
     "check_name": "assist/source/organizeImports",
     "fingerprint": "15695086553598122883",
     "severity": "critical",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
@@ -258,9 +258,9 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "The imports and exports are not sorted.",
+    "description": "Some imports or exports are not organized.",
     "check_name": "assist/source/organizeImports",
-    "fingerprint": "4789482553704082688",
+    "fingerprint": "8970064143624904929",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -678,9 +678,9 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "The imports and exports are not sorted.",
+    "description": "Some imports or exports are not organized.",
     "check_name": "assist/source/organizeImports",
-    "fingerprint": "71463377061397589",
+    "fingerprint": "16289383351071945716",
     "severity": "critical",
     "location": {
       "path": "main.ts",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
@@ -260,7 +260,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
   {
     "description": "Some imports or exports are not organized.",
     "check_name": "assist/source/organizeImports",
-    "fingerprint": "8970064143624904929",
+    "fingerprint": "8459329872035046942",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -680,7 +680,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
   {
     "description": "Some imports or exports are not organized.",
     "check_name": "assist/source/organizeImports",
-    "fingerprint": "16289383351071945716",
+    "fingerprint": "15695086553598122883",
     "severity": "critical",
     "location": {
       "path": "main.ts",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command.snap
@@ -153,14 +153,25 @@ The --json option is unstable/experimental and its output might change between p
 		},
 		{
 			"severity": "error",
-			"message": "The imports and exports are not sorted.",
+			"message": "Some imports or exports are not organized.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "index.ts",
-				"start": { "line": 1, "column": 1 },
-				"end": { "line": 1, "column": 21 }
+				"start": { "line": 0, "column": 0 },
+				"end": { "line": 0, "column": 0 }
 			},
-			"advices": []
+			"advices": [
+				{
+					"start": { "line": 2, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Sort this chunk of imports."
+				},
+				{
+					"start": { "line": 1, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Safe fix: Organize imports and exports (Biome)"
+				}
+			]
 		},
 		{
 			"severity": "error",
@@ -253,14 +264,25 @@ The --json option is unstable/experimental and its output might change between p
 		},
 		{
 			"severity": "error",
-			"message": "The imports and exports are not sorted.",
+			"message": "Some imports or exports are not organized.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "main.ts",
-				"start": { "line": 1, "column": 1 },
-				"end": { "line": 1, "column": 21 }
+				"start": { "line": 0, "column": 0 },
+				"end": { "line": 0, "column": 0 }
 			},
-			"advices": []
+			"advices": [
+				{
+					"start": { "line": 2, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Sort this chunk of imports."
+				},
+				{
+					"start": { "line": 1, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Safe fix: Organize imports and exports (Biome)"
+				}
+			]
 		},
 		{
 			"severity": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command.snap
@@ -157,8 +157,8 @@ The --json option is unstable/experimental and its output might change between p
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "index.ts",
-				"start": { "line": 0, "column": 0 },
-				"end": { "line": 0, "column": 0 }
+				"start": { "line": 1, "column": 1 },
+				"end": { "line": 2, "column": 33 }
 			},
 			"advices": [
 				{
@@ -268,8 +268,8 @@ The --json option is unstable/experimental and its output might change between p
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "main.ts",
-				"start": { "line": 0, "column": 0 },
-				"end": { "line": 0, "column": 0 }
+				"start": { "line": 1, "column": 1 },
+				"end": { "line": 2, "column": 33 }
 			},
 			"advices": [
 				{

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command.snap
@@ -164,7 +164,7 @@ The --json option is unstable/experimental and its output might change between p
 				{
 					"start": { "line": 2, "column": 1 },
 					"end": { "line": 2, "column": 33 },
-					"text": "Sort this chunk of imports."
+					"text": "Sort these imports."
 				},
 				{
 					"start": { "line": 1, "column": 1 },
@@ -275,7 +275,7 @@ The --json option is unstable/experimental and its output might change between p
 				{
 					"start": { "line": 2, "column": 1 },
 					"end": { "line": 2, "column": 33 },
-					"text": "Sort this chunk of imports."
+					"text": "Sort these imports."
 				},
 				{
 					"start": { "line": 1, "column": 1 },

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command.snap
@@ -153,25 +153,14 @@ The --json option is unstable/experimental and its output might change between p
 		},
 		{
 			"severity": "error",
-			"message": "Some imports or exports are not organized.",
+			"message": "Sort these imports.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "index.ts",
 				"start": { "line": 1, "column": 1 },
 				"end": { "line": 2, "column": 33 }
 			},
-			"advices": [
-				{
-					"start": { "line": 2, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Sort these imports."
-				},
-				{
-					"start": { "line": 1, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Safe fix: Organize imports and exports (Biome)"
-				}
-			]
+			"advices": []
 		},
 		{
 			"severity": "error",
@@ -264,25 +253,14 @@ The --json option is unstable/experimental and its output might change between p
 		},
 		{
 			"severity": "error",
-			"message": "Some imports or exports are not organized.",
+			"message": "Sort these imports.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "main.ts",
 				"start": { "line": 1, "column": 1 },
 				"end": { "line": 2, "column": 33 }
 			},
-			"advices": [
-				{
-					"start": { "line": 2, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Sort these imports."
-				},
-				{
-					"start": { "line": 1, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Safe fix: Organize imports and exports (Biome)"
-				}
-			]
+			"advices": []
 		},
 		{
 			"severity": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command_file.snap
@@ -110,25 +110,14 @@ expression: redactor(content)
 		},
 		{
 			"severity": "error",
-			"message": "Some imports or exports are not organized.",
+			"message": "Sort these imports.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "index.ts",
 				"start": { "line": 1, "column": 1 },
 				"end": { "line": 2, "column": 33 }
 			},
-			"advices": [
-				{
-					"start": { "line": 2, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Sort these imports."
-				},
-				{
-					"start": { "line": 1, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Safe fix: Organize imports and exports (Biome)"
-				}
-			]
+			"advices": []
 		},
 		{
 			"severity": "error",
@@ -221,25 +210,14 @@ expression: redactor(content)
 		},
 		{
 			"severity": "error",
-			"message": "Some imports or exports are not organized.",
+			"message": "Sort these imports.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "main.ts",
 				"start": { "line": 1, "column": 1 },
 				"end": { "line": 2, "column": 33 }
 			},
-			"advices": [
-				{
-					"start": { "line": 2, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Sort these imports."
-				},
-				{
-					"start": { "line": 1, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Safe fix: Organize imports and exports (Biome)"
-				}
-			]
+			"advices": []
 		},
 		{
 			"severity": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command_file.snap
@@ -114,8 +114,8 @@ expression: redactor(content)
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "index.ts",
-				"start": { "line": 0, "column": 0 },
-				"end": { "line": 0, "column": 0 }
+				"start": { "line": 1, "column": 1 },
+				"end": { "line": 2, "column": 33 }
 			},
 			"advices": [
 				{
@@ -225,8 +225,8 @@ expression: redactor(content)
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "main.ts",
-				"start": { "line": 0, "column": 0 },
-				"end": { "line": 0, "column": 0 }
+				"start": { "line": 1, "column": 1 },
+				"end": { "line": 2, "column": 33 }
 			},
 			"advices": [
 				{

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command_file.snap
@@ -110,14 +110,25 @@ expression: redactor(content)
 		},
 		{
 			"severity": "error",
-			"message": "The imports and exports are not sorted.",
+			"message": "Some imports or exports are not organized.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "index.ts",
-				"start": { "line": 1, "column": 1 },
-				"end": { "line": 1, "column": 21 }
+				"start": { "line": 0, "column": 0 },
+				"end": { "line": 0, "column": 0 }
 			},
-			"advices": []
+			"advices": [
+				{
+					"start": { "line": 2, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Sort this chunk of imports."
+				},
+				{
+					"start": { "line": 1, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Safe fix: Organize imports and exports (Biome)"
+				}
+			]
 		},
 		{
 			"severity": "error",
@@ -210,14 +221,25 @@ expression: redactor(content)
 		},
 		{
 			"severity": "error",
-			"message": "The imports and exports are not sorted.",
+			"message": "Some imports or exports are not organized.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "main.ts",
-				"start": { "line": 1, "column": 1 },
-				"end": { "line": 1, "column": 21 }
+				"start": { "line": 0, "column": 0 },
+				"end": { "line": 0, "column": 0 }
 			},
-			"advices": []
+			"advices": [
+				{
+					"start": { "line": 2, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Sort this chunk of imports."
+				},
+				{
+					"start": { "line": 1, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Safe fix: Organize imports and exports (Biome)"
+				}
+			]
 		},
 		{
 			"severity": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_check_command_file.snap
@@ -121,7 +121,7 @@ expression: redactor(content)
 				{
 					"start": { "line": 2, "column": 1 },
 					"end": { "line": 2, "column": 33 },
-					"text": "Sort this chunk of imports."
+					"text": "Sort these imports."
 				},
 				{
 					"start": { "line": 1, "column": 1 },
@@ -232,7 +232,7 @@ expression: redactor(content)
 				{
 					"start": { "line": 2, "column": 1 },
 					"end": { "line": 2, "column": 33 },
-					"text": "Sort this chunk of imports."
+					"text": "Sort these imports."
 				},
 				{
 					"start": { "line": 1, "column": 1 },

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_ci_command.snap
@@ -153,14 +153,25 @@ The --json option is unstable/experimental and its output might change between p
 		},
 		{
 			"severity": "error",
-			"message": "The imports and exports are not sorted.",
+			"message": "Some imports or exports are not organized.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "index.ts",
-				"start": { "line": 1, "column": 1 },
-				"end": { "line": 1, "column": 21 }
+				"start": { "line": 0, "column": 0 },
+				"end": { "line": 0, "column": 0 }
 			},
-			"advices": []
+			"advices": [
+				{
+					"start": { "line": 2, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Sort this chunk of imports."
+				},
+				{
+					"start": { "line": 1, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Safe fix: Organize imports and exports (Biome)"
+				}
+			]
 		},
 		{
 			"severity": "error",
@@ -253,14 +264,25 @@ The --json option is unstable/experimental and its output might change between p
 		},
 		{
 			"severity": "error",
-			"message": "The imports and exports are not sorted.",
+			"message": "Some imports or exports are not organized.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "main.ts",
-				"start": { "line": 1, "column": 1 },
-				"end": { "line": 1, "column": 21 }
+				"start": { "line": 0, "column": 0 },
+				"end": { "line": 0, "column": 0 }
 			},
-			"advices": []
+			"advices": [
+				{
+					"start": { "line": 2, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Sort this chunk of imports."
+				},
+				{
+					"start": { "line": 1, "column": 1 },
+					"end": { "line": 2, "column": 33 },
+					"text": "Safe fix: Organize imports and exports (Biome)"
+				}
+			]
 		},
 		{
 			"severity": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_ci_command.snap
@@ -157,8 +157,8 @@ The --json option is unstable/experimental and its output might change between p
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "index.ts",
-				"start": { "line": 0, "column": 0 },
-				"end": { "line": 0, "column": 0 }
+				"start": { "line": 1, "column": 1 },
+				"end": { "line": 2, "column": 33 }
 			},
 			"advices": [
 				{
@@ -268,8 +268,8 @@ The --json option is unstable/experimental and its output might change between p
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "main.ts",
-				"start": { "line": 0, "column": 0 },
-				"end": { "line": 0, "column": 0 }
+				"start": { "line": 1, "column": 1 },
+				"end": { "line": 2, "column": 33 }
 			},
 			"advices": [
 				{

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_ci_command.snap
@@ -164,7 +164,7 @@ The --json option is unstable/experimental and its output might change between p
 				{
 					"start": { "line": 2, "column": 1 },
 					"end": { "line": 2, "column": 33 },
-					"text": "Sort this chunk of imports."
+					"text": "Sort these imports."
 				},
 				{
 					"start": { "line": 1, "column": 1 },
@@ -275,7 +275,7 @@ The --json option is unstable/experimental and its output might change between p
 				{
 					"start": { "line": 2, "column": 1 },
 					"end": { "line": 2, "column": 33 },
-					"text": "Sort this chunk of imports."
+					"text": "Sort these imports."
 				},
 				{
 					"start": { "line": 1, "column": 1 },

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_ci_command.snap
@@ -153,25 +153,14 @@ The --json option is unstable/experimental and its output might change between p
 		},
 		{
 			"severity": "error",
-			"message": "Some imports or exports are not organized.",
+			"message": "Sort these imports.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "index.ts",
 				"start": { "line": 1, "column": 1 },
 				"end": { "line": 2, "column": 33 }
 			},
-			"advices": [
-				{
-					"start": { "line": 2, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Sort these imports."
-				},
-				{
-					"start": { "line": 1, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Safe fix: Organize imports and exports (Biome)"
-				}
-			]
+			"advices": []
 		},
 		{
 			"severity": "error",
@@ -264,25 +253,14 @@ The --json option is unstable/experimental and its output might change between p
 		},
 		{
 			"severity": "error",
-			"message": "Some imports or exports are not organized.",
+			"message": "Sort these imports.",
 			"category": "assist/source/organizeImports",
 			"location": {
 				"path": "main.ts",
 				"start": { "line": 1, "column": 1 },
 				"end": { "line": 2, "column": 33 }
 			},
-			"advices": [
-				{
-					"start": { "line": 2, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Sort these imports."
-				},
-				{
-					"start": { "line": 1, "column": 1 },
-					"end": { "line": 2, "column": 33 },
-					"text": "Safe fix: Organize imports and exports (Biome)"
-				}
-			]
+			"advices": []
 		},
 		{
 			"severity": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
@@ -88,7 +88,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
+            <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -123,7 +123,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
+            <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
@@ -45,7 +45,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="20" failures="20" errors="16" time="<TIME>">
+<testsuites name="Biome" tests="22" failures="22" errors="16" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
@@ -84,6 +84,11 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
+            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -114,6 +119,11 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
+            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
@@ -45,7 +45,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="22" failures="22" errors="16" time="<TIME>">
+<testsuites name="Biome" tests="20" failures="20" errors="16" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
@@ -84,11 +84,6 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="The imports and exports are not sorted.">line 1, col 1, The imports and exports are not sorted.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -119,11 +114,6 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="The imports and exports are not sorted.">line 1, col 1, The imports and exports are not sorted.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
@@ -6,7 +6,7 @@ expression: redactor(content)
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="20" failures="20" errors="16" time="<TIME>">
+<testsuites name="Biome" tests="22" failures="22" errors="16" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
@@ -45,6 +45,11 @@ expression: redactor(content)
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
+            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -75,6 +80,11 @@ expression: redactor(content)
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
+            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
@@ -49,7 +49,7 @@ expression: redactor(content)
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
+            <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -84,7 +84,7 @@ expression: redactor(content)
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
+            <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
@@ -6,7 +6,7 @@ expression: redactor(content)
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="22" failures="22" errors="16" time="<TIME>">
+<testsuites name="Biome" tests="20" failures="20" errors="16" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
@@ -45,11 +45,6 @@ expression: redactor(content)
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="The imports and exports are not sorted.">line 1, col 1, The imports and exports are not sorted.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -80,11 +75,6 @@ expression: redactor(content)
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="The imports and exports are not sorted.">line 1, col 1, The imports and exports are not sorted.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
@@ -88,7 +88,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
+            <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -123,7 +123,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
+            <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
@@ -45,7 +45,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="22" failures="22" errors="16" time="<TIME>">
+<testsuites name="Biome" tests="20" failures="20" errors="16" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
@@ -84,11 +84,6 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="The imports and exports are not sorted.">line 1, col 1, The imports and exports are not sorted.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -119,11 +114,6 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
-            <failure message="The imports and exports are not sorted.">line 1, col 1, The imports and exports are not sorted.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
@@ -45,7 +45,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="20" failures="20" errors="16" time="<TIME>">
+<testsuites name="Biome" tests="22" failures="22" errors="16" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
@@ -84,6 +84,11 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
+            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -114,6 +119,11 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
+            <failure message="Some imports or exports are not organized.">line 1, col 1, Some imports or exports are not organized.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
@@ -215,20 +215,35 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
       },
-      "location": {
-        "path": "index.ts",
-        "range": {
-          "end": {
-            "column": 21,
-            "line": 1
+      "message": "Some imports or exports are not organized.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 2
+            }
           },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
+          "text": "Sort this chunk of imports."
+        },
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": "Safe fix: Organize imports and exports (Biome)"
         }
-      },
-      "message": "The imports and exports are not sorted."
+      ]
     },
     {
       "code": {
@@ -391,20 +406,35 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
       },
-      "location": {
-        "path": "main.ts",
-        "range": {
-          "end": {
-            "column": 21,
-            "line": 1
+      "message": "Some imports or exports are not organized.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 2
+            }
           },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
+          "text": "Sort this chunk of imports."
+        },
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": "Safe fix: Organize imports and exports (Biome)"
         }
-      },
-      "message": "The imports and exports are not sorted."
+      ]
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
@@ -215,6 +215,19 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
       },
+      "location": {
+        "path": "index.ts",
+        "range": {
+          "end": {
+            "column": 33,
+            "line": 2
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        }
+      },
       "message": "Some imports or exports are not organized.",
       "suggestions": [
         {
@@ -405,6 +418,19 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
       "code": {
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
+      },
+      "location": {
+        "path": "main.ts",
+        "range": {
+          "end": {
+            "column": 33,
+            "line": 2
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        }
       },
       "message": "Some imports or exports are not organized.",
       "suggestions": [

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
@@ -241,7 +241,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
               "line": 2
             }
           },
-          "text": "Sort this chunk of imports."
+          "text": "Sort these imports."
         },
         {
           "range": {
@@ -445,7 +445,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
               "line": 2
             }
           },
-          "text": "Sort this chunk of imports."
+          "text": "Sort these imports."
         },
         {
           "range": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
@@ -228,35 +228,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Some imports or exports are not organized.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 2
-            }
-          },
-          "text": "Sort these imports."
-        },
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 1
-            }
-          },
-          "text": "Safe fix: Organize imports and exports (Biome)"
-        }
-      ]
+      "message": "Sort these imports."
     },
     {
       "code": {
@@ -432,35 +404,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Some imports or exports are not organized.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 2
-            }
-          },
-          "text": "Sort these imports."
-        },
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 1
-            }
-          },
-          "text": "Safe fix: Organize imports and exports (Biome)"
-        }
-      ]
+      "message": "Sort these imports."
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
@@ -176,6 +176,19 @@ expression: redactor(content)
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
       },
+      "location": {
+        "path": "index.ts",
+        "range": {
+          "end": {
+            "column": 33,
+            "line": 2
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        }
+      },
       "message": "Some imports or exports are not organized.",
       "suggestions": [
         {
@@ -366,6 +379,19 @@ expression: redactor(content)
       "code": {
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
+      },
+      "location": {
+        "path": "main.ts",
+        "range": {
+          "end": {
+            "column": 33,
+            "line": 2
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        }
       },
       "message": "Some imports or exports are not organized.",
       "suggestions": [

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
@@ -176,20 +176,35 @@ expression: redactor(content)
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
       },
-      "location": {
-        "path": "index.ts",
-        "range": {
-          "end": {
-            "column": 21,
-            "line": 1
+      "message": "Some imports or exports are not organized.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 2
+            }
           },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
+          "text": "Sort this chunk of imports."
+        },
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": "Safe fix: Organize imports and exports (Biome)"
         }
-      },
-      "message": "The imports and exports are not sorted."
+      ]
     },
     {
       "code": {
@@ -352,20 +367,35 @@ expression: redactor(content)
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
       },
-      "location": {
-        "path": "main.ts",
-        "range": {
-          "end": {
-            "column": 21,
-            "line": 1
+      "message": "Some imports or exports are not organized.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 2
+            }
           },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
+          "text": "Sort this chunk of imports."
+        },
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": "Safe fix: Organize imports and exports (Biome)"
         }
-      },
-      "message": "The imports and exports are not sorted."
+      ]
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
@@ -202,7 +202,7 @@ expression: redactor(content)
               "line": 2
             }
           },
-          "text": "Sort this chunk of imports."
+          "text": "Sort these imports."
         },
         {
           "range": {
@@ -406,7 +406,7 @@ expression: redactor(content)
               "line": 2
             }
           },
-          "text": "Sort this chunk of imports."
+          "text": "Sort these imports."
         },
         {
           "range": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
@@ -189,35 +189,7 @@ expression: redactor(content)
           }
         }
       },
-      "message": "Some imports or exports are not organized.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 2
-            }
-          },
-          "text": "Sort these imports."
-        },
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 1
-            }
-          },
-          "text": "Safe fix: Organize imports and exports (Biome)"
-        }
-      ]
+      "message": "Sort these imports."
     },
     {
       "code": {
@@ -393,35 +365,7 @@ expression: redactor(content)
           }
         }
       },
-      "message": "Some imports or exports are not organized.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 2
-            }
-          },
-          "text": "Sort these imports."
-        },
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 1
-            }
-          },
-          "text": "Safe fix: Organize imports and exports (Biome)"
-        }
-      ]
+      "message": "Sort these imports."
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
@@ -215,20 +215,35 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
       },
-      "location": {
-        "path": "index.ts",
-        "range": {
-          "end": {
-            "column": 21,
-            "line": 1
+      "message": "Some imports or exports are not organized.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 2
+            }
           },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
+          "text": "Sort this chunk of imports."
+        },
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": "Safe fix: Organize imports and exports (Biome)"
         }
-      },
-      "message": "The imports and exports are not sorted."
+      ]
     },
     {
       "code": {
@@ -391,20 +406,35 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
       },
-      "location": {
-        "path": "main.ts",
-        "range": {
-          "end": {
-            "column": 21,
-            "line": 1
+      "message": "Some imports or exports are not organized.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 2
+            }
           },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
+          "text": "Sort this chunk of imports."
+        },
+        {
+          "range": {
+            "end": {
+              "column": 33,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": "Safe fix: Organize imports and exports (Biome)"
         }
-      },
-      "message": "The imports and exports are not sorted."
+      ]
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
@@ -215,6 +215,19 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
       },
+      "location": {
+        "path": "index.ts",
+        "range": {
+          "end": {
+            "column": 33,
+            "line": 2
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        }
+      },
       "message": "Some imports or exports are not organized.",
       "suggestions": [
         {
@@ -405,6 +418,19 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
       "code": {
         "url": "https://biomejs.dev/assist/actions/organize-imports",
         "value": "assist/source/organizeImports"
+      },
+      "location": {
+        "path": "main.ts",
+        "range": {
+          "end": {
+            "column": 33,
+            "line": 2
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        }
       },
       "message": "Some imports or exports are not organized.",
       "suggestions": [

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
@@ -228,35 +228,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Some imports or exports are not organized.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 2
-            }
-          },
-          "text": "Sort these imports."
-        },
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 1
-            }
-          },
-          "text": "Safe fix: Organize imports and exports (Biome)"
-        }
-      ]
+      "message": "Sort these imports."
     },
     {
       "code": {
@@ -432,35 +404,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Some imports or exports are not organized.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 2
-            }
-          },
-          "text": "Sort these imports."
-        },
-        {
-          "range": {
-            "end": {
-              "column": 33,
-              "line": 2
-            },
-            "start": {
-              "column": 1,
-              "line": 1
-            }
-          },
-          "text": "Safe fix: Organize imports and exports (Biome)"
-        }
-      ]
+      "message": "Sort these imports."
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
@@ -241,7 +241,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
               "line": 2
             }
           },
-          "text": "Sort this chunk of imports."
+          "text": "Sort these imports."
         },
         {
           "range": {
@@ -445,7 +445,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
               "line": 2
             }
           },
-          "text": "Sort this chunk of imports."
+          "text": "Sort these imports."
         },
         {
           "range": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_check_command.snap
@@ -294,7 +294,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           "ruleId": "assist/source/organizeImports",
           "level": "error",
           "message": {
-            "text": "Some imports or exports are not organized."
+            "text": "Sort these imports."
           },
           "locations": [
             {
@@ -464,7 +464,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           "ruleId": "assist/source/organizeImports",
           "level": "error",
           "message": {
-            "text": "Some imports or exports are not organized."
+            "text": "Sort these imports."
           },
           "locations": [
             {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_check_command.snap
@@ -301,6 +301,12 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "index.ts"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 2,
+                  "endColumn": 33
                 }
               }
             }
@@ -465,6 +471,12 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "main.ts"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 2,
+                  "endColumn": 33
                 }
               }
             }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_check_command.snap
@@ -294,19 +294,13 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           "ruleId": "assist/source/organizeImports",
           "level": "error",
           "message": {
-            "text": "The imports and exports are not sorted."
+            "text": "Some imports or exports are not organized."
           },
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "index.ts"
-                },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 21
                 }
               }
             }
@@ -464,19 +458,13 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           "ruleId": "assist/source/organizeImports",
           "level": "error",
           "message": {
-            "text": "The imports and exports are not sorted."
+            "text": "Some imports or exports are not organized."
           },
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "main.ts"
-                },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 21
                 }
               }
             }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_ci_command.snap
@@ -301,6 +301,12 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "index.ts"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 2,
+                  "endColumn": 33
                 }
               }
             }
@@ -465,6 +471,12 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "main.ts"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 2,
+                  "endColumn": 33
                 }
               }
             }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_ci_command.snap
@@ -294,7 +294,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           "ruleId": "assist/source/organizeImports",
           "level": "error",
           "message": {
-            "text": "Some imports or exports are not organized."
+            "text": "Sort these imports."
           },
           "locations": [
             {
@@ -464,7 +464,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           "ruleId": "assist/source/organizeImports",
           "level": "error",
           "message": {
-            "text": "Some imports or exports are not organized."
+            "text": "Sort these imports."
           },
           "locations": [
             {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_sarif/reports_diagnostics_sarif_ci_command.snap
@@ -294,19 +294,13 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           "ruleId": "assist/source/organizeImports",
           "level": "error",
           "message": {
-            "text": "The imports and exports are not sorted."
+            "text": "Some imports or exports are not organized."
           },
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "index.ts"
-                },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 21
                 }
               }
             }
@@ -464,19 +458,13 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           "ruleId": "assist/source/organizeImports",
           "level": "error",
           "message": {
-            "text": "The imports and exports are not sorted."
+            "text": "Some imports or exports are not organized."
           },
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "main.ts"
-                },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 21
                 }
               }
             }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
@@ -142,9 +142,16 @@ index.css format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-index.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+index.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Some imports or exports are not organized.
+  
+  > 1 │ import { z} from "z"
+      │ ^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import { z, b , a} from "lodash"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ a ==b
   
   i Sort the imported names.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
@@ -142,16 +142,28 @@ index.css format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-index.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+index.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The imports and exports are not sorted.
+  × Some imports or exports are not organized.
+  
+  i Sort the imported names.
+  
+    1 │ import { z} from "z"
+  > 2 │ import { z, b , a} from "lodash"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ a ==b
+  
+  i Sort this chunk of imports.
   
   > 1 │ import { z} from "z"
       │ ^^^^^^^^^^^^^^^^^^^^
-    2 │ import { z, b , a} from "lodash"
+  > 2 │ import { z, b , a} from "lodash"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     3 │ 
+    4 │ a ==b
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
      1    │ - import·{·z}·from·"z"
      2    │ - import·{·z,·b·,·a}·from·"lodash"

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
@@ -144,24 +144,7 @@ index.css format ━━━━━━━━━━━━━━━━━━━━━
 ```block
 index.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Some imports or exports are not organized.
-  
-  > 1 │ import { z} from "z"
-      │ ^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import { z, b , a} from "lodash"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ 
-    4 │ a ==b
-  
-  i Sort the imported names.
-  
-    1 │ import { z} from "z"
-  > 2 │ import { z, b , a} from "lodash"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ 
-    4 │ a ==b
-  
-  i Sort these imports.
+  × Sort these imports.
   
   > 1 │ import { z} from "z"
       │ ^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
@@ -161,7 +161,7 @@ index.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━
     3 │ 
     4 │ a ==b
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import { z} from "z"
       │ ^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_file.snap
@@ -53,16 +53,28 @@ index.css format ━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
   
-index.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+index.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ The imports and exports are not sorted.
+  ✖ Some imports or exports are not organized.
+  
+  ℹ Sort the imported names.
+  
+    1 │ import { z} from "z"
+  > 2 │ import { z, b , a} from "lodash"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ a ==b
+  
+  ℹ Sort this chunk of imports.
   
   > 1 │ import { z} from "z"
       │ ^^^^^^^^^^^^^^^^^^^^
-    2 │ import { z, b , a} from "lodash"
+  > 2 │ import { z, b , a} from "lodash"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     3 │ 
+    4 │ a ==b
   
-  ℹ Safe fix: Organize Imports (Biome)
+  ℹ Safe fix: Organize imports and exports (Biome)
   
      1    │ - import·{·z}·from·"z"
      2    │ - import·{·z,·b·,·a}·from·"lodash"

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_file.snap
@@ -72,7 +72,7 @@ index.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━
     3 │ 
     4 │ a ==b
   
-  ℹ Sort this chunk of imports.
+  ℹ Sort these imports.
   
   > 1 │ import { z} from "z"
       │ ^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_file.snap
@@ -55,24 +55,7 @@ index.css format ━━━━━━━━━━━━━━━━━━━━━
   
 index.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Some imports or exports are not organized.
-  
-  > 1 │ import { z} from "z"
-      │ ^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import { z, b , a} from "lodash"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ 
-    4 │ a ==b
-  
-  ℹ Sort the imported names.
-  
-    1 │ import { z} from "z"
-  > 2 │ import { z, b , a} from "lodash"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ 
-    4 │ a ==b
-  
-  ℹ Sort these imports.
+  ✖ Sort these imports.
   
   > 1 │ import { z} from "z"
       │ ^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_file.snap
@@ -53,9 +53,16 @@ index.css format ━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
   
-index.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+index.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Some imports or exports are not organized.
+  
+  > 1 │ import { z} from "z"
+      │ ^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import { z, b , a} from "lodash"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ a ==b
   
   ℹ Sort the imported names.
   

--- a/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check_when_enforced.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check_when_enforced.snap
@@ -64,9 +64,14 @@ check.js:2:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━�
 ```
 
 ```block
-check.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+check.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Some imports or exports are not organized.
+  
+  > 1 │ import { lorem, foom, bar } from "foo";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ import * as something from "../something";
+    3 │ 
   
   i Sort the imported names.
   

--- a/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check_when_enforced.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check_when_enforced.snap
@@ -66,14 +66,7 @@ check.js:2:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━�
 ```block
 check.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Some imports or exports are not organized.
-  
-  > 1 │ import { lorem, foom, bar } from "foo";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import * as something from "../something";
-    3 │ 
-  
-  i Sort the imported names.
+  × Sort the imported names.
   
   > 1 │ import { lorem, foom, bar } from "foo";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check_when_enforced.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check_when_enforced.snap
@@ -64,16 +64,18 @@ check.js:2:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━�
 ```
 
 ```block
-check.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+check.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The imports and exports are not sorted.
+  × Some imports or exports are not organized.
+  
+  i Sort the imported names.
   
   > 1 │ import { lorem, foom, bar } from "foo";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ import * as something from "../something";
     3 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·{·lorem,·foom,·bar·}·from·"foo";
       1 │ + import·{·bar,·foom,·lorem·}·from·"foo";

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
@@ -90,16 +90,19 @@ file.js:3:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━�
 ```
 
 ```block
-file.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The imports and exports are not sorted.
+  × Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 2 │ import { B, C } from "b.js"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import A from "a.js"
+  > 3 │ import A from "a.js"
+      │ ^^^^^^^^^^^^^^^^^^^^
     4 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   
     2   │ - import·{·B,·C·}·from·"b.js"

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
@@ -92,7 +92,7 @@ file.js:3:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━�
 ```block
 file.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Sort this chunk of imports.
+  × Sort these imports.
   
   > 2 │ import { B, C } from "b.js"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
@@ -92,15 +92,7 @@ file.js:3:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━�
 ```block
 file.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Some imports or exports are not organized.
-  
-  > 2 │ import { B, C } from "b.js"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 3 │ import A from "a.js"
-      │ ^^^^^^^^^^^^^^^^^^^^
-    4 │ 
-  
-  i Sort this chunk of imports.
+  × Sort this chunk of imports.
   
   > 2 │ import { B, C } from "b.js"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_formatter_linter_organize_imports.snap
@@ -90,9 +90,15 @@ file.js:3:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━�
 ```
 
 ```block
-file.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Some imports or exports are not organized.
+  
+  > 2 │ import { B, C } from "b.js"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ import A from "a.js"
+      │ ^^^^^^^^^^^^^^^^^^^^
+    4 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -766,7 +766,7 @@ impl Rule for OrganizeImports {
         let root = ctx.query();
         let root_items = root.items();
         let mut located_issue_kinds: Vec<LocatedIssueKind> = Vec::with_capacity(state.len());
-        let mut last_unsorted_chunk_message_index = 0;
+        let mut next_unsorted_chunk_message_index = 0;
         let mut action_range: Option<TextRange> = None;
         for issue in state {
             let located_issue_kind = match issue {
@@ -818,8 +818,8 @@ impl Rule for OrganizeImports {
                         .syntax()
                         .text_trimmed_range()
                         .cover(last_text_range);
-                    let mut i = last_unsorted_chunk_message_index + 1;
-                    // Remove issues that are covered by the current one.
+                    let mut i = next_unsorted_chunk_message_index;
+                    // Remove issues that are covered by the unsorted chunk diagnostic.
                     while i < located_issue_kinds.len() {
                         if range.contains_range(located_issue_kinds[i].range) {
                             located_issue_kinds.remove(i);
@@ -827,7 +827,7 @@ impl Rule for OrganizeImports {
                             i += 1;
                         }
                     }
-                    last_unsorted_chunk_message_index = located_issue_kinds.len();
+                    next_unsorted_chunk_message_index = located_issue_kinds.len() + 1;
                     let kind = if matches!(first_stmt, AnyJsModuleItem::JsImport(_)) {
                         IssueKind::UnsortedImportChunk
                     } else {

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -768,13 +768,15 @@ impl Rule for OrganizeImports {
         let root_items = root.items();
         let mut located_issue_kinds: Vec<LocatedIssueKind> = Vec::with_capacity(state.len());
         let mut last_unsorted_chunk_message_index = 0;
+        let mut action_range: Option<TextRange> = None;
         for issue in state {
             let located_issue_kind = match issue {
                 Issue::AddLeadingNewline { slot_index } => {
                     let statement = root_items.iter().nth(*slot_index as usize)?;
                     let statement = statement.syntax();
+                    let range = statement.text_trimmed_range();
                     LocatedIssueKind {
-                        range: statement.text_trimmed_range(),
+                        range,
                         kind: IssueKind::MissingNewlineBetweenChunks,
                     }
                 }
@@ -786,7 +788,7 @@ impl Rule for OrganizeImports {
                 } => {
                     let statement = root_items.iter().nth(*slot_index as usize)?;
                     let statement = statement.syntax();
-                    let issue_kind = if *are_specifiers_unsorted {
+                    let kind = if *are_specifiers_unsorted {
                         if statement.kind() == JsSyntaxKind::JS_IMPORT {
                             IssueKind::UnorganizedImportedNames
                         } else {
@@ -806,10 +808,8 @@ impl Rule for OrganizeImports {
                             }
                         }
                     };
-                    LocatedIssueKind {
-                        range: statement.text_trimmed_range(),
-                        kind: issue_kind,
-                    }
+                    let range = statement.text_trimmed_range();
+                    LocatedIssueKind { range, kind }
                 }
                 Issue::UnsortedChunk { slot_indexes } => {
                     let first_statement = root_items.iter().nth(slot_indexes.start as usize)?;
@@ -819,33 +819,35 @@ impl Rule for OrganizeImports {
                         .nth((slot_indexes.end - 1) as usize)?
                         .syntax()
                         .text_trimmed_range();
-                    let text_range = first_statement.text_trimmed_range().cover(last_text_range);
+                    let range = first_statement.text_trimmed_range().cover(last_text_range);
                     let mut i = last_unsorted_chunk_message_index + 1;
                     // Remove issues that are covered by the current one.
                     while i < located_issue_kinds.len() {
-                        if text_range.contains_range(located_issue_kinds[i].range) {
+                        if range.contains_range(located_issue_kinds[i].range) {
                             located_issue_kinds.remove(i);
                         } else {
                             i += 1;
                         }
                     }
                     last_unsorted_chunk_message_index = located_issue_kinds.len();
-                    let issue_kind = if first_statement.kind() == JsSyntaxKind::JS_IMPORT {
+                    let kind = if first_statement.kind() == JsSyntaxKind::JS_IMPORT {
                         IssueKind::UnsortedImportChunk
                     } else {
                         IssueKind::UnsortedExportChunk
                     };
-                    LocatedIssueKind {
-                        range: text_range,
-                        kind: issue_kind,
-                    }
+                    LocatedIssueKind { range, kind }
                 }
             };
+            action_range = Some(if let Some(action_range) = action_range {
+                action_range.cover(located_issue_kind.range.clone())
+            } else {
+                located_issue_kind.range.clone()
+            });
             located_issue_kinds.push(located_issue_kind);
         }
         let mut diagnostic = RuleDiagnostic::new(
             category!("assist/source/organizeImports"),
-            None as Option<TextRange>,
+            action_range.or_else(|| Self::text_range(ctx, state)),
             markup! {
                 "Some imports or exports are not organized."
             },

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -15,7 +15,8 @@ use biome_js_syntax::{
     JsModuleItemList, JsSyntaxKind, T, TsDeclarationModule, TsModuleBlock,
 };
 use biome_rowan::{
-    AstNode, BatchMutationExt, TextRange, TriviaPieceKind, chain_trivia_pieces, declare_node_union,
+    AstNode, AstNodeList, BatchMutationExt, TextRange, TriviaPieceKind, chain_trivia_pieces,
+    declare_node_union,
 };
 use biome_rule_options::{organize_imports::OrganizeImportsOptions, sort_order::SortOrder};
 use import_key::{ImportInfo, ImportKey};
@@ -729,13 +730,131 @@ impl Rule for OrganizeImports {
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic::new(
+        enum IssueKind {
+            MissingNewlineBetweenChunks,
+            MissingNewlineBetweenGroups,
+            ExtraNewlines,
+            UnorganizedImportedNames,
+            UnorganizedExportedNames,
+            UnorganizedAttributes,
+            UnsortedImportChunk,
+            UnsortedExportChunk,
+        }
+        impl IssueKind {
+            const fn message(self) -> &'static str {
+                match self {
+                    Self::MissingNewlineBetweenChunks => {
+                        "This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement."
+                    }
+                    Self::MissingNewlineBetweenGroups => {
+                        "This statement ends a group that must be preceded by a blank line. Add a newline before this statement."
+                    }
+                    Self::ExtraNewlines => {
+                        "There are too many newlines preceding this statement. Remove these extra newlines."
+                    }
+                    Self::UnorganizedImportedNames => "Sort the imported names.",
+                    Self::UnorganizedExportedNames => "Sort the exported names.",
+                    Self::UnorganizedAttributes => "Sort the attributes.",
+                    Self::UnsortedImportChunk => "Sort this chunk of imports.",
+                    Self::UnsortedExportChunk => "Sort this chunk of exports.",
+                }
+            }
+        }
+        struct LocatedIssueKind {
+            range: TextRange,
+            kind: IssueKind,
+        }
+        let root = ctx.query();
+        let root_items = root.items();
+        let mut located_issue_kinds: Vec<LocatedIssueKind> = Vec::with_capacity(state.len());
+        let mut last_unsorted_chunk_message_index = 0;
+        for issue in state {
+            let located_issue_kind = match issue {
+                Issue::AddLeadingNewline { slot_index } => {
+                    let statement = root_items.iter().nth(*slot_index as usize)?;
+                    let statement = statement.syntax();
+                    LocatedIssueKind {
+                        range: statement.text_trimmed_range(),
+                        kind: IssueKind::MissingNewlineBetweenChunks,
+                    }
+                }
+                Issue::UnorganizedItem {
+                    slot_index,
+                    are_attributes_unsorted,
+                    are_specifiers_unsorted,
+                    newline_issue,
+                } => {
+                    let statement = root_items.iter().nth(*slot_index as usize)?;
+                    let statement = statement.syntax();
+                    let issue_kind = if *are_specifiers_unsorted {
+                        if statement.kind() == JsSyntaxKind::JS_IMPORT {
+                            IssueKind::UnorganizedImportedNames
+                        } else {
+                            IssueKind::UnorganizedExportedNames
+                        }
+                    } else if *are_attributes_unsorted {
+                        IssueKind::UnorganizedAttributes
+                    } else {
+                        match newline_issue {
+                            NewLineIssue::None => unreachable!(
+                                "Issue::UnorganizedItem must report at least one issue."
+                            ),
+                            NewLineIssue::ExtraNewLine => IssueKind::ExtraNewlines,
+                            NewLineIssue::MissingNewLine => IssueKind::MissingNewlineBetweenChunks,
+                            NewLineIssue::MissingNewLineBetweenGroups => {
+                                IssueKind::MissingNewlineBetweenGroups
+                            }
+                        }
+                    };
+                    LocatedIssueKind {
+                        range: statement.text_trimmed_range(),
+                        kind: issue_kind,
+                    }
+                }
+                Issue::UnsortedChunk { slot_indexes } => {
+                    let first_statement = root_items.iter().nth(slot_indexes.start as usize)?;
+                    let first_statement = first_statement.syntax();
+                    let last_text_range = root_items
+                        .iter()
+                        .nth((slot_indexes.end - 1) as usize)?
+                        .syntax()
+                        .text_trimmed_range();
+                    let text_range = first_statement.text_trimmed_range().cover(last_text_range);
+                    let mut i = last_unsorted_chunk_message_index + 1;
+                    // Remove issues that are covered by the current one.
+                    while i < located_issue_kinds.len() {
+                        if text_range.contains_range(located_issue_kinds[i].range) {
+                            located_issue_kinds.remove(i);
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    last_unsorted_chunk_message_index = located_issue_kinds.len();
+                    let issue_kind = if first_statement.kind() == JsSyntaxKind::JS_IMPORT {
+                        IssueKind::UnsortedImportChunk
+                    } else {
+                        IssueKind::UnsortedExportChunk
+                    };
+                    LocatedIssueKind {
+                        range: text_range,
+                        kind: issue_kind,
+                    }
+                }
+            };
+            located_issue_kinds.push(located_issue_kind);
+        }
+        let mut diagnostic = RuleDiagnostic::new(
             category!("assist/source/organizeImports"),
-            Self::text_range(ctx, state),
+            None as Option<TextRange>,
             markup! {
-                "The imports and exports are not sorted."
+                "Some imports or exports are not organized."
             },
-        ))
+        );
+        for located_issue_kind in located_issue_kinds {
+            diagnostic =
+                diagnostic.detail(located_issue_kind.range, located_issue_kind.kind.message());
+        }
+        Some(diagnostic)
     }
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -756,7 +875,7 @@ impl Rule for OrganizeImports {
             if let Some(chunk) = chunk
                 && !chunk.slot_indexes.is_empty()
             {
-                result.push(Issue::UnsortedChunkPrefix {
+                result.push(Issue::UnsortedChunk {
                     slot_indexes: chunk.slot_indexes,
                 });
             }
@@ -800,7 +919,11 @@ impl Rule for OrganizeImports {
                     // Some groups must be separated by a blank line
                     blank_line_separated_groups)
                 {
-                    NewLineIssue::MissingNewLine
+                    if blank_line_separated_groups {
+                        NewLineIssue::MissingNewLineBetweenGroups
+                    } else {
+                        NewLineIssue::MissingNewLine
+                    }
                 } else if leading_newline_count > 1
                     && !starts_chunk
                     // Ignore blank lines when groups are not explicitly set
@@ -815,9 +938,9 @@ impl Rule for OrganizeImports {
                 };
                 if are_specifiers_unsorted
                     || are_attributes_unsorted
-                    || !matches!(newline_issue, NewLineIssue::None)
+                    || newline_issue != NewLineIssue::None
                 {
-                    // Report the violation of one of the previous requirement
+                    // Report the violation of one of the previous requirements
                     result.push(Issue::UnorganizedItem {
                         slot_index: key.slot_index,
                         are_specifiers_unsorted,
@@ -969,7 +1092,8 @@ impl Rule for OrganizeImports {
                                 .skip(leading_newlines(&item).count() - 1);
                             item = item.with_leading_trivia_pieces(leading_trivia)?;
                         }
-                        NewLineIssue::MissingNewLine => {
+                        NewLineIssue::MissingNewLine
+                        | NewLineIssue::MissingNewLineBetweenGroups => {
                             // Add missing newline
                             let newline = leading_newlines(&item).next();
                             item = item.prepend_trivia_pieces(newline.into_iter())?
@@ -978,7 +1102,7 @@ impl Rule for OrganizeImports {
                     // Save the node
                     organized_items.insert(*slot_index, AnyJsModuleItem::cast(item)?);
                 }
-                Issue::UnsortedChunkPrefix { slot_indexes } => {
+                Issue::UnsortedChunk { slot_indexes } => {
                     debug_assert!(import_keys.is_empty(), "import_keys was previously drained");
                     // Collect all import keys and the associated items.
                     import_keys.reserve(slot_indexes.len());
@@ -1113,7 +1237,7 @@ impl Rule for OrganizeImports {
         Some(JsRuleAction::new(
             ActionCategory::Source(SourceActionKind::OrganizeImports),
             ctx.metadata().applicability(),
-            "Organize Imports (Biome)",
+            "Organize imports and exports (Biome)",
             mutation,
         ))
     }
@@ -1138,11 +1262,6 @@ pub enum Issue {
         // Slot index of a statement that must starts with a blank line
         slot_index: u32,
     },
-    /// Prefix of an unsorted chunk of imports or exports
-    UnsortedChunkPrefix {
-        /// Slot indexes of all the first imports or exports.
-        slot_indexes: std::ops::Range<u32>,
-    },
     /// Import or export with one or several of the following issues:
     /// - has unsorted specifiers
     /// - has unsorted attributes
@@ -1154,14 +1273,20 @@ pub enum Issue {
         are_specifiers_unsorted: bool,
         newline_issue: NewLineIssue,
     },
+    /// Unsorted chunk of imports or exports
+    UnsortedChunk {
+        /// Slot indexes of all the first imports or exports.
+        slot_indexes: std::ops::Range<u32>,
+    },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum NewLineIssue {
     /// No issue
     None,
     ExtraNewLine,
     MissingNewLine,
+    MissingNewLineBetweenGroups,
 }
 
 fn merge(

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -743,7 +743,7 @@ impl Rule for OrganizeImports {
             const fn message(&self) -> &'static str {
                 match self {
                     Self::MissingNewlineBetweenChunks => {
-                        "This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement."
+                        "This statement must be preceded by a blank line. Add a newline before this statement."
                     }
                     Self::MissingNewlineBetweenGroups => {
                         "This statement ends a group that must be preceded by a blank line. Add a newline before this statement."
@@ -754,8 +754,8 @@ impl Rule for OrganizeImports {
                     Self::UnorganizedImportedNames => "Sort the imported names.",
                     Self::UnorganizedExportedNames => "Sort the exported names.",
                     Self::UnorganizedAttributes => "Sort the attributes.",
-                    Self::UnsortedImportChunk => "Sort this chunk of imports.",
-                    Self::UnsortedExportChunk => "Sort this chunk of exports.",
+                    Self::UnsortedImportChunk => "Sort these imports.",
+                    Self::UnsortedExportChunk => "Sort these exports.",
                 }
             }
         }
@@ -814,7 +814,10 @@ impl Rule for OrganizeImports {
                         .nth((slot_indexes.end - 1) as usize)?
                         .syntax()
                         .text_trimmed_range();
-                    let range = first_stmt.syntax().text_trimmed_range().cover(last_text_range);
+                    let range = first_stmt
+                        .syntax()
+                        .text_trimmed_range()
+                        .cover(last_text_range);
                     let mut i = last_unsorted_chunk_message_index + 1;
                     // Remove issues that are covered by the current one.
                     while i < located_issue_kinds.len() {
@@ -841,7 +844,9 @@ impl Rule for OrganizeImports {
             located_issue_kinds.push(located_issue_kind);
         }
         // If we have only one detailed diagnostic, then use it as main diagnostic.
-        if located_issue_kinds.len() == 1 && let Some(localized) = located_issue_kinds.first() {
+        if located_issue_kinds.len() == 1
+            && let Some(localized) = located_issue_kinds.first()
+        {
             Some(RuleDiagnostic::new(
                 category!("assist/source/organizeImports"),
                 localized.range,
@@ -851,7 +856,7 @@ impl Rule for OrganizeImports {
             let mut diagnostic = RuleDiagnostic::new(
                 category!("assist/source/organizeImports"),
                 action_range.or_else(|| Self::text_range(ctx, state)),
-                "Some imports or exports are not organized."
+                "Some imports or exports are not organized.",
             );
             for located_issue_kind in located_issue_kinds {
                 diagnostic =

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -7,7 +7,6 @@ use biome_analyze::{
     ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource, SourceActionKind,
     context::RuleContext, declare_source_rule,
 };
-use biome_console::markup;
 use biome_diagnostics::category;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -741,7 +740,7 @@ impl Rule for OrganizeImports {
             UnsortedExportChunk,
         }
         impl IssueKind {
-            const fn message(self) -> &'static str {
+            const fn message(&self) -> &'static str {
                 match self {
                     Self::MissingNewlineBetweenChunks => {
                         "This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement."
@@ -773,10 +772,8 @@ impl Rule for OrganizeImports {
             let located_issue_kind = match issue {
                 Issue::AddLeadingNewline { slot_index } => {
                     let statement = root_items.iter().nth(*slot_index as usize)?;
-                    let statement = statement.syntax();
-                    let range = statement.text_trimmed_range();
                     LocatedIssueKind {
-                        range,
+                        range: statement.syntax().text_trimmed_range(),
                         kind: IssueKind::MissingNewlineBetweenChunks,
                     }
                 }
@@ -787,9 +784,8 @@ impl Rule for OrganizeImports {
                     newline_issue,
                 } => {
                     let statement = root_items.iter().nth(*slot_index as usize)?;
-                    let statement = statement.syntax();
                     let kind = if *are_specifiers_unsorted {
-                        if statement.kind() == JsSyntaxKind::JS_IMPORT {
+                        if matches!(statement, AnyJsModuleItem::JsImport(_)) {
                             IssueKind::UnorganizedImportedNames
                         } else {
                             IssueKind::UnorganizedExportedNames
@@ -808,18 +804,17 @@ impl Rule for OrganizeImports {
                             }
                         }
                     };
-                    let range = statement.text_trimmed_range();
+                    let range = statement.syntax().text_trimmed_range();
                     LocatedIssueKind { range, kind }
                 }
                 Issue::UnsortedChunk { slot_indexes } => {
-                    let first_statement = root_items.iter().nth(slot_indexes.start as usize)?;
-                    let first_statement = first_statement.syntax();
+                    let first_stmt = root_items.iter().nth(slot_indexes.start as usize)?;
                     let last_text_range = root_items
                         .iter()
                         .nth((slot_indexes.end - 1) as usize)?
                         .syntax()
                         .text_trimmed_range();
-                    let range = first_statement.text_trimmed_range().cover(last_text_range);
+                    let range = first_stmt.syntax().text_trimmed_range().cover(last_text_range);
                     let mut i = last_unsorted_chunk_message_index + 1;
                     // Remove issues that are covered by the current one.
                     while i < located_issue_kinds.len() {
@@ -830,7 +825,7 @@ impl Rule for OrganizeImports {
                         }
                     }
                     last_unsorted_chunk_message_index = located_issue_kinds.len();
-                    let kind = if first_statement.kind() == JsSyntaxKind::JS_IMPORT {
+                    let kind = if matches!(first_stmt, AnyJsModuleItem::JsImport(_)) {
                         IssueKind::UnsortedImportChunk
                     } else {
                         IssueKind::UnsortedExportChunk
@@ -839,24 +834,31 @@ impl Rule for OrganizeImports {
                 }
             };
             action_range = Some(if let Some(action_range) = action_range {
-                action_range.cover(located_issue_kind.range.clone())
+                action_range.cover(located_issue_kind.range)
             } else {
-                located_issue_kind.range.clone()
+                located_issue_kind.range
             });
             located_issue_kinds.push(located_issue_kind);
         }
-        let mut diagnostic = RuleDiagnostic::new(
-            category!("assist/source/organizeImports"),
-            action_range.or_else(|| Self::text_range(ctx, state)),
-            markup! {
+        // If we have only one detailed diagnostic, then use it as main diagnostic.
+        if located_issue_kinds.len() == 1 && let Some(localized) = located_issue_kinds.first() {
+            Some(RuleDiagnostic::new(
+                category!("assist/source/organizeImports"),
+                localized.range,
+                localized.kind.message(),
+            ))
+        } else {
+            let mut diagnostic = RuleDiagnostic::new(
+                category!("assist/source/organizeImports"),
+                action_range.or_else(|| Self::text_range(ctx, state)),
                 "Some imports or exports are not organized."
-            },
-        );
-        for located_issue_kind in located_issue_kinds {
-            diagnostic =
-                diagnostic.detail(located_issue_kind.range, located_issue_kind.kind.message());
+            );
+            for located_issue_kind in located_issue_kinds {
+                diagnostic =
+                    diagnostic.detail(located_issue_kind.range, located_issue_kind.kind.message());
+            }
+            Some(diagnostic)
         }
-        Some(diagnostic)
     }
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk-with-bare-export.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk-with-bare-export.js.snap
@@ -13,7 +13,7 @@ export { A };
 ```
 chunk-with-bare-export.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  i This statement must be preceded by a blank line. Add a newline before this statement.
   
     1 │ import { A } from "package";
   > 2 │ export { A };

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk-with-bare-export.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk-with-bare-export.js.snap
@@ -11,16 +11,18 @@ export { A };
 
 # Diagnostics
 ```
-chunk-with-bare-export.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+chunk-with-bare-export.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
   
-  > 1 │ import { A } from "package";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ export { A };
+  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  
+    1 │ import { A } from "package";
+  > 2 │ export { A };
+      │ ^^^^^^^^^^^^^
     3 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   import { A } from "package";
       2 │ + 

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk-with-bare-export.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk-with-bare-export.js.snap
@@ -11,9 +11,14 @@ export { A };
 
 # Diagnostics
 ```
-chunk-with-bare-export.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+chunk-with-bare-export.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+    1 │ import { A } from "package";
+  > 2 │ export { A };
+      │ ^^^^^^^^^^^^^
+    3 │ 
   
   i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk-with-bare-export.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk-with-bare-export.js.snap
@@ -13,13 +13,6 @@ export { A };
 ```
 chunk-with-bare-export.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-    1 │ import { A } from "package";
-  > 2 │ export { A };
-      │ ^^^^^^^^^^^^^
-    3 │ 
-  
   i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
   
     1 │ import { A } from "package";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk_newline.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk_newline.js.snap
@@ -14,16 +14,28 @@ import { A } from "a";
 
 # Diagnostics
 ```
-chunk_newline.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+chunk_newline.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
   
-  > 1 │ import { C } from "c";
-      │ ^^^^^^^^^^^^^^^^^^^^^^
+  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  
     2 │ import "a";
     3 │ import { B } from "b";
+  > 4 │ f();
+      │ ^^^^
+    5 │ import { A } from "a";
+    6 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  
+    3 │ import { B } from "b";
+    4 │ f();
+  > 5 │ import { A } from "a";
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
     2 2 │   import "a";
     3 3 │   import { B } from "b";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk_newline.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk_newline.js.snap
@@ -26,7 +26,7 @@ chunk_newline.js:4:1 assist/source/organizeImports  FIXABLE  ━━━━━━�
       │ ^^^^^^^^^^^^^^^^^^^^^^
     6 │ 
   
-  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  i This statement must be preceded by a blank line. Add a newline before this statement.
   
     2 │ import "a";
     3 │ import { B } from "b";
@@ -35,7 +35,7 @@ chunk_newline.js:4:1 assist/source/organizeImports  FIXABLE  ━━━━━━�
     5 │ import { A } from "a";
     6 │ 
   
-  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  i This statement must be preceded by a blank line. Add a newline before this statement.
   
     3 │ import { B } from "b";
     4 │ f();

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk_newline.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunk_newline.js.snap
@@ -14,9 +14,17 @@ import { A } from "a";
 
 # Diagnostics
 ```
-chunk_newline.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+chunk_newline.js:4:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+    2 │ import "a";
+    3 │ import { B } from "b";
+  > 4 │ f();
+      │ ^^^^
+  > 5 │ import { A } from "a";
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
   
   i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunks.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunks.js.snap
@@ -29,9 +29,21 @@ import { G } from "g";
 
 # Diagnostics
 ```
-chunks.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+chunks.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+     1 │ // Header file comment to keep at the top
+   > 2 │ import { D } from "d";
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+   > 3 │ import { B } from "b";
+   > 4 │ 
+        ...
+  > 10 │ // Attached A
+  > 11 │ import { A3, A1, A2 } from "a" with { "k2": "", "k1": "" };
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // Attached E
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunks.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunks.js.snap
@@ -29,17 +29,33 @@ import { G } from "g";
 
 # Diagnostics
 ```
-chunks.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+chunks.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
     1 │ // Header file comment to keep at the top
   > 2 │ import { D } from "d";
       │ ^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import { B } from "b";
+  > 3 │ import { B } from "b";
+      │ ^^^^^^^^^^^^^^^^^^^^^^
     4 │ 
+    5 │ // Detached comment (Start of Chunk 2)
   
-  i Safe fix: Organize Imports (Biome)
+  i Sort this chunk of imports.
+  
+     7 │ // Attached C
+   > 8 │ import { C } from "c";
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+   > 9 │ 
+  > 10 │ // Attached A
+  > 11 │ import { A3, A1, A2 } from "a" with { "k2": "", "k1": "" };
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // Attached E
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1  1 │   // Header file comment to keep at the top
      2    │ - import·{·D·}·from·"d";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/chunks.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/chunks.js.snap
@@ -45,7 +45,7 @@ chunks.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━�
     12 │ 
     13 │ // Attached E
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
     1 │ // Header file comment to keep at the top
   > 2 │ import { D } from "d";
@@ -55,7 +55,7 @@ chunks.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━�
     4 │ 
     5 │ // Detached comment (Start of Chunk 2)
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
      7 │ // Attached C
    > 8 │ import { C } from "c";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-exports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-exports.ts.snap
@@ -14,7 +14,7 @@ export type { T };
 ```
 custom-order-exports.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of exports.
+  i Sort these exports.
   
   > 1 │ export { O };
       │ ^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-exports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-exports.ts.snap
@@ -12,16 +12,20 @@ export type { T };
 
 # Diagnostics
 ```
-custom-order-exports.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+custom-order-exports.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of exports.
   
   > 1 │ export { O };
       │ ^^^^^^^^^^^^^
-    2 │ export * as path from "node:path";
-    3 │ export type { T };
+  > 2 │ export * as path from "node:path";
+  > 3 │ export type { T };
+      │ ^^^^^^^^^^^^^^^^^^
+    4 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - export·{·O·};
       1 │ + export·type·{·T·};

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-exports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-exports.ts.snap
@@ -14,15 +14,6 @@ export type { T };
 ```
 custom-order-exports.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ export { O };
-      │ ^^^^^^^^^^^^^
-  > 2 │ export * as path from "node:path";
-  > 3 │ export type { T };
-      │ ^^^^^^^^^^^^^^^^^^
-    4 │ 
-  
   i Sort this chunk of exports.
   
   > 1 │ export { O };

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-exports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-exports.ts.snap
@@ -12,9 +12,16 @@ export type { T };
 
 # Diagnostics
 ```
-custom-order-exports.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+custom-order-exports.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ export { O };
+      │ ^^^^^^^^^^^^^
+  > 2 │ export * as path from "node:path";
+  > 3 │ export type { T };
+      │ ^^^^^^^^^^^^^^^^^^
+    4 │ 
   
   i Sort this chunk of exports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
@@ -14,16 +14,31 @@ import path from "./path";
 
 # Diagnostics
 ```
-custom-order-mixed-glob-groups.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+custom-order-mixed-glob-groups.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
+  
+    1 │ import { A } from "@my/lib";
+    2 │ import { B } from "@my/lib/subpath";
+  > 3 │ import alias from "@/alias";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ import alias from "@scoped/package";
+    5 │ import path from "./path";
+  
+  i Sort this chunk of imports.
   
   > 1 │ import { A } from "@my/lib";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import { B } from "@my/lib/subpath";
-    3 │ import alias from "@/alias";
+  > 2 │ import { B } from "@my/lib/subpath";
+  > 3 │ import alias from "@/alias";
+  > 4 │ import alias from "@scoped/package";
+  > 5 │ import path from "./path";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·{·A·}·from·"@my/lib";
     2   │ - import·{·B·}·from·"@my/lib/subpath";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
@@ -36,7 +36,7 @@ custom-order-mixed-glob-groups.js:1:1 assist/source/organizeImports  FIXABLE  �
     4 │ import alias from "@scoped/package";
     5 │ import path from "./path";
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import { A } from "@my/lib";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
@@ -16,26 +16,6 @@ import path from "./path";
 ```
 custom-order-mixed-glob-groups.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import { A } from "@my/lib";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import { B } from "@my/lib/subpath";
-  > 3 │ import alias from "@/alias";
-  > 4 │ import alias from "@scoped/package";
-  > 5 │ import path from "./path";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    6 │ 
-  
-  i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
-  
-    1 │ import { A } from "@my/lib";
-    2 │ import { B } from "@my/lib/subpath";
-  > 3 │ import alias from "@/alias";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ import alias from "@scoped/package";
-    5 │ import path from "./path";
-  
   i Sort these imports.
   
   > 1 │ import { A } from "@my/lib";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
@@ -14,9 +14,18 @@ import path from "./path";
 
 # Diagnostics
 ```
-custom-order-mixed-glob-groups.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+custom-order-mixed-glob-groups.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import { A } from "@my/lib";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import { B } from "@my/lib/subpath";
+  > 3 │ import alias from "@/alias";
+  > 4 │ import alias from "@scoped/package";
+  > 5 │ import path from "./path";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
   
   i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-sorted-imports-missing-blank-lines.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-sorted-imports-missing-blank-lines.js.snap
@@ -12,9 +12,16 @@ import bare from "bare"
 
 # Diagnostics
 ```
-custom-order-sorted-imports-missing-blank-lines.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━
+custom-order-sorted-imports-missing-blank-lines.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+    1 │ import { test as testBun } from "bun:test"
+  > 2 │ import { test as testNode } from "node:test"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ import bare from "bare"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
   
   i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-sorted-imports-missing-blank-lines.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-sorted-imports-missing-blank-lines.js.snap
@@ -12,16 +12,27 @@ import bare from "bare"
 
 # Diagnostics
 ```
-custom-order-sorted-imports-missing-blank-lines.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━
+custom-order-sorted-imports-missing-blank-lines.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
   
-  > 1 │ import { test as testBun } from "bun:test"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import { test as testNode } from "node:test"
+  i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
+  
+    1 │ import { test as testBun } from "bun:test"
+  > 2 │ import { test as testNode } from "node:test"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     3 │ import bare from "bare"
+    4 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
+  
+    1 │ import { test as testBun } from "bun:test"
+    2 │ import { test as testNode } from "node:test"
+  > 3 │ import bare from "bare"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   import { test as testBun } from "bun:test"
       2 │ + 

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-unsorted-imports-missing-blank-lines.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-unsorted-imports-missing-blank-lines.js.snap
@@ -31,7 +31,7 @@ custom-order-unsorted-imports-missing-blank-lines.js:1:1 assist/source/organizeI
     3 │ import path from "node:path"
     4 │ 
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import { test as testBun } from "bun:test"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-unsorted-imports-missing-blank-lines.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-unsorted-imports-missing-blank-lines.js.snap
@@ -14,23 +14,6 @@ import path from "node:path"
 ```
 custom-order-unsorted-imports-missing-blank-lines.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import { test as testBun } from "bun:test"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import { test as testNode } from "node:test"
-  > 3 │ import path from "node:path"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ 
-  
-  i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
-  
-    1 │ import { test as testBun } from "bun:test"
-  > 2 │ import { test as testNode } from "node:test"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import path from "node:path"
-    4 │ 
-  
   i Sort these imports.
   
   > 1 │ import { test as testBun } from "bun:test"

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-unsorted-imports-missing-blank-lines.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-unsorted-imports-missing-blank-lines.js.snap
@@ -12,16 +12,28 @@ import path from "node:path"
 
 # Diagnostics
 ```
-custom-order-unsorted-imports-missing-blank-lines.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━
+custom-order-unsorted-imports-missing-blank-lines.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
+  
+    1 │ import { test as testBun } from "bun:test"
+  > 2 │ import { test as testNode } from "node:test"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ import path from "node:path"
+    4 │ 
+  
+  i Sort this chunk of imports.
   
   > 1 │ import { test as testBun } from "bun:test"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import { test as testNode } from "node:test"
-    3 │ import path from "node:path"
+  > 2 │ import { test as testNode } from "node:test"
+  > 3 │ import path from "node:path"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   import { test as testBun } from "bun:test"
     2   │ - import·{·test·as·testNode·}·from·"node:test"

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-unsorted-imports-missing-blank-lines.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-unsorted-imports-missing-blank-lines.js.snap
@@ -12,9 +12,16 @@ import path from "node:path"
 
 # Diagnostics
 ```
-custom-order-unsorted-imports-missing-blank-lines.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━
+custom-order-unsorted-imports-missing-blank-lines.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import { test as testBun } from "bun:test"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import { test as testNode } from "node:test"
+  > 3 │ import path from "node:path"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
   
   i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order.js.snap
@@ -16,16 +16,33 @@ import { test as testNode } from "@scopeB/lib"
 
 # Diagnostics
 ```
-custom-order.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+custom-order.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
+  
+    1 │ import { test as testBun } from "bun:test"
+    2 │ import { test as testNode } from "node:test"
+  > 3 │ import { test as testNode } from "@scopeX/special/subpath"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ import { test as testNode } from "@scopeX/special"
+    5 │ import { test as testNode } from "@scopeX/lib"
+  
+  i Sort this chunk of imports.
   
   > 1 │ import { test as testBun } from "bun:test"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import { test as testNode } from "node:test"
-    3 │ import { test as testNode } from "@scopeX/special/subpath"
+  > 2 │ import { test as testNode } from "node:test"
+  > 3 │ import { test as testNode } from "@scopeX/special/subpath"
+  > 4 │ import { test as testNode } from "@scopeX/special"
+  > 5 │ import { test as testNode } from "@scopeX/lib"
+  > 6 │ import { test as testNode } from "@scopeA/lib"
+  > 7 │ import { test as testNode } from "@scopeB/lib"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   import { test as testBun } from "bun:test"
     2 2 │   import { test as testNode } from "node:test"

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order.js.snap
@@ -40,7 +40,7 @@ custom-order.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━�
     4 │ import { test as testNode } from "@scopeX/special"
     5 │ import { test as testNode } from "@scopeX/lib"
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import { test as testBun } from "bun:test"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order.js.snap
@@ -16,9 +16,20 @@ import { test as testNode } from "@scopeB/lib"
 
 # Diagnostics
 ```
-custom-order.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+custom-order.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import { test as testBun } from "bun:test"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import { test as testNode } from "node:test"
+  > 3 │ import { test as testNode } from "@scopeX/special/subpath"
+  > 4 │ import { test as testNode } from "@scopeX/special"
+  > 5 │ import { test as testNode } from "@scopeX/lib"
+  > 6 │ import { test as testNode } from "@scopeA/lib"
+  > 7 │ import { test as testNode } from "@scopeB/lib"
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
   
   i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order.js.snap
@@ -18,28 +18,6 @@ import { test as testNode } from "@scopeB/lib"
 ```
 custom-order.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import { test as testBun } from "bun:test"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import { test as testNode } from "node:test"
-  > 3 │ import { test as testNode } from "@scopeX/special/subpath"
-  > 4 │ import { test as testNode } from "@scopeX/special"
-  > 5 │ import { test as testNode } from "@scopeX/lib"
-  > 6 │ import { test as testNode } from "@scopeA/lib"
-  > 7 │ import { test as testNode } from "@scopeB/lib"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    8 │ 
-  
-  i This statement ends a group that must be preceded by a blank line. Add a newline before this statement.
-  
-    1 │ import { test as testBun } from "bun:test"
-    2 │ import { test as testNode } from "node:test"
-  > 3 │ import { test as testNode } from "@scopeX/special/subpath"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ import { test as testNode } from "@scopeX/special"
-    5 │ import { test as testNode } from "@scopeX/lib"
-  
   i Sort these imports.
   
   > 1 │ import { test as testBun } from "bun:test"

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-lexicographic.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-lexicographic.js.snap
@@ -31,16 +31,32 @@ _Note: The parser emitted 2 diagnostics which are not shown here._
 
 # Diagnostics
 ```
-custom-sort-lexicographic.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+custom-sort-lexicographic.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the imported names.
   
   > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
     3 │ import {
   
-  i Safe fix: Organize Imports (Biome)
+  i Sort this chunk of imports.
+  
+   > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
+   > 3 │ import {
+   > 4 │   BlindedBeaconBlock,··
+        ...
+  > 18 │   CommitteeIndex,
+  > 19 │   BeaconBlockOrContents,
+  > 20 │ } from "@lodestar/types";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1    │ - import·{·Module,·module,·Module1,·Module2,·module2,·module1,·module21,·module1,·module2,·module11··}·from·"@scopeX/special"
      2    │ - import·{·var1,·var2,·var21,·var11,·var12,·var22·}·from·'custom-package'

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-lexicographic.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-lexicographic.js.snap
@@ -54,7 +54,7 @@ custom-sort-lexicographic.js:1:1 assist/source/organizeImports  FIXABLE  ━━�
     2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
     3 │ import {
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
    > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-lexicographic.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-lexicographic.js.snap
@@ -31,9 +31,21 @@ _Note: The parser emitted 2 diagnostics which are not shown here._
 
 # Diagnostics
 ```
-custom-sort-lexicographic.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+custom-sort-lexicographic.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+   > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
+   > 3 │ import {
+   > 4 │   BlindedBeaconBlock,··
+        ...
+  > 18 │   CommitteeIndex,
+  > 19 │   BeaconBlockOrContents,
+  > 20 │ } from "@lodestar/types";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
   
   i Sort the imported names.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-lexicographic.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-lexicographic.js.snap
@@ -33,27 +33,6 @@ _Note: The parser emitted 2 diagnostics which are not shown here._
 ```
 custom-sort-lexicographic.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-   > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   > 2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
-   > 3 │ import {
-   > 4 │   BlindedBeaconBlock,··
-        ...
-  > 18 │   CommitteeIndex,
-  > 19 │   BeaconBlockOrContents,
-  > 20 │ } from "@lodestar/types";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
-    21 │ 
-  
-  i Sort the imported names.
-  
-  > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
-    3 │ import {
-  
   i Sort these imports.
   
    > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-natural.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-natural.js.snap
@@ -33,27 +33,6 @@ _Note: The parser emitted 2 diagnostics which are not shown here._
 ```
 custom-sort-natural.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-   > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   > 2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
-   > 3 │ import {
-   > 4 │   BlindedBeaconBlock,··
-        ...
-  > 18 │   CommitteeIndex,
-  > 19 │   BeaconBlockOrContents,
-  > 20 │ } from "@lodestar/types";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
-    21 │ 
-  
-  i Sort the imported names.
-  
-  > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
-    3 │ import {
-  
   i Sort these imports.
   
    > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-natural.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-natural.js.snap
@@ -31,9 +31,21 @@ _Note: The parser emitted 2 diagnostics which are not shown here._
 
 # Diagnostics
 ```
-custom-sort-natural.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+custom-sort-natural.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+   > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
+   > 3 │ import {
+   > 4 │   BlindedBeaconBlock,··
+        ...
+  > 18 │   CommitteeIndex,
+  > 19 │   BeaconBlockOrContents,
+  > 20 │ } from "@lodestar/types";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
   
   i Sort the imported names.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-natural.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-natural.js.snap
@@ -31,16 +31,32 @@ _Note: The parser emitted 2 diagnostics which are not shown here._
 
 # Diagnostics
 ```
-custom-sort-natural.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+custom-sort-natural.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the imported names.
   
   > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
     3 │ import {
   
-  i Safe fix: Organize Imports (Biome)
+  i Sort this chunk of imports.
+  
+   > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
+   > 3 │ import {
+   > 4 │   BlindedBeaconBlock,··
+        ...
+  > 18 │   CommitteeIndex,
+  > 19 │   BeaconBlockOrContents,
+  > 20 │ } from "@lodestar/types";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1    │ - import·{·Module,·module,·Module1,·Module2,·module2,·module1,·module21,·module1,·module2,·module11··}·from·"@scopeX/special"
      2    │ - import·{·var1,·var2,·var21,·var11,·var12,·var22·}·from·'custom-package'

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-natural.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-sort-natural.js.snap
@@ -54,7 +54,7 @@ custom-sort-natural.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━�
     2 │ import { var1, var2, var21, var11, var12, var22 } from 'custom-package'
     3 │ import {
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
    > 1 │ import { Module, module, Module1, Module2, module2, module1, module21, module1, module2, module11  } from "@scopeX/special"
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
@@ -16,9 +16,15 @@ _Note: The parser emitted 2 diagnostics which are not shown here._
 
 # Diagnostics
 ```
-issue-5710.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue-5710.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+    1 │ // The last `inject` specifier is a bogus node.
+  > 2 │ import { inject, Injectable, inject } from '@angular/core';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ // The last `key` attribute is a bogus node.
   
   i Sort the imported names.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
@@ -16,9 +16,11 @@ _Note: The parser emitted 2 diagnostics which are not shown here._
 
 # Diagnostics
 ```
-issue-5710.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue-5710.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the imported names.
   
     1 │ // The last `inject` specifier is a bogus node.
   > 2 │ import { inject, Injectable, inject } from '@angular/core';
@@ -26,7 +28,7 @@ issue-5710.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━�
     3 │ 
     4 │ // The last `key` attribute is a bogus node.
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   // The last `inject` specifier is a bogus node.
     2   │ - import·{·inject,·Injectable,·inject·}·from·'@angular/core';

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
@@ -18,14 +18,6 @@ _Note: The parser emitted 2 diagnostics which are not shown here._
 ```
 issue-5710.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-    1 │ // The last `inject` specifier is a bogus node.
-  > 2 │ import { inject, Injectable, inject } from '@angular/core';
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ 
-    4 │ // The last `key` attribute is a bogus node.
-  
   i Sort the imported names.
   
     1 │ // The last `inject` specifier is a bogus node.

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
@@ -10,15 +10,18 @@ import { Moment } from 'moment';
 
 # Diagnostics
 ```
-issue5985.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue5985.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 1 │ import moment from 'moment';
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import { Moment } from 'moment';
+  > 2 │ import { Moment } from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·moment·from·'moment';
     2   │ - import·{·Moment·}·from·'moment';

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
@@ -12,13 +12,6 @@ import { Moment } from 'moment';
 ```
 issue5985.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import moment from 'moment';
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import { Moment } from 'moment';
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  
   i Sort this chunk of imports.
   
   > 1 │ import moment from 'moment';

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
@@ -10,9 +10,14 @@ import { Moment } from 'moment';
 
 # Diagnostics
 ```
-issue5985.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue5985.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import moment from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import { Moment } from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
@@ -12,7 +12,7 @@ import { Moment } from 'moment';
 ```
 issue5985.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import moment from 'moment';
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
@@ -15,15 +15,6 @@ import { A } from "a";
 ```
 issue6211.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import { B } from "bc";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import { C } from "bc";
-  > 3 │ import { A } from "a";
-      │ ^^^^^^^^^^^^^^^^^^^^^^
-    4 │ 
-  
   i Sort this chunk of imports.
   
   > 1 │ import { B } from "bc";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
@@ -13,9 +13,16 @@ import { A } from "a";
 
 # Diagnostics
 ```
-issue6211.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue6211.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import { B } from "bc";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import { C } from "bc";
+  > 3 │ import { A } from "a";
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
@@ -15,7 +15,7 @@ import { A } from "a";
 ```
 issue6211.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import { B } from "bc";
       │ ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
@@ -13,16 +13,20 @@ import { A } from "a";
 
 # Diagnostics
 ```
-issue6211.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue6211.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 1 │ import { B } from "bc";
       │ ^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import { C } from "bc";
-    3 │ import { A } from "a";
+  > 2 │ import { C } from "bc";
+  > 3 │ import { A } from "a";
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·{·B·}·from·"bc";
     2   │ - import·{·C·}·from·"bc";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6492.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6492.js.snap
@@ -14,17 +14,22 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 # Diagnostics
 ```
-issue6492.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue6492.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
     1 │ // some comment
   > 2 │ import react from "@vitejs/plugin-react";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import svgr from "vite-plugin-svgr";
-    4 │ import { defineConfig } from "vite";
+  > 3 │ import svgr from "vite-plugin-svgr";
+  > 4 │ import { defineConfig } from "vite";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ import tsconfigPaths from "vite-tsconfig-paths";
+    6 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   // some comment
     2 2 │   import react from "@vitejs/plugin-react";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6492.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6492.js.snap
@@ -16,7 +16,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 ```
 issue6492.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
     1 │ // some comment
   > 2 │ import react from "@vitejs/plugin-react";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6492.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6492.js.snap
@@ -14,9 +14,18 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 # Diagnostics
 ```
-issue6492.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+issue6492.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+    1 │ // some comment
+  > 2 │ import react from "@vitejs/plugin-react";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ import svgr from "vite-plugin-svgr";
+  > 4 │ import { defineConfig } from "vite";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ import tsconfigPaths from "vite-tsconfig-paths";
+    6 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6492.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6492.js.snap
@@ -16,17 +16,6 @@ import tsconfigPaths from "vite-tsconfig-paths";
 ```
 issue6492.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-    1 │ // some comment
-  > 2 │ import react from "@vitejs/plugin-react";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 3 │ import svgr from "vite-plugin-svgr";
-  > 4 │ import { defineConfig } from "vite";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    5 │ import tsconfigPaths from "vite-tsconfig-paths";
-    6 │ 
-  
   i Sort this chunk of imports.
   
     1 │ // some comment

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-bare-exports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-bare-exports.js.snap
@@ -12,9 +12,16 @@ export { b, d };
 
 # Diagnostics
 ```
-mergeable-bare-exports.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable-bare-exports.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ export { a };
+      │ ^^^^^^^^^^^^^
+  > 2 │ export { c };
+  > 3 │ export { b, d };
+      │ ^^^^^^^^^^^^^^^^
+    4 │ 
   
   i Sort this chunk of exports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-bare-exports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-bare-exports.js.snap
@@ -14,7 +14,7 @@ export { b, d };
 ```
 mergeable-bare-exports.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of exports.
+  i Sort these exports.
   
   > 1 │ export { a };
       │ ^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-bare-exports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-bare-exports.js.snap
@@ -12,16 +12,20 @@ export { b, d };
 
 # Diagnostics
 ```
-mergeable-bare-exports.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable-bare-exports.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of exports.
   
   > 1 │ export { a };
       │ ^^^^^^^^^^^^^
-    2 │ export { c };
-    3 │ export { b, d };
+  > 2 │ export { c };
+  > 3 │ export { b, d };
+      │ ^^^^^^^^^^^^^^^^
+    4 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - export·{·a·};
     2   │ - export·{·c·};

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-bare-exports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-bare-exports.js.snap
@@ -14,15 +14,6 @@ export { b, d };
 ```
 mergeable-bare-exports.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ export { a };
-      │ ^^^^^^^^^^^^^
-  > 2 │ export { c };
-  > 3 │ export { b, d };
-      │ ^^^^^^^^^^^^^^^^
-    4 │ 
-  
   i Sort this chunk of exports.
   
   > 1 │ export { a };

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
@@ -15,16 +15,6 @@ import { Moment } from 'moment';
 ```
 mergeable-with_header.js:3:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-    1 │ // Header comment
-    2 │ 
-  > 3 │ import moment from 'moment';
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 4 │ import { Moment } from 'moment';
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    5 │ 
-  
   i Sort this chunk of imports.
   
     1 │ // Header comment

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
@@ -13,18 +13,21 @@ import { Moment } from 'moment';
 
 # Diagnostics
 ```
-mergeable-with_header.js:3:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable-with_header.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
     1 │ // Header comment
     2 │ 
   > 3 │ import moment from 'moment';
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ import { Moment } from 'moment';
+  > 4 │ import { Moment } from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     5 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   // Header comment
     2 2 │   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
@@ -15,7 +15,7 @@ import { Moment } from 'moment';
 ```
 mergeable-with_header.js:3:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
     1 │ // Header comment
     2 │ 

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
@@ -13,9 +13,17 @@ import { Moment } from 'moment';
 
 # Diagnostics
 ```
-mergeable-with_header.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable-with_header.js:3:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+    1 │ // Header comment
+    2 │ 
+  > 3 │ import moment from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 4 │ import { Moment } from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
@@ -14,7 +14,7 @@ import { Moment } from 'moment';
 ```
 mergeable-with_leading_newline.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 2 │ import moment from 'moment';
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
@@ -12,9 +12,15 @@ import { Moment } from 'moment';
 
 # Diagnostics
 ```
-mergeable-with_leading_newline.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable-with_leading_newline.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 2 │ import moment from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ import { Moment } from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
@@ -12,16 +12,19 @@ import { Moment } from 'moment';
 
 # Diagnostics
 ```
-mergeable-with_leading_newline.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+mergeable-with_leading_newline.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 2 │ import moment from 'moment';
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import { Moment } from 'moment';
+  > 3 │ import { Moment } from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   
     2   │ - import·moment·from·'moment';

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
@@ -14,14 +14,6 @@ import { Moment } from 'moment';
 ```
 mergeable-with_leading_newline.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 2 │ import moment from 'moment';
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 3 │ import { Moment } from 'moment';
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ 
-  
   i Sort this chunk of imports.
   
   > 2 │ import moment from 'moment';

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
@@ -41,7 +41,7 @@ mergeable_export.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━�
     3 │ // Comment 2
     4 │ export type { T3, T1 } from "mod";
   
-  i Sort this chunk of exports.
+  i Sort these exports.
   
     1 │ // Comment 1
   > 2 │ export type { T4, T2 } from "mod";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
@@ -17,9 +17,11 @@ export { B, C } from "mod";
 
 # Diagnostics
 ```
-mergeable_export.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable_export.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the exported names.
   
     1 │ // Comment 1
   > 2 │ export type { T4, T2 } from "mod";
@@ -27,7 +29,21 @@ mergeable_export.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━�
     3 │ // Comment 2
     4 │ export type { T3, T1 } from "mod";
   
-  i Safe fix: Organize Imports (Biome)
+  i Sort this chunk of exports.
+  
+    1 │ // Comment 1
+  > 2 │ export type { T4, T2 } from "mod";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ // Comment 2
+  > 4 │ export type { T3, T1 } from "mod";
+  > 5 │ // Comment 3
+  > 6 │ export { A, D } from "mod";
+  > 7 │ // Comment 4
+  > 8 │ export { B, C } from "mod";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    9 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   // Comment 1
     2   │ - export·type·{·T4,·T2·}·from·"mod";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
@@ -19,28 +19,6 @@ export { B, C } from "mod";
 ```
 mergeable_export.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-    1 │ // Comment 1
-  > 2 │ export type { T4, T2 } from "mod";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 3 │ // Comment 2
-  > 4 │ export type { T3, T1 } from "mod";
-  > 5 │ // Comment 3
-  > 6 │ export { A, D } from "mod";
-  > 7 │ // Comment 4
-  > 8 │ export { B, C } from "mod";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    9 │ 
-  
-  i Sort the exported names.
-  
-    1 │ // Comment 1
-  > 2 │ export type { T4, T2 } from "mod";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ // Comment 2
-    4 │ export type { T3, T1 } from "mod";
-  
   i Sort these exports.
   
     1 │ // Comment 1

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
@@ -17,9 +17,21 @@ export { B, C } from "mod";
 
 # Diagnostics
 ```
-mergeable_export.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable_export.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+    1 │ // Comment 1
+  > 2 │ export type { T4, T2 } from "mod";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ // Comment 2
+  > 4 │ export type { T3, T1 } from "mod";
+  > 5 │ // Comment 3
+  > 6 │ export { A, D } from "mod";
+  > 7 │ // Comment 4
+  > 8 │ export { B, C } from "mod";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    9 │ 
   
   i Sort the exported names.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
@@ -26,28 +26,6 @@ import * as ns from "mod";
 ```
 mergeable_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-     1 │ // Comment 1
-   > 2 │ import type { T4, T2 } from "mod";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   > 3 │ // Comment 2
-   > 4 │ import type { T3, T1 } from "mod";
-        ...
-  > 13 │ // Comment 7
-  > 14 │ import I from "mod";
-  > 15 │ import * as ns from "mod";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    16 │ 
-  
-  i Sort the imported names.
-  
-    1 │ // Comment 1
-  > 2 │ import type { T4, T2 } from "mod";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ // Comment 2
-    4 │ import type { T3, T1 } from "mod";
-  
   i Sort these imports.
   
      1 │ // Comment 1

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
@@ -24,9 +24,21 @@ import * as ns from "mod";
 
 # Diagnostics
 ```
-mergeable_imports.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+     1 │ // Comment 1
+   > 2 │ import type { T4, T2 } from "mod";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 3 │ // Comment 2
+   > 4 │ import type { T3, T1 } from "mod";
+        ...
+  > 13 │ // Comment 7
+  > 14 │ import I from "mod";
+  > 15 │ import * as ns from "mod";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    16 │ 
   
   i Sort the imported names.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
@@ -48,7 +48,7 @@ mergeable_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━
     3 │ // Comment 2
     4 │ import type { T3, T1 } from "mod";
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
      1 │ // Comment 1
    > 2 │ import type { T4, T2 } from "mod";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
@@ -24,9 +24,11 @@ import * as ns from "mod";
 
 # Diagnostics
 ```
-mergeable_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable_imports.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the imported names.
   
     1 │ // Comment 1
   > 2 │ import type { T4, T2 } from "mod";
@@ -34,7 +36,21 @@ mergeable_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━
     3 │ // Comment 2
     4 │ import type { T3, T1 } from "mod";
   
-  i Safe fix: Organize Imports (Biome)
+  i Sort this chunk of imports.
+  
+     1 │ // Comment 1
+   > 2 │ import type { T4, T2 } from "mod";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 3 │ // Comment 2
+   > 4 │ import type { T3, T1 } from "mod";
+        ...
+  > 13 │ // Comment 7
+  > 14 │ import I from "mod";
+  > 15 │ import * as ns from "mod";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    16 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1  1 │   // Comment 1
      2    │ - import·type·{·T4,·T2·}·from·"mod";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
@@ -48,7 +48,7 @@ mergeable_unsorted_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━
        │ ^^^^^^^^^^^^^^^^^^^^^^^^
     24 │ 
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
      1 │ // File header comment
    > 2 │ import type { T1, T2 } from "mod";
@@ -62,7 +62,7 @@ mergeable_unsorted_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━
     17 │ 
     18 │ // Chunk 2
   
-  i Sort this chunk of imports.
+  i Sort these imports.
   
     20 │ // Comment 9
   > 21 │ import type { U3 } from "package";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
@@ -32,17 +32,35 @@ import { E } from "mod";
 
 # Diagnostics
 ```
-mergeable_unsorted_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable_unsorted_imports.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
   
-    1 │ // File header comment
-  > 2 │ import type { T1, T2 } from "mod";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ // Comment 2
-    4 │ import type { U1 } from "package";
+  i Sort this chunk of imports.
   
-  i Safe fix: Organize Imports (Biome)
+     1 │ // File header comment
+   > 2 │ import type { T1, T2 } from "mod";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 3 │ // Comment 2
+   > 4 │ import type { U1 } from "package";
+        ...
+  > 15 │ // Comment 8
+  > 16 │ import type { U2 } from "package";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    17 │ 
+    18 │ // Chunk 2
+  
+  i Sort this chunk of imports.
+  
+    20 │ // Comment 9
+  > 21 │ import type { U3 } from "package";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 22 │ // Comment 10
+  > 23 │ import { E } from "mod";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1  1 │   // File header comment
      2    │ - import·type·{·T1,·T2·}·from·"mod";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
@@ -32,9 +32,21 @@ import { E } from "mod";
 
 # Diagnostics
 ```
-mergeable_unsorted_imports.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+mergeable_unsorted_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+     1 │ // File header comment
+   > 2 │ import type { T1, T2 } from "mod";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 3 │ // Comment 2
+   > 4 │ import type { U1 } from "package";
+        ...
+  > 21 │ import type { U3 } from "package";
+  > 22 │ // Comment 10
+  > 23 │ import { E } from "mod";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/one-liner.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/one-liner.js.snap
@@ -9,14 +9,16 @@ import { B } from "b"; import { A } from "a"; function f() {}
 
 # Diagnostics
 ```
-one-liner.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+one-liner.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 1 │ import { B } from "b"; import { A } from "a"; function f() {}
-      │ ^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·{·B·}·from·"b";·import·{·A·}·from·"a";·function·f()·{}
       1 │ + import·{·A·}·from·"a";·

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/one-liner.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/one-liner.js.snap
@@ -11,11 +11,6 @@ import { B } from "b"; import { A } from "a"; function f() {}
 ```
 one-liner.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import { B } from "b"; import { A } from "a"; function f() {}
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  
   i Sort this chunk of imports.
   
   > 1 │ import { B } from "b"; import { A } from "a"; function f() {}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/one-liner.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/one-liner.js.snap
@@ -11,7 +11,7 @@ import { B } from "b"; import { A } from "a"; function f() {}
 ```
 one-liner.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import { B } from "b"; import { A } from "a"; function f() {}
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/one-liner.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/one-liner.js.snap
@@ -9,9 +9,12 @@ import { B } from "b"; import { A } from "a"; function f() {}
 
 # Diagnostics
 ```
-one-liner.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+one-liner.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import { B } from "b"; import { A } from "a"; function f() {}
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/single-chunk-imports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/single-chunk-imports.js.snap
@@ -21,16 +21,25 @@ import { ScopedPackage } from "@scope/package";
 
 # Diagnostics
 ```
-single-chunk-imports.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+single-chunk-imports.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
   
-  > 1 │ import { Bun } from "bun:test";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ // URL
-    3 │ import { URL } from "https://example.org";
+  i Sort this chunk of imports.
   
-  i Safe fix: Organize Imports (Biome)
+   > 1 │ import { Bun } from "bun:test";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ // URL
+   > 3 │ import { URL } from "https://example.org";
+   > 4 │ import { Relative } from ".";
+        ...
+  > 10 │ import { B } from "b";
+  > 11 │ // This is a scoped package
+  > 12 │ import { ScopedPackage } from "@scope/package";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1    │ - import·{·Bun·}·from·"bun:test";
      2    │ - //·URL

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/single-chunk-imports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/single-chunk-imports.js.snap
@@ -21,9 +21,21 @@ import { ScopedPackage } from "@scope/package";
 
 # Diagnostics
 ```
-single-chunk-imports.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+single-chunk-imports.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+   > 1 │ import { Bun } from "bun:test";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ // URL
+   > 3 │ import { URL } from "https://example.org";
+   > 4 │ import { Relative } from ".";
+        ...
+  > 10 │ import { B } from "b";
+  > 11 │ // This is a scoped package
+  > 12 │ import { ScopedPackage } from "@scope/package";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/single-chunk-imports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/single-chunk-imports.js.snap
@@ -23,20 +23,6 @@ import { ScopedPackage } from "@scope/package";
 ```
 single-chunk-imports.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-   > 1 │ import { Bun } from "bun:test";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   > 2 │ // URL
-   > 3 │ import { URL } from "https://example.org";
-   > 4 │ import { Relative } from ".";
-        ...
-  > 10 │ import { B } from "b";
-  > 11 │ // This is a scoped package
-  > 12 │ import { ScopedPackage } from "@scope/package";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    13 │ 
-  
   i Sort this chunk of imports.
   
    > 1 │ import { Bun } from "bun:test";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/single-chunk-imports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/single-chunk-imports.js.snap
@@ -23,7 +23,7 @@ import { ScopedPackage } from "@scope/package";
 ```
 single-chunk-imports.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
    > 1 │ import { Bun } from "bun:test";
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
@@ -13,9 +13,16 @@ export { A, B };
 
 # Diagnostics
 ```
-ts-declaration.d.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ts-declaration.d.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import B from "b";
+      │ ^^^^^^^^^^^^^^^^^^
+  > 2 │ import A from "a";
+      │ ^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ export { A, B };
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
@@ -15,7 +15,7 @@ export { A, B };
 ```
 ts-declaration.d.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import B from "b";
       │ ^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
@@ -13,16 +13,20 @@ export { A, B };
 
 # Diagnostics
 ```
-ts-declaration.d.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ts-declaration.d.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 1 │ import B from "b";
       │ ^^^^^^^^^^^^^^^^^^
-    2 │ import A from "a";
+  > 2 │ import A from "a";
+      │ ^^^^^^^^^^^^^^^^^^
     3 │ 
+    4 │ export { A, B };
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·B·from·"b";
     2   │ - import·A·from·"a";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
@@ -15,15 +15,6 @@ export { A, B };
 ```
 ts-declaration.d.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import B from "b";
-      │ ^^^^^^^^^^^^^^^^^^
-  > 2 │ import A from "a";
-      │ ^^^^^^^^^^^^^^^^^^
-    3 │ 
-    4 │ export { A, B };
-  
   i Sort this chunk of imports.
   
   > 1 │ import B from "b";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
@@ -17,16 +17,6 @@ declare module "module" {
 ```
 ts-module.ts:2:2 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-    1 │ declare module "module" {
-  > 2 │ 	import type { B } from "b";
-      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 3 │ 	import type { A } from "a";
-      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ 
-    5 │ 	type X = [A, B];
-  
   i Sort this chunk of imports.
   
     1 │ declare module "module" {

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
@@ -15,17 +15,21 @@ declare module "module" {
 
 # Diagnostics
 ```
-ts-module.ts:2:2 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ts-module.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
     1 │ declare module "module" {
   > 2 │ 	import type { B } from "b";
       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ 	import type { A } from "a";
+  > 3 │ 	import type { A } from "a";
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ 
+    5 │ 	type X = [A, B];
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   declare module "module" {
     2   │ - → import·type·{·B·}·from·"b";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
@@ -17,7 +17,7 @@ declare module "module" {
 ```
 ts-module.ts:2:2 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
     1 │ declare module "module" {
   > 2 │ 	import type { B } from "b";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
@@ -15,9 +15,17 @@ declare module "module" {
 
 # Diagnostics
 ```
-ts-module.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ts-module.ts:2:2 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+    1 │ declare module "module" {
+  > 2 │ 	import type { B } from "b";
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ 	import type { A } from "a";
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
+    5 │ 	type X = [A, B];
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
@@ -21,7 +21,7 @@ import type T4 from "https://example.com";
 ```
 type-first-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
    > 1 │ import V1 from "bun:package";
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
@@ -19,16 +19,26 @@ import type T4 from "https://example.com";
 
 # Diagnostics
 ```
-type-first-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+type-first-groups.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
   
-  > 1 │ import V1 from "bun:package";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import V2 from "node:package";
-    3 │ import V3 from "package";
+  i Sort this chunk of imports.
   
-  i Safe fix: Organize Imports (Biome)
+   > 1 │ import V1 from "bun:package";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ import V2 from "node:package";
+   > 3 │ import V3 from "package";
+   > 4 │ import V4 from "https://example.com";
+   > 5 │ import V5 from "exception";
+   > 6 │ import type T1 from "bun:package";
+   > 7 │ import type T2 from "node:package";
+   > 8 │ import type T3 from "package";
+   > 9 │ import type T4 from "https://example.com";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1    │ - import·V1·from·"bun:package";
      2    │ - import·V2·from·"node:package";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
@@ -21,21 +21,6 @@ import type T4 from "https://example.com";
 ```
 type-first-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-   > 1 │ import V1 from "bun:package";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   > 2 │ import V2 from "node:package";
-   > 3 │ import V3 from "package";
-   > 4 │ import V4 from "https://example.com";
-   > 5 │ import V5 from "exception";
-   > 6 │ import type T1 from "bun:package";
-   > 7 │ import type T2 from "node:package";
-   > 8 │ import type T3 from "package";
-   > 9 │ import type T4 from "https://example.com";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    10 │ 
-  
   i Sort this chunk of imports.
   
    > 1 │ import V1 from "bun:package";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
@@ -19,9 +19,22 @@ import type T4 from "https://example.com";
 
 # Diagnostics
 ```
-type-first-groups.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+type-first-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+   > 1 │ import V1 from "bun:package";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ import V2 from "node:package";
+   > 3 │ import V3 from "package";
+   > 4 │ import V4 from "https://example.com";
+   > 5 │ import V5 from "exception";
+   > 6 │ import type T1 from "bun:package";
+   > 7 │ import type T2 from "node:package";
+   > 8 │ import type T3 from "package";
+   > 9 │ import type T4 from "https://example.com";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
@@ -17,18 +17,6 @@ import V3 from "package";
 ```
 type-last-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import type T1 from "bun:package";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 2 │ import type T2 from "node:package";
-  > 3 │ import type T3 from "package";
-  > 4 │ import V1 from "bun:package";
-  > 5 │ import V2 from "node:package";
-  > 6 │ import V3 from "package";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
-    7 │ 
-  
   i Sort this chunk of imports.
   
   > 1 │ import type T1 from "bun:package";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
@@ -15,9 +15,19 @@ import V3 from "package";
 
 # Diagnostics
 ```
-type-last-groups.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+type-last-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import type T1 from "bun:package";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import type T2 from "node:package";
+  > 3 │ import type T3 from "package";
+  > 4 │ import V1 from "bun:package";
+  > 5 │ import V2 from "node:package";
+  > 6 │ import V3 from "package";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
@@ -15,16 +15,23 @@ import V3 from "package";
 
 # Diagnostics
 ```
-type-last-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+type-last-groups.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 1 │ import type T1 from "bun:package";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import type T2 from "node:package";
-    3 │ import type T3 from "package";
+  > 2 │ import type T2 from "node:package";
+  > 3 │ import type T3 from "package";
+  > 4 │ import V1 from "bun:package";
+  > 5 │ import V2 from "node:package";
+  > 6 │ import V3 from "package";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·type·T1·from·"bun:package";
     2   │ - import·type·T2·from·"node:package";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
@@ -17,7 +17,7 @@ import V3 from "package";
 ```
 type-last-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import type T1 from "bun:package";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-bare-export-specifiers.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-bare-export-specifiers.js.snap
@@ -10,9 +10,13 @@ export { b, a }
 
 # Diagnostics
 ```
-unorganized-bare-export-specifiers.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+unorganized-bare-export-specifiers.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ export { b, a }
+      │ ^^^^^^^^^^^^^^^
+    2 │ 
   
   i Sort the exported names.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-bare-export-specifiers.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-bare-export-specifiers.js.snap
@@ -10,15 +10,17 @@ export { b, a }
 
 # Diagnostics
 ```
-unorganized-bare-export-specifiers.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━
+unorganized-bare-export-specifiers.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the exported names.
   
   > 1 │ export { b, a }
       │ ^^^^^^^^^^^^^^^
     2 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - export·{·b,·a·}
       1 │ + export·{·a,·b·}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-bare-export-specifiers.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-bare-export-specifiers.js.snap
@@ -12,12 +12,6 @@ export { b, a }
 ```
 unorganized-bare-export-specifiers.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ export { b, a }
-      │ ^^^^^^^^^^^^^^^
-    2 │ 
-  
   i Sort the exported names.
   
   > 1 │ export { b, a }

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-attributes.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-attributes.js.snap
@@ -10,15 +10,17 @@ export { A, B } from "" with { "k2": "", "k1": "" };
 
 # Diagnostics
 ```
-unorganized-export-attributes.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+unorganized-export-attributes.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the attributes.
   
   > 1 │ export { A, B } from "" with { "k2": "", "k1": "" };
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - export·{·A,·B·}·from·""·with·{·"k2":·"",·"k1":·""·};
       1 │ + export·{·A,·B·}·from·""·with·{·"k1":·"",·"k2":·""·};

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-attributes.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-attributes.js.snap
@@ -12,12 +12,6 @@ export { A, B } from "" with { "k2": "", "k1": "" };
 ```
 unorganized-export-attributes.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ export { A, B } from "" with { "k2": "", "k1": "" };
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ 
-  
   i Sort the attributes.
   
   > 1 │ export { A, B } from "" with { "k2": "", "k1": "" };

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-attributes.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-attributes.js.snap
@@ -10,9 +10,13 @@ export { A, B } from "" with { "k2": "", "k1": "" };
 
 # Diagnostics
 ```
-unorganized-export-attributes.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unorganized-export-attributes.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ export { A, B } from "" with { "k2": "", "k1": "" };
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ 
   
   i Sort the attributes.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-specifiers.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-specifiers.js.snap
@@ -11,16 +11,25 @@ export { Y, X } from "x";
 
 # Diagnostics
 ```
-unorganized-export-specifiers.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+unorganized-export-specifiers.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the exported names.
   
   > 1 │ export { B, A } from "a";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ export { Y, X } from "x";
     3 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Sort the exported names.
+  
+    1 │ export { B, A } from "a";
+  > 2 │ export { Y, X } from "x";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - export·{·B,·A·}·from·"a";
     2   │ - export·{·Y,·X·}·from·"x";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-specifiers.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-export-specifiers.js.snap
@@ -11,9 +11,15 @@ export { Y, X } from "x";
 
 # Diagnostics
 ```
-unorganized-export-specifiers.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unorganized-export-specifiers.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ export { B, A } from "a";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ export { Y, X } from "x";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
   
   i Sort the exported names.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-attributes.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-attributes.js.snap
@@ -10,9 +10,13 @@ import { A, B } from "" with { "k2": "", "k1": "" };
 
 # Diagnostics
 ```
-unorganized-import-attributes.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unorganized-import-attributes.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import { A, B } from "" with { "k2": "", "k1": "" };
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ 
   
   i Sort the attributes.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-attributes.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-attributes.js.snap
@@ -10,15 +10,17 @@ import { A, B } from "" with { "k2": "", "k1": "" };
 
 # Diagnostics
 ```
-unorganized-import-attributes.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+unorganized-import-attributes.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the attributes.
   
   > 1 │ import { A, B } from "" with { "k2": "", "k1": "" };
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·{·A,·B·}·from·""·with·{·"k2":·"",·"k1":·""·};
       1 │ + import·{·A,·B·}·from·""·with·{·"k1":·"",·"k2":·""·};

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-attributes.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-attributes.js.snap
@@ -12,12 +12,6 @@ import { A, B } from "" with { "k2": "", "k1": "" };
 ```
 unorganized-import-attributes.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import { A, B } from "" with { "k2": "", "k1": "" };
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ 
-  
   i Sort the attributes.
   
   > 1 │ import { A, B } from "" with { "k2": "", "k1": "" };

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-specifiers.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-specifiers.js.snap
@@ -11,9 +11,15 @@ import { Y, X } from "x";
 
 # Diagnostics
 ```
-unorganized-import-specifiers.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unorganized-import-specifiers.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import D, { B, A } from "a";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ import { Y, X } from "x";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
   
   i Sort the imported names.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-specifiers.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unorganized-import-specifiers.js.snap
@@ -11,16 +11,25 @@ import { Y, X } from "x";
 
 # Diagnostics
 ```
-unorganized-import-specifiers.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+unorganized-import-specifiers.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort the imported names.
   
   > 1 │ import D, { B, A } from "a";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ import { Y, X } from "x";
     3 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Sort the imported names.
+  
+    1 │ import D, { B, A } from "a";
+  > 2 │ import { Y, X } from "x";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·D,·{·B,·A·}·from·"a";
     2   │ - import·{·Y,·X·}·from·"x";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
@@ -20,21 +20,6 @@ import { e } from '$e'
 ```
 unsorted-alias.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-     1 │ /* should generate diagnostics */
-   > 2 │ import { aa } from './aa'
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
-   > 3 │ import { a } from '%f'
-   > 4 │ import { b } from '#b'
-   > 5 │ import { bb } from './bb'
-   > 6 │ import { c } from '~c'
-   > 7 │ import { d } from '@/d'
-   > 8 │ import { cc } from '../cc'
-   > 9 │ import { e } from '$e'
-       │ ^^^^^^^^^^^^^^^^^^^^^^
-    10 │ 
-  
   i Sort this chunk of imports.
   
      1 │ /* should generate diagnostics */

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
@@ -18,9 +18,22 @@ import { e } from '$e'
 
 # Diagnostics
 ```
-unsorted-alias.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unsorted-alias.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+     1 │ /* should generate diagnostics */
+   > 2 │ import { aa } from './aa'
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 3 │ import { a } from '%f'
+   > 4 │ import { b } from '#b'
+   > 5 │ import { bb } from './bb'
+   > 6 │ import { c } from '~c'
+   > 7 │ import { d } from '@/d'
+   > 8 │ import { cc } from '../cc'
+   > 9 │ import { e } from '$e'
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
@@ -20,7 +20,7 @@ import { e } from '$e'
 ```
 unsorted-alias.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
      1 │ /* should generate diagnostics */
    > 2 │ import { aa } from './aa'

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
@@ -18,17 +18,26 @@ import { e } from '$e'
 
 # Diagnostics
 ```
-unsorted-alias.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unsorted-alias.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
   
-    1 │ /* should generate diagnostics */
-  > 2 │ import { aa } from './aa'
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import { a } from '%f'
-    4 │ import { b } from '#b'
+  i Sort this chunk of imports.
   
-  i Safe fix: Organize Imports (Biome)
+     1 │ /* should generate diagnostics */
+   > 2 │ import { aa } from './aa'
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 3 │ import { a } from '%f'
+   > 4 │ import { b } from '#b'
+   > 5 │ import { bb } from './bb'
+   > 6 │ import { c } from '~c'
+   > 7 │ import { d } from '@/d'
+   > 8 │ import { cc } from '../cc'
+   > 9 │ import { e } from '$e'
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1  1 │   /* should generate diagnostics */
      2    │ - import·{·aa·}·from·'./aa'

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-imports-empty-header.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-imports-empty-header.js.snap
@@ -13,7 +13,7 @@ import {} from "a"
 ```
 unsorted-imports-empty-header.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 1 │ import {} from "b"
       │ ^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-imports-empty-header.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-imports-empty-header.js.snap
@@ -11,16 +11,19 @@ import {} from "a"
 
 # Diagnostics
 ```
-unsorted-imports-empty-header.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+unsorted-imports-empty-header.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 1 │ import {} from "b"
       │ ^^^^^^^^^^^^^^^^^^
-    2 │ import {} from "a"
+  > 2 │ import {} from "a"
+      │ ^^^^^^^^^^^^^^^^^^
     3 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1   │ - import·{}·from·"b"
     2   │ - import·{}·from·"a"

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-imports-empty-header.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-imports-empty-header.js.snap
@@ -11,9 +11,15 @@ import {} from "a"
 
 # Diagnostics
 ```
-unsorted-imports-empty-header.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unsorted-imports-empty-header.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 1 │ import {} from "b"
+      │ ^^^^^^^^^^^^^^^^^^
+  > 2 │ import {} from "a"
+      │ ^^^^^^^^^^^^^^^^^^
+    3 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-imports-empty-header.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-imports-empty-header.js.snap
@@ -13,14 +13,6 @@ import {} from "a"
 ```
 unsorted-imports-empty-header.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 1 │ import {} from "b"
-      │ ^^^^^^^^^^^^^^^^^^
-  > 2 │ import {} from "a"
-      │ ^^^^^^^^^^^^^^^^^^
-    3 │ 
-  
   i Sort this chunk of imports.
   
   > 1 │ import {} from "b"

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
@@ -20,7 +20,7 @@ import type * as types from "source";
 ```
 unsorted-same-source.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
    > 1 │ import { A, B } from "source";
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
@@ -20,21 +20,6 @@ import type * as types from "source";
 ```
 unsorted-same-source.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-   > 1 │ import { A, B } from "source";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   > 2 │ import Json from "source" with { "type": "json "};
-   > 3 │ import G, * as H from "source";
-   > 4 │ import D, { E, F } from "source";
-   > 5 │ import * as N from "source";
-   > 6 │ import { m1, m2 } from "source" with { "type": "macro "};
-   > 7 │ import * as macros from "source" with { "type": "macro "};
-   > 8 │ import type { T1, T2 } from "source";
-   > 9 │ import type * as types from "source";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    10 │ 
-  
   i Sort this chunk of imports.
   
    > 1 │ import { A, B } from "source";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
@@ -18,9 +18,22 @@ import type * as types from "source";
 
 # Diagnostics
 ```
-unsorted-same-source.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unsorted-same-source.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+   > 1 │ import { A, B } from "source";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ import Json from "source" with { "type": "json "};
+   > 3 │ import G, * as H from "source";
+   > 4 │ import D, { E, F } from "source";
+   > 5 │ import * as N from "source";
+   > 6 │ import { m1, m2 } from "source" with { "type": "macro "};
+   > 7 │ import * as macros from "source" with { "type": "macro "};
+   > 8 │ import type { T1, T2 } from "source";
+   > 9 │ import type * as types from "source";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
@@ -18,16 +18,26 @@ import type * as types from "source";
 
 # Diagnostics
 ```
-unsorted-same-source.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unsorted-same-source.ts assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
   
-  > 1 │ import { A, B } from "source";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ import Json from "source" with { "type": "json "};
-    3 │ import G, * as H from "source";
+  i Sort this chunk of imports.
   
-  i Safe fix: Organize Imports (Biome)
+   > 1 │ import { A, B } from "source";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 2 │ import Json from "source" with { "type": "json "};
+   > 3 │ import G, * as H from "source";
+   > 4 │ import D, { E, F } from "source";
+   > 5 │ import * as N from "source";
+   > 6 │ import { m1, m2 } from "source" with { "type": "macro "};
+   > 7 │ import * as macros from "source" with { "type": "macro "};
+   > 8 │ import type { T1, T2 } from "source";
+   > 9 │ import type * as types from "source";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1   │ - import·{·A,·B·}·from·"source";
        1 │ + import·*·as·macros·from·"source"·with·{·"type":·"macro·"};

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-starts-with-blank-line.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-starts-with-blank-line.js.snap
@@ -12,9 +12,15 @@ import { A } from "a";
 
 # Diagnostics
 ```
-unsorted-starts-with-blank-line.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+unsorted-starts-with-blank-line.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+  > 2 │ import { B } from "b";
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ import { A } from "a";
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
   
   i Sort this chunk of imports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-starts-with-blank-line.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-starts-with-blank-line.js.snap
@@ -12,16 +12,19 @@ import { A } from "a";
 
 # Diagnostics
 ```
-unsorted-starts-with-blank-line.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+unsorted-starts-with-blank-line.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of imports.
   
   > 2 │ import { B } from "b";
       │ ^^^^^^^^^^^^^^^^^^^^^^
-    3 │ import { A } from "a";
+  > 3 │ import { A } from "a";
+      │ ^^^^^^^^^^^^^^^^^^^^^^
     4 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Safe fix: Organize imports and exports (Biome)
   
     1 1 │   
     2   │ - import·{·B·}·from·"b";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-starts-with-blank-line.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-starts-with-blank-line.js.snap
@@ -14,7 +14,7 @@ import { A } from "a";
 ```
 unsorted-starts-with-blank-line.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
 
-  i Sort this chunk of imports.
+  i Sort these imports.
   
   > 2 │ import { B } from "b";
       │ ^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-starts-with-blank-line.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-starts-with-blank-line.js.snap
@@ -14,14 +14,6 @@ import { A } from "a";
 ```
 unsorted-starts-with-blank-line.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
 
-  i Some imports or exports are not organized.
-  
-  > 2 │ import { B } from "b";
-      │ ^^^^^^^^^^^^^^^^^^^^^^
-  > 3 │ import { A } from "a";
-      │ ^^^^^^^^^^^^^^^^^^^^^^
-    4 │ 
-  
   i Sort this chunk of imports.
   
   > 2 │ import { B } from "b";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted_export_chunk.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted_export_chunk.js.snap
@@ -22,17 +22,51 @@ export { X }
 
 # Diagnostics
 ```
-unsorted_export_chunk.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unsorted_export_chunk.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i The imports and exports are not sorted.
+  i Some imports or exports are not organized.
+  
+  i Sort this chunk of exports.
   
     1 │ // File header comment to keep at the top
   > 2 │ export { A, B } from "y";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │ // Attached comment X
-    4 │ export * from "x";
+  > 3 │ // Attached comment X
+  > 4 │ export * from "x";
+      │ ^^^^^^^^^^^^^^^^^^
+    5 │ // Detached comment
+    6 │ 
   
-  i Safe fix: Organize Imports (Biome)
+  i Sort this chunk of exports.
+  
+     7 │ // Attached comment S
+   > 8 │ export * as S from "s";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
+   > 9 │ // Attached S
+  > 10 │ export { R } from "r";
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    11 │ function f() {}
+    12 │ export { A } from "a";
+  
+  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  
+     9 │ // Attached S
+    10 │ export { R } from "r";
+  > 11 │ function f() {}
+       │ ^^^^^^^^^^^^^^^
+    12 │ export { A } from "a";
+    13 │ export { X }
+  
+  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  
+    10 │ export { R } from "r";
+    11 │ function f() {}
+  > 12 │ export { A } from "a";
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    13 │ export { X }
+    14 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
   
      1  1 │   // File header comment to keep at the top
      2    │ - export·{·A,·B·}·from·"y";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted_export_chunk.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted_export_chunk.js.snap
@@ -22,9 +22,21 @@ export { X }
 
 # Diagnostics
 ```
-unsorted_export_chunk.js assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+unsorted_export_chunk.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Some imports or exports are not organized.
+  
+     1 │ // File header comment to keep at the top
+   > 2 │ export { A, B } from "y";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 3 │ // Attached comment X
+   > 4 │ export * from "x";
+        ...
+  > 11 │ function f() {}
+  > 12 │ export { A } from "a";
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    13 │ export { X }
+    14 │ 
   
   i Sort this chunk of exports.
   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted_export_chunk.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted_export_chunk.js.snap
@@ -38,7 +38,7 @@ unsorted_export_chunk.js:2:1 assist/source/organizeImports  FIXABLE  ━━━�
     13 │ export { X }
     14 │ 
   
-  i Sort this chunk of exports.
+  i Sort these exports.
   
     1 │ // File header comment to keep at the top
   > 2 │ export { A, B } from "y";
@@ -49,7 +49,7 @@ unsorted_export_chunk.js:2:1 assist/source/organizeImports  FIXABLE  ━━━�
     5 │ // Detached comment
     6 │ 
   
-  i Sort this chunk of exports.
+  i Sort these exports.
   
      7 │ // Attached comment S
    > 8 │ export * as S from "s";
@@ -60,7 +60,7 @@ unsorted_export_chunk.js:2:1 assist/source/organizeImports  FIXABLE  ━━━�
     11 │ function f() {}
     12 │ export { A } from "a";
   
-  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  i This statement must be preceded by a blank line. Add a newline before this statement.
   
      9 │ // Attached S
     10 │ export { R } from "r";
@@ -69,7 +69,7 @@ unsorted_export_chunk.js:2:1 assist/source/organizeImports  FIXABLE  ━━━�
     12 │ export { A } from "a";
     13 │ export { X }
   
-  i This statement ends a chunk of imports or exports and thus must be preceded by a blank line. Add a newline before this statement.
+  i This statement must be preceded by a blank line. Add a newline before this statement.
   
     10 │ export { R } from "r";
     11 │ function f() {}

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -2286,7 +2286,7 @@ if(a === -0) {}
     );
 
     let expected_code_action = CodeActionOrCommand::CodeAction(CodeAction {
-        title: String::from("Organize Imports (Biome)"),
+        title: String::from("Organize imports and exports (Biome)"),
         kind: Some(CodeActionKind::new("source.organizeImports.biome")),
         diagnostics: None,
         edit: Some(WorkspaceEdit {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Fix https://github.com/biomejs/biome/issues/9530#issuecomment-4081494337

This PR adds detailed diagnostics for the issues reported by the `organizeImports`.
I personally find it a bit too verbose. Any opinion?

Note I didn't change `Rule::text_range` to keep the current behavior for biome-ignore comments: they have to be placed on the first import or export that appears in the file.

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

- [x] changelog entry

## Test Plan

I updated the snapshot.

## Docs

Nochange.
