### PR TITLE
fix(cli): escape backslashes in JSON reporter file paths

### DIFF
--- a/.changeset/fix-json-asfffvaf.md
+++ b/.changeset/fix-json-asfffvaf.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9899](https://github.com/biomejs/biome/issues/9899): `--reporter=json` now properly escapes backslashes in file paths. Previously, Windows paths containing backslashes were emitted unescaped, producing invalid JSON output.

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -109,7 +109,9 @@ fn location_report_to_json(location: &LocationReport) -> AnyJsonValue {
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("path"))),
             token(T![:]),
-            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&location.path))),
+            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&json_escape(
+                &location.path,
+            )))),
         ),
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("start"))),


### PR DESCRIPTION
## Summary

The `--reporter=json` and `--reporter=json-pretty` reporters emit file paths without escaping special characters. On Windows, paths contain backslashes (`\`) which are not valid unescaped in JSON strings, producing invalid JSON output.

## Issue

Fixes #9899

## Changes

- Applied `json_escape()` to the `location.path` value in `location_report_to_json()`. This function already exists in the file and is used for `message` and suggestion `text` fields, but was missing for the path field.

## Testing

The fix applies the same `json_escape()` helper that is already used for other string values in the JSON reporter. On Windows, a path like `typescript\src\file.tsx` will now be correctly serialized as `typescript\\src\\file.tsx` (or `typescript/src/file.tsx` depending on path normalization).

## AI Disclosure

This PR was authored with the assistance of Claude Code.