### PR TITLE
fix(lint): handle merged namespaces in noUnusedVariables

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -95,6 +95,16 @@ declare_lint_rule! {
     /// console.log(rest);
     /// ```
     ///
+    /// TypeScript namespaces that participate in declaration merging with an exported
+    /// or referenced value of the same name are not flagged.
+    /// ```ts
+    /// const MyComponent = () => {};
+    /// namespace MyComponent {
+    ///     export type Props = { id: string };
+    /// }
+    /// export default MyComponent;
+    /// ```
+    ///
     /// In Astro files, a top-level interface or a type alias named `Props` is always ignored
     /// as it's implicitly read by the framework.
     /// ```astro,ignore
@@ -471,29 +481,124 @@ impl Rule for NoUnusedVariables {
     }
 }
 
-/// Returns `true` if `binding` is considered as unused.
-pub fn is_unused(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> bool {
-    if matches!(binding, AnyJsIdentifierBinding::TsLiteralEnumMemberName(_)) {
-        // Enum members can be unused.
-        return false;
+fn containing_statement_list(decl: &AnyJsBindingDeclaration) -> Option<JsSyntaxNode> {
+    decl.syntax().ancestors().find(|ancestor| {
+        matches!(
+            ancestor.kind(),
+            JsSyntaxKind::JS_MODULE_ITEM_LIST | JsSyntaxKind::JS_STATEMENT_LIST
+        )
+    })
+}
+
+fn is_namespace_declaration(decl: &AnyJsBindingDeclaration) -> bool {
+    matches!(decl, AnyJsBindingDeclaration::TsModuleDeclaration(_))
+}
+
+fn is_namespace_merge_value_declaration(decl: &AnyJsBindingDeclaration) -> bool {
+    matches!(
+        decl,
+        AnyJsBindingDeclaration::JsVariableDeclarator(_)
+            | AnyJsBindingDeclaration::JsFunctionDeclaration(_)
+            | AnyJsBindingDeclaration::JsClassDeclaration(_)
+            | AnyJsBindingDeclaration::TsEnumDeclaration(_)
+    )
+}
+
+fn is_merge_candidate_used(
+    model: &SemanticModel,
+    binding: &AnyJsIdentifierBinding,
+    other: &AnyJsIdentifierBinding,
+    name: &str,
+    is_merge_candidate: fn(&AnyJsBindingDeclaration) -> bool,
+) -> Option<bool> {
+    if other.syntax().text_trimmed_range() == binding.syntax().text_trimmed_range() {
+        return None;
     }
 
-    // Ignore expressions
-    if binding.parent::<JsFunctionExpression>().is_some()
-        || binding.parent::<JsClassExpression>().is_some()
-    {
-        return false;
+    if other.name_token().ok()?.text_trimmed() != name {
+        return None;
     }
 
-    if model.is_exported(binding) {
-        return false;
+    let other_decl = other.declaration()?;
+    if !is_merge_candidate(&other_decl) {
+        return None;
     }
 
-    // We need to check if all uses of this binding are somehow recursive or unused
+    // Only look at direct usage/export information here so merged bindings don't
+    // recurse back through `is_unused`.
+    Some(model.is_exported(other) || !is_unused_by_references(model, other))
+}
+
+fn is_namespace_merged_with_used_value(
+    model: &SemanticModel,
+    binding: &AnyJsIdentifierBinding,
+) -> Option<bool> {
+    let decl = binding.declaration()?;
+    let name_token = binding.name_token().ok()?;
+    let name = name_token.text_trimmed();
+    let statement_list = containing_statement_list(&decl)?;
+    let scope = model.scope(&statement_list);
+
+    for scope_binding in scope.bindings() {
+        let other = scope_binding.tree();
+        if let Some(is_used) = is_merge_candidate_used(
+            model,
+            binding,
+            &other,
+            &name,
+            is_namespace_merge_value_declaration,
+        ) {
+            return Some(is_used);
+        }
+    }
+
+    Some(false)
+}
+
+fn is_value_merged_with_used_namespace(
+    model: &SemanticModel,
+    binding: &AnyJsIdentifierBinding,
+) -> Option<bool> {
+    let decl = binding.declaration()?;
+    let name_token = binding.name_token().ok()?;
+    let name = name_token.text_trimmed();
+    let statement_list = containing_statement_list(&decl)?;
+    let scope = model.scope(&statement_list);
+
+    for scope_binding in scope.bindings() {
+        let other = scope_binding.tree();
+        if let Some(is_used) =
+            is_merge_candidate_used(model, binding, &other, &name, is_namespace_declaration)
+        {
+            return Some(is_used);
+        }
+    }
+
+    Some(false)
+}
+
+fn is_declaration_merged_with_used(
+    model: &SemanticModel,
+    binding: &AnyJsIdentifierBinding,
+) -> Option<bool> {
+    let decl = binding.declaration()?;
+    match decl {
+        AnyJsBindingDeclaration::TsModuleDeclaration(_) => {
+            is_namespace_merged_with_used_value(model, binding)
+        }
+        _ if is_namespace_merge_value_declaration(&decl) => {
+            is_value_merged_with_used_namespace(model, binding)
+        }
+        _ => None,
+    }
+}
+
+fn is_unused_by_references(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> bool {
     let Some(declaration) = binding.declaration() else {
         return false;
     };
     let declaration = declaration.syntax();
+
     binding
         .all_references(model)
         .filter_map(|reference| {
@@ -503,15 +608,15 @@ pub fn is_unused(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> boo
                 // Ensure that the assignment is not used in an used expression.
                 let is_statement_like = ref_parent
                     .ancestors()
-                    .find(|x| {
+                    .find(|node| {
                         matches!(
-                            x.kind(),
+                            node.kind(),
                             JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION
                                 | JsSyntaxKind::JS_POST_UPDATE_EXPRESSION
                                 | JsSyntaxKind::JS_PRE_UPDATE_EXPRESSION
                         )
                     })
-                    .and_then(|x| is_unused_expression(&x).ok())
+                    .and_then(|node| is_unused_expression(&node).ok())
                     .unwrap_or(false);
                 if is_statement_like {
                     return None;
@@ -559,6 +664,31 @@ pub fn is_unused(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> boo
             // Always false when the ref is outside the declaration
             false
         })
+}
+
+/// Returns `true` if `binding` is considered as unused.
+pub fn is_unused(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> bool {
+    if matches!(binding, AnyJsIdentifierBinding::TsLiteralEnumMemberName(_)) {
+        // Enum members can be unused.
+        return false;
+    }
+
+    // Ignore expressions
+    if binding.parent::<JsFunctionExpression>().is_some()
+        || binding.parent::<JsClassExpression>().is_some()
+    {
+        return false;
+    }
+
+    if model.is_exported(binding) {
+        return false;
+    }
+
+    if !is_unused_by_references(model, binding) {
+        return false;
+    }
+
+    !is_declaration_merged_with_used(model, binding).unwrap_or(false)
 }
 
 /// Returns `true` if `expr` is unused.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidNamespaceUnused.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidNamespaceUnused.ts
@@ -1,0 +1,18 @@
+/* should generate diagnostics */
+
+namespace Standalone {
+    export type X = string;
+}
+
+const Both = () => {};
+namespace Both {
+    export type Y = number;
+}
+
+namespace Shadowed {
+    export type Z = boolean;
+}
+function useShadowed() {
+    const Shadowed = 42;
+    console.log(Shadowed);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidNamespaceUnused.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidNamespaceUnused.ts.snap
@@ -1,0 +1,129 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidNamespaceUnused.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+
+namespace Standalone {
+    export type X = string;
+}
+
+const Both = () => {};
+namespace Both {
+    export type Y = number;
+}
+
+namespace Shadowed {
+    export type Z = boolean;
+}
+function useShadowed() {
+    const Shadowed = 42;
+    console.log(Shadowed);
+}
+
+```
+
+# Diagnostics
+```
+invalidNamespaceUnused.ts:3:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable Standalone is unused.
+  
+    1 │ /* should generate diagnostics */
+    2 │ 
+  > 3 │ namespace Standalone {
+      │           ^^^^^^^^^^
+    4 │     export type X = string;
+    5 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+
+```
+
+```
+invalidNamespaceUnused.ts:7:7 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable Both is unused.
+  
+    5 │ }
+    6 │ 
+  > 7 │ const Both = () => {};
+      │       ^^^^
+    8 │ namespace Both {
+    9 │     export type Y = number;
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend Both with an underscore.
+  
+     5  5 │   }
+     6  6 │   
+     7    │ - const·Both·=·()·=>·{};
+        7 │ + const·_Both·=·()·=>·{};
+     8  8 │   namespace Both {
+     9  9 │       export type Y = number;
+  
+
+```
+
+```
+invalidNamespaceUnused.ts:8:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable Both is unused.
+  
+     7 │ const Both = () => {};
+   > 8 │ namespace Both {
+       │           ^^^^
+     9 │     export type Y = number;
+    10 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+
+```
+
+```
+invalidNamespaceUnused.ts:12:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable Shadowed is unused.
+  
+    10 │ }
+    11 │ 
+  > 12 │ namespace Shadowed {
+       │           ^^^^^^^^
+    13 │     export type Z = boolean;
+    14 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+
+```
+
+```
+invalidNamespaceUnused.ts:15:10 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function useShadowed is unused.
+  
+    13 │     export type Z = boolean;
+    14 │ }
+  > 15 │ function useShadowed() {
+       │          ^^^^^^^^^^^
+    16 │     const Shadowed = 42;
+    17 │     console.log(Shadowed);
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend useShadowed with an underscore.
+  
+    13 13 │       export type Z = boolean;
+    14 14 │   }
+    15    │ - function·useShadowed()·{
+       15 │ + function·_useShadowed()·{
+    16 16 │       const Shadowed = 42;
+    17 17 │       console.log(Shadowed);
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMerging.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMerging.ts
@@ -1,0 +1,7 @@
+/* should not generate diagnostics */
+
+const MyComponent = () => {};
+namespace MyComponent {
+    export type Props = { id: string };
+}
+export default MyComponent;

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMerging.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMerging.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validNamespaceDeclarationMerging.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+const MyComponent = () => {};
+namespace MyComponent {
+    export type Props = { id: string };
+}
+export default MyComponent;
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingClass.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingClass.ts
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+
+export class Store {}
+namespace Store {
+    export type Options = { id: string };
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingClass.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingClass.ts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validNamespaceDeclarationMergingClass.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+export class Store {}
+namespace Store {
+    export type Options = { id: string };
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingEnum.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingEnum.ts
@@ -1,0 +1,9 @@
+/* should not generate diagnostics */
+
+export enum Foo {
+    A,
+}
+
+namespace Foo {
+    export type Bar = string;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingEnum.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingEnum.ts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validNamespaceDeclarationMergingEnum.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+export enum Foo {
+    A,
+}
+
+namespace Foo {
+    export type Bar = string;
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingFunction.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingFunction.ts
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+
+export function MyFunction() {}
+namespace MyFunction {
+    export type Config = { timeout: number };
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingFunction.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingFunction.ts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validNamespaceDeclarationMergingFunction.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+export function MyFunction() {}
+namespace MyFunction {
+    export type Config = { timeout: number };
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingPropertyAccess.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingPropertyAccess.ts
@@ -1,0 +1,7 @@
+/* should not generate diagnostics */
+
+function registry() {}
+namespace registry {
+    export const item = 1;
+}
+console.log(registry.item);

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingPropertyAccess.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMergingPropertyAccess.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validNamespaceDeclarationMergingPropertyAccess.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+function registry() {}
+namespace registry {
+    export const item = 1;
+}
+console.log(registry.item);
+
+```


### PR DESCRIPTION
## Summary
- fix `noUnusedVariables` for TypeScript declaration merging between namespaces and same-name values
- treat merged namespaces as used when the paired value is exported or referenced, including local property-access cases like `registry.item`
- add regression coverage for const/function/class/enum merges and for truly unused namespaces

## Context
- fixes #7664
- follow-up to #9320 on top of current `main`

## Testing
- cargo test -p biome_js_analyze --test spec_tests namespace_declaration_merging
- cargo test -p biome_js_analyze --test spec_tests invalid_namespace_unused