### PR TITLE
fix(html): allow Vue v-bind object syntax

### DIFF
--- a/crates/biome_html_analyze/src/lint/nursery/use_vue_valid_v_bind.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_vue_valid_v_bind.rs
@@ -7,10 +7,9 @@ use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_vue_valid_v_bind::UseVueValidVBindOptions;
 
 declare_lint_rule! {
-    /// Forbids `v-bind` directives with missing arguments or invalid modifiers.
+    /// Forbids `v-bind` directives with missing values or invalid modifiers.
     ///
     /// This rule reports v-bind directives in the following cases:
-    /// - The directive does not have an argument. E.g. `<div v-bind></div>`
     /// - The directive does not have a value. E.g. `<div v-bind:aaa></div>`
     /// - The directive has invalid modifiers. E.g. `<div v-bind:aaa.bbb="ccc"></div>`
     ///
@@ -19,14 +18,14 @@ declare_lint_rule! {
     /// ### Invalid
     ///
     /// ```vue,expect_diagnostic
-    /// <Foo v-bind />
-    /// ```
-    ///
-    /// ```vue,expect_diagnostic
     /// <div v-bind></div>
     /// ```
     ///
     /// ### Valid
+    ///
+    /// ```vue
+    /// <Foo v-bind="props" />
+    /// ```
     ///
     /// ```vue
     /// <Foo v-bind:foo="foo" />
@@ -46,7 +45,6 @@ const VALID_MODIFIERS: &[&str] = &["prop", "camel", "sync", "attr"];
 
 pub enum ViolationKind {
     MissingValue,
-    MissingArgument,
     InvalidModifier(TextRange),
 }
 
@@ -66,10 +64,6 @@ impl Rule for UseVueValidVBind {
 
                 if vue_directive.initializer().is_none() {
                     return Some(ViolationKind::MissingValue);
-                }
-
-                if vue_directive.arg().is_none() {
-                    return Some(ViolationKind::MissingArgument);
                 }
 
                 if let Some(invalid_range) = find_invalid_modifiers(&vue_directive.modifiers()) {
@@ -109,18 +103,6 @@ impl Rule for UseVueValidVBind {
                         "v-bind directives require a value."
                 }).note(markup! {
                         "Add a value to the directive, e.g. "<Emphasis>"v-bind:foo=\"bar\""</Emphasis>"."
-                }),
-                ViolationKind::MissingArgument => RuleDiagnostic::new(
-                    rule_category!(),
-                    ctx.query().range(),
-                    markup! {
-                        "This v-bind directive is missing an argument."
-                    },
-                )
-                .note(markup! {
-                        "v-bind directives require an argument to specify which attribute to bind to."
-                }).note(markup! {
-                        "For example, use " <Emphasis>"v-bind:foo"</Emphasis> " to bind to the " <Emphasis>"foo"</Emphasis> " attribute."
                 }),
                 ViolationKind::InvalidModifier(invalid_range) =>
                     RuleDiagnostic::new(

--- a/crates/biome_html_analyze/tests/specs/nursery/useVueValidVBind/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/nursery/useVueValidVBind/invalid.vue
@@ -1,16 +1,16 @@
 <!-- should generate diagnostics -->
 
 <template>
-  <!-- Missing argument: long-form without an argument -->
+  <!-- Missing value: long-form without a value -->
   <div v-bind></div>
   <div v-bind />
   <Foo v-bind />
 
-  <!-- Missing value -->
+  <!-- Missing value with an argument -->
   <Foo v-bind:foo />
   <Foo :foo />
 
-  <!-- Missing argument with modifier -->
+  <!-- Missing value with a modifier -->
   <div v-bind.prop></div>
 
   <!-- Invalid single modifier on long-form -->

--- a/crates/biome_html_analyze/tests/specs/nursery/useVueValidVBind/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/useVueValidVBind/invalid.vue.snap
@@ -7,16 +7,16 @@ expression: invalid.vue
 <!-- should generate diagnostics -->
 
 <template>
-  <!-- Missing argument: long-form without an argument -->
+  <!-- Missing value: long-form without a value -->
   <div v-bind></div>
   <div v-bind />
   <Foo v-bind />
 
-  <!-- Missing value -->
+  <!-- Missing value with an argument -->
   <Foo v-bind:foo />
   <Foo :foo />
 
-  <!-- Missing argument with modifier -->
+  <!-- Missing value with a modifier -->
   <div v-bind.prop></div>
 
   <!-- Invalid single modifier on long-form -->
@@ -47,7 +47,7 @@ invalid.vue:5:8 lint/nursery/useVueValidVBind ━━━━━━━━━━━�
   i This v-bind directive is missing a value.
   
     3 │ <template>
-    4 │   <!-- Missing argument: long-form without an argument -->
+    4 │   <!-- Missing value: long-form without a value -->
   > 5 │   <div v-bind></div>
       │        ^^^^^^
     6 │   <div v-bind />
@@ -67,7 +67,7 @@ invalid.vue:6:8 lint/nursery/useVueValidVBind ━━━━━━━━━━━�
 
   i This v-bind directive is missing a value.
   
-    4 │   <!-- Missing argument: long-form without an argument -->
+    4 │   <!-- Missing value: long-form without a value -->
     5 │   <div v-bind></div>
   > 6 │   <div v-bind />
       │        ^^^^^^
@@ -93,7 +93,7 @@ invalid.vue:7:8 lint/nursery/useVueValidVBind ━━━━━━━━━━━�
   > 7 │   <Foo v-bind />
       │        ^^^^^^
     8 │ 
-    9 │   <!-- Missing value -->
+    9 │   <!-- Missing value with an argument -->
   
   i v-bind directives require a value.
   
@@ -109,7 +109,7 @@ invalid.vue:10:8 lint/nursery/useVueValidVBind ━━━━━━━━━━━
 
   i This v-bind directive is missing a value.
   
-     9 │   <!-- Missing value -->
+     9 │   <!-- Missing value with an argument -->
   > 10 │   <Foo v-bind:foo />
        │        ^^^^^^^^^^
     11 │   <Foo :foo />
@@ -129,12 +129,12 @@ invalid.vue:11:8 lint/nursery/useVueValidVBind ━━━━━━━━━━━
 
   i This v-bind directive is missing a value.
   
-     9 │   <!-- Missing value -->
+     9 │   <!-- Missing value with an argument -->
     10 │   <Foo v-bind:foo />
   > 11 │   <Foo :foo />
        │        ^^^^
     12 │ 
-    13 │   <!-- Missing argument with modifier -->
+    13 │   <!-- Missing value with a modifier -->
   
   i v-bind directives require a value.
   
@@ -150,7 +150,7 @@ invalid.vue:14:8 lint/nursery/useVueValidVBind ━━━━━━━━━━━
 
   i This v-bind directive is missing a value.
   
-    13 │   <!-- Missing argument with modifier -->
+    13 │   <!-- Missing value with a modifier -->
   > 14 │   <div v-bind.prop></div>
        │        ^^^^^^^^^^^
     15 │ 

--- a/crates/biome_html_analyze/tests/specs/nursery/useVueValidVBind/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/nursery/useVueValidVBind/valid.vue
@@ -16,6 +16,10 @@
 <!-- Dynamic argument (bracketed) is an argument, not a missing one -->
 <div v-bind:[dynamicName]="value"></div>
 
+<!-- Object syntax without an argument is valid -->
+<div v-bind="props"></div>
+<MyComponent v-bind="{ disabled: isDisabled, title: tooltip }"></MyComponent>
+
 <!-- Template-level binding -->
 <template v-bind:id="componentId"></template>
 

--- a/crates/biome_html_analyze/tests/specs/nursery/useVueValidVBind/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/useVueValidVBind/valid.vue.snap
@@ -22,6 +22,10 @@ expression: valid.vue
 <!-- Dynamic argument (bracketed) is an argument, not a missing one -->
 <div v-bind:[dynamicName]="value"></div>
 
+<!-- Object syntax without an argument is valid -->
+<div v-bind="props"></div>
+<MyComponent v-bind="{ disabled: isDisabled, title: tooltip }"></MyComponent>
+
 <!-- Template-level binding -->
 <template v-bind:id="componentId"></template>
 


### PR DESCRIPTION
## Summary
- stop reporting `v-bind` directives as invalid when they omit an argument but still provide an object value
- add a Vue fixture for `v-bind="props"` and update the existing invalid fixture wording to match the rule behavior
- keep the rule focused on missing values and invalid modifiers, which matches `eslint-plugin-vue`

## Testing
- `rustfmt --check crates/biome_html_analyze/src/lint/nursery/use_vue_valid_v_bind.rs`
- `cargo test -p biome_html_analyze --test spec_tests useVueValidVBind -j 1` *(fails locally on this machine because the Windows environment runs out of paging/disk space while compiling shared dependencies)*

Closes #9347.