### PR TITLE
fix: respect .gitignore whitelist parents in vcs ignore checks

### DIFF
--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1092,12 +1092,14 @@ impl VcsIgnoredPatterns {
     ) -> bool {
         let root_ignored = {
             let path = path.strip_prefix(root.path()).unwrap_or(path);
-            root.matched(path, is_dir).is_ignore()
+            root.matched_path_or_any_parents(path, is_dir).is_ignore()
         };
 
         let nested_ignored = nested.iter().any(|gitignore| {
             if let Ok(stripped_path) = path.strip_prefix(gitignore.path()) {
-                gitignore.matched(stripped_path, is_dir).is_ignore()
+                gitignore
+                    .matched_path_or_any_parents(stripped_path, is_dir)
+                    .is_ignore()
             } else {
                 false
             }

--- a/crates/biome_service/src/settings.tests.rs
+++ b/crates/biome_service/src/settings.tests.rs
@@ -1,6 +1,6 @@
 use crate::scanner::ScanKind;
 use crate::settings::{
-    LanguageSettings, ModuleGraphResolutionKind, ServiceLanguage, Settings,
+    LanguageSettings, ModuleGraphResolutionKind, ServiceLanguage, Settings, VcsIgnoredPatterns,
     to_json_language_settings,
 };
 use crate::workspace::DocumentFileSource;
@@ -293,5 +293,34 @@ fn test_project_scan_disables_module_graph_type_inference() {
     assert!(
         !project_kind.is_modules_and_types(),
         "Project scan should NOT enable type inference"
+    );
+}
+
+#[test]
+fn vcs_ignore_whitelist_patterns_are_respected_for_child_paths() {
+    let ignored_patterns = VcsIgnoredPatterns::Git {
+        root: VcsIgnoredPatterns::git_ignore(
+            Utf8Path::new("repo"),
+            &["/*", "!/src", "!/biome.jsonc", "!/.gitignore"],
+        )
+        .unwrap(),
+        nested: vec![],
+    };
+
+    assert!(
+        !ignored_patterns.is_ignored(
+            Utf8Path::new("repo/src/file.js"),
+            false,
+            Some(Utf8Path::new("repo"))
+        ),
+        "whitelisted directories should keep their children visible to VCS ignore checks"
+    );
+    assert!(
+        ignored_patterns.is_ignored(
+            Utf8Path::new("repo/tests/file.js"),
+            false,
+            Some(Utf8Path::new("repo"))
+        ),
+        "non-whitelisted directories should still be ignored"
     );
 }


### PR DESCRIPTION
## Summary
- use `matched_path_or_any_parents` when evaluating `.gitignore` matches so parent whitelist entries like `!/src` affect child files
- add a regression test for the `/*` + `!/src` case reported in #9105

## Testing
- `cargo test -p biome_service vcs_ignore_whitelist_patterns_are_respected_for_child_paths -- --exact` *(blocked on this shared machine by repeated disk / PDB filesystem failures during workspace compilation)*

Fixes #9105