### PR TITLE
docs: clarify that elements in scope for useAltText is not configurable

### DIFF
--- a/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
@@ -11,7 +11,7 @@ declare_lint_rule! {
     /// Enforce that all elements that require alternative text have meaningful information to relay back to the end user.
     ///
     /// This is a critical component of accessibility for screen reader users in order for them to understand the content's purpose on the page.
-    /// By default, this rule checks for alternative text on the following elements: `<img>`, `<area>`, `<input type="image">`, and `<object>`.
+    /// This rule checks for alternative text on the following elements: `<img>`, `<area>`, `<input type="image">`, and `<object>`.
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The wording "by default" implies that the list of elements covered by this rule may be configured, but I couldn't see any option on [the docs page](https://biomejs.dev/linter/rules/use-alt-text/) for such configuration. Looking at the source code, the dictionary of elements covered is hard-coded: https://github.com/biomejs/biome/blob/main/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs#L94-L142
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
N/A
## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

I wasn't sure whether the corresponding docs page is generated from this comment or not, so I opened a sister PR over on the docs site: biomejs/website#4114, but coderabbit confirmed it is auto-generated, so I've closed that. Hope that's right 👍 