### PR TITLE
feat(formatter): add delimiterSpacing option

### DIFF
--- a/.changeset/delimiter-spacing-option.md
+++ b/.changeset/delimiter-spacing-option.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added the `delimiterSpacing` formatter option. This option inserts spaces inside delimiters (after the opening delimiter and before the closing delimiter) when the content fits on a single line. Empty delimiters are not affected, and no space is added before the opening delimiter. The specific delimiters affected depend on the language. It can be configured globally via `formatter.delimiterSpacing` or per-language via `javascript.formatter.delimiterSpacing`, `json.formatter.delimiterSpacing`, and `css.formatter.delimiterSpacing`. Defaults to false.

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -235,6 +235,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::Configuration {
             bracket_same_line: Some(value.bracket_line.into()),
             attribute_position: Some(AttributePosition::default()),
             bracket_spacing: Some(BracketSpacing::default()),
+            delimiter_spacing: None,
             expand: Some(value.object_wrap.into()),
             format_with_errors: Some(false.into()),
             includes: None,

--- a/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
@@ -46,6 +46,13 @@ The configuration that is contained inside the file `biome.json`
                               apply to self closing elements).
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
+        --delimiter-spacing=<true|false>  Whether to insert spaces inside delimiters (after the
+                              opening delimiter and before the closing delimiter), such as
+                              parentheses, brackets, angle brackets, and template literal
+                              interpolations. Spaces are not added before the opening delimiter, and
+                              empty delimiters are not affected. Only applies when the content fits
+                              on a single line. The specific delimiters affected depend on the
+                              language. Defaults to false.
         --expand=<auto|always|never>  Whether to expand arrays and objects on multiple lines. When
                               set to `auto`, object literals are formatted on multiple lines if the
                               first property has a newline, and array literals are formatted on a

--- a/crates/biome_cli/tests/snapshots/main_cases_help/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/ci_help.snap
@@ -47,6 +47,13 @@ The configuration that is contained inside the file `biome.json`
                               apply to self closing elements).
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
+        --delimiter-spacing=<true|false>  Whether to insert spaces inside delimiters (after the
+                              opening delimiter and before the closing delimiter), such as
+                              parentheses, brackets, angle brackets, and template literal
+                              interpolations. Spaces are not added before the opening delimiter, and
+                              empty delimiters are not affected. Only applies when the content fits
+                              on a single line. The specific delimiters affected depend on the
+                              language. Defaults to false.
         --expand=<auto|always|never>  Whether to expand arrays and objects on multiple lines. When
                               set to `auto`, object literals are formatted on multiple lines if the
                               first property has a newline, and array literals are formatted on a

