### PR TITLE
fix(lint): honor embedded template refs in noUnusedImports

### DIFF
--- a/crates/biome_cli/tests/cases/handle_svelte_files.rs
+++ b/crates/biome_cli/tests/cases/handle_svelte_files.rs
@@ -40,6 +40,32 @@ var foo: string = "";
 </script>
 <div></div>"#;
 
+const SVELTE_FILE_REEXPORTED_COMPONENT_ALIAS: &str = r#"<script lang="ts">
+import { Thing as Something, Thing } from "./file";
+</script>
+
+<Something />
+<Thing />
+"#;
+
+const SVELTE_REEXPORTED_COMPONENT_MODULE: &str =
+    r#"export { default as Thing } from "./AnotherComponent.svelte";"#;
+
+const SVELTE_COMPONENT_WITH_NAMED_EXPORT: &str = r#"<script context="module" lang="ts">
+export const someConstant = Symbol();
+</script>
+
+<div></div>
+"#;
+
+const SVELTE_FILE_COMPONENT_DEFAULT_AND_NAMED_IMPORTS: &str = r#"<script lang="ts">
+import AnotherComponent, { someConstant } from "./AnotherComponent.svelte";
+</script>
+
+<AnotherComponent {someConstant} />
+<AnotherComponent someConstant={someConstant} />
+"#;
+
 #[test]
 fn sorts_imports_check() {
     let fs = MemoryFileSystem::default();
@@ -311,6 +337,97 @@ const props: Props = { title: "Hello" };
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "full_support_ts",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn no_unused_imports_not_triggered_for_reexported_component_aliases() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{ "html": { "experimentalFullSupportEnabled": true, "linter": { "enabled": true } } }"#
+            .as_bytes(),
+    );
+
+    let svelte_file_path = Utf8Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_FILE_REEXPORTED_COMPONENT_ALIAS.as_bytes(),
+    );
+    fs.insert(
+        "file.ts".into(),
+        SVELTE_REEXPORTED_COMPONENT_MODULE.as_bytes(),
+    );
+    fs.insert("AnotherComponent.svelte".into(), "<div></div>".as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "lint",
+                "--only=correctness/noUnusedImports",
+                svelte_file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "no_unused_imports_not_triggered_for_reexported_component_aliases",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn no_unused_imports_not_triggered_for_default_and_named_component_imports() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{ "html": { "experimentalFullSupportEnabled": true, "linter": { "enabled": true } } }"#
+            .as_bytes(),
+    );
+
+    let svelte_file_path = Utf8Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        SVELTE_FILE_COMPONENT_DEFAULT_AND_NAMED_IMPORTS.as_bytes(),
+    );
+    fs.insert(
+        "AnotherComponent.svelte".into(),
+        SVELTE_COMPONENT_WITH_NAMED_EXPORT.as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "lint",
+                "--only=correctness/noUnusedImports",
+                svelte_file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "no_unused_imports_not_triggered_for_default_and_named_component_imports",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/no_unused_imports_not_triggered_for_default_and_named_component_imports.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/no_unused_imports_not_triggered_for_default_and_named_component_imports.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "experimentalFullSupportEnabled": true,
+    "linter": { "enabled": true }
+  }
+}
+```
+
+## `AnotherComponent.svelte`
+
+```svelte
+<script context="module" lang="ts">
+export const someConstant = Symbol();
+</script>
+
+<div></div>
+
+```
+
+## `file.svelte`
+
+```svelte
+<script lang="ts">
+import AnotherComponent, { someConstant } from "./AnotherComponent.svelte";
+</script>
+
+<AnotherComponent {someConstant} />
+<AnotherComponent someConstant={someConstant} />
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/no_unused_imports_not_triggered_for_reexported_component_aliases.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/no_unused_imports_not_triggered_for_reexported_component_aliases.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "experimentalFullSupportEnabled": true,
+    "linter": { "enabled": true }
+  }
+}
+```
+
+## `AnotherComponent.svelte`
+
+```svelte
+<div></div>
+```
+
+## `file.svelte`
+
+```svelte
+<script lang="ts">
+import { Thing as Something, Thing } from "./file";
+</script>
+
+<Something />
+<Thing />
+
+```
+
+## `file.ts`
+
+```ts
+export { default as Thing } from "./AnotherComponent.svelte";
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```
+

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -6,6 +6,7 @@ use crate::{
 use biome_rule_options::no_unused_imports::NoUnusedImportsOptions;
 
 use crate::services::embedded_bindings::EmbeddedBindings;
+use crate::services::embedded_value_references::EmbeddedValueReferences;
 use biome_analyze::{
     AddVisitor, FixKind, FromServices, Phase, Phases, QueryKey, Queryable, Rule, RuleDiagnostic,
     RuleKey, RuleMetadata, RuleSource, ServiceBag, ServicesDiagnostic, SyntaxVisitor, Visitor,
@@ -276,6 +277,9 @@ impl Rule for NoUnusedImports {
         let embedded_bindings = ctx
             .get_service::<EmbeddedBindings>()
             .expect("embedded bindings service");
+        let embedded_references = ctx
+            .get_service::<EmbeddedValueReferences>()
+            .expect("embedded value references service");
 
         match ctx.query() {
             AnyJsImportClause::JsImportBareClause(_) => {
@@ -285,11 +289,20 @@ impl Rule for NoUnusedImports {
             AnyJsImportClause::JsImportCombinedClause(clause) => {
                 let default_local_name = clause.default_specifier().ok()?.local_name().ok()?;
 
-                let is_default_import_unused =
-                    is_unused(ctx, embedded_bindings, &default_local_name);
+                let is_default_import_unused = is_unused(
+                    ctx,
+                    embedded_bindings,
+                    embedded_references,
+                    &default_local_name,
+                );
                 let (is_combined_unused, named_import_range) = match clause.specifier().ok()? {
                     AnyJsCombinedSpecifier::JsNamedImportSpecifiers(specifiers) => {
-                        match unused_named_specifiers(ctx, embedded_bindings, &specifiers) {
+                        match unused_named_specifiers(
+                            ctx,
+                            embedded_bindings,
+                            embedded_references,
+                            &specifiers,
+                        ) {
                             Some(Unused::AllImports(range) | Unused::EmptyStatement(range)) => {
                                 (true, range)
                             }
@@ -309,7 +322,7 @@ impl Rule for NoUnusedImports {
                     AnyJsCombinedSpecifier::JsNamespaceImportSpecifier(specifier) => {
                         let local_name = specifier.local_name().ok()?;
                         (
-                            is_unused(ctx, embedded_bindings, &local_name),
+                            is_unused(ctx, embedded_bindings, embedded_references, &local_name),
                             local_name.range(),
                         )
                     }
@@ -326,7 +339,7 @@ impl Rule for NoUnusedImports {
             }
             AnyJsImportClause::JsImportDefaultClause(clause) => {
                 let local_name = clause.default_specifier().ok()?.local_name().ok()?;
-                is_unused(ctx, embedded_bindings, &local_name)
+                is_unused(ctx, embedded_bindings, embedded_references, &local_name)
                     .then_some(Unused::AllImports(local_name.range()))
             }
             AnyJsImportClause::JsImportNamedClause(clause) => {
@@ -339,11 +352,16 @@ impl Rule for NoUnusedImports {
                     return None;
                 }
 
-                unused_named_specifiers(ctx, embedded_bindings, &clause.named_specifiers().ok()?)
+                unused_named_specifiers(
+                    ctx,
+                    embedded_bindings,
+                    embedded_references,
+                    &clause.named_specifiers().ok()?,
+                )
             }
             AnyJsImportClause::JsImportNamespaceClause(clause) => {
                 let local_name = clause.namespace_specifier().ok()?.local_name().ok()?;
-                is_unused(ctx, embedded_bindings, &local_name)
+                is_unused(ctx, embedded_bindings, embedded_references, &local_name)
                     .then_some(Unused::AllImports(local_name.range()))
             }
         }
@@ -650,6 +668,7 @@ pub enum Unused {
 fn unused_named_specifiers(
     ctx: &RuleContext<NoUnusedImports>,
     embedded_bindings: &EmbeddedBindings,
+    embedded_references: &EmbeddedValueReferences,
     named_specifiers: &JsNamedImportSpecifiers,
 ) -> Option<Unused> {
     let specifiers = named_specifiers.specifiers();
@@ -663,7 +682,7 @@ fn unused_named_specifiers(
             let Some(local_name) = specifier.local_name() else {
                 continue;
             };
-            if is_unused(ctx, embedded_bindings, &local_name) {
+            if is_unused(ctx, embedded_bindings, embedded_references, &local_name) {
                 unused_imports.push(specifier);
             }
         }
@@ -682,6 +701,7 @@ fn unused_named_specifiers(
 fn is_unused(
     ctx: &RuleContext<NoUnusedImports>,
     embedded_bindings: &EmbeddedBindings,
+    embedded_references: &EmbeddedValueReferences,
     local_name: &AnyJsBinding,
 ) -> bool {
     let AnyJsBinding::JsIdentifierBinding(binding) = &local_name else {
@@ -693,6 +713,14 @@ fn is_unused(
         .ok()
         .is_some_and(|token| embedded_bindings.contains_binding(token.text_trimmed()));
     if is_defined_in_embed {
+        return false;
+    }
+
+    let is_used_as_value = binding
+        .name_token()
+        .ok()
+        .is_some_and(|token| embedded_references.is_used_as_value(token.text_trimmed()));
+    if is_used_as_value {
         return false;
     }
 


### PR DESCRIPTION
## Summary
- treat embedded template value references as real usages in `noUnusedImports`, matching the existing `noUnusedVariables` and `useImportType` behavior
- add Svelte CLI regressions for reexported component aliases and default + named component imports from `.svelte` files

Fixes #9543.

## Testing
- `rustfmt --edition 2024 crates/biome_cli/tests/cases/handle_svelte_files.rs crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs`
- `cargo test -p biome_cli no_unused_imports_not_triggered_for_ --test main`

The targeted cargo test build did not complete on this Windows worker because `rustc` hit local paging-file / OOM limits during compilation before the new tests finished building.