### PR TITLE
refactor(markdown): cleanup nits from #9746

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -96,7 +96,7 @@ fn compute_marker_indent(p: &MarkdownParser) -> usize {
         }
 
         // Virtual line start: compute actual column from source text.
-        // The leading whitespace was skipped as trivia, but we need the
+        // The leading whitespace was consumed as trivia, but we need the
         // real column for indented code block detection in nested lists.
         let source = p.source().source_text();
         let pos: usize = p.cur_range().start().into();

--- a/crates/biome_markdown_parser/src/syntax/quote.rs
+++ b/crates/biome_markdown_parser/src/syntax/quote.rs
@@ -86,11 +86,7 @@ pub(crate) fn parse_quote(p: &mut MarkdownParser) -> ParsedSyntax {
         // so they don't attach as Skipped trivia on normal content nodes.
         let bogus_m = p.start();
         p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-        if p.at(T![>]) {
-            p.bump(T![>]);
-        } else if p.at(MD_TEXTUAL_LITERAL) && p.cur_text() == ">" {
-            p.bump_remap(T![>]);
-        }
+        try_bump_quote_marker(p);
         let has_indented_code = at_quote_indented_code_start(p);
         emit_optional_marker_space(p, has_indented_code);
         return Present(bogus_m.complete(p, MD_BOGUS_BLOCK));

--- a/crates/biome_markdown_parser/src/to_html.rs
+++ b/crates/biome_markdown_parser/src/to_html.rs
@@ -1132,7 +1132,7 @@ fn header_level(header: &MdHeader) -> usize {
     // Count total hash characters in the before list.
     // The lexer emits all consecutive `#` chars as a single HASH token,
     // so we sum the text lengths of all hash tokens.
-    // Use text_trimmed() to exclude any leading trivia (skipped indentation spaces).
+    // Use text_trimmed() to exclude any leading trivia (indentation whitespace).
     header
         .before()
         .iter()
@@ -1303,7 +1303,7 @@ fn render_html_block(
 /// Render textual content.
 fn render_textual(text: &MdTextual, out: &mut String) {
     if let Ok(token) = text.value_token() {
-        // Use text_trimmed() to exclude skipped trivia (e.g., indentation stripped during parsing)
+        // Use text_trimmed() to exclude trivia (e.g., indentation stripped during parsing)
         let raw = token.text_trimmed();
         // Process backslash escapes and escape HTML
         let processed = process_escapes(raw);


### PR DESCRIPTION
> [!NOTE]
> This PR was created with AI assistance (Claude Code).

## Summary

Small follow-up to #9746.

- Use `try_bump_quote_marker` in the depth-overflow recovery path instead of duplicating the quote-marker consumption logic.
- Update three stale doc comments that referenced "skipped trivia" to reflect the current `Whitespace` trivia model.

## Test Plan

- `just test-crate biome_markdown_parser`

## Docs

N/A.