### PR TITLE
fix(format/html): preserve block indentation if already present in some cases

### DIFF
--- a/.changeset/purple-grapes-leave.md
+++ b/.changeset/purple-grapes-leave.md
@@ -1,0 +1,21 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9099](https://github.com/biomejs/biome/issues/9099): the HTML formatter collapsing non-text children (inline elements, Svelte expressions, comments) onto a single line when the source had them on separate lines. Biome now preserves the user's intended line breaks for exclusively non-text children.
+
+For example, the following Svelte snippet is now preserved instead of being collapsed to `<div>{name}<!-- comment --></div>`:
+
+```svelte
+<div>
+  {name}<!-- comment -->
+</div>
+```
+
+Similarly, HTML elements like `<span>` inside a `<div>` are now preserved when written on their own line:
+
+```html
+<div>
+  <span>text</span>
+</div>
+```

--- a/.changeset/warm-roses-dream.md
+++ b/.changeset/warm-roses-dream.md
@@ -1,0 +1,16 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9450](https://github.com/biomejs/biome/issues/9450): the HTML formatter now correctly preserves multiline formatting for nested `<template>` elements (e.g. `<template #body>`) when the source has children on separate lines. Previously, the children were collapsed onto a single line.
+
+```diff
+ <template>
+   <UModal>
+-    <template #body> <p>content</p> </template>
++    <template #body>
++      <p>content</p>
++    </template>
+   </UModal>
+ </template>
+```

--- a/crates/biome_html_formatter/src/html/auxiliary/element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/element.rs
@@ -138,7 +138,6 @@ impl FormatHtmlElement {
             // third one is either `HtmlRoot` or another `HtmlElement`
             .nth(2)
             .is_some_and(|ancestor| HtmlRoot::can_cast(ancestor.kind()));
-        // If `<template>` is at the root level, force multiline formatting of its children.
         let is_template_element = get_tag_name_text(&tag_name)
             .is_some_and(|tt| tt.to_ascii_lowercase_cow() == "template");
 
@@ -175,8 +174,28 @@ impl FormatHtmlElement {
                 .ok()
                 .is_some_and(|tok| tok.has_leading_whitespace_or_newline());
 
-        let forces_break_children =
-            should_force_break_content || (is_root_element_list && is_template_element);
+        // Check if there is a newline between the opening tag and the first child.
+        // This is distinct from `content_has_leading_whitespace` which also matches spaces.
+        let content_has_leading_newline = opening_element
+            .r_angle_token()
+            .ok()
+            .is_some_and(|tok| tok.trailing_trivia().pieces().any(|p| p.is_newline()))
+            || children
+                .syntax()
+                .first_token()
+                .is_some_and(|tok| tok.leading_trivia().pieces().any(|p| p.is_newline()));
+
+        let forces_break_children = should_force_break_content
+            // If `<template>` is at the root level, always force multiline formatting of its children.
+            || (is_root_element_list && is_template_element)
+            // Nested `<template>` elements with a leading newline
+            // and direct element children should also force multiline, since `<template>` acts
+            // as a structural container in frameworks like Vue/Svelte.
+            // Without a leading newline (e.g. `<template #body><p>foo</p></template>`),
+            // the children stay inline.
+            || (is_template_element
+                && content_has_leading_newline
+                && has_non_text_child(&children));
 
         // "Borrowing" in this context refers to tokens in nodes that would normally be
         // formatted by that node's formatter, but are instead formatted by a sibling

--- a/crates/biome_html_formatter/src/html/auxiliary/opening_element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/opening_element.rs
@@ -4,7 +4,9 @@ use crate::{
     utils::{css_display::get_css_display_from_tag, metadata::should_lowercase_html_tag},
 };
 use biome_formatter::{FormatRuleWithOptions, GroupId, trivia::format_dangling_comments, write};
-use biome_html_syntax::{HtmlElement, HtmlOpeningElement, HtmlOpeningElementFields, HtmlSyntaxToken};
+use biome_html_syntax::{
+    HtmlElement, HtmlOpeningElement, HtmlOpeningElementFields, HtmlSyntaxToken,
+};
 use biome_rowan::AstNode;
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlOpeningElement {

--- a/crates/biome_html_formatter/src/html/auxiliary/opening_element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/opening_element.rs
@@ -3,8 +3,9 @@ use crate::{
     prelude::*,
     utils::{css_display::get_css_display_from_tag, metadata::should_lowercase_html_tag},
 };
-use biome_formatter::{FormatRuleWithOptions, GroupId, write};
-use biome_html_syntax::{HtmlOpeningElement, HtmlOpeningElementFields, HtmlSyntaxToken};
+use biome_formatter::{FormatRuleWithOptions, GroupId, trivia::format_dangling_comments, write};
+use biome_html_syntax::{HtmlElement, HtmlOpeningElement, HtmlOpeningElementFields, HtmlSyntaxToken};
+use biome_rowan::AstNode;
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlOpeningElement {
     /// Whether or not the r_angle is borrowed by the children of the element (aka [`HtmlElementList`][HtmlElementList]). See also: [`FormatHtmlElementList`][FormatHtmlElementList]
@@ -47,6 +48,35 @@ impl FormatRuleWithOptions<HtmlOpeningElement> for FormatHtmlOpeningElement {
 }
 
 impl FormatNodeRule<HtmlOpeningElement> for FormatHtmlOpeningElement {
+    fn fmt_dangling_comments(
+        &self,
+        node: &HtmlOpeningElement,
+        f: &mut HtmlFormatter,
+    ) -> FormatResult<()> {
+        if !f.comments().has_dangling_comments(node.syntax()) {
+            return Ok(());
+        }
+
+        // Check if the source had newlines around the dangling comments.
+        // If so, use hard_block_indent to preserve the multiline layout.
+        // This handles: <div>\n  <!-- comment -->\n</div>
+        let has_source_newline = node
+            .parent::<HtmlElement>()
+            .and_then(|el| el.closing_element().ok())
+            .and_then(|c| c.l_angle_token().ok())
+            .is_some_and(|tok| tok.has_leading_whitespace_or_newline());
+
+        if has_source_newline {
+            format_dangling_comments(node.syntax())
+                .with_block_indent()
+                .fmt(f)
+        } else {
+            format_dangling_comments(node.syntax())
+                .with_soft_block_indent()
+                .fmt(f)
+        }
+    }
+
     fn fmt_fields(&self, node: &HtmlOpeningElement, f: &mut HtmlFormatter) -> FormatResult<()> {
         let HtmlOpeningElementFields {
             l_angle_token,

--- a/crates/biome_html_formatter/src/html/lists/element_list.rs
+++ b/crates/biome_html_formatter/src/html/lists/element_list.rs
@@ -313,6 +313,13 @@ struct ChildrenMeta {
     /// `true` if children contains a block-like element
     has_block_element: bool,
 
+    /// `true` if children contains any non-text child (element, expression, etc.)
+    has_non_text_child: bool,
+
+    /// `true` if children contains text (Word) content
+    /// Comments are not included.
+    has_word: bool,
+
     /// `true` if there are multiple non-text children
     multiple_block_elements: bool,
 }
@@ -326,6 +333,7 @@ impl FormatHtmlElementList {
         for child in children {
             match child {
                 HtmlChild::NonText(element) => {
+                    meta.has_non_text_child = true;
                     // Check if this is a block element
                     let display = get_element_css_display(element);
                     if display.is_block_like() {
@@ -334,7 +342,14 @@ impl FormatHtmlElementList {
                     }
                 }
                 HtmlChild::Verbatim(_) => {
+                    meta.has_non_text_child = true;
                     block_element_count += 1;
+                }
+                HtmlChild::Comment(_) => {
+                    meta.has_non_text_child = true;
+                }
+                HtmlChild::Word(_) => {
+                    meta.has_word = true;
                 }
                 _ => {}
             }
@@ -400,12 +415,24 @@ impl FormatHtmlElementList {
                 }
             }
 
-            // Force multiline if there was a leading newline AND there are block elements
-            // This respects the user's intent to break when they have:
+            // Force multiline if there was a leading newline AND:
+            // - There are block elements (original behavior), OR
+            // - Children are exclusively non-text (no mixed text content)
+            //
+            // The first case handles block elements mixed with text:
+            // <div>a<div>b</div>c</div>
+            //
+            // The second case preserves the user's intent to break non-text children:
             // <div>
-            //   <div>...</div>
+            //   <span>...</span>
             // </div>
-            if had_leading_newline && children_meta.has_block_element {
+            // <div>
+            //   {expression}
+            // </div>
+            if had_leading_newline
+                && (children_meta.has_block_element
+                    || (children_meta.has_non_text_child && !children_meta.has_word))
+            {
                 force_multiline = true;
             }
 

--- a/crates/biome_html_formatter/tests/quick_test.rs
+++ b/crates/biome_html_formatter/tests/quick_test.rs
@@ -1,7 +1,9 @@
+use biome_configuration::{Configuration, HtmlConfiguration, html::HtmlFormatterConfiguration};
 use biome_fs::{BiomePath, MemoryFileSystem};
+use biome_service::settings::ModuleGraphResolutionKind;
 use biome_service::workspace::{
     ChangeFileParams, FileContent, FormatFileParams, GetFormatterIRParams, OpenFileParams,
-    OpenProjectParams, server,
+    OpenProjectParams, UpdateSettingsParams, server,
 };
 use std::sync::Arc;
 
@@ -9,15 +11,7 @@ use std::sync::Arc;
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
-    let src = r#"
-{#snippet ff.call()}
-    {page.value}
-    {second.value}
-    <div>
-        <span></span>
-    </div>
-{/snippet}
-"#;
+    let src = r#""#;
     let fs = MemoryFileSystem::default();
     let workspace = server(Arc::new(fs), None);
 
@@ -25,6 +19,26 @@ fn quick_test() {
         .open_project(OpenProjectParams {
             path: BiomePath::new(""),
             open_uninitialized: true,
+        })
+        .unwrap();
+
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key: project.project_key,
+            configuration: Configuration {
+                html: Some(HtmlConfiguration {
+                    experimental_full_support_enabled: Some(true.into()),
+                    formatter: Some(HtmlFormatterConfiguration {
+                        enabled: Some(true.into()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            workspace_directory: None,
+            extended_configurations: Default::default(),
+            module_graph_resolution_kind: ModuleGraphResolutionKind::None,
         })
         .unwrap();
 

--- a/crates/biome_html_formatter/tests/specs/html/interpolation/interpolation.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/interpolation/interpolation.html.snap
@@ -32,6 +32,8 @@ info: interpolation/interpolation.html
 # Formatted
 
 ```html
-<div>{{ $interpolation }}</div>
+<div>
+	{{ $interpolation }}
+</div>
 
 ```

--- a/crates/biome_html_formatter/tests/specs/html/svelte/html.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/html.svelte.snap
@@ -18,7 +18,9 @@ info: svelte/html.svelte
 # Formatted
 
 ```svelte
-<article>{@html content}</article>
+<article>
+	{@html content}
+</article>
 
 {@html '<div>'}content{@html '</div>'}
 

--- a/crates/biome_html_formatter/tests/specs/html/svelte/preserve_newline_nontext_children.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/preserve_newline_nontext_children.svelte
@@ -1,0 +1,21 @@
+<!-- Newlines around expression should be preserved -->
+<div>
+	{name}
+</div>
+
+<!-- No newlines = stays inline -->
+<div>{name}</div>
+
+<!-- Newlines around expression + comment should be preserved -->
+<div>
+	{name}<!-- comment -->
+</div>
+
+<!-- No newlines around expression + comment = stays inline -->
+<div>{name}<!-- comment --></div>
+
+<!-- Multiple expressions with newlines -->
+<div>
+	{foo}
+	{bar}
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/preserve_newline_nontext_children.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/preserve_newline_nontext_children.svelte.snap
@@ -1,0 +1,59 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/preserve_newline_nontext_children.svelte
+---
+
+# Input
+
+```svelte
+<!-- Newlines around expression should be preserved -->
+<div>
+	{name}
+</div>
+
+<!-- No newlines = stays inline -->
+<div>{name}</div>
+
+<!-- Newlines around expression + comment should be preserved -->
+<div>
+	{name}<!-- comment -->
+</div>
+
+<!-- No newlines around expression + comment = stays inline -->
+<div>{name}<!-- comment --></div>
+
+<!-- Multiple expressions with newlines -->
+<div>
+	{foo}
+	{bar}
+</div>
+
+```
+
+
+# Formatted
+
+```svelte
+<!-- Newlines around expression should be preserved -->
+<div>
+	{name}
+</div>
+
+<!-- No newlines = stays inline -->
+<div>{name}</div>
+
+<!-- Newlines around expression + comment should be preserved -->
+<div>
+	{name}<!-- comment -->
+</div>
+
+<!-- No newlines around expression + comment = stays inline -->
+<div>{name}<!-- comment --></div>
+
+<!-- Multiple expressions with newlines -->
+<div>
+	{foo}
+	{bar}
+</div>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/vue/inner-template.vue
+++ b/crates/biome_html_formatter/tests/specs/html/vue/inner-template.vue
@@ -1,0 +1,21 @@
+<template>
+	<UModal>
+		<!--
+		because the children of this inner template already has a newline,
+		the multiline formatting should be preserved
+		-->
+		<template #body>
+			<p>{{ store.options.text }}</p>
+		</template>
+	</UModal>
+</template>
+
+<template>
+	<UModal>
+		<!--
+		because the children of this inner template does not have a newline,
+		the children should NOT be multiline formatted
+		-->
+		<template #body><p>foo</p></template>
+	</UModal>
+</template>

--- a/crates/biome_html_formatter/tests/specs/html/vue/inner-template.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/vue/inner-template.vue.snap
@@ -1,0 +1,59 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: vue/inner-template.vue
+---
+
+# Input
+
+```vue
+<template>
+	<UModal>
+		<!--
+		because the children of this inner template already has a newline,
+		the multiline formatting should be preserved
+		-->
+		<template #body>
+			<p>{{ store.options.text }}</p>
+		</template>
+	</UModal>
+</template>
+
+<template>
+	<UModal>
+		<!--
+		because the children of this inner template does not have a newline,
+		the children should NOT be multiline formatted
+		-->
+		<template #body><p>foo</p></template>
+	</UModal>
+</template>
+
+```
+
+
+# Formatted
+
+```vue
+<template>
+	<UModal>
+		<!--
+		because the children of this inner template already has a newline,
+		the multiline formatting should be preserved
+		-->
+		<template #body>
+			<p>{{ store.options.text }}</p>
+		</template>
+	</UModal>
+</template>
+
+<template>
+	<UModal>
+		<!--
+		because the children of this inner template does not have a newline,
+		the children should NOT be multiline formatted
+		-->
+		<template #body><p>foo</p></template>
+	</UModal>
+</template>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/preserve-newline-nontext-children.html
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/preserve-newline-nontext-children.html
@@ -1,0 +1,26 @@
+<!-- Newlines around inline element should be preserved -->
+<div>
+	<span>text</span>
+</div>
+
+<!-- No newlines = stays inline -->
+<div><span>text</span></div>
+
+<!-- Newlines around multiple inline elements should be preserved -->
+<div>
+	<span>Foo</span>
+	<span>Bar</span>
+</div>
+
+<!-- Mixed content (element + text) should NOT force multiline -->
+<div>
+	<span>Foo</span> Bar
+</div>
+
+<!-- Comment-only child with newlines should be preserved -->
+<div>
+	<!-- comment -->
+</div>
+
+<!-- Comment-only child inline stays inline -->
+<div><!-- comment --></div>

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/preserve-newline-nontext-children.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/preserve-newline-nontext-children.html.snap
@@ -1,0 +1,67 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: whitespace/preserve-newline-nontext-children.html
+---
+
+# Input
+
+```html
+<!-- Newlines around inline element should be preserved -->
+<div>
+	<span>text</span>
+</div>
+
+<!-- No newlines = stays inline -->
+<div><span>text</span></div>
+
+<!-- Newlines around multiple inline elements should be preserved -->
+<div>
+	<span>Foo</span>
+	<span>Bar</span>
+</div>
+
+<!-- Mixed content (element + text) should NOT force multiline -->
+<div>
+	<span>Foo</span> Bar
+</div>
+
+<!-- Comment-only child with newlines should be preserved -->
+<div>
+	<!-- comment -->
+</div>
+
+<!-- Comment-only child inline stays inline -->
+<div><!-- comment --></div>
+
+```
+
+
+# Formatted
+
+```html
+<!-- Newlines around inline element should be preserved -->
+<div>
+	<span>text</span>
+</div>
+
+<!-- No newlines = stays inline -->
+<div><span>text</span></div>
+
+<!-- Newlines around multiple inline elements should be preserved -->
+<div>
+	<span>Foo</span>
+	<span>Bar</span>
+</div>
+
+<!-- Mixed content (element + text) should NOT force multiline -->
+<div><span>Foo</span> Bar</div>
+
+<!-- Comment-only child with newlines should be preserved -->
+<div>
+	<!-- comment -->
+</div>
+
+<!-- Comment-only child inline stays inline -->
+<div><!-- comment --></div>
+
+```

--- a/crates/biome_html_formatter/tests/specs/prettier/vue/html-vue/hello-world.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/vue/html-vue/hello-world.html.snap
@@ -37,20 +37,15 @@ info: vue/html-vue/hello-world.html
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,22 +1,20 @@
+@@ -1,5 +1,5 @@
  <!-- Hello World example from https://github.com/vuejs/vuejs.org/blob/master/src/v2/examples/vue-20-hello-world/index.html -->
 -<!doctype html>
 +<!DOCTYPE html>
  <html>
    <head>
      <title>My first Vue app</title>
-     <script src="https://unpkg.com/vue"></script>
-   </head>
-   <body>
--    <div id="app">
--      {{ message }}
--    </div>
-+    <div id="app">{{ message }}</div>
+@@ -11,12 +11,12 @@
+     </div>
  
      <script>
 -      var app = new Vue({
@@ -82,7 +77,9 @@ info: vue/html-vue/hello-world.html
     <script src="https://unpkg.com/vue"></script>
   </head>
   <body>
-    <div id="app">{{ message }}</div>
+    <div id="app">
+      {{ message }}
+    </div>
 
     <script>
     var app = new Vue({


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The change is pretty small, but the logic is pretty complex. However, this does result in a small improvement to our prettier snapshots.

generated by opus 4.6. with very heavy guidance
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #9099
fixes #9450

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots
## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
