### PR TITLE
fix(js): report organizeImports diagnostics on unsorted export chunks

### DIFF
--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -705,16 +705,21 @@ impl Rule for OrganizeImports {
     type Signals = Option<Self::State>;
     type Options = OrganizeImportsOptions;
 
-    fn text_range(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<TextRange> {
+    fn text_range(ctx: &RuleContext<Self>, state: &Self::State) -> Option<TextRange> {
+        let first_issue_slot = state
+            .iter()
+            .filter_map(|issue| match issue {
+                Issue::AddLeadingNewline { slot_index }
+                | Issue::UnorganizedItem { slot_index, .. } => Some(*slot_index),
+                Issue::UnsortedChunkPrefix { slot_indexes } => Some(slot_indexes.start),
+            })
+            .min()?;
+
         ctx.query()
             .items()
             .into_iter()
-            .find(|item| {
-                matches!(
-                    item,
-                    AnyJsModuleItem::JsImport(_) | AnyJsModuleItem::JsExport(_)
-                )
-            })
+            .skip(first_issue_slot as usize)
+            .next()
             .map(|item| item.range())
     }
 

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -158,3 +158,74 @@ function App() {
     // Should not report any errors because h and Fragment are used as JSX factory functions
     assert_eq!(error_ranges.as_slice(), &[]);
 }
+
+#[test]
+fn organize_imports_reports_unsorted_exports_at_export_chunk() {
+    const FILENAME: &str = "issue9530.ts";
+    const SOURCE: &str = r#"import "a";
+import "b";
+
+
+const a = "a";
+const b = "b";
+
+export { b, a };
+"#;
+
+    let parsed = parse(SOURCE, JsFileSource::ts(), JsParserOptions::default());
+    let file_path = Utf8PathBuf::from(FILENAME);
+    let options = AnalyzerOptions::default().with_file_path(file_path);
+    let rule_filter = RuleFilter::Rule("source", "organizeImports");
+    let services = JsAnalyzerServices::default();
+
+    let mut diagnostics = Vec::new();
+    let mut organized_code = None;
+
+    analyze(
+        &parsed.tree(),
+        AnalysisFilter {
+            enabled_rules: Some(slice::from_ref(&rule_filter)),
+            ..AnalysisFilter::default()
+        },
+        &options,
+        &[],
+        services,
+        |signal| {
+            if let Some(diag) = signal.diagnostic() {
+                let error = diag
+                    .with_severity(Severity::Warning)
+                    .with_file_path(FILENAME)
+                    .with_file_source_code(SOURCE);
+                diagnostics.push(print_diagnostic_to_string(&error));
+            }
+
+            for action in signal.actions(ActionFilter::all()) {
+                if !action.is_suppression() {
+                    organized_code = Some(action.mutation.commit());
+                }
+            }
+
+            ControlFlow::<Never>::Continue(())
+        },
+    );
+
+    let diagnostic = diagnostics.join("\n");
+    assert!(
+        diagnostic.contains("issue9530.ts:8:1 assist/source/organizeImports"),
+        "unexpected diagnostic output: {diagnostic}",
+    );
+    assert_eq!(
+        organized_code.as_deref(),
+        Some(
+            r#"import "a";
+import "b";
+
+
+const a = "a";
+const b = "b";
+
+export { a, b };
+"#,
+        ),
+    );
+}


### PR DESCRIPTION
## Summary
- report organizeImports diagnostics from the earliest recorded issue slot instead of the first import/export in the file
- add a regression test that covers unsorted export specifiers after sorted bare imports

Closes #9530.

## Testing
- `git diff --check`
- local `cargo test -p biome_js_analyze --test quick_test organize_imports_reports_unsorted_exports_at_export_chunk -- --exact --nocapture` is blocked in this environment by disk-space exhaustion during Rust compilation