### PR TITLE
chore(deps): update rust crate terminal_size to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "smallvec",
- "terminal_size 0.4.3",
+ "terminal_size 0.4.4",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -487,7 +487,7 @@ dependencies = [
  "serde",
  "serde_json",
  "termcolor",
- "terminal_size 0.4.3",
+ "terminal_size 0.4.4",
  "trybuild",
  "unicode-width 0.1.12",
 ]
@@ -5353,12 +5353,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ smallvec                     = { version = "1.15.1", features = ["const_new", "s
 static_assertions            = "1.1"
 syn                          = "1.0.109"
 termcolor                    = "1.4.1"
-terminal_size                = "0.4.3"
+terminal_size                = "0.4.4"
 tests_macros                 = { path = "./crates/tests_macros" }
 tikv-jemallocator            = "0.6.1"
 tokio                        = "1.49.0"


### PR DESCRIPTION
## Summary
- update the workspace `terminal_size` dependency from `0.4.3` to `0.4.4`
- refresh `Cargo.lock` for the direct `terminal_size@0.4.3` entry
- follow up on the Renovate dependency dashboard in #2188

## Verification
- `cargo check -p biome_diagnostics --locked -j 1`
- attempted `cargo check -p biome_cli --locked -j 1`, but the local Windows environment hit a `rustc-LLVM ERROR: IO failure on output stream: no space on device` while compiling `biome_css_analyze`