### PR TITLE
fix(noFloatingPromises): respect overload signatures

### DIFF
--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -353,39 +353,199 @@ pub(super) fn flattened_expression(
 /// `Interface`, `Object`) until a `Function` is found, bounded by
 /// [`MAX_FLATTEN_DEPTH`] iterations.
 ///
-/// Returns `None` if no function can be reached.
+/// Returns the first call signature compatible with the arguments in `expr`,
+/// falling back to the first reachable call signature when compatibility
+/// cannot be determined.
 fn resolve_callee_to_function(
+    expr: &TypeofCallExpression,
     callee: TypeData,
     resolver: &mut dyn TypeResolver,
 ) -> Option<Box<Function>> {
-    let mut callee = callee;
+    let functions = collect_callee_functions(callee, resolver)?;
+    functions
+        .iter()
+        .find(|function| call_matches_function(expr, function, resolver))
+        .cloned()
+        .or_else(|| functions.into_iter().next())
+}
+
+fn collect_callee_functions(
+    callee: TypeData,
+    resolver: &mut dyn TypeResolver,
+) -> Option<Vec<Box<Function>>> {
+    let mut current = vec![callee];
+
     for _ in 0..MAX_FLATTEN_DEPTH {
-        match callee {
-            TypeData::Function(function) => return Some(function),
-            TypeData::InstanceOf(instance) => {
-                let instance_callee = resolver.resolve_and_get(&instance.ty)?;
-                callee = if instance_callee.is_function() {
-                    instance_callee.to_data()
-                } else {
-                    instance_callee
-                        .find_member(resolver, |member| member.kind().is_call_signature())
-                        .map(ResolvedTypeMember::to_member)
-                        .and_then(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))?
-                        .to_data()
-                };
+        let mut functions = Vec::new();
+        let mut next = Vec::new();
+
+        for callee in current {
+            match callee {
+                TypeData::Function(function) => functions.push(function),
+                TypeData::InstanceOf(instance) => {
+                    let instance_callee = resolver.resolve_and_get(&instance.ty)?;
+                    if instance_callee.is_function() {
+                        next.push(instance_callee.to_data());
+                    } else {
+                        functions.extend(call_signature_functions(instance_callee, resolver));
+                    }
+                }
+                TypeData::Interface(_) | TypeData::Object(_) => {
+                    let resolved =
+                        ResolvedTypeData::from((ResolverId::from_level(resolver.level()), &callee));
+                    functions.extend(call_signature_functions(resolved, resolver));
+                }
+                _ => {}
             }
-            TypeData::Interface(_) | TypeData::Object(_) => {
-                callee =
-                    ResolvedTypeData::from((ResolverId::from_level(resolver.level()), &callee))
-                        .find_member(resolver, |member| member.kind().is_call_signature())
-                        .map(ResolvedTypeMember::to_member)
-                        .and_then(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))?
-                        .to_data();
-            }
-            _ => break,
         }
+
+        if !functions.is_empty() {
+            return Some(functions);
+        }
+        if next.is_empty() {
+            return None;
+        }
+
+        current = next;
     }
+
     None
+}
+
+fn call_signature_functions(
+    resolved: ResolvedTypeData,
+    resolver: &dyn TypeResolver,
+) -> Vec<Box<Function>> {
+    resolved
+        .all_members(resolver)
+        .filter(|member| member.kind().is_call_signature())
+        .filter_map(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))
+        .filter_map(|resolved| match resolved.to_data() {
+            TypeData::Function(function) => Some(function),
+            _ => None,
+        })
+        .collect()
+}
+
+fn call_matches_function(
+    expr: &TypeofCallExpression,
+    function: &Function,
+    resolver: &dyn TypeResolver,
+) -> bool {
+    let provided_args = expr.arguments.len();
+    let required_params = function
+        .parameters
+        .iter()
+        .filter(|param| match param {
+            FunctionParameter::Named(param) => !param.is_optional && !param.is_rest,
+            FunctionParameter::Pattern(param) => !param.is_optional && !param.is_rest,
+        })
+        .count();
+    let has_rest = function.parameters.iter().any(|param| match param {
+        FunctionParameter::Named(param) => param.is_rest,
+        FunctionParameter::Pattern(param) => param.is_rest,
+    });
+
+    if provided_args < required_params {
+        return false;
+    }
+    if !has_rest && provided_args > function.parameters.len() {
+        return false;
+    }
+
+    function
+        .parameters
+        .iter()
+        .zip(expr.arguments.iter())
+        .all(|(param, arg)| parameter_accepts_argument(param, arg, resolver))
+}
+
+fn parameter_accepts_argument(
+    parameter: &FunctionParameter,
+    argument: &CallArgumentType,
+    resolver: &dyn TypeResolver,
+) -> bool {
+    let CallArgumentType::Argument(argument) = argument else {
+        return true;
+    };
+
+    let Some(parameter_ty) = resolver.resolve_and_get(parameter.ty()) else {
+        return true;
+    };
+    let Some(argument_ty) = resolver.resolve_and_get(argument) else {
+        return true;
+    };
+
+    if let (Some(expected), Some(actual)) = (
+        first_callable_function(parameter_ty.to_data(), resolver),
+        first_callable_function(argument_ty.to_data(), resolver),
+    ) {
+        return callback_signature_matches(&expected, &actual, resolver);
+    }
+
+    !parameter_ty.is_promise_instance(resolver) || argument_ty.is_promise_instance(resolver)
+}
+
+fn first_callable_function(callee: TypeData, resolver: &dyn TypeResolver) -> Option<Box<Function>> {
+    let mut current = vec![callee];
+
+    for _ in 0..MAX_FLATTEN_DEPTH {
+        let mut next = Vec::new();
+
+        for callee in current {
+            match callee {
+                TypeData::Function(function) => return Some(function),
+                TypeData::InstanceOf(instance) => {
+                    let instance_callee = resolver.resolve_and_get(&instance.ty)?;
+                    if instance_callee.is_function() {
+                        next.push(instance_callee.to_data());
+                    } else {
+                        return call_signature_functions(instance_callee, resolver)
+                            .into_iter()
+                            .next();
+                    }
+                }
+                TypeData::Interface(_) | TypeData::Object(_) => {
+                    let resolved =
+                        ResolvedTypeData::from((ResolverId::from_level(resolver.level()), &callee));
+                    return call_signature_functions(resolved, resolver)
+                        .into_iter()
+                        .next();
+                }
+                _ => {}
+            }
+        }
+
+        if next.is_empty() {
+            return None;
+        }
+
+        current = next;
+    }
+
+    None
+}
+
+fn callback_signature_matches(
+    expected: &Function,
+    actual: &Function,
+    resolver: &dyn TypeResolver,
+) -> bool {
+    let Some(expected_return_ty) = expected.return_type.as_type() else {
+        return true;
+    };
+    let Some(actual_return_ty) = actual.return_type.as_type() else {
+        return true;
+    };
+    let Some(expected_return_ty) = resolver.resolve_and_get(expected_return_ty) else {
+        return true;
+    };
+    let Some(actual_return_ty) = resolver.resolve_and_get(actual_return_ty) else {
+        return true;
+    };
+
+    !expected_return_ty.is_promise_instance(resolver)
+        || actual_return_ty.is_promise_instance(resolver)
 }
 
 fn flattened_call(
@@ -415,7 +575,8 @@ fn flattened_call(
                     }
                     _ => {}
                 }
