### PR TITLE
fix(markdown): replace panicking code with safe fallbacks in lexer

### DIFF
--- a/crates/biome_markdown_parser/src/lexer/mod.rs
+++ b/crates/biome_markdown_parser/src/lexer/mod.rs
@@ -785,7 +785,10 @@ impl<'src> MarkdownLexer<'src> {
                 b'*' => STAR,
                 b'_' => UNDERSCORE,
                 b'-' => MINUS,
-                _ => unreachable!(),
+                _ => {
+                    debug_assert!(false, "unexpected byte in emphasis marker");
+                    MD_TEXTUAL_LITERAL
+                }
             };
         }
 
@@ -796,7 +799,10 @@ impl<'src> MarkdownLexer<'src> {
             return match start_char {
                 b'*' => DOUBLE_STAR,
                 b'_' => DOUBLE_UNDERSCORE,
-                _ => unreachable!(),
+                _ => {
+                    debug_assert!(false, "unexpected byte in double emphasis marker");
+                    MD_TEXTUAL_LITERAL
+                }
             };
         }
 
@@ -806,7 +812,10 @@ impl<'src> MarkdownLexer<'src> {
             b'*' => STAR,
             b'_' => UNDERSCORE,
             b'-' => MINUS,
-            _ => unreachable!(),
+            _ => {
+                debug_assert!(false, "unexpected byte in single emphasis marker");
+                MD_TEXTUAL_LITERAL
+            }
         }
     }
 

--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -229,7 +229,7 @@ fn is_thematic_break_pattern(p: &mut MarkdownParser) -> bool {
     // Determine which character to check for
     let first_char = line.trim_start().chars().next();
     let break_char = match first_char {
-        Some('*' | '-' | '_') => first_char.unwrap(),
+        Some(c @ ('*' | '-' | '_')) => c,
         _ => return false,
     };
 


### PR DESCRIPTION
> [!NOTE]
> This PR was created with AI assistance (Claude Code).

## Summary

Replace `unreachable!()` and unnecessary `.unwrap()` in user-facing parser/lexer paths with safe fallbacks, per maintainer guidance on avoiding panicking code where user input flows.

- `list.rs`: bind matched char with `c @` pattern instead of `.unwrap()` on already-matched `Some` value.
- `lexer/mod.rs`: replace `unreachable!()` in three emphasis marker match arms with `debug_assert!` + `MD_TEXTUAL_LITERAL` fallback.

## Test Plan

- `just test-crate biome_markdown_parser` — all passed
- `just test-crate biome_markdown_formatter` — all passed
- `just test-markdown-conformance` — 652/652
- `just f`
- `just l`

## Docs

N/A.