### PR TITLE
feat: go-to definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,7 @@ dependencies = [
  "tower",
  "tower-lsp-server",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -1667,6 +1668,7 @@ dependencies = [
  "biome_project_layout",
  "biome_resolver",
  "biome_rowan",
+ "biome_service",
  "biome_string_case",
  "biome_text_edit",
  "boxcar",

--- a/crates/biome_cli/src/execute/migrate.rs
+++ b/crates/biome_cli/src/execute/migrate.rs
@@ -200,6 +200,7 @@ fn migrate_file(payload: MigrateFile) -> Result<MigrationFileResult, CliDiagnost
         ),
         persist_node_cache: false,
         inline_config: None,
+        needs_document_services: None,
     })?;
     let parsed = parse_json_with_cache(&biome_config_content, &mut cache, parse_options);
 

--- a/crates/biome_cli/src/runner/impls/process_file/format.rs
+++ b/crates/biome_cli/src/runner/impls/process_file/format.rs
@@ -172,6 +172,7 @@ impl ProcessFile for FormatProcessFile {
                 document_file_source: None,
                 persist_node_cache: false,
                 inline_config: None,
+                needs_document_services: None,
             })?;
             let printed = workspace.format_file(FormatFileParams {
                 project_key,

--- a/crates/biome_cli/src/runner/impls/process_file/lint_and_assist.rs
+++ b/crates/biome_cli/src/runner/impls/process_file/lint_and_assist.rs
@@ -187,6 +187,7 @@ impl ProcessFile for LintAssistProcessFile {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })?;
 
         // apply fix file of the linter

--- a/crates/biome_cli/src/runner/process_file.rs
+++ b/crates/biome_cli/src/runner/process_file.rs
@@ -264,6 +264,7 @@ impl<'ctx, 'app> WorkspaceFile<'ctx, 'app> {
                 content: FileContent::from_client(&input),
                 persist_node_cache: false,
                 inline_config: None,
+                needs_document_services: None,
             })?;
 
             Ok(Self { guard, path, file })