--- a/crates/biome_cli/tests/snapshots/main_cases_help/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/format_help.snap
@@ -23,6 +23,13 @@ Generic options applied to all files
                               apply to self closing elements).
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
+        --delimiter-spacing=<true|false>  Whether to insert spaces inside delimiters (after the
+                              opening delimiter and before the closing delimiter), such as
+                              parentheses, brackets, angle brackets, and template literal
+                              interpolations. Spaces are not added before the opening delimiter, and
+                              empty delimiters are not affected. Only applies when the content fits
+                              on a single line. The specific delimiters affected depend on the
+                              language. Defaults to false.
         --expand=<auto|always|never>  Whether to expand arrays and objects on multiple lines. When
                               set to `auto`, object literals are formatted on multiple lines if the
                               first property has a newline, and array literals are formatted on a

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -1,8 +1,8 @@
 use crate::bool::Bool;
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::{
-    AttributePosition, BracketSameLine, BracketSpacing, Expand, IndentStyle, IndentWidth,
-    LineEnding, LineWidth, TrailingNewline,
+    AttributePosition, BracketSameLine, BracketSpacing, DelimiterSpacing, Expand, IndentStyle,
+    IndentWidth, LineEnding, LineWidth, TrailingNewline,
 };
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
@@ -63,6 +63,15 @@ pub struct FormatterConfiguration {
     #[bpaf(long("bracket-spacing"), argument("true|false"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_spacing: Option<BracketSpacing>,
+
+    /// Whether to insert spaces inside delimiters (after the opening delimiter and before the
+    /// closing delimiter), such as parentheses, brackets, angle brackets, and template literal
+    /// interpolations. Spaces are not added before the opening delimiter, and empty delimiters
+    /// are not affected. Only applies when the content fits on a single line. The specific
+    /// delimiters affected depend on the language. Defaults to false.
+    #[bpaf(long("delimiter-spacing"), argument("true|false"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delimiter_spacing: Option<DelimiterSpacing>,
 
     /// Whether to expand arrays and objects on multiple lines.
     /// When set to `auto`, object literals are formatted on multiple lines if the first property has a newline,
@@ -134,6 +143,10 @@ impl FormatterConfiguration {
 
     pub fn bracket_spacing_resolved(&self) -> BracketSpacing {
         self.bracket_spacing.unwrap_or_default()
+    }
+
+    pub fn delimiter_spacing_resolved(&self) -> DelimiterSpacing {
+        self.delimiter_spacing.unwrap_or_default()
     }
 
     pub fn expand_resolved(&self) -> Expand {

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::{
-    AttributePosition, BracketSameLine, BracketSpacing, Expand, IndentStyle, IndentWidth,
-    LineEnding, LineWidth, TrailingNewline,
+    AttributePosition, BracketSameLine, BracketSpacing, DelimiterSpacing, Expand, IndentStyle,
+    IndentWidth, LineEnding, LineWidth, TrailingNewline,
 };
 use biome_plugin_loader::Plugins;
 use bpaf::Bpaf;
@@ -164,6 +164,15 @@ pub struct OverrideFormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(long("bracket-spacing"), argument("true|false"))]
     pub bracket_spacing: Option<BracketSpacing>,
+
+    /// Whether to insert spaces inside delimiters (after the opening delimiter and before the
+    /// closing delimiter), such as parentheses, brackets, angle brackets, and template literal
+    /// interpolations. Spaces are not added before the opening delimiter, and empty delimiters
+    /// are not affected. Only applies when the content fits on a single line. The specific
+    /// delimiters affected depend on the language. Defaults to false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[bpaf(long("delimiter-spacing"), argument("true|false"))]
+    pub delimiter_spacing: Option<DelimiterSpacing>,
 
     /// Whether to expand arrays and objects on multiple lines.
     /// When set to `auto`, object literals are formatted on multiple lines if the first property has a newline,

--- a/crates/biome_configuration/tests/invalid/formatter_extraneous_field.json.snap
+++ b/crates/biome_configuration/tests/invalid/formatter_extraneous_field.json.snap
@@ -24,6 +24,7 @@ formatter_extraneous_field.json:3:3 deserialize ━━━━━━━━━━�
   - attributePosition
   - bracketSameLine
   - bracketSpacing
+  - delimiterSpacing
   - expand
   - trailingNewline
   - useEditorconfig

--- a/crates/biome_configuration/tests/invalid/formatter_quote_style.json.snap
+++ b/crates/biome_configuration/tests/invalid/formatter_quote_style.json.snap
@@ -24,6 +24,7 @@ formatter_quote_style.json:3:9 deserialize ━━━━━━━━━━━━�
   - attributePosition
   - bracketSameLine
   - bracketSpacing
+  - delimiterSpacing
   - expand
   - trailingNewline
   - useEditorconfig

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -711,6 +711,60 @@ impl FromStr for BracketSpacing {
     }
 }
 
+/// Whether to insert spaces inside delimiters (after the opening delimiter and before the closing
+/// delimiter), such as parentheses, brackets, angle brackets, and template literal interpolations.
+/// Spaces are not added before the opening delimiter, and empty delimiters are not affected.
+/// Only applies when the content fits on a single line; when content breaks across multiple lines,
+/// no extra spaces are added. The specific delimiters affected depend on the language.
+#[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DelimiterSpacing(bool);
+
+impl DelimiterSpacing {
+    /// Return the boolean value for this [DelimiterSpacing]
+    pub fn value(&self) -> bool {
+        self.0
+    }
+}
+
+impl From<bool> for DelimiterSpacing {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for DelimiterSpacing {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "{:?}", self.value())
+    }
+}
+
+impl biome_console::fmt::Display for DelimiterSpacing {
+    fn fmt(&self, fmt: &mut biome_console::fmt::Formatter) -> std::io::Result<()> {
+        fmt.write_str(&self.0.to_string())
+    }
+}
+
+impl FromStr for DelimiterSpacing {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = bool::from_str(s);
+
+        match value {
+            Ok(value) => Ok(Self(value)),
+            Err(_) => Err(
+                "Value not supported for DelimiterSpacing. Supported values are 'true' and 'false'.",
+            ),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -23,8 +23,8 @@ use biome_css_parser::{CssModulesKind, CssParserOptions};
 use biome_css_syntax::CssLanguage;
 use biome_deserialize::Merge;
 use biome_formatter::{
-    AttributePosition, BracketSameLine, BracketSpacing, Expand, IndentStyle, IndentWidth,
-    LineEnding, LineWidth, TrailingNewline,
+    AttributePosition, BracketSameLine, BracketSpacing, DelimiterSpacing, Expand, IndentStyle,
+    IndentWidth, LineEnding, LineWidth, TrailingNewline,
 };
 use biome_fs::BiomePath;
 use biome_graphql_formatter::context::GraphqlFormatOptions;
@@ -554,6 +554,7 @@ pub struct FormatSettings {
     pub attribute_position: Option<AttributePosition>,
     pub bracket_same_line: Option<BracketSameLine>,
     pub bracket_spacing: Option<BracketSpacing>,
+    pub delimiter_spacing: Option<DelimiterSpacing>,
     pub trailing_newline: Option<TrailingNewline>,
     pub expand: Option<Expand>,
     /// List of included paths/files
@@ -579,6 +580,7 @@ pub struct OverrideFormatSettings {
     pub line_ending: Option<LineEnding>,
     pub line_width: Option<LineWidth>,
     pub bracket_spacing: Option<BracketSpacing>,
+    pub delimiter_spacing: Option<DelimiterSpacing>,
     pub bracket_same_line: Option<BracketSameLine>,
     pub attribute_position: Option<AttributePosition>,
     pub expand: Option<Expand>,
@@ -595,6 +597,7 @@ impl From<OverrideFormatterConfiguration> for OverrideFormatSettings {
             line_ending: conf.line_ending,
             line_width: conf.line_width,
             bracket_spacing: conf.bracket_spacing,
+            delimiter_spacing: conf.delimiter_spacing,
             bracket_same_line: conf.bracket_same_line,
             attribute_position: conf.attribute_position,
             expand: conf.expand,
@@ -1924,6 +1927,7 @@ pub fn to_override_settings(
                 line_ending: formatter.line_ending,
                 line_width: formatter.line_width,
                 bracket_spacing: formatter.bracket_spacing,
+                delimiter_spacing: formatter.delimiter_spacing,
                 bracket_same_line: formatter.bracket_same_line,
                 attribute_position: formatter.attribute_position,
                 expand: formatter.expand,
@@ -2129,6 +2133,7 @@ pub fn to_format_settings(
         attribute_position: conf.attribute_position,
         bracket_same_line: conf.bracket_same_line,
         bracket_spacing: conf.bracket_spacing,
+        delimiter_spacing: conf.delimiter_spacing,
         expand: conf.expand,
         trailing_newline: conf.trailing_newline,
         includes: Includes::new(working_directory, conf.includes),
@@ -2155,6 +2160,7 @@ impl TryFrom<OverrideFormatterConfiguration> for FormatSettings {
             attribute_position: Some(AttributePosition::default()),
             bracket_same_line: conf.bracket_same_line,
             bracket_spacing: Some(BracketSpacing::default()),
+            delimiter_spacing: conf.delimiter_spacing,
             expand: conf.expand,
             format_with_errors: conf.format_with_errors,
             trailing_newline: conf.trailing_newline,

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -176,6 +176,14 @@ export interface FormatterConfiguration {
 	 * Whether to insert spaces around brackets in object literals. Defaults to true.
 	 */
 	bracketSpacing?: BracketSpacing;
+	/**
+	* Whether to insert spaces inside delimiters (after the opening delimiter and before the
+closing delimiter), such as parentheses, brackets, angle brackets, and template literal
+interpolations. Spaces are not added before the opening delimiter, and empty delimiters
+are not affected. Only applies when the content fits on a single line. The specific
+delimiters affected depend on the language. Defaults to false. 
+	 */
+	delimiterSpacing?: DelimiterSpacing;
 	enabled?: Bool;
 	/**
 	* Whether to expand arrays and objects on multiple lines.
@@ -491,6 +499,14 @@ export type AttributePosition = "auto" | "multiline";
  */
 export type BracketSameLine = boolean;
 export type BracketSpacing = boolean;
+/**
+	* Whether to insert spaces inside delimiters (after the opening delimiter and before the closing
+delimiter), such as parentheses, brackets, angle brackets, and template literal interpolations.
+Spaces are not added before the opening delimiter, and empty delimiters are not affected.
+Only applies when the content fits on a single line; when content breaks across multiple lines,
+no extra spaces are added. The specific delimiters affected depend on the language. 
+	 */
+export type DelimiterSpacing = boolean;
 export type Expand = "auto" | "always" | "never";
 export type IndentStyle = "tab" | "space";
 export type IndentWidth = number;
@@ -1141,6 +1157,14 @@ export interface OverrideFormatterConfiguration {
 	 * Whether to insert spaces around brackets in object literals. Defaults to true.
 	 */
 	bracketSpacing?: BracketSpacing;
+	/**
+	* Whether to insert spaces inside delimiters (after the opening delimiter and before the
+closing delimiter), such as parentheses, brackets, angle brackets, and template literal
+interpolations. Spaces are not added before the opening delimiter, and empty delimiters
+are not affected. Only applies when the content fits on a single line. The specific
+delimiters affected depend on the language. Defaults to false. 
+	 */
+	delimiterSpacing?: DelimiterSpacing;
 	enabled?: Bool;
 	/**
 	* Whether to expand arrays and objects on multiple lines.

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1533,6 +1533,10 @@
 				}
 			]
 		},
+		"DelimiterSpacing": {
+			"description": "Whether to insert spaces inside delimiters (after the opening delimiter and before the closing\ndelimiter), such as parentheses, brackets, angle brackets, and template literal interpolations.\nSpaces are not added before the opening delimiter, and empty delimiters are not affected.\nOnly applies when the content fits on a single line; when content breaks across multiple lines,\nno extra spaces are added. The specific delimiters affected depend on the language.",
+			"type": "boolean"
+		},
 		"DependencyAvailability": {
 			"oneOf": [
 				{
@@ -1669,6 +1673,10 @@
 				"bracketSpacing": {
 					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
 					"anyOf": [{ "$ref": "#/$defs/BracketSpacing" }, { "type": "null" }]
+				},
+				"delimiterSpacing": {
+					"description": "Whether to insert spaces inside delimiters (after the opening delimiter and before the\nclosing delimiter), such as parentheses, brackets, angle brackets, and template literal\ninterpolations. Spaces are not added before the opening delimiter, and empty delimiters\nare not affected. Only applies when the content fits on a single line. The specific\ndelimiters affected depend on the language. Defaults to false.",
+					"anyOf": [{ "$ref": "#/$defs/DelimiterSpacing" }, { "type": "null" }]
 				},
 				"enabled": {
 					"anyOf": [{ "$ref": "#/$defs/Bool" }, { "type": "null" }]
@@ -6834,6 +6842,10 @@
 				"bracketSpacing": {
 					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
 					"anyOf": [{ "$ref": "#/$defs/BracketSpacing" }, { "type": "null" }]
+				},
+				"delimiterSpacing": {
+					"description": "Whether to insert spaces inside delimiters (after the opening delimiter and before the\nclosing delimiter), such as parentheses, brackets, angle brackets, and template literal\ninterpolations. Spaces are not added before the opening delimiter, and empty delimiters\nare not affected. Only applies when the content fits on a single line. The specific\ndelimiters affected depend on the language. Defaults to false.",
+					"anyOf": [{ "$ref": "#/$defs/DelimiterSpacing" }, { "type": "null" }]
 				},
 				"enabled": {
 					"anyOf": [{ "$ref": "#/$defs/Bool" }, { "type": "null" }]


### PR DESCRIPTION
_Huge kudos to @orballo for doing most of the work in discovering which parts of the Biome formatter needed to be changed to add this option in his proof of concept: https://github.com/orballo/biome/pull/1_

## Summary

This PR adds the `delimiterSpacing` formatter option infrastructure. When enabled, it inserts spaces inside delimiters when the content fits on a single line. Empty delimiters are not affected, and no space is added before the opening delimiter. The specific delimiters affected depend on the language.

See https://github.com/biomejs/biome/discussions/2360#discussioncomment-10690814.

This PR includes only the shared infrastructure:

- The `DelimiterSpacing` type in `biome_formatter`
- Global configuration (`formatter.delimiterSpacing`)
- Overrides support
- Prettier migration compatibility
- CLI flag (`--delimiter-spacing`)
- Generated schema and bindings

Configuration example:

```json
{
  "formatter": {
    "delimiterSpacing": true
  }
}
```

The actual formatting behavior is implemented in follow-up PRs:

- #9719 (JS)
  - #9720 (JSX, depends on JS)
    - #9721 (TypeScript, depends on JSX)
- #9722 (CSS)
- #9723 (JSON)
- #9724 (ESLint migration)

## AI usage

As the [Gutenberg](https://github.com/wordpress/gutenberg) project is using a [non-official fork of Prettier](https://github.com/WordPress/gutenberg/blob/e2d8385f01f5995cf69bdfb40b8b4d9c8015eed0/package.json#L102), I ran [@orballo's Biome version](https://github.com/orballo/biome/pull/1) in the Gutenberg repository and used AI to extract all the tests and edge cases. Then AI assisted me in converting the changes made by @orballo's proof of concept to changes in the current formatter. AI also assisted in splitting the original PR into per-language PRs.

## Test Plan

- [x] Updated CLI help snapshots
- [x] Updated configuration validation snapshots

## Website PR (needs to be updated with latest documentation changes)

- https://github.com/biomejs/website/pull/3910