### PR TITLE
fix(lint): ignore useJsxKeyInIterable in Astro

### DIFF
--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -75,6 +75,13 @@ const title = "My Page";
 </body>
 </html>"#;
 
+const ASTRO_FILE_USE_JSX_KEY_IN_ITERABLE: &str = r#"---
+const items = ["one", "two", "three"];
+---
+<ul>
+    {items.map((item) => <li>{item}</li>)}
+</ul>"#;
+
 #[test]
 fn format_astro_files() {
     let fs = MemoryFileSystem::default();
@@ -285,6 +292,52 @@ schema + sure()
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "full_support",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn use_jsx_key_in_iterable_is_ignored_for_astro_files() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{
+    "linter": {
+        "domains": {
+            "react": "recommended"
+        }
+    },
+    "html": {
+        "linter": {
+            "enabled": true
+        },
+        "experimentalFullSupportEnabled": true
+    }
+}"#
+        .as_bytes(),
+    );
+
+    let astro_file_path = Utf8Path::new("file.astro");
+    fs.insert(
+        astro_file_path.into(),
+        ASTRO_FILE_USE_JSX_KEY_IN_ITERABLE.as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", astro_file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "use_jsx_key_in_iterable_is_ignored_for_astro_files",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/use_jsx_key_in_iterable_is_ignored_for_astro_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/use_jsx_key_in_iterable_is_ignored_for_astro_files.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "domains": {
+      "react": "recommended"
+    }
+  },
+  "html": {
+    "linter": { "enabled": true },
+    "experimentalFullSupportEnabled": true
+  }
+}
+```
+
+## `file.astro`
+
+```astro
+---
+const items = ["one", "two", "three"];
+---
+<ul>
+    {items.map((item) => <li>{item}</li>)}
+</ul>
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -7,9 +7,10 @@ use biome_diagnostics::Severity;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsFunctionBody, AnyJsMemberExpression, AnyJsObjectMember, AnyJsStatement,
-    AnyJsSwitchClause, AnyJsxAttribute, AnyJsxChild, JsArrayElementList, JsArrayExpression,
-    JsCallArgumentList, JsCallArguments, JsCallExpression, JsFunctionBody, JsNewExpression,
-    JsObjectExpression, JsStatementList, JsxAttributeList, JsxExpressionChild, JsxTagExpression,
+    AnyJsSwitchClause, AnyJsxAttribute, AnyJsxChild, EmbeddingKind, JsArrayElementList,
+    JsArrayExpression, JsCallArgumentList, JsCallArguments, JsCallExpression, JsFileSource,
+    JsFunctionBody, JsNewExpression, JsObjectExpression, JsStatementList, JsxAttributeList,
+    JsxExpressionChild, JsxTagExpression,
 };
 use biome_rowan::{AstNode, AstNodeList, AstSeparatedList, TextRange, declare_node_union};
 use biome_rule_options::use_jsx_key_in_iterable::UseJsxKeyInIterableOptions;
@@ -84,6 +85,13 @@ impl Rule for UseJsxKeyInIterable {
     type Options = UseJsxKeyInIterableOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        if matches!(
+            ctx.source_type::<JsFileSource>().as_embedding_kind(),
+            EmbeddingKind::Astro { .. }
+        ) {
+            return Vec::new().into_boxed_slice();
+        }
+
         let node = ctx.query();
         let model = ctx.model();
         let options = ctx.options();


### PR DESCRIPTION
## Summary
- skip `useJsxKeyInIterable` when analyzing Astro embeddings
- add an Astro CLI regression with the React domain enabled
- add the expected snapshot for the new regression

Closes #9507.

## Testing
- `rustfmt --edition 2021 --check crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs crates/biome_cli/tests/cases/handle_astro_files.rs`
- `cargo test -p biome_cli use_jsx_key_in_iterable_is_ignored_for_astro_files -- --exact` (blocked locally on the shared worker machine by `no space on device` / long-running compile contention)