--- a/crates/biome_html_analyze/src/lint/nursery/no_undeclared_classes.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/no_undeclared_classes.rs
@@ -129,7 +129,7 @@ impl Rule for NoUndeclaredClasses {
             for step in &css_steps {
                 if step
                     .css_classes
-                    .iter()
+                    .keys()
                     .any(|token| token.text() == class_name)
                 {
                     found_class = true;

--- a/crates/biome_js_analyze/src/lint/nursery/no_undeclared_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_undeclared_classes.rs
@@ -74,7 +74,7 @@ impl Rule for NoUndeclaredClasses {
             for step in module_graph.traverse_import_tree_for_classes(file_path) {
                 if step
                     .css_classes
-                    .iter()
+                    .keys()
                     .any(|token| token.text() == class_name)
                 {
                     found_class = true;

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -37,6 +37,7 @@ serde_json           = { workspace = true }
 tokio                = { workspace = true, features = ["io-std", "rt"] }
 tower-lsp-server     = { workspace = true }
 tracing              = { workspace = true, features = ["attributes"] }
+url                  = { workspace = true }
 uuid                 = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/biome_lsp/src/capabilities.rs
+++ b/crates/biome_lsp/src/capabilities.rs
@@ -94,6 +94,18 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
             }
         });
 
+    let definition_provider = capabilities
+        .text_document
+        .as_ref()
+        .and_then(|text_document| text_document.definition.as_ref())
+        .and_then(|definition| {
+            if definition.dynamic_registration.unwrap_or(false) {
+                None
+            } else {
+                Some(OneOf::Left(true))
+            }
+        });
+
     ServerCapabilities {
         position_encoding: Some(match negotiated_encoding(capabilities) {
             PositionEncoding::Utf8 => PositionEncodingKind::UTF8,
@@ -109,6 +121,7 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
         document_range_formatting_provider: supports_range_formatter_dynamic_registration,
         document_on_type_formatting_provider: supports_on_type_formatter_dynamic_registration,
         code_action_provider,
+        definition_provider,
         rename_provider: None,
         workspace: Some(WorkspaceServerCapabilities {
             workspace_folders: Some(WorkspaceFoldersServerCapabilities {

--- a/crates/biome_lsp/src/diagnostics.rs
+++ b/crates/biome_lsp/src/diagnostics.rs
@@ -55,7 +55,9 @@ pub(crate) async fn handle_lsp_error<T>(
     match err {
         LspError::WorkspaceError(err) => match err {
             // diagnostics that shouldn't raise an hard error, but send a message to the user
-            WorkspaceError::FormatWithErrorsDisabled(_) | WorkspaceError::FileIgnored(_) => {
+            WorkspaceError::FormatWithErrorsDisabled(_)
+            | WorkspaceError::FileIgnored(_)
+            | WorkspaceError::GoToDefinitionDisabled(_) => {
                 let message = format!("{err}");
                 client.log_message(MessageType::WARNING, message).await;
                 Ok(None)

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -31,6 +31,9 @@ pub struct WorkspaceSettings {
 
     /// Inline configuration, which gets merged before applying querying instructions via workspace
     pub inline_config: Option<Configuration>,
+
+    /// Enables the "go-to" features, by-passing the use of linting or assist
+    pub go_to_definition: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -77,5 +80,9 @@ impl ExtensionSettings {
 
     pub(crate) fn inline_config(&self) -> Option<Configuration> {
         self.settings.inline_config.clone()
+    }
+
+    pub(crate) fn goto_definition_enabled(&self) -> bool {
+        self.settings.go_to_definition.unwrap_or_default()
     }
 }

--- a/crates/biome_lsp/src/handlers.rs
+++ b/crates/biome_lsp/src/handlers.rs
@@ -1,3 +1,4 @@
 pub(crate) mod analysis;
 pub(crate) mod formatting;
+pub(crate) mod navigation;
 pub(crate) mod text_document;

--- a/crates/biome_lsp/src/handlers/navigation.rs
+++ b/crates/biome_lsp/src/handlers/navigation.rs
@@ -1,0 +1,90 @@
+use crate::diagnostics::LspError;
+use crate::session::Session;
+use anyhow::Context;
+use biome_fs::BiomePath;
+use biome_line_index::LineIndex;
+use biome_lsp_converters::{from_proto, to_proto};
+use biome_rowan::TextRange;
+use biome_service::workspace::{GetFileContentParams, GoToDefinitionParams};
+use std::str::FromStr;
+use tower_lsp_server::ls_types::*;
+
+pub(crate) fn goto_definition(
+    session: &Session,
+    params: GotoDefinitionParams,
+) -> Result<Option<GotoDefinitionResponse>, LspError> {
+    let url = params.text_document_position_params.text_document.uri;
+    let path = session.file_path(&url)?;
+    let Some(doc) = session.document(&url) else {
+        return Ok(None);
+    };
+
+    let position_encoding = session.position_encoding();
+    let cursor_offset = from_proto::offset(
+        &doc.line_index,
+        params.text_document_position_params.position,
+        position_encoding,
+    )
+    .with_context(|| {
+        format!(
+            "failed to access position {:?} in document {}",
+            params.text_document_position_params.position,
+            url.as_str()
+        )
+    })?;
+
+    let cursor_range = TextRange::new(cursor_offset, cursor_offset);
+
+    let enabled = session
+        .extension_settings
+        .read()
+        .unwrap()
+        .goto_definition_enabled();
+
+    let result = session.workspace.go_to_definition(GoToDefinitionParams {
+        project_key: doc.project_key,
+        path: path.clone(),
+        cursor_range,
+        enabled,
+    })?;
+
+    match result {
+        Some(definition) => {
+            let target_uri = uri_from_path(&definition.path)?;
+
+            // For same-file definitions, reuse the existing LineIndex.
+            // For cross-file definitions, read the target and build a LineIndex.
+            let target_range = if definition.path == path {
+                to_proto::range(&doc.line_index, definition.range, position_encoding)?
+            } else {
+                match session.workspace.get_file_content(GetFileContentParams {
+                    project_key: doc.project_key,
+                    path: definition.path.clone(),
+                }) {
+                    Ok(content) => {
+                        let target_line_index = LineIndex::new(&content);
+                        to_proto::range(&target_line_index, definition.range, position_encoding)?
+                    }
+                    Err(_) => Range::default(),
+                }
+            };
+
+            Ok(Some(GotoDefinitionResponse::Scalar(Location {
+                uri: target_uri,
+                range: target_range,
+            })))
+        }
+        None => Ok(None),
+    }
+}
+
+fn uri_from_path(path: &BiomePath) -> Result<Uri, LspError> {
+    let url = url::Url::from_file_path(path.as_path()).map_err(|_| {
+        LspError::from(anyhow::anyhow!(
+            "failed to convert path to URL: {}",
+            path.as_path()
+        ))
+    })?;
+    Uri::from_str(url.as_str())
+        .map_err(|err| LspError::from(anyhow::anyhow!("failed to convert URL to URI: {err}")))
+}

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -137,6 +137,13 @@ pub(crate) async fn did_open(
         document_file_source: Some(language_hint),
         persist_node_cache: true,
         inline_config: session.inline_config(),
+        needs_document_services: Some(
+            session
+                .extension_settings
+                .read()
+                .unwrap()
+                .goto_definition_enabled(),
+        ),
     })?;
 
     session.insert_document(url.clone(), doc);

--- a/crates/biome_lsp/src/lib.rs
+++ b/crates/biome_lsp/src/lib.rs
@@ -7,6 +7,8 @@ mod extension_settings;
 mod handlers;
 mod requests;
 mod server;
+#[cfg(test)]
+mod server_test_utils;
 mod session;
 mod utils;
 

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -268,6 +268,16 @@ impl LSPServer {
             },
         );
 
+        capabilities.add_capability(
+            "biome_go_to_definition",
+            "textDocument/definition",
+            if is_linting_and_formatting_disabled || !self.session.can_register_goto_definition() {
+                CapabilityStatus::Disable
+            } else {
+                CapabilityStatus::Enable(None)
+            },
+        );
+
         self.session.register_capabilities(capabilities).await;
     }
 
@@ -487,6 +497,17 @@ impl LanguageServer for LSPServer {
 
         self.map_op_error(result).await
     }
+
+    async fn goto_definition(
+        &self,
+        params: GotoDefinitionParams,
+    ) -> LspResult<Option<GotoDefinitionResponse>> {
+        let result = biome_diagnostics::panic::catch_unwind(move || {
+            handlers::navigation::goto_definition(&self.session, params)
+        });
+
+        self.map_op_error(result).await
+    }
 }
 
 impl Drop for LSPServer {
@@ -676,6 +697,7 @@ impl ServerFactory {
         workspace_method!(builder, format_on_type);
         workspace_method!(builder, fix_file);
         workspace_method!(builder, rename);
+        workspace_method!(builder, go_to_definition);
         workspace_method!(builder, parse_pattern);
         workspace_method!(builder, search_pattern);
         workspace_method!(builder, drop_pattern);
@@ -723,3 +745,7 @@ impl ServerConnection {
 #[cfg(test)]
 #[path = "server.tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "server_navigation.tests.rs"]
+mod navigation_tests;

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1,12 +1,7 @@
-use std::any::type_name;
-use std::collections::{BTreeMap, HashMap};
-use std::fmt::Display;
-use std::slice;
-use std::str::FromStr;
-
-use super::*;
 use crate::WorkspaceSettings;
-use anyhow::{Context, Error, Result, bail};
+use crate::capabilities::DEFAULT_CODE_ACTION_CAPABILITIES;
+use crate::server_test_utils::*;
+use anyhow::{Context, Result};
 use biome_analyze::RuleCategories;
 use biome_configuration::analyzer::RuleSelector;
 use biome_configuration::analyzer::assist::AssistConfiguration;
@@ -20,77 +15,26 @@ use biome_service::workspace::{
     ScanProjectResult,
 };
 use biome_service::{Watcher, WatcherOptions};
-use camino::Utf8PathBuf;
-use futures::channel::mpsc::{Sender, channel};
-use futures::{Sink, SinkExt, Stream, StreamExt};
-use serde::Serialize;
-use serde::de::DeserializeOwned;
-use serde_json::{from_value, to_value};
-use tokio::time::{Duration, sleep, timeout};
-use tower::timeout::Timeout;
-use tower::{Service, ServiceExt};
-use tower_lsp_server::LspService;
-use tower_lsp_server::jsonrpc::{self, Request, Response};
+use futures::channel::mpsc::channel;
+use std::collections::{BTreeMap, HashMap};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::spawn_blocking;
+use tokio::time::sleep;
 use tower_lsp_server::ls_types::{
-    self as lsp, ClientCapabilities, CodeDescription, DidChangeConfigurationParams,
-    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DidSaveTextDocumentParams, DocumentFormattingParams, FormattingOptions, InitializeParams,
-    InitializeResult, InitializedParams, Position, PublishDiagnosticsParams, Range,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, TextEdit, Uri,
-    VersionedTextDocumentIdentifier, WorkDoneProgressParams, WorkspaceFolder,
+    self as lsp, ClientCapabilities, CodeAction, CodeActionContext, CodeActionKind,
+    CodeActionOrCommand, CodeActionParams, CodeActionResponse, CodeDescription, Diagnostic,
+    DiagnosticRelatedInformation, DiagnosticSeverity, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentFormattingParams,
+    DocumentRangeFormattingParams, FormattingOptions, InitializeParams, InitializeResult, Location,
+    MessageType, NumberOrString, PartialResultParams, Position, PublishDiagnosticsParams, Range,
+    ShowMessageParams, TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
+    TextEdit, Uri, WorkDoneProgressParams, WorkspaceEdit, WorkspaceFolder,
 };
 
-/// Statically build an [Uri] instance that points to the file at `$path`
-/// within the workspace. The filesystem path contained in the return URI is
-/// guaranteed to be a valid path for the underlying operating system, but
-/// doesn't have to refer to an existing file on the host machine.
-macro_rules! uri {
-    ($path:literal) => {
-        if cfg!(windows) {
-            lsp::Uri::from_str(concat!("file:///z%3A/workspace/", $path)).unwrap()
-        } else {
-            lsp::Uri::from_str(concat!("file:///workspace/", $path)).unwrap()
-        }
-    };
-}
-
-macro_rules! await_notification {
-    ($channel:expr) => {
-        sleep(Duration::from_millis(1000)).await;
-
-        timeout(Duration::from_secs(2), $channel.changed())
-            .await
-            .expect("expected notification within timeout")
-            .expect("expected notification");
-    };
-}
-
-macro_rules! clear_notifications {
-    ($channel:expr) => {
-        // On Windows, wait until any previous event has been delivered.
-        // On macOS, wait until the fsevents watcher sets up before receiving the first event.
-        let duration = if cfg!(any(target_os = "windows", target_os = "macos")) {
-            Duration::from_secs(1)
-        } else {
-            Duration::from_millis(200)
-        };
-        sleep(duration).await;
-
-        if $channel
-            .has_changed()
-            .expect("Channel should not be closed")
-        {
-            let _ = $channel.changed().await;
-        }
-    };
-}
-
-fn to_utf8_file_path_buf(uri: Uri) -> Utf8PathBuf {
-    Utf8PathBuf::from_path_buf(uri.to_file_path().unwrap().to_path_buf()).unwrap()
-}
-
-fn fixable_diagnostic(line: u32) -> Result<Diagnostic> {
-    Ok(Diagnostic {
+fn fixable_diagnostic(line: u32) -> Result<lsp::Diagnostic> {
+    Ok(lsp::Diagnostic {
         range: Range {
             start: Position { line, character: 3 },
             end: Position {
@@ -98,8 +42,8 @@ fn fixable_diagnostic(line: u32) -> Result<Diagnostic> {
                 character: 11,
             },
         },
-        severity: Some(DiagnosticSeverity::ERROR),
-        code: Some(NumberOrString::String(String::from(
+        severity: Some(lsp::DiagnosticSeverity::ERROR),
+        code: Some(lsp::NumberOrString::String(String::from(
             "lint/suspicious/noCompareNegZero",
         ))),
         code_description: None,
@@ -109,389 +53,6 @@ fn fixable_diagnostic(line: u32) -> Result<Diagnostic> {
         tags: None,
         data: None,
     })
-}
-
-struct Server {
-    service: Timeout<LspService<LSPServer>>,
-}
-
-impl Server {
-    fn new(service: LspService<LSPServer>) -> Self {
-        Self {
-            service: Timeout::new(service, Duration::from_secs(1)),
-        }
-    }
-
-    async fn notify<P>(&mut self, method: &'static str, params: P) -> Result<()>
-    where
-        P: Serialize,
-    {
-        self.service
-            .ready()
-            .await
-            .map_err(Error::msg)
-            .context("ready() returned an error")?
-            .call(
-                Request::build(method)
-                    .params(to_value(&params).context("failed to serialize params")?)
-                    .finish(),
-            )
-            .await
-            .map_err(Error::msg)
-            .context("call() returned an error")
-            .and_then(|res| {
-                if let Some(res) = res {
-                    bail!("shutdown returned {:?}", res)
-                } else {
-                    Ok(())
-                }
-            })
-    }
-
-    async fn request<P, R>(
-        &mut self,
-        method: &'static str,
-        id: &'static str,
-        params: P,
-    ) -> Result<Option<R>>
-    where
-        P: Serialize,
-        R: DeserializeOwned,
-    {
-        self.service
-            .ready()
-            .await
-            .map_err(Error::msg)
-            .context("ready() returned an error")?
-            .call(
-                Request::build(method)
-                    .id(id)
-                    .params(to_value(&params).context("failed to serialize params")?)
-                    .finish(),
-            )
-            .await
-            .map_err(Error::msg)
-            .context("call() returned an error")?
-            .map(|res| {
-                let (_, body) = res.into_parts();
-
-                let body =
-                    body.with_context(|| format!("response to {method:?} contained an error"))?;
-
-                from_value(body.clone()).with_context(|| {
-                    format!(
-                        "failed to deserialize type {} from response {body:?}",
-                        type_name::<R>()
-                    )
-                })
-            })
-            .transpose()
-    }
-
-    /// Basic implementation of the `initialize` request for tests
-    // The `root_path` field is deprecated, but we still need to specify it
-    #[expect(deprecated)]
-    async fn initialize(&mut self) -> Result<()> {
-        let _res: InitializeResult = self
-            .request(
-                "initialize",
-                "_init",
-                InitializeParams {
-                    process_id: None,
-                    root_path: None,
-                    root_uri: Some(uri!("")),
-                    initialization_options: None,
-                    capabilities: ClientCapabilities::default(),
-                    trace: None,
-                    workspace_folders: None,
-                    client_info: None,
-                    locale: None,
-                    work_done_progress_params: Default::default(),
-                },
-            )
-            .await?
-            .context("initialize returned None")?;
-
-        Ok(())
-    }
-
-    /// It creates two projects, one at folder `test_one` and the other in `test_two`.
-    ///
-    /// Hence, the two roots will be `/workspace/test_one` and `/workspace/test_two`
-    // The `root_path` field is deprecated, but we still need to specify it
-    #[expect(deprecated)]
-    async fn initialize_projects(&mut self) -> Result<()> {
-        let _res: InitializeResult = self
-            .request(
-                "initialize",
-                "_init",
-                InitializeParams {
-                    process_id: None,
-                    root_path: None,
-                    root_uri: Some(uri!("/")),
-                    initialization_options: None,
-                    capabilities: ClientCapabilities::default(),
-                    trace: None,
-                    workspace_folders: Some(vec![
-                        WorkspaceFolder {
-                            name: "test_one".to_string(),
-                            uri: uri!("test_one"),
-                        },
-                        WorkspaceFolder {
-                            name: "test_two".to_string(),
-                            uri: uri!("test_two"),
-                        },
-                    ]),
-                    client_info: None,
-                    locale: None,
-                    work_done_progress_params: Default::default(),
-                },
-            )
-            .await?
-            .context("initialize returned None")?;
-
-        Ok(())
-    }
-
-    /// Basic implementation of the `initialized` notification for tests
-    async fn initialized(&mut self) -> Result<()> {
-        self.notify("initialized", InitializedParams {}).await
-    }
-
-    /// Basic implementation of the `shutdown` notification for tests
-    async fn shutdown(&mut self) -> Result<()> {
-        self.service
-            .ready()
-            .await
-            .map_err(Error::msg)
-            .context("ready() returned an error")?
-            .call(Request::build("shutdown").finish())
-            .await
-            .map_err(Error::msg)
-            .context("call() returned an error")
-            .and_then(|res| {
-                if let Some(res) = res {
-                    bail!("shutdown returned {:?}", res)
-                } else {
-                    Ok(())
-                }
-            })
-    }
-
-    async fn open_document(&mut self, text: impl Display) -> Result<()> {
-        self.notify(
-            "textDocument/didOpen",
-            DidOpenTextDocumentParams {
-                text_document: TextDocumentItem {
-                    uri: uri!("document.js"),
-                    language_id: String::from("javascript"),
-                    version: 0,
-                    text: text.to_string(),
-                },
-            },
-        )
-        .await
-    }
-
-    async fn open_untitled_document(&mut self, text: impl Display) -> Result<()> {
-        self.notify(
-            "textDocument/didOpen",
-            DidOpenTextDocumentParams {
-                text_document: TextDocumentItem {
-                    uri: uri!("untitled-1"),
-                    language_id: String::from("javascript"),
-                    version: 0,
-                    text: text.to_string(),
-                },
-            },
-        )
-        .await
-    }
-
-    /// Opens a document with given contents and given name. The name must contain the extension too
-    async fn open_named_document(
-        &mut self,
-        text: impl Display,
-        document_name: Uri,
-        language: impl Display,
-    ) -> Result<()> {
-        self.notify(
-            "textDocument/didOpen",
-            DidOpenTextDocumentParams {
-                text_document: TextDocumentItem {
-                    uri: document_name,
-                    language_id: language.to_string(),
-                    version: 0,
-                    text: text.to_string(),
-                },
-            },
-        )
-        .await
-    }
-
-    /// When calling this function, remember to insert the file inside the memory file system
-    async fn load_configuration(&mut self) -> Result<()> {
-        self.notify(
-            "workspace/didChangeConfiguration",
-            DidChangeConfigurationParams {
-                settings: to_value(())?,
-            },
-        )
-        .await
-    }
-
-    /// When calling this function, remember to insert the file inside the memory file system
-    async fn load_configuration_with_settings<V>(&mut self, value: V) -> Result<()>
-    where
-        V: Serialize,
-    {
-        self.notify(
-            "workspace/didChangeConfiguration",
-            DidChangeConfigurationParams {
-                settings: to_value(value)?,
-            },
-        )
-        .await
-    }
-
-    async fn change_document(
-        &mut self,
-        version: i32,
-        content_changes: Vec<TextDocumentContentChangeEvent>,
-    ) -> Result<()> {
-        self.notify(
-            "textDocument/didChange",
-            DidChangeTextDocumentParams {
-                text_document: VersionedTextDocumentIdentifier {
-                    uri: uri!("document.js"),
-                    version,
-                },
-                content_changes,
-            },
-        )
-        .await
-    }
-
-    async fn close_document(&mut self) -> Result<()> {
-        self.notify(
-            "textDocument/didClose",
-            DidCloseTextDocumentParams {
-                text_document: TextDocumentIdentifier {
-                    uri: uri!("document.js"),
-                },
-            },
-        )
-        .await
-    }
-
-    /// Basic implementation of the `biome/shutdown` request for tests
-    async fn biome_shutdown(&mut self) -> Result<()> {
-        self.request::<_, ()>("biome/shutdown", "_biome_shutdown", ())
-            .await?
-            .context("biome/shutdown returned None")?;
-        Ok(())
-    }
-}
-
-/// Number of notifications buffered by the server-to-client channel before it starts blocking the current task
-const CHANNEL_BUFFER_SIZE: usize = 8;
-
-#[derive(Debug, PartialEq, Eq)]
-enum ServerNotification {
-    PublishDiagnostics(PublishDiagnosticsParams),
-    ShowMessage(ShowMessageParams),
-}
-impl ServerNotification {
-    pub fn is_publish_diagnostics(&self) -> bool {
-        matches!(self, Self::PublishDiagnostics(_))
-    }
-
-    pub fn is_show_message(&self) -> bool {
-        matches!(self, Self::ShowMessage(_))
-    }
-}
-
-async fn wait_for_notification(
-    receiver: &mut (impl Stream<Item = ServerNotification> + Unpin),
-    check: impl Fn(&ServerNotification) -> bool,
-) -> Option<ServerNotification> {
-    loop {
-        let notification = tokio::select! {
-            msg = receiver.next() => msg,
-            _ = sleep(Duration::from_secs(3)) => {
-                panic!("timed out waiting for the server to send diagnostics")
-            }
-        };
-
-        match notification {
-            Some(notification) => {
-                if check(&notification) {
-                    return Some(notification);
-                }
-            }
-            None => break None,
-        }
-    }
-}
-
-/// Basic handler for requests and notifications coming from the server for tests
-async fn client_handler<I, O>(stream: I, sink: O, notify: Sender<ServerNotification>) -> Result<()>
-where
-    I: Stream<Item = Request> + Unpin,
-    O: Sink<Response> + Unpin,
-{
-    client_handler_with_settings(stream, sink, notify, WorkspaceSettings::default()).await
-}
-
-/// Handler for requests and notifications coming from the server for tests with custom settings
-async fn client_handler_with_settings<I, O>(
-    mut stream: I,
-    mut sink: O,
-    mut notify: Sender<ServerNotification>,
-    settings: WorkspaceSettings,
-) -> Result<()>
-where
-    // This function has to be generic as `RequestStream` and `ResponseSink`
-    // are not exported from `tower_lsp` and cannot be named in the signature
-    I: Stream<Item = Request> + Unpin,
-    O: Sink<Response> + Unpin,
-{
-    while let Some(req) = stream.next().await {
-        let params = req.params().expect("invalid request").clone();
-        if let Some(notification) = match req.method() {
-            "textDocument/publishDiagnostics" => Some(ServerNotification::PublishDiagnostics(
-                from_value(params).expect("invalid params"),
-            )),
-            "window/showMessage" => Some(ServerNotification::ShowMessage(
-                from_value(params).expect("invalid params"),
-            )),
-            _ => None,
-        } {
-            match notify.send(notification).await {
-                Ok(_) => continue,
-                Err(_) => break,
-            }
-        }
-
-        let id = match req.id() {
-            Some(id) => id,
-            None => continue,
-        };
-
-        let res = match req.method() {
-            "workspace/configuration" => {
-                let result =
-                    to_value(slice::from_ref(&settings)).context("failed to serialize settings")?;
-
-                Response::from_ok(id.clone(), result)
-            }
-            _ => Response::from_error(id.clone(), jsonrpc::Error::method_not_found()),
-        };
-
-        sink.send(res).await.ok();
-    }
-
-    Ok(())
 }
 
 #[tokio::test]
@@ -3634,6 +3195,7 @@ export function bar() {
                 document_file_source: None,
                 persist_node_cache: false,
                 inline_config: None,
+                needs_document_services: None,
             },
         )
         .await?
@@ -3850,6 +3412,7 @@ export function bar() {
                 document_file_source: None,
                 persist_node_cache: false,
                 inline_config: None,
+                needs_document_services: None,
             },
         )
         .await?

--- a/crates/biome_lsp/src/server_navigation.tests.rs
+++ b/crates/biome_lsp/src/server_navigation.tests.rs
@@ -1,0 +1,431 @@
+use std::str::FromStr;
+
+use crate::server_test_utils::*;
+use anyhow::{Context, Result};
+use biome_fs::TemporaryFs;
+use biome_service::workspace::{
+    FileContent, OpenFileParams, OpenFileResult, OpenProjectParams, OpenProjectResult, ScanKind,
+    ScanProjectParams, ScanProjectResult,
+};
+use biome_service::{Watcher, WatcherOptions};
+use futures::channel::mpsc::channel;
+use tokio::task::spawn_blocking;
+use tower_lsp_server::ls_types::{
+    self as lsp, DidOpenTextDocumentParams, Position, Range, TextDocumentIdentifier,
+    TextDocumentItem, WorkDoneProgressParams,
+};
+
+#[tokio::test]
+async fn goto_definition_same_file_local_binding() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    // `const myVar = 42;\nconsole.log(myVar);\n`
+    // Cursor on `myVar` in `console.log(myVar)` (line 1, character 12)
+    server
+        .open_document("const myVar = 42;\nconsole.log(myVar);\n")
+        .await?;
+
+    let res: Option<lsp::GotoDefinitionResponse> = server
+        .request(
+            "textDocument/definition",
+            "goto_definition",
+            lsp::GotoDefinitionParams {
+                text_document_position_params: lsp::TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: uri!("document.js"),
+                    },
+                    position: Position {
+                        line: 1,
+                        character: 12,
+                    },
+                },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: lsp::PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+        )
+        .await?
+        .context("goto_definition returned None")?;
+
+    let definition = res.context("goto_definition returned empty response")?;
+
+    match definition {
+        lsp::GotoDefinitionResponse::Scalar(location) => {
+            assert_eq!(location.uri, uri!("document.js"));
+            // `myVar` declaration is at line 0, characters 6..11
+            assert_eq!(
+                location.range,
+                Range {
+                    start: Position {
+                        line: 0,
+                        character: 6,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 11,
+                    },
+                }
+            );
+        }
+        other => panic!("expected Scalar response, got: {other:?}"),
+    }
+
+    server.close_document().await?;
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn goto_definition_returns_none_for_non_identifier() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    // Cursor on `=` (line 0, character 8) — not an identifier
+    server.open_document("const x = 1;\n").await?;
+
+    let res: Option<lsp::GotoDefinitionResponse> = server
+        .request(
+            "textDocument/definition",
+            "goto_definition",
+            lsp::GotoDefinitionParams {
+                text_document_position_params: lsp::TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: uri!("document.js"),
+                    },
+                    position: Position {
+                        line: 0,
+                        character: 8,
+                    },
+                },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: lsp::PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+        )
+        .await?
+        .context("goto_definition returned None")?;
+
+    assert!(res.is_none(), "expected None for non-identifier position");
+
+    server.close_document().await?;
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn goto_definition_cross_file_named_import() -> Result<()> {
+    let mut fs = TemporaryFs::new("goto_definition_cross_file_named_import");
+    fs.create_file("biome.json", r#"{ "linter": { "enabled": true } }"#);
+    fs.create_file("utils.js", "export function greet() { return 'hello'; }\n");
+    fs.create_file("main.js", "import { greet } from './utils.js';\ngreet();\n");
+
+    let (watcher, instruction_channel) = Watcher::new(WatcherOptions::default())?;
+
+    let factory = ServerFactory::new(true, instruction_channel.sender.clone());
+
+    let workspace = factory.workspace();
+    spawn_blocking(move || {
+        workspace.start_watcher(watcher);
+    });
+
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+
+    let OpenProjectResult { project_key } = server
+        .request(
+            "biome/open_project",
+            "open_project",
+            OpenProjectParams {
+                path: fs.working_directory.clone().into(),
+                open_uninitialized: true,
+            },
+        )
+        .await?
+        .expect("open_project returned an error");
+
+    let result: ScanProjectResult = server
+        .request(
+            "biome/scan_project",
+            "scan_project",
+            ScanProjectParams {
+                project_key,
+                watch: true,
+                force: false,
+                scan_kind: ScanKind::Project,
+                verbose: false,
+            },
+        )
+        .await?
+        .expect("scan_project returned an error");
+    assert_eq!(result.diagnostics.len(), 0);
+
+    let main_path = fs.working_directory.join("main.js");
+    let main_uri =
+        lsp::Uri::from_str(url::Url::from_file_path(&main_path).unwrap().as_str()).unwrap();
+
+    let _: OpenFileResult = server
+        .request(
+            "biome/open_file",
+            "open_file",
+            OpenFileParams {
+                project_key,
+                path: main_path.clone().into(),
+                content: FileContent::FromServer,
+                document_file_source: None,
+                persist_node_cache: false,
+                inline_config: None,
+                needs_document_services: None,
+            },
+        )
+        .await?
+        .expect("open_file returned an error");
+
+    // Open the document via didOpen so the session tracks it
+    server
+        .notify(
+            "textDocument/didOpen",
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: main_uri.clone(),
+                    language_id: String::from("javascript"),
+                    version: 0,
+                    text: String::from("import { greet } from './utils.js';\ngreet();\n"),
+                },
+            },
+        )
+        .await?;
+
+    // Cursor on `greet` in `greet()` at line 1, character 0
+    let res: Option<lsp::GotoDefinitionResponse> = server
+        .request(
+            "textDocument/definition",
+            "goto_definition",
+            lsp::GotoDefinitionParams {
+                text_document_position_params: lsp::TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri: main_uri },
+                    position: Position {
+                        line: 1,
+                        character: 0,
+                    },
+                },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: lsp::PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+        )
+        .await?
+        .context("goto_definition returned None")?;
+
+    let definition = res.context("goto_definition returned empty response")?;
+
+    match definition {
+        lsp::GotoDefinitionResponse::Scalar(location) => {
+            let utils_path = fs.working_directory.join("utils.js");
+            let expected_uri =
+                lsp::Uri::from_str(url::Url::from_file_path(&utils_path).unwrap().as_str())
+                    .unwrap();
+            assert_eq!(location.uri, expected_uri);
+            // `greet` binding in `export function greet()` starts at character 16
+            assert_eq!(
+                location.range,
+                Range {
+                    start: Position {
+                        line: 0,
+                        character: 16,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 21,
+                    },
+                }
+            );
+        }
+        other => panic!("expected Scalar response, got: {other:?}"),
+    }
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn goto_definition_on_import_specifier() -> Result<()> {
+    let mut fs = TemporaryFs::new("goto_definition_on_import_specifier");
+    fs.create_file("biome.json", r#"{ "linter": { "enabled": true } }"#);
+    fs.create_file("utils.js", "export function greet() { return 'hello'; }\n");
+    fs.create_file("main.js", "import { greet } from './utils.js';\ngreet();\n");
+
+    let (watcher, instruction_channel) = Watcher::new(WatcherOptions::default())?;
+
+    let factory = ServerFactory::new(true, instruction_channel.sender.clone());
+
+    let workspace = factory.workspace();
+    spawn_blocking(move || {
+        workspace.start_watcher(watcher);
+    });
+
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+
+    let OpenProjectResult { project_key } = server
+        .request(
+            "biome/open_project",
+            "open_project",
+            OpenProjectParams {
+                path: fs.working_directory.clone().into(),
+                open_uninitialized: true,
+            },
+        )
+        .await?
+        .expect("open_project returned an error");
+
+    let result: ScanProjectResult = server
+        .request(
+            "biome/scan_project",
+            "scan_project",
+            ScanProjectParams {
+                project_key,
+                watch: true,
+                force: false,
+                scan_kind: ScanKind::Project,
+                verbose: false,
+            },
+        )
+        .await?
+        .expect("scan_project returned an error");
+    assert_eq!(result.diagnostics.len(), 0);
+
+    let main_path = fs.working_directory.join("main.js");
+    let main_uri =
+        lsp::Uri::from_str(url::Url::from_file_path(&main_path).unwrap().as_str()).unwrap();
+
+    let _: OpenFileResult = server
+        .request(
+            "biome/open_file",
+            "open_file",
+            OpenFileParams {
+                project_key,
+                path: main_path.clone().into(),
+                content: FileContent::FromServer,
+                document_file_source: None,
+                persist_node_cache: false,
+                inline_config: None,
+                needs_document_services: None,
+            },
+        )
+        .await?
+        .expect("open_file returned an error");
+
+    server
+        .notify(
+            "textDocument/didOpen",
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: main_uri.clone(),
+                    language_id: String::from("javascript"),
+                    version: 0,
+                    text: String::from("import { greet } from './utils.js';\ngreet();\n"),
+                },
+            },
+        )
+        .await?;
+
+    // Cursor on `greet` in the import specifier `import { greet }` at line 0, character 9
+    let res: Option<lsp::GotoDefinitionResponse> = server
+        .request(
+            "textDocument/definition",
+            "goto_definition",
+            lsp::GotoDefinitionParams {
+                text_document_position_params: lsp::TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri: main_uri },
+                    position: Position {
+                        line: 0,
+                        character: 9,
+                    },
+                },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: lsp::PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+        )
+        .await?
+        .context("goto_definition returned None")?;
+
+    let definition = res.context("goto_definition returned empty response")?;
+
+    match definition {
+        lsp::GotoDefinitionResponse::Scalar(location) => {
+            let utils_path = fs.working_directory.join("utils.js");
+            let expected_uri =
+                lsp::Uri::from_str(url::Url::from_file_path(&utils_path).unwrap().as_str())
+                    .unwrap();
+            assert_eq!(location.uri, expected_uri);
+            // `greet` binding in `export function greet()` starts at character 16
+            assert_eq!(
+                location.range,
+                Range {
+                    start: Position {
+                        line: 0,
+                        character: 16,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 21,
+                    },
+                }
+            );
+        }
+        other => panic!("expected Scalar response, got: {other:?}"),
+    }
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}

--- a/crates/biome_lsp/src/server_test_utils.rs
+++ b/crates/biome_lsp/src/server_test_utils.rs
@@ -1,0 +1,453 @@
+use std::any::type_name;
+use std::fmt::Display;
+use std::slice;
+use std::str::FromStr;
+
+use crate::WorkspaceSettings;
+pub(crate) use crate::server::{LSPServer, ServerFactory};
+use anyhow::{Context, Error, Result, bail};
+use futures::channel::mpsc::Sender;
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::{from_value, to_value};
+use tokio::time::{Duration, sleep};
+use tower::timeout::Timeout;
+use tower::{Service, ServiceExt};
+use tower_lsp_server::LspService;
+use tower_lsp_server::jsonrpc::{self, Request, Response};
+use tower_lsp_server::ls_types::{
+    self as lsp, ClientCapabilities, DidChangeConfigurationParams, DidChangeTextDocumentParams,
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, InitializeParams, InitializeResult,
+    InitializedParams, PublishDiagnosticsParams, ShowMessageParams, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, Uri, VersionedTextDocumentIdentifier,
+    WorkspaceFolder,
+};
+
+/// Statically build an [Uri] instance that points to the file at `$path`
+/// within the workspace.
+macro_rules! uri {
+    ($path:literal) => {
+        if cfg!(windows) {
+            lsp::Uri::from_str(concat!("file:///z%3A/workspace/", $path)).unwrap()
+        } else {
+            lsp::Uri::from_str(concat!("file:///workspace/", $path)).unwrap()
+        }
+    };
+}
+
+macro_rules! await_notification {
+    ($channel:expr) => {
+        sleep(Duration::from_millis(1000)).await;
+
+        tokio::time::timeout(Duration::from_secs(2), $channel.changed())
+            .await
+            .expect("expected notification within timeout")
+            .expect("expected notification");
+    };
+}
+
+macro_rules! clear_notifications {
+    ($channel:expr) => {
+        // On Windows, wait until any previous event has been delivered.
+        // On macOS, wait until the fsevents watcher sets up before receiving the first event.
+        let duration = if cfg!(any(target_os = "windows", target_os = "macos")) {
+            Duration::from_secs(1)
+        } else {
+            Duration::from_millis(200)
+        };
+        sleep(duration).await;
+
+        if $channel
+            .has_changed()
+            .expect("Channel should not be closed")
+        {
+            let _ = $channel.changed().await;
+        }
+    };
+}
+
+pub(crate) use await_notification;
+pub(crate) use clear_notifications;
+pub(crate) use uri;
+
+pub(crate) fn to_utf8_file_path_buf(uri: Uri) -> camino::Utf8PathBuf {
+    camino::Utf8PathBuf::from_path_buf(uri.to_file_path().unwrap().to_path_buf()).unwrap()
+}
+
+pub(crate) struct Server {
+    service: Timeout<LspService<LSPServer>>,
+}
+
+impl Server {
+    pub(crate) fn new(service: LspService<LSPServer>) -> Self {
+        Self {
+            service: Timeout::new(service, Duration::from_secs(1)),
+        }
+    }
+
+    pub(crate) async fn notify<P>(&mut self, method: &'static str, params: P) -> Result<()>
+    where
+        P: Serialize,
+    {
+        self.service
+            .ready()
+            .await
+            .map_err(Error::msg)
+            .context("ready() returned an error")?
+            .call(
+                Request::build(method)
+                    .params(to_value(&params).context("failed to serialize params")?)
+                    .finish(),
+            )
+            .await
+            .map_err(Error::msg)
+            .context("call() returned an error")
+            .and_then(|res| {
+                if let Some(res) = res {
+                    bail!("shutdown returned {:?}", res)
+                } else {
+                    Ok(())
+                }
+            })
+    }
+
+    pub(crate) async fn request<P, R>(
+        &mut self,
+        method: &'static str,
+        id: &'static str,
+        params: P,
+    ) -> Result<Option<R>>
+    where
+        P: Serialize,
+        R: DeserializeOwned,
+    {
+        self.service
+            .ready()
+            .await
+            .map_err(Error::msg)
+            .context("ready() returned an error")?
+            .call(
+                Request::build(method)
+                    .id(id)
+                    .params(to_value(&params).context("failed to serialize params")?)
+                    .finish(),
+            )
+            .await
+            .map_err(Error::msg)
+            .context("call() returned an error")?
+            .map(|res| {
+                let (_, body) = res.into_parts();
+
+                let body =
+                    body.with_context(|| format!("response to {method:?} contained an error"))?;
+
+                from_value(body.clone()).with_context(|| {
+                    format!(
+                        "failed to deserialize type {} from response {body:?}",
+                        type_name::<R>()
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    /// Basic implementation of the `initialize` request for tests
+    // The `root_path` field is deprecated, but we still need to specify it
+    #[expect(deprecated)]
+    pub(crate) async fn initialize(&mut self) -> Result<()> {
+        let _res: InitializeResult = self
+            .request(
+                "initialize",
+                "_init",
+                InitializeParams {
+                    process_id: None,
+                    root_path: None,
+                    root_uri: Some(uri!("")),
+                    initialization_options: None,
+                    capabilities: ClientCapabilities::default(),
+                    trace: None,
+                    workspace_folders: None,
+                    client_info: None,
+                    locale: None,
+                    work_done_progress_params: Default::default(),
+                },
+            )
+            .await?
+            .context("initialize returned None")?;
+
+        Ok(())
+    }
+
+    /// It creates two projects, one at folder `test_one` and the other in `test_two`.
+    #[expect(deprecated)]
+    pub(crate) async fn initialize_projects(&mut self) -> Result<()> {
+        let _res: InitializeResult = self
+            .request(
+                "initialize",
+                "_init",
+                InitializeParams {
+                    process_id: None,
+                    root_path: None,
+                    root_uri: Some(uri!("/")),
+                    initialization_options: None,
+                    capabilities: ClientCapabilities::default(),
+                    trace: None,
+                    workspace_folders: Some(vec![
+                        WorkspaceFolder {
+                            name: "test_one".to_string(),
+                            uri: uri!("test_one"),
+                        },
+                        WorkspaceFolder {
+                            name: "test_two".to_string(),
+                            uri: uri!("test_two"),
+                        },
+                    ]),
+                    client_info: None,
+                    locale: None,
+                    work_done_progress_params: Default::default(),
+                },
+            )
+            .await?
+            .context("initialize returned None")?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn initialized(&mut self) -> Result<()> {
+        self.notify("initialized", InitializedParams {}).await
+    }
+
+    pub(crate) async fn shutdown(&mut self) -> Result<()> {
+        self.service
+            .ready()
+            .await
+            .map_err(Error::msg)
+            .context("ready() returned an error")?
+            .call(Request::build("shutdown").finish())
+            .await
+            .map_err(Error::msg)
+            .context("call() returned an error")
+            .and_then(|res| {
+                if let Some(res) = res {
+                    bail!("shutdown returned {:?}", res)
+                } else {
+                    Ok(())
+                }
+            })
+    }
+
+    pub(crate) async fn open_document(&mut self, text: impl Display) -> Result<()> {
+        self.notify(
+            "textDocument/didOpen",
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri!("document.js"),
+                    language_id: String::from("javascript"),
+                    version: 0,
+                    text: text.to_string(),
+                },
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn open_untitled_document(&mut self, text: impl Display) -> Result<()> {
+        self.notify(
+            "textDocument/didOpen",
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri!("untitled-1"),
+                    language_id: String::from("javascript"),
+                    version: 0,
+                    text: text.to_string(),
+                },
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn open_named_document(
+        &mut self,
+        text: impl Display,
+        document_name: Uri,
+        language: impl Display,
+    ) -> Result<()> {
+        self.notify(
+            "textDocument/didOpen",
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: document_name,
+                    language_id: language.to_string(),
+                    version: 0,
+                    text: text.to_string(),
+                },
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn load_configuration(&mut self) -> Result<()> {
+        self.notify(
+            "workspace/didChangeConfiguration",
+            DidChangeConfigurationParams {
+                settings: to_value(())?,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn load_configuration_with_settings<V>(&mut self, value: V) -> Result<()>
+    where
+        V: Serialize,
+    {
+        self.notify(
+            "workspace/didChangeConfiguration",
+            DidChangeConfigurationParams {
+                settings: to_value(value)?,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn change_document(
+        &mut self,
+        version: i32,
+        content_changes: Vec<TextDocumentContentChangeEvent>,
+    ) -> Result<()> {
+        self.notify(
+            "textDocument/didChange",
+            DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier {
+                    uri: uri!("document.js"),
+                    version,
+                },
+                content_changes,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn close_document(&mut self) -> Result<()> {
+        self.notify(
+            "textDocument/didClose",
+            DidCloseTextDocumentParams {
+                text_document: TextDocumentIdentifier {
+                    uri: uri!("document.js"),
+                },
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn biome_shutdown(&mut self) -> Result<()> {
+        self.request::<_, ()>("biome/shutdown", "_biome_shutdown", ())
+            .await?
+            .context("biome/shutdown returned None")?;
+        Ok(())
+    }
+}
+
+/// Number of notifications buffered by the server-to-client channel before it starts blocking the current task
+pub(crate) const CHANNEL_BUFFER_SIZE: usize = 8;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ServerNotification {
+    PublishDiagnostics(PublishDiagnosticsParams),
+    ShowMessage(ShowMessageParams),
+}
+
+impl ServerNotification {
+    pub(crate) fn is_publish_diagnostics(&self) -> bool {
+        matches!(self, Self::PublishDiagnostics(_))
+    }
+
+    pub(crate) fn is_show_message(&self) -> bool {
+        matches!(self, Self::ShowMessage(_))
+    }
+}
+
+pub(crate) async fn wait_for_notification(
+    receiver: &mut (impl Stream<Item = ServerNotification> + Unpin),
+    check: impl Fn(&ServerNotification) -> bool,
+) -> Option<ServerNotification> {
+    loop {
+        let notification = tokio::select! {
+            msg = receiver.next() => msg,
+            _ = sleep(Duration::from_secs(3)) => {
+                panic!("timed out waiting for the server to send diagnostics")
+            }
+        };
+
+        match notification {
+            Some(notification) => {
+                if check(&notification) {
+                    return Some(notification);
+                }
+            }
+            None => break None,
+        }
+    }
+}
+
+/// Basic handler for requests and notifications coming from the server for tests
+pub(crate) async fn client_handler<I, O>(
+    stream: I,
+    sink: O,
+    notify: Sender<ServerNotification>,
+) -> Result<()>
+where
+    I: Stream<Item = Request> + Unpin,
+    O: Sink<Response> + Unpin,
+{
+    client_handler_with_settings(stream, sink, notify, WorkspaceSettings::default()).await
+}
+
+/// Handler for requests and notifications coming from the server for tests with custom settings
+pub(crate) async fn client_handler_with_settings<I, O>(
+    mut stream: I,
+    mut sink: O,
+    mut notify: Sender<ServerNotification>,
+    settings: WorkspaceSettings,
+) -> Result<()>
+where
+    I: Stream<Item = Request> + Unpin,
+    O: Sink<Response> + Unpin,
+{
+    while let Some(req) = stream.next().await {
+        let params = req.params().expect("invalid request").clone();
+        if let Some(notification) = match req.method() {
+            "textDocument/publishDiagnostics" => Some(ServerNotification::PublishDiagnostics(
+                from_value(params).expect("invalid params"),
+            )),
+            "window/showMessage" => Some(ServerNotification::ShowMessage(
+                from_value(params).expect("invalid params"),
+            )),
+            _ => None,
+        } {
+            match notify.send(notification).await {
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+
+        let id = match req.id() {
+            Some(id) => id,
+            None => continue,
+        };
+
+        let res = match req.method() {
+            "workspace/configuration" => {
+                let result =
+                    to_value(slice::from_ref(&settings)).context("failed to serialize settings")?;
+
+                Response::from_ok(id.clone(), result)
+            }
+            _ => Response::from_error(id.clone(), jsonrpc::Error::method_not_found()),
+        };
+
+        sink.send(res).await.ok();
+    }
+
+    Ok(())
+}

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -615,6 +615,24 @@ impl Session {
         result
     }
 
+    pub(crate) fn can_register_goto_definition(&self) -> bool {
+        let result = self
+            .initialize_params
+            .get()
+            .and_then(|c| c.client_capabilities.text_document.as_ref())
+            .and_then(|c| c.definition.as_ref())
+            .and_then(|c| c.dynamic_registration)
+            == Some(true)
+            || self
+                .extension_settings
+                .read()
+                .unwrap()
+                .goto_definition_enabled();
+        info!("Can register gotoDefinition: {result}");
+
+        result
+    }
+
     /// Get the current workspace folders
     pub(crate) fn get_workspace_folders(&self) -> Option<Vec<WorkspaceFolder>> {
         self.workspace_folders.read().unwrap().clone()

--- a/crates/biome_module_graph/src/css_module_info/mod.rs
+++ b/crates/biome_module_graph/src/css_module_info/mod.rs
@@ -3,9 +3,9 @@ mod visitor;
 
 use biome_css_syntax::EmbeddingStyleApplicability;
 use biome_resolver::ResolvedPath;
-use biome_rowan::{Text, TokenText};
+use biome_rowan::{Text, TextRange, TextSize, TokenText};
 use camino::Utf8PathBuf;
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
@@ -23,6 +23,13 @@ pub(crate) use visitor::CssModuleVisitor;
 pub struct CssClassDefinition {
     /// The name of the class.
     pub name: TokenText,
+
+    /// The text range of the class name token (snippet-local for embedded styles).
+    pub range: TextRange,
+
+    /// Content offset of the embedded snippet within the parent document.
+    /// `None` for standalone CSS files, `Some(offset)` for inline `<style>` blocks.
+    pub content_offset: Option<TextSize>,
 
     /// How this CSS class should be applied.
     pub applicability: EmbeddingStyleApplicability,
@@ -106,7 +113,7 @@ impl Deref for CssModuleInfo {
 }
 
 impl CssModuleInfo {
-    pub(crate) fn new(imports: CssImports, classes: IndexSet<TokenText>) -> Self {
+    pub(crate) fn new(imports: CssImports, classes: IndexMap<TokenText, TextRange>) -> Self {
         let info = CssModuleInfoInner { imports, classes };
         Self(Arc::new(info))
     }
@@ -122,7 +129,7 @@ impl CssModuleInfo {
             classes: self
                 .0
                 .classes
-                .iter()
+                .keys()
                 .map(|token| token.text().to_string())
                 .collect(),
         }
@@ -139,14 +146,15 @@ pub struct CssModuleInfoInner {
     /// (for instance, if the path is outside the project's scope).
     pub imports: CssImports,
 
-    /// Set of all CSS class names defined in this file (via class selectors).
+    /// Map of all CSS class names to their selector ranges in this file.
     ///
     /// Collected by walking all `CssClassSelector` nodes in the CST, including
     /// those inside nested rules and at-rules. Does not include classes inside
     /// `:global(...)` pseudo-class selectors.
     ///
-    /// Each `TokenText` represents a single class name (e.g., "header" from `.header`).
-    pub classes: IndexSet<TokenText>,
+    /// Keys are class names (e.g., "header" from `.header`), values are the
+    /// `TextRange` of the class selector in the source file.
+    pub classes: IndexMap<TokenText, TextRange>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/biome_module_graph/src/css_module_info/traverse.rs
+++ b/crates/biome_module_graph/src/css_module_info/traverse.rs
@@ -1,8 +1,8 @@
 use crate::ModuleInfo;
 use biome_console::markup;
-use biome_rowan::TokenText;
+use biome_rowan::{TextRange, TokenText};
 use camino::{Utf8Path, Utf8PathBuf};
-use indexmap::IndexSet;
+use indexmap::IndexMap;
 use rustc_hash::FxHashSet;
 use std::vec::IntoIter;
 
@@ -12,8 +12,8 @@ use std::vec::IntoIter;
 pub struct CssClassStep {
     /// The path of the CSS file discovered in this step
     pub css_path: Utf8PathBuf,
-    /// The CSS class names found in this CSS file
-    pub css_classes: IndexSet<TokenText>,
+    /// The CSS class names and their selector ranges found in this CSS file
+    pub css_classes: IndexMap<TokenText, TextRange>,
 }
 
 /// Rich diagnostic information including component chain.

--- a/crates/biome_module_graph/src/css_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/css_module_info/visitor.rs
@@ -4,9 +4,9 @@ use biome_css_syntax::{
     AnyCssImportUrl, AnyCssRoot, CssClassSelector, CssPseudoClassFunctionSelector,
 };
 use biome_resolver::{ResolveOptions, ResolvedPath, resolve};
-use biome_rowan::{AstNode, Text, TokenText, WalkEvent};
+use biome_rowan::{AstNode, Text, TextRange, TokenText, WalkEvent};
 use camino::Utf8Path;
-use indexmap::IndexSet;
+use indexmap::IndexMap;
 
 pub const SUPPORTED_EXTENSIONS: &[&str] = &["css"];
 
@@ -31,7 +31,7 @@ impl<'a> CssModuleVisitor<'a> {
 
     pub(crate) fn visit(self) -> CssModuleInfo {
         let mut imports = CssImports::default();
-        let mut classes: IndexSet<TokenText> = IndexSet::default();
+        let mut classes: IndexMap<TokenText, TextRange> = IndexMap::default();
         // Tracks nesting depth inside `:global(...)` pseudo-class selectors.
         // Class selectors inside `:global()` are globally scoped and cannot be
         // statically traced to specific `class="..."` references, so we skip them.
@@ -72,12 +72,15 @@ impl<'a> CssModuleVisitor<'a> {
     /// `TokenText` into the set.
     ///
     /// Each token represents a single class name (e.g., "header" from `.header`).
-    fn visit_class_selector(node: CssClassSelector, classes: &mut IndexSet<TokenText>) {
+    fn visit_class_selector(node: CssClassSelector, classes: &mut IndexMap<TokenText, TextRange>) {
         if let Ok(name) = node.name()
             && let Some(name) = name.as_css_custom_identifier()
             && let Ok(token) = name.value_token()
         {
-            classes.insert(token.token_text_trimmed());
+            // Store the range of the class name token (without the dot)
+            classes
+                .entry(token.token_text_trimmed())
+                .or_insert_with(|| token.text_trimmed_range());
         }
     }
 

--- a/crates/biome_module_graph/src/format_module_graph.rs
+++ b/crates/biome_module_graph/src/format_module_graph.rs
@@ -680,7 +680,7 @@ impl Format<FormatTypeContext> for crate::css_module_info::CssModuleInfoInner {
         f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         let classes_section = format_with(|f| {
-            let mut sorted: Vec<_> = self.classes.iter().map(|t| t.text().to_string()).collect();
+            let mut sorted: Vec<_> = self.classes.keys().map(|t| t.text().to_string()).collect();
             sorted.sort();
             if sorted.is_empty() {
                 write!(f, [token("No classes")])

--- a/crates/biome_module_graph/src/html_module_info/mod.rs
+++ b/crates/biome_module_graph/src/html_module_info/mod.rs
@@ -4,7 +4,7 @@ use crate::css_module_info::{CssClassDefinition, CssClassReference};
 use biome_css_syntax::{AnyCssRoot, CssFileSource};
 use biome_js_syntax::AnyJsRoot;
 use biome_resolver::ResolvedPath;
-use biome_rowan::Text;
+use biome_rowan::{Text, TextSize};
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use std::collections::BTreeSet;
@@ -27,10 +27,11 @@ pub(crate) use visitor::HtmlModuleVisitor;
 /// The module graph is responsible for all downstream logic (class collection,
 /// import resolution, upward traversal).
 pub enum HtmlEmbeddedContent {
-    /// A `<style>` block with its resolved CSS source (carries [`EmbeddingApplicability`]).
+    /// A `<style>` block with its resolved CSS source and content offset
+    /// within the parent document.
     ///
     /// [`EmbeddingApplicability`]: biome_css_syntax::EmbeddingStyleApplicability
-    Css(AnyCssRoot, CssFileSource),
+    Css(AnyCssRoot, CssFileSource, TextSize),
     /// A `<script>` block parsed as JS/TS.
     Js(AnyJsRoot),
 }

--- a/crates/biome_module_graph/src/html_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/html_module_info/visitor.rs
@@ -10,7 +10,7 @@ use biome_html_syntax::{
 };
 use biome_js_syntax::{AnyJsImportLike, AnyJsRoot};
 use biome_resolver::{ResolveOptions, ResolvedPath, resolve};
-use biome_rowan::{AstNode, Text, TokenText, WalkEvent};
+use biome_rowan::{AstNode, Text, TextSize, TokenText, WalkEvent};
 use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::{IndexMap, IndexSet};
 
@@ -88,8 +88,8 @@ impl<'a> HtmlModuleVisitor<'a> {
         for content in self.embedded_content {
             match content {
                 // CSS block: collect class definitions (with applicability scoping).
-                HtmlEmbeddedContent::Css(css_root, file_source) => {
-                    collect_css_classes(css_root, &mut style_classes, file_source);
+                HtmlEmbeddedContent::Css(css_root, file_source, content_offset) => {
+                    collect_css_classes(css_root, &mut style_classes, file_source, *content_offset);
                 }
                 // JS block: collect static import paths for upward traversal.
                 HtmlEmbeddedContent::Js(js_root) => {
@@ -274,6 +274,7 @@ pub(crate) fn collect_css_classes(
     css_root: &AnyCssRoot,
     classes: &mut IndexSet<CssClassDefinition>,
     file_source: &CssFileSource,
+    content_offset: TextSize,
 ) {
     // Applicability for selectors *not* inside :global(...).
     // Selectors inside :global(...) are unconditionally Global.
@@ -301,6 +302,8 @@ pub(crate) fn collect_css_classes(
                     };
                     classes.insert(CssClassDefinition {
                         name: token.token_text_trimmed(),
+                        range: token.text_trimmed_range(),
+                        content_offset: Some(content_offset),
                         applicability,
                     });
                 }

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -178,6 +178,17 @@ impl JsModuleInfo {
                 .collect::<BTreeSet<_>>(),
         }
     }
+
+    pub fn find_resolved_path_by_symbol(&self, name: &str) -> Option<&Utf8Path> {
+        self.static_imports
+            .get(name)
+            .and_then(|import| import.resolved_path.as_path())
+            .or_else(|| {
+                self.dynamic_import_paths
+                    .get(name)
+                    .and_then(|import| import.resolved_path.as_path())
+            })
+    }
 }
 
 #[derive(Debug)]

--- a/crates/biome_module_graph/src/module_graph.rs
+++ b/crates/biome_module_graph/src/module_graph.rs
@@ -28,9 +28,10 @@ use biome_js_type_info::ImportSymbol;
 use biome_jsdoc_comment::JsdocComment;
 use biome_project_layout::ProjectLayout;
 use biome_resolver::{FsWithResolverProxy, PathInfo};
+use biome_rowan::{TextRange, TextSize};
 use camino::{Utf8Path, Utf8PathBuf};
 pub(crate) use fs_proxy::ModuleGraphFsProxy;
-use indexmap::IndexSet;
+use indexmap::IndexMap;
 use papaya::{HashMap, HashMapRef, LocalGuard};
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use std::collections::VecDeque;
@@ -280,6 +281,63 @@ impl ModuleGraph {
         })
     }
 
+    /// Finds the CSS file and text range where a class is defined, searching
+    /// all available paths: JS imports, HTML inline styles, linked stylesheets,
+    /// and CSS imports from embedded `<script>` blocks.
+    ///
+    /// Returns the CSS file path, the selector range, and an optional content
+    /// offset for inline `<style>` blocks (needed to translate snippet-local
+    /// ranges to parent document coordinates).
+    pub fn find_css_class_definition(
+        &self,
+        path: &Utf8Path,
+        class_name: &str,
+    ) -> Option<(Utf8PathBuf, TextRange, Option<TextSize>)> {
+        // 1. Check inline style classes in HTML-like files (carry content_offset)
+        if let Some(html_info) = self.html_module_info_for_path(path) {
+            for class_def in &html_info.style_classes {
+                if class_def.name.text() == class_name {
+                    return Some((
+                        path.to_path_buf(),
+                        class_def.range,
+                        class_def.content_offset,
+                    ));
+                }
+            }
+        }
+
+        // 2. Check CSS files reachable from HTML (linked stylesheets + script imports)
+        for step in self.traverse_import_tree_for_html_classes(path) {
+            if step.css_path == path {
+                continue; // Already checked inline styles above
+            }
+            if let Some(range) = step.css_classes.iter().find_map(|(token, range)| {
+                if token.text() == class_name {
+                    Some(*range)
+                } else {
+                    None
+                }
+            }) {
+                return Some((step.css_path, range, None));
+            }
+        }
+
+        // 3. Check CSS files imported by JS (e.g., `import './styles.css'` in JSX)
+        for step in self.traverse_import_tree_for_classes(path) {
+            if let Some(range) = step.css_classes.iter().find_map(|(token, range)| {
+                if token.text() == class_name {
+                    Some(*range)
+                } else {
+                    None
+                }
+            }) {
+                return Some((step.css_path, range, None));
+            }
+        }
+
+        None
+    }
+
     /// Builds diagnostic information with full component chains for error reporting.
     ///
     /// This re-traverses the import tree to build the component chain for each CSS file.
@@ -440,10 +498,10 @@ impl ModuleGraph {
             // For same-file checks, scoped styles still apply to the component's own
             // elements, so both Global and Local classes are valid. Only when classes
             // are traversed from imported/parent files do we restrict to Global.
-            let all_inline_classes: IndexSet<_> = html_info
+            let all_inline_classes: IndexMap<_, _> = html_info
                 .style_classes
                 .iter()
-                .map(|c| c.name.clone())
+                .map(|c| (c.name.clone(), c.range))
                 .collect();
             if !all_inline_classes.is_empty() {
                 inline_steps.push(CssClassStep {
@@ -452,9 +510,22 @@ impl ModuleGraph {
                 });
             }
 
-            // 2. Directly linked external stylesheets.
+            // 2. Directly linked external stylesheets (<link rel="stylesheet">).
             for stylesheet_path in &html_info.imported_stylesheets {
                 if let Some(path) = stylesheet_path.as_path()
+                    && let Some(css_info) = self.css_module_info_for_path(path)
+                {
+                    linked_steps.push(CssClassStep {
+                        css_path: path.to_path_buf(),
+                        css_classes: css_info.classes.clone(),
+                    });
+                }
+            }
+
+            // 2b. CSS files imported from embedded <script> blocks
+            // (e.g., `import "./index.css"` in Astro frontmatter).
+            for import_path in html_info.static_import_paths.values() {
+                if let Some(path) = import_path.as_path()
                     && let Some(css_info) = self.css_module_info_for_path(path)
                 {
                     linked_steps.push(CssClassStep {
@@ -543,7 +614,7 @@ impl ModuleGraph {
                 if let Some(path) = import_path.as_path()
                     && let Some(css_info) = self.css_module_info_for_path(path)
                 {
-                    for class in css_info.classes.iter() {
+                    for (class, _range) in css_info.classes.iter() {
                         let class_name = class.text().to_string();
                         available_classes.insert(class_name.clone());
                     }
@@ -606,7 +677,7 @@ impl ModuleGraph {
                                 if let Some(path) = import_path.as_path()
                                     && let Some(css_info) = self.css_module_info_for_path(path)
                                 {
-                                    for class in css_info.classes.iter() {
+                                    for (class, _range) in css_info.classes.iter() {
                                         let class_name = class.text().to_string();
                                         available_classes.insert(class_name.clone());
                                     }
@@ -634,7 +705,7 @@ impl ModuleGraph {
                                 if let Some(path) = stylesheet_path.as_path()
                                     && let Some(css_info) = self.css_module_info_for_path(path)
                                 {
-                                    for class in css_info.classes.iter() {
+                                    for (class, _range) in css_info.classes.iter() {
                                         let class_name = class.text().to_string();
                                         available_classes.insert(class_name.clone());
                                     }

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -2705,11 +2705,11 @@ export function App() {
         .css_module_info_for_path(Utf8Path::new("/src/styles.css"))
         .expect("styles.css must be in module graph");
     assert!(
-        css_info.classes.contains("button"),
+        css_info.classes.contains_key("button"),
         "styles.css must define class 'button'"
     );
     assert!(
-        css_info.classes.contains("header"),
+        css_info.classes.contains_key("header"),
         "styles.css must define class 'header'"
     );
 
@@ -3271,7 +3271,7 @@ fn parse_embedded_css(src: &str, file_source: CssFileSource) -> HtmlEmbeddedCont
         ..Default::default()
     };
     let parsed = biome_css_parser::parse_css(src, file_source, options);
-    HtmlEmbeddedContent::Css(parsed.tree(), file_source)
+    HtmlEmbeddedContent::Css(parsed.tree(), file_source, biome_rowan::TextSize::from(0))
 }
 
 /// Parses an HTML snippet and returns a `HtmlRoot`.
@@ -3350,7 +3350,7 @@ fn test_html_inline_style_classes_are_global() {
     // The traversal must yield the class.
     let found = module_graph
         .traverse_import_tree_for_html_classes(Utf8Path::new("/src/index.html"))
-        .any(|step| step.css_classes.iter().any(|c| c.text() == "card"));
+        .any(|step| step.css_classes.keys().any(|c| c.text() == "card"));
     assert!(found, "Global class must appear in traversal");
 }
 
@@ -3418,7 +3418,7 @@ fn test_vue_unscoped_style_classes_are_global() {
 
     let found = module_graph
         .traverse_import_tree_for_html_classes(Utf8Path::new("/src/Comp.vue"))
-        .any(|step| step.css_classes.iter().any(|c| c.text() == "card"));
+        .any(|step| step.css_classes.keys().any(|c| c.text() == "card"));
     assert!(found, "Global class must appear in traversal");
 }
 
@@ -3459,7 +3459,7 @@ fn test_vue_scoped_style_classes_are_local_and_hidden() {
     // because scoped styles still apply to the component's own elements.
     let found = module_graph
         .traverse_import_tree_for_html_classes(Utf8Path::new("/src/Scoped.vue"))
-        .any(|step| step.css_classes.iter().any(|c| c.text() == "alpha"));
+        .any(|step| step.css_classes.keys().any(|c| c.text() == "alpha"));
     assert!(
         found,
         "Local inline class MUST appear in same-file traversal"
@@ -3498,7 +3498,7 @@ fn test_vue_mixed_scoped_and_unscoped() {
         .traverse_import_tree_for_html_classes(Utf8Path::new("/src/Mixed.vue"))
         .flat_map(|step| {
             step.css_classes
-                .iter()
+                .keys()
                 .map(|c| c.text().to_string())
                 .collect::<Vec<_>>()
         })
@@ -3543,7 +3543,7 @@ fn test_astro_local_style_classes_are_hidden() {
     // parent/consumer files.
     let found = module_graph
         .traverse_import_tree_for_html_classes(Utf8Path::new("/src/Page.astro"))
-        .any(|step| step.css_classes.iter().any(|c| c.text() == "hero"));
+        .any(|step| step.css_classes.keys().any(|c| c.text() == "hero"));
     assert!(
         found,
         "Astro local class MUST appear in same-file traversal"
@@ -3566,7 +3566,7 @@ fn test_astro_global_style_classes_are_visible() {
 
     let found = module_graph
         .traverse_import_tree_for_html_classes(Utf8Path::new("/src/Layout.astro"))
-        .any(|step| step.css_classes.iter().any(|c| c.text() == "wrapper"));
+        .any(|step| step.css_classes.keys().any(|c| c.text() == "wrapper"));
     assert!(found, "Astro is:global class must appear in traversal");
 }
 
@@ -3606,7 +3606,7 @@ fn test_svelte_local_style_classes_are_hidden() {
     // parent/consumer files.
     let found = module_graph
         .traverse_import_tree_for_html_classes(Utf8Path::new("/src/Button.svelte"))
-        .any(|step| step.css_classes.iter().any(|c| c.text() == "btn"));
+        .any(|step| step.css_classes.keys().any(|c| c.text() == "btn"));
     assert!(
         found,
         "Svelte local class MUST appear in same-file traversal"
@@ -3651,7 +3651,7 @@ fn test_svelte_global_pseudo_class_is_visible() {
     // And it must appear in the traversal.
     let found = module_graph
         .traverse_import_tree_for_html_classes(Utf8Path::new("/src/Global.svelte"))
-        .any(|step| step.css_classes.iter().any(|c| c.text() == "prose"));
+        .any(|step| step.css_classes.keys().any(|c| c.text() == "prose"));
     assert!(found, ":global class must appear in traversal");
 }
 
@@ -3758,7 +3758,7 @@ fn test_vue_upward_traversal() {
     // Verify upward traversal finds btn from app.css
     let available_classes: Vec<_> = module_graph
         .traverse_import_tree_for_html_classes(Utf8Path::new("/src/Button.vue"))
-        .flat_map(|step| step.css_classes.into_iter())
+        .flat_map(|step| step.css_classes.into_keys())
         .collect();
 
     assert!(

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -87,6 +87,7 @@ web-time                 = { workspace = true }
 
 [dev-dependencies]
 biome_configuration = { path = "../biome_configuration", features = ["test-utils"] }
+biome_service       = { path = ".", features = ["testing"] }
 insta               = { workspace = true }
 
 [features]

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -93,6 +93,9 @@ pub enum WorkspaceError {
 
     /// Error in the workspace watcher.
     WatchError(WatchError),
+
+    /// Go-to definition requires the linter or assist to be enabled.
+    GoToDefinitionDisabled(GoToDefinitionDisabled),
 }
 
 impl WorkspaceError {
@@ -156,6 +159,10 @@ impl WorkspaceError {
             file_path: file_path.into(),
             verbose_advice: ProtectedFileAdvice,
         })
+    }
+
+    pub fn go_to_definition_disabled() -> Self {
+        Self::GoToDefinitionDisabled(GoToDefinitionDisabled)
     }
 
     pub fn is_editor_config_error(&self) -> bool {
@@ -312,6 +319,14 @@ impl Panic {
     message = "Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option."
 )]
 pub struct FormatWithErrorsDisabled;
+
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+#[diagnostic(
+    category = "project",
+    severity = Warning,
+    message = "Go-to definition is available only when linting or assist are enabled, or the editor setting is enabled."
+)]
+pub struct GoToDefinitionDisabled;
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]
 #[diagnostic(

--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -1,8 +1,8 @@
 use crate::WorkspaceError;
 use crate::file_handlers::{
-    AnalyzerCapabilities, Capabilities, CodeActionsParams, DebugCapabilities, EnabledForPath,
-    ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
-    ParserCapabilities, javascript,
+    AnalyzerCapabilities, Capabilities, CodeActionsParams, DebugCapabilities, EditorCapabilities,
+    EnabledForPath, ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults,
+    ParseResult, ParserCapabilities, javascript,
 };
 use crate::settings::SettingsWithEditor;
 use crate::workspace::{DocumentFileSource, FixFileResult, PullActionsResult};
@@ -103,6 +103,10 @@ impl ExtensionHandler for AstroFileHandler {
             },
             // TODO: We should be able to search JS portions already
             search: SearchCapabilities { search: None },
+            editors: EditorCapabilities {
+                resolve_binding: None,
+                resolve_definition: None,
+            },
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -1,6 +1,7 @@
 use super::{
-    AnalyzerVisitorBuilder, CodeActionsParams, EnabledForPath, ExtensionHandler, FixAllParams,
-    LintParams, LintResults, ParseResult, ProcessFixAll, ProcessLint, SearchCapabilities, search,
+    AnalyzerVisitorBuilder, CodeActionsParams, EditorCapabilities, EnabledForPath,
+    ExtensionHandler, FixAllParams, LintParams, LintResults, ParseResult, ProcessFixAll,
+    ProcessLint, ResolveDefinitionParams, SearchCapabilities, search,
 };
 use crate::WorkspaceError;
 use crate::configuration::to_analyzer_rules;
@@ -13,7 +14,8 @@ use crate::settings::{
     Settings, SettingsWithEditor, check_feature_activity, check_override_feature_activity,
 };
 use crate::workspace::{
-    CodeAction, DocumentFileSource, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
+    CodeAction, DefinitionReference, DocumentFileSource, FixFileResult, GetSyntaxTreeResult,
+    GoToDefinitionResult, PullActionsResult,
 };
 use biome_analyze::options::PreferredQuote;
 use biome_analyze::{AnalysisFilter, AnalyzerConfiguration, AnalyzerOptions, ControlFlow, Never};
@@ -393,6 +395,10 @@ impl ExtensionHandler for CssFileHandler {
                 linter: Some(linter_enabled),
                 assist: Some(assist_enabled),
                 search: Some(search_enabled),
+            },
+            editors: EditorCapabilities {
+                resolve_binding: None,
+                resolve_definition: Some(resolve_definition),
             },
         }
     }
@@ -774,6 +780,29 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
                 params.embeds_initial_indent,
             );
         }
+    }
+}
+
+/// Destination-side capability for CSS: resolves a binding reference to a
+/// CSS class definition location.
+pub(crate) fn resolve_definition(params: ResolveDefinitionParams) -> Option<GoToDefinitionResult> {
+    match params.definition_ref {
+        DefinitionReference::CssClass { class_name } => {
+            let path = params.path.as_path();
+            let (css_path, mut range, content_offset) = params
+                .module_graph
+                .find_css_class_definition(path, class_name)?;
+            // For inline `<style>` blocks, the range is snippet-local.
+            // Apply the content_offset to get parent document coordinates.
+            if let Some(offset) = content_offset {
+                range += offset;
+            }
+            Some(GoToDefinitionResult {
+                path: BiomePath::new(css_path.to_string()),
+                range,
+            })
+        }
+        _ => None,
     }
 }
 

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -1,7 +1,7 @@
 use super::{
-    AnalyzerVisitorBuilder, CodeActionsParams, DocumentFileSource, EnabledForPath,
-    ExtensionHandler, FixAllParams, LintParams, LintResults, ParseResult, ProcessFixAll,
-    ProcessLint, SearchCapabilities,
+    AnalyzerVisitorBuilder, CodeActionsParams, DocumentFileSource, EditorCapabilities,
+    EnabledForPath, ExtensionHandler, FixAllParams, LintParams, LintResults, ParseResult,
+    ProcessFixAll, ProcessLint, SearchCapabilities,
 };
 use crate::WorkspaceError;
 use crate::configuration::to_analyzer_rules;
@@ -307,6 +307,10 @@ impl ExtensionHandler for GraphqlFileHandler {
                 format_embedded: None,
             },
             search: SearchCapabilities { search: None },
+            editors: EditorCapabilities {
+                resolve_binding: None,
+                resolve_definition: None,
+            },
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/grit.rs
+++ b/crates/biome_service/src/file_handlers/grit.rs
@@ -1,7 +1,7 @@
 use super::{
-    AnalyzerCapabilities, Capabilities, DebugCapabilities, DocumentFileSource, EnabledForPath,
-    ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
-    ParserCapabilities, SearchCapabilities,
+    AnalyzerCapabilities, Capabilities, DebugCapabilities, DocumentFileSource, EditorCapabilities,
+    EnabledForPath, ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults,
+    ParseResult, ParserCapabilities, SearchCapabilities,
 };
 use crate::settings::{
     OverrideSettings, SettingsWithEditor, check_feature_activity, check_override_feature_activity,
@@ -285,6 +285,10 @@ impl ExtensionHandler for GritFileHandler {
                 format_embedded: None,
             },
             search: SearchCapabilities { search: None },
+            editors: EditorCapabilities {
+                resolve_binding: None,
+                resolve_definition: None,
+            },
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -1,8 +1,9 @@
 use super::{
     AnalyzerCapabilities, AnalyzerVisitorBuilder, Capabilities, CodeActionsParams,
-    DebugCapabilities, DocumentFileSource, EnabledForPath, ExtensionHandler, FixAllParams,
-    FormatEmbedNode, FormatterCapabilities, LintParams, LintResults, ParseEmbedResult, ParseResult,
-    ParserCapabilities, ProcessFixAll, ProcessLint, SearchCapabilities, UpdateSnippetsNodes,
+    DebugCapabilities, DocumentFileSource, EditorCapabilities, EnabledForPath, ExtensionHandler,
+    FixAllParams, FormatEmbedNode, FormatterCapabilities, LintParams, LintResults,
+    ParseEmbedResult, ParseResult, ParserCapabilities, ProcessFixAll, ProcessLint,
+    ResolveBindingParams, SearchCapabilities, UpdateSnippetsNodes,
 };
 use crate::configuration::to_analyzer_rules;
 use crate::embed::registry::{EmbedDetectorsRegistry, EmbedMatch};
@@ -13,7 +14,8 @@ use crate::settings::{
 use crate::workspace::document::AnyEmbeddedSnippet;
 use crate::workspace::document::services::embedded_bindings::EmbeddedBuilder;
 use crate::workspace::{
-    CodeAction, CssDocumentServices, DocumentServices, EmbeddedSnippet, JsDocumentServices,
+    CodeAction, CssDocumentServices, DefinitionReference, DocumentServices, EmbeddedSnippet,
+    JsDocumentServices,
 };
 use crate::workspace::{FixFileResult, PullActionsResult};
 use crate::{
@@ -49,9 +51,10 @@ use biome_html_formatter::{
 use biome_html_parser::{HtmlParserOptions, parse_html_with_cache};
 use biome_html_syntax::element_ext::AnyEmbeddedContent;
 use biome_html_syntax::{
-    AnyAstroDirective, AnySvelteDirective, AstroEmbeddedContent, HtmlAttribute,
-    HtmlAttributeInitializerClause, HtmlDoubleTextExpression, HtmlElement, HtmlFileSource,
-    HtmlLanguage, HtmlRoot, HtmlSingleTextExpression, HtmlSyntaxNode, HtmlTextExpression,
+    AnyAstroDirective, AnyHtmlAttributeInitializer, AnyHtmlTagName, AnySvelteDirective,
+    AstroEmbeddedContent, HtmlAttribute, HtmlAttributeInitializerClause, HtmlDoubleTextExpression,
+    HtmlElement, HtmlFileSource, HtmlLanguage, HtmlOpeningElement, HtmlRoot,
+    HtmlSelfClosingElement, HtmlSingleTextExpression, HtmlSyntaxNode, HtmlTextExpression,
     HtmlTextExpressions, HtmlVariant, SvelteAwaitBlock, SvelteEachBlock, SvelteIfBlock,
     SvelteKeyBlock, VueDirective, VueVBindShorthandDirective, VueVOnShorthandDirective,
     VueVSlotShorthandDirective,
@@ -61,7 +64,10 @@ use biome_js_syntax::{EmbeddingKind, JsFileSource, JsLanguage};
 use biome_json_parser::parse_json_with_offset_and_cache;
 use biome_json_syntax::{JsonFileSource, JsonLanguage};
 use biome_parser::AnyParse;
-use biome_rowan::{AstNode, AstNodeList, BatchMutation, NodeCache, SendNode, TextSize};
+use biome_rowan::{
+    AstNode, AstNodeList, BatchMutation, NodeCache, SendNode, SyntaxNodeCast, TextSize,
+    TokenAtOffset,
+};
 use camino::Utf8Path;
 use either::Either;
 use std::borrow::Cow;
@@ -372,6 +378,10 @@ impl ExtensionHandler for HtmlFileHandler {
                 format_embedded: Some(format_embedded),
             },
             search: SearchCapabilities { search: None },
+            editors: EditorCapabilities {
+                resolve_binding: Some(resolve_binding_html),
+                resolve_definition: None,
+            },
         }
     }
 }
@@ -1791,4 +1801,98 @@ fn read_trailing_trivia(value: &str) -> Cow<'_, str> {
     } else {
         Cow::Borrowed("")
     }
+}
+
+/// Checks if the attribute belongs to a component element rather than a
+/// regular HTML tag. Components are identified by uppercase-starting tag
+/// names, hyphenated names, member expressions, or explicit component nodes.
+fn is_component_element(attr: &HtmlAttribute) -> bool {
+    let tag_name = attr.syntax().ancestors().skip(1).find_map(|ancestor| {
+        if let Some(opening) = HtmlOpeningElement::cast_ref(&ancestor) {
+            opening.name().ok()
+        } else if let Some(self_closing) = HtmlSelfClosingElement::cast_ref(&ancestor) {
+            self_closing.name().ok()
+        } else {
+            None
+        }
+    });
+
+    let Some(tag_name) = tag_name else {
+        return false;
+    };
+
+    match tag_name {
+        AnyHtmlTagName::HtmlComponentName(_) | AnyHtmlTagName::HtmlMemberName(_) => true,
+        AnyHtmlTagName::HtmlTagName(name) => {
+            let Ok(token) = name.value_token() else {
+                return false;
+            };
+            let text = token.text_trimmed();
+            text.chars().next().is_some_and(|c| c.is_uppercase()) || text.contains('-')
+        }
+    }
+}
+
+/// Source-side capability for HTML: detects a CSS class name at the cursor
+/// position inside a `class` attribute.
+pub(crate) fn resolve_binding_html(params: ResolveBindingParams) -> Option<DefinitionReference> {
+    let root: HtmlRoot = params.parse.tree();
+
+    let token = match root.syntax().token_at_offset(params.cursor_offset) {
+        TokenAtOffset::Single(token) => token,
+        TokenAtOffset::Between(_, right) => right,
+        TokenAtOffset::None => return None,
+    };
+
+    // Walk up to find an HtmlAttribute ancestor
+    let html_attribute = token.ancestors().find_map(|n| n.cast::<HtmlAttribute>())?;
+
+    let name_token = html_attribute.name().ok()?.value_token().ok()?;
+    if !name_token.text_trimmed().eq_ignore_ascii_case("class") {
+        return None;
+    }
+
+    // Skip component elements — class on a component is a prop, not a CSS class
+    if is_component_element(&html_attribute) {
+        return None;
+    }
+
+    let initializer = html_attribute.initializer()?;
+    let value = initializer.value().ok()?;
+
+    let html_string = match value {
+        AnyHtmlAttributeInitializer::HtmlString(s) => s,
+        _ => return None,
+    };
+
+    let value_token = html_string.value_token().ok()?;
+    let inner_text = html_string.inner_string_text().ok()?;
+    let inner_source_range = inner_text.source_range(value_token.text_trimmed_range());
+
+    let relative_offset = params
+        .cursor_offset
+        .checked_sub(inner_source_range.start())?;
+    let relative_offset: usize = relative_offset.into();
+
+    let text = inner_text.text();
+    if relative_offset > text.len() {
+        return None;
+    }
+
+    // Find which whitespace-separated class name the cursor falls within
+    let mut pos = 0usize;
+    for class_name in text.split_ascii_whitespace() {
+        let start = text[pos..].find(class_name).map(|i| i + pos)?;
+        let end = start + class_name.len();
+
+        if relative_offset >= start && relative_offset <= end {
+            return Some(DefinitionReference::CssClass {
+                class_name: class_name.to_string(),
+            });
+        }
+
+        pos = end;
+    }
+
+    None
 }

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -1,9 +1,9 @@
 use super::{
     AnalyzerCapabilities, AnalyzerVisitorBuilder, CodeActionsParams, DebugCapabilities,
-    DiagnosticsAndActionsParams, EnabledForPath, ExtensionHandler, FormatEmbedNode,
-    FormatterCapabilities, LintParams, LintResults, ParseEmbedResult, ParseResult,
+    DiagnosticsAndActionsParams, EditorCapabilities, EnabledForPath, ExtensionHandler,
+    FormatEmbedNode, FormatterCapabilities, LintParams, LintResults, ParseEmbedResult, ParseResult,
     ParserCapabilities, ProcessDiagnosticsAndActions, ProcessFixAll, ProcessLint,
-    SearchCapabilities, UpdateSnippetsNodes, search,
+    ResolveBindingParams, ResolveDefinitionParams, SearchCapabilities, UpdateSnippetsNodes, search,
 };
 use crate::configuration::to_analyzer_rules;
 use crate::diagnostics::extension_error;
@@ -17,7 +17,10 @@ use crate::settings::{
     check_override_feature_activity,
 };
 use crate::workspace::document::services::embedded_bindings::EmbeddedBuilder;
-use crate::workspace::{DocumentFileSource, EmbeddedSnippet, PullDiagnosticsAndActionsResult};
+use crate::workspace::{
+    DefinitionReference, DocumentFileSource, EmbeddedSnippet, GoToDefinitionResult,
+    PullDiagnosticsAndActionsResult,
+};
 use crate::{
     WorkspaceError,
     settings::{FormatSettings, LanguageListSettings, LanguageSettings, ServiceLanguage},
@@ -55,18 +58,20 @@ use biome_js_formatter::context::{
 use biome_js_formatter::format_node;
 use biome_js_parser::JsParserOptions;
 use biome_js_semantic::{SemanticModelOptions, semantic_model};
+use biome_js_syntax::binding_ext::AnyJsIdentifierBinding;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsRoot, AnyJsTemplateElement, JsCallArgumentList, JsCallArguments,
-    JsCallExpression, JsClassDeclaration, JsClassExpression, JsFileSource, JsFunctionDeclaration,
-    JsLanguage, JsSyntaxNode, JsTemplateChunkElement, JsTemplateExpression, JsVariableDeclarator,
+    AnyJsExpression, AnyJsRoot, AnyJsTemplateElement, AnyJsxAttributeValue, JsCallArgumentList,
+    JsCallArguments, JsCallExpression, JsClassDeclaration, JsClassExpression, JsFileSource,
+    JsFunctionDeclaration, JsLanguage, JsReferenceIdentifier, JsSyntaxKind, JsSyntaxNode,
+    JsTemplateChunkElement, JsTemplateExpression, JsVariableDeclarator, JsxAttribute, JsxString,
     TextRange, TextSize, TokenAtOffset,
 };
 use biome_js_type_info::{GlobalsResolver, ScopeId, TypeData, TypeResolver};
-use biome_module_graph::ModuleGraph;
+use biome_module_graph::{JsOwnExport, ModuleGraph};
 use biome_parser::AnyParse;
 use biome_rowan::{
     AstNode, AstNodeList, BatchMutation, BatchMutationExt, Direction, NodeCache, SendNode,
-    WalkEvent,
+    SyntaxNodeCast, WalkEvent,
 };
 use camino::Utf8Path;
 use either::Either;
@@ -538,6 +543,10 @@ impl ExtensionHandler for JsFileHandler {
             },
             search: SearchCapabilities {
                 search: Some(search),
+            },
+            editors: EditorCapabilities {
+                resolve_binding: Some(resolve_binding),
+                resolve_definition: Some(resolve_definition),
             },
         }
     }
@@ -1475,4 +1484,189 @@ fn update_snippets(
     let root = mutation.commit();
 
     Ok(root.as_send().unwrap())
+}
+
+/// Source-side capability: given a cursor position, identify what binding the user clicked on.
+pub(crate) fn resolve_binding(params: ResolveBindingParams) -> Option<DefinitionReference> {
+    let root: AnyJsRoot = params.parse.tree();
+
+    let token = match root.syntax().token_at_offset(params.cursor_offset) {
+        TokenAtOffset::Single(token) => token,
+        TokenAtOffset::Between(_, right) => right,
+        TokenAtOffset::None => return None,
+    };
+
+    // Check if cursor is inside a JSX className/class attribute string.
+    // This doesn't need the semantic model, so try it before the model check.
+    if let Some(class_name) = extract_css_class_at_offset(&token, params.cursor_offset) {
+        return Some(DefinitionReference::CssClass { class_name });
+    }
+
+    let semantic_model = params.services.as_js_services()?.semantic_model.as_ref()?;
+
+    // Try to resolve as a reference (e.g., `foo` in `console.log(foo)`)
+    if let Some(reference) = token
+        .ancestors()
+        .find_map(|p| p.cast::<JsReferenceIdentifier>())
+        && let Some(binding) = semantic_model.binding(&reference)
+    {
+        let binding_syntax = binding.syntax();
+        if is_under_import_clause(&binding_syntax) {
+            let name = binding_syntax.text_trimmed().to_string();
+            return Some(DefinitionReference::Import { local_name: name });
+        }
+        return Some(DefinitionReference::Local {
+            range: binding_syntax.text_trimmed_range(),
+        });
+    }
+
+    // Try to resolve when cursor is directly on an import binding name.
+    // E.g., cursor on `foo` in `import { foo } from './utils'`
+    if let Some(binding_node) = token
+        .ancestors()
+        .find_map(|p| p.cast::<AnyJsIdentifierBinding>())
+    {
+        let binding_range = binding_node.name_token().ok()?.text_trimmed_range();
+        let binding_text = binding_node.name_token().ok()?.text_trimmed().to_string();
+
+        if is_under_import_clause(binding_node.syntax()) {
+            return Some(DefinitionReference::Import {
+                local_name: binding_text,
+            });
+        }
+
+        return Some(DefinitionReference::Local {
+            range: binding_range,
+        });
+    }
+
+    None
+}
+
+/// Destination-side capability: given a binding reference, resolve the definition location.
+pub(crate) fn resolve_definition(params: ResolveDefinitionParams) -> Option<GoToDefinitionResult> {
+    match params.definition_ref {
+        DefinitionReference::Local { range } => Some(GoToDefinitionResult {
+            path: BiomePath::new(params.path.as_path().to_string()),
+            range: *range,
+        }),
+        DefinitionReference::Import { local_name } => {
+            resolve_import_definition(local_name, params.path.as_path(), params.module_graph)
+        }
+        // CssClass is routed to the CSS handler by the orchestrator
+        _ => None,
+    }
+}
+
+/// Resolves an imported symbol to its definition in the target module.
+fn resolve_import_definition(
+    local_name: &str,
+    current_path: &Utf8Path,
+    module_graph: &ModuleGraph,
+) -> Option<GoToDefinitionResult> {
+    use biome_js_type_info::ImportSymbol;
+
+    let module_info = module_graph.js_module_info_for_path(current_path)?;
+    let js_import = module_info.static_imports.get(local_name)?;
+
+    let target_path = js_import.resolved_path.as_path()?;
+
+    // Skip files not in the module graph
+    if !module_graph.contains(target_path) {
+        return None;
+    }
+
+    let target_module = module_graph.js_module_info_for_path(target_path)?;
+
+    let export_name = match &js_import.symbol {
+        ImportSymbol::Named(name) => name.text(),
+        ImportSymbol::Default => "default",
+        ImportSymbol::All => {
+            // Namespace import: navigate to the target module file
+            return Some(GoToDefinitionResult {
+                path: BiomePath::new(target_path.to_string()),
+                range: TextRange::new(TextSize::from(0), TextSize::from(0)),
+            });
+        }
+    };
+
+    let own_export = target_module.find_js_exported_symbol(module_graph, export_name)?;
+
+    match own_export {
+        JsOwnExport::Binding(range) => Some(GoToDefinitionResult {
+            path: BiomePath::new(target_path.to_string()),
+            range,
+        }),
+        // Type-only exports and namespace exports don't have a binding location
+        JsOwnExport::Type(_) | JsOwnExport::Namespace(_) => None,
+    }
+}
+
+/// Checks if a syntax node is under an import clause.
+fn is_under_import_clause(node: &biome_rowan::SyntaxNode<JsLanguage>) -> bool {
+    node.ancestors().skip(1).any(|ancestor| {
+        matches!(
+            ancestor.kind(),
+            JsSyntaxKind::JS_IMPORT_NAMED_CLAUSE
+                | JsSyntaxKind::JS_IMPORT_DEFAULT_CLAUSE
+                | JsSyntaxKind::JS_IMPORT_NAMESPACE_CLAUSE
+                | JsSyntaxKind::JS_IMPORT_COMBINED_CLAUSE
+        )
+    })
+}
+
+/// Extracts the CSS class name at the given cursor offset from a JSX
+/// `className` or `class` attribute string value.
+///
+/// Given `<div className="foo bar baz">` with cursor on `bar`, returns
+/// `Some("bar")`.
+fn extract_css_class_at_offset(
+    token: &biome_rowan::SyntaxToken<JsLanguage>,
+    cursor_offset: TextSize,
+) -> Option<String> {
+    // Walk up to find a JsxAttribute ancestor
+    let jsx_attribute = token.ancestors().find_map(JsxAttribute::cast)?;
+
+    let name_token = jsx_attribute.name_value_token().ok()?;
+    let name_text = name_token.text_trimmed();
+
+    if name_text != "className" && name_text != "class" {
+        return None;
+    }
+
+    let initializer = jsx_attribute.initializer()?;
+    let value = initializer.value().ok()?;
+
+    let string_literal: JsxString = match value {
+        AnyJsxAttributeValue::JsxString(s) => s,
+        _ => return None,
+    };
+
+    let value_token = string_literal.value_token().ok()?;
+    let inner_text = string_literal.inner_string_text().ok()?;
+    let inner_source_range = inner_text.source_range(value_token.text_trimmed_range());
+
+    let relative_offset = cursor_offset.checked_sub(inner_source_range.start())?;
+    let relative_offset: usize = relative_offset.into();
+
+    let text = inner_text.text();
+    if relative_offset > text.len() {
+        return None;
+    }
+
+    // Find which whitespace-separated class name the cursor falls within
+    let mut pos = 0usize;
+    for class_name in text.split_ascii_whitespace() {
+        // Find actual start (skip whitespace)
+        let start = text[pos..].find(class_name).map(|i| i + pos)?;
+        let end = start + class_name.len();
+
+        if relative_offset >= start && relative_offset <= end {
+            return Some(class_name.to_string());
+        }
+
+        pos = end;
+    }
+
+    None
 }

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -1,6 +1,7 @@
 use super::{
-    AnalyzerVisitorBuilder, CodeActionsParams, DocumentFileSource, EnabledForPath,
-    ExtensionHandler, ParseResult, ProcessFixAll, ProcessLint, SearchCapabilities, search,
+    AnalyzerVisitorBuilder, CodeActionsParams, DocumentFileSource, EditorCapabilities,
+    EnabledForPath, ExtensionHandler, ParseResult, ProcessFixAll, ProcessLint, SearchCapabilities,
+    search,
 };
 use crate::configuration::to_analyzer_rules;
 use crate::file_handlers::DebugCapabilities;
@@ -370,6 +371,10 @@ impl ExtensionHandler for JsonFileHandler {
             },
             search: SearchCapabilities {
                 search: Some(search),
+            },
+            editors: EditorCapabilities {
+                resolve_binding: None,
+                resolve_definition: None,
             },
         }
     }

--- a/crates/biome_service/src/file_handlers/md.rs
+++ b/crates/biome_service/src/file_handlers/md.rs
@@ -1,6 +1,6 @@
 use super::{
-    Capabilities, DebugCapabilities, DocumentFileSource, EnabledForPath, ExtensionHandler,
-    FormatterCapabilities, ParseResult, ParserCapabilities, SearchCapabilities,
+    Capabilities, DebugCapabilities, DocumentFileSource, EditorCapabilities, EnabledForPath,
+    ExtensionHandler, FormatterCapabilities, ParseResult, ParserCapabilities, SearchCapabilities,
 };
 use crate::WorkspaceError;
 use crate::settings::{
@@ -250,6 +250,10 @@ impl ExtensionHandler for MarkdownFileHandler {
                 format_embedded: None,
             },
             search: SearchCapabilities { search: None },
+            editors: EditorCapabilities {
+                resolve_binding: None,
+                resolve_definition: None,
+            },
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -13,8 +13,9 @@ use crate::settings::{Settings, SettingsWithEditor};
 use crate::utils::growth_guard::GrowthGuard;
 use crate::workspace::document::services::embedded_bindings::EmbeddedBuilder;
 use crate::workspace::{
-    AnyEmbeddedSnippet, CodeAction, DocumentServices, FixAction, FixFileMode, FixFileResult,
-    GetSyntaxTreeResult, PullActionsResult, PullDiagnosticsAndActionsResult, RenameResult,
+    AnyEmbeddedSnippet, CodeAction, DefinitionReference, DocumentServices, FixAction, FixFileMode,
+    FixFileResult, GetSyntaxTreeResult, GoToDefinitionResult, PullActionsResult,
+    PullDiagnosticsAndActionsResult, RenameResult,
 };
 use biome_analyze::{
     AnalyzerAction, AnalyzerDiagnostic, AnalyzerOptions, AnalyzerPluginVec, AnalyzerSignal,
@@ -522,6 +523,7 @@ pub struct Capabilities {
     pub(crate) formatter: FormatterCapabilities,
     pub(crate) search: SearchCapabilities,
     pub(crate) enabled_for_path: EnabledForPath,
+    pub(crate) editors: EditorCapabilities,
 }
 
 #[derive(Clone)]
@@ -1136,6 +1138,27 @@ pub(crate) struct EnabledForPath {
     pub(crate) assist: Option<Enabled>,
     pub(crate) search: Option<Enabled>,
 }
+
+#[derive(Default)]
+pub(crate) struct EditorCapabilities {
+    pub(crate) resolve_binding: Option<ResolveBinding>,
+    pub(crate) resolve_definition: Option<ResolveDefinition>,
+}
+
+pub(crate) struct ResolveBindingParams<'a> {
+    pub(crate) parse: AnyParse,
+    pub(crate) cursor_offset: TextSize,
+    pub(crate) services: &'a DocumentServices,
+}
+
+pub(crate) struct ResolveDefinitionParams<'a> {
+    pub(crate) path: &'a BiomePath,
+    pub(crate) definition_ref: &'a DefinitionReference,
+    pub(crate) module_graph: &'a ModuleGraph,
+}
+
+type ResolveBinding = fn(ResolveBindingParams) -> Option<DefinitionReference>;
+type ResolveDefinition = fn(ResolveDefinitionParams) -> Option<GoToDefinitionResult>;
 
 /// Main trait to use to add a new language to Biome
 pub(crate) trait ExtensionHandler {

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -1,4 +1,7 @@
-use super::{ParsedLangAndSetup, SearchCapabilities, parse_lang_and_setup_from_script_opening_tag};
+use super::{
+    EditorCapabilities, ParsedLangAndSetup, SearchCapabilities,
+    parse_lang_and_setup_from_script_opening_tag,
+};
 use crate::WorkspaceError;
 use crate::file_handlers::{
     AnalyzerCapabilities, Capabilities, CodeActionsParams, DebugCapabilities, EnabledForPath,
@@ -120,6 +123,10 @@ impl ExtensionHandler for SvelteFileHandler {
             },
             // TODO: We should be able to search JS portions already
             search: SearchCapabilities { search: None },
+            editors: EditorCapabilities {
+                resolve_binding: None,
+                resolve_definition: None,
+            },
         }
     }
 }

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -1,4 +1,7 @@
-use super::{ParsedLangAndSetup, SearchCapabilities, parse_lang_and_setup_from_script_opening_tag};
+use super::{
+    EditorCapabilities, ParsedLangAndSetup, SearchCapabilities,
+    parse_lang_and_setup_from_script_opening_tag,
+};
 use crate::WorkspaceError;
 use crate::file_handlers::{
     AnalyzerCapabilities, Capabilities, CodeActionsParams, DebugCapabilities, EnabledForPath,
@@ -126,6 +129,10 @@ impl ExtensionHandler for VueFileHandler {
             },
             // TODO: We should be able to search JS portions already
             search: SearchCapabilities { search: None },
+            editors: EditorCapabilities {
+                resolve_binding: None,
+                resolve_definition: None,
+            },
         }
     }
 }

--- a/crates/biome_service/src/scanner/watcher.rs
+++ b/crates/biome_service/src/scanner/watcher.rs
@@ -450,7 +450,7 @@ impl Watcher {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, workspace))]
+    #[tracing::instrument(level = "debug", skip(self, workspace, paths))]
     fn watch_folders(
         &mut self,
         workspace: &impl WorkspaceWatcherBridge,

--- a/crates/biome_service/src/scanner/workspace_scanner_bridge.tests.rs
+++ b/crates/biome_service/src/scanner/workspace_scanner_bridge.tests.rs
@@ -53,6 +53,7 @@ fn close_file_through_watcher_before_client() {
             document_file_source: None,
             persist_node_cache: true,
             inline_config: None,
+            needs_document_services: None,
         })
         .expect("can also open from client");
 
@@ -118,6 +119,7 @@ fn close_file_from_client_before_watcher() {
             document_file_source: None,
             persist_node_cache: true,
             inline_config: None,
+            needs_document_services: None,
         })
         .expect("can open from client");
 

--- a/crates/biome_service/src/scanner/workspace_watcher_bridge.tests.rs
+++ b/crates/biome_service/src/scanner/workspace_watcher_bridge.tests.rs
@@ -44,6 +44,7 @@ fn close_modified_file_from_client_before_watcher() {
             document_file_source: None,
             persist_node_cache: true,
             inline_config: None,
+            needs_document_services: None,
         })
         .expect("can open from client");
 

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -403,6 +403,7 @@ impl From<&ScanKind> for ModuleGraphResolutionKind {
 }
 
 pub type SettingsWithEditor<'a> = SettingsHandle<'a, Option<Configuration>>;
+pub type SettingsWithCapability<'a> = SettingsHandle<'a, bool>;
 
 /// Handle object holding a temporary lock on the workspace settings until
 /// the deferred language-specific options resolution is called
@@ -536,6 +537,12 @@ impl<'a> SettingsHandle<'a, Option<Configuration>> {
     {
         let settings = self.as_merged_settings();
         L::assist_enabled_for_file_path(&settings, path)
+    }
+}
+
+impl<'a> SettingsHandle<'a, bool> {
+    pub fn is_capability_enabled(&self) -> bool {
+        self.editor
     }
 }
 

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -839,6 +839,10 @@ pub struct OpenFileParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_config: Option<Configuration>,
+
+    /// Used to enable further document services e.g. semantic model
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub needs_document_services: Option<bool>,
 }
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -1214,6 +1218,37 @@ pub struct RenameResult {
     pub range: TextRange,
     /// List of text edit operations to apply on the source code
     pub indels: TextEdit,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct GoToDefinitionParams {
+    pub project_key: ProjectKey,
+    pub path: BiomePath,
+    pub cursor_range: TextRange,
+    pub enabled: bool,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct GoToDefinitionResult {
+    pub path: BiomePath,
+    pub range: TextRange,
+}
+
+/// The definition kind of definition
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub enum DefinitionReference {
+    /// The binding is in the same file at this range.
+    Local { range: TextRange },
+    /// Imported symbol — needs module graph resolution.
+    Import { local_name: String },
+    /// A CSS class name from a JSX className/class attribute or a CSS-in-JS snippet (not yet supported)
+    CssClass { class_name: String },
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -1597,6 +1632,15 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
 
     /// Returns the content of the file after renaming a symbol.
     fn rename(&self, params: RenameParams) -> Result<RenameResult, WorkspaceError>;
+
+    /// Navigates to the definition of the symbol at the given cursor position.
+    ///
+    /// Returns `None` if the symbol cannot be resolved (e.g., external
+    /// dependency, cursor not on an identifier, or no definition found).
+    fn go_to_definition(
+        &self,
+        params: GoToDefinitionParams,
+    ) -> Result<Option<GoToDefinitionResult>, WorkspaceError>;
 
     /// Closes a file that is opened in the workspace.
     ///

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -53,6 +53,7 @@ fn debug_control_flow() {
             document_file_source: Some(DocumentFileSource::from(JsFileSource::default())),
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -76,6 +77,7 @@ fn recognize_typescript_definition_file() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -98,6 +100,7 @@ fn correctly_handle_json_files() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -114,6 +117,7 @@ fn correctly_handle_json_files() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -130,6 +134,7 @@ fn correctly_handle_json_files() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -146,6 +151,7 @@ fn correctly_handle_json_files() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -162,6 +168,7 @@ fn correctly_handle_json_files() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -178,6 +185,7 @@ fn correctly_handle_json_files() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -198,6 +206,7 @@ fn correctly_handle_json_files() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -218,6 +227,7 @@ fn correctly_handle_json_files() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -242,6 +252,7 @@ fn correctly_handle_json_files() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -279,6 +290,7 @@ type User {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -311,6 +323,7 @@ fn correctly_pulls_lint_diagnostics() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -347,6 +360,7 @@ fn pull_grit_debug_info() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -419,6 +433,7 @@ fn files_loaded_by_the_scanner_are_only_unloaded_when_the_project_is_unregistere
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -483,6 +498,7 @@ fn too_large_files_are_tracked_but_not_parsed() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -544,6 +560,7 @@ fn plugins_are_loaded_and_used_during_analysis() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -615,6 +632,7 @@ language css;
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -682,6 +700,7 @@ fn plugins_may_use_invalid_span() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -814,6 +833,7 @@ const hasOwn = Object.hasOwn({ foo: 'bar' }, 'foo');"#,
                 document_file_source: None,
                 persist_node_cache: false,
                 inline_config: None,
+                needs_document_services: None,
             })
             .unwrap();
 
@@ -927,6 +947,7 @@ fn correctly_scope_plugin_with_includes() {
                 document_file_source: None,
                 persist_node_cache: false,
                 inline_config: None,
+                needs_document_services: None,
             })
             .unwrap();
 
@@ -996,6 +1017,7 @@ class Person {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1031,6 +1053,7 @@ class Person {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1066,6 +1089,7 @@ class Person {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1114,6 +1138,7 @@ fn debug_module_graph_mixed_project() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1127,6 +1152,7 @@ fn debug_module_graph_mixed_project() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1140,6 +1166,7 @@ fn debug_module_graph_mixed_project() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1202,6 +1229,7 @@ async function test() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1220,6 +1248,7 @@ export const debounce = function debounce() {};
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1236,6 +1265,7 @@ export const squash = function squash() {};
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 

--- a/crates/biome_service/src/workspace/client.rs
+++ b/crates/biome_service/src/workspace/client.rs
@@ -2,11 +2,12 @@ use super::{
     ChangeFileParams, ChangeFileResult, CloseFileParams, FileExitsParams, FixFileParams,
     FixFileResult, FormatFileParams, FormatOnTypeParams, FormatRangeParams,
     GetControlFlowGraphParams, GetFormatterIRParams, GetModuleGraphParams, GetModuleGraphResult,
-    GetSemanticModelParams, GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams,
-    OpenFileResult, PullActionsParams, PullActionsResult, PullDiagnosticsAndActionsParams,
-    PullDiagnosticsAndActionsResult, PullDiagnosticsParams, PullDiagnosticsResult, RenameParams,
-    RenameResult, ScanProjectParams, ScanProjectResult, SearchPatternParams, SearchResults,
-    SupportsFeatureParams, UpdateModuleGraphParams, UpdateSettingsParams, UpdateSettingsResult,
+    GetSemanticModelParams, GetSyntaxTreeParams, GetSyntaxTreeResult, GoToDefinitionParams,
+    GoToDefinitionResult, OpenFileParams, OpenFileResult, PullActionsParams, PullActionsResult,
+    PullDiagnosticsAndActionsParams, PullDiagnosticsAndActionsResult, PullDiagnosticsParams,
+    PullDiagnosticsResult, RenameParams, RenameResult, ScanProjectParams, ScanProjectResult,
+    SearchPatternParams, SearchResults, SupportsFeatureParams, UpdateModuleGraphParams,
+    UpdateSettingsParams, UpdateSettingsResult,
 };
 use crate::workspace::{
     CheckFileSizeParams, CheckFileSizeResult, CloseProjectParams, FileFeaturesResult,
@@ -197,6 +198,13 @@ where
 
     fn rename(&self, params: RenameParams) -> Result<RenameResult, WorkspaceError> {
         self.request("biome/rename", params)
+    }
+
+    fn go_to_definition(
+        &self,
+        params: GoToDefinitionParams,
+    ) -> Result<Option<GoToDefinitionResult>, WorkspaceError> {
+        self.request("biome/go_to_definition", params)
     }
 
     fn close_file(&self, params: CloseFileParams) -> Result<(), WorkspaceError> {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -4,14 +4,17 @@ use crate::configuration::{LoadedConfiguration, ProjectScanComputer, read_config
 use crate::diagnostics::{FileTooLarge, NoIgnoreFileFound, VcsDiagnostic};
 use crate::file_handlers::{
     Capabilities, CodeActionsParams, DiagnosticsAndActionsParams, DocumentFileSource, Features,
-    FixAllParams, FormatEmbedNode, LintParams, LintResults, ParseResult, UpdateSnippetsNodes,
+    FixAllParams, FormatEmbedNode, LintParams, LintResults, ParseResult, ResolveBindingParams,
+    ResolveDefinitionParams, UpdateSnippetsNodes,
 };
 use crate::projects::{GetFileFeaturesParams, ProjectKey, Projects};
 use crate::scanner::{
     IndexRequestKind, IndexTrigger, ScanOptions, Scanner, ScannerWatcherBridge, WatcherInstruction,
     WorkspaceScannerBridge,
 };
-use crate::settings::{ModuleGraphResolutionKind, SettingsHandle, SettingsWithEditor};
+use crate::settings::{
+    ModuleGraphResolutionKind, SettingsHandle, SettingsWithCapability, SettingsWithEditor,
+};
 use crate::workspace::document::services::embedded_bindings::{
     EmbeddedBuilder, EmbeddedExportedBindings,
 };
@@ -24,13 +27,14 @@ use crate::workspace::{
     FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFileContentParams,
     GetFormatterIRParams, GetModuleGraphParams, GetModuleGraphResult, GetRegisteredTypesParams,
     GetSemanticModelParams, GetSyntaxTreeParams, GetSyntaxTreeResult, GetTypeInfoParams,
-    IgnoreKind, OpenFileParams, OpenFileResult, OpenProjectParams, OpenProjectResult,
-    ParsePatternParams, ParsePatternResult, PathIsIgnoredParams, PatternId, PullActionsParams,
-    PullActionsResult, PullDiagnosticsAndActionsParams, PullDiagnosticsAndActionsResult,
-    PullDiagnosticsParams, PullDiagnosticsResult, RageEntry, RageParams, RageResult, RenameParams,
-    RenameResult, ScanKind, ScanProjectParams, ScanProjectResult, SearchPatternParams,
-    SearchResults, ServerInfo, ServiceNotification, Settings, SupportsFeatureParams,
-    UpdateModuleGraphParams, UpdateSettingsParams, UpdateSettingsResult,
+    GoToDefinitionParams, GoToDefinitionResult, IgnoreKind, OpenFileParams, OpenFileResult,
+    OpenProjectParams, OpenProjectResult, ParsePatternParams, ParsePatternResult,
+    PathIsIgnoredParams, PatternId, PullActionsParams, PullActionsResult,
+    PullDiagnosticsAndActionsParams, PullDiagnosticsAndActionsResult, PullDiagnosticsParams,
+    PullDiagnosticsResult, RageEntry, RageParams, RageResult, RenameParams, RenameResult, ScanKind,
+    ScanProjectParams, ScanProjectResult, SearchPatternParams, SearchResults, ServerInfo,
+    ServiceNotification, Settings, SupportsFeatureParams, UpdateModuleGraphParams,
+    UpdateSettingsParams, UpdateSettingsResult,
 };
 use crate::{Workspace, WorkspaceError};
 use biome_analyze::{AnalyzerPluginVec, RuleCategory};
@@ -38,7 +42,7 @@ use biome_configuration::bool::Bool;
 use biome_configuration::max_size::MaxSize;
 use biome_configuration::vcs::VcsClientKind;
 use biome_configuration::{BiomeDiagnostic, Configuration, ConfigurationPathHint};
-use biome_css_syntax::{AnyCssRoot, CssVariant};
+use biome_css_syntax::{AnyCssRoot, CssFileSource, CssVariant};
 use biome_deserialize::json::deserialize_from_json_str;
 use biome_deserialize::{Deserialized, Merge};
 use biome_diagnostics::print_diagnostic_to_string;
@@ -191,6 +195,7 @@ impl WorkspaceServer {
                     document_file_source: Some(document_file_source),
                     persist_node_cache: false,
                     inline_config: None,
+                    needs_document_services: None,
                 },
             );
         }
@@ -201,6 +206,14 @@ impl WorkspaceServer {
         settings: &'a Settings,
         editor: Option<Configuration>,
     ) -> SettingsWithEditor<'a> {
+        SettingsHandle::new(settings, editor)
+    }
+
+    fn settings_handle_with_capability<'a>(
+        &self,
+        settings: &'a Settings,
+        editor: bool,
+    ) -> SettingsWithCapability<'a> {
         SettingsHandle::new(settings, editor)
     }
 
@@ -354,6 +367,7 @@ impl WorkspaceServer {
             document_file_source,
             persist_node_cache,
             inline_config,
+            needs_document_services,
         } = params;
         let path: Utf8PathBuf = biome_path.clone().into();
 
@@ -472,7 +486,10 @@ impl WorkspaceServer {
             if let Some(language) = language {
                 file_source_index = self.insert_source(language);
 
-                if settings.is_linter_enabled() || settings.is_assist_enabled() {
+                if settings.is_linter_enabled()
+                    || settings.is_assist_enabled()
+                    || needs_document_services.unwrap_or_default()
+                {
                     if language.is_css_like() {
                         services = CssDocumentServices::default()
                             .with_css_semantic_model(&any_parse.tree())
@@ -707,6 +724,91 @@ impl WorkspaceServer {
                 },
                 None => Err(WorkspaceError::not_found(path.to_string())),
             })
+    }
+
+    /// Tries to resolve a binding reference at the given cursor offset.
+    ///
+    /// First checks if checks if the binding is inside its main parsed root, then it
+    /// checks if it's inside its snippets.
+    ///
+    /// Returns the definition reference (if found), the effective path for the binding,
+    /// the capabilities that produced it (needed for calling `resolve_definition`).
+    fn resolve_binding_in_document_or_snippets(
+        &self,
+        path: &BiomePath,
+        cursor_offset: TextSize,
+        parse: &AnyParse,
+        services: &DocumentServices,
+        embedded_snippets: &[AnyEmbeddedSnippet],
+        language: DocumentFileSource,
+    ) -> Result<(Option<DefinitionReference>, BiomePath, Capabilities), WorkspaceError> {
+        let capabilities = self.features.get_capabilities(language);
+
+        // Resolve the correct capabilities for the definition side based on
+        // the definition reference kind (e.g., CssClass → CSS handler).
+        let resolve_capabilities =
+            |def_ref: &Option<DefinitionReference>, default_caps: Capabilities| -> Capabilities {
+                match def_ref {
+                    None => default_caps,
+                    Some(def_ref) => match def_ref {
+                        DefinitionReference::Local { .. } | DefinitionReference::Import { .. } => {
+                            default_caps
+                        }
+                        DefinitionReference::CssClass { .. } => self
+                            .features
+                            .get_capabilities(DocumentFileSource::Css(CssFileSource::css())),
+                    },
+                }
+            };
+
+        if let Some(resolve) = capabilities.editors.resolve_binding {
+            let result = resolve(ResolveBindingParams {
+                parse: parse.clone(),
+                cursor_offset,
+                services,
+            });
+            let caps = resolve_capabilities(&result, capabilities);
+            return Ok((result, path.clone(), caps));
+        }
+
+        // Check if cursor falls within an embedded snippet
+        for snippet in embedded_snippets {
+            let content_range = snippet.content_range();
+            if !content_range.contains(cursor_offset) {
+                continue;
+            }
+
+            let snippet_offset = snippet.content_offset();
+            let local_cursor = cursor_offset - snippet_offset;
+
+            let Some(file_source) = self.get_source(snippet.file_source_index()) else {
+                continue;
+            };
+            let snippet_caps = self.features.get_capabilities(file_source);
+            let Some(resolve) = snippet_caps.editors.resolve_binding else {
+                continue;
+            };
+
+            let snippet_services = snippet.as_snippet_services();
+            let result = resolve(ResolveBindingParams {
+                parse: snippet.parse(),
+                cursor_offset: local_cursor,
+                services: snippet_services,
+            });
+
+            // If binding is Local, adjust range back to parent document coordinates
+            let adjusted = result.map(|b| match b {
+                DefinitionReference::Local { range } => DefinitionReference::Local {
+                    range: range + snippet_offset,
+                },
+                other => other,
+            });
+
+            let capabilities = resolve_capabilities(&adjusted, snippet_caps);
+            return Ok((adjusted, path.clone(), capabilities));
+        }
+
+        Ok((None, path.clone(), capabilities))
     }
 
     fn get_parse_with_embedded_format_nodes(
@@ -1100,7 +1202,11 @@ impl WorkspaceServer {
                                         let css_source = self
                                             .get_source(css.file_source_index)
                                             .and_then(|src| src.to_css_file_source())?;
-                                        Some(HtmlEmbeddedContent::Css(css.parse.tree(), css_source))
+                                        Some(HtmlEmbeddedContent::Css(
+                                            css.parse.tree(),
+                                            css_source,
+                                            css.content_offset,
+                                        ))
                                     } else {
                                         s.as_js_embedded_snippet()
                                             .map(|js| HtmlEmbeddedContent::Js(js.parse.tree()))
@@ -2395,7 +2501,64 @@ impl Workspace for WorkspaceServer {
         Ok(result)
     }
 
-    /// Closes a file that is opened in the workspace.
+    fn go_to_definition(
+        &self,
+        params: GoToDefinitionParams,
+    ) -> Result<Option<GoToDefinitionResult>, WorkspaceError> {
+        let path = &params.path;
+        let cursor_offset = params.cursor_range.start();
+
+        let settings = self
+            .projects
+            .get_settings_based_on_path(params.project_key, path)
+            .ok_or_else(WorkspaceError::no_project)?;
+
+        let settings = self.settings_handle_with_capability(&settings, params.enabled);
+
+        let has_document_services = settings.is_capability_enabled()
+            || settings.as_ref().is_linter_enabled()
+            || settings.as_ref().is_assist_enabled();
+        if !has_document_services {
+            return Ok(None);
+        }
+
+        let (parse, embedded_snippets, services) =
+            self.get_parse_with_snippets_and_services(path.as_path())?;
+
+        let language = self.get_file_source(
+            path,
+            settings.as_ref().experimental_full_html_support_enabled(),
+        );
+
+        // Try to resolve the binding, checking embedded snippets first
+        let (definition_ref, effective_path, capabilities) = self
+            .resolve_binding_in_document_or_snippets(
+                path,
+                cursor_offset,
+                &parse,
+                &services,
+                &embedded_snippets,
+                language,
+            )?;
+
+        let Some(definition_ref) = definition_ref else {
+            return Ok(None);
+        };
+
+        let resolve_definition = capabilities
+            .editors
+            .resolve_definition
+            // NOTE: here we might want to silent the error because it could be noisy
+            .ok_or_else(self.build_capability_error(path))?;
+
+        Ok(resolve_definition(ResolveDefinitionParams {
+            path: &effective_path,
+            definition_ref: &definition_ref,
+            module_graph: &self.module_graph,
+        }))
+    }
+
+    /// Closes a file opened in the workspace.
     ///
     /// This only unloads the document from the workspace if the file is NOT
     /// indexed by the scanner. If the scanner has the file indexed, it may
@@ -2582,6 +2745,7 @@ impl WorkspaceScannerBridge for WorkspaceServer {
                 persist_node_cache: false,
                 // TODO: review here, it feels wrong that we can't pass the inline config
                 inline_config: None,
+                needs_document_services: None,
             },
         )
         .map(|result| (result.dependencies, result.diagnostics))

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::settings::ModuleGraphResolutionKind;
 use crate::test_utils::setup_workspace_and_open_project;
+use crate::workspace::UpdateSettingsParams;
 use biome_configuration::{
     FormatterConfiguration, JsConfiguration,
     analyzer::AnalyzerSelector,
@@ -40,6 +41,7 @@ fn commonjs_file_rejects_import_statement() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -94,6 +96,7 @@ fn store_embedded_nodes_with_current_ranges() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -156,6 +159,7 @@ fn format_html_with_scripts_and_css() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -266,6 +270,7 @@ function Foo({cond}) {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -277,6 +282,7 @@ function Foo({cond}) {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -383,6 +389,7 @@ function Foo({cond}) {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -394,6 +401,7 @@ function Foo({cond}) {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -461,6 +469,7 @@ fn pull_diagnostics_and_actions_for_js_file() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -542,6 +551,7 @@ fn no_diagnostics_for_unsupported_script_types() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -608,6 +618,7 @@ const Bar = styled(Component)`
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -688,6 +699,7 @@ const Baz = graphql`
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -774,6 +786,7 @@ const highlight = foo`some tagged template` // unknown tagged template
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -823,6 +836,7 @@ fn no_undeclared_classes_reports_unknown_class() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -883,6 +897,7 @@ fn no_undeclared_classes_passes_when_class_is_defined() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -937,6 +952,7 @@ fn no_undeclared_classes_silent_without_style_info() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -991,6 +1007,7 @@ fn no_undeclared_classes_reports_only_undeclared_in_multi_class() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1046,6 +1063,7 @@ fn no_unused_classes_reports_unreferenced_class() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1107,6 +1125,7 @@ fn no_unused_classes_passes_when_class_is_referenced_in_jsx() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1162,6 +1181,7 @@ fn no_unused_classes_reports_only_unreferenced_classes() {
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .unwrap();
 
@@ -1234,6 +1254,7 @@ fn no_unused_classes_passes_with_transitive_css_import() {
                 document_file_source: None,
                 persist_node_cache: false,
                 inline_config: None,
+                needs_document_services: None,
             })
             .unwrap();
     }
@@ -1257,4 +1278,712 @@ fn no_unused_classes_passes_with_transitive_css_import() {
             "Expected no diagnostics for {path} — all classes are transitively referenced"
         );
     }
+}
+
+#[test]
+fn go_to_definition_named_import() {
+    const UTILS_CONTENT: &str = "export function greet() { return 'hello'; }\n";
+    const MAIN_CONTENT: &str = "import { greet } from './utils.js';\ngreet();\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        Utf8PathBuf::from("/project/utils.js"),
+        UTILS_CONTENT.as_bytes(),
+    );
+    fs.insert(
+        Utf8PathBuf::from("/project/main.js"),
+        MAIN_CONTENT.as_bytes(),
+    );
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on `greet` in `import { greet }` — byte offset 9 (start of "greet")
+    let cursor_range = TextRange::new(TextSize::from(9), TextSize::from(9));
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/project/main.js"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should find a definition");
+    assert_eq!(
+        definition.path.as_path(),
+        Utf8Path::new("/project/utils.js")
+    );
+    // The `greet` binding in utils.js starts at byte 16 (after "export function ")
+    assert_eq!(definition.range.start(), TextSize::from(16));
+    assert_eq!(definition.range.end(), TextSize::from(21));
+}
+
+#[test]
+fn go_to_definition_default_import() {
+    const UTILS_CONTENT: &str = "export default function myFunc() { return 42; }\n";
+    const MAIN_CONTENT: &str = "import myFunc from './utils.js';\nmyFunc();\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        Utf8PathBuf::from("/project/utils.js"),
+        UTILS_CONTENT.as_bytes(),
+    );
+    fs.insert(
+        Utf8PathBuf::from("/project/main.js"),
+        MAIN_CONTENT.as_bytes(),
+    );
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on `myFunc` in `import myFunc` — byte offset 7
+    let cursor_range = TextRange::new(TextSize::from(7), TextSize::from(7));
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/project/main.js"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should find a definition for default import");
+    assert_eq!(
+        definition.path.as_path(),
+        Utf8Path::new("/project/utils.js")
+    );
+}
+
+#[test]
+fn go_to_definition_same_file_local_binding() {
+    const CONTENT: &str = "const myVar = 42;\nconsole.log(myVar);\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from("/project/main.js"), CONTENT.as_bytes());
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on `myVar` in `console.log(myVar)` — byte offset 30
+    let cursor_range = TextRange::new(TextSize::from(30), TextSize::from(30));
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/project/main.js"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should find a local definition");
+    assert_eq!(definition.path.as_path(), Utf8Path::new("/project/main.js"));
+    // `myVar` is declared at byte 6 (after "const ")
+    assert_eq!(definition.range.start(), TextSize::from(6));
+}
+
+#[test]
+fn go_to_definition_returns_none_for_node_modules() {
+    const UTILS_CONTENT: &str = "export function helper() {}\n";
+    const MAIN_CONTENT: &str = "import { helper } from 'external-pkg';\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        Utf8PathBuf::from("/project/node_modules/external-pkg/index.js"),
+        UTILS_CONTENT.as_bytes(),
+    );
+    fs.insert(
+        Utf8PathBuf::from("/project/main.js"),
+        MAIN_CONTENT.as_bytes(),
+    );
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on `helper` in `import { helper }` — byte offset 9
+    let cursor_range = TextRange::new(TextSize::from(9), TextSize::from(9));
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/project/main.js"),
+            cursor_range,
+        })
+        .unwrap();
+
+    assert!(result.is_none(), "should not resolve node_modules imports");
+}
+
+#[test]
+fn go_to_definition_returns_none_for_cursor_on_non_identifier() {
+    const CONTENT: &str = "const x = 1;\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from("/project/main.js"), CONTENT.as_bytes());
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on `=` at byte offset 8
+    let cursor_range = TextRange::new(TextSize::from(8), TextSize::from(8));
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/project/main.js"),
+            cursor_range,
+        })
+        .unwrap();
+
+    assert!(
+        result.is_none(),
+        "should return None when cursor is not on an identifier"
+    );
+}
+
+#[test]
+fn go_to_definition_jsx_classname_to_css() {
+    // `.btn { color: red; }\n` — "btn" starts at offset 1
+    const CSS_CONTENT: &str = ".btn { color: red; }\n";
+    // `import './styles.css';\n<div className="btn" />\n`
+    // "btn" in className is at offset 38 (after the opening quote at 37)
+    const JSX_CONTENT: &str = "import './styles.css';\n<div className=\"btn\" />\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        Utf8PathBuf::from("/project/styles.css"),
+        CSS_CONTENT.as_bytes(),
+    );
+    fs.insert(
+        Utf8PathBuf::from("/project/App.jsx"),
+        JSX_CONTENT.as_bytes(),
+    );
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on "btn" inside className="btn" — byte offset 39
+    let cursor_range = TextRange::new(TextSize::from(39), TextSize::from(39));
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/project/App.jsx"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should resolve className to CSS class");
+    assert_eq!(definition.path, BiomePath::new("/project/styles.css"));
+    // "btn" in `.btn` starts at offset 1 (after the dot)
+    assert_eq!(
+        definition.range,
+        TextRange::new(TextSize::from(1), TextSize::from(4))
+    );
+}
+
+#[test]
+fn go_to_definition_jsx_classname_multiple_classes() {
+    const CSS_CONTENT: &str = ".foo { } .bar { } .baz { }\n";
+    // `import './styles.css';\n<div className="foo bar baz" />\n`
+    const JSX_CONTENT: &str = "import './styles.css';\n<div className=\"foo bar baz\" />\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        Utf8PathBuf::from("/project/styles.css"),
+        CSS_CONTENT.as_bytes(),
+    );
+    fs.insert(
+        Utf8PathBuf::from("/project/App.jsx"),
+        JSX_CONTENT.as_bytes(),
+    );
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on "bar" inside className="foo bar baz" — "bar" starts at offset 43
+    let cursor_range = TextRange::new(TextSize::from(43), TextSize::from(43));
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/project/App.jsx"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should resolve to .bar in CSS");
+    assert_eq!(definition.path, BiomePath::new("/project/styles.css"));
+    // ".bar" is at offset 9, so "bar" name starts at 10
+    assert_eq!(
+        definition.range,
+        TextRange::new(TextSize::from(10), TextSize::from(13))
+    );
+}
+
+#[test]
+fn go_to_definition_html_class_to_css() {
+    const CSS_CONTENT: &str = ".header { margin: 0; }\n";
+    const HTML_CONTENT: &str =
+        "<link rel=\"stylesheet\" href=\"./styles.css\" />\n<div class=\"header\">Hello</div>\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        Utf8PathBuf::from("/project/styles.css"),
+        CSS_CONTENT.as_bytes(),
+    );
+    fs.insert(
+        Utf8PathBuf::from("/project/index.html"),
+        HTML_CONTENT.as_bytes(),
+    );
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on "header" inside class="header" — find the offset
+    // `<link rel="stylesheet" href="./styles.css" />\n<div class="header">Hello</div>\n`
+    // The `class="header"` part: "header" starts after the quote
+    let class_value_start = HTML_CONTENT.find("\"header\"").unwrap() + 1; // after the quote
+    let cursor_range = TextRange::new(
+        TextSize::from(class_value_start as u32),
+        TextSize::from(class_value_start as u32),
+    );
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/project/index.html"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should resolve HTML class to CSS class");
+    assert_eq!(definition.path, BiomePath::new("/project/styles.css"));
+    // "header" in `.header` starts at offset 1
+    assert_eq!(
+        definition.range,
+        TextRange::new(TextSize::from(1), TextSize::from(7))
+    );
+}
+
+#[test]
+fn go_to_definition_html_class_inline_style() {
+    const HTML_CONTENT: &str =
+        "<style>.card { padding: 1rem; }</style>\n<div class=\"card\">Content</div>\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        Utf8PathBuf::from("/project/index.html"),
+        HTML_CONTENT.as_bytes(),
+    );
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on "card" inside class="card"
+    let class_value_start = HTML_CONTENT.find("\"card\"").unwrap() + 1;
+    let cursor_range = TextRange::new(
+        TextSize::from(class_value_start as u32),
+        TextSize::from(class_value_start as u32),
+    );
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/project/index.html"),
+            cursor_range,
+        })
+        .unwrap();
+
+    // Inline style classes should resolve to the same HTML file
+    let definition = result.expect("should resolve HTML class to inline style");
+    assert_eq!(definition.path, BiomePath::new("/project/index.html"));
+    // "card" in `.card` inside <style> block — must be in parent document coordinates
+    let style_offset = HTML_CONTENT.find("<style>").unwrap() + "<style>".len();
+    // ".card" starts at offset 0 in snippet, "card" at offset 1
+    let expected_start = style_offset + 1;
+    let expected_end = expected_start + 4;
+    assert_eq!(
+        definition.range,
+        TextRange::new(
+            TextSize::from(expected_start as u32),
+            TextSize::from(expected_end as u32),
+        ),
+        "range should be in parent document coordinates"
+    );
+}
+
+#[test]
+fn go_to_definition_vue_class_to_inline_style() {
+    const VUE_CONTENT: &str = "\
+<template>
+  <div class=\"card\">Hello</div>
+</template>
+
+<style>
+.card { padding: 1rem; }
+</style>
+";
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from("/App.vue"), VUE_CONTENT.as_bytes());
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    let configuration =
+        biome_deserialize::json::deserialize_from_json_str::<biome_configuration::Configuration>(
+            r#"{ "html": { "experimentalFullSupportEnabled": true } }"#,
+            biome_json_parser::JsonParserOptions::default(),
+            "",
+        )
+        .into_deserialized()
+        .unwrap();
+
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            configuration,
+            workspace_directory: Some(BiomePath::new("/")),
+            extended_configurations: Default::default(),
+            module_graph_resolution_kind: ModuleGraphResolutionKind::ModulesAndTypes,
+        })
+        .unwrap();
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on "card" inside class="card"
+    let class_value_start = VUE_CONTENT.find("\"card\"").unwrap() + 1;
+    let cursor_range = TextRange::new(
+        TextSize::from(class_value_start as u32),
+        TextSize::from(class_value_start as u32),
+    );
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/App.vue"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should resolve Vue class to inline style");
+    assert_eq!(definition.path, BiomePath::new("/App.vue"));
+    // "card" in `.card` inside <style> block — range must be in parent document coordinates
+    let style_offset = VUE_CONTENT.find("<style>").unwrap() + "<style>\n".len();
+    // ".card" starts at offset 0 in snippet, "card" at offset 1
+    let expected_start = style_offset + 1;
+    let expected_end = expected_start + 4;
+    assert_eq!(
+        definition.range,
+        TextRange::new(
+            TextSize::from(expected_start as u32),
+            TextSize::from(expected_end as u32),
+        ),
+        "range should be in parent document coordinates, not snippet-local"
+    );
+}
+
+#[test]
+fn go_to_definition_vue_class_with_script_and_style() {
+    const VUE_CONTENT: &str = "\
+<script setup>
+import { foo } from './file.ts';
+foo();
+</script>
+
+<div class=\"btn\">Hello</div>
+
+<style>
+.btn {
+    bottom: 0;
+}
+</style>
+";
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from("/App.vue"), VUE_CONTENT.as_bytes());
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    let configuration =
+        biome_deserialize::json::deserialize_from_json_str::<biome_configuration::Configuration>(
+            r#"{ "html": { "experimentalFullSupportEnabled": true } }"#,
+            biome_json_parser::JsonParserOptions::default(),
+            "",
+        )
+        .into_deserialized()
+        .unwrap();
+
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            configuration,
+            workspace_directory: Some(BiomePath::new("/")),
+            extended_configurations: Default::default(),
+            module_graph_resolution_kind: ModuleGraphResolutionKind::ModulesAndTypes,
+        })
+        .unwrap();
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on "btn" inside class="btn"
+    let class_value_start = VUE_CONTENT.find("\"btn\"").unwrap() + 1;
+    let cursor_range = TextRange::new(
+        TextSize::from(class_value_start as u32),
+        TextSize::from(class_value_start as u32),
+    );
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/App.vue"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should resolve Vue class to inline style with script present");
+    assert_eq!(definition.path, BiomePath::new("/App.vue"));
+    // "btn" in `.btn` inside <style> — must be in parent document coordinates
+    let style_offset = VUE_CONTENT.find("<style>").unwrap() + "<style>\n".len();
+    let expected_start = style_offset + 1; // skip the dot in `.btn`
+    let expected_end = expected_start + 3;
+    assert_eq!(
+        definition.range,
+        TextRange::new(
+            TextSize::from(expected_start as u32),
+            TextSize::from(expected_end as u32),
+        ),
+        "range should be in parent document coordinates when both script and style exist"
+    );
+}
+
+#[test]
+fn go_to_definition_vue_class_to_external_css() {
+    const CSS_CONTENT: &str = ".wrapper { display: flex; }\n";
+    const VUE_CONTENT: &str = "\
+<link rel=\"stylesheet\" href=\"./styles.css\" />
+<template>
+  <div class=\"wrapper\">Hello</div>
+</template>
+";
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from("/styles.css"), CSS_CONTENT.as_bytes());
+    fs.insert(Utf8PathBuf::from("/App.vue"), VUE_CONTENT.as_bytes());
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    let configuration =
+        biome_deserialize::json::deserialize_from_json_str::<biome_configuration::Configuration>(
+            r#"{ "html": { "experimentalFullSupportEnabled": true } }"#,
+            biome_json_parser::JsonParserOptions::default(),
+            "",
+        )
+        .into_deserialized()
+        .unwrap();
+
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            configuration,
+            workspace_directory: Some(BiomePath::new("/")),
+            extended_configurations: Default::default(),
+            module_graph_resolution_kind: ModuleGraphResolutionKind::ModulesAndTypes,
+        })
+        .unwrap();
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on "wrapper" inside class="wrapper"
+    let class_value_start = VUE_CONTENT.find("\"wrapper\"").unwrap() + 1;
+    let cursor_range = TextRange::new(
+        TextSize::from(class_value_start as u32),
+        TextSize::from(class_value_start as u32),
+    );
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/App.vue"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should resolve Vue class to external CSS");
+    assert_eq!(definition.path, BiomePath::new("/styles.css"));
+    // "wrapper" in `.wrapper` starts at offset 1
+    assert_eq!(
+        definition.range,
+        TextRange::new(TextSize::from(1), TextSize::from(8))
+    );
+}
+
+#[test]
+fn go_to_definition_html_class_to_css_imported_from_script() {
+    const CSS_CONTENT: &str = ".foo { color: red; }\n";
+    // Astro-like: CSS imported via JS in a <script> block
+    const HTML_CONTENT: &str = "\
+<script>
+import './styles.css';
+</script>
+
+<div class=\"foo\">Hello</div>
+
+<style>
+.local { margin: 0; }
+</style>
+";
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from("/styles.css"), CSS_CONTENT.as_bytes());
+    fs.insert(Utf8PathBuf::from("/index.html"), HTML_CONTENT.as_bytes());
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::TypeAware,
+            verbose: false,
+        })
+        .unwrap();
+
+    // Cursor on "foo" inside class="foo"
+    let class_value_start = HTML_CONTENT.find("\"foo\"").unwrap() + 1;
+    let cursor_range = TextRange::new(
+        TextSize::from(class_value_start as u32),
+        TextSize::from(class_value_start as u32),
+    );
+
+    let result = workspace
+        .go_to_definition(GoToDefinitionParams {
+            project_key,
+            enabled: true,
+            path: BiomePath::new("/index.html"),
+            cursor_range,
+        })
+        .unwrap();
+
+    let definition = result.expect("should resolve class to CSS imported from script block");
+    assert_eq!(definition.path, BiomePath::new("/styles.css"));
+    // "foo" in `.foo` starts at offset 1
+    assert_eq!(
+        definition.range,
+        TextRange::new(TextSize::from(1), TextSize::from(4))
+    );
 }

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -1105,6 +1105,7 @@ pub fn analyze_with_workspace(input_file: &Utf8Path, group: &str, rule: &str) ->
             document_file_source: None,
             persist_node_cache: false,
             inline_config: None,
+            needs_document_services: None,
         })
         .expect("failed to open file");
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Part of #9618 

This PR sets the foundations of go-to definition and implements part of the logic.

- Added editor settings
- Added conditional enabling via settings handle
- Added dynamic registration of the capability
- Features currently implemented
	- Simple JS binding detection and go-to in file and in another file
	- Simple class/className string detection of JSX attributes and HTML attributes, with go to the same file or another file 
	

### How it works

I added a new `editor` capability to the list. This new type now contains two functions, which are essentially two side of the same coin:
- resolve_reference: essentially, when the cursor hovers over an entity, we resolve it against the CST of the document and its snippets. If we support it, we then return information such as the file path and the text range. Each language implements this function. Here, we also return a `DefinitionReference` that says: the reference is here (checked against the semantic model), the reference has been imported (via JS import for now, but it's been left generic), or the reference is a CSS string.
- resolve_definition: It's the function that tries to find where the entity has been defined. It uses a mix of module graph and semantic model, depending on what we're looking for.

The module graph has been modified. We now store the content offset of the CSS snippets found in the HTML document. This information is needed so that, when we resolve the style definition, we can compute the correct offset. 


> [!NOTE]
> I used a coding agent to help me with tests, refactor of testing infra, updates things across tests. The majority of the architecture was designed by me. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added plenty of tests.
Manually tested with Zed. It works like a charm for the things we're implementing. 
Happy to share a recording if you want.

CI won't run, but I checked that `just l` and `just f` work. And all tests pass. 

I refactored the tests of server.tests.ts because it was becoming a 2k lines of tests. I moved all the navigation tests into its own file, and added a new file to share the common utilities

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
