### PR TITLE
test(noUnusedVariables): add Svelte onclick regression coverage

### DIFF
--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid_issue_9136.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid_issue_9136.svelte
@@ -1,0 +1,8 @@
+<!-- should not generate diagnostics -->
+<script lang="ts">
+function handleClick() {
+    console.log("hey");
+}
+</script>
+
+<button type="button" onclick={handleClick}>greeting</button>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid_issue_9136.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid_issue_9136.svelte.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid_issue_9136.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script lang="ts">
+function handleClick() {
+    console.log("hey");
+}
+</script>
+
+<button type="button" onclick={handleClick}>greeting</button>
+
+```


### PR DESCRIPTION
## Summary
- add a 
oUnusedVariables regression spec for Svelte 5 onclick={handler} usage
- cover issue #9136 with a no-diagnostics snapshot through the workspace HTML embedding path

## Testing
- cargo test -j 1 -p biome_js_analyze --test spec_tests valid_issue_9136 -- --nocapture *(fails on this machine due pagefile and disk limits during Cargo build)*