### PR TITLE
chore(deps): update rust crate rustc-hash to 2.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
  "enumflags2",
  "indexmap",
  "insta",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
 ]
@@ -223,7 +223,7 @@ dependencies = [
  "quick-junit",
  "rayon",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "serial_test",
@@ -266,7 +266,7 @@ dependencies = [
  "insta",
  "mimalloc",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "tests_macros",
@@ -313,7 +313,7 @@ name = "biome_control_flow"
 version = "0.5.7"
 dependencies = [
  "biome_rowan",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -344,7 +344,7 @@ dependencies = [
  "mimalloc",
  "phf 0.13.1",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "tests_macros",
@@ -423,7 +423,7 @@ dependencies = [
  "biome_formatter",
  "biome_rowan",
  "biome_string_case",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ dependencies = [
  "drop_bomb",
  "indexmap",
  "insta",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "unicode-width 0.1.12",
@@ -577,7 +577,7 @@ dependencies = [
  "parking_lot",
  "path-absolutize",
  "rayon",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "serde_json",
@@ -619,7 +619,7 @@ dependencies = [
  "filetime",
  "insta",
  "jiff",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "tests_macros",
@@ -690,7 +690,7 @@ dependencies = [
  "biome_graphql_parser",
  "biome_graphql_syntax",
  "biome_rowan",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ dependencies = [
  "path-absolutize",
  "rand 0.8.5",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "serde_json",
@@ -955,7 +955,7 @@ dependencies = [
  "mimalloc",
  "regex",
  "roaring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "smallvec",
@@ -1033,7 +1033,7 @@ dependencies = [
  "mimalloc",
  "quickcheck",
  "quickcheck_macros",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "serde_json",
@@ -1053,7 +1053,7 @@ dependencies = [
  "biome_text_size",
  "boa_engine",
  "camino",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -1067,7 +1067,7 @@ dependencies = [
  "biome_js_syntax",
  "biome_rowan",
  "rust-lapper",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "smallvec",
 ]
 
@@ -1120,7 +1120,7 @@ dependencies = [
  "camino",
  "hashbrown 0.15.5",
  "insta",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -1169,7 +1169,7 @@ dependencies = [
  "filetime",
  "insta",
  "mimalloc",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "tests_macros",
  "tikv-jemallocator",
 ]
@@ -1257,7 +1257,7 @@ dependencies = [
  "biome_json_syntax",
  "biome_rowan",
  "indexmap",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "static_assertions",
 ]
 
@@ -1266,7 +1266,7 @@ name = "biome_line_index"
 version = "0.1.0"
 dependencies = [
  "biome_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -1291,7 +1291,7 @@ dependencies = [
  "crossbeam",
  "futures",
  "papaya",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "tokio",
@@ -1308,7 +1308,7 @@ dependencies = [
  "anyhow",
  "biome_line_index",
  "biome_text_size",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "tower",
  "tower-lsp-server",
 ]
@@ -1407,7 +1407,7 @@ dependencies = [
  "biome_test_utils",
  "camino",
  "insta",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "tests_macros",
 ]
 
@@ -1443,7 +1443,7 @@ dependencies = [
  "mimalloc",
  "once_cell",
  "papaya",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "serde_json",
@@ -1472,7 +1472,7 @@ dependencies = [
  "indexmap",
  "insta",
  "mimalloc",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "static_assertions",
  "tests_macros",
@@ -1520,7 +1520,7 @@ dependencies = [
  "insta",
  "libc",
  "papaya",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "windows 0.62.2",
@@ -1535,7 +1535,7 @@ dependencies = [
  "biome_rowan",
  "camino",
  "papaya",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -1562,7 +1562,7 @@ dependencies = [
  "iai",
  "quickcheck",
  "quickcheck_macros",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "serde_json",
@@ -1584,7 +1584,7 @@ dependencies = [
  "camino",
  "enumflags2",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "serde_json",
@@ -1676,7 +1676,7 @@ dependencies = [
  "papaya",
  "rayon",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "serde_json",
@@ -1927,7 +1927,7 @@ dependencies = [
  "boa_string",
  "indexmap",
  "num-bigint",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -1968,7 +1968,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.2",
  "regress",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "ryu-js",
  "serde",
  "serde_json",
@@ -2006,7 +2006,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "phf 0.13.1",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "static_assertions",
 ]
 
@@ -2039,7 +2039,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "regress",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -2051,7 +2051,7 @@ dependencies = [
  "fast-float2",
  "itoa",
  "paste",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "ryu-js",
  "static_assertions",
 ]
@@ -4801,9 +4801,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ quote                        = "1.0.45"
 rayon                        = "1.11.0"
 regex                        = "1.12.3"
 rust-lapper                  = "1.2.0"
-rustc-hash                   = "2.1.1"
+rustc-hash                   = "2.1.2"
 schemars                     = { version = "1.2.1", features = ["indexmap2", "smallvec1"] }
 serde                        = { version = "1.0.228", features = ["derive"] }
 serde_json                   = "1.0.149"


### PR DESCRIPTION
## Summary
- update the workspace `rustc-hash` dependency from `2.1.1` to `2.1.2`
- refresh `Cargo.lock` to the new checksum and resolved version

## Testing
- `cargo metadata --locked --format-version 1`
- `cargo tree --locked -p rustc-hash@2.1.2`
- `cargo check --locked -p biome_cli` (attempted multiple times, but this shared runner kept hitting cargo package-cache contention before completion)

Part of #2188.