### PR TITLE
fix: organizeImports adding newlines in HTML-ish templating languages when `:BLANK_LINE:` was involved

### DIFF
--- a/.changeset/fix-embedded-organize-imports-groups.md
+++ b/.changeset/fix-embedded-organize-imports-groups.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9097](https://github.com/biomejs/biome/issues/9097): `organizeImports` no longer misapplies `:BLANK_LINE:` group separators inside Astro, Vue, and Svelte embedded script/frontmatter snippets.
+
+Biome now trims delimiter-adjacent whitespace consistently when extracting embedded JavaScript and TypeScript, so import sorting behaves the same as it does in standalone JS and TS files.

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 520
 expression: redactor(content)
 ---
 ## `file.astro`
@@ -37,11 +38,8 @@ file.astro:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━�
   
   i Unsafe fix: Remove debugger statement
   
-    1   │ - 
-    2   │ - debugger;
-      1 │ + 
-    3 2 │   
-  
+    1 │ debugger;
+      │ ---------
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 520
 expression: redactor(content)
 ---
 ## `file.astro`
@@ -38,12 +39,10 @@ file.astro:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━�
   
   i Safe fix: Organize Imports (Biome)
   
-    1 1 │   
-    2   │ - import·{·getLocale·}·from·"astro:i18n";
-    3   │ - import·{·Code·}·from·"astro:components";
-      2 │ + import·{·Code·}·from·"astro:components";
-      3 │ + import·{·getLocale·}·from·"astro:i18n";
-    4 4 │   
+    1   │ - import·{·getLocale·}·from·"astro:i18n";
+    2   │ - import·{·Code·}·from·"astro:components";
+      1 │ + import·{·Code·}·from·"astro:components";
+      2 │ + import·{·getLocale·}·from·"astro:i18n";
   
 
 ```

--- a/crates/biome_configuration/src/generated/linter_options_check.rs
+++ b/crates/biome_configuration/src/generated/linter_options_check.rs
@@ -380,6 +380,11 @@ pub fn config_side_rule_options_types() -> Vec<(&'static str, &'static str, Type
         "noDuplicateProperties",
         TypeId::of::<biome_rule_options::no_duplicate_properties::NoDuplicatePropertiesOptions>(),
     ));
+    result.push((
+        "nursery",
+        "noDuplicateSelectors",
+        TypeId::of::<biome_rule_options::no_duplicate_selectors::NoDuplicateSelectorsOptions>(),
+    ));
     result.push(("suspicious", "noDuplicateSelectorsKeyframeBlock", TypeId::of::<biome_rule_options::no_duplicate_selectors_keyframe_block::NoDuplicateSelectorsKeyframeBlockOptions>()));
     result.push((
         "suspicious",

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue9097_plain_js_valid/options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue9097_plain_js_valid/options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [":NODE:", ":BLANK_LINE:", ":PACKAGE:", ":BLANK_LINE:", ":PATH:"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue9097_plain_js_valid/valid.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue9097_plain_js_valid/valid.js
@@ -1,0 +1,2 @@
+// should not generate diagnostics
+import Page from "./page.js";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue9097_plain_js_valid/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue9097_plain_js_valid/valid.js.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: valid.js
+---
+# Input
+```js
+// should not generate diagnostics
+import Page from "./page.js";
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-astro.astro
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-astro.astro
@@ -1,0 +1,6 @@
+<!-- should not generate diagnostics -->
+---
+import Page from "./page.astro";
+---
+
+<div />

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-astro.astro.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-astro.astro.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: valid-issue-9097-astro.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+---
+import Page from "./page.astro";
+---
+
+<div />
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-astro.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-astro.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [":NODE:", ":BLANK_LINE:", ":PACKAGE:", ":BLANK_LINE:", ":PATH:"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-svelte.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-svelte.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [":NODE:", ":BLANK_LINE:", ":PACKAGE:", ":BLANK_LINE:", ":PATH:"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-svelte.svelte
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-svelte.svelte
@@ -1,0 +1,6 @@
+<!-- should not generate diagnostics -->
+<script lang="ts">
+import Page from "./page.svelte";
+</script>
+
+<div />

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-svelte.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-svelte.svelte.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: valid-issue-9097-svelte.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script lang="ts">
+import Page from "./page.svelte";
+</script>
+
+<div />
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-vue.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-vue.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [":NODE:", ":BLANK_LINE:", ":PACKAGE:", ":BLANK_LINE:", ":PATH:"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-vue.vue
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-vue.vue
@@ -1,0 +1,6 @@
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import Page from "./page.vue";
+</script>
+
+<template />

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-vue.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/valid-issue-9097-vue.vue.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: valid-issue-9097-vue.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import Page from "./page.vue";
+</script>
+
+<template />
+
+```

--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -13,6 +13,7 @@ use biome_js_syntax::{JsFileSource, TextRange, TextSize};
 use biome_parser::AnyParse;
 use biome_rowan::NodeCache;
 use regex::{Matches, Regex, RegexBuilder};
+use std::ops::Range;
 use std::sync::LazyLock;
 
 use super::SearchCapabilities;
@@ -32,16 +33,12 @@ impl AstroFileHandler {
     ///
     /// If the frontmatter doesn't exist, an empty string is returned.
     pub fn input(text: &str) -> &str {
-        let mut matches = Self::matches(text);
-        match (matches.next(), matches.next()) {
-            (Some(start), Some(end)) => &text[start.end()..end.start()],
-            _ => "",
-        }
+        Self::content_range(text).map_or("", |range| &text[range])
     }
 
     /// Returns the start byte offset of the Astro fence
     pub fn start(input: &str) -> Option<u32> {
-        ASTRO_FENCE.find_iter(input).next().map(|m| m.end() as u32)
+        Self::content_range(input).map(|range| range.start as u32)
     }
 
     fn matches(input: &str) -> Matches<'_, '_> {
@@ -51,17 +48,47 @@ impl AstroFileHandler {
     /// It takes the original content of an Astro file, and new output of an Astro file. The output is only the content contained inside the
     /// Astro fences. The function replaces `output` inside those fences.
     pub fn output(input: &str, output: &str) -> String {
-        let mut matches = Self::matches(input);
-        if let (Some(start), Some(end)) = (matches.next(), matches.next()) {
-            format!(
-                "{}{}{}",
-                &input[..start.end() + 1],
-                output.trim_start(),
-                &input[end.start()..]
-            )
+        if let Some(range) = Self::content_range(input) {
+            format!("{}{}{}", &input[..range.start], output, &input[range.end..])
         } else {
             input.to_string()
         }
+    }
+
+    /// Returns the byte range of the actual frontmatter code inside the `---` fences.
+    ///
+    /// Astro frontmatter commonly includes a newline immediately after the opening
+    /// fence and before the closing fence. Those wrapper-adjacent bytes are part of
+    /// the host document layout, but they should not be treated as part of the
+    /// embedded JavaScript/TypeScript snippet itself.
+    ///
+    /// Keeping them in the embedded slice makes snippet-based assists like
+    /// `organizeImports` observe a different input than standalone JS/TS, which can
+    /// lead to incorrect blank-line edits at the snippet boundary. By trimming only
+    /// the fence-adjacent whitespace, we keep parser offsets and fix application
+    /// aligned to the meaningful frontmatter content while still preserving the host
+    /// document's surrounding layout.
+    fn content_range(input: &str) -> Option<Range<usize>> {
+        let mut matches = Self::matches(input);
+        let (start, end) = (matches.next()?, matches.next()?);
+        let content = &input[start.end()..end.start()];
+        let leading_whitespace = content
+            .bytes()
+            .take_while(|byte| matches!(byte, b' ' | b'\t' | b'\n' | b'\r'))
+            .count();
+        let trailing_whitespace = content
+            .bytes()
+            .rev()
+            .take_while(|byte| matches!(byte, b' ' | b'\t' | b'\n' | b'\r'))
+            .count();
+        let content_start = start.end() + leading_whitespace;
+        let content_end = if leading_whitespace == content.len() {
+            content_start
+        } else {
+            end.start() - trailing_whitespace
+        };
+
+        Some(content_start..content_end)
     }
 }
 

--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -48,8 +48,33 @@ impl AstroFileHandler {
     /// It takes the original content of an Astro file, and new output of an Astro file. The output is only the content contained inside the
     /// Astro fences. The function replaces `output` inside those fences.
     pub fn output(input: &str, output: &str) -> String {
-        if let Some(range) = Self::content_range(input) {
-            format!("{}{}{}", &input[..range.start], output, &input[range.end..])
+        let mut matches = Self::matches(input);
+        if let (Some(start), Some(end)) = (matches.next(), matches.next()) {
+            // Keep legacy reconstruction behavior here.
+            //
+            // `content_range()` trims frontmatter for parsing and fix offsets, but
+            // when we write the final file back we still want the canonical fence
+            // layout: opening fence line, content, closing fence line. Rebuilding
+            // from the raw fence matches preserves that layout and avoids gluing the
+            // closing `---` onto the last line of code.
+            let line_ending = if input[start.end()..end.start()].contains("\r\n") {
+                "\r\n"
+            } else {
+                "\n"
+            };
+            let output = output.trim_start();
+            let output = if output.is_empty() || output.ends_with(['\n', '\r']) {
+                output.to_string()
+            } else {
+                format!("{output}{line_ending}")
+            };
+
+            format!(
+                "{}{}{}",
+                &input[..start.end() + 1],
+                output,
+                &input[end.start()..]
+            )
         } else {
             input.to_string()
         }

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -58,7 +58,9 @@ use biome_js_syntax::{EmbeddingKind, JsFileSource, JsLanguage};
 use biome_json_parser::parse_json_with_offset_and_cache;
 use biome_json_syntax::{JsonFileSource, JsonLanguage};
 use biome_parser::AnyParse;
-use biome_rowan::{AstNode, AstNodeList, BatchMutation, NodeCache, SendNode, TextSize};
+use biome_rowan::{
+    AstNode, AstNodeList, BatchMutation, NodeCache, SendNode, TextRange, TextSize, TokenText,
+};
 use camino::Utf8Path;
 use either::Either;
 use std::borrow::Cow;
@@ -961,17 +963,17 @@ fn build_html_candidate(element: &HtmlElement) -> Option<EmbedCandidate> {
         child.as_html_embedded_content().cloned()
     })?;
     let value_token = content_child.value_token().ok()?;
+    let (content_range, text) =
+        trim_embedded_content(value_token.text_range(), value_token.token_text());
 
     Some(EmbedCandidate::Element {
         tag_name,
         attributes,
         content: EmbedContent {
             element_range: content_child.range(),
-            content_range: value_token.text_range(),
-            content_offset: value_token.text_range().start(),
-            // Use full token text (including trivia) to match the untrimmed content_offset.
-            // The parser needs text and offset to be consistent.
-            text: value_token.token_text(),
+            content_range,
+            content_offset: content_range.start(),
+            text,
         },
     })
 }
@@ -979,15 +981,15 @@ fn build_html_candidate(element: &HtmlElement) -> Option<EmbedCandidate> {
 /// Build an `EmbedCandidate::Frontmatter` from Astro's `---` block.
 fn build_astro_frontmatter_candidate(element: &AstroEmbeddedContent) -> Option<EmbedCandidate> {
     let content_token = element.content_token()?;
+    let (content_range, text) =
+        trim_embedded_content(content_token.text_range(), content_token.token_text());
 
     Some(EmbedCandidate::Frontmatter {
         content: EmbedContent {
             element_range: element.range(),
-            content_range: content_token.text_trimmed_range(),
-            content_offset: content_token.text_range().start(),
-            // Use full token text (including trivia) to match the untrimmed content_offset.
-            // The parser needs text and offset to be consistent.
-            text: content_token.token_text(),
+            content_range,
+            content_offset: content_range.start(),
+            text,
         },
     })
 }
@@ -1644,12 +1646,17 @@ pub(crate) fn update_snippets(
         };
 
         if let Some(value_token) = element.value_token() {
-            let leading_trivia = read_leading_trivia(value_token.text_trimmed());
-            let trailing_trivia = read_trailing_trivia(value_token.text_trimmed());
+            let token_text = value_token.token_text();
+            let leading_trivia = if matches!(element, AnyEmbeddedContent::AstroEmbeddedContent(_)) {
+                Cow::Borrowed("")
+            } else {
+                read_leading_trivia(&token_text)
+            };
+            let trailing_trivia = read_trailing_trivia(&token_text);
             let new_token = ident(&format!(
                 "{}{}{}",
                 leading_trivia,
-                snippet.new_code.trim(), // trim to avoid duplicating trivia
+                snippet.new_code.as_str(),
                 trailing_trivia
             ));
             mutation.replace_token(value_token, new_token);
@@ -1691,6 +1698,42 @@ fn read_leading_trivia(value: &str) -> Cow<'_, str> {
     } else {
         Cow::Borrowed("")
     }
+}
+
+/// Trims wrapper-adjacent whitespace from a source-level embedded snippet.
+///
+/// For `<script>`-like embedded content and Astro frontmatter in the HTML full
+/// support pipeline, the syntax token usually includes leading and trailing
+/// whitespace that belongs to the host document structure rather than to the
+/// embedded JS/TS program itself.
+///
+/// This helper returns a `TextRange` and `TokenText` slice that both point to the
+/// meaningful embedded source only. Keeping the text and range trimmed in lockstep
+/// ensures that parsing, diagnostic remapping, and code-action application all use
+/// the same snippet boundaries. Without this, assists like `organizeImports` can
+/// infer extra blank lines from host-side wrapper whitespace and then reinsert those
+/// edits incorrectly into Astro, Vue, or Svelte files.
+fn trim_embedded_content(range: TextRange, value: TokenText) -> (TextRange, TokenText) {
+    let leading_len = read_leading_trivia(value.text()).len();
+    let trailing_len = read_trailing_trivia(value.text()).len();
+    let value_len = value.len();
+    let content_start = range.start() + TextSize::from(leading_len as u32);
+    let all_whitespace = value_len == TextSize::from(leading_len as u32);
+    let content_end = if all_whitespace {
+        content_start
+    } else {
+        range.end() - TextSize::from(trailing_len as u32)
+    };
+    let text = if all_whitespace {
+        value.slice(TextRange::empty(TextSize::from(0)))
+    } else {
+        value.slice(TextRange::new(
+            TextSize::from(leading_len as u32),
+            value_len - TextSize::from(trailing_len as u32),
+        ))
+    };
+
+    (TextRange::new(content_start, content_end), text)
 }
 
 /// Extracts all trailing whitespace (spaces, tabs, newlines, carriage returns) from a string.

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -963,17 +963,21 @@ fn build_html_candidate(element: &HtmlElement) -> Option<EmbedCandidate> {
         child.as_html_embedded_content().cloned()
     })?;
     let value_token = content_child.value_token().ok()?;
-    let (content_range, text) =
-        trim_embedded_content(value_token.text_range(), value_token.token_text());
 
     Some(EmbedCandidate::Element {
         tag_name,
         attributes,
         content: EmbedContent {
             element_range: content_child.range(),
-            content_range,
-            content_offset: content_range.start(),
-            text,
+            // Keep the full token range here.
+            //
+            // `content_range` is also used by the HTML formatter's embedded-node
+            // placeholders. If we trim it to the inner JS/TS text, formatter-driven
+            // delegation no longer spans the original host token and full-support
+            // formatting starts dropping or misplacing wrapper whitespace.
+            content_range: value_token.text_range(),
+            content_offset: value_token.text_range().start(),
+            text: value_token.token_text(),
         },
     })
 }
@@ -981,15 +985,17 @@ fn build_html_candidate(element: &HtmlElement) -> Option<EmbedCandidate> {
 /// Build an `EmbedCandidate::Frontmatter` from Astro's `---` block.
 fn build_astro_frontmatter_candidate(element: &AstroEmbeddedContent) -> Option<EmbedCandidate> {
     let content_token = element.content_token()?;
-    let (content_range, text) =
-        trim_embedded_content(content_token.text_range(), content_token.token_text());
 
     Some(EmbedCandidate::Frontmatter {
         content: EmbedContent {
             element_range: element.range(),
-            content_range,
-            content_offset: content_range.start(),
-            text,
+            // Frontmatter is special: the formatter delegates using the whole
+            // `AstroEmbeddedContent` node range (`element_range`), not this token
+            // range. We can therefore use the trimmed token range here to keep
+            // frontmatter diagnostics/code-action ranges anchored to the actual code.
+            content_range: content_token.text_trimmed_range(),
+            content_offset: content_token.text_range().start(),
+            text: content_token.token_text(),
         },
     })
 }
@@ -1200,13 +1206,26 @@ fn parse_matched_embed(
                 _ => false,
             };
 
+            let (content_offset, content_text) = if is_source_level {
+                // For source-level snippets (`<script>` and frontmatter), parse the
+                // embedded program as if the wrapper-adjacent newline/indent bytes
+                // were not part of the guest language.
+                //
+                // This is the actual issue #9097 fix: assists such as
+                // `organizeImports` should reason about the JS/TS source only, not
+                // about the host document's padding around that source.
+                trim_embedded_content(content.content_offset, content.text.clone())
+            } else {
+                (content.content_offset, content.text.clone())
+            };
+
             let doc_source = DocumentFileSource::Js(js_source);
             let options = ctx
                 .settings
                 .parse_options::<JsLanguage>(ctx.biome_path, &doc_source);
             let parse = parse_js_with_offset_and_cache(
-                content.text.text(),
-                content.content_offset,
+                content_text.text(),
+                content_offset,
                 js_source,
                 options,
                 ctx.cache,
@@ -1220,8 +1239,12 @@ fn parse_matched_embed(
             let snippet: EmbeddedSnippet<JsLanguage> = EmbeddedSnippet::new(
                 parse.into(),
                 content.element_range,
+                // Preserve the original host-side range for snippet bookkeeping.
+                // The parse offset above is trimmed for source-level analysis, but
+                // the snippet still needs to point back at the host document span
+                // used by formatter delegation and snippet replacement.
                 content.content_range,
-                content.content_offset,
+                content_offset,
             );
 
             // Source-level embeds get full services; expression-level don't
@@ -1646,17 +1669,12 @@ pub(crate) fn update_snippets(
         };
 
         if let Some(value_token) = element.value_token() {
-            let token_text = value_token.token_text();
-            let leading_trivia = if matches!(element, AnyEmbeddedContent::AstroEmbeddedContent(_)) {
-                Cow::Borrowed("")
-            } else {
-                read_leading_trivia(&token_text)
-            };
-            let trailing_trivia = read_trailing_trivia(&token_text);
+            let leading_trivia = read_leading_trivia(value_token.text_trimmed());
+            let trailing_trivia = read_trailing_trivia(value_token.text_trimmed());
             let new_token = ident(&format!(
                 "{}{}{}",
                 leading_trivia,
-                snippet.new_code.as_str(),
+                snippet.new_code.trim(),
                 trailing_trivia
             ));
             mutation.replace_token(value_token, new_token);
@@ -1707,23 +1725,20 @@ fn read_leading_trivia(value: &str) -> Cow<'_, str> {
 /// whitespace that belongs to the host document structure rather than to the
 /// embedded JS/TS program itself.
 ///
-/// This helper returns a `TextRange` and `TokenText` slice that both point to the
-/// meaningful embedded source only. Keeping the text and range trimmed in lockstep
-/// ensures that parsing, diagnostic remapping, and code-action application all use
-/// the same snippet boundaries. Without this, assists like `organizeImports` can
-/// infer extra blank lines from host-side wrapper whitespace and then reinsert those
-/// edits incorrectly into Astro, Vue, or Svelte files.
-fn trim_embedded_content(range: TextRange, value: TokenText) -> (TextRange, TokenText) {
+/// This helper is intentionally used only for source-level JS/TS parsing and
+/// diagnostic/code-action offsets.
+///
+/// We do *not* use it to rewrite `content_range`, because the HTML formatter and
+/// embedded-snippet replacement logic still need the original host-document span.
+/// In other words:
+/// - trimmed `offset`/`text` are for guest-language analysis
+/// - untrimmed `content_range` is for host-document plumbing
+fn trim_embedded_content(offset: TextSize, value: TokenText) -> (TextSize, TokenText) {
     let leading_len = read_leading_trivia(value.text()).len();
     let trailing_len = read_trailing_trivia(value.text()).len();
     let value_len = value.len();
-    let content_start = range.start() + TextSize::from(leading_len as u32);
+    let content_start = offset + TextSize::from(leading_len as u32);
     let all_whitespace = value_len == TextSize::from(leading_len as u32);
-    let content_end = if all_whitespace {
-        content_start
-    } else {
-        range.end() - TextSize::from(trailing_len as u32)
-    };
     let text = if all_whitespace {
         value.slice(TextRange::empty(TextSize::from(0)))
     } else {
@@ -1733,7 +1748,7 @@ fn trim_embedded_content(range: TextRange, value: TokenText) -> (TextRange, Toke
         ))
     };
 
-    (TextRange::new(content_start, content_end), text)
+    (content_start, text)
 }
 
 /// Extracts all trailing whitespace (spaces, tabs, newlines, carriage returns) from a string.


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
generated by gpt 5.4

This one was a bit weird because the bug happened across both with and without full html support, but only on astro. vue and svelte was bugged only with full html support enabled.

Essentially, this was an interaction between how we extract embedded snippets vs how the rule deals with the `:BLANK_LINE:` group.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #9097

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
