### PR TITLE
fix: handle quoted > in legacy script fences

### DIFF
--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -24,7 +24,10 @@ pub struct SvelteFileHandler;
 
 // https://regex101.com/r/E4n4hh/6
 pub static SVELTE_FENCE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?ixs)(?<opening><script(?:\s.*?)?>)\r?\n?(?<script>(?U:.*))</script>"#).unwrap()
+    Regex::new(
+        r#"(?ixs)(?<opening><script\b(?:\s+(?:"[^"]*"|'[^']*'|[^'">])*)?\s*>)\r?\n?(?<script>(?U:.*))</script>"#,
+    )
+    .unwrap()
 });
 
 impl SvelteFileHandler {

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -24,7 +24,10 @@ pub struct VueFileHandler;
 
 // https://regex101.com/r/E4n4hh/6
 pub static VUE_FENCE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?ixs)(?<opening><script(?:\s.*?)?>)\r?\n(?<script>(?U:.*))</script>"#).unwrap()
+    Regex::new(
+        r#"(?ixs)(?<opening><script\b(?:\s+(?:"[^"]*"|'[^']*'|[^'">])*)?\s*>)\r?\n(?<script>(?U:.*))</script>"#,
+    )
+    .unwrap()
 });
 
 impl VueFileHandler {


### PR DESCRIPTION
## Summary
- fix the legacy Svelte `<script>` fence regex so quoted `>` inside attributes does not terminate the opening tag early
- apply the same quoted-attribute handling to the matching Vue legacy fence for consistency
- keep the existing newline behavior of each handler intact while only tightening the opening-tag capture

## Validation
- reproduced the old regex behavior locally against the issue shape and confirmed it captured the script body starting with `">`
- validated the new regex against Svelte and Vue-shaped `<script ...>` tags with quoted generic attributes and confirmed the full opening tag stays in the `opening` capture