### PR TITLE
fix(linter): keep Svelte exported module-script bindings visible

### DIFF
--- a/.changeset/contributor-13-biome-9541.md
+++ b/.changeset/contributor-13-biome-9541.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9541](https://github.com/biomejs/biome/issues/9541): Svelte `noUndeclaredVariables` analysis now keeps exported declarations from `<script module>` blocks visible to the rest of the file.
+
+Previously, bindings declared as `export const`, `export function`, and similar module-script declarations were dropped from embedded binding collection, so later instance scripts could report false undeclared-variable diagnostics.

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -44,6 +44,7 @@ mod reporter_summary;
 mod reporter_terminal;
 mod rules_via_dependencies;
 mod suppressions;
+mod svelte_cross_language_rules;
 mod tailwind_directives;
 mod unknown_files;
 mod vcs_ignored_files;

--- a/crates/biome_cli/tests/cases/svelte_cross_language_rules.rs
+++ b/crates/biome_cli/tests/cases/svelte_cross_language_rules.rs
@@ -1,0 +1,54 @@
+use crate::run_cli;
+use crate::snap_test::{SnapshotPayload, assert_cli_snapshot};
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+use bpaf::Args;
+use camino::Utf8Path;
+
+const BIOME_CONFIG_HTML_FULL_SUPPORT: &str =
+    r#"{ "html": { "linter": {"enabled": true}, "experimentalFullSupportEnabled": true } }"#;
+
+#[test]
+fn no_undeclared_variables_not_triggered_for_exported_module_script_functions() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+    fs.insert(
+        "biome.json".into(),
+        BIOME_CONFIG_HTML_FULL_SUPPORT.as_bytes(),
+    );
+    let file = Utf8Path::new("file.svelte");
+    fs.insert(
+        file.into(),
+        r#"
+<script lang="ts" module>
+	export const someFunction = () => {
+		console.log("hai!");
+	};
+
+	const someOtherFunction = () => {
+		console.log("heyyy");
+	};
+</script>
+
+<script lang="ts">
+	someFunction();
+	someOtherFunction();
+</script>
+"#
+        .as_bytes(),
+    );
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", "--only=noUndeclaredVariables", file.as_str()].as_slice()),
+    );
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "no_undeclared_variables_not_triggered_for_exported_module_script_functions",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_svelte_cross_language_rules/no_undeclared_variables_not_triggered_for_exported_module_script_functions.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_svelte_cross_language_rules/no_undeclared_variables_not_triggered_for_exported_module_script_functions.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "linter": { "enabled": true },
+    "experimentalFullSupportEnabled": true
+  }
+}
+```
+
+## `file.svelte`
+
+```svelte
+
+<script lang="ts" module>
+	export const someFunction = () => {
+		console.log("hai!");
+	};
+
+	const someOtherFunction = () => {
+		console.log("heyyy");
+	};
+</script>
+
+<script lang="ts">
+	someFunction();
+	someOtherFunction();
+</script>
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_service/src/workspace/document/services/embedded_bindings.rs
+++ b/crates/biome_service/src/workspace/document/services/embedded_bindings.rs
@@ -1,8 +1,9 @@
 use biome_js_syntax::{
-    AnyJsArrayBindingPatternElement, AnyJsBindingPattern, AnyJsExpression, AnyJsModuleItem,
+    AnyJsArrayBindingPatternElement, AnyJsBinding, AnyJsBindingPattern, AnyJsDeclarationClause,
+    AnyJsExportClause, AnyJsExportDefaultDeclaration, AnyJsExpression, AnyJsModuleItem,
     AnyJsObjectBindingPatternMember, AnyJsObjectMember, AnyJsRoot, AnyJsStatement,
     AnyTsIdentifierBinding, AnyTsType, JsCallExpression, JsExport, JsImport, JsModuleItemList,
-    JsVariableStatement,
+    JsVariableDeclaration, JsVariableDeclarationClause, JsVariableStatement,
 };
 use biome_rowan::{AstNode, AstSeparatedList, TextRange, TokenText, WalkEvent};
 use rustc_hash::FxHashMap;
@@ -93,6 +94,36 @@ impl EmbeddedBuilder {
         }
     }
 
+    fn visit_declaration_clause(&mut self, declaration: AnyJsDeclarationClause) {
+        match declaration {
+            AnyJsDeclarationClause::JsVariableDeclarationClause(variable_clause) => {
+                self.visit_js_variable_declaration_clause(variable_clause);
+            }
+            AnyJsDeclarationClause::JsFunctionDeclaration(decl) => {
+                self.register_js_binding(decl.id());
+            }
+            AnyJsDeclarationClause::JsClassDeclaration(decl) => {
+                self.register_js_binding(decl.id());
+            }
+            AnyJsDeclarationClause::TsEnumDeclaration(decl) => {
+                self.register_js_binding(decl.id());
+            }
+            AnyJsDeclarationClause::TsInterfaceDeclaration(decl) => {
+                self.register_ts_identifier_binding(decl.id());
+            }
+            AnyJsDeclarationClause::TsTypeAliasDeclaration(decl) => {
+                self.register_ts_identifier_binding(decl.binding_identifier());
+            }
+            AnyJsDeclarationClause::TsDeclareFunctionDeclaration(decl) => {
+                self.register_js_binding(decl.id());
+            }
+            AnyJsDeclarationClause::TsExternalModuleDeclaration(_)
+            | AnyJsDeclarationClause::TsGlobalDeclaration(_)
+            | AnyJsDeclarationClause::TsImportEqualsDeclaration(_)
+            | AnyJsDeclarationClause::TsModuleDeclaration(_) => {}
+        }
+    }
+
     fn visit_js_import(&mut self, import: JsImport) -> Option<()> {
         let clause = import.import_clause().ok()?;
         if let Some(named_specifiers) = clause.named_specifiers() {
@@ -144,6 +175,46 @@ impl EmbeddedBuilder {
         // would be preferable since they could help reduce the duplicated logic for this.
 
         let clause = export.export_clause().ok()?;
+
+        match &clause {
+            AnyJsExportClause::AnyJsDeclarationClause(declaration) => {
+                self.visit_declaration_clause(declaration.clone());
+                return Some(());
+            }
+            AnyJsExportClause::JsExportDefaultDeclarationClause(default_clause) => {
+                let declaration = default_clause.declaration().ok()?;
+                match declaration {
+                    AnyJsExportDefaultDeclaration::JsClassExportDefaultDeclaration(decl) => {
+                        if let Some(binding) = decl.id() {
+                            self.register_any_js_binding(binding);
+                        }
+                    }
+                    AnyJsExportDefaultDeclaration::JsFunctionExportDefaultDeclaration(decl) => {
+                        if let Some(binding) = decl.id() {
+                            self.register_any_js_binding(binding);
+                        }
+                    }
+                    AnyJsExportDefaultDeclaration::TsDeclareFunctionExportDefaultDeclaration(
+                        decl,
+                    ) => {
+                        if let Some(binding) = decl.id() {
+                            self.register_any_js_binding(binding);
+                        }
+                    }
+                    AnyJsExportDefaultDeclaration::TsInterfaceDeclaration(decl) => {
+                        self.register_ts_identifier_binding(decl.id());
+                    }
+                }
+                return Some(());
+            }
+            AnyJsExportClause::JsExportDefaultExpressionClause(_) => {}
+            AnyJsExportClause::JsExportFromClause(_)
+            | AnyJsExportClause::JsExportNamedClause(_)
+            | AnyJsExportClause::JsExportNamedFromClause(_)
+            | AnyJsExportClause::TsExportAsNamespaceClause(_)
+            | AnyJsExportClause::TsExportAssignmentClause(_)
+            | AnyJsExportClause::TsExportDeclareClause(_) => return Some(()),
+        }
 
         // Only handle `export default { ... }` patterns
         let default_clause = clause.as_js_export_default_expression_clause()?;
@@ -213,9 +284,13 @@ impl EmbeddedBuilder {
     /// `TsEnumDeclaration::id()`, and `TsDeclareFunctionDeclaration::id()`.
     fn register_js_binding(
         &mut self,
-        result: biome_rowan::SyntaxResult<biome_js_syntax::AnyJsBinding>,
+        result: biome_rowan::SyntaxResult<AnyJsBinding>,
     ) -> Option<()> {
         let binding = result.ok()?;
+        self.register_any_js_binding(binding)
+    }
+
+    fn register_any_js_binding(&mut self, binding: AnyJsBinding) -> Option<()> {
         let identifier = binding.as_js_identifier_binding()?;
         let token = identifier.name_token().ok()?;
         self.js_bindings
@@ -239,6 +314,18 @@ impl EmbeddedBuilder {
 
     fn visit_js_variable_statement(&mut self, statement: JsVariableStatement) -> Option<()> {
         let declaration = statement.declaration().ok()?;
+        self.visit_js_variable_declaration(declaration)
+    }
+
+    fn visit_js_variable_declaration_clause(
+        &mut self,
+        clause: JsVariableDeclarationClause,
+    ) -> Option<()> {
+        let declaration = clause.declaration().ok()?;
+        self.visit_js_variable_declaration(declaration)
+    }
+
+    fn visit_js_variable_declaration(&mut self, declaration: JsVariableDeclaration) -> Option<()> {
         for declarator in declaration.declarators().iter().flatten() {
             // If the initializer is a defineProps(...) call, extract prop names from it.
             if let Some(initializer) = declarator.initializer()
@@ -669,5 +756,32 @@ const props = defineProps(['foo'])
         visit_js_root(&mut builder, &parse_js(source));
         service.finish(builder);
         assert!(contains_binding(&service, "foo"));
+    }
+
+    #[test]
+    fn tracks_exported_declarations() {
+        let source = r#"
+export const someFunction = () => {};
+export function someOtherFunction() {}
+export class SomeService {}
+export type UserId = string;
+export interface UserProfile {
+	name: string;
+}
+export enum Direction {
+	Up,
+	Down,
+}
+"#;
+        let mut service = EmbeddedExportedBindings::default();
+        let mut builder = service.builder();
+        visit_js_root(&mut builder, &parse_js(source));
+        service.finish(builder);
+        assert!(contains_binding(&service, "someFunction"));
+        assert!(contains_binding(&service, "someOtherFunction"));
+        assert!(contains_binding(&service, "SomeService"));
+        assert!(contains_binding(&service, "UserId"));
+        assert!(contains_binding(&service, "UserProfile"));
+        assert!(contains_binding(&service, "Direction"));
     }
 }


### PR DESCRIPTION
## Summary
- register exported declaration clauses when collecting embedded bindings for embedded JavaScript snippets
- add a Svelte `noUndeclaredVariables` regression for exported `<script module>` functions
- add an `@biomejs/biome` patch changeset for the user-visible fix

## Test Plan
- `cargo test -p biome_service tracks_exported_declarations -- --nocapture`
- `cargo test -p biome_cli no_undeclared_variables_not_triggered_for_exported_module_script_functions -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`

Closes #9541