### PR TITLE
fix(lint): flag bound hook calls in non-hook arrow functions

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
@@ -100,14 +100,14 @@ impl AnyJsFunctionOrMethod {
         false
     }
 
-    fn is_function_expression(&self) -> bool {
+    fn is_unbound_function_expression(&self) -> bool {
         matches!(
             self,
             Self::AnyJsFunction(
                 AnyJsFunction::JsArrowFunctionExpression(_)
                     | AnyJsFunction::JsFunctionExpression(_)
             )
-        )
+        ) && self.name().is_none()
     }
 
     fn name(&self) -> Option<Text> {
@@ -590,7 +590,7 @@ impl Rule for UseHookAtTopLevel {
         }
 
         if enclosing_function_if_call_is_at_top_level(call).is_some_and(|function| {
-            !function.is_react_component_or_hook() && !function.is_function_expression()
+            !function.is_react_component_or_hook() && !function.is_unbound_function_expression()
         }) {
             return Some(Suggestion {
                 hook_name_range: get_hook_name_range()?,

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js
@@ -190,3 +190,7 @@ function useRecursiveHookA() {
 function useRecursiveHookB() {
     useRecursiveHookA();
 }
+
+const clearlyNotAHookOrComponent = () => {
+    useEffect();
+};

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js.snap
@@ -197,6 +197,10 @@ function useRecursiveHookB() {
     useRecursiveHookA();
 }
 
+const clearlyNotAHookOrComponent = () => {
+    useEffect();
+};
+
 ```
 
 _Note: The parser emitted 3 diagnostics which are not shown here._
@@ -914,5 +918,21 @@ invalid.js:191:5 lint/correctness/useHookAtTopLevel ━━━━━━━━━�
   
   i See https://react.dev/reference/rules/rules-of-hooks
   
+
+```
+```
+invalid.js:196:5 lint/correctness/useHookAtTopLevel ââââââââââââââââââââââââââââââââââââââââââââ
+
+  Ã This hook is being called from within a function or method that is not a hook or component.
+
+    195 â const clearlyNotAHookOrComponent = () => {
+  > 196 â     useEffect();
+      â     ^^^^^^^^^
+    197 â };
+
+  i Move the hook call into the top level of a hook or component in order to use it.
+
+  i See https://react.dev/reference/rules/rules-of-hooks
+
 
 ```


### PR DESCRIPTION
## Summary
- stop exempting bound arrow/function expressions from useHookAtTopLevel
- keep the inline callback carve-out by only skipping unbound function expressions
- add a regression case for const clearlyNotAHookOrComponent = () => { useEffect(); }

Closes #9556.

## Testing
- attempted cargo test -p biome_js_analyze --test spec_tests useHookAtTopLevel -- --list
- attempted cargo check -p biome_js_analyze --lib
- full Cargo validation was blocked on this worker by C: disk pressure and Windows paging/linker failures during dependency builds