### PR TITLE
test(js): add noUnusedImports regression for Svelte bind:this

### DIFF
--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_9118.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_9118.svelte
@@ -1,0 +1,8 @@
+<!-- should not generate diagnostics -->
+<script lang="ts">
+import MyElement, { type MyElementShape } from "./my-element.svelte";
+
+let myElement = $state<MyElementShape>();
+</script>
+
+<MyElement bind:this={myElement} />

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_9118.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_9118.svelte.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_9118.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script lang="ts">
+import MyElement, { type MyElementShape } from "./my-element.svelte";
+
+let myElement = $state<MyElementShape>();
+</script>
+
+<MyElement bind:this={myElement} />
+
+```


### PR DESCRIPTION
## Summary
- add a focused 
oUnusedImports spec for the Svelte ind:this pattern from #9118
- cover the reported default import plus type import shape in a .svelte fixture
- lock in the expected no-diagnostic snapshot for the workspace-based HTML-ish analyzer path

## Testing
- local cargo test -p biome_js_analyze --test spec_tests issue_9118 -- --nocapture is blocked on this machine by disk space exhaustion during compilation