### PR TITLE
fix(lint): avoid unsafe useSimplifiedLogicExpression simplifications

### DIFF
--- a/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
@@ -84,14 +84,14 @@ impl Rule for UseSimplifiedLogicExpression {
                     AnyJsLiteralExpression::JsBooleanLiteralExpression(literal),
                 ) = left
                 {
-                    return simplify_or_expression(literal, right).map(|expr| (false, expr));
+                    return simplify_or_expression(literal, right, true).map(|expr| (false, expr));
                 }
 
                 if let AnyJsExpression::AnyJsLiteralExpression(
                     AnyJsLiteralExpression::JsBooleanLiteralExpression(literal),
                 ) = right
                 {
-                    return simplify_or_expression(literal, left).map(|expr| (false, expr));
+                    return simplify_or_expression(literal, left, false).map(|expr| (false, expr));
                 }
 
                 if could_apply_de_morgan(node).unwrap_or(false) {
@@ -104,14 +104,14 @@ impl Rule for UseSimplifiedLogicExpression {
                     AnyJsLiteralExpression::JsBooleanLiteralExpression(literal),
                 ) = left
                 {
-                    return simplify_and_expression(literal, right).map(|expr| (false, expr));
+                    return simplify_and_expression(literal, right, true).map(|expr| (false, expr));
                 }
 
                 if let AnyJsExpression::AnyJsLiteralExpression(
                     AnyJsLiteralExpression::JsBooleanLiteralExpression(literal),
                 ) = right
                 {
-                    return simplify_and_expression(literal, left).map(|expr| (false, expr));
+                    return simplify_and_expression(literal, left, false).map(|expr| (false, expr));
                 }
 
                 if could_apply_de_morgan(node).unwrap_or(false) {
@@ -186,33 +186,65 @@ fn could_apply_de_morgan(node: &JsLogicalExpression) -> Option<bool> {
 fn simplify_and_expression(
     literal: JsBooleanLiteralExpression,
     expression: AnyJsExpression,
+    literal_on_left: bool,
 ) -> Option<AnyJsExpression> {
-    keep_expression_if_literal(literal, expression, true)
+    keep_expression_if_literal(literal, expression, true, literal_on_left)
 }
 
 fn simplify_or_expression(
     literal: JsBooleanLiteralExpression,
     expression: AnyJsExpression,
+    literal_on_left: bool,
 ) -> Option<AnyJsExpression> {
-    keep_expression_if_literal(literal, expression, false)
+    keep_expression_if_literal(literal, expression, false, literal_on_left)
 }
 
 fn keep_expression_if_literal(
     literal: JsBooleanLiteralExpression,
     expression: AnyJsExpression,
     expected_value: bool,
+    literal_on_left: bool,
 ) -> Option<AnyJsExpression> {
     let eval_value = match literal.value_token().ok()?.kind() {
         T![true] => true,
         T![false] => false,
         _ => return None,
     };
+
     if eval_value == expected_value {
-        Some(expression)
+        (literal_on_left || is_boolean_expression(&expression)).then_some(expression)
     } else {
         Some(AnyJsExpression::AnyJsLiteralExpression(
             AnyJsLiteralExpression::JsBooleanLiteralExpression(literal),
         ))
+    }
+}
+
+fn is_boolean_expression(expression: &AnyJsExpression) -> bool {
+    match expression.clone().omit_parentheses() {
+        AnyJsExpression::AnyJsLiteralExpression(
+            AnyJsLiteralExpression::JsBooleanLiteralExpression(_),
+        )
+        | AnyJsExpression::JsInExpression(_)
+        | AnyJsExpression::JsInstanceofExpression(_) => true,
+        AnyJsExpression::JsBinaryExpression(expr) => expr.is_comparison_operator(),
+        AnyJsExpression::JsUnaryExpression(expr) => {
+            matches!(expr.operator(), Ok(JsUnaryOperator::LogicalNot))
+        }
+        AnyJsExpression::JsLogicalExpression(expr) => {
+            matches!(
+                expr.operator(),
+                Ok(biome_js_syntax::JsLogicalOperator::LogicalAnd
+                    | biome_js_syntax::JsLogicalOperator::LogicalOr)
+            ) && expr
+                .left()
+                .ok()
+                .zip(expr.right().ok())
+                .is_some_and(|(left, right)| {
+                    is_boolean_expression(&left) && is_boolean_expression(&right)
+                })
+        }
+        _ => false,
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/valid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/valid.js
@@ -6,3 +6,5 @@ const boolExpr5 = true;
 const boolExpr6 = false;
 const r6 = !!boolExpr1 || !!boolExpr2;
 !!x;
+const account = { test: 1 };
+const foo = { bar: account?.test || false };

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/valid.js.snap
@@ -12,5 +12,7 @@ const boolExpr5 = true;
 const boolExpr6 = false;
 const r6 = !!boolExpr1 || !!boolExpr2;
 !!x;
+const account = { test: 1 };
+const foo = { bar: account?.test || false };
 
 ```


### PR DESCRIPTION
## Summary
- avoid simplifying `expr || false` and `expr && true` when the literal is on the right unless the other operand is syntactically boolean
- keep the safe left-literal simplifications and De Morgan rewrite behavior unchanged
- add a regression fixture for the reported optional-chain fallback case from #8577

Closes #8577