### PR TITLE
fix(lint): recognize aliased Svelte imports in templates

### DIFF
--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/Issue9543Component.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/Issue9543Component.svelte
@@ -1,0 +1,6 @@
+<!-- should not generate diagnostics -->
+<script>
+export let value = "ok";
+</script>
+
+<div>{value}</div>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/Issue9543Component.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/Issue9543Component.svelte.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: Issue9543Component.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script>
+export let value = "ok";
+</script>
+
+<div>{value}</div>
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue-9543-reexport.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue-9543-reexport.ts
@@ -1,0 +1,1 @@
+export { default as Thing } from "./Issue9543Component.svelte";

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue-9543-reexport.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue-9543-reexport.ts.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue-9543-reexport.ts
+---
+# Input
+```ts
+export { default as Thing } from "./Issue9543Component.svelte";
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-issue-9543.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-issue-9543.svelte
@@ -1,0 +1,7 @@
+<!-- should not generate diagnostics -->
+<script>
+import { Thing as Something, Thing } from "./issue-9543-reexport";
+</script>
+
+<Something />
+<Thing />

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-issue-9543.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-issue-9543.svelte.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-issue-9543.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script>
+import { Thing as Something, Thing } from "./issue-9543-reexport";
+</script>
+
+<Something />
+<Thing />
+
+```

--- a/crates/biome_service/src/workspace/document/services/embedded_bindings.rs
+++ b/crates/biome_service/src/workspace/document/services/embedded_bindings.rs
@@ -96,19 +96,19 @@ impl EmbeddedBuilder {
     fn visit_js_import(&mut self, import: JsImport) -> Option<()> {
         let clause = import.import_clause().ok()?;
         if let Some(named_specifiers) = clause.named_specifiers() {
-            let imported_names = named_specifiers
-                .specifiers()
-                .iter()
-                .flatten()
-                .map(|specifier| specifier.imported_name());
-
-            for imported_name in imported_names {
-                let Some(imported_name) = imported_name else {
+            for specifier in named_specifiers.specifiers().iter().flatten() {
+                let Some(local_name) = specifier.local_name() else {
+                    continue;
+                };
+                let Some(local_name) = local_name.as_js_identifier_binding() else {
+                    continue;
+                };
+                let Ok(local_name) = local_name.name_token() else {
                     continue;
                 };
                 self.js_bindings.insert(
-                    imported_name.text_trimmed_range(),
-                    imported_name.token_text_trimmed(),
+                    local_name.text_trimmed_range(),
+                    local_name.token_text_trimmed(),
                 );
             }
         }
@@ -495,6 +495,20 @@ let variable = "salut";
         assert!(contains_binding(&service, "Component"));
         assert!(contains_binding(&service, "Component2"));
         assert!(contains_binding(&service, "variable"));
+    }
+
+    #[test]
+    fn tracks_renamed_named_imports_by_local_name() {
+        let source = r#"import { Thing as Something } from "somewhere";"#;
+
+        let mut service = EmbeddedExportedBindings::default();
+        let mut builder = service.builder();
+        visit_js_root(&mut builder, &parse_js(source));
+
+        service.finish(builder);
+
+        assert!(contains_binding(&service, "Something"));
+        assert!(!contains_binding(&service, "Thing"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- track named imports in embedded Svelte bindings by their local binding name instead of the imported symbol
- add a focused embedded-bindings unit test for aliased named imports
- add a `noUnusedImports` Svelte regression spec for the reexported component alias case from #9543

## Testing
- `git diff --check`
- `rustfmt --check crates/biome_service/src/workspace/document/services/embedded_bindings.rs`
- attempted `cargo test -p biome_service --lib tracks_renamed_named_imports_by_local_name -- --exact --nocapture` on this Windows worker, but it timed out during compilation

Closes #9543.