### PR TITLE
fix(js): count file-level JSDoc links in noUnusedImports

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -18,15 +18,14 @@ use biome_js_factory::make;
 use biome_js_factory::make::{js_identifier_binding, js_module, js_module_item_list};
 use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::{
-    AnyJsBinding, AnyJsClassMember, AnyJsCombinedSpecifier, AnyJsDeclaration, AnyJsExportClause,
-    AnyJsExportNamedSpecifier, AnyJsImportClause, AnyJsModuleItem, AnyJsNamedImportSpecifier,
-    AnyJsObjectMember, AnyTsTypeMember, EmbeddingKind, JsExport, JsFileSource, JsLanguage,
-    JsNamedImportSpecifiers, JsStaticMemberAssignment, JsSyntaxNode, T, TsEnumMember,
+    AnyJsBinding, AnyJsCombinedSpecifier, AnyJsExportClause, AnyJsExportNamedSpecifier,
+    AnyJsImportClause, AnyJsModuleItem, AnyJsNamedImportSpecifier, EmbeddingKind, JsFileSource,
+    JsLanguage, JsNamedImportSpecifiers, JsSyntaxNode, T,
 };
 use biome_jsdoc_comment::JsdocComment;
 use biome_rowan::{
     AstNode, AstNodeList, AstSeparatedElement, AstSeparatedList, BatchMutationExt, Language,
-    NodeOrToken, SyntaxNode, TextRange, TriviaPieceKind, WalkEvent, declare_node_union,
+    Direction, NodeOrToken, SyntaxNode, TextRange, TriviaPieceKind, WalkEvent,
 };
 use regex::Regex;
 use rustc_hash::FxHashSet;
@@ -134,10 +133,6 @@ struct JsDocTypeCollectorVisitor {
     jsdoc_types: JsDocTypeModel,
 }
 
-declare_node_union! {
-    pub AnyJsWithTypeReferencingJsDoc = AnyJsDeclaration | AnyJsClassMember | AnyJsObjectMember | AnyTsTypeMember | TsEnumMember | JsExport | JsStaticMemberAssignment
-}
-
 impl Visitor for JsDocTypeCollectorVisitor {
     type Language = JsLanguage;
     fn visit(
@@ -147,8 +142,8 @@ impl Visitor for JsDocTypeCollectorVisitor {
     ) {
         match event {
             WalkEvent::Enter(node) => {
-                if AnyJsWithTypeReferencingJsDoc::can_cast(node.kind()) {
-                    load_jsdoc_types_from_node(&mut self.jsdoc_types, node);
+                if node.parent().is_none() {
+                    load_jsdoc_types_from_file(&mut self.jsdoc_types, node);
                 }
             }
             WalkEvent::Leave(_) => {}
@@ -160,10 +155,19 @@ impl Visitor for JsDocTypeCollectorVisitor {
     }
 }
 
-fn load_jsdoc_types_from_node(model: &mut JsDocTypeModel, node: &SyntaxNode<JsLanguage>) {
-    JsdocComment::for_each(node, |comment| {
-        load_jsdoc_types_from_jsdoc_comment(model, comment)
-    });
+fn load_jsdoc_types_from_file(model: &mut JsDocTypeModel, node: &SyntaxNode<JsLanguage>) {
+    for token in node.descendants_tokens(Direction::Next) {
+        for trivia in token.leading_trivia().pieces() {
+            let text = trivia.text();
+            if matches!(
+                trivia.kind(),
+                TriviaPieceKind::SingleLineComment | TriviaPieceKind::MultiLineComment
+            ) && JsdocComment::text_is_jsdoc_comment(text)
+            {
+                load_jsdoc_types_from_jsdoc_comment(model, text);
+            }
+        }
+    }
 }
 
 static JSDOC_INLINE_TAG_REGEX: LazyLock<Regex> = LazyLock::new(|| {

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_8762_file_level_jsdoc.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_8762_file_level_jsdoc.ts
@@ -1,0 +1,17 @@
+// See https://github.com/biomejs/biome/issues/8762
+
+/**
+ * {@linkcode TopLevelDoc}
+ * @module
+ */
+import type { EndOfFileDoc, StatementDoc, TopLevelDoc } from "mod";
+
+/**
+ * {@linkcode StatementDoc}
+ */
+void 0;
+
+/**
+ * {@linkcode EndOfFileDoc}
+ * @packageDocumentation
+ */

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_8762_file_level_jsdoc.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_8762_file_level_jsdoc.ts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_8762_file_level_jsdoc.ts
+---
+# Input
+```ts
+// See https://github.com/biomejs/biome/issues/8762
+
+/**
+ * {@linkcode TopLevelDoc}
+ * @module
+ */
+import type { EndOfFileDoc, StatementDoc, TopLevelDoc } from "mod";
+
+/**
+ * {@linkcode StatementDoc}
+ */
+void 0;
+
+/**
+ * {@linkcode EndOfFileDoc}
+ * @packageDocumentation
+ */
+
+```


### PR DESCRIPTION
## Summary
- collect JSDoc import references from every token in the file instead of only declaration-like nodes
- cover top-of-file, statement-attached, and EOF-attached JSDoc links in a new 
oUnusedImports regression spec

## Testing
- cargo fmt -p biome_js_analyze --manifest-path crates/biome_js_analyze/Cargo.toml
- cargo test -p biome_js_analyze --test spec_tests issue_8762_file_level_jsdoc *(blocked in this environment by Windows execution policy / compiler instability after dependency resolution)*