### PR TITLE
fix(service): map embedded GraphQL ranges through TSX rewrites

### DIFF
--- a/crates/biome_js_formatter/src/js/auxiliary/template_chunk_element.rs
+++ b/crates/biome_js_formatter/src/js/auxiliary/template_chunk_element.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::write;
+use biome_formatter::{FormatContext, write};
 
 use biome_js_syntax::{
     AnyJsExpression, JsCallArgumentList, JsCallArguments, JsCallExpression, JsSyntaxToken,
@@ -25,27 +25,40 @@ impl FormatNodeRule<JsTemplateChunkElement> for FormatJsTemplateChunkElement {
         node: &JsTemplateChunkElement,
         f: &mut JsFormatter,
     ) -> Option<TextRange> {
-        if !f.context().should_delegate_fmt_embedded_nodes() {
-            return None;
-        }
-
-        // Only mark template chunks that belong to a plausible embed candidate.
-        // A template is a candidate when it has a tag (e.g. css``, gql``, styled.div``)
-        // or is an argument to a simple call expression (e.g. graphql(`...`)).
-        // Plain templates like console.log(`test`) must NOT be marked, otherwise
-        // the formatter emits StartEmbedded/EndEmbedded tags that never get resolved
-        // and corrupt the printer's tag stack.
-        let template = node
-            .syntax()
-            .ancestors()
-            .find_map(JsTemplateExpression::cast)?;
-
-        if !is_plausible_embed_template(&template)? {
-            return None;
-        }
-
-        Some(node.template_chunk_token().ok()?.text_range())
+        embedded_template_chunk_range(&AnyTemplateChunkElement::from(node.clone()), f)
     }
+}
+
+pub(crate) fn embedded_template_chunk_range(
+    node: &AnyTemplateChunkElement,
+    f: &mut JsFormatter,
+) -> Option<TextRange> {
+    if !f.context().should_delegate_fmt_embedded_nodes() {
+        return None;
+    }
+
+    // Only mark template chunks that belong to a plausible embed candidate.
+    // A template is a candidate when it has a tag (e.g. css``, gql``, styled.div``)
+    // or is an argument to a simple call expression (e.g. graphql(`...`)).
+    // Plain templates like console.log(`test`) must NOT be marked, otherwise
+    // the formatter emits StartEmbedded/EndEmbedded tags that never get resolved
+    // and corrupt the printer's tag stack.
+    let template = node
+        .syntax()
+        .ancestors()
+        .find_map(JsTemplateExpression::cast)?;
+
+    if !is_plausible_embed_template(&template)? {
+        return None;
+    }
+
+    let range = node.template_chunk_token().ok()?.text_range();
+
+    Some(
+        f.context()
+            .source_map()
+            .map_or(range, |source_map| source_map.source_range(range)),
+    )
 }
 
 /// Known identifier tag names that produce embedded languages.

--- a/crates/biome_js_formatter/src/ts/auxiliary/template_chunk_element.rs
+++ b/crates/biome_js_formatter/src/ts/auxiliary/template_chunk_element.rs
@@ -1,7 +1,10 @@
 use crate::prelude::*;
 
-use crate::js::auxiliary::template_chunk_element::AnyTemplateChunkElement;
+use crate::js::auxiliary::template_chunk_element::{
+    AnyTemplateChunkElement, embedded_template_chunk_range,
+};
 use biome_js_syntax::TsTemplateChunkElement;
+use biome_text_size::TextRange;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsTemplateChunkElement;
@@ -13,5 +16,13 @@ impl FormatNodeRule<TsTemplateChunkElement> for FormatTsTemplateChunkElement {
         formatter: &mut JsFormatter,
     ) -> FormatResult<()> {
         AnyTemplateChunkElement::from(node.clone()).fmt(formatter)
+    }
+
+    fn embedded_node_range(
+        &self,
+        node: &TsTemplateChunkElement,
+        f: &mut JsFormatter,
+    ) -> Option<TextRange> {
+        embedded_template_chunk_range(&AnyTemplateChunkElement::from(node.clone()), f)
     }
 }

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -794,6 +794,87 @@ const Baz = graphql`
 }
 
 #[test]
+fn issue_9484() {
+    const FILE_PATH: &str = "/project/file.tsx";
+    const FILE_CONTENT: &str = r#"import { graphql, useLazyLoadQuery } from "react-relay";
+
+export const Page = () => {
+  return (<div></div>);
+};
+
+const Table = () => {
+  const query = useLazyLoadQuery(graphql`
+      query Q {
+        field
+      }
+    `, {});
+  return <div></div>;
+};
+"#;
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from(FILE_PATH), FILE_CONTENT);
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            workspace_directory: None,
+            configuration: Configuration {
+                formatter: Some(FormatterConfiguration {
+                    indent_style: Some(IndentStyle::Space),
+                    ..Default::default()
+                }),
+                javascript: Some(JsConfiguration {
+                    experimental_embedded_snippets_enabled: Some(true.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            extended_configurations: vec![],
+            module_graph_resolution_kind: ModuleGraphResolutionKind::None,
+        })
+        .unwrap();
+
+    workspace
+        .open_file(OpenFileParams {
+            project_key,
+            path: BiomePath::new(FILE_PATH),
+            content: FileContent::FromServer,
+            document_file_source: None,
+            persist_node_cache: false,
+            inline_config: None,
+        })
+        .unwrap();
+
+    let result = workspace
+        .format_file(FormatFileParams {
+            project_key,
+            path: Utf8PathBuf::from(FILE_PATH).into(),
+            inline_config: None,
+        })
+        .unwrap();
+
+    insta::assert_snapshot!(result.as_code(), @r#"
+    import { graphql, useLazyLoadQuery } from "react-relay";
+
+    export const Page = () => {
+      return <div></div>;
+    };
+
+    const Table = () => {
+      const query = useLazyLoadQuery(graphql`
+        query Q {
+          field
+        }
+      `, {});
+      return <div></div>;
+    };
+    "#);
+}
+
+#[test]
 fn issue_9131() {
     const FILE_PATH: &str = "/project/file.js";
     const FILE_CONTENT: &str = r#"


### PR DESCRIPTION
## Summary
- map embedded template chunk ranges back through formatter source maps before the embedded snippet lookup
- share the range logic between JS and TS template chunk formatters so TSX rewritten nodes resolve correctly
- add a regression test for the `react-relay` TSX case from #9484

## Testing
- rustfmt --check crates/biome_js_formatter/src/js/auxiliary/template_chunk_element.rs crates/biome_js_formatter/src/ts/auxiliary/template_chunk_element.rs crates/biome_service/src/workspace/server.tests.rs
- cargo test -j 1 -p biome_service issue_9484 -- --nocapture *(blocked intermittently on this machine by shared Cargo cache lock contention and disk pressure during dependency builds)*

Supersedes #9636, whose head branch accumulated unrelated changes.
Closes #9484.