### PR TITLE
feat(lint/js): add `noBaseToString`

### DIFF
--- a/.changeset/tidy-lamps-bake.md
+++ b/.changeset/tidy-lamps-bake.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Added the nursery rule [`noBaseToString`](https://biomejs.dev/linter/rules/no-base-to-string/), which reports stringification sites that fall back to Object's default `"[object Object]"` formatting. The rule also supports the `ignoredTypeNames` option and `biome migrate eslint` now preserves that option from `@typescript-eslint/no-base-to-string`.
+Added the nursery rule [`noBaseToString`](https://biomejs.dev/linter/rules/no-base-to-string/), which reports stringification sites that fall back to Object's default `"[object Object]"` formatting. The rule also supports the `ignoredTypeNames` option.

--- a/.changeset/tidy-lamps-bake.md
+++ b/.changeset/tidy-lamps-bake.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added the nursery rule [`noBaseToString`](https://biomejs.dev/linter/rules/no-base-to-string/), which reports stringification sites that fall back to Object's default `"[object Object]"` formatting. The rule also supports the `ignoredTypeNames` option and `biome migrate eslint` now preserves that option from `@typescript-eslint/no-base-to-string`.

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -709,6 +709,18 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "@typescript-eslint/no-base-to-string" => {
+            if !options.include_nursery {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_base_to_string
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
         "@typescript-eslint/no-deprecated" => {
             if !options.include_inspired {
                 results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);

--- a/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
@@ -581,6 +581,11 @@ impl Deserializable for Rules {
                                 result.insert(Rule::TypeScriptNoShadow(conf));
                             }
                         }
+                        "@typescript-eslint/no-base-to-string" => {
+                            if let Some(conf) = RuleConf::deserialize(ctx, &value, name) {
+                                result.insert(Rule::TypeScriptNoBaseToString(conf));
+                            }
+                        }
                         "unicorn/filename-case" => {
                             if let Some(conf) = RuleConf::deserialize(ctx, &value, name) {
                                 result.insert(Rule::UnicornFilenameCase(conf));
@@ -672,6 +677,7 @@ pub(crate) enum Rule {
     TypeScriptExplicitMemberAccessibility(
         RuleConf<eslint_typescript::ExplicitMemberAccessibilityOptions>,
     ),
+    TypeScriptNoBaseToString(RuleConf<eslint_typescript::NoBaseToStringOptions>),
     TypeScriptNamingConvention(RuleConf<Box<eslint_typescript::NamingConventionSelection>>),
     TypeScriptNoShadow(RuleConf<eslint_typescript::NoShadowOptions>),
     UnicornFilenameCase(RuleConf<eslint_unicorn::FilenameCaseOptions>),
@@ -691,6 +697,9 @@ impl Rule {
             }
             Self::TypeScriptExplicitMemberAccessibility(_) => {
                 Cow::Borrowed("@typescript-eslint/explicit-member-accessibility")
+            }
+            Self::TypeScriptNoBaseToString(_) => {
+                Cow::Borrowed("@typescript-eslint/no-base-to-string")
             }
             Self::TypeScriptNamingConvention(_) => {
                 Cow::Borrowed("@typescript-eslint/naming-convention")

--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -780,6 +780,21 @@ fn migrate_eslint_rule(
                 }
             }
         }
+        eslint_eslint::Rule::TypeScriptNoBaseToString(conf) => {
+            if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results)
+                && let eslint_eslint::RuleConf::Option(severity, rule_options) = conf
+            {
+                let group = rules.nursery.get_or_insert_with(Default::default);
+                if let SeverityOrGroup::Group(group) = group {
+                    group.no_base_to_string = Some(biome_config::RuleConfiguration::WithOptions(
+                        biome_config::RuleWithOptions {
+                            level: severity.into(),
+                            options: rule_options.into(),
+                        },
+                    ));
+                }
+            }
+        }
         eslint_eslint::Rule::TypeScriptNamingConvention(conf) => {
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 let severity = conf.severity();

--- a/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
@@ -8,9 +8,28 @@ use biome_deserialize::Deserializable;
 use biome_deserialize_macros::Deserializable;
 use biome_rule_options::restricted_regex::RestrictedRegex;
 use biome_rule_options::{
-    no_shadow, use_consistent_array_type, use_consistent_member_accessibility, use_import_type,
-    use_naming_convention,
+    no_base_to_string, no_shadow, use_consistent_array_type, use_consistent_array_type,
+    use_consistent_member_accessibility, use_consistent_member_accessibility, use_import_type,
+    use_import_type, use_naming_convention, use_naming_convention,
 };
+
+#[derive(Debug, Default, Deserializable)]
+#[deserializable(unknown_fields = "allow")]
+pub(crate) struct NoBaseToStringOptions {
+    #[deserializable(rename = "ignoredTypeNames")]
+    ignored_type_names: Option<Box<[Box<str>]>>,
+    #[deserializable(rename = "checkUnknown")]
+    check_unknown: Option<bool>,
+}
+
+impl From<NoBaseToStringOptions> for no_base_to_string::NoBaseToStringOptions {
+    fn from(value: NoBaseToStringOptions) -> Self {
+        let _ = value.check_unknown;
+        Self {
+            ignored_type_names: value.ignored_type_names,
+        }
+    }
+}
 
 #[derive(Debug, Default, Deserializable)]
 pub(crate) struct ArrayTypeOptions {

--- a/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
@@ -8,9 +8,8 @@ use biome_deserialize::Deserializable;
 use biome_deserialize_macros::Deserializable;
 use biome_rule_options::restricted_regex::RestrictedRegex;
 use biome_rule_options::{
-    no_base_to_string, no_shadow, use_consistent_array_type, use_consistent_array_type,
-    use_consistent_member_accessibility, use_consistent_member_accessibility, use_import_type,
-    use_import_type, use_naming_convention, use_naming_convention,
+    no_base_to_string, no_shadow, use_consistent_array_type, use_consistent_member_accessibility,
+    use_import_type, use_naming_convention,
 };
 
 #[derive(Debug, Default, Deserializable)]

--- a/crates/biome_cli/tests/commands/migrate_eslint.rs
+++ b/crates/biome_cli/tests/commands/migrate_eslint.rs
@@ -397,6 +397,52 @@ fn migrate_eslintrcjson_rule_options() {
 }
 
 #[test]
+fn migrate_eslintrcjson_nursery_rule_options() {
+    let biomejson = r#"{ "linter": { "enabled": true } }"#;
+    let eslintrc = r#"{
+        "rules": {
+            "@typescript-eslint/no-base-to-string": ["error", {
+                "ignoredTypeNames": ["Error", "CustomStringLike"],
+                "checkUnknown": true
+            }]
+        },
+        "overrides": [{
+            "files": ["default.ts"],
+            "rules": {
+                "@typescript-eslint/no-base-to-string": "error"
+            }
+        }]
+    }"#;
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8Path::new("biome.json").into(), biomejson.as_bytes());
+    fs.insert(Utf8Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
+
+    let mut console = BufferConsole::default();
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "migrate",
+                "eslint",
+                "--include-inspired",
+                "--include-nursery",
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "migrate_eslintrcjson_nursery_rule_options",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn migrate_eslintrcjson_empty() {
     let biomejson = r#"{ "linter": { "enabled": true } }
 "#;

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_nursery_rule_options.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_nursery_rule_options.snap
@@ -1,0 +1,87 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{ "linter": { "enabled": true } }
+```
+
+## `.eslintrc.json`
+
+```json
+{
+        "rules": {
+            "@typescript-eslint/no-base-to-string": ["error", {
+                "ignoredTypeNames": ["Error", "CustomStringLike"],
+                "checkUnknown": true
+            }]
+        },
+        "overrides": [{
+            "files": ["default.ts"],
+            "rules": {
+                "@typescript-eslint/no-base-to-string": "error"
+            }
+        }]
+    }
+```
+
+# Emitted Messages
+
+```block
+biome.json migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1    │ - {·"linter":·{·"enabled":·true·}·}
+       1 │ + {
+       2 │ + → "linter":·{
+       3 │ + → → "enabled":·true,
+       4 │ + → → "rules":·{
+       5 │ + → → → "recommended":·false,
+       6 │ + → → → "nursery":·{
+       7 │ + → → → → "noBaseToString":·{
+       8 │ + → → → → → "level":·"error",
+       9 │ + → → → → → "options":·{·"ignoredTypeNames":·["Error",·"CustomStringLike"]·}
+      10 │ + → → → → }
+      11 │ + → → → }
+      12 │ + → → }
+      13 │ + → },
+      14 │ + → "overrides":·[
+      15 │ + → → {
+      16 │ + → → → "includes":·["default.ts"],
+      17 │ + → → → "linter":·{·"rules":·{·"nursery":·{·"noBaseToString":·"error"·}·}·}
+      18 │ + → → }
+      19 │ + → ]
+      20 │ + }
+      21 │ + 
+  
+
+```
+
+```block
+migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i 1 ESLint rules found
+    - 1 can be migrated to Biome's rules (run with --write to migrate)
+    - 100% (1) of your ESLint rules are fully covered by Biome
+      - 100% (1) via direct migration to Biome rules
+  
+  
+
+```
+
+```block
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Migration results:
+  
+  - biome.json: configuration needs migration.
+  
+  i Use --write to apply the changes.
+  
+  $ biome migrate --write
+  
+
+```

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -105,6 +105,7 @@ pub enum RuleName {
     NoAwaitInLoops,
     NoBannedTypes,
     NoBarrelFile,
+    NoBaseToString,
     NoBeforeInteractiveScriptOutsideDocument,
     NoBiomeFirstException,
     NoBitwiseOperators,
@@ -601,6 +602,7 @@ impl RuleName {
             Self::NoAwaitInLoops => "noAwaitInLoops",
             Self::NoBannedTypes => "noBannedTypes",
             Self::NoBarrelFile => "noBarrelFile",
+            Self::NoBaseToString => "noBaseToString",
             Self::NoBeforeInteractiveScriptOutsideDocument => {
                 "noBeforeInteractiveScriptOutsideDocument"
             }
@@ -1105,6 +1107,7 @@ impl RuleName {
             Self::NoAwaitInLoops => RuleGroup::Performance,
             Self::NoBannedTypes => RuleGroup::Complexity,
             Self::NoBarrelFile => RuleGroup::Performance,
+            Self::NoBaseToString => RuleGroup::Nursery,
             Self::NoBeforeInteractiveScriptOutsideDocument => RuleGroup::Nursery,
             Self::NoBiomeFirstException => RuleGroup::Suspicious,
             Self::NoBitwiseOperators => RuleGroup::Suspicious,
@@ -1604,6 +1607,7 @@ impl std::str::FromStr for RuleName {
             "noAwaitInLoops" => Ok(Self::NoAwaitInLoops),
             "noBannedTypes" => Ok(Self::NoBannedTypes),
             "noBarrelFile" => Ok(Self::NoBarrelFile),
+            "noBaseToString" => Ok(Self::NoBaseToString),
             "noBeforeInteractiveScriptOutsideDocument" => {
                 Ok(Self::NoBeforeInteractiveScriptOutsideDocument)
             }

--- a/crates/biome_configuration/src/generated/domain_selector.rs
+++ b/crates/biome_configuration/src/generated/domain_selector.rs
@@ -124,6 +124,7 @@ static TURBOREPO_FILTERS: LazyLock<Vec<RuleFilter<'static>>> =
     LazyLock::new(|| vec![RuleFilter::Rule("nursery", "noUndeclaredEnvVars")]);
 static TYPES_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
     vec![
+        RuleFilter::Rule("nursery", "noBaseToString"),
         RuleFilter::Rule("nursery", "noFloatingPromises"),
         RuleFilter::Rule("nursery", "noMisleadingReturnType"),
         RuleFilter::Rule("nursery", "noMisusedPromises"),

--- a/crates/biome_configuration/src/generated/linter_options_check.rs
+++ b/crates/biome_configuration/src/generated/linter_options_check.rs
@@ -85,6 +85,11 @@ pub fn config_side_rule_options_types() -> Vec<(&'static str, &'static str, Type
         "noBarrelFile",
         TypeId::of::<biome_rule_options::no_barrel_file::NoBarrelFileOptions>(),
     ));
+    result.push((
+        "nursery",
+        "noBaseToString",
+        TypeId::of::<biome_rule_options::no_base_to_string::NoBaseToStringOptions>(),
+    ));
     result.push(("nursery", "noBeforeInteractiveScriptOutsideDocument", TypeId::of::<biome_rule_options::no_before_interactive_script_outside_document::NoBeforeInteractiveScriptOutsideDocumentOptions>()));
     result.push((
         "suspicious",

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -174,6 +174,7 @@ define_categories! {
     "lint/correctness/useValidTypeof": "https://biomejs.dev/linter/rules/use-valid-typeof",
     "lint/correctness/useYield": "https://biomejs.dev/linter/rules/use-yield",
     "lint/nursery/noAmbiguousAnchorText": "https://biomejs.dev/linter/rules/no-ambiguous-anchor-text",
+    "lint/nursery/noBaseToString": "https://biomejs.dev/linter/rules/no-base-to-string",
     "lint/nursery/noBeforeInteractiveScriptOutsideDocument": "https://biomejs.dev/linter/rules/no-before-interactive-script-outside-document",
     "lint/nursery/noColorInvalidHex": "https://biomejs.dev/linter/rules/no-color-invalid-hex",
     "lint/nursery/noComponentHookFactories": "https://biomejs.dev/linter/rules/no-component-hook-factories",

--- a/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
@@ -1,0 +1,877 @@
+use crate::services::typed::Typed;
+use std::collections::HashSet;
+
+use biome_analyze::{
+    Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext, declare_lint_rule,
+};
+use biome_console::markup;
+use biome_js_syntax::{
+    AnyJsAssignment, AnyJsAssignmentPattern, AnyJsExpression, AnyJsTemplateElement,
+    JsAssignmentExpression, JsAssignmentOperator, JsBinaryExpression, JsBinaryOperator,
+    JsCallExpression, JsTemplateExpression, global_identifier,
+};
+use biome_js_type_info::{Literal, ResolvedTypeData, ResolverId, Type, TypeData, TypeId};
+use biome_rowan::{AstNode, AstSeparatedList, TextRange, declare_node_union};
+use biome_rule_options::no_base_to_string::NoBaseToStringOptions;
+
+const DEFAULT_IGNORED_TYPE_NAMES: &[&str] = &["Error", "RegExp", "URL", "URLSearchParams"];
+
+declare_lint_rule! {
+    /// Require stringification to avoid values that only use the default object representation.
+    ///
+    /// JavaScript coerces values to strings in several places, such as `String(value)`,
+    /// `value.toString()`, string concatenation, template interpolation, and `Array#join()`.
+    /// When the value only inherits the default object stringification, that often produces
+    /// `"[object Object]"` instead of something intentionally readable.
+    ///
+    /// This rule reports stringification sites that are known to use that default object
+    /// formatting. It supports the upstream `ignoredTypeNames` option, but intentionally does
+    /// not implement `checkUnknown`.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```ts,expect_diagnostic,file=invalid-string.ts
+    /// const value: {} = {};
+    /// String(value);
+    /// ```
+    ///
+    /// ```ts,expect_diagnostic,file=invalid-template.ts
+    /// const value: {} = {};
+    /// `${value}`;
+    /// ```
+    ///
+    /// ```ts,expect_diagnostic,file=invalid-join.ts
+    /// const values: {}[] = [{}];
+    /// values.join(",");
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```ts
+    /// String(1);
+    /// ```
+    ///
+    /// ```ts
+    /// class CustomToString {
+    ///     toString() {
+    ///         return "ok";
+    ///     }
+    /// }
+    ///
+    /// `${new CustomToString()}`;
+    /// ```
+    pub NoBaseToString {
+        version: "next",
+        name: "noBaseToString",
+        language: "js",
+        recommended: false,
+        sources: &[RuleSource::EslintTypeScript("no-base-to-string").same()],
+        domains: &[RuleDomain::Types],
+    }
+}
+
+declare_node_union! {
+    pub AnyNoBaseToStringQuery =
+        JsAssignmentExpression
+        | JsBinaryExpression
+        | JsCallExpression
+        | JsTemplateExpression
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RuleState {
+    kind: DiagnosticKind,
+    certainty: Usefulness,
+    range: TextRange,
+}
+
+impl Rule for NoBaseToString {
+    type Query = Typed<AnyNoBaseToStringQuery>;
+    type State = RuleState;
+    type Signals = Box<[Self::State]>;
+    type Options = NoBaseToStringOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        match ctx.query() {
+            AnyNoBaseToStringQuery::JsCallExpression(call) => {
+                run_call_expression(ctx, call).into_iter().collect()
+            }
+            AnyNoBaseToStringQuery::JsBinaryExpression(binary) => {
+                run_binary_expression(ctx, binary).into_iter().collect()
+            }
+            AnyNoBaseToStringQuery::JsAssignmentExpression(assignment) => {
+                run_assignment_expression(ctx, assignment)
+                    .into_iter()
+                    .collect()
+            }
+            AnyNoBaseToStringQuery::JsTemplateExpression(template) => {
+                run_template_expression(ctx, template).into_iter().collect()
+            }
+        }
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let certainty = match state.certainty {
+            Usefulness::Always => return None,
+            Usefulness::Sometimes => "may",
+            Usefulness::Never => "will",
+        };
+
+        let diagnostic = match state.kind {
+            DiagnosticKind::BaseToString => RuleDiagnostic::new(
+                rule_category!(),
+                state.range,
+                markup! {
+                    "This expression "{certainty}" use the default object stringification format, such as "<Emphasis>"[object Object]"</Emphasis>", when stringified."
+                },
+            )
+            .note(markup! {
+                "Stringify a primitive value, define a custom stringification method, or serialize the object explicitly."
+            }),
+            DiagnosticKind::BaseArrayJoin => RuleDiagnostic::new(
+                rule_category!(),
+                state.range,
+                markup! {
+                    "This "<Emphasis>"join()"</Emphasis>" call "{certainty}" stringify one or more elements with the default object format, such as "<Emphasis>"[object Object]"</Emphasis>"."
+                },
+            )
+            .note(markup! {
+                "Ensure every joined element has a useful string representation, or map the values before joining."
+            }),
+        };
+
+        Some(diagnostic)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DiagnosticKind {
+    BaseToString,
+    BaseArrayJoin,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Usefulness {
+    Always,
+    Sometimes,
+    Never,
+}
+
+type VisitedTypes = HashSet<(ResolverId, TypeId)>;
+
+#[derive(Clone, Copy)]
+enum AnalysisMode {
+    Join,
+    ToString,
+}
+
+enum AnalysisTask {
+    Eval(Type, AnalysisMode),
+    Aggregate(AggregateKind, usize),
+    Leave((ResolverId, TypeId)),
+}
+
+#[derive(Clone, Copy)]
+enum AggregateKind {
+    Intersection,
+    Tuple,
+    Union,
+}
+
+fn run_call_expression(
+    ctx: &RuleContext<NoBaseToString>,
+    node: &JsCallExpression,
+) -> Option<RuleState> {
+    run_builtin_string_call(ctx, node).or_else(|| run_member_call(ctx, node))
+}
+
+fn run_builtin_string_call(
+    ctx: &RuleContext<NoBaseToString>,
+    node: &JsCallExpression,
+) -> Option<RuleState> {
+    let callee = node.callee().ok()?;
+    let (reference, name) = global_identifier(&callee.clone().omit_parentheses())?;
+    if name.text() != "String" || ctx.has_binding(&reference) {
+        return None;
+    }
+
+    let args = node.arguments().ok()?.args();
+    if args.len() != 1 {
+        return None;
+    }
+
+    let first_arg = args.first()?.ok()?;
+    let arg = first_arg.as_any_js_expression()?;
+    check_expression(ctx, arg, DiagnosticKind::BaseToString)
+}
+
+fn run_member_call(
+    ctx: &RuleContext<NoBaseToString>,
+    node: &JsCallExpression,
+) -> Option<RuleState> {
+    let callee = node.callee().ok()?.omit_parentheses();
+    let member = callee.as_js_static_member_expression()?;
+    let property = member.member().ok()?;
+    let property_token = property.value_token().ok()?;
+    let property_name = property_token.text_trimmed();
+    let object = member.object().ok()?;
+
+    match property_name {
+        "join" => check_expression(ctx, &object, DiagnosticKind::BaseArrayJoin),
+        "toString" | "toLocaleString" => {
+            check_expression(ctx, &object, DiagnosticKind::BaseToString)
+        }
+        _ => None,
+    }
+}
+
+fn run_binary_expression(
+    ctx: &RuleContext<NoBaseToString>,
+    node: &JsBinaryExpression,
+) -> Option<RuleState> {
+    if node.operator().ok()? != JsBinaryOperator::Plus {
+        return None;
+    }
+
+    let left = node.left().ok()?;
+    let right = node.right().ok()?;
+
+    if ctx.type_of_expression(&left).is_string_or_string_literal() {
+        return check_expression(ctx, &right, DiagnosticKind::BaseToString);
+    }
+
+    if ctx.type_of_expression(&right).is_string_or_string_literal() {
+        return check_expression(ctx, &left, DiagnosticKind::BaseToString);
+    }
+
+    None
+}
+
+fn run_assignment_expression(
+    ctx: &RuleContext<NoBaseToString>,
+    node: &JsAssignmentExpression,
+) -> Option<RuleState> {
+    if node.operator().ok()? != JsAssignmentOperator::AddAssign {
+        return None;
+    }
+
+    let left = node.left().ok()?;
+    let left_ty = type_of_assignment_target(ctx, node, &left)?;
+    if !left_ty.is_string_or_string_literal() {
+        return None;
+    }
+
+    check_expression(ctx, &node.right().ok()?, DiagnosticKind::BaseToString)
+}
+
+fn run_template_expression(
+    ctx: &RuleContext<NoBaseToString>,
+    node: &JsTemplateExpression,
+) -> Option<RuleState> {
+    if node.tag().is_some() {
+        return None;
+    }
+
+    node.elements()
+        .into_iter()
+        .find_map(|element| match element {
+            AnyJsTemplateElement::JsTemplateElement(template_element) => {
+                template_element.expression().ok().and_then(|expression| {
+                    check_expression(ctx, &expression, DiagnosticKind::BaseToString)
+                })
+            }
+            AnyJsTemplateElement::JsTemplateChunkElement(_) => None,
+        })
+}
+
+fn type_of_assignment_target(
+    ctx: &RuleContext<NoBaseToString>,
+    assignment: &JsAssignmentExpression,
+    left: &AnyJsAssignmentPattern,
+) -> Option<Type> {
+    match left {
+        AnyJsAssignmentPattern::AnyJsAssignment(assignment_target) => {
+            type_of_assignment(ctx, assignment, assignment_target)
+        }
+        AnyJsAssignmentPattern::JsArrayAssignmentPattern(_)
+        | AnyJsAssignmentPattern::JsObjectAssignmentPattern(_) => None,
+    }
+}
+
+fn type_of_assignment(
+    ctx: &RuleContext<NoBaseToString>,
+    assignment: &JsAssignmentExpression,
+    target: &AnyJsAssignment,
+) -> Option<Type> {
+    match target {
+        AnyJsAssignment::JsIdentifierAssignment(identifier) => {
+            let name = identifier.name_token().ok()?;
+            Some(ctx.type_of_named_value(assignment.range(), name.text_trimmed()))
+        }
+        AnyJsAssignment::JsParenthesizedAssignment(parenthesized) => {
+            type_of_assignment(ctx, assignment, &parenthesized.assignment().ok()?)
+        }
+        AnyJsAssignment::TsAsAssignment(ts_as) => {
+            type_of_assignment(ctx, assignment, &ts_as.assignment().ok()?)
+        }
+        AnyJsAssignment::TsNonNullAssertionAssignment(non_null) => {
+            type_of_assignment(ctx, assignment, &non_null.assignment().ok()?)
+        }
+        AnyJsAssignment::TsSatisfiesAssignment(satisfies) => {
+            type_of_assignment(ctx, assignment, &satisfies.assignment().ok()?)
+        }
+        AnyJsAssignment::TsTypeAssertionAssignment(assertion) => {
+            type_of_assignment(ctx, assignment, &assertion.assignment().ok()?)
+        }
+        AnyJsAssignment::JsBogusAssignment(_)
+        | AnyJsAssignment::JsComputedMemberAssignment(_)
+        | AnyJsAssignment::JsStaticMemberAssignment(_) => None,
+    }
+}
+
+fn check_expression(
+    ctx: &RuleContext<NoBaseToString>,
+    expression: &AnyJsExpression,
+    kind: DiagnosticKind,
+) -> Option<RuleState> {
+    if is_literal_expression(expression) {
+        return None;
+    }
+
+    let ty = ctx.type_of_expression(expression);
+    let certainty = match kind {
+        DiagnosticKind::BaseArrayJoin => collect_certainty(&ty, ctx.options(), AnalysisMode::Join),
+        DiagnosticKind::BaseToString => {
+            collect_certainty(&ty, ctx.options(), AnalysisMode::ToString)
+        }
+    };
+
+    (certainty != Usefulness::Always).then_some(RuleState {
+        kind,
+        certainty,
+        range: expression.range(),
+    })
+}
+
+fn is_literal_expression(expression: &AnyJsExpression) -> bool {
+    matches!(
+        expression.clone().omit_parentheses(),
+        AnyJsExpression::AnyJsLiteralExpression(_) | AnyJsExpression::JsArrayExpression(_)
+    )
+}
+
+/// Computes whether stringification is always useful, sometimes useful, or never useful
+/// without recursion.
+///
+/// The analysis walks nested unions, intersections, tuples, arrays, aliases, and
+/// inheritance edges with an explicit worklist.
+fn collect_certainty(ty: &Type, options: &NoBaseToStringOptions, mode: AnalysisMode) -> Usefulness {
+    let mut active_types = HashSet::new();
+    let mut results = Vec::new();
+    let mut tasks = vec![AnalysisTask::Eval(ty.clone(), mode)];
+
+    while let Some(task) = tasks.pop() {
+        match task {
+            AnalysisTask::Eval(ty, mode) => {
+                let Some(key) = visited_type(&ty) else {
+                    results.push(Usefulness::Always);
+                    continue;
+                };
+
+                if active_types.contains(&key) {
+                    results.push(Usefulness::Always);
+                    continue;
+                }
+
+                if let Some(raw) = ty.resolved_data().map(ResolvedTypeData::as_raw_data) {
+                    match raw {
+                        TypeData::Generic(generic) if generic.constraint.is_known() => {
+                            if let Some(constraint) = ty.resolve(&generic.constraint) {
+                                tasks.push(AnalysisTask::Eval(constraint, mode));
+                            } else {
+                                results.push(Usefulness::Always);
+                            }
+                            continue;
+                        }
+                        TypeData::Generic(_) => {
+                            results.push(Usefulness::Always);
+                            continue;
+                        }
+                        _ => {}
+                    }
+                }
+
+                if matches!(mode, AnalysisMode::ToString)
+                    && (is_ignored_type(&ty, options, &mut HashSet::new())
+                        || is_primitive_or_otherwise_safe(&ty))
+                {
+                    results.push(Usefulness::Always);
+                    continue;
+                }
+
+                let union_variants: Vec<_> = ty.flattened_union_variants().collect();
+                if !union_variants.is_empty() {
+                    active_types.insert(key);
+                    tasks.push(AnalysisTask::Leave(key));
+                    tasks.push(AnalysisTask::Aggregate(
+                        AggregateKind::Union,
+                        union_variants.len(),
+                    ));
+                    for variant in union_variants.into_iter().rev() {
+                        tasks.push(AnalysisTask::Eval(variant, mode));
+                    }
+                    continue;
+                }
+
+                let Some(raw) = ty.resolved_data().map(ResolvedTypeData::as_raw_data) else {
+                    results.push(Usefulness::Always);
+                    continue;
+                };
+
+                if let TypeData::Intersection(intersection) = raw {
+                    let variants: Vec<_> = intersection
+                        .types()
+                        .iter()
+                        .filter_map(|reference| ty.resolve(reference))
+                        .collect();
+
+                    if variants.is_empty() {
+                        results.push(Usefulness::Never);
+                    } else {
+                        active_types.insert(key);
+                        tasks.push(AnalysisTask::Leave(key));
+                        tasks.push(AnalysisTask::Aggregate(
+                            AggregateKind::Intersection,
+                            variants.len(),
+                        ));
+                        for variant in variants.into_iter().rev() {
+                            tasks.push(AnalysisTask::Eval(variant, mode));
+                        }
+                    }
+                    continue;
+                }
+
+                if let Some(tuple_elements) = tuple_element_types(&ty) {
+                    if tuple_elements.is_empty() {
+                        results.push(Usefulness::Always);
+                    } else {
+                        active_types.insert(key);
+                        tasks.push(AnalysisTask::Leave(key));
+                        tasks.push(AnalysisTask::Aggregate(
+                            AggregateKind::Tuple,
+                            tuple_elements.len(),
+                        ));
+                        for element in tuple_elements.into_iter().rev() {
+                            tasks.push(AnalysisTask::Eval(element, AnalysisMode::ToString));
+                        }
+                    }
+                    continue;
+                }
+
+                if let Some(element_ty) = array_element_type(&ty) {
+                    active_types.insert(key);
+                    tasks.push(AnalysisTask::Leave(key));
+                    tasks.push(AnalysisTask::Eval(element_ty, AnalysisMode::ToString));
+                    continue;
+                }
+
+                let certainty = match mode {
+                    AnalysisMode::Join => Usefulness::Always,
+                    AnalysisMode::ToString => {
+                        match is_to_string_like_from_object(&ty, &mut HashSet::new()) {
+                            Some(true) => Usefulness::Never,
+                            Some(false) | None => Usefulness::Always,
+                        }
+                    }
+                };
+                results.push(certainty);
+            }
+            AnalysisTask::Aggregate(kind, count) => {
+                let start = results.len().saturating_sub(count);
+                let values = results.split_off(start);
+                let combined = match kind {
+                    AggregateKind::Intersection => combine_intersection(values.into_iter()),
+                    AggregateKind::Tuple => combine_tuple(values.into_iter()),
+                    AggregateKind::Union => combine_union(values.into_iter()),
+                };
+                results.push(combined);
+            }
+            AnalysisTask::Leave(key) => {
+                active_types.remove(&key);
+            }
+        }
+    }
+
+    results.pop().unwrap_or(Usefulness::Always)
+}
+
+fn tuple_element_types(ty: &Type) -> Option<Vec<Type>> {
+    let raw = ty.resolved_data().map(ResolvedTypeData::as_raw_data)?;
+    let TypeData::Tuple(tuple) = raw else {
+        return None;
+    };
+
+    Some(
+        tuple
+            .elements()
+            .iter()
+            .filter_map(|element| ty.resolve(&element.ty))
+            .collect(),
+    )
+}
+
+fn array_element_type(ty: &Type) -> Option<Type> {
+    if !ty.is_array_of(|_| true) {
+        return None;
+    }
+
+    let TypeData::InstanceOf(instance) = ty.resolved_data().map(ResolvedTypeData::as_raw_data)?
+    else {
+        return None;
+    };
+
+    let element_ty = instance
+        .type_parameters
+        .first()
+        .and_then(|reference| ty.resolve(reference))?;
+
+    Some(element_ty)
+}
+
+fn combine_union(certainties: impl Iterator<Item = Usefulness>) -> Usefulness {
+    let certainties: Vec<_> = certainties.collect();
+    if certainties.is_empty() {
+        return Usefulness::Always;
+    }
+
+    if certainties
+        .iter()
+        .all(|certainty| *certainty == Usefulness::Never)
+    {
+        Usefulness::Never
+    } else if certainties
+        .iter()
+        .all(|certainty| *certainty == Usefulness::Always)
+    {
+        Usefulness::Always
+    } else {
+        Usefulness::Sometimes
+    }
+}
+
+fn combine_intersection(certainties: impl Iterator<Item = Usefulness>) -> Usefulness {
+    if certainties
+        .into_iter()
+        .any(|certainty| certainty == Usefulness::Always)
+    {
+        Usefulness::Always
+    } else {
+        Usefulness::Never
+    }
+}
+
+fn combine_tuple(certainties: impl Iterator<Item = Usefulness>) -> Usefulness {
+    let mut saw_sometimes = false;
+
+    for certainty in certainties {
+        match certainty {
+            Usefulness::Always => {}
+            Usefulness::Sometimes => saw_sometimes = true,
+            Usefulness::Never => return Usefulness::Never,
+        }
+    }
+
+    if saw_sometimes {
+        Usefulness::Sometimes
+    } else {
+        Usefulness::Always
+    }
+}
+
+fn is_primitive_or_otherwise_safe(ty: &Type) -> bool {
+    if ty.is_string_or_string_literal() || ty.is_number_or_number_literal() {
+        return true;
+    }
+
+    let Some(raw) = ty.resolved_data().map(ResolvedTypeData::as_raw_data) else {
+        return true;
+    };
+
+    match raw {
+        TypeData::AnyKeyword
+        | TypeData::BigInt
+        | TypeData::Boolean
+        | TypeData::Function(_)
+        | TypeData::Null
+        | TypeData::Number
+        | TypeData::String
+        | TypeData::Symbol
+        | TypeData::Undefined
+        | TypeData::Unknown
+        | TypeData::UnknownKeyword
+        | TypeData::NeverKeyword
+        | TypeData::VoidKeyword => true,
+        TypeData::Literal(literal) => matches!(
+            literal.as_ref(),
+            Literal::BigInt(_)
+                | Literal::Boolean(_)
+                | Literal::Number(_)
+                | Literal::String(_)
+                | Literal::Template(_)
+        ),
+        _ => false,
+    }
+}
+
+fn is_to_string_like_from_object(ty: &Type, visited: &mut VisitedTypes) -> Option<bool> {
+    let mut stack = vec![ty.clone()];
+    let mut saw_true = false;
+    let mut saw_unknown = false;
+
+    while let Some(current) = stack.pop() {
+        let Some(key) = visited_type(&current) else {
+            saw_unknown = true;
+            continue;
+        };
+
+        if !visited.insert(key) {
+            return Some(false);
+        }
+
+        let Some(raw) = current.resolved_data().map(ResolvedTypeData::as_raw_data) else {
+            saw_unknown = true;
+            continue;
+        };
+
+        if has_custom_stringification_member(raw) {
+            return Some(false);
+        }
+
+        match raw {
+            TypeData::Class(class) => {
+                if let Some(base) = class
+                    .extends
+                    .as_ref()
+                    .and_then(|reference| current.resolve(reference))
+                {
+                    stack.push(base);
+                } else {
+                    saw_true = true;
+                }
+            }
+            TypeData::InstanceOf(instance) => {
+                if let Some(base) = current.resolve(&instance.ty) {
+                    stack.push(base);
+                } else {
+                    saw_true = true;
+                }
+            }
+            TypeData::Interface(interface) => {
+                let bases: Vec<_> = interface
+                    .extends
+                    .iter()
+                    .filter_map(|reference| current.resolve(reference))
+                    .collect();
+                if bases.is_empty() {
+                    saw_true = true;
+                } else {
+                    stack.extend(bases);
+                }
+            }
+            TypeData::Literal(literal) => match literal.as_ref() {
+                Literal::Object(object) => {
+                    if has_custom_object_literal_member(object.members()) {
+                        return Some(false);
+                    } else {
+                        saw_true = true;
+                    }
+                }
+                Literal::RegExp(_) => saw_true = true,
+                _ => return Some(false),
+            },
+            TypeData::MergedReference(reference) => {
+                if let Some(resolved) = reference
+                    .ty
+                    .as_ref()
+                    .and_then(|reference| current.resolve(reference))
+                {
+                    stack.push(resolved);
+                } else {
+                    saw_unknown = true;
+                }
+            }
+            TypeData::Object(_) | TypeData::ObjectKeyword => saw_true = true,
+            TypeData::Reference(reference) => {
+                if let Some(resolved) = current.resolve(reference) {
+                    stack.push(resolved);
+                } else {
+                    saw_unknown = true;
+                }
+            }
+            TypeData::TypeofValue(value) => {
+                if let Some(resolved) = current.resolve(&value.ty) {
+                    stack.push(resolved);
+                } else {
+                    saw_unknown = true;
+                }
+            }
+            _ => return None,
+        }
+    }
+
+    if saw_true {
+        Some(true)
+    } else {
+        let _ = saw_unknown;
+        None
+    }
+}
+
+fn has_custom_stringification_member(raw: &TypeData) -> bool {
+    raw.own_members().any(|member| {
+        member.has_name("toLocaleString")
+            || member.has_name("toString")
+            || member.has_name("valueOf")
+    })
+}
+
+fn has_custom_object_literal_member(members: &[biome_js_type_info::TypeMember]) -> bool {
+    members.iter().any(|member| {
+        member.has_name("toLocaleString")
+            || member.has_name("toString")
+            || member.has_name("valueOf")
+    })
+}
+
+fn is_ignored_type(ty: &Type, options: &NoBaseToStringOptions, visited: &mut VisitedTypes) -> bool {
+    let is_ignored_name = |name: &str| {
+        options.ignored_type_names.as_deref().map_or_else(
+            || DEFAULT_IGNORED_TYPE_NAMES.contains(&name),
+            |ignored| ignored.iter().any(|candidate| candidate.as_ref() == name),
+        )
+    };
+
+    let is_ignored_key = |key: &str| {
+        options.ignored_type_names.as_deref().map_or_else(
+            || {
+                DEFAULT_IGNORED_TYPE_NAMES
+                    .iter()
+                    .any(|ignored| key.contains(ignored))
+            },
+            |ignored| {
+                ignored
+                    .iter()
+                    .any(|candidate| key.contains(candidate.as_ref()))
+            },
+        )
+    };
+
+    let mut stack = vec![ty.clone()];
+
+    while let Some(current) = stack.pop() {
+        let key = current.to_string();
+        let Some(visited_key) = visited_type(&current) else {
+            continue;
+        };
+
+        if !visited.insert(visited_key) {
+            continue;
+        }
+
+        if type_name(&current)
+            .or_else(|| extract_identifier(&key))
+            .is_some_and(is_ignored_name)
+            || is_ignored_key(&key)
+        {
+            return true;
+        }
+
+        match current.resolved_data().map(ResolvedTypeData::as_raw_data) {
+            Some(TypeData::Class(class)) => {
+                if let Some(base) = class
+                    .extends
+                    .as_ref()
+                    .and_then(|reference| current.resolve(reference))
+                {
+                    stack.push(base);
+                }
+            }
+            Some(TypeData::Generic(generic)) if generic.constraint.is_known() => {
+                if let Some(constraint) = current.resolve(&generic.constraint) {
+                    stack.push(constraint);
+                }
+            }
+            Some(TypeData::InstanceOf(instance)) => {
+                if let Some(base) = current.resolve(&instance.ty) {
+                    stack.push(base);
+                }
+            }
+            Some(TypeData::Interface(interface)) => {
+                stack.extend(
+                    interface
+                        .extends
+                        .iter()
+                        .filter_map(|reference| current.resolve(reference)),
+                );
+            }
+            Some(TypeData::MergedReference(reference)) => {
+                if let Some(resolved) = reference
+                    .ty
+                    .as_ref()
+                    .and_then(|reference| current.resolve(reference))
+                {
+                    stack.push(resolved);
+                }
+            }
+            Some(TypeData::Reference(reference)) => {
+                if let Some(resolved) = current.resolve(reference) {
+                    stack.push(resolved);
+                }
+            }
+            Some(TypeData::TypeofValue(value)) => {
+                if let Some(resolved) = current.resolve(&value.ty) {
+                    stack.push(resolved);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn visited_type(ty: &Type) -> Option<(ResolverId, TypeId)> {
+    Some((ty.resolved_data()?.resolver_id(), ty.id()))
+}
+
+fn type_name(ty: &Type) -> Option<&str> {
+    let raw = ty.resolved_data().map(ResolvedTypeData::as_raw_data)?;
+    match raw {
+        TypeData::Class(class) => class.name.as_ref().map(|name| name.text()),
+        TypeData::Generic(generic) => Some(generic.name.text()),
+        TypeData::Interface(interface) => Some(interface.name.text()),
+        TypeData::Literal(literal) => match literal.as_ref() {
+            Literal::RegExp(_) => Some("RegExp"),
+            _ => None,
+        },
+        TypeData::TypeofValue(value) => Some(value.identifier.text()),
+        _ => None,
+    }
+}
+
+fn extract_identifier(text: &str) -> Option<&str> {
+    let text = text
+        .strip_prefix("instanceof ")
+        .or_else(|| text.strip_prefix("typeof "))
+        .unwrap_or(text);
+
+    let end = text
+        .find(|character: char| {
+            !(character.is_ascii_alphanumeric() || character == '_' || character == '$')
+        })
+        .unwrap_or(text.len());
+
+    (!text.is_empty() && end > 0).then_some(&text[..end])
+}

--- a/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
@@ -10,7 +10,9 @@ use biome_js_syntax::{
     JsAssignmentExpression, JsAssignmentOperator, JsBinaryExpression, JsBinaryOperator,
     JsCallExpression, JsTemplateExpression, global_identifier,
 };
-use biome_js_type_info::{Literal, ResolvedTypeData, ResolverId, Type, TypeData, TypeId};
+use biome_js_type_info::{
+    ImportSymbol, Literal, ResolvedTypeData, ResolverId, Type, TypeData, TypeId, TypeReference,
+};
 use biome_rowan::{AstNode, AstSeparatedList, TextRange, declare_node_union};
 use biome_rule_options::no_base_to_string::NoBaseToStringOptions;
 
@@ -23,10 +25,6 @@ declare_lint_rule! {
     /// `value.toString()`, string concatenation, template interpolation, and `Array#join()`.
     /// When the value only inherits the default object stringification, that often produces
     /// `"[object Object]"` instead of something intentionally readable.
-    ///
-    /// This rule reports stringification sites that are known to use that default object
-    /// formatting. It supports the upstream `ignoredTypeNames` option, but intentionally does
-    /// not implement `checkUnknown`.
     ///
     /// ## Examples
     ///
@@ -167,12 +165,17 @@ enum AnalysisMode {
     ToString,
 }
 
+/// Worklist entries used by `collect_certainty()` to traverse type graphs.
 enum AnalysisTask {
+    /// Analyze a type under the given stringification mode.
     Eval(Type, AnalysisMode),
+    /// Combine the next `usize` collected child results using the given strategy.
     Aggregate(AggregateKind, usize),
+    /// Remove a type from the active traversal set after finishing its children.
     Leave((ResolverId, TypeId)),
 }
 
+/// Describes how a group of child results should be combined.
 #[derive(Clone, Copy)]
 enum AggregateKind {
     Intersection,
@@ -187,6 +190,7 @@ fn run_call_expression(
     run_builtin_string_call(ctx, node).or_else(|| run_member_call(ctx, node))
 }
 
+/// Handle `String(value)` calls.
 fn run_builtin_string_call(
     ctx: &RuleContext<NoBaseToString>,
     node: &JsCallExpression,
@@ -207,6 +211,7 @@ fn run_builtin_string_call(
     check_expression(ctx, arg, DiagnosticKind::BaseToString)
 }
 
+/// Handle `value.join()`, `value.toString()`, and `value.toLocaleString()` calls.
 fn run_member_call(
     ctx: &RuleContext<NoBaseToString>,
     node: &JsCallExpression,
@@ -227,6 +232,7 @@ fn run_member_call(
     }
 }
 
+/// Handle `value + ""` and `"" + value`.
 fn run_binary_expression(
     ctx: &RuleContext<NoBaseToString>,
     node: &JsBinaryExpression,
@@ -249,6 +255,7 @@ fn run_binary_expression(
     None
 }
 
+/// Handle `value += ""`.
 fn run_assignment_expression(
     ctx: &RuleContext<NoBaseToString>,
     node: &JsAssignmentExpression,
@@ -266,6 +273,7 @@ fn run_assignment_expression(
     check_expression(ctx, &node.right().ok()?, DiagnosticKind::BaseToString)
 }
 
+/// Handle template strings like `${value}`.
 fn run_template_expression(
     ctx: &RuleContext<NoBaseToString>,
     node: &JsTemplateExpression,
@@ -305,29 +313,33 @@ fn type_of_assignment(
     assignment: &JsAssignmentExpression,
     target: &AnyJsAssignment,
 ) -> Option<Type> {
-    match target {
-        AnyJsAssignment::JsIdentifierAssignment(identifier) => {
-            let name = identifier.name_token().ok()?;
-            Some(ctx.type_of_named_value(assignment.range(), name.text_trimmed()))
+    let mut current = target.clone();
+
+    loop {
+        match current {
+            AnyJsAssignment::JsIdentifierAssignment(identifier) => {
+                let name = identifier.name_token().ok()?;
+                return Some(ctx.type_of_named_value(assignment.range(), name.text_trimmed()));
+            }
+            AnyJsAssignment::JsParenthesizedAssignment(parenthesized) => {
+                current = parenthesized.assignment().ok()?;
+            }
+            AnyJsAssignment::TsAsAssignment(ts_as) => {
+                current = ts_as.assignment().ok()?;
+            }
+            AnyJsAssignment::TsNonNullAssertionAssignment(non_null) => {
+                current = non_null.assignment().ok()?;
+            }
+            AnyJsAssignment::TsSatisfiesAssignment(satisfies) => {
+                current = satisfies.assignment().ok()?;
+            }
+            AnyJsAssignment::TsTypeAssertionAssignment(assertion) => {
+                current = assertion.assignment().ok()?;
+            }
+            AnyJsAssignment::JsBogusAssignment(_)
+            | AnyJsAssignment::JsComputedMemberAssignment(_)
+            | AnyJsAssignment::JsStaticMemberAssignment(_) => return None,
         }
-        AnyJsAssignment::JsParenthesizedAssignment(parenthesized) => {
-            type_of_assignment(ctx, assignment, &parenthesized.assignment().ok()?)
-        }
-        AnyJsAssignment::TsAsAssignment(ts_as) => {
-            type_of_assignment(ctx, assignment, &ts_as.assignment().ok()?)
-        }
-        AnyJsAssignment::TsNonNullAssertionAssignment(non_null) => {
-            type_of_assignment(ctx, assignment, &non_null.assignment().ok()?)
-        }
-        AnyJsAssignment::TsSatisfiesAssignment(satisfies) => {
-            type_of_assignment(ctx, assignment, &satisfies.assignment().ok()?)
-        }
-        AnyJsAssignment::TsTypeAssertionAssignment(assertion) => {
-            type_of_assignment(ctx, assignment, &assertion.assignment().ok()?)
-        }
-        AnyJsAssignment::JsBogusAssignment(_)
-        | AnyJsAssignment::JsComputedMemberAssignment(_)
-        | AnyJsAssignment::JsStaticMemberAssignment(_) => None,
     }
 }
 
@@ -348,11 +360,15 @@ fn check_expression(
         }
     };
 
-    (certainty != Usefulness::Always).then_some(RuleState {
-        kind,
-        certainty,
-        range: expression.range(),
-    })
+    if certainty == Usefulness::Always {
+        None
+    } else {
+        Some(RuleState {
+            kind,
+            certainty,
+            range: expression.range(),
+        })
+    }
 }
 
 fn is_literal_expression(expression: &AnyJsExpression) -> bool {
@@ -362,11 +378,7 @@ fn is_literal_expression(expression: &AnyJsExpression) -> bool {
     )
 }
 
-/// Computes whether stringification is always useful, sometimes useful, or never useful
-/// without recursion.
-///
-/// The analysis walks nested unions, intersections, tuples, arrays, aliases, and
-/// inheritance edges with an explicit worklist.
+/// Computes whether stringification is always useful, sometimes useful, or never useful. The core business logic for the rule.
 fn collect_certainty(ty: &Type, options: &NoBaseToStringOptions, mode: AnalysisMode) -> Usefulness {
     let mut active_types = HashSet::new();
     let mut results = Vec::new();
@@ -411,17 +423,14 @@ fn collect_certainty(ty: &Type, options: &NoBaseToStringOptions, mode: AnalysisM
                     continue;
                 }
 
-                let union_variants: Vec<_> = ty.flattened_union_variants().collect();
-                if !union_variants.is_empty() {
-                    active_types.insert(key);
-                    tasks.push(AnalysisTask::Leave(key));
-                    tasks.push(AnalysisTask::Aggregate(
-                        AggregateKind::Union,
-                        union_variants.len(),
-                    ));
-                    for variant in union_variants.into_iter().rev() {
-                        tasks.push(AnalysisTask::Eval(variant, mode));
-                    }
+                if push_aggregate_tasks(
+                    &mut tasks,
+                    &mut active_types,
+                    key,
+                    AggregateKind::Union,
+                    ty.flattened_union_variants(),
+                    mode,
+                ) {
                     continue;
                 }
 
@@ -431,41 +440,35 @@ fn collect_certainty(ty: &Type, options: &NoBaseToStringOptions, mode: AnalysisM
                 };
 
                 if let TypeData::Intersection(intersection) = raw {
-                    let variants: Vec<_> = intersection
-                        .types()
-                        .iter()
-                        .filter_map(|reference| ty.resolve(reference))
-                        .collect();
-
-                    if variants.is_empty() {
+                    if !push_aggregate_tasks(
+                        &mut tasks,
+                        &mut active_types,
+                        key,
+                        AggregateKind::Intersection,
+                        intersection
+                            .types()
+                            .iter()
+                            .filter_map(|reference| ty.resolve(reference)),
+                        mode,
+                    ) {
                         results.push(Usefulness::Never);
-                    } else {
-                        active_types.insert(key);
-                        tasks.push(AnalysisTask::Leave(key));
-                        tasks.push(AnalysisTask::Aggregate(
-                            AggregateKind::Intersection,
-                            variants.len(),
-                        ));
-                        for variant in variants.into_iter().rev() {
-                            tasks.push(AnalysisTask::Eval(variant, mode));
-                        }
                     }
                     continue;
                 }
 
-                if let Some(tuple_elements) = tuple_element_types(&ty) {
-                    if tuple_elements.is_empty() {
+                if let TypeData::Tuple(tuple) = raw {
+                    if !push_aggregate_tasks(
+                        &mut tasks,
+                        &mut active_types,
+                        key,
+                        AggregateKind::Tuple,
+                        tuple
+                            .elements()
+                            .iter()
+                            .filter_map(|element| ty.resolve(&element.ty)),
+                        AnalysisMode::ToString,
+                    ) {
                         results.push(Usefulness::Always);
-                    } else {
-                        active_types.insert(key);
-                        tasks.push(AnalysisTask::Leave(key));
-                        tasks.push(AnalysisTask::Aggregate(
-                            AggregateKind::Tuple,
-                            tuple_elements.len(),
-                        ));
-                        for element in tuple_elements.into_iter().rev() {
-                            tasks.push(AnalysisTask::Eval(element, AnalysisMode::ToString));
-                        }
                     }
                     continue;
                 }
@@ -490,11 +493,10 @@ fn collect_certainty(ty: &Type, options: &NoBaseToStringOptions, mode: AnalysisM
             }
             AnalysisTask::Aggregate(kind, count) => {
                 let start = results.len().saturating_sub(count);
-                let values = results.split_off(start);
                 let combined = match kind {
-                    AggregateKind::Intersection => combine_intersection(values.into_iter()),
-                    AggregateKind::Tuple => combine_tuple(values.into_iter()),
-                    AggregateKind::Union => combine_union(values.into_iter()),
+                    AggregateKind::Intersection => combine_intersection(results.drain(start..)),
+                    AggregateKind::Tuple => combine_tuple(results.drain(start..)),
+                    AggregateKind::Union => combine_union(results.drain(start..)),
                 };
                 results.push(combined);
             }
@@ -507,19 +509,34 @@ fn collect_certainty(ty: &Type, options: &NoBaseToStringOptions, mode: AnalysisM
     results.pop().unwrap_or(Usefulness::Always)
 }
 
-fn tuple_element_types(ty: &Type) -> Option<Vec<Type>> {
-    let raw = ty.resolved_data().map(ResolvedTypeData::as_raw_data)?;
-    let TypeData::Tuple(tuple) = raw else {
-        return None;
-    };
+fn push_aggregate_tasks(
+    tasks: &mut Vec<AnalysisTask>,
+    active_types: &mut VisitedTypes,
+    key: (ResolverId, TypeId),
+    kind: AggregateKind,
+    types: impl Iterator<Item = Type>,
+    mode: AnalysisMode,
+) -> bool {
+    active_types.insert(key);
+    tasks.push(AnalysisTask::Leave(key));
+    let aggregate_index = tasks.len();
+    tasks.push(AnalysisTask::Aggregate(kind, 0));
 
-    Some(
-        tuple
-            .elements()
-            .iter()
-            .filter_map(|element| ty.resolve(&element.ty))
-            .collect(),
-    )
+    let mut count = 0;
+    for ty in types {
+        tasks.push(AnalysisTask::Eval(ty, mode));
+        count += 1;
+    }
+
+    if count == 0 {
+        tasks.pop();
+        tasks.pop();
+        active_types.remove(&key);
+        return false;
+    }
+
+    tasks[aggregate_index] = AnalysisTask::Aggregate(kind, count);
+    true
 }
 
 fn array_element_type(ty: &Type) -> Option<Type> {
@@ -540,27 +557,22 @@ fn array_element_type(ty: &Type) -> Option<Type> {
     Some(element_ty)
 }
 
+/// Combine the certainties of union variants. If all variants have the same certainty, that is returned. Otherwise, `Sometimes` is returned.
 fn combine_union(certainties: impl Iterator<Item = Usefulness>) -> Usefulness {
-    let certainties: Vec<_> = certainties.collect();
-    if certainties.is_empty() {
-        return Usefulness::Always;
+    let mut combined = None;
+
+    for certainty in certainties {
+        match combined {
+            None => combined = Some(certainty),
+            Some(existing) if existing == certainty => {}
+            Some(_) => return Usefulness::Sometimes,
+        }
     }
 
-    if certainties
-        .iter()
-        .all(|certainty| *certainty == Usefulness::Never)
-    {
-        Usefulness::Never
-    } else if certainties
-        .iter()
-        .all(|certainty| *certainty == Usefulness::Always)
-    {
-        Usefulness::Always
-    } else {
-        Usefulness::Sometimes
-    }
+    combined.unwrap_or(Usefulness::Always)
 }
 
+/// Combine the certainties of intersection constituents. If any constituent is `Always`, the result is `Always`. Otherwise, the result is `Never`.
 fn combine_intersection(certainties: impl Iterator<Item = Usefulness>) -> Usefulness {
     if certainties
         .into_iter()
@@ -572,6 +584,7 @@ fn combine_intersection(certainties: impl Iterator<Item = Usefulness>) -> Useful
     }
 }
 
+/// Combine the certainties of tuple elements. If any element is `Never`, the result is `Never`. Otherwise, if any element is `Sometimes`, the result is `Sometimes`. Otherwise, the result is `Always`.
 fn combine_tuple(certainties: impl Iterator<Item = Usefulness>) -> Usefulness {
     let mut saw_sometimes = false;
 
@@ -596,6 +609,7 @@ fn is_primitive_or_otherwise_safe(ty: &Type) -> bool {
     }
 
     let Some(raw) = ty.resolved_data().map(ResolvedTypeData::as_raw_data) else {
+        // if we can't resolve the type, assume it's safe to avoid false positives
         return true;
     };
 
@@ -625,6 +639,13 @@ fn is_primitive_or_otherwise_safe(ty: &Type) -> bool {
     }
 }
 
+/// Returns whether `ty` ultimately falls back to object-style stringification
+/// like `[object Object]`, which is what the rule wants to flag.
+///
+/// `Some(true)` means the reachable type graph bottoms out in plain object-like
+/// behavior without a custom `toString`-like member. `Some(false)` means a
+/// custom stringification member was found. `None` means the type shape is not
+/// one this rule can classify with confidence.
 fn is_to_string_like_from_object(ty: &Type, visited: &mut VisitedTypes) -> Option<bool> {
     let mut stack = vec![ty.clone()];
     let mut saw_true = false;
@@ -669,12 +690,12 @@ fn is_to_string_like_from_object(ty: &Type, visited: &mut VisitedTypes) -> Optio
                 }
             }
             TypeData::Interface(interface) => {
-                let bases: Vec<_> = interface
+                let mut bases = interface
                     .extends
                     .iter()
                     .filter_map(|reference| current.resolve(reference))
-                    .collect();
-                if bases.is_empty() {
+                    .peekable();
+                if bases.peek().is_none() {
                     saw_true = true;
                 } else {
                     stack.extend(bases);
@@ -746,32 +767,12 @@ fn has_custom_object_literal_member(members: &[biome_js_type_info::TypeMember]) 
 }
 
 fn is_ignored_type(ty: &Type, options: &NoBaseToStringOptions, visited: &mut VisitedTypes) -> bool {
-    let is_ignored_name = |name: &str| {
-        options.ignored_type_names.as_deref().map_or_else(
-            || DEFAULT_IGNORED_TYPE_NAMES.contains(&name),
-            |ignored| ignored.iter().any(|candidate| candidate.as_ref() == name),
-        )
-    };
-
-    let is_ignored_key = |key: &str| {
-        options.ignored_type_names.as_deref().map_or_else(
-            || {
-                DEFAULT_IGNORED_TYPE_NAMES
-                    .iter()
-                    .any(|ignored| key.contains(ignored))
-            },
-            |ignored| {
-                ignored
-                    .iter()
-                    .any(|candidate| key.contains(candidate.as_ref()))
-            },
-        )
-    };
-
     let mut stack = vec![ty.clone()];
 
     while let Some(current) = stack.pop() {
-        let key = current.to_string();
+        let Some(raw) = current.resolved_data().map(ResolvedTypeData::as_raw_data) else {
+            continue;
+        };
         let Some(visited_key) = visited_type(&current) else {
             continue;
         };
@@ -780,16 +781,12 @@ fn is_ignored_type(ty: &Type, options: &NoBaseToStringOptions, visited: &mut Vis
             continue;
         }
 
-        if type_name(&current)
-            .or_else(|| extract_identifier(&key))
-            .is_some_and(is_ignored_name)
-            || is_ignored_key(&key)
-        {
+        if matches_ignored_type_name(raw, options) {
             return true;
         }
 
-        match current.resolved_data().map(ResolvedTypeData::as_raw_data) {
-            Some(TypeData::Class(class)) => {
+        match raw {
+            TypeData::Class(class) => {
                 if let Some(base) = class
                     .extends
                     .as_ref()
@@ -798,17 +795,17 @@ fn is_ignored_type(ty: &Type, options: &NoBaseToStringOptions, visited: &mut Vis
                     stack.push(base);
                 }
             }
-            Some(TypeData::Generic(generic)) if generic.constraint.is_known() => {
+            TypeData::Generic(generic) if generic.constraint.is_known() => {
                 if let Some(constraint) = current.resolve(&generic.constraint) {
                     stack.push(constraint);
                 }
             }
-            Some(TypeData::InstanceOf(instance)) => {
+            TypeData::InstanceOf(instance) => {
                 if let Some(base) = current.resolve(&instance.ty) {
                     stack.push(base);
                 }
             }
-            Some(TypeData::Interface(interface)) => {
+            TypeData::Interface(interface) => {
                 stack.extend(
                     interface
                         .extends
@@ -816,7 +813,7 @@ fn is_ignored_type(ty: &Type, options: &NoBaseToStringOptions, visited: &mut Vis
                         .filter_map(|reference| current.resolve(reference)),
                 );
             }
-            Some(TypeData::MergedReference(reference)) => {
+            TypeData::MergedReference(reference) => {
                 if let Some(resolved) = reference
                     .ty
                     .as_ref()
@@ -825,12 +822,22 @@ fn is_ignored_type(ty: &Type, options: &NoBaseToStringOptions, visited: &mut Vis
                     stack.push(resolved);
                 }
             }
-            Some(TypeData::Reference(reference)) => {
+            TypeData::Reference(reference) => {
                 if let Some(resolved) = current.resolve(reference) {
                     stack.push(resolved);
                 }
             }
-            Some(TypeData::TypeofValue(value)) => {
+            TypeData::TypeofType(reference) => {
+                if let Some(resolved) = current.resolve(reference) {
+                    stack.push(resolved);
+                }
+            }
+            TypeData::TypeOperator(operator) => {
+                if let Some(resolved) = current.resolve(&operator.ty) {
+                    stack.push(resolved);
+                }
+            }
+            TypeData::TypeofValue(value) => {
                 if let Some(resolved) = current.resolve(&value.ty) {
                     stack.push(resolved);
                 }
@@ -842,36 +849,81 @@ fn is_ignored_type(ty: &Type, options: &NoBaseToStringOptions, visited: &mut Vis
     false
 }
 
-fn visited_type(ty: &Type) -> Option<(ResolverId, TypeId)> {
-    Some((ty.resolved_data()?.resolver_id(), ty.id()))
-}
-
-fn type_name(ty: &Type) -> Option<&str> {
-    let raw = ty.resolved_data().map(ResolvedTypeData::as_raw_data)?;
+fn matches_ignored_type_name(raw: &TypeData, options: &NoBaseToStringOptions) -> bool {
     match raw {
-        TypeData::Class(class) => class.name.as_ref().map(|name| name.text()),
-        TypeData::Generic(generic) => Some(generic.name.text()),
-        TypeData::Interface(interface) => Some(interface.name.text()),
-        TypeData::Literal(literal) => match literal.as_ref() {
-            Literal::RegExp(_) => Some("RegExp"),
-            _ => None,
-        },
-        TypeData::TypeofValue(value) => Some(value.identifier.text()),
-        _ => None,
+        TypeData::Class(class) => class
+            .name
+            .as_ref()
+            .is_some_and(|name| is_ignored_type_name(name.text(), options)),
+        TypeData::Generic(generic) => is_ignored_type_name(generic.name.text(), options),
+        TypeData::InstanceOf(instance) => matches_ignored_type_reference(&instance.ty, options),
+        TypeData::Interface(interface) => is_ignored_type_name(interface.name.text(), options),
+        TypeData::Literal(literal) => {
+            matches!(literal.as_ref(), Literal::RegExp(_))
+                && is_ignored_type_name("RegExp", options)
+        }
+        TypeData::MergedReference(reference) => {
+            reference
+                .ty
+                .as_ref()
+                .is_some_and(|reference| matches_ignored_type_reference(reference, options))
+                || reference
+                    .value_ty
+                    .as_ref()
+                    .is_some_and(|reference| matches_ignored_type_reference(reference, options))
+                || reference
+                    .namespace_ty
+                    .as_ref()
+                    .is_some_and(|reference| matches_ignored_type_reference(reference, options))
+        }
+        TypeData::Reference(reference) => matches_ignored_type_reference(reference, options),
+        TypeData::TypeofType(reference) => matches_ignored_type_reference(reference, options),
+        TypeData::TypeOperator(operator) => matches_ignored_type_reference(&operator.ty, options),
+        TypeData::TypeofValue(value) => is_ignored_type_name(value.identifier.text(), options),
+        _ => false,
     }
 }
 
-fn extract_identifier(text: &str) -> Option<&str> {
-    let text = text
-        .strip_prefix("instanceof ")
-        .or_else(|| text.strip_prefix("typeof "))
-        .unwrap_or(text);
+fn matches_ignored_type_reference(
+    reference: &TypeReference,
+    options: &NoBaseToStringOptions,
+) -> bool {
+    let mut stack = vec![reference];
 
-    let end = text
-        .find(|character: char| {
-            !(character.is_ascii_alphanumeric() || character == '_' || character == '$')
-        })
-        .unwrap_or(text.len());
+    while let Some(reference) = stack.pop() {
+        match reference {
+            TypeReference::Qualifier(qualifier) => {
+                if qualifier
+                    .path
+                    .iter()
+                    .any(|part| is_ignored_type_name(part.text(), options))
+                {
+                    return true;
+                }
 
-    (!text.is_empty() && end > 0).then_some(&text[..end])
+                stack.extend(qualifier.type_parameters.iter());
+            }
+            TypeReference::Import(import) => {
+                if let ImportSymbol::Named(name) = &import.symbol
+                    && is_ignored_type_name(name.text(), options)
+                {
+                    return true;
+                }
+            }
+            TypeReference::Resolved(_) => {}
+        }
+    }
+
+    false
+}
+
+fn is_ignored_type_name(name: &str, options: &NoBaseToStringOptions) -> bool {
+    options.ignored_type_names.as_deref().map_or_else(
+        || DEFAULT_IGNORED_TYPE_NAMES.contains(&name),
+        |ignored| ignored.iter().any(|candidate| candidate.as_ref() == name),
+    )
+}
+
+fn visited_type(ty: &Type) -> Option<(ResolverId, TypeId)> {
+    Some((ty.resolved_data()?.resolver_id(), ty.id()))
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
@@ -244,11 +244,11 @@ fn run_binary_expression(
     let left = node.left().ok()?;
     let right = node.right().ok()?;
 
-    if ctx.type_of_expression(&left).is_string_or_string_literal() {
+    if is_string_like_type(&ctx.type_of_expression(&left)) {
         return check_expression(ctx, &right, DiagnosticKind::BaseToString);
     }
 
-    if ctx.type_of_expression(&right).is_string_or_string_literal() {
+    if is_string_like_type(&ctx.type_of_expression(&right)) {
         return check_expression(ctx, &left, DiagnosticKind::BaseToString);
     }
 
@@ -266,7 +266,7 @@ fn run_assignment_expression(
 
     let left = node.left().ok()?;
     let left_ty = type_of_assignment_target(ctx, node, &left)?;
-    if !left_ty.is_string_or_string_literal() {
+    if !is_string_like_type(&left_ty) {
         return None;
     }
 
@@ -310,7 +310,7 @@ fn type_of_assignment_target(
 
 fn type_of_assignment(
     ctx: &RuleContext<NoBaseToString>,
-    assignment: &JsAssignmentExpression,
+    _assignment: &JsAssignmentExpression,
     target: &AnyJsAssignment,
 ) -> Option<Type> {
     let mut current = target.clone();
@@ -319,7 +319,9 @@ fn type_of_assignment(
         match current {
             AnyJsAssignment::JsIdentifierAssignment(identifier) => {
                 let name = identifier.name_token().ok()?;
-                return Some(ctx.type_of_named_value(assignment.range(), name.text_trimmed()));
+                return Some(
+                    ctx.type_of_named_value(name.text_trimmed_range(), name.text_trimmed()),
+                );
             }
             AnyJsAssignment::JsParenthesizedAssignment(parenthesized) => {
                 current = parenthesized.assignment().ok()?;
@@ -376,6 +378,43 @@ fn is_literal_expression(expression: &AnyJsExpression) -> bool {
         expression.clone().omit_parentheses(),
         AnyJsExpression::AnyJsLiteralExpression(_) | AnyJsExpression::JsArrayExpression(_)
     )
+}
+
+fn is_string_like_type(ty: &Type) -> bool {
+    let mut saw_variant = false;
+    let mut pending = vec![ty.clone()];
+
+    while let Some(current) = pending.pop() {
+        if current.is_union() {
+            let mut variants = current.flattened_union_variants().peekable();
+            if variants.peek().is_none() {
+                return false;
+            }
+
+            saw_variant = true;
+            pending.extend(variants);
+            continue;
+        }
+
+        let Some(raw) = current.resolved_data().map(ResolvedTypeData::as_raw_data) else {
+            return false;
+        };
+
+        match raw {
+            TypeData::Generic(generic) if generic.constraint.is_known() => {
+                let Some(constraint) = current.resolve(&generic.constraint) else {
+                    return false;
+                };
+
+                pending.push(constraint);
+            }
+            TypeData::Generic(_) => return false,
+            _ if current.is_string_or_string_literal() => saw_variant = true,
+            _ => return false,
+        }
+    }
+
+    saw_variant
 }
 
 /// Computes whether stringification is always useful, sometimes useful, or never useful. The core business logic for the rule.

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/invalid.ts
@@ -1,0 +1,29 @@
+/* should generate diagnostics */
+
+String({});
+({}).toString();
+({}).toLocaleString();
+`${{}}`;
+
+declare const objectOrString: {} | string;
+String(objectOrString);
+
+class PlainObject {
+    value: string;
+}
+
+declare const plainInstance: PlainObject;
+plainInstance.toString();
+"prefix: " + plainInstance;
+
+declare const joined: [{}];
+joined.join(",");
+
+declare const stringOrPlainArray: (string | PlainObject)[];
+stringOrPlainArray.join(",");
+
+declare const pair: [string, PlainObject];
+`${pair}`;
+
+declare let sink: string;
+sink += plainInstance;

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/invalid.ts.snap
@@ -1,0 +1,222 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+
+String({});
+({}).toString();
+({}).toLocaleString();
+`${{}}`;
+
+declare const objectOrString: {} | string;
+String(objectOrString);
+
+class PlainObject {
+    value: string;
+}
+
+declare const plainInstance: PlainObject;
+plainInstance.toString();
+"prefix: " + plainInstance;
+
+declare const joined: [{}];
+joined.join(",");
+
+declare const stringOrPlainArray: (string | PlainObject)[];
+stringOrPlainArray.join(",");
+
+declare const pair: [string, PlainObject];
+`${pair}`;
+
+declare let sink: string;
+sink += plainInstance;
+
+```
+
+# Diagnostics
+```
+invalid.ts:3:8 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This expression will use the default object stringification format, such as [object Object], when stringified.
+  
+    1 │ /* should generate diagnostics */
+    2 │ 
+  > 3 │ String({});
+      │        ^^
+    4 │ ({}).toString();
+    5 │ ({}).toLocaleString();
+  
+  i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:4:1 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This expression will use the default object stringification format, such as [object Object], when stringified.
+  
+    3 │ String({});
+  > 4 │ ({}).toString();
+      │ ^^^^
+    5 │ ({}).toLocaleString();
+    6 │ `${{}}`;
+  
+  i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:5:1 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This expression will use the default object stringification format, such as [object Object], when stringified.
+  
+    3 │ String({});
+    4 │ ({}).toString();
+  > 5 │ ({}).toLocaleString();
+      │ ^^^^
+    6 │ `${{}}`;
+    7 │ 
+  
+  i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:6:4 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This expression will use the default object stringification format, such as [object Object], when stringified.
+  
+    4 │ ({}).toString();
+    5 │ ({}).toLocaleString();
+  > 6 │ `${{}}`;
+      │    ^^
+    7 │ 
+    8 │ declare const objectOrString: {} | string;
+  
+  i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:9:8 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This expression may use the default object stringification format, such as [object Object], when stringified.
+  
+     8 │ declare const objectOrString: {} | string;
+   > 9 │ String(objectOrString);
+       │        ^^^^^^^^^^^^^^
+    10 │ 
+    11 │ class PlainObject {
+  
+  i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:16:1 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This expression will use the default object stringification format, such as [object Object], when stringified.
+  
+    15 │ declare const plainInstance: PlainObject;
+  > 16 │ plainInstance.toString();
+       │ ^^^^^^^^^^^^^
+    17 │ "prefix: " + plainInstance;
+    18 │ 
+  
+  i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:17:14 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This expression will use the default object stringification format, such as [object Object], when stringified.
+  
+    15 │ declare const plainInstance: PlainObject;
+    16 │ plainInstance.toString();
+  > 17 │ "prefix: " + plainInstance;
+       │              ^^^^^^^^^^^^^
+    18 │ 
+    19 │ declare const joined: [{}];
+  
+  i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:20:1 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This join() call will stringify one or more elements with the default object format, such as [object Object].
+  
+    19 │ declare const joined: [{}];
+  > 20 │ joined.join(",");
+       │ ^^^^^^
+    21 │ 
+    22 │ declare const stringOrPlainArray: (string | PlainObject)[];
+  
+  i Ensure every joined element has a useful string representation, or map the values before joining.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:23:1 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This join() call may stringify one or more elements with the default object format, such as [object Object].
+  
+    22 │ declare const stringOrPlainArray: (string | PlainObject)[];
+  > 23 │ stringOrPlainArray.join(",");
+       │ ^^^^^^^^^^^^^^^^^^
+    24 │ 
+    25 │ declare const pair: [string, PlainObject];
+  
+  i Ensure every joined element has a useful string representation, or map the values before joining.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:26:4 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This expression will use the default object stringification format, such as [object Object], when stringified.
+  
+    25 │ declare const pair: [string, PlainObject];
+  > 26 │ `${pair}`;
+       │    ^^^^
+    27 │ 
+    28 │ declare let sink: string;
+  
+  i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/invalid.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
 expression: invalid.ts
 ---
 # Input
@@ -213,6 +214,23 @@ invalid.ts:26:4 lint/nursery/noBaseToString ━━━━━━━━━━━━
        │    ^^^^
     27 │ 
     28 │ declare let sink: string;
+  
+  i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:29:9 lint/nursery/noBaseToString ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This expression will use the default object stringification format, such as [object Object], when stringified.
+  
+    28 │ declare let sink: string;
+  > 29 │ sink += plainInstance;
+       │         ^^^^^^^^^^^^^
+    30 │ 
   
   i Stringify a primitive value, define a custom stringification method, or serialize the object explicitly.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/valid.ts
@@ -1,0 +1,35 @@
+/* should not generate diagnostics */
+
+String(1);
+`${true}`;
+
+class CustomToString {
+    toString() {
+        return "ok";
+    }
+}
+
+class CustomLocaleString {
+    toLocaleString() {
+        return "ok";
+    }
+}
+
+declare const custom: CustomToString;
+declare const localised: CustomLocaleString;
+declare const error: Error;
+declare const regex: RegExp;
+declare const unknownValue: unknown;
+declare const values: string[];
+
+custom.toString();
+`${custom}`;
+String(custom);
+localised.toLocaleString();
+
+values.join(",");
+String(values);
+
+String(error);
+`${regex}`;
+String(unknownValue);

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/valid.ts.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+String(1);
+`${true}`;
+
+class CustomToString {
+    toString() {
+        return "ok";
+    }
+}
+
+class CustomLocaleString {
+    toLocaleString() {
+        return "ok";
+    }
+}
+
+declare const custom: CustomToString;
+declare const localised: CustomLocaleString;
+declare const error: Error;
+declare const regex: RegExp;
+declare const unknownValue: unknown;
+declare const values: string[];
+
+custom.toString();
+`${custom}`;
+String(custom);
+localised.toLocaleString();
+
+values.join(",");
+String(values);
+
+String(error);
+`${regex}`;
+String(unknownValue);
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validIgnoredTypeNames.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validIgnoredTypeNames.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noBaseToString": {
+          "level": "error",
+          "options": {
+            "ignoredTypeNames": ["IgnoredStringLike"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validIgnoredTypeNames.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validIgnoredTypeNames.ts
@@ -1,0 +1,11 @@
+/* should not generate diagnostics */
+
+class IgnoredStringLike {
+    value: string;
+}
+
+declare const ignored: IgnoredStringLike;
+
+String(ignored);
+ignored.toString();
+`${ignored}`;

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validIgnoredTypeNames.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validIgnoredTypeNames.ts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validIgnoredTypeNames.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+class IgnoredStringLike {
+    value: string;
+}
+
+declare const ignored: IgnoredStringLike;
+
+String(ignored);
+ignored.toString();
+`${ignored}`;
+
+```

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -519,6 +519,7 @@ impl JsModuleInfoCollector {
         let references = self.get_writable_references(semantic_model, binding.range);
         let mut union_collector = UnionCollector::new();
         union_collector.add(ty.clone());
+        let mut saw_widening_reference = false;
         for reference in references {
             let node = reference.syntax();
             let reference_scope = reference.scope().id();
@@ -536,7 +537,12 @@ impl JsModuleInfoCollector {
                 let data = TypeData::from_any_js_expression(self, scope_id, &right);
                 let assigned_type = self.reference_to_owned_data(data);
                 union_collector.add(assigned_type);
+                saw_widening_reference = true;
             }
+        }
+
+        if !saw_widening_reference {
+            return ty.clone();
         }
 
         let id = self.register_type(union_collector.finish());

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -969,6 +969,43 @@ fn test_resolve_type_of_property_with_getter() {
     snapshot.assert_snapshot("test_resolve_type_of_property_with_getter");
 }
 
+#[test]
+fn test_writable_annotated_binding_does_not_become_singleton_union() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+        declare let sink: string;
+        sink += "";
+        "#,
+    );
+
+    let added_paths = [BiomePath::new("/src/index.ts")];
+    let added_paths = get_added_js_paths(&fs, &added_paths);
+
+    let module_graph = Arc::new(ModuleGraph::default());
+    module_graph.update_graph_for_js_paths(&fs, &ProjectLayout::default(), &added_paths, true);
+
+    let index_module = module_graph
+        .js_module_info_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
+
+    let sink_id = resolver
+        .resolve_type_of(&Text::new_static("sink"), ScopeId::GLOBAL)
+        .expect("sink variable not found");
+    let sink_ty = resolver.resolved_type_for_id(sink_id);
+
+    assert!(sink_ty.is_string_or_string_literal());
+    assert!(!matches!(
+        sink_ty.resolved_data().unwrap().as_raw_data(),
+        TypeData::Union(_)
+    ));
+}
+
 macro_rules! class_tests {
     ($($name:ident: $prefix:expr,)*) => {
     $(

--- a/crates/biome_rule_options/src/lib.rs
+++ b/crates/biome_rule_options/src/lib.rs
@@ -18,6 +18,7 @@ pub mod no_autofocus;
 pub mod no_await_in_loops;
 pub mod no_banned_types;
 pub mod no_barrel_file;
+pub mod no_base_to_string;
 pub mod no_before_interactive_script_outside_document;
 pub mod no_biome_first_exception;
 pub mod no_bitwise_operators;

--- a/crates/biome_rule_options/src/no_base_to_string.rs
+++ b/crates/biome_rule_options/src/no_base_to_string.rs
@@ -1,0 +1,18 @@
+use biome_deserialize_macros::Deserializable;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Clone, Debug, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct NoBaseToStringOptions {
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub ignored_type_names: Option<Box<[Box<str>]>>,
+}
+
+impl biome_deserialize::Merge for NoBaseToStringOptions {
+    fn merge_with(&mut self, other: Self) {
+        if let Some(ignored_type_names) = other.ignored_type_names {
+            self.ignored_type_names = Some(ignored_type_names);
+        }
+    }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2043,7 +2043,7 @@ See https://biomejs.dev/linter/rules/no-ambiguous-anchor-text
 	 */
 	noAmbiguousAnchorText?: NoAmbiguousAnchorTextConfiguration;
 	/**
-	* Succinct description of the rule.
+	* Require stringification to avoid values that only use the default object representation.
 See https://biomejs.dev/linter/rules/no-base-to-string 
 	 */
 	noBaseToString?: NoBaseToStringConfiguration;
@@ -7774,7 +7774,9 @@ export interface NoAmbiguousAnchorTextOptions {
 	 */
 	words?: string[];
 }
-export type NoBaseToStringOptions = {};
+export interface NoBaseToStringOptions {
+	ignoredTypeNames?: string[];
+}
 export type NoBeforeInteractiveScriptOutsideDocumentOptions = {};
 export type NoComponentHookFactoriesOptions = {};
 export type NoConditionalExpectOptions = {};

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2043,6 +2043,11 @@ See https://biomejs.dev/linter/rules/no-ambiguous-anchor-text
 	 */
 	noAmbiguousAnchorText?: NoAmbiguousAnchorTextConfiguration;
 	/**
+	* Succinct description of the rule.
+See https://biomejs.dev/linter/rules/no-base-to-string 
+	 */
+	noBaseToString?: NoBaseToStringConfiguration;
+	/**
 	* Prevent usage of next/script's beforeInteractive strategy outside of pages/_document.js in a Next.js project.
 See https://biomejs.dev/linter/rules/no-before-interactive-script-outside-document 
 	 */
@@ -4247,6 +4252,9 @@ export type UseYieldConfiguration =
 export type NoAmbiguousAnchorTextConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoAmbiguousAnchorTextOptions;
+export type NoBaseToStringConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoBaseToStringOptions;
 export type NoBeforeInteractiveScriptOutsideDocumentConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoBeforeInteractiveScriptOutsideDocumentOptions;
@@ -5983,6 +5991,10 @@ export interface RuleWithUseYieldOptions {
 export interface RuleWithNoAmbiguousAnchorTextOptions {
 	level: RulePlainConfiguration;
 	options?: NoAmbiguousAnchorTextOptions;
+}
+export interface RuleWithNoBaseToStringOptions {
+	level: RulePlainConfiguration;
+	options?: NoBaseToStringOptions;
 }
 export interface RuleWithNoBeforeInteractiveScriptOutsideDocumentOptions {
 	level: RulePlainConfiguration;
@@ -7762,6 +7774,7 @@ export interface NoAmbiguousAnchorTextOptions {
 	 */
 	words?: string[];
 }
+export type NoBaseToStringOptions = {};
 export type NoBeforeInteractiveScriptOutsideDocumentOptions = {};
 export type NoComponentHookFactoriesOptions = {};
 export type NoConditionalExpectOptions = {};
@@ -9016,6 +9029,7 @@ export type Category =
 	| "lint/correctness/useValidTypeof"
 	| "lint/correctness/useYield"
 	| "lint/nursery/noAmbiguousAnchorText"
+	| "lint/nursery/noBaseToString"
 	| "lint/nursery/noBeforeInteractiveScriptOutsideDocument"
 	| "lint/nursery/noColorInvalidHex"
 	| "lint/nursery/noComponentHookFactories"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2784,6 +2784,16 @@
 			]
 		},
 		"NoBarrelFileOptions": { "type": "object", "additionalProperties": false },
+		"NoBaseToStringConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoBaseToStringOptions" }
+			]
+		},
+		"NoBaseToStringOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
 		"NoBeforeInteractiveScriptOutsideDocumentConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },
@@ -6052,6 +6062,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noBaseToString": {
+					"description": "Succinct description of the rule.\nSee https://biomejs.dev/linter/rules/no-base-to-string",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoBaseToStringConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noBeforeInteractiveScriptOutsideDocument": {
 					"description": "Prevent usage of next/script's beforeInteractive strategy outside of pages/_document.js in a Next.js project.\nSee https://biomejs.dev/linter/rules/no-before-interactive-script-outside-document",
 					"anyOf": [
@@ -7724,6 +7741,15 @@
 			"properties": {
 				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
 				"options": { "$ref": "#/$defs/NoBarrelFileOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithNoBaseToStringOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoBaseToStringOptions" }
 			},
 			"additionalProperties": false,
 			"required": ["level"]

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2792,6 +2792,12 @@
 		},
 		"NoBaseToStringOptions": {
 			"type": "object",
+			"properties": {
+				"ignoredTypeNames": {
+					"type": ["array", "null"],
+					"items": { "type": "string" }
+				}
+			},
 			"additionalProperties": false
 		},
 		"NoBeforeInteractiveScriptOutsideDocumentConfiguration": {
@@ -6063,7 +6069,7 @@
 					]
 				},
 				"noBaseToString": {
-					"description": "Succinct description of the rule.\nSee https://biomejs.dev/linter/rules/no-base-to-string",
+					"description": "Require stringification to avoid values that only use the default object representation.\nSee https://biomejs.dev/linter/rules/no-base-to-string",
 					"anyOf": [
 						{ "$ref": "#/$defs/NoBaseToStringConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR adds noBaseToString which is a port of https://typescript-eslint.io/rules/no-base-to-string/

Generated by gpt 5.4

ngl, this one sucks. It's very complicated. 

The goal of this rule is to prevent accidentally rendering `[object Object]` in a string.

As psuedo code, the rule is essentially:

```
if expression is a trivial literal {
    return None;
}

let ty = inferred_type(expression);
let certainty = analyze_type(ty, mode);

if certainty == Always {
    None
} else {
    Some(diagnostic)
}

```

So a lot of the code is mostly dealing with evaluating type info.

`AnalysisMode` has two cases:

- `ToString`: used for `String(x)`, `x.toString()`, template interpolation, string concatenation.
- `Join`: used for `array.join(",")`.

The distinction matters because `join()` stringifies the elements, not the object itself.

### `collect_certainty()` 

`collect_certainty()` is pretty much the core business logic of the rule. It determines a type's `Usefulness`, which is a label of how useful the type text is if you call `.toString()` on it. If we can't resolve a type, we bail to avoid raising false positives.

`collect_certainty()` uses a stack of `AnalysisTask`s. The agent's summary:

- `Eval(type, mode)` means “analyze this type”
- `Aggregate(kind, count)` means “combine the next `count` child results”
- `Leave(key)` means “we’re done exploring this type, remove it from the active cycle set”

Those task types are defined at `:172-183`.

That function handles types in this order:

- If the type is a constrained generic, analyze the constraint instead (`:397-410`).
- If the type is a primitive or otherwise safe type, return `Always` (`:415-420`, `:600-633`).
- If the type is in the ignored-type list, return `Always` (`:415-420`, `:755-911`).
- If the type is a union, analyze all variants and combine them (`:423-431`, `:557-569`).
- If the type is an intersection, analyze all parts and combine them (`:439-453`, `:571-580`).
- If the type is a tuple, analyze all elements (`:456-470`, `:582-598`).
- If the type is an array, analyze the element type (`:473-477`, `:539-555`).
- Otherwise, in `ToString` mode, ask: “does this ultimately behave like plain `Object.prototype.toString`?” (`:480-487`, `:635-737`).

How unions, intersections, and tuples are handled is explained in doc comments.

### How It Detects “Plain Object Stringification”

`is_to_string_like_from_object()` essentially checks: will this use the default object stringification? or does it implement a custom `.toString()` or similar to avoid that?

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
