### PR TITLE
fix(markdown): trim hard-line markers before empty lines

### DIFF
--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/hard_line.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/hard_line.rs
@@ -1,12 +1,18 @@
 use crate::prelude::*;
 use biome_formatter::write;
-use biome_markdown_syntax::MdHardLine;
+use biome_markdown_syntax::{MdHardLine, MdTextual};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatMdHardLine;
+
 impl FormatNodeRule<MdHardLine> for FormatMdHardLine {
     fn fmt_fields(&self, node: &MdHardLine, f: &mut MarkdownFormatter) -> FormatResult<()> {
         let token = node.value_token()?;
         let text_content = token.text();
+
+        if is_followed_by_empty_line(node) {
+            return write!(f, [format_removed(&token), hard_line_break()]);
+        }
 
         if text_content.trim_end().ends_with('\\') {
             // Preserve backslash form
@@ -32,4 +38,11 @@ impl FormatNodeRule<MdHardLine> for FormatMdHardLine {
             )
         }
     }
+}
+
+fn is_followed_by_empty_line(node: &MdHardLine) -> bool {
+    node.syntax()
+        .next_sibling()
+        .and_then(MdTextual::cast)
+        .is_some_and(|text| text.is_newline().unwrap_or(false))
 }

--- a/crates/biome_markdown_formatter/tests/specs/markdown/hard_line_empty_line.md
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/hard_line_empty_line.md
@@ -1,0 +1,9 @@
+keep-space  
+next
+
+trim-space  
+
+keep-backslash\
+next
+
+trim-backslash\

--- a/crates/biome_markdown_formatter/tests/specs/markdown/hard_line_empty_line.md.snap
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/hard_line_empty_line.md.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: markdown/hard_line_empty_line.md
+---
+
+# Input
+
+```md
+keep-space  
+next
+
+trim-space  
+
+keep-backslash\
+next
+
+trim-backslash\
+```
+
+
+# Formatted
+
+```md
+keep-space  
+next
+
+trim-space
+
+keep-backslash\
+next
+
+trim-backslash
+```


### PR DESCRIPTION
## Summary
- trim Markdown hard-line markers when the following line is empty
- preserve hard-line markers when the following line still has content
- add a formatter regression spec for both space and backslash forms

## Testing
- `cargo test -p biome_markdown_formatter --test spec_tests hard_line_empty_line -- --exact` *(this worker hit `os error 112` / disk exhaustion while compiling the test harness)*

Closes #9481.