### PR TITLE
fix(css_parser): allow styled declarations in conditional blocks

### DIFF
--- a/crates/biome_css_parser/src/syntax/block/conditional_block.rs
+++ b/crates/biome_css_parser/src/syntax/block/conditional_block.rs
@@ -1,4 +1,5 @@
 use crate::parser::CssParser;
+use biome_css_syntax::EmbeddingKind;
 use biome_parser::CompletedMarker;
 
 use crate::syntax::block::{parse_declaration_or_rule_list_block, parse_rule_block};
@@ -18,7 +19,10 @@ use crate::syntax::block::{parse_declaration_or_rule_list_block, parse_rule_bloc
 ///
 #[inline]
 pub(crate) fn parse_conditional_block(p: &mut CssParser) -> CompletedMarker {
-    if p.state_mut().is_nesting_block {
+    let allow_declarations = p.state().is_nesting_block
+        || matches!(p.source_type.as_embedding_kind(), EmbeddingKind::Styled);
+
+    if allow_declarations {
         parse_declaration_or_rule_list_block(p)
     } else {
         parse_rule_block(p)

--- a/crates/biome_css_parser/tests/embedded_styled_media.rs
+++ b/crates/biome_css_parser/tests/embedded_styled_media.rs
@@ -1,0 +1,31 @@
+use biome_css_parser::{CssParserOptions, parse_css};
+use biome_css_syntax::{CssFileSource, EmbeddingKind};
+use biome_test_utils::has_bogus_nodes_or_empty_slots;
+
+#[test]
+fn parses_media_queries_in_styled_embeds() {
+    let code = r#"
+height: 20px;
+
+@media screen and (min-width: 768px) {
+  height: 40px;
+}
+"#;
+
+    let parsed = parse_css(
+        code,
+        CssFileSource::css().with_embedding_kind(EmbeddingKind::Styled),
+        CssParserOptions::default(),
+    );
+
+    let syntax = parsed.syntax();
+    assert!(
+        parsed.diagnostics().is_empty(),
+        "Expected styled embed to parse without diagnostics, got: {:#?}",
+        parsed.diagnostics()
+    );
+    assert!(
+        !has_bogus_nodes_or_empty_slots(&syntax),
+        "Styled embed contains bogus nodes or empty slots:\n{syntax:#?}"
+    );
+}


### PR DESCRIPTION
## Summary
- allow styled embedded CSS to keep parsing declaration-or-rule blocks inside conditional at-rules like @media
- add a parser regression test for styled embedded media queries

## Testing
- Local cargo test -p biome_css_parser --test embedded_styled_media -- --nocapture could not complete on this worker because rustc ran out of disk space on the machine during compilation.