### PR TITLE
fix(grit): match namespace and multi-specifier import patterns

### DIFF
--- a/.changeset/odd-cycles-match.md
+++ b/.changeset/odd-cycles-match.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7727](https://github.com/biomejs/biome/issues/7727): GritQL `import $what from $where` patterns now match namespace imports and import clauses with multiple named specifiers, bringing Biome's matcher back in line with `grit apply`.

--- a/crates/biome_grit_patterns/src/grit_code_snippet.rs
+++ b/crates/biome_grit_patterns/src/grit_code_snippet.rs
@@ -43,11 +43,17 @@ impl Matcher<GritQueryContext> for GritCodeSnippet {
             return Ok(false);
         };
 
-        // First, try to match with the exact kind (fast path)
-        if let Some((_, pattern)) = self.patterns.iter().find(|(kind, _)| *kind == node.kind())
-            && pattern.execute(resolved, state, context, logs)?
+        // Try every parse of the snippet with the same outer kind.
+        for (_, pattern) in self
+            .patterns
+            .iter()
+            .filter(|(kind, _)| *kind == node.kind())
         {
-            return Ok(true);
+            let mut candidate_state = state.clone();
+            if pattern.execute(resolved, &mut candidate_state, context, logs)? {
+                *state = candidate_state;
+                return Ok(true);
+            }
         }
 
         // If node has a single child, try matching against the child
@@ -58,7 +64,9 @@ impl Matcher<GritQueryContext> for GritCodeSnippet {
         {
             let child_binding = GritResolvedPattern::from_node_binding(child);
             for (_, pattern) in &self.patterns {
-                if pattern.execute(&child_binding, state, context, logs)? {
+                let mut candidate_state = state.clone();
+                if pattern.execute(&child_binding, &mut candidate_state, context, logs)? {
+                    *state = candidate_state;
                     return Ok(true);
                 }
             }

--- a/crates/biome_grit_patterns/src/grit_node_patterns.rs
+++ b/crates/biome_grit_patterns/src/grit_node_patterns.rs
@@ -10,7 +10,7 @@ use grit_pattern_matcher::pattern::{
     ResolvedPattern, State,
 };
 use grit_util::error::GritResult;
-use grit_util::{AnalysisLogs, AstNode, Language};
+use grit_util::{AnalysisLogs, Language};
 
 /// Check if two syntax kinds are compatible for import pattern matching
 fn are_import_kinds_compatible(
@@ -26,26 +26,32 @@ fn are_import_kinds_compatible(
 
     use biome_js_syntax::JsSyntaxKind::*;
 
-    // Only allow specific import transformations to avoid over-matching
+    // Only allow specific import transformations to avoid over-matching.
     match (pattern_js_kind, node_js_kind) {
-        // Default import pattern can match named import
-        (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMED_CLAUSE) => true,
-        // Named import pattern can match default import
-        (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_DEFAULT_CLAUSE) => true,
-        // Default import specifier can match individual named specifiers
-        (JS_DEFAULT_IMPORT_SPECIFIER, JS_SHORTHAND_NAMED_IMPORT_SPECIFIER) => true,
-        (JS_DEFAULT_IMPORT_SPECIFIER, JS_NAMED_IMPORT_SPECIFIER) => true,
-        (JS_DEFAULT_IMPORT_SPECIFIER, JS_NAMESPACE_IMPORT_SPECIFIER) => true,
-        // Named specifiers can match default specifier
-        (JS_SHORTHAND_NAMED_IMPORT_SPECIFIER, JS_DEFAULT_IMPORT_SPECIFIER) => true,
-        (JS_NAMED_IMPORT_SPECIFIER, JS_DEFAULT_IMPORT_SPECIFIER) => true,
-        (JS_NAMESPACE_IMPORT_SPECIFIER, JS_DEFAULT_IMPORT_SPECIFIER) => true,
         // Import clauses can match each other
         (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_DEFAULT_CLAUSE) => true,
         (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_NAMED_CLAUSE) => true,
         (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_NAMESPACE_CLAUSE) => true,
         (JS_IMPORT_COMBINED_CLAUSE, JS_IMPORT_COMBINED_CLAUSE) => true,
         (JS_IMPORT_BARE_CLAUSE, JS_IMPORT_BARE_CLAUSE) => true,
+        (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMED_CLAUSE) => true,
+        (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_DEFAULT_CLAUSE) => true,
+        (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMESPACE_CLAUSE) => true,
+        (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_DEFAULT_CLAUSE) => true,
+        (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_NAMESPACE_CLAUSE) => true,
+        (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_NAMED_CLAUSE) => true,
+        // Import specifier wrappers can match the equivalent binding forms
+        (JS_DEFAULT_IMPORT_SPECIFIER, JS_NAMED_IMPORT_SPECIFIERS) => true,
+        (JS_NAMED_IMPORT_SPECIFIERS, JS_DEFAULT_IMPORT_SPECIFIER) => true,
+        (JS_DEFAULT_IMPORT_SPECIFIER, JS_NAMESPACE_IMPORT_SPECIFIER) => true,
+        (JS_NAMESPACE_IMPORT_SPECIFIER, JS_DEFAULT_IMPORT_SPECIFIER) => true,
+        (JS_NAMED_IMPORT_SPECIFIERS, JS_NAMESPACE_IMPORT_SPECIFIER) => true,
+        (JS_NAMESPACE_IMPORT_SPECIFIER, JS_NAMED_IMPORT_SPECIFIERS) => true,
+        // Default import specifiers may also line up with a single named specifier
+        (JS_DEFAULT_IMPORT_SPECIFIER, JS_SHORTHAND_NAMED_IMPORT_SPECIFIER) => true,
+        (JS_DEFAULT_IMPORT_SPECIFIER, JS_NAMED_IMPORT_SPECIFIER) => true,
+        (JS_SHORTHAND_NAMED_IMPORT_SPECIFIER, JS_DEFAULT_IMPORT_SPECIFIER) => true,
+        (JS_NAMED_IMPORT_SPECIFIER, JS_DEFAULT_IMPORT_SPECIFIER) => true,
         _ => false,
     }
 }
@@ -151,14 +157,17 @@ impl Matcher<GritQueryContext> for GritNodePattern {
 
                 // Import slot mapping table
                 let source_slot = match (pattern_js_kind, node_js_kind, slot_index) {
-                    // type_token, phase_token
-                    (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMED_CLAUSE, 0 | 1) => None,
-                    // default_specifier -> first named specifier
+                    // type_token -> type_token, phase_token is absent on named clauses
+                    (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMED_CLAUSE, 0) => Some(0),
+                    (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMED_CLAUSE, 1) => None,
+                    // default_specifier -> named_specifiers
                     (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMED_CLAUSE, 2) => Some(1),
                     // from_token, source, assertion
                     (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMED_CLAUSE, 3..=5) => {
                         Some(slot_index - 1)
                     }
+                    // default and namespace clauses have the same outer slot layout
+                    (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMESPACE_CLAUSE, _) => Some(*slot_index),
                     // type_token
                     (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_DEFAULT_CLAUSE, 0) => Some(0),
                     // named_specifiers -> default specifier
@@ -167,24 +176,31 @@ impl Matcher<GritQueryContext> for GritNodePattern {
                     (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_DEFAULT_CLAUSE, 2..=4) => {
                         Some(slot_index + 1)
                     }
+                    // type_token
+                    (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_NAMESPACE_CLAUSE, 0) => Some(0),
+                    // named_specifiers -> namespace specifier
+                    (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_NAMESPACE_CLAUSE, 1) => Some(2),
+                    // from_token, source, assertion
+                    (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_NAMESPACE_CLAUSE, 2..=4) => {
+                        Some(slot_index + 1)
+                    }
+                    // default and namespace clauses have the same outer slot layout
+                    (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_DEFAULT_CLAUSE, _) => Some(*slot_index),
+                    // type_token -> type_token, phase_token is absent on named clauses
+                    (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_NAMED_CLAUSE, 0) => Some(0),
+                    (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_NAMED_CLAUSE, 1) => None,
+                    // namespace specifier -> named_specifiers
+                    (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_NAMED_CLAUSE, 2) => Some(1),
+                    // from_token, source, assertion
+                    (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_NAMED_CLAUSE, 3..=5) => {
+                        Some(slot_index - 1)
+                    }
                     // normal case
                     _ => Some(*slot_index),
                 };
 
                 match source_slot {
                     None => GritResolvedPattern::from_empty_binding(node.clone(), *slot_index),
-                    Some(1)
-                        if pattern_js_kind == JS_IMPORT_DEFAULT_CLAUSE
-                            && node_js_kind == JS_IMPORT_NAMED_CLAUSE =>
-                    {
-                        // Special case: default_specifier -> first named specifier
-                        node.child_by_slot_index(1)
-                            .and_then(|specifiers| specifiers.children().next())
-                            .map_or(
-                                GritResolvedPattern::from_empty_binding(node.clone(), *slot_index),
-                                GritResolvedPattern::from_node_binding,
-                            )
-                    }
                     Some(source) => get_child(source),
                 }
             } else {
@@ -228,6 +244,10 @@ impl GritNodePattern {
             (pattern_js_kind, node_js_kind),
             (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMED_CLAUSE)
                 | (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_DEFAULT_CLAUSE)
+                | (JS_IMPORT_DEFAULT_CLAUSE, JS_IMPORT_NAMESPACE_CLAUSE)
+                | (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_DEFAULT_CLAUSE)
+                | (JS_IMPORT_NAMED_CLAUSE, JS_IMPORT_NAMESPACE_CLAUSE)
+                | (JS_IMPORT_NAMESPACE_CLAUSE, JS_IMPORT_NAMED_CLAUSE)
         )
     }
 }

--- a/crates/biome_grit_patterns/tests/specs/ts/import_patterns.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/import_patterns.snap
@@ -5,7 +5,13 @@ expression: import_patterns
 SnapshotResult {
     messages: [],
     matched_ranges: [
-        "2:1-2:27",
+        "2:1-2:24",
+        "5:1-5:20",
+        "8:1-8:25",
+        "11:1-11:29",
+        "14:1-14:27",
+        "17:1-17:32",
+        "18:1-18:32",
     ],
     rewritten_files: [],
     created_files: [],

--- a/crates/biome_grit_patterns/tests/specs/ts/import_patterns.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/import_patterns.ts
@@ -1,2 +1,18 @@
 // Named import
-import { baz } from "foo";
+import { a } from "foo";
+
+// Default import
+import b from "foo";
+
+// Namespace import
+import * as c from "foo";
+
+// Type import
+import type { d } from "foo";
+
+// Multiple named imports
+import { e, f } from "foo";
+
+// Multiple named imports with type import
+import type { g, h } from "foo";
+import { i, type j } from "foo";


### PR DESCRIPTION
## Summary
- try every same-kind import snippet parse before giving up on a code-snippet match
- extend import-clause transformations to cover namespace clauses and multi-specifier named imports
- add the #7727 regression fixture and expected snapshot

## Testing
- `git diff --check`
- Unable to run `cargo test -p biome_grit_patterns ...` in this environment because the drive only had about 0.8 GB free and rustc/link failed with `os error 112` while creating `target/debug`

Fixes #7727.