### PR TITLE
fix: honor embedded template references in noUnusedImports

### DIFF
--- a/crates/biome_cli/tests/cases/handle_svelte_files.rs
+++ b/crates/biome_cli/tests/cases/handle_svelte_files.rs
@@ -318,6 +318,38 @@ const props: Props = { title: "Hello" };
 }
 
 #[test]
+fn namespace_imports_used_in_svelte_templates_are_not_reported_as_unused() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{ "html": { "linter": {"enabled": true}, "experimentalFullSupportEnabled": true } }"#
+            .as_bytes(),
+    );
+
+    let svelte_file_path = Utf8Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        r#"<script lang="ts">
+import * as Tabs from "tabs";
+</script>
+
+<Tabs.Root />
+"#
+        .as_bytes(),
+    );
+
+    let (_fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", svelte_file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+}
+
+#[test]
 fn format_stdin_successfully() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -6,6 +6,7 @@ use crate::{
 use biome_rule_options::no_unused_imports::NoUnusedImportsOptions;
 
 use crate::services::embedded_bindings::EmbeddedBindings;
+use crate::services::embedded_value_references::EmbeddedValueReferences;
 use biome_analyze::{
     AddVisitor, FixKind, FromServices, Phase, Phases, QueryKey, Queryable, Rule, RuleDiagnostic,
     RuleKey, RuleMetadata, RuleSource, ServiceBag, ServicesDiagnostic, SyntaxVisitor, Visitor,
@@ -276,6 +277,9 @@ impl Rule for NoUnusedImports {
         let embedded_bindings = ctx
             .get_service::<EmbeddedBindings>()
             .expect("embedded bindings service");
+        let embedded_references = ctx
+            .get_service::<EmbeddedValueReferences>()
+            .expect("embedded references service");
 
         match ctx.query() {
             AnyJsImportClause::JsImportBareClause(_) => {
@@ -285,11 +289,20 @@ impl Rule for NoUnusedImports {
             AnyJsImportClause::JsImportCombinedClause(clause) => {
                 let default_local_name = clause.default_specifier().ok()?.local_name().ok()?;
 
-                let is_default_import_unused =
-                    is_unused(ctx, embedded_bindings, &default_local_name);
+                let is_default_import_unused = is_unused(
+                    ctx,
+                    embedded_bindings,
+                    embedded_references,
+                    &default_local_name,
+                );
                 let (is_combined_unused, named_import_range) = match clause.specifier().ok()? {
                     AnyJsCombinedSpecifier::JsNamedImportSpecifiers(specifiers) => {
-                        match unused_named_specifiers(ctx, embedded_bindings, &specifiers) {
+                        match unused_named_specifiers(
+                            ctx,
+                            embedded_bindings,
+                            embedded_references,
+                            &specifiers,
+                        ) {
                             Some(Unused::AllImports(range) | Unused::EmptyStatement(range)) => {
                                 (true, range)
                             }
@@ -309,7 +322,7 @@ impl Rule for NoUnusedImports {
                     AnyJsCombinedSpecifier::JsNamespaceImportSpecifier(specifier) => {
                         let local_name = specifier.local_name().ok()?;
                         (
-                            is_unused(ctx, embedded_bindings, &local_name),
+                            is_unused(ctx, embedded_bindings, embedded_references, &local_name),
                             local_name.range(),
                         )
                     }
@@ -326,7 +339,7 @@ impl Rule for NoUnusedImports {
             }
             AnyJsImportClause::JsImportDefaultClause(clause) => {
                 let local_name = clause.default_specifier().ok()?.local_name().ok()?;
-                is_unused(ctx, embedded_bindings, &local_name)
+                is_unused(ctx, embedded_bindings, embedded_references, &local_name)
                     .then_some(Unused::AllImports(local_name.range()))
             }
             AnyJsImportClause::JsImportNamedClause(clause) => {
@@ -339,11 +352,16 @@ impl Rule for NoUnusedImports {
                     return None;
                 }
 
-                unused_named_specifiers(ctx, embedded_bindings, &clause.named_specifiers().ok()?)
+                unused_named_specifiers(
+                    ctx,
+                    embedded_bindings,
+                    embedded_references,
+                    &clause.named_specifiers().ok()?,
+                )
             }
             AnyJsImportClause::JsImportNamespaceClause(clause) => {
                 let local_name = clause.namespace_specifier().ok()?.local_name().ok()?;
-                is_unused(ctx, embedded_bindings, &local_name)
+                is_unused(ctx, embedded_bindings, embedded_references, &local_name)
                     .then_some(Unused::AllImports(local_name.range()))
             }
         }
@@ -650,6 +668,7 @@ pub enum Unused {
 fn unused_named_specifiers(
     ctx: &RuleContext<NoUnusedImports>,
     embedded_bindings: &EmbeddedBindings,
+    embedded_references: &EmbeddedValueReferences,
     named_specifiers: &JsNamedImportSpecifiers,
 ) -> Option<Unused> {
     let specifiers = named_specifiers.specifiers();
@@ -663,7 +682,7 @@ fn unused_named_specifiers(
             let Some(local_name) = specifier.local_name() else {
                 continue;
             };
-            if is_unused(ctx, embedded_bindings, &local_name) {
+            if is_unused(ctx, embedded_bindings, embedded_references, &local_name) {
                 unused_imports.push(specifier);
             }
         }
@@ -682,6 +701,7 @@ fn unused_named_specifiers(
 fn is_unused(
     ctx: &RuleContext<NoUnusedImports>,
     embedded_bindings: &EmbeddedBindings,
+    embedded_references: &EmbeddedValueReferences,
     local_name: &AnyJsBinding,
 ) -> bool {
     let AnyJsBinding::JsIdentifierBinding(binding) = &local_name else {
@@ -693,6 +713,14 @@ fn is_unused(
         .ok()
         .is_some_and(|token| embedded_bindings.contains_binding(token.text_trimmed()));
     if is_defined_in_embed {
+        return false;
+    }
+
+    let is_used_as_reference = binding
+        .name_token()
+        .ok()
+        .is_some_and(|token| embedded_references.is_used_as_value(token.text_trimmed()));
+    if is_used_as_reference {
         return false;
     }
 

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -12,8 +12,10 @@ use biome_js_semantic::{SemanticModelOptions, semantic_model};
 use biome_js_syntax::JsFileSource;
 use biome_package::{Dependencies, PackageJson};
 use biome_project_layout::ProjectLayout;
+use biome_rowan::{RawSyntaxKind, TextRange as RowanTextRange, TextSize, TokenText};
 use biome_test_utils::module_graph_for_test_file;
 use camino::Utf8PathBuf;
+use rustc_hash::FxHashMap;
 use std::slice;
 use std::sync::Arc;
 
@@ -156,5 +158,54 @@ function App() {
     );
 
     // Should not report any errors because h and Fragment are used as JSX factory functions
+    assert_eq!(error_ranges.as_slice(), &[]);
+}
+
+#[test]
+fn no_unused_imports_respects_embedded_value_references() {
+    const FILENAME: &str = "file.ts";
+    const SOURCE: &str = r#"import * as Tabs from "tabs";"#;
+
+    let parsed = parse(SOURCE, JsFileSource::ts(), JsParserOptions::default());
+    let file_path = Utf8PathBuf::from(FILENAME);
+
+    let mut error_ranges: Vec<TextRange> = Vec::new();
+    let options = AnalyzerOptions::default().with_file_path(file_path.clone());
+    let rule_filter = RuleFilter::Rule("correctness", "noUnusedImports");
+
+    let project_layout = Arc::new(ProjectLayout::default());
+    let semantic_model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+    let mut services = JsAnalyzerServices::from((
+        module_graph_for_test_file(file_path.as_path(), project_layout.as_ref()),
+        project_layout,
+        JsFileSource::ts(),
+        Some(semantic_model),
+    ));
+
+    let mut embedded_references = FxHashMap::default();
+    embedded_references.insert(
+        RowanTextRange::new(TextSize::from(0), TextSize::from(4)),
+        TokenText::new_raw(RawSyntaxKind(0), "Tabs"),
+    );
+    services.set_embedded_value_references(vec![embedded_references]);
+
+    analyze(
+        &parsed.tree(),
+        AnalysisFilter {
+            enabled_rules: Some(slice::from_ref(&rule_filter)),
+            ..AnalysisFilter::default()
+        },
+        &options,
+        &[],
+        services,
+        |signal| {
+            if let Some(diag) = signal.diagnostic() {
+                error_ranges.push(diag.location().span.unwrap());
+            }
+
+            ControlFlow::<Never>::Continue(())
+        },
+    );
+
     assert_eq!(error_ranges.as_slice(), &[]);
 }


### PR DESCRIPTION
Closes #9193.

## Summary
- teach `noUnusedImports` to honor embedded template value references like `<Tabs.Root />`
- add analyzer coverage for embedded value references reaching the import rule
- add a Svelte CLI regression test for namespace imports used from templates

## Testing
- `rustfmt crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs crates/biome_js_analyze/tests/quick_test.rs crates/biome_cli/tests/cases/handle_svelte_files.rs`
- `cargo test -p biome_cli namespace_imports_used_in_svelte_templates_are_not_reported_as_unused -- --exact` (blocked on this worker by host rustc/disk/linker failures)
- `cargo check -p biome_js_analyze --test quick_test --target-dir C:\t41_nd` (blocked on this worker by host rustc/linker failures)