### PR TITLE
fix(useNamingConvention): honor affixes for custom formats

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -815,6 +815,16 @@ impl Rule for UseNamingConvention {
                 }
             }
             if !convention.formats.is_empty() {
+                if is_not_trimmed {
+                    let (prefix_len, trimmed_name) = trim_underscore_dollar(name);
+                    name_range_start += prefix_len;
+                    name = trimmed_name;
+                    is_not_trimmed = false;
+                }
+                if name.is_empty() {
+                    // Empty strings are always valid.
+                    return None;
+                }
                 let actual_case = Case::identify(name, options.strict_case());
                 if (*convention.formats | Case::Uni).contains(actual_case) {
                     // Valid case

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validCustomStyleDestructuredRename.js
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validCustomStyleDestructuredRename.js
@@ -1,0 +1,16 @@
+/* should not generate diagnostics */
+const values = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4,
+};
+
+const {
+    a: _snake_case,
+    b: snake_case_,
+    c: $snake_case,
+    d: snake_case$,
+} = values;
+
+console.log(_snake_case, snake_case_, $snake_case, snake_case$);

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validCustomStyleDestructuredRename.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validCustomStyleDestructuredRename.js.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validCustomStyleDestructuredRename.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+const values = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4,
+};
+
+const {
+    a: _snake_case,
+    b: snake_case_,
+    c: $snake_case,
+    d: snake_case$,
+} = values;
+
+console.log(_snake_case, snake_case_, $snake_case, snake_case$);
+```

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validCustomStyleDestructuredRename.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validCustomStyleDestructuredRename.options.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"style": {
+				"useNamingConvention": {
+					"level": "error",
+					"options": {
+						"conventions": [
+							{
+								"selector": {
+									"kind": "any"
+								},
+								"formats": ["snake_case"]
+							}
+						]
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- trim leading and trailing `_` and `$` before applying custom `formats` conventions
- keep regex-based custom matching behavior unchanged unless the convention still relies on the untrimmed name
- add a regression spec for destructuring renames like `_snake_case` and `snake_case$`

## Testing
- cargo test -p biome_js_analyze --test spec_tests use_naming_convention -- --exact *(blocked by shared Cargo package-cache lock contention on this machine)*

Fixes #8953.