### PR TITLE
fix(js): suppress unsafe noSkippedTests fixes for conditional skips

### DIFF
--- a/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
@@ -93,6 +93,7 @@ impl Rule for NoSkippedTests {
                 return Some(SkipState {
                     range: function_name.text_trimmed_range(),
                     annotation,
+                    can_fix: true,
                 });
             }
         }
@@ -121,6 +122,10 @@ impl Rule for NoSkippedTests {
     }
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
+        if !state.can_fix {
+            return None;
+        }
+
         let node = ctx.query();
         let callee = node.callee().ok()?;
 
@@ -169,6 +174,7 @@ pub struct SkipState {
     range: TextRange,
     /// The type of annotation: "skip" or "fixme".
     annotation: &'static str,
+    can_fix: bool,
 }
 
 /// Detects bare `test.skip()` / `test.fixme()` calls that don't pass `is_test_call_expression()`
@@ -245,6 +251,7 @@ fn detect_bare_skip_call(
                 return Some(SkipState {
                     range: name_range,
                     annotation,
+                    can_fix: true,
                 });
             }
             // 1-2 arg conditional skip
@@ -252,6 +259,7 @@ fn detect_bare_skip_call(
                 return Some(SkipState {
                     range: name_range,
                     annotation,
+                    can_fix: false,
                 });
             }
             // Bracket notation with standard test args: test["skip"]("name", fn)
@@ -259,6 +267,7 @@ fn detect_bare_skip_call(
                 return Some(SkipState {
                     range: name_range,
                     annotation,
+                    can_fix: true,
                 });
             }
             // Standard static member: handled by Path 1
@@ -272,6 +281,7 @@ fn detect_bare_skip_call(
             return Some(SkipState {
                 range: name_range,
                 annotation,
+                can_fix: true,
             });
         }
     }
@@ -281,6 +291,7 @@ fn detect_bare_skip_call(
     Some(SkipState {
         range: name_range,
         annotation,
+        can_fix: true,
     })
 }
 

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/invalid.js
@@ -31,3 +31,9 @@ test["skip"]("bracket notation", async () => {});
 test("bare skip", async () => {
     test.skip();
 });
+
+// Conditional skip/fixme inside a test body
+test("conditional skip", async ({ browserName }) => {
+    test.skip(browserName === "firefox", "Still working on it");
+    test.fixme(browserName === "webkit");
+});

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/invalid.js.snap
@@ -38,6 +38,12 @@ test("bare skip", async () => {
     test.skip();
 });
 
+// Conditional skip/fixme inside a test body
+test("conditional skip", async ({ browserName }) => {
+    test.skip(browserName === "firefox", "Still working on it");
+    test.fixme(browserName === "webkit");
+});
+
 ```
 
 # Diagnostics
@@ -556,5 +562,41 @@ invalid.js:32:10 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━�
     33 33 │   });
     34 34 │   
   
+
+```
+```
+invalid.js:37:10 lint/suspicious/noSkippedTests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+
+    35 │ // Conditional skip/fixme inside a test body
+    36 │ test("conditional skip", async ({ browserName }) => {
+  > 37 │     test.skip(browserName === "firefox", "Still working on it");
+       │          ^^^^
+    38 │     test.fixme(browserName === "webkit");
+    39 │ });
+
+  i Disabling tests is useful when debugging or creating placeholder while working.
+
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+
+
+```
+
+```
+invalid.js:38:10 lint/suspicious/noSkippedTests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+
+    36 │ test("conditional skip", async ({ browserName }) => {
+    37 │     test.skip(browserName === "firefox", "Still working on it");
+  > 38 │     test.fixme(browserName === "webkit");
+       │          ^^^^^
+    39 │ });
+
+  i Disabling tests is useful when debugging or creating placeholder while working.
+
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+
 
 ```


### PR DESCRIPTION
Closes #9295.

## Summary
- stop offering the noSkippedTests quick fix for conditional test.skip/test.fixme calls
- keep the diagnostics in place and add regression coverage for 1-arg and 2-arg conditional skips

## Testing
- git diff --check
- cargo test -p biome_js_analyze --test spec_tests noSkippedTests -- --nocapture (fails on this Windows machine because rustc/LLVM runs out of memory while compiling biome_js_syntax)