### PR TITLE
fix(format): don't remove trailing comments when formatting is suppressed

### DIFF
--- a/.changeset/itchy-hats-refuse.md
+++ b/.changeset/itchy-hats-refuse.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9781](https://github.com/biomejs/biome/issues/9781): Trailing comments after a top-level `biome-ignore-all format` suppression are now preserved instead of being dropped. This applies to JavaScript, CSS, HTML, JSONC, GraphQL, and Grit files.

--- a/crates/biome_css_formatter/src/verbatim.rs
+++ b/crates/biome_css_formatter/src/verbatim.rs
@@ -39,6 +39,18 @@ pub struct FormatCssVerbatimNode<'node> {
 
 impl Format<CssFormatContext> for FormatCssVerbatimNode<'_> {
     fn fmt(&self, f: &mut Formatter<CssFormatContext>) -> FormatResult<()> {
+        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
+        where
+            Context: CstFormatContext,
+        {
+            f.context()
+                .source_map()
+                .map_or_else(|| range, |source_map| source_map.source_range(range))
+        }
+
+        let preserve_outer_trivia =
+            matches!(self.kind, VerbatimKind::Suppressed) && self.node.parent().is_none();
+
         for element in self.node.descendants_with_tokens(Direction::Next) {
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
@@ -56,21 +68,22 @@ impl Format<CssFormatContext> for FormatCssVerbatimNode<'_> {
         // The trimmed range of a node is its range without any of its leading or trailing trivia.
         // Except for nodes that used to be parenthesized, the range than covers the source from the
         // `(` to the `)` (the trimmed range of the parenthesized expression, not the inner expression)
-        let trimmed_source_range = f.context().source_map().map_or_else(
-            || self.node.text_trimmed_range(),
-            |source_map| source_map.trimmed_source_range(self.node),
-        );
+        let verbatim_source_range = if preserve_outer_trivia {
+            source_range(f, self.node.text_range_with_trivia())
+        } else {
+            f.context().source_map().map_or_else(
+                || self.node.text_trimmed_range(),
+                |source_map| source_map.trimmed_source_range(self.node),
+            )
+        };
+
+        let verbatim_text_start = if preserve_outer_trivia {
+            self.node.text_range_with_trivia().start()
+        } else {
+            self.node.text_trimmed_range().start()
+        };
 
         f.write_element(FormatElement::Tag(Tag::StartVerbatim(self.kind)))?;
-
-        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
-        where
-            Context: CstFormatContext,
-        {
-            f.context()
-                .source_map()
-                .map_or_else(|| range, |source_map| source_map.source_range(range))
-        }
 
         // Format all leading comments that are outside of the node's source range.
         if self.format_comments {
@@ -78,7 +91,7 @@ impl Format<CssFormatContext> for FormatCssVerbatimNode<'_> {
             let leading_comments = comments.leading_comments(self.node);
 
             let outside_trimmed_range = leading_comments.partition_point(|comment| {
-                comment.piece().text_range().end() <= trimmed_source_range.start()
+                comment.piece().text_range().end() <= verbatim_source_range.start()
             });
 
             let (outside_trimmed_range, in_trimmed_range) =
@@ -100,23 +113,29 @@ impl Format<CssFormatContext> for FormatCssVerbatimNode<'_> {
             .flat_map(|trivia| trivia.pieces())
             .filter(|trivia| trivia.is_skipped())
             .map(|trivia| source_range(f, trivia.text_range()).start())
-            .take_while(|start| *start < trimmed_source_range.start())
+            .take_while(|start| *start < verbatim_source_range.start())
             .next()
-            .unwrap_or_else(|| trimmed_source_range.start());
+            .unwrap_or_else(|| verbatim_source_range.start());
 
         let original_source = f.context().source_map().map_or_else(
-            || self.node.text_trimmed().to_string(),
+            || {
+                if preserve_outer_trivia {
+                    self.node.text_with_trivia().to_string()
+                } else {
+                    self.node.text_trimmed().to_string()
+                }
+            },
             |source_map| {
                 source_map
                     .source()
-                    .text_slice(trimmed_source_range.cover_offset(start_source))
+                    .text_slice(verbatim_source_range.cover_offset(start_source))
                     .to_string()
             },
         );
 
         text(
             &normalize_newlines(&original_source, LINE_TERMINATORS),
-            self.node.text_trimmed_range().start(),
+            verbatim_text_start,
         )
         .fmt(f)?;
 
@@ -131,7 +150,7 @@ impl Format<CssFormatContext> for FormatCssVerbatimNode<'_> {
             let trailing_comments = comments.trailing_comments(self.node);
 
             let outside_trimmed_range_start = trailing_comments.partition_point(|comment| {
-                source_range(f, comment.piece().text_range()).end() <= trimmed_source_range.end()
+                source_range(f, comment.piece().text_range()).end() <= verbatim_source_range.end()
             });
 
             let (in_trimmed_range, outside_trimmed_range) =

--- a/crates/biome_css_formatter/tests/specs/css/global_suppression.css
+++ b/crates/biome_css_formatter/tests/specs/css/global_suppression.css
@@ -8,3 +8,10 @@
 
 #exampleInputEmail1 { color: red;
 }
+
+/* biome-ignore-all format: intentional */
+.code {
+	color: red;
+}
+
+/* Biome format should keep this comment */

--- a/crates/biome_css_formatter/tests/specs/css/global_suppression.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/global_suppression.css.snap
@@ -17,6 +17,13 @@ info: css/global_suppression.css
 #exampleInputEmail1 { color: red;
 }
 
+/* biome-ignore-all format: intentional */
+.code {
+	color: red;
+}
+
+/* Biome format should keep this comment */
+
 ```
 
 
@@ -33,4 +40,12 @@ info: css/global_suppression.css
 
 #exampleInputEmail1 { color: red;
 }
+
+/* biome-ignore-all format: intentional */
+.code {
+	color: red;
+}
+
+/* Biome format should keep this comment */
+
 ```

--- a/crates/biome_css_formatter/tests/specs/css/suppression_trailing_comments.css
+++ b/crates/biome_css_formatter/tests/specs/css/suppression_trailing_comments.css
@@ -1,0 +1,5 @@
+.card {
+	/* biome-ignore format: preserve the nested declaration formatting */
+	background: linear-gradient( 90deg, red,   blue ); /* keep this trailing comment after the suppressed declaration */
+	color: red;
+}

--- a/crates/biome_css_formatter/tests/specs/css/suppression_trailing_comments.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/suppression_trailing_comments.css.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/suppression_trailing_comments.css
+---
+
+# Input
+
+```css
+.card {
+	/* biome-ignore format: preserve the nested declaration formatting */
+	background: linear-gradient( 90deg, red,   blue ); /* keep this trailing comment after the suppressed declaration */
+	color: red;
+}
+
+```
+
+
+# Formatted
+
+```css
+.card {
+	/* biome-ignore format: preserve the nested declaration formatting */
+	background: linear-gradient( 90deg, red,   blue ); /* keep this trailing comment after the suppressed declaration */
+	color: red;
+}
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    3: 	background: linear-gradient( 90deg, red,   blue ); /* keep this trailing comment after the suppressed declaration */
+```

--- a/crates/biome_graphql_formatter/src/verbatim.rs
+++ b/crates/biome_graphql_formatter/src/verbatim.rs
@@ -40,6 +40,18 @@ pub struct FormatGraphqlVerbatimNode<'node> {
 
 impl Format<GraphqlFormatContext> for FormatGraphqlVerbatimNode<'_> {
     fn fmt(&self, f: &mut Formatter<GraphqlFormatContext>) -> FormatResult<()> {
+        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
+        where
+            Context: CstFormatContext,
+        {
+            f.context()
+                .source_map()
+                .map_or_else(|| range, |source_map| source_map.source_range(range))
+        }
+
+        let preserve_outer_trivia =
+            matches!(self.kind, VerbatimKind::Suppressed) && self.node.parent().is_none();
+
         for element in self.node.descendants_with_tokens(Direction::Next) {
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
@@ -57,21 +69,22 @@ impl Format<GraphqlFormatContext> for FormatGraphqlVerbatimNode<'_> {
         // The trimmed range of a node is its range without any of its leading or trailing trivia.
         // Except for nodes that used to be parenthesized, the range than covers the source from the
         // `(` to the `)` (the trimmed range of the parenthesized expression, not the inner expression)
-        let trimmed_source_range = f.context().source_map().map_or_else(
-            || self.node.text_trimmed_range(),
-            |source_map| source_map.trimmed_source_range(self.node),
-        );
+        let verbatim_source_range = if preserve_outer_trivia {
+            source_range(f, self.node.text_range_with_trivia())
+        } else {
+            f.context().source_map().map_or_else(
+                || self.node.text_trimmed_range(),
+                |source_map| source_map.trimmed_source_range(self.node),
+            )
+        };
+
+        let verbatim_text_start = if preserve_outer_trivia {
+            self.node.text_range_with_trivia().start()
+        } else {
+            self.node.text_trimmed_range().start()
+        };
 
         f.write_element(FormatElement::Tag(Tag::StartVerbatim(self.kind)))?;
-
-        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
-        where
-            Context: CstFormatContext,
-        {
-            f.context()
-                .source_map()
-                .map_or_else(|| range, |source_map| source_map.source_range(range))
-        }
 
         // Format all leading comments that are outside of the node's source range.
         if self.format_comments {
@@ -80,7 +93,7 @@ impl Format<GraphqlFormatContext> for FormatGraphqlVerbatimNode<'_> {
             let leading_comments = comments.leading_comments(self.node);
 
             let outside_trimmed_range = leading_comments.partition_point(|comment| {
-                comment.piece().text_range().end() <= trimmed_source_range.start()
+                comment.piece().text_range().end() <= verbatim_source_range.start()
             });
 
             let (outside_trimmed_range, in_trimmed_range) =
@@ -102,23 +115,29 @@ impl Format<GraphqlFormatContext> for FormatGraphqlVerbatimNode<'_> {
             .flat_map(|trivia| trivia.pieces())
             .filter(|trivia| trivia.is_skipped())
             .map(|trivia| source_range(f, trivia.text_range()).start())
-            .take_while(|start| *start < trimmed_source_range.start())
+            .take_while(|start| *start < verbatim_source_range.start())
             .next()
-            .unwrap_or_else(|| trimmed_source_range.start());
+            .unwrap_or_else(|| verbatim_source_range.start());
 
         let original_source = f.context().source_map().map_or_else(
-            || self.node.text_trimmed().to_string(),
+            || {
+                if preserve_outer_trivia {
+                    self.node.text_with_trivia().to_string()
+                } else {
+                    self.node.text_trimmed().to_string()
+                }
+            },
             |source_map| {
                 source_map
                     .source()
-                    .text_slice(trimmed_source_range.cover_offset(start_source))
+                    .text_slice(verbatim_source_range.cover_offset(start_source))
                     .to_string()
             },
         );
 
         text(
             &normalize_newlines(&original_source, LINE_TERMINATORS),
-            self.node.text_trimmed_range().start(),
+            verbatim_text_start,
         )
         .fmt(f)?;
 
@@ -133,7 +152,7 @@ impl Format<GraphqlFormatContext> for FormatGraphqlVerbatimNode<'_> {
             let trailing_comments = comments.trailing_comments(self.node);
 
             let outside_trimmed_range_start = trailing_comments.partition_point(|comment| {
-                source_range(f, comment.piece().text_range()).end() <= trimmed_source_range.end()
+                source_range(f, comment.piece().text_range()).end() <= verbatim_source_range.end()
             });
 
             let (in_trimmed_range, outside_trimmed_range) =

--- a/crates/biome_graphql_formatter/tests/specs/graphql/suppression.graphql
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/suppression.graphql
@@ -9,6 +9,11 @@
 	@addExternalFields(source: "profiles")
 }
 
+# biome-ignore-all format: intentional
+query { hero }
+
+# Biome format should keep this comment
+
 
 {
 	hero

--- a/crates/biome_graphql_formatter/tests/specs/graphql/suppression.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/suppression.graphql.snap
@@ -17,6 +17,11 @@ info: graphql/suppression.graphql
 	@addExternalFields(source: "profiles")
 }
 
+# biome-ignore-all format: intentional
+query { hero }
+
+# Biome format should keep this comment
+
 
 {
 	hero
@@ -44,6 +49,11 @@ info: graphql/suppression.graphql
 	@addExternalFields(source: "profiles")
 }
 
+# biome-ignore-all format: intentional
+query { hero }
+
+# Biome format should keep this comment
+
 
 {
 	hero
@@ -53,4 +63,5 @@ info: graphql/suppression.graphql
 		reason: "Deprecated")
 	@addExternalFields(source: "profiles")
 }
+
 ```

--- a/crates/biome_graphql_formatter/tests/specs/graphql/suppression_trailing_comments.graphql
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/suppression_trailing_comments.graphql
@@ -1,0 +1,9 @@
+query DemoQuery {
+	user(
+		# biome-ignore format: preserve the nested argument formatting
+		filter: { id: $id,  active: true } # keep this trailing comment after the suppressed argument
+		status: ACTIVE
+	) {
+		id
+	}
+}

--- a/crates/biome_graphql_formatter/tests/specs/graphql/suppression_trailing_comments.graphql.snap
+++ b/crates/biome_graphql_formatter/tests/specs/graphql/suppression_trailing_comments.graphql.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: graphql/suppression_trailing_comments.graphql
+---
+
+# Input
+
+```graphql
+query DemoQuery {
+	user(
+		# biome-ignore format: preserve the nested argument formatting
+		filter: { id: $id,  active: true } # keep this trailing comment after the suppressed argument
+		status: ACTIVE
+	) {
+		id
+	}
+}
+
+```
+
+
+# Formatted
+
+```graphql
+query DemoQuery {
+	user(
+		# biome-ignore format: preserve the nested argument formatting
+		filter: { id: $id,  active: true } # keep this trailing comment after the suppressed argument
+		status: ACTIVE
+	) {
+		id
+	}
+}
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    4: 		filter: { id: $id,  active: true } # keep this trailing comment after the suppressed argument
+```

--- a/crates/biome_grit_formatter/src/verbatim.rs
+++ b/crates/biome_grit_formatter/src/verbatim.rs
@@ -40,6 +40,18 @@ pub struct FormatGraphqlVerbatimNode<'node> {
 
 impl Format<GritFormatContext> for FormatGraphqlVerbatimNode<'_> {
     fn fmt(&self, f: &mut Formatter<GritFormatContext>) -> FormatResult<()> {
+        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
+        where
+            Context: CstFormatContext,
+        {
+            f.context()
+                .source_map()
+                .map_or_else(|| range, |source_map| source_map.source_range(range))
+        }
+
+        let preserve_outer_trivia =
+            matches!(self.kind, VerbatimKind::Suppressed) && self.node.parent().is_none();
+
         for element in self.node.descendants_with_tokens(Direction::Next) {
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
@@ -57,21 +69,22 @@ impl Format<GritFormatContext> for FormatGraphqlVerbatimNode<'_> {
         // The trimmed range of a node is its range without any of its leading or trailing trivia.
         // Except for nodes that used to be parenthesized, the range than covers the source from the
         // `(` to the `)` (the trimmed range of the parenthesized expression, not the inner expression)
-        let trimmed_source_range = f.context().source_map().map_or_else(
-            || self.node.text_trimmed_range(),
-            |source_map| source_map.trimmed_source_range(self.node),
-        );
+        let verbatim_source_range = if preserve_outer_trivia {
+            source_range(f, self.node.text_range_with_trivia())
+        } else {
+            f.context().source_map().map_or_else(
+                || self.node.text_trimmed_range(),
+                |source_map| source_map.trimmed_source_range(self.node),
+            )
+        };
+
+        let verbatim_text_start = if preserve_outer_trivia {
+            self.node.text_range_with_trivia().start()
+        } else {
+            self.node.text_trimmed_range().start()
+        };
 
         f.write_element(FormatElement::Tag(Tag::StartVerbatim(self.kind)))?;
-
-        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
-        where
-            Context: CstFormatContext,
-        {
-            f.context()
-                .source_map()
-                .map_or_else(|| range, |source_map| source_map.source_range(range))
-        }
 
         // Format all leading comments that are outside of the node's source range.
         if self.format_comments {
@@ -79,7 +92,7 @@ impl Format<GritFormatContext> for FormatGraphqlVerbatimNode<'_> {
             let leading_comments = comments.leading_comments(self.node);
 
             let outside_trimmed_range = leading_comments.partition_point(|comment| {
-                comment.piece().text_range().end() <= trimmed_source_range.start()
+                comment.piece().text_range().end() <= verbatim_source_range.start()
             });
 
             let (outside_trimmed_range, in_trimmed_range) =
@@ -101,23 +114,29 @@ impl Format<GritFormatContext> for FormatGraphqlVerbatimNode<'_> {
             .flat_map(|trivia| trivia.pieces())
             .filter(|trivia| trivia.is_skipped())
             .map(|trivia| source_range(f, trivia.text_range()).start())
-            .take_while(|start| *start < trimmed_source_range.start())
+            .take_while(|start| *start < verbatim_source_range.start())
             .next()
-            .unwrap_or_else(|| trimmed_source_range.start());
+            .unwrap_or_else(|| verbatim_source_range.start());
 
         let original_source = f.context().source_map().map_or_else(
-            || self.node.text_trimmed().to_string(),
+            || {
+                if preserve_outer_trivia {
+                    self.node.text_with_trivia().to_string()
+                } else {
+                    self.node.text_trimmed().to_string()
+                }
+            },
             |source_map| {
                 source_map
                     .source()
-                    .text_slice(trimmed_source_range.cover_offset(start_source))
+                    .text_slice(verbatim_source_range.cover_offset(start_source))
                     .to_string()
             },
         );
 
         text(
             &normalize_newlines(&original_source, LINE_TERMINATORS),
-            self.node.text_trimmed_range().start(),
+            verbatim_text_start,
         )
         .fmt(f)?;
 
@@ -132,7 +151,7 @@ impl Format<GritFormatContext> for FormatGraphqlVerbatimNode<'_> {
             let trailing_comments = comments.trailing_comments(self.node);
 
             let outside_trimmed_range_start = trailing_comments.partition_point(|comment| {
-                source_range(f, comment.piece().text_range()).end() <= trimmed_source_range.end()
+                source_range(f, comment.piece().text_range()).end() <= verbatim_source_range.end()
             });
 
             let (in_trimmed_range, outside_trimmed_range) =

--- a/crates/biome_grit_formatter/tests/specs/grit/global_suppression.grit
+++ b/crates/biome_grit_formatter/tests/specs/grit/global_suppression.grit
@@ -7,3 +7,8 @@
 		$names[-1]
 	}
 }
+
+// biome-ignore-all format: intentional
+`const value = $value`
+
+// Biome format should keep this comment

--- a/crates/biome_grit_formatter/tests/specs/grit/global_suppression.grit.snap
+++ b/crates/biome_grit_formatter/tests/specs/grit/global_suppression.grit.snap
@@ -16,6 +16,11 @@ info: grit/global_suppression.grit
 	}
 }
 
+// biome-ignore-all format: intentional
+`const value = $value`
+
+// Biome format should keep this comment
+
 ```
 
 
@@ -24,10 +29,17 @@ info: grit/global_suppression.grit
 ```grit
 // biome-ignore-all format:test
 
+
 `const names = [$names]` where {
 			if 		($names[0] <: $names[-1]) {
 		$names =>
 		$names[-1]
 	}
 }
+
+// biome-ignore-all format: intentional
+`const value = $value`
+
+// Biome format should keep this comment
+
 ```

--- a/crates/biome_grit_formatter/tests/specs/grit/suppression_trailing_comments.grit
+++ b/crates/biome_grit_formatter/tests/specs/grit/suppression_trailing_comments.grit
@@ -1,0 +1,6 @@
+`const value = $value` where {
+	$value =>
+		// biome-ignore format: preserve the nested pattern formatting
+		`call(  foo,  bar )` // keep this trailing comment after the suppressed pattern
+	$done => `ok`
+}

--- a/crates/biome_grit_formatter/tests/specs/grit/suppression_trailing_comments.grit.snap
+++ b/crates/biome_grit_formatter/tests/specs/grit/suppression_trailing_comments.grit.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: grit/suppression_trailing_comments.grit
+---
+
+# Input
+
+```grit
+`const value = $value` where {
+	$value =>
+		// biome-ignore format: preserve the nested pattern formatting
+		`call(  foo,  bar )` // keep this trailing comment after the suppressed pattern
+	$done => `ok`
+}
+
+```
+
+
+# Formatted
+
+```grit
+`const value = $value` where {
+	$value =>
+		// biome-ignore format: preserve the nested pattern formatting
+		`call(  foo,  bar )` // keep this trailing comment after the suppressed pattern
+	$done => `ok`
+}
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    4: 		`call(  foo,  bar )` // keep this trailing comment after the suppressed pattern
+```

--- a/crates/biome_html_formatter/src/verbatim.rs
+++ b/crates/biome_html_formatter/src/verbatim.rs
@@ -55,6 +55,18 @@ pub struct FormatHtmlVerbatimNode<'node> {
 
 impl Format<HtmlFormatContext> for FormatHtmlVerbatimNode<'_> {
     fn fmt(&self, f: &mut Formatter<HtmlFormatContext>) -> FormatResult<()> {
+        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
+        where
+            Context: CstFormatContext,
+        {
+            f.context()
+                .source_map()
+                .map_or_else(|| range, |source_map| source_map.source_range(range))
+        }
+
+        let preserve_outer_trivia =
+            matches!(self.kind, VerbatimKind::Suppressed) && self.node.parent().is_none();
+
         for element in self.node.descendants_with_tokens(Direction::Next) {
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
@@ -72,21 +84,22 @@ impl Format<HtmlFormatContext> for FormatHtmlVerbatimNode<'_> {
         // The trimmed range of a node is its range without any of its leading or trailing trivia.
         // Except for nodes that used to be parenthesized, the range than covers the source from the
         // `(` to the `)` (the trimmed range of the parenthesized expression, not the inner expression)
-        let trimmed_source_range = f.context().source_map().map_or_else(
-            || self.node.text_trimmed_range(),
-            |source_map| source_map.trimmed_source_range(self.node),
-        );
+        let verbatim_source_range = if preserve_outer_trivia {
+            source_range(f, self.node.text_range_with_trivia())
+        } else {
+            f.context().source_map().map_or_else(
+                || self.node.text_trimmed_range(),
+                |source_map| source_map.trimmed_source_range(self.node),
+            )
+        };
+
+        let verbatim_text_start = if preserve_outer_trivia {
+            self.node.text_range_with_trivia().start()
+        } else {
+            self.node.text_trimmed_range().start()
+        };
 
         f.write_element(FormatElement::Tag(Tag::StartVerbatim(self.kind)))?;
-
-        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
-        where
-            Context: CstFormatContext,
-        {
-            f.context()
-                .source_map()
-                .map_or_else(|| range, |source_map| source_map.source_range(range))
-        }
 
         // Format all leading comments that are outside of the node's source range.
         if self.format_comments {
@@ -94,7 +107,7 @@ impl Format<HtmlFormatContext> for FormatHtmlVerbatimNode<'_> {
             let leading_comments = comments.leading_comments(self.node);
 
             let outside_trimmed_range = leading_comments.partition_point(|comment| {
-                comment.piece().text_range().end() <= trimmed_source_range.start()
+                comment.piece().text_range().end() <= verbatim_source_range.start()
             });
 
             let (outside_trimmed_range, in_trimmed_range) =
@@ -116,23 +129,29 @@ impl Format<HtmlFormatContext> for FormatHtmlVerbatimNode<'_> {
             .flat_map(|trivia| trivia.pieces())
             .filter(|trivia| trivia.is_skipped())
             .map(|trivia| source_range(f, trivia.text_range()).start())
-            .take_while(|start| *start < trimmed_source_range.start())
+            .take_while(|start| *start < verbatim_source_range.start())
             .next()
-            .unwrap_or_else(|| trimmed_source_range.start());
+            .unwrap_or_else(|| verbatim_source_range.start());
 
         let original_source = f.context().source_map().map_or_else(
-            || self.node.text_trimmed().to_string(),
+            || {
+                if preserve_outer_trivia {
+                    self.node.text_with_trivia().to_string()
+                } else {
+                    self.node.text_trimmed().to_string()
+                }
+            },
             |source_map| {
                 source_map
                     .source()
-                    .text_slice(trimmed_source_range.cover_offset(start_source))
+                    .text_slice(verbatim_source_range.cover_offset(start_source))
                     .to_string()
             },
         );
 
         text(
             &normalize_newlines(&original_source, LINE_TERMINATORS),
-            self.node.text_trimmed_range().start(),
+            verbatim_text_start,
         )
         .fmt(f)?;
 
@@ -147,7 +166,7 @@ impl Format<HtmlFormatContext> for FormatHtmlVerbatimNode<'_> {
             let trailing_comments = comments.trailing_comments(self.node);
 
             let outside_trimmed_range_start = trailing_comments.partition_point(|comment| {
-                source_range(f, comment.piece().text_range()).end() <= trimmed_source_range.end()
+                source_range(f, comment.piece().text_range()).end() <= verbatim_source_range.end()
             });
 
             let (in_trimmed_range, outside_trimmed_range) =

--- a/crates/biome_html_formatter/tests/specs/html/suppressions/global_suppression.html
+++ b/crates/biome_html_formatter/tests/specs/html/suppressions/global_suppression.html
@@ -10,3 +10,8 @@
 
 
 <html>      </html>
+
+<!-- biome-ignore-all format: intentional -->
+<div>   code   </div>
+
+<!-- Biome format should keep this comment -->

--- a/crates/biome_html_formatter/tests/specs/html/suppressions/global_suppression.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/suppressions/global_suppression.html.snap
@@ -19,6 +19,11 @@ info: suppressions/global_suppression.html
 
 <html>      </html>
 
+<!-- biome-ignore-all format: intentional -->
+<div>   code   </div>
+
+<!-- Biome format should keep this comment -->
+
 ```
 
 
@@ -37,4 +42,10 @@ info: suppressions/global_suppression.html
 
 
 <html>      </html>
+
+<!-- biome-ignore-all format: intentional -->
+<div>   code   </div>
+
+<!-- Biome format should keep this comment -->
+
 ```

--- a/crates/biome_html_formatter/tests/specs/html/suppressions/suppression_trailing_comments.html
+++ b/crates/biome_html_formatter/tests/specs/html/suppressions/suppression_trailing_comments.html
@@ -1,0 +1,5 @@
+<div>
+	<!-- biome-ignore format: preserve the nested element formatting -->
+	<span>one     two</span><!-- keep this trailing comment after the suppressed element -->
+	<p>done</p>
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/suppressions/suppression_trailing_comments.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/suppressions/suppression_trailing_comments.html.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: suppressions/suppression_trailing_comments.html
+---
+
+# Input
+
+```html
+<div>
+	<!-- biome-ignore format: preserve the nested element formatting -->
+	<span>one     two</span><!-- keep this trailing comment after the suppressed element -->
+	<p>done</p>
+</div>
+
+```
+
+
+# Formatted
+
+```html
+<div>
+	<!-- biome-ignore format: preserve the nested element formatting -->
+	<span>one     two</span><!-- keep this trailing comment after the suppressed element -->
+	<p>done</p>
+</div>
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    3: 	<span>one     two</span><!-- keep this trailing comment after the suppressed element -->
+```

--- a/crates/biome_js_formatter/src/verbatim.rs
+++ b/crates/biome_js_formatter/src/verbatim.rs
@@ -40,6 +40,18 @@ pub struct FormatJsVerbatimNode<'node> {
 
 impl Format<JsFormatContext> for FormatJsVerbatimNode<'_> {
     fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
+        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
+        where
+            Context: CstFormatContext,
+        {
+            f.context()
+                .source_map()
+                .map_or_else(|| range, |source_map| source_map.source_range(range))
+        }
+
+        let preserve_outer_trivia =
+            matches!(self.kind, VerbatimKind::Suppressed) && self.node.parent().is_none();
+
         for element in self.node.descendants_with_tokens(Direction::Next) {
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
@@ -57,21 +69,22 @@ impl Format<JsFormatContext> for FormatJsVerbatimNode<'_> {
         // The trimmed range of a node is its range without any of its leading or trailing trivia.
         // Except for nodes that used to be parenthesized, the range than covers the source from the
         // `(` to the `)` (the trimmed range of the parenthesized expression, not the inner expression)
-        let trimmed_source_range = f.context().source_map().map_or_else(
-            || self.node.text_trimmed_range(),
-            |source_map| source_map.trimmed_source_range(self.node),
-        );
+        let verbatim_source_range = if preserve_outer_trivia {
+            source_range(f, self.node.text_range_with_trivia())
+        } else {
+            f.context().source_map().map_or_else(
+                || self.node.text_trimmed_range(),
+                |source_map| source_map.trimmed_source_range(self.node),
+            )
+        };
+
+        let verbatim_text_start = if preserve_outer_trivia {
+            self.node.text_range_with_trivia().start()
+        } else {
+            self.node.text_trimmed_range().start()
+        };
 
         f.write_element(FormatElement::Tag(Tag::StartVerbatim(self.kind)))?;
-
-        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
-        where
-            Context: CstFormatContext,
-        {
-            f.context()
-                .source_map()
-                .map_or_else(|| range, |source_map| source_map.source_range(range))
-        }
 
         // Format all leading comments that are outside of the node's source range.
         if self.format_comments {
@@ -79,7 +92,7 @@ impl Format<JsFormatContext> for FormatJsVerbatimNode<'_> {
             let leading_comments = comments.leading_comments(self.node);
 
             let outside_trimmed_range = leading_comments.partition_point(|comment| {
-                comment.piece().text_range().end() <= trimmed_source_range.start()
+                comment.piece().text_range().end() <= verbatim_source_range.start()
             });
 
             let (outside_trimmed_range, in_trimmed_range) =
@@ -101,23 +114,29 @@ impl Format<JsFormatContext> for FormatJsVerbatimNode<'_> {
             .flat_map(|trivia| trivia.pieces())
             .filter(|trivia| trivia.is_skipped())
             .map(|trivia| source_range(f, trivia.text_range()).start())
-            .take_while(|start| *start < trimmed_source_range.start())
+            .take_while(|start| *start < verbatim_source_range.start())
             .next()
-            .unwrap_or_else(|| trimmed_source_range.start());
+            .unwrap_or_else(|| verbatim_source_range.start());
 
         let original_source = f.context().source_map().map_or_else(
-            || self.node.text_trimmed().to_string(),
+            || {
+                if preserve_outer_trivia {
+                    self.node.text_with_trivia().to_string()
+                } else {
+                    self.node.text_trimmed().to_string()
+                }
+            },
             |source_map| {
                 source_map
                     .source()
-                    .text_slice(trimmed_source_range.cover_offset(start_source))
+                    .text_slice(verbatim_source_range.cover_offset(start_source))
                     .to_string()
             },
         );
 
         text(
             &normalize_newlines(&original_source, LINE_TERMINATORS),
-            self.node.text_trimmed_range().start(),
+            verbatim_text_start,
         )
         .fmt(f)?;
 
@@ -132,7 +151,7 @@ impl Format<JsFormatContext> for FormatJsVerbatimNode<'_> {
             let trailing_comments = comments.trailing_comments(self.node);
 
             let outside_trimmed_range_start = trailing_comments.partition_point(|comment| {
-                source_range(f, comment.piece().text_range()).end() <= trimmed_source_range.end()
+                source_range(f, comment.piece().text_range()).end() <= verbatim_source_range.end()
             });
 
             let (in_trimmed_range, outside_trimmed_range) =

--- a/crates/biome_js_formatter/tests/specs/js/module/global_suppression.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/global_suppression.js
@@ -3,3 +3,8 @@
 let a = 		1	;
 
 function name() { return "    "     };
+
+// biome-ignore-all format: intentional
+console.log("code")
+
+// Biome format should keep this comment

--- a/crates/biome_js_formatter/tests/specs/js/module/global_suppression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/global_suppression.js.snap
@@ -12,6 +12,11 @@ let a = 		1	;
 
 function name() { return "    "     };
 
+// biome-ignore-all format: intentional
+console.log("code")
+
+// Biome format should keep this comment
+
 ```
 
 
@@ -23,4 +28,10 @@ function name() { return "    "     };
 let a = 		1	;
 
 function name() { return "    "     };
+
+// biome-ignore-all format: intentional
+console.log("code")
+
+// Biome format should keep this comment
+
 ```

--- a/crates/biome_js_formatter/tests/specs/js/module/suppression_trailing_comments.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/suppression_trailing_comments.js
@@ -1,0 +1,20 @@
+const config = {
+	items:
+		// biome-ignore format: preserve the inner array formatting
+		[foo  , bar], // keep this trailing comment attached after the suppressed value
+	enabled: true,
+};
+
+callExpression(
+	firstArg,
+	// biome-ignore format: preserve the callback body formatting
+	function () { return { a: 1,  b: 2 } }, // keep this trailing comment after the suppressed callback argument
+	lastArg,
+);
+
+const output = wrapper({
+	value:
+		// biome-ignore format: preserve the conditional expression formatting
+		condition?left:right, // keep this trailing comment after the suppressed conditional value
+	label: "done",
+});

--- a/crates/biome_js_formatter/tests/specs/js/module/suppression_trailing_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/suppression_trailing_comments.js.snap
@@ -1,0 +1,64 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/suppression_trailing_comments.js
+---
+
+# Input
+
+```js
+const config = {
+	items:
+		// biome-ignore format: preserve the inner array formatting
+		[foo  , bar], // keep this trailing comment attached after the suppressed value
+	enabled: true,
+};
+
+callExpression(
+	firstArg,
+	// biome-ignore format: preserve the callback body formatting
+	function () { return { a: 1,  b: 2 } }, // keep this trailing comment after the suppressed callback argument
+	lastArg,
+);
+
+const output = wrapper({
+	value:
+		// biome-ignore format: preserve the conditional expression formatting
+		condition?left:right, // keep this trailing comment after the suppressed conditional value
+	label: "done",
+});
+
+```
+
+
+# Formatted
+
+```js
+const config = {
+	items:
+		// biome-ignore format: preserve the inner array formatting
+		[foo  , bar], // keep this trailing comment attached after the suppressed value
+	enabled: true,
+};
+
+callExpression(
+	firstArg,
+	// biome-ignore format: preserve the callback body formatting
+	function () { return { a: 1,  b: 2 } }, // keep this trailing comment after the suppressed callback argument
+	lastArg,
+);
+
+const output = wrapper({
+	value:
+		// biome-ignore format: preserve the conditional expression formatting
+		condition?left:right, // keep this trailing comment after the suppressed conditional value
+	label: "done",
+});
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    4: 		[foo  , bar], // keep this trailing comment attached after the suppressed value
+   11: 	function () { return { a: 1,  b: 2 } }, // keep this trailing comment after the suppressed callback argument
+   18: 		condition?left:right, // keep this trailing comment after the suppressed conditional value
+```

--- a/crates/biome_js_formatter/tests/specs/ts/suppressions_trailing_comments.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/suppressions_trailing_comments.ts
@@ -1,0 +1,6 @@
+interface SuppressionsWithTrailingComments {
+	value:
+		// biome-ignore format: preserve the nested type formatting
+		Array<string|number>; // keep this trailing comment after the suppressed type
+	done: void;
+}

--- a/crates/biome_js_formatter/tests/specs/ts/suppressions_trailing_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/suppressions_trailing_comments.ts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/suppressions_trailing_comments.ts
+---
+
+# Input
+
+```ts
+interface SuppressionsWithTrailingComments {
+	value:
+		// biome-ignore format: preserve the nested type formatting
+		Array<string|number>; // keep this trailing comment after the suppressed type
+	done: void;
+}
+
+```
+
+
+# Formatted
+
+```ts
+interface SuppressionsWithTrailingComments {
+	value: // biome-ignore format: preserve the nested type formatting
+	Array<string|number>; // keep this trailing comment after the suppressed type
+	done: void;
+}
+
+```

--- a/crates/biome_json_formatter/src/verbatim.rs
+++ b/crates/biome_json_formatter/src/verbatim.rs
@@ -39,6 +39,18 @@ pub struct FormatJsonVerbatimNode<'node> {
 
 impl Format<JsonFormatContext> for FormatJsonVerbatimNode<'_> {
     fn fmt(&self, f: &mut Formatter<JsonFormatContext>) -> FormatResult<()> {
+        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
+        where
+            Context: CstFormatContext,
+        {
+            f.context()
+                .source_map()
+                .map_or_else(|| range, |source_map| source_map.source_range(range))
+        }
+
+        let preserve_outer_trivia =
+            matches!(self.kind, VerbatimKind::Suppressed) && self.node.parent().is_none();
+
         for element in self.node.descendants_with_tokens(Direction::Next) {
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
@@ -56,21 +68,22 @@ impl Format<JsonFormatContext> for FormatJsonVerbatimNode<'_> {
         // The trimmed range of a node is its range without any of its leading or trailing trivia.
         // Except for nodes that used to be parenthesized, the range than covers the source from the
         // `(` to the `)` (the trimmed range of the parenthesized expression, not the inner expression)
-        let trimmed_source_range = f.context().source_map().map_or_else(
-            || self.node.text_trimmed_range(),
-            |source_map| source_map.trimmed_source_range(self.node),
-        );
+        let verbatim_source_range = if preserve_outer_trivia {
+            source_range(f, self.node.text_range_with_trivia())
+        } else {
+            f.context().source_map().map_or_else(
+                || self.node.text_trimmed_range(),
+                |source_map| source_map.trimmed_source_range(self.node),
+            )
+        };
+
+        let verbatim_text_start = if preserve_outer_trivia {
+            self.node.text_range_with_trivia().start()
+        } else {
+            self.node.text_trimmed_range().start()
+        };
 
         f.write_element(FormatElement::Tag(Tag::StartVerbatim(self.kind)))?;
-
-        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
-        where
-            Context: CstFormatContext,
-        {
-            f.context()
-                .source_map()
-                .map_or_else(|| range, |source_map| source_map.source_range(range))
-        }
 
         // Format all leading comments that are outside of the node's source range.
         if self.format_comments {
@@ -78,7 +91,7 @@ impl Format<JsonFormatContext> for FormatJsonVerbatimNode<'_> {
             let leading_comments = comments.leading_comments(self.node);
 
             let outside_trimmed_range = leading_comments.partition_point(|comment| {
-                comment.piece().text_range().end() <= trimmed_source_range.start()
+                comment.piece().text_range().end() <= verbatim_source_range.start()
             });
 
             let (outside_trimmed_range, in_trimmed_range) =
@@ -100,23 +113,29 @@ impl Format<JsonFormatContext> for FormatJsonVerbatimNode<'_> {
             .flat_map(|trivia| trivia.pieces())
             .filter(|trivia| trivia.is_skipped())
             .map(|trivia| source_range(f, trivia.text_range()).start())
-            .take_while(|start| *start < trimmed_source_range.start())
+            .take_while(|start| *start < verbatim_source_range.start())
             .next()
-            .unwrap_or_else(|| trimmed_source_range.start());
+            .unwrap_or_else(|| verbatim_source_range.start());
 
         let original_source = f.context().source_map().map_or_else(
-            || self.node.text_trimmed().to_string(),
+            || {
+                if preserve_outer_trivia {
+                    self.node.text_with_trivia().to_string()
+                } else {
+                    self.node.text_trimmed().to_string()
+                }
+            },
             |source_map| {
                 source_map
                     .source()
-                    .text_slice(trimmed_source_range.cover_offset(start_source))
+                    .text_slice(verbatim_source_range.cover_offset(start_source))
                     .to_string()
             },
         );
 
         text(
             &normalize_newlines(&original_source, LINE_TERMINATORS),
-            self.node.text_trimmed_range().start(),
+            verbatim_text_start,
         )
         .fmt(f)?;
 
@@ -131,7 +150,7 @@ impl Format<JsonFormatContext> for FormatJsonVerbatimNode<'_> {
             let trailing_comments = comments.trailing_comments(self.node);
 
             let outside_trimmed_range_start = trailing_comments.partition_point(|comment| {
-                source_range(f, comment.piece().text_range()).end() <= trimmed_source_range.end()
+                source_range(f, comment.piece().text_range()).end() <= verbatim_source_range.end()
             });
 
             let (in_trimmed_range, outside_trimmed_range) =

--- a/crates/biome_json_formatter/tests/specs/json/global_suppression.jsonc
+++ b/crates/biome_json_formatter/tests/specs/json/global_suppression.jsonc
@@ -6,3 +6,8 @@
 
 	    "a": "b", "c": "d", "e": "f"
 }
+
+// biome-ignore-all format: intentional
+{"code":true}
+
+// Biome format should keep this comment

--- a/crates/biome_json_formatter/tests/specs/json/global_suppression.jsonc.snap
+++ b/crates/biome_json_formatter/tests/specs/json/global_suppression.jsonc.snap
@@ -15,6 +15,11 @@ info: json/global_suppression.jsonc
 	    "a": "b", "c": "d", "e": "f"
 }
 
+// biome-ignore-all format: intentional
+{"code":true}
+
+// Biome format should keep this comment
+
 ```
 
 
@@ -23,9 +28,16 @@ info: json/global_suppression.jsonc
 ```jsonc
 // biome-ignore-all format: test
 
+
 {
 
 
 	    "a": "b", "c": "d", "e": "f"
 }
+
+// biome-ignore-all format: intentional
+{"code":true}
+
+// Biome format should keep this comment
+
 ```

--- a/crates/biome_json_formatter/tests/specs/json/suppression_trailing_comments.jsonc
+++ b/crates/biome_json_formatter/tests/specs/json/suppression_trailing_comments.jsonc
@@ -1,0 +1,8 @@
+{
+	"items": [
+		// biome-ignore format: preserve the nested object formatting
+		{"a":1,"b":2}, // keep this trailing comment after the suppressed element
+		3,
+	],
+	"done": true
+}

--- a/crates/biome_json_formatter/tests/specs/json/suppression_trailing_comments.jsonc.snap
+++ b/crates/biome_json_formatter/tests/specs/json/suppression_trailing_comments.jsonc.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: json/suppression_trailing_comments.jsonc
+---
+
+# Input
+
+```jsonc
+{
+	"items": [
+		// biome-ignore format: preserve the nested object formatting
+		{"a":1,"b":2}, // keep this trailing comment after the suppressed element
+		3,
+	],
+	"done": true
+}
+
+```
+
+
+# Formatted
+
+```jsonc
+{
+	"items": [
+		// biome-ignore format: preserve the nested object formatting
+		{"a":1,"b":2}, // keep this trailing comment after the suppressed element
+		3
+	],
+	"done": true
+}
+
+```

--- a/crates/biome_yaml_formatter/src/verbatim.rs
+++ b/crates/biome_yaml_formatter/src/verbatim.rs
@@ -40,6 +40,18 @@ pub struct FormatYamlVerbatimNode<'node> {
 
 impl Format<YamlFormatContext> for FormatYamlVerbatimNode<'_> {
     fn fmt(&self, f: &mut Formatter<YamlFormatContext>) -> FormatResult<()> {
+        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
+        where
+            Context: CstFormatContext,
+        {
+            f.context()
+                .source_map()
+                .map_or_else(|| range, |source_map| source_map.source_range(range))
+        }
+
+        let preserve_outer_trivia =
+            matches!(self.kind, VerbatimKind::Suppressed) && self.node.parent().is_none();
+
         for element in self.node.descendants_with_tokens(Direction::Next) {
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
@@ -57,21 +69,22 @@ impl Format<YamlFormatContext> for FormatYamlVerbatimNode<'_> {
         // The trimmed range of a node is its range without any of its leading or trailing trivia.
         // Except for nodes that used to be parenthesized, the range than covers the source from the
         // `(` to the `)` (the trimmed range of the parenthesized expression, not the inner expression)
-        let trimmed_source_range = f.context().source_map().map_or_else(
-            || self.node.text_trimmed_range(),
-            |source_map| source_map.trimmed_source_range(self.node),
-        );
+        let verbatim_source_range = if preserve_outer_trivia {
+            source_range(f, self.node.text_range_with_trivia())
+        } else {
+            f.context().source_map().map_or_else(
+                || self.node.text_trimmed_range(),
+                |source_map| source_map.trimmed_source_range(self.node),
+            )
+        };
+
+        let verbatim_text_start = if preserve_outer_trivia {
+            self.node.text_range_with_trivia().start()
+        } else {
+            self.node.text_trimmed_range().start()
+        };
 
         f.write_element(FormatElement::Tag(Tag::StartVerbatim(self.kind)))?;
-
-        fn source_range<Context>(f: &Formatter<Context>, range: TextRange) -> TextRange
-        where
-            Context: CstFormatContext,
-        {
-            f.context()
-                .source_map()
-                .map_or_else(|| range, |source_map| source_map.source_range(range))
-        }
 
         // Format all leading comments that are outside of the node's source range.
         if self.format_comments {
@@ -79,7 +92,7 @@ impl Format<YamlFormatContext> for FormatYamlVerbatimNode<'_> {
             let leading_comments = comments.leading_comments(self.node);
 
             let outside_trimmed_range = leading_comments.partition_point(|comment| {
-                comment.piece().text_range().end() <= trimmed_source_range.start()
+                comment.piece().text_range().end() <= verbatim_source_range.start()
             });
 
             let (outside_trimmed_range, in_trimmed_range) =
@@ -101,23 +114,29 @@ impl Format<YamlFormatContext> for FormatYamlVerbatimNode<'_> {
             .flat_map(|trivia| trivia.pieces())
             .filter(|trivia| trivia.is_skipped())
             .map(|trivia| source_range(f, trivia.text_range()).start())
-            .take_while(|start| *start < trimmed_source_range.start())
+            .take_while(|start| *start < verbatim_source_range.start())
             .next()
-            .unwrap_or_else(|| trimmed_source_range.start());
+            .unwrap_or_else(|| verbatim_source_range.start());
 
         let original_source = f.context().source_map().map_or_else(
-            || self.node.text_trimmed().to_string(),
+            || {
+                if preserve_outer_trivia {
+                    self.node.text_with_trivia().to_string()
+                } else {
+                    self.node.text_trimmed().to_string()
+                }
+            },
             |source_map| {
                 source_map
                     .source()
-                    .text_slice(trimmed_source_range.cover_offset(start_source))
+                    .text_slice(verbatim_source_range.cover_offset(start_source))
                     .to_string()
             },
         );
 
         text(
             &normalize_newlines(&original_source, LINE_TERMINATORS),
-            self.node.text_trimmed_range().start(),
+            verbatim_text_start,
         )
         .fmt(f)?;
 
@@ -132,7 +151,7 @@ impl Format<YamlFormatContext> for FormatYamlVerbatimNode<'_> {
             let trailing_comments = comments.trailing_comments(self.node);
 
             let outside_trimmed_range_start = trailing_comments.partition_point(|comment| {
-                source_range(f, comment.piece().text_range()).end() <= trimmed_source_range.end()
+                source_range(f, comment.piece().text_range()).end() <= verbatim_source_range.end()
             });
 
             let (in_trimmed_range, outside_trimmed_range) =


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Previously, we were throwing away some trivia after suppressed nodes. This PR fixes that.

Generated by gpt 5.4

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #9781
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added snapshot tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
