### PR TITLE
fix(linter): enable useOptionalChain in Astro templates

### DIFF
--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -75,6 +75,12 @@ const title = "My Page";
 </body>
 </html>"#;
 
+const ASTRO_FILE_USE_OPTIONAL_CHAIN_TEMPLATE_BEFORE: &str = r#"---
+const post = { author: { name: "Biome" } };
+const authorName = post && post.author && post.author.name;
+---
+<p>{post && post.author && post.author.name}</p>"#;
+
 #[test]
 fn format_astro_files() {
     let fs = MemoryFileSystem::default();
@@ -285,6 +291,49 @@ schema + sure()
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "full_support",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn check_astro_template_use_optional_chain_write_unsafe() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{ "html": { "linter": {"enabled": true}, "experimentalFullSupportEnabled": true } }"#
+            .as_bytes(),
+    );
+
+    let astro_file_path = Utf8Path::new("file.astro");
+    fs.insert(
+        astro_file_path.into(),
+        ASTRO_FILE_USE_OPTIONAL_CHAIN_TEMPLATE_BEFORE.as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "check",
+                "--write",
+                "--unsafe",
+                "--only=complexity/useOptionalChain",
+                astro_file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "check_astro_template_use_optional_chain_write_unsafe",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/check_astro_template_use_optional_chain_write_unsafe.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/check_astro_template_use_optional_chain_write_unsafe.snap
@@ -1,0 +1,30 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "linter": { "enabled": true },
+    "experimentalFullSupportEnabled": true
+  }
+}
+```
+
+## `file.astro`
+
+```astro
+---
+const post = { author: { name: "Biome" } };
+const authorName = post?.author?.name;
+---
+<p>{post?.author?.name}</p>
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -1233,10 +1233,13 @@ fn parse_matched_embed(
                 content.content_offset,
             );
 
-            // Source-level embeds get full services; expression-level don't
-            let js_services = if is_source_level
-                && (ctx.settings.as_ref().is_linter_enabled()
-                    || ctx.settings.as_ref().is_assist_enabled())
+            let should_build_semantic_model = ctx.settings.as_ref().is_linter_enabled()
+                || ctx.settings.as_ref().is_assist_enabled();
+
+            // Astro template expressions need semantic services for JS rules such as
+            // `useOptionalChain`, even though they aren't source-level snippets.
+            let js_services = if should_build_semantic_model
+                && (is_source_level || ctx.host_file_source.is_astro())
             {
                 JsDocumentServices::default()
                     .with_js_semantic_model(&snippet.tree())


### PR DESCRIPTION
## Summary
- enable JS semantic services for non-frontmatter Astro embeds so semantic rules can run in template expressions
- cover useOptionalChain with an Astro check --write --unsafe CLI regression

Closes #9179.

## Testing
- ustfmt --check crates/biome_service/src/file_handlers/html.rs crates/biome_cli/tests/cases/handle_astro_files.rs
- cargo test -p biome_cli -j1 check_astro_template_use_optional_chain_write_unsafe -- --nocapture *(shared Windows cargo environment was too noisy to complete cleanly from this worker; added the regression snapshot directly based on the standard CLI snapshot format)*