### PR TITLE
fix(module-graph): preserve jsdoc for export declaration clauses

### DIFF
--- a/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/declare.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/declare.ts
@@ -1,0 +1,5 @@
+/** @deprecated Use Grid2 instead. */
+export declare const Grid: unknown;
+
+/** @deprecated Use Grid2 instead. */
+export const GridValid = null;

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/declare.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/declare.ts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: declare.ts
+---
+# Input
+```ts
+/** @deprecated Use Grid2 instead. */
+export declare const Grid: unknown;
+
+/** @deprecated Use Grid2 instead. */
+export const GridValid = null;
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/invalidDeclare.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/invalidDeclare.ts
@@ -1,0 +1,3 @@
+/* should generate diagnostics */
+import { Grid } from "./declare";
+import { GridValid } from "./declare";

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/invalidDeclare.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/invalidDeclare.ts.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: invalidDeclare.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+import { Grid } from "./declare";
+import { GridValid } from "./declare";
+
+```
+
+# Diagnostics
+```
+invalidDeclare.ts:2:10 lint/suspicious/noDeprecatedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Deprecated import: Use Grid2 instead.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ import { Grid } from "./declare";
+      │          ^^^^
+    3 │ import { GridValid } from "./declare";
+    4 │ 
+  
+  i An @deprecated annotation indicates the author doesn't want you to rely on this import anymore.
+  
+  i You should probably import a different symbol instead.
+  
+
+```
+
+```
+invalidDeclare.ts:3:10 lint/suspicious/noDeprecatedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Deprecated import: Use Grid2 instead.
+  
+    1 │ /* should generate diagnostics */
+    2 │ import { Grid } from "./declare";
+  > 3 │ import { GridValid } from "./declare";
+      │          ^^^^^^^^^
+    4 │ 
+  
+  i An @deprecated annotation indicates the author doesn't want you to rely on this import anymore.
+  
+  i You should probably import a different symbol instead.
+  
+
+```

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -4,11 +4,11 @@ use biome_js_semantic::{
     BindingId, ScopeId, SemanticEvent, SemanticEventExtractor, TsBindingReference,
 };
 use biome_js_syntax::{
-    AnyJsCombinedSpecifier, AnyJsDeclaration, AnyJsExportDefaultDeclaration, AnyJsExpression,
-    AnyJsImportClause, JsAssignmentExpression, JsForVariableDeclaration, JsFormalParameter,
-    JsIdentifierBinding, JsRestParameter, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
-    JsVariableDeclaration, TsIdentifierBinding, TsTypeParameter, TsTypeParameterName,
-    inner_string_text,
+    AnyJsCombinedSpecifier, AnyJsDeclaration, AnyJsDeclarationClause,
+    AnyJsExportDefaultDeclaration, AnyJsExpression, AnyJsImportClause, JsAssignmentExpression,
+    JsForVariableDeclaration, JsFormalParameter, JsIdentifierBinding, JsRestParameter,
+    JsSyntaxKind, JsSyntaxNode, JsSyntaxToken, JsVariableDeclaration, TsIdentifierBinding,
+    TsTypeParameter, TsTypeParameterName, inner_string_text,
 };
 use biome_js_type_info::{
     FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, GenericTypeParameter, MAX_FLATTEN_DEPTH,
@@ -1192,7 +1192,9 @@ impl JsModuleInfo {
 
 fn find_jsdoc(node: &JsSyntaxNode) -> Option<JsdocComment> {
     node.ancestors().find_map(|ancestor| {
-        if let Some(export) = biome_js_syntax::JsExport::cast_ref(&ancestor) {
+        if let Some(decl) = AnyJsDeclarationClause::cast_ref(&ancestor) {
+            JsdocComment::try_from(decl.syntax()).ok()
+        } else if let Some(export) = biome_js_syntax::JsExport::cast_ref(&ancestor) {
             JsdocComment::try_from(export.syntax()).ok()
         } else if let Some(decl) = AnyJsDeclaration::cast(ancestor) {
             JsdocComment::try_from(decl.syntax()).ok()


### PR DESCRIPTION
## Summary
- preserve JSDoc when module-graph bindings come from export declaration clauses such as `export declare const`
- add `noDeprecatedImports` regression fixtures covering deprecated declaration exports

## Testing
- rustfmt --check crates/biome_module_graph/src/js_module_info/collector.rs
- target/debug/deps/spec_tests-afb18462c8581224.exe specs::suspicious::no_deprecated_imports --nocapture

Closes #7635.