### PR TITLE
fix(module-graph): preserve jsdoc on declared exports

### DIFF
--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -7,8 +7,8 @@ use biome_js_syntax::{
     AnyJsCombinedSpecifier, AnyJsDeclaration, AnyJsExportDefaultDeclaration, AnyJsExpression,
     AnyJsImportClause, JsAssignmentExpression, JsForVariableDeclaration, JsFormalParameter,
     JsIdentifierBinding, JsRestParameter, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
-    JsVariableDeclaration, TsIdentifierBinding, TsTypeParameter, TsTypeParameterName,
-    inner_string_text,
+    JsVariableDeclaration, TsDeclareStatement, TsIdentifierBinding, TsTypeParameter,
+    TsTypeParameterName, inner_string_text,
 };
 use biome_js_type_info::{
     FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, GenericTypeParameter, MAX_FLATTEN_DEPTH,
@@ -1194,6 +1194,8 @@ fn find_jsdoc(node: &JsSyntaxNode) -> Option<JsdocComment> {
     node.ancestors().find_map(|ancestor| {
         if let Some(export) = biome_js_syntax::JsExport::cast_ref(&ancestor) {
             JsdocComment::try_from(export.syntax()).ok()
+        } else if let Some(declare_statement) = TsDeclareStatement::cast_ref(&ancestor) {
+            JsdocComment::try_from(declare_statement.syntax()).ok()
         } else if let Some(decl) = AnyJsDeclaration::cast(ancestor) {
             JsdocComment::try_from(decl.syntax()).ok()
         } else {

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -458,6 +458,56 @@ fn test_export_const_type_declaration_with_namespace() {
 }
 
 #[test]
+fn test_find_jsdoc_for_declared_exports() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/source.ts".into(),
+        r#"
+            /** @deprecated Use modernDeclared instead. */
+            export declare const declaredExport: string;
+
+            /** @deprecated Use modernReexported instead. */
+            declare const reexportedDeclare: string;
+            export { reexportedDeclare };
+
+            export declare const modernDeclared: string;
+
+            declare const modernReexported: string;
+            export { modernReexported };
+        "#,
+    );
+
+    let project_layout = ProjectLayout::default();
+    project_layout.insert_node_manifest(
+        "/".into(),
+        PackageJson::new("test-pkg").with_version("0.0.0"),
+    );
+
+    let added_paths = [BiomePath::new("/src/source.ts")];
+    let added_paths = get_added_js_paths(&fs, &added_paths);
+
+    let module_graph = Arc::new(ModuleGraph::default());
+    module_graph.update_graph_for_js_paths(&fs, &project_layout, &added_paths, true);
+
+    let source = module_graph
+        .js_module_info_for_path(Utf8Path::new("/src/source.ts"))
+        .expect("module must exist");
+
+    assert_eq!(
+        source.find_jsdoc_for_exported_symbol(module_graph.as_ref(), "declaredExport"),
+        Some(JsdocComment::from_comment_text(
+            "/** @deprecated Use modernDeclared instead. */",
+        )),
+    );
+    assert_eq!(
+        source.find_jsdoc_for_exported_symbol(module_graph.as_ref(), "reexportedDeclare"),
+        Some(JsdocComment::from_comment_text(
+            "/** @deprecated Use modernReexported instead. */",
+        )),
+    );
+}
+
+#[test]
 fn test_resolve_exports() {
     let fs = MemoryFileSystem::default();
     fs.insert(


### PR DESCRIPTION
## Summary
- preserve exported JSDoc when a binding is wrapped in a TypeScript declare statement
- add a module-graph regression test covering both export-declare and declare-plus-export forms

Fixes #7635.

## Testing
- git diff --check -- crates/biome_module_graph/src/js_module_info/collector.rs crates/biome_module_graph/tests/spec_tests.rs`n- cargo test -p biome_module_graph test_find_jsdoc_for_declared_exports --test spec_tests -- --exact *(timed out in this environment before completion)*