### PR TITLE
refactor(flags): make variables predictable

### DIFF
--- a/crates/biome_cli/src/commands/clean.rs
+++ b/crates/biome_cli/src/commands/clean.rs
@@ -7,8 +7,7 @@ use std::fs::{create_dir, remove_dir_all};
 /// Runs the clean command
 pub fn clean(_cli_session: CliSession) -> Result<(), CliDiagnostic> {
     let logs_path = biome_env()
-        .biome_log_path
-        .value()
+        .value_for("BIOME_LOG_PATH")
         .map_or(default_biome_log_path(), Utf8PathBuf::from);
     remove_dir_all(logs_path.clone()).and_then(|_| create_dir(logs_path))?;
     Ok(())

--- a/crates/biome_cli/src/commands/explain.rs
+++ b/crates/biome_cli/src/commands/explain.rs
@@ -18,8 +18,7 @@ pub(crate) fn explain(session: CliSession, doc: Doc) -> Result<(), CliDiagnostic
         }
         Doc::DaemonLogs => {
             let cache_dir = biome_env()
-                .biome_log_path
-                .value()
+                .value_for("BIOME_LOG_PATH")
                 .unwrap_or(default_biome_log_path().to_string());
             session.app.console.error(markup! {
                 <Info>"The daemon logs are available in the directory: \n"</Info>

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -423,10 +423,11 @@ struct BiomeServerLog;
 impl Display for BiomeServerLog {
     fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
         if let Ok(Some(log)) = read_most_recent_log_file(
-            biome_env().biome_log_path.value().map(Utf8PathBuf::from),
             biome_env()
-                .biome_log_prefix_name
-                .value()
+                .value_for("BIOME_LOG_PATH")
+                .map(Utf8PathBuf::from),
+            biome_env()
+                .value_for("BIOME_LOG_PREFIX_NAME")
                 .unwrap_or("server.log".to_string()),
         ) {
             markup!("\n"<Emphasis><Underline>"Biome Server Log:"</Underline></Emphasis>"

--- a/crates/biome_flags/src/lib.rs
+++ b/crates/biome_flags/src/lib.rs
@@ -16,56 +16,48 @@ pub fn is_unstable() -> bool {
 /// The internal version of Biome. This is usually supplied during the CI build
 pub static BIOME_VERSION: LazyLock<Option<&str>> = LazyLock::new(|| option_env!("BIOME_VERSION"));
 
-pub struct BiomeEnv {
-    pub biome_log_path: BiomeEnvVariable,
-    pub biome_log_prefix_name: BiomeEnvVariable,
-    pub biome_config_path: BiomeEnvVariable,
-    pub biome_threads: BiomeEnvVariable,
-    pub biome_watcher_kind: BiomeEnvVariable,
-    pub biome_watcher_polling_interval: BiomeEnvVariable,
-    pub biome_log_level: BiomeEnvVariable,
-    pub biome_log_kind: BiomeEnvVariable,
-}
+#[derive(Default)]
+pub struct BiomeEnv {}
 
 pub static BIOME_ENV: OnceLock<BiomeEnv> = OnceLock::new();
 
 impl BiomeEnv {
-    fn new() -> Self {
-        Self {
-            biome_log_path: BiomeEnvVariable::new(
-                "BIOME_LOG_PATH",
-                "The directory where the Daemon logs will be saved.",
-            ),
-            biome_log_prefix_name: BiomeEnvVariable::new(
-                "BIOME_LOG_PREFIX_NAME",
-                "A prefix that's added to the name of the log. Default: `server.log.`",
-            ),
-            biome_config_path: BiomeEnvVariable::new(
-                "BIOME_CONFIG_PATH",
-                "A path to the configuration file",
-            ),
-            biome_threads: BiomeEnvVariable::new(
-                "BIOME_THREADS",
-                "The number of threads to use in CI.",
-            ),
-            biome_watcher_kind: BiomeEnvVariable::new(
-                "BIOME_WATCHER_KIND",
-                "The kind of watcher to use. Possible values: polling, recommended, none. Default: recommended.",
-            ),
-            biome_watcher_polling_interval: BiomeEnvVariable::new(
-                "BIOME_WATCHER_POLLING_INTERVAL",
-                "The polling interval in milliseconds. This is only applicable when using the polling watcher. Default: 2000.",
-            ),
-            biome_log_level: BiomeEnvVariable::new(
-                "BIOME_LOG_LEVEL",
-                "The level of logging. Possible values: none, tracing, debug, info, warn, error. Default: info.",
-            ),
-            biome_log_kind: BiomeEnvVariable::new(
-                "BIOME_LOG_KIND",
-                "What the log should look like. Possible values: pretty, compact, json. Default: pretty.",
-            ),
-        }
+    /// It attempts to read the value of the variable from the environment using [env::var]
+    pub fn value_for(&self, name: &str) -> Option<String> {
+        Self::ENV_VARIABLES
+            .iter()
+            .find(|variable| variable.name == name)
+            .and_then(|variable| variable.value())
     }
+
+    pub const ENV_VARIABLES: &[&BiomeEnvVariable] = &[
+        &BiomeEnvVariable::new(
+            "BIOME_LOG_PATH",
+            "The directory where the logs of the Biome Daemon are stored.",
+        ),
+        &BiomeEnvVariable::new(
+            "BIOME_LOG_PREFIX_NAME",
+            "A prefix that's added to the name of the log. Default: `server.log.`",
+        ),
+        &BiomeEnvVariable::new(
+            "BIOME_LOG_LEVEL",
+            "The level of logging. Possible values: none, tracing, debug, info, warn, error. Default: info.",
+        ),
+        &BiomeEnvVariable::new(
+            "BIOME_LOG_KIND",
+            "What the log should look like. Possible values: pretty, compact, json. Default: pretty.",
+        ),
+        &BiomeEnvVariable::new("BIOME_CONFIG_PATH", "A path to the configuration file"),
+        &BiomeEnvVariable::new("BIOME_THREADS", "The number of threads to use in CI."),
+        &BiomeEnvVariable::new(
+            "BIOME_WATCHER_KIND",
+            "The kind of watcher to use. Possible values: polling, recommended, none. Default: recommended.",
+        ),
+        &BiomeEnvVariable::new(
+            "BIOME_WATCHER_POLLING_INTERVAL",
+            "The polling interval in milliseconds. This is only applicable when using the polling watcher. Default: 2000.",
+        ),
+    ];
 }
 
 pub struct BiomeEnvVariable {
@@ -77,11 +69,11 @@ pub struct BiomeEnvVariable {
 }
 
 impl BiomeEnvVariable {
-    fn new(name: &'static str, description: &'static str) -> Self {
+    const fn new(name: &'static str, description: &'static str) -> Self {
         Self { name, description }
     }
 
-    /// It attempts to read the value of the variable
+    /// It attempts to read the value of the variable from the environment using [env::var]
     pub fn value(&self) -> Option<String> {
         env::var(self.name).ok()
     }
@@ -98,129 +90,27 @@ impl BiomeEnvVariable {
 }
 
 pub fn biome_env() -> &'static BiomeEnv {
-    BIOME_ENV.get_or_init(BiomeEnv::new)
+    BIOME_ENV.get_or_init(BiomeEnv::default)
 }
 
 impl Display for BiomeEnv {
     fn fmt(&self, fmt: &mut Formatter) -> std::io::Result<()> {
         let padding = 35usize;
-        match self.biome_log_path.value() {
-            None => {
-                KeyValuePair::new(self.biome_log_path.name, markup! { <Dim>"unset"</Dim> })
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-            Some(value) => {
-                KeyValuePair::new(self.biome_log_path.name, markup! {{DebugDisplay(value)}})
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-        };
-        match self.biome_log_prefix_name.value() {
-            None => {
-                KeyValuePair::new(
-                    self.biome_log_prefix_name.name,
-                    markup! { <Dim>"unset"</Dim> },
-                )
-                .with_padding(padding)
-                .fmt(fmt)?;
-            }
-            Some(value) => {
-                KeyValuePair::new(
-                    self.biome_log_prefix_name.name,
-                    markup! {{DebugDisplay(value)}},
-                )
-                .with_padding(padding)
-                .fmt(fmt)?;
-            }
-        };
 
-        match self.biome_log_level.value() {
-            None => {
-                KeyValuePair::new(self.biome_log_level.name, markup! { <Dim>"unset"</Dim> })
-                    .with_padding(padding)
-                    .fmt(fmt)?;
+        for variable in Self::ENV_VARIABLES {
+            match variable.value() {
+                None => {
+                    KeyValuePair::new(variable.name, markup! { <Dim>"unset"</Dim> })
+                        .with_padding(padding)
+                        .fmt(fmt)?;
+                }
+                Some(value) => {
+                    KeyValuePair::new(variable.name, markup! {{DebugDisplay(value)}})
+                        .with_padding(padding)
+                        .fmt(fmt)?;
+                }
             }
-            Some(value) => {
-                KeyValuePair::new(self.biome_log_level.name, markup! {{DebugDisplay(value)}})
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-        };
-
-        match self.biome_log_kind.value() {
-            None => {
-                KeyValuePair::new(self.biome_log_kind.name, markup! { <Dim>"unset"</Dim> })
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-            Some(value) => {
-                KeyValuePair::new(self.biome_log_kind.name, markup! {{DebugDisplay(value)}})
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-        };
-
-        match self.biome_config_path.value() {
-            None => {
-                KeyValuePair::new(self.biome_config_path.name, markup! { <Dim>"unset"</Dim> })
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-            Some(value) => {
-                KeyValuePair::new(self.biome_config_path.name, markup! {{DebugDisplay(value)}})
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-        };
-
-        match self.biome_threads.value() {
-            None => {
-                KeyValuePair::new(self.biome_threads.name, markup! { <Dim>"unset"</Dim> })
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-            Some(value) => {
-                KeyValuePair::new(self.biome_threads.name, markup! {{DebugDisplay(value)}})
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-        };
-
-        match self.biome_watcher_kind.value() {
-            None => {
-                KeyValuePair::new(self.biome_watcher_kind.name, markup! { <Dim>"unset"</Dim> })
-                    .with_padding(padding)
-                    .fmt(fmt)?;
-            }
-            Some(value) => {
-                KeyValuePair::new(
-                    self.biome_watcher_kind.name,
-                    markup! {{DebugDisplay(value)}},
-                )
-                .with_padding(padding)
-                .fmt(fmt)?;
-            }
-        };
-
-        match self.biome_watcher_polling_interval.value() {
-            None => {
-                KeyValuePair::new(
-                    self.biome_watcher_polling_interval.name,
-                    markup! { <Dim>"unset"</Dim> },
-                )
-                .with_padding(padding)
-                .fmt(fmt)?;
-            }
-            Some(value) => {
-                KeyValuePair::new(
-                    self.biome_watcher_polling_interval.name,
-                    markup! {{DebugDisplay(value)}},
-                )
-                .with_padding(padding)
-                .fmt(fmt)?;
-            }
-        };
+        }
 
         Ok(())
     }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR refactors our `BiomeEnv`, and stores our environment variables in a list instead of struct fields. The reason is simple: the code gen requires manual updates whenever we add a new field, and we haven't been doing so consistently. https://biomejs.dev/reference/environment-variables/

With a list, the code gen will update automatically every time we add a new environment variable.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Green CI

<!-- What demonstrates that your implementation is correct? -->

## Docs

I'll update the codegen after merging this

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
