### PR TITLE
fix(resolver): resolution of namespace members

### DIFF
--- a/.changeset/three-peaches-dress.md
+++ b/.changeset/three-peaches-dress.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9626](https://github.com/biomejs/biome/issues/9626): [`noUnresolvedImports`](https://biomejs.dev/linter/rules/no-unresolved-imports/) no longer reports false positives for named imports from packages that have a corresponding `@types/*` package installed. For example, `import { useState } from "react"` with `@types/react` installed is now correctly recognised.

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -543,6 +543,11 @@ impl JsModuleInfoCollector {
     ) {
         if self.infer_types {
             self.infer_all_types(semantic_model);
+        }
+
+        self.populate_namespace_and_module_members();
+
+        if self.infer_types {
             self.resolve_all_and_downgrade_project_references();
 
             // Purging before flattening will save us from duplicate work during
@@ -710,14 +715,11 @@ impl JsModuleInfoCollector {
         ResolvedTypeId::new(self.level(), id).into()
     }
 
-    /// After the first pass of the collector, import references have been
-    /// resolved to an import binding. But we can't store the information of the
-    /// import target inside the `ResolvedTypeId`, because it resides in the
-    /// module's semantic data, and `ResolvedTypeId` is only 8 bytes. So during
-    /// resolving, we "downgrade" the import references from
-    /// [`TypeReference::Resolved`] to [`TypeReference::Import`].
-    fn resolve_all_and_downgrade_project_references(&mut self) {
-        // First do a pass in which we populate module and namespace members:
+    /// Fills in the `members` field of `TypeData::Module` and
+    /// `TypeData::Namespace` entries that already exist in the type store.
+    /// These entries are created with empty member lists; this pass walks the
+    /// scope tree to collect the bindings that belong to each one.
+    fn populate_namespace_and_module_members(&mut self) {
         let mut i = 0;
         while i < self.types.len() {
             match self.types.get(i).as_ref() {
@@ -725,7 +727,6 @@ impl JsModuleInfoCollector {
                     if let Some(module_binding) = self.find_binding_for_type_index(i) {
                         let ty = TypeData::from(Module {
                             name: module.name.clone(),
-                            // Populate module members:
                             members: self.find_type_members_in_scope(module_binding.scope_id),
                         });
                         self.types.replace(i, ty);
@@ -735,7 +736,6 @@ impl JsModuleInfoCollector {
                     if let Some(namespace_binding) = self.find_binding_for_type_index(i) {
                         let ty = TypeData::from(Namespace {
                             path: namespace.path.clone(),
-                            // Populate namespace members:
                             members: self.find_type_members_in_scope(namespace_binding.scope_id),
                         });
                         self.types.replace(i, ty);
@@ -745,8 +745,15 @@ impl JsModuleInfoCollector {
             }
             i += 1;
         }
+    }
 
-        // Now perform a pass for the actual resolving:
+    /// After the first pass of the collector, import references have been
+    /// resolved to an import binding. But we can't store the information of the
+    /// import target inside the `ResolvedTypeId`, because it resides in the
+    /// module's semantic data, and `ResolvedTypeId` is only 8 bytes. So during
+    /// resolving, we "downgrade" the import references from
+    /// [`TypeReference::Resolved`] to [`TypeReference::Import`].
+    fn resolve_all_and_downgrade_project_references(&mut self) {
         let mut i = 0;
         while i < self.types.len() {
             let ty = self.types.get(i);
@@ -821,6 +828,46 @@ impl JsModuleInfoCollector {
                 ty: binding.ty.clone(),
             })
             .collect()
+    }
+
+    /// Given a binding name and scope, looks up the binding and, if it is a
+    /// namespace or module declaration, inserts all direct child-scope bindings
+    /// into `exports`.
+    fn collect_namespace_exports_for_binding(
+        &self,
+        name: &str,
+        scope_id: ScopeId,
+        exports: &mut IndexMap<Text, JsExport>,
+    ) {
+        let Some(binding_ref) = self.find_binding_in_scope(name, scope_id) else {
+            return;
+        };
+
+        let binding_id = binding_ref.value_ty_or_ty();
+        let binding = &self.bindings[binding_id.index()];
+
+        if !binding.declaration_kind.declares_namespace() {
+            return;
+        }
+
+        // Collect bindings from immediate child scopes of the namespace
+        // binding's scope — the same approach used by
+        // `find_type_members_in_scope` during full type inference.
+        for child_binding in &self.bindings {
+            if child_binding.name.is_empty() {
+                continue;
+            }
+
+            let child_scope = &self.scopes[child_binding.scope_id.index()];
+            if child_scope
+                .parent
+                .is_some_and(|parent| parent == binding.scope_id)
+            {
+                exports
+                    .entry(child_binding.name.clone())
+                    .or_insert_with(|| JsExport::Own(JsOwnExport::Binding(child_binding.range)));
+            }
+        }
     }
 
     fn flatten_all(&mut self) {
@@ -905,6 +952,7 @@ impl JsModuleInfoCollector {
                 }
                 JsCollectedExport::ExportDefaultAssignment { ty } => {
                     let resolved = self.resolve_reference(&ty).unwrap_or(GLOBAL_UNKNOWN_ID);
+                    let mut found_members = false;
 
                     if let Some(data) = self.get_by_resolved_id(resolved) {
                         for member in data.as_raw_data().own_members() {
@@ -923,6 +971,26 @@ impl JsModuleInfoCollector {
                             if let Some(resolved_member) = self.resolve_reference(&member.ty) {
                                 let export = JsExport::Own(JsOwnExport::Type(resolved_member));
                                 finalised_exports.insert(name, export);
+                                found_members = true;
+                            }
+                        }
+                    }
+
+                    // If the resolved type has no members (e.g., the
+                    // reference is still an unresolved qualifier), fall back
+                    // to the scope tree to collect namespace bindings directly.
+                    if !found_members {
+                        if let Some(data) = self.get_by_resolved_id(resolved) {
+                            if let TypeData::Reference(TypeReference::Qualifier(qualifier)) =
+                                data.as_raw_data()
+                            {
+                                if let Some(first_part) = qualifier.path.iter().next() {
+                                    self.collect_namespace_exports_for_binding(
+                                        first_part,
+                                        qualifier.scope_id,
+                                        &mut finalised_exports,
+                                    );
+                                }
                             }
                         }
                     }

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -979,20 +979,17 @@ impl JsModuleInfoCollector {
                     // If the resolved type has no members (e.g., the
                     // reference is still an unresolved qualifier), fall back
                     // to the scope tree to collect namespace bindings directly.
-                    if !found_members {
-                        if let Some(data) = self.get_by_resolved_id(resolved) {
-                            if let TypeData::Reference(TypeReference::Qualifier(qualifier)) =
-                                data.as_raw_data()
-                            {
-                                if let Some(first_part) = qualifier.path.iter().next() {
-                                    self.collect_namespace_exports_for_binding(
-                                        first_part,
-                                        qualifier.scope_id,
-                                        &mut finalised_exports,
-                                    );
-                                }
-                            }
-                        }
+                    if !found_members
+                        && let Some(data) = self.get_by_resolved_id(resolved)
+                        && let TypeData::Reference(TypeReference::Qualifier(qualifier)) =
+                            data.as_raw_data()
+                        && let Some(first_part) = qualifier.path.iter().next()
+                    {
+                        self.collect_namespace_exports_for_binding(
+                            first_part,
+                            qualifier.scope_id,
+                            &mut finalised_exports,
+                        );
                     }
 
                     let export = JsExport::Own(JsOwnExport::Type(resolved));

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -2620,6 +2620,46 @@ fn test_namespace_reexport_type_inference() {
     snapshot.assert_snapshot("test_namespace_reexport_type_inference");
 }
 
+#[test]
+fn test_export_equals_namespace_without_type_inference() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/node_modules/@types/react/index.d.ts".into(),
+        include_bytes!("../../biome_resolver/tests/fixtures/resolver_cases_5/node_modules/@types/react/index.d.ts"),
+    );
+
+    let added_paths = [BiomePath::new("/node_modules/@types/react/index.d.ts")];
+    let added_paths = get_added_js_paths(&fs, &added_paths);
+
+    let project_layout = ProjectLayout::default();
+    project_layout.insert_node_manifest(
+        "/".into(),
+        PackageJson::new("frontend")
+            .with_version("0.0.0")
+            .with_dependencies(Dependencies(Box::new([("react".into(), "19.0.0".into())]))),
+    );
+
+    // infer_types = false, matching the `project` domain behavior
+    let module_graph = Arc::new(ModuleGraph::default());
+    module_graph.update_graph_for_js_paths(&fs, &project_layout, &added_paths, false);
+
+    let react_module = module_graph
+        .js_module_info_for_path(Utf8Path::new("/node_modules/@types/react/index.d.ts"))
+        .expect("react module must exist");
+
+    let use_state = react_module.find_js_exported_symbol(module_graph.as_ref(), "useState");
+    assert!(
+        use_state.is_some(),
+        "`useState` must be visible as a named export from `@types/react` even without type inference"
+    );
+
+    let use_callback = react_module.find_js_exported_symbol(module_graph.as_ref(), "useCallback");
+    assert!(
+        use_callback.is_some(),
+        "`useCallback` must be visible as a named export from `@types/react` even without type inference"
+    );
+}
+
 fn find_files_recursively_in_directory(
     directory: &Utf8Path,
     predicate: impl Fn(&Utf8Path) -> bool,


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/9626

There were two problems:
- The resolution of the members was gated by the `infer_types`, and since in 2.4.0 we broke down the project domain and type domain, this surfaced and started to fail
- Members weren't correctly resolved using the scopes we have

Implemented with the help of an AI agent

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a regression test

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