-                if let Some(function) = resolve_callee_to_function(resolved.to_data(), resolver)
+                if let Some(function) =
+                    resolve_callee_to_function(expr, resolved.to_data(), resolver)
                     && let Some(result) = flattened_function_call(expr, &function, resolver)
                 {
                     return_types.push(result);
@@ -437,7 +598,7 @@ fn flattened_call(
             }
         }
         callee => {
-            let function = resolve_callee_to_function(callee, resolver)?;
+            let function = resolve_callee_to_function(expr, callee, resolver)?;
             flattened_function_call(expr, &function, resolver)
         }
     }

--- a/crates/biome_js_type_info/tests/flattening.rs
+++ b/crates/biome_js_type_info/tests/flattening.rs
@@ -320,6 +320,62 @@ fn infer_flattened_type_from_static_promise_function() {
 }
 
 #[test]
+fn infer_flattened_type_from_overloaded_callable_uses_matching_signature() {
+    const CODE: &str = r#"interface BestEffort {
+    <T>(cb: () => Promise<T>): Promise<T | undefined>;
+    <T>(cb: () => T): T | undefined;
+}
+
+bestEffort(() => 1)"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_interface_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let interface_ty =
+        TypeData::from_ts_interface_declaration(&mut resolver, ScopeId::GLOBAL, &decl)
+            .expect("interface must be inferred");
+    resolver.run_inference();
+
+    let expr = get_expression(&root);
+    let mut resolver = HardcodedSymbolResolver::new("bestEffort", interface_ty, resolver);
+    let expr_ty = TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expr);
+    let expr_ty = expr_ty.inferred(&mut resolver);
+
+    let TypeData::Union(union) = expr_ty else {
+        panic!("expected overload resolution to produce a union, got: {expr_ty}");
+    };
+
+    assert!(
+        union
+            .types()
+            .iter()
+            .any(|ty| resolver.resolve_and_get(ty).is_some_and(|resolved| {
+                matches!(
+                    resolved.as_raw_data(),
+                    TypeData::Literal(_) | TypeData::Number
+                )
+            })),
+        "expected a non-promise return variant, got: {union:?}",
+    );
+    assert!(
+        union.types().iter().any(|ty| {
+            resolver
+                .resolve_and_get(ty)
+                .is_some_and(|resolved| matches!(resolved.as_raw_data(), TypeData::Undefined))
+        }),
+        "expected overload resolution to preserve undefined, got: {union:?}",
+    );
+    assert!(
+        !union.types().iter().any(|ty| {
+            resolver
+                .resolve_and_get(ty)
+                .is_some_and(|resolved| resolved.is_promise_instance(&resolver))
+        }),
+        "expected overload resolution to avoid the promise overload, got: {union:?}",
+    );
+}
+
+#[test]
 fn infer_flattened_type_of_destructured_array_element() {
     const CODE: &str = r#"const [a]: Array<string> = [];"#;
 

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -1,19 +1,20 @@
 use std::{borrow::Cow, sync::Arc};
 
 use biome_js_semantic::{
-    BindingId, ScopeId, SemanticEvent, SemanticEventExtractor, TsBindingReference,
+    BindingId, JsDeclarationKind, ScopeId, SemanticEvent, SemanticEventExtractor,
+    TsBindingReference,
 };
 use biome_js_syntax::{
     AnyJsCombinedSpecifier, AnyJsDeclaration, AnyJsExportDefaultDeclaration, AnyJsExpression,
     AnyJsImportClause, JsAssignmentExpression, JsForVariableDeclaration, JsFormalParameter,
     JsIdentifierBinding, JsRestParameter, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
-    JsVariableDeclaration, TsIdentifierBinding, TsTypeParameter, TsTypeParameterName,
-    inner_string_text,
+    JsVariableDeclaration, TsDeclareFunctionDeclaration, TsIdentifierBinding, TsTypeParameter,
+    TsTypeParameterName, inner_string_text,
 };
 use biome_js_type_info::{
-    FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, GenericTypeParameter, MAX_FLATTEN_DEPTH,
-    Module, Namespace, Resolvable, ResolvedTypeData, ResolvedTypeId, TypeData, TypeId,
-    TypeImportQualifier, TypeMember, TypeMemberKind, TypeReference, TypeReferenceQualifier,
+    FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, GenericTypeParameter, Interface,
+    MAX_FLATTEN_DEPTH, Module, Namespace, Resolvable, ResolvedTypeData, ResolvedTypeId, TypeData,
+    TypeId, TypeImportQualifier, TypeMember, TypeMemberKind, TypeReference, TypeReferenceQualifier,
     TypeResolver, TypeResolverLevel, TypeStore, UnionCollector,
 };
 use biome_jsdoc_comment::JsdocComment;
@@ -130,6 +131,12 @@ pub(super) enum JsCollectedExport {
         /// Re-export definition.
         reexport: JsReexport,
     },
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum FunctionBindingKind {
+    Implementation,
+    Signature,
 }
 
 impl JsModuleInfoCollector {
@@ -1145,16 +1152,20 @@ impl JsModuleInfoCollector {
     ///
     /// Maps binding ranges to their type information and JSDoc comments.
     fn build_binding_type_data(
-        &self,
+        &mut self,
         _semantic_model: &biome_js_semantic::SemanticModel,
     ) -> FxHashMap<TextRange, super::BindingTypeData> {
         let mut binding_type_data = FxHashMap::default();
 
-        for binding in &self.bindings {
+        for index in 0..self.bindings.len() {
+            let binding = self.bindings[index].clone();
+            let ty = self
+                .overload_type_for_binding(index)
+                .unwrap_or_else(|| binding.ty.clone());
             binding_type_data.insert(
                 binding.range,
                 super::BindingTypeData {
-                    ty: binding.ty.clone(),
+                    ty,
                     jsdoc: binding.jsdoc.clone(),
                     export_ranges: binding.export_ranges.clone(),
                 },
@@ -1162,6 +1173,84 @@ impl JsModuleInfoCollector {
         }
 
         binding_type_data
+    }
+
+    fn overload_type_for_binding(&mut self, binding_index: usize) -> Option<TypeReference> {
+        let binding = self.bindings.get(binding_index)?.clone();
+        let binding_kind = self.function_binding_kind(&binding)?;
+
+        let overload_bindings: Vec<_> = self
+            .bindings
+            .iter()
+            .filter(|candidate| {
+                candidate.name == binding.name
+                    && candidate.scope_id == binding.scope_id
+                    && candidate.declaration_kind == JsDeclarationKind::HoistedValue
+            })
+            .filter_map(|candidate| {
+                self.function_binding_kind(candidate)
+                    .map(|kind| (candidate.clone(), kind))
+            })
+            .collect();
+
+        if overload_bindings.len() < 2 {
+            return None;
+        }
+
+        let last_binding = overload_bindings.last()?;
+        if last_binding.0.range != binding.range {
+            return None;
+        }
+
+        let signature_bindings: Vec<_> = overload_bindings
+            .iter()
+            .filter(|(_, kind)| *kind == FunctionBindingKind::Signature)
+            .map(|(binding, _)| binding)
+            .collect();
+
+        if signature_bindings.is_empty() {
+            return None;
+        }
+
+        if binding_kind == FunctionBindingKind::Signature
+            && overload_bindings
+                .iter()
+                .any(|(_, kind)| *kind == FunctionBindingKind::Implementation)
+        {
+            return None;
+        }
+
+        let interface = Interface {
+            name: binding.name.clone(),
+            type_parameters: [].into(),
+            extends: [].into(),
+            members: signature_bindings
+                .into_iter()
+                .map(|binding| TypeMember {
+                    kind: TypeMemberKind::CallSignature,
+                    ty: binding.ty.clone(),
+                })
+                .collect(),
+        };
+
+        Some(self.reference_to_owned_data(TypeData::from(interface)))
+    }
+
+    fn function_binding_kind(&self, binding: &JsBindingData) -> Option<FunctionBindingKind> {
+        if binding.declaration_kind != JsDeclarationKind::HoistedValue {
+            return None;
+        }
+
+        let node = self.binding_node_by_start.get(&binding.range.start())?;
+        node.ancestors().find_map(|ancestor| {
+            if biome_js_syntax::JsFunctionDeclaration::can_cast(ancestor.kind()) {
+                Some(FunctionBindingKind::Implementation)
+            } else if TsDeclareFunctionDeclaration::can_cast(ancestor.kind()) {
+                Some(FunctionBindingKind::Signature)
+            } else {
+                None
+            }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- expose TypeScript overload signatures through module binding type data instead of only the implementation signature
- prefer the first overload-compatible call signature when flattening callable types
- add a type-info regression test for overload-aware callable flattening

## Testing
- `rustfmt crates/biome_js_type_info/src/flattening/expressions.rs crates/biome_js_type_info/tests/flattening.rs crates/biome_module_graph/src/js_module_info/collector.rs`
- `cargo test -j 1 -p biome_js_type_info infer_flattened_type_from_overloaded_callable_uses_matching_signature --test flattening -- --nocapture` (did not complete successfully in this environment)