### PR TITLE
refactor(core): semantic model in collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "biome_js_syntax",
  "biome_jsdoc_comment",
  "biome_rowan",
+ "insta",
  "rust-lapper",
  "rustc-hash 2.1.2",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,7 @@ dependencies = [
  "biome_formatter",
  "biome_js_parser",
  "biome_js_syntax",
+ "biome_jsdoc_comment",
  "biome_rowan",
  "rust-lapper",
  "rustc-hash 2.1.2",
@@ -1143,7 +1144,6 @@ dependencies = [
  "biome_formatter",
  "biome_js_parser",
  "biome_js_syntax",
- "biome_js_type_info",
  "biome_rowan",
 ]
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -161,9 +161,8 @@ impl Visitor for JsDocTypeCollectorVisitor {
 }
 
 fn load_jsdoc_types_from_node(model: &mut JsDocTypeModel, node: &SyntaxNode<JsLanguage>) {
-    JsdocComment::for_each(node, |comment| {
-        load_jsdoc_types_from_jsdoc_comment(model, comment)
-    });
+    JsdocComment::get_jsdocs(node)
+        .for_each(|comment| load_jsdoc_types_from_jsdoc_comment(model, comment.as_str()));
 }
 
 static JSDOC_INLINE_TAG_REGEX: LazyLock<Regex> = LazyLock::new(|| {

--- a/crates/biome_js_semantic/Cargo.toml
+++ b/crates/biome_js_semantic/Cargo.toml
@@ -24,6 +24,7 @@ smallvec            = { workspace = true }
 biome_console     = { path = "../biome_console" }
 biome_diagnostics = { path = "../biome_diagnostics" }
 biome_js_parser   = { path = "../biome_js_parser" }
+insta             = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/biome_js_semantic/Cargo.toml
+++ b/crates/biome_js_semantic/Cargo.toml
@@ -12,12 +12,13 @@ categories.workspace = true
 publish              = true
 
 [dependencies]
-biome_formatter = { workspace = true }
-biome_js_syntax = { workspace = true }
-biome_rowan     = { workspace = true }
-rust-lapper     = { workspace = true }
-rustc-hash      = { workspace = true }
-smallvec        = { workspace = true }
+biome_formatter     = { workspace = true }
+biome_js_syntax     = { workspace = true }
+biome_jsdoc_comment = { workspace = true }
+biome_rowan         = { workspace = true }
+rust-lapper         = { workspace = true }
+rustc-hash          = { workspace = true }
+smallvec            = { workspace = true }
 
 [dev-dependencies]
 biome_console     = { path = "../biome_console" }

--- a/crates/biome_js_semantic/src/format_semantic_model.rs
+++ b/crates/biome_js_semantic/src/format_semantic_model.rs
@@ -1,3 +1,4 @@
+use crate::{Binding, BindingId, JsDeclarationKind, Scope, ScopeId, SemanticModel};
 use biome_formatter::prelude::*;
 use biome_formatter::{
     FormatContext, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
@@ -5,8 +6,6 @@ use biome_formatter::{
 };
 use biome_formatter::{format_args, write};
 use biome_js_syntax::TextSize;
-
-use crate::{Binding, BindingId, Scope, ScopeId, SemanticModel};
 
 pub struct FormatSemanticModelOptions;
 
@@ -141,19 +140,41 @@ impl Format<FormatSemanticModelContext> for Scope {
 
 impl Format<FormatSemanticModelContext> for Binding {
     fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
+        let is_imported = format_with(|f| {
+            if self.is_imported() {
+                write!(f, [token("Imported: true"), hard_line_break()])
+            } else {
+                write!(f, [token("Imported: false"), hard_line_break()])
+            }
+        });
+
+        let is_exported = format_with(|f| {
+            if self.is_exported() {
+                write!(f, [token("Exported: true"), hard_line_break()])
+            } else {
+                write!(f, [token("Exported: false"), hard_line_break()])
+            }
+        });
+
         let formatted_binding_info = format_with(|f| {
             let range = std::format!("{:?}", self.syntax().text_trimmed_range());
+
             write!(
                 f,
                 [
-                    token("id: "),
+                    token("Id: "),
                     self.id,
                     token(" @ "),
                     text(range.as_str(), TextSize::default()),
                     hard_line_break()
                 ]
             )?;
-            write!(f, [token("scope: "), self.scope().id, hard_line_break()])?;
+            write!(f, [token("Scope: "), self.scope().id, hard_line_break()])?;
+            write!(f, [is_imported, is_exported])?;
+            write!(
+                f,
+                [token("Kind: "), self.declaration_kind(), hard_line_break()]
+            )?;
             let full_text = self.syntax().text_trimmed().into_text();
             write!(
                 f,
@@ -163,6 +184,17 @@ impl Format<FormatSemanticModelContext> for Binding {
                     hard_line_break()
                 ]
             )?;
+
+            if let Some(jsdoc) = self.to_fmt_jsonc() {
+                write!(
+                    f,
+                    [
+                        token("JsDoc Comments: "),
+                        text(jsdoc.as_str(), TextSize::default())
+                    ]
+                )?;
+            }
+
             Ok(())
         });
         write!(
@@ -190,5 +222,12 @@ impl Format<FormatSemanticModelContext> for BindingId {
     fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
         let binding_text = std::format!("BindingId({})", self.0);
         write!(f, [text(binding_text.as_str(), TextSize::default())])
+    }
+}
+
+impl Format<FormatSemanticModelContext> for JsDeclarationKind {
+    fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
+        let text_kind = std::format!("{:?}", self);
+        write!(f, [text(text_kind.as_str(), TextSize::default())])
     }
 }

--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -609,10 +609,20 @@ impl Binding {
         super::is_imported(&self.syntax())
     }
 
+    pub fn is_exported(&self) -> bool {
+        self.data.is_exported(self.syntax().text_trimmed_range())
+    }
+
     /// Returns the JSDoc comment associated with this binding, if any.
     pub fn jsdoc(&self) -> Option<&JsdocComment> {
         let binding = self.data.binding(self.id);
         binding.jsdoc.as_ref()
+    }
+
+    /// Returns the formatted JsDoc comment
+    pub fn to_fmt_jsonc(&self) -> Option<String> {
+        let binding = self.data.binding(self.id);
+        binding.jsdoc.clone().map(|jsdoc| jsdoc.to_string())
     }
 
     /// Returns the text ranges of all export sites for this binding.

--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -4,6 +4,7 @@ use biome_js_syntax::{
     AnyJsDeclaration, JsImport, JsVariableKind, TextRange, TsTypeParameter, TsTypeParameterName,
     binding_ext::AnyJsIdentifierBinding,
 };
+use biome_jsdoc_comment::JsdocComment;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
@@ -457,9 +458,11 @@ pub(crate) struct SemanticModelBindingData {
     pub(crate) range: TextRange,
     pub(crate) references: Vec<SemanticModelReference>,
     // We use a SmallVec because most of the time a binding is expected once.
-    pub(crate) export_by_start: smallvec::SmallVec<[TextSize; 4]>,
+    pub(crate) export_ranges: smallvec::SmallVec<[TextRange; 4]>,
     /// The kind of declaration that introduced this binding.
     pub(crate) declaration_kind: JsDeclarationKind,
+    /// JSDoc comment associated with the binding.
+    pub(crate) jsdoc: Option<JsdocComment>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -596,13 +599,26 @@ impl Binding {
     /// itself an `export` statement) or an identifier usage.
     pub fn exports(&self) -> impl Iterator<Item = JsSyntaxNode> + '_ {
         let binding = self.data.binding(self.id);
-        binding.export_by_start.iter().map(|export_start| {
-            self.data.binding_node_by_start[export_start].to_node(self.data.to_root().syntax())
+        binding.export_ranges.iter().map(|export_start| {
+            self.data.binding_node_by_start[&export_start.start()]
+                .to_node(self.data.to_root().syntax())
         })
     }
 
     pub fn is_imported(&self) -> bool {
         super::is_imported(&self.syntax())
+    }
+
+    /// Returns the JSDoc comment associated with this binding, if any.
+    pub fn jsdoc(&self) -> Option<&JsdocComment> {
+        let binding = self.data.binding(self.id);
+        binding.jsdoc.as_ref()
+    }
+
+    /// Returns the text ranges of all export sites for this binding.
+    pub fn export_ranges(&self) -> &[TextRange] {
+        let binding = self.data.binding(self.id);
+        binding.export_ranges.as_slice()
     }
 }
 

--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -599,9 +599,11 @@ impl Binding {
     /// itself an `export` statement) or an identifier usage.
     pub fn exports(&self) -> impl Iterator<Item = JsSyntaxNode> + '_ {
         let binding = self.data.binding(self.id);
-        binding.export_ranges.iter().map(|export_start| {
-            self.data.binding_node_by_start[&export_start.start()]
-                .to_node(self.data.to_root().syntax())
+        binding.export_ranges.iter().filter_map(|export_start| {
+            self.data
+                .binding_node_by_start
+                .get(&export_start.start())
+                .map(|ptr| ptr.to_node(self.data.to_root().syntax()))
         })
     }
 

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -1,5 +1,9 @@
 use super::*;
-use biome_js_syntax::{AnyJsRoot, JsSyntaxNode, TextRange, TsConditionalType, TsTypeParameterName};
+use biome_js_syntax::{
+    AnyJsDeclaration, AnyJsRoot, JsExport, JsSyntaxNode, TextRange, TsConditionalType,
+    TsTypeParameterName,
+};
+use biome_jsdoc_comment::JsdocComment;
 use biome_rowan::SyntaxNodePtr;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::hash_map::Entry;
@@ -27,6 +31,7 @@ pub struct SemanticModelBuilder {
     declared_at_by_start: FxHashMap<TextSize, BindingId>,
     exported: FxHashSet<TextSize>,
     unresolved_references: Vec<SemanticModelUnresolvedReference>,
+    pub(crate) export_jsdoc_by_range: FxHashMap<TextRange, JsdocComment>,
 }
 
 impl SemanticModelBuilder {
@@ -45,6 +50,7 @@ impl SemanticModelBuilder {
             declared_at_by_start: FxHashMap::default(),
             exported: FxHashSet::default(),
             unresolved_references: Vec::new(),
+            export_jsdoc_by_range: FxHashMap::default(),
         }
     }
 
@@ -112,6 +118,12 @@ impl SemanticModelBuilder {
             | TS_MAPPED_TYPE => {
                 self.scope_node_by_range
                     .insert(node.text_trimmed_range(), node.clone());
+            }
+            JS_EXPORT => {
+                if let Ok(jsdoc) = JsdocComment::try_from(node) {
+                    self.export_jsdoc_by_range
+                        .insert(node.text_trimmed_range(), jsdoc);
+                }
             }
             _ => {
                 if let Some(conditional_type) = TsConditionalType::cast_ref(node)
@@ -181,11 +193,16 @@ impl SemanticModelBuilder {
                 debug_assert!((binding_scope_id.index()) < self.scopes.len());
 
                 let binding_id = BindingId::new(self.bindings.len());
+                let jsdoc = self
+                    .binding_node_by_start
+                    .get(&range.start())
+                    .and_then(find_jsdoc);
                 self.bindings.push(SemanticModelBindingData {
                     range,
                     references: Vec::new(),
-                    export_by_start: smallvec::SmallVec::new(),
+                    export_ranges: smallvec::SmallVec::new(),
                     declaration_kind,
+                    jsdoc,
                 });
                 self.bindings_by_start.insert(range.start(), binding_id);
 
@@ -345,7 +362,7 @@ impl SemanticModelBuilder {
 
                 let binding_id = self.bindings_by_start[&declaration_at];
                 let binding = &mut self.bindings[binding_id.index()];
-                binding.export_by_start.push(range.start());
+                binding.export_ranges.push(range);
             }
         }
     }
@@ -379,7 +396,20 @@ impl SemanticModelBuilder {
             exported: self.exported,
             unresolved_references: self.unresolved_references,
             globals: self.globals,
+            export_jsdoc_by_range: self.export_jsdoc_by_range,
         };
         SemanticModel::new(data)
     }
+}
+
+fn find_jsdoc(node: &JsSyntaxNode) -> Option<JsdocComment> {
+    node.ancestors().find_map(|ancestor| {
+        if let Some(export) = JsExport::cast_ref(&ancestor) {
+            JsdocComment::try_from(export.syntax()).ok()
+        } else if let Some(decl) = AnyJsDeclaration::cast(ancestor) {
+            JsdocComment::try_from(decl.syntax()).ok()
+        } else {
+            None
+        }
+    })
 }

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -1,5 +1,6 @@
 use super::*;
 use biome_js_syntax::{AnyJsFunction, AnyJsRoot, JsSyntaxNodePtr};
+use biome_jsdoc_comment::JsdocComment;
 use biome_rowan::SendNode;
 use std::sync::Arc;
 
@@ -93,6 +94,8 @@ pub(crate) struct SemanticModelData {
     pub(crate) unresolved_references: Vec<SemanticModelUnresolvedReference>,
     /// All globals references
     pub(crate) globals: Vec<SemanticModelGlobalBindingData>,
+    /// JSDoc comments attached to export statements (keyed by the JsExport node's range).
+    pub(crate) export_jsdoc_by_range: FxHashMap<TextRange, JsdocComment>,
 }
 
 impl SemanticModelData {
@@ -512,5 +515,28 @@ impl SemanticModel {
                 .as_js_identifier_binding()?
                 .all_reads(self),
         })
+    }
+
+    /// Returns a [Binding] for the declaration at the given range if one exists.
+    pub fn as_binding_by_range(&self, range: TextRange) -> Option<Binding> {
+        let binding_id = self.data.bindings_by_start.get(&range.start())?;
+        Some(Binding {
+            data: self.data.clone(),
+            id: *binding_id,
+        })
+    }
+
+    /// Returns a [Binding] for the declaration at the given start range
+    pub fn as_binding_by_range_start(&self, range: TextSize) -> Option<Binding> {
+        let binding_id = self.data.bindings_by_start.get(&range)?;
+        Some(Binding {
+            data: self.data.clone(),
+            id: *binding_id,
+        })
+    }
+
+    /// Returns the JSDoc comment attached to the export statement at `range`, if any.
+    pub fn export_jsdoc(&self, range: TextRange) -> Option<&JsdocComment> {
+        self.data.export_jsdoc_by_range.get(&range)
     }
 }

--- a/crates/biome_js_semantic/src/snapshots/format_js.snap
+++ b/crates/biome_js_semantic/src/snapshots/format_js.snap
@@ -1,0 +1,251 @@
+---
+source: crates/biome_js_semantic/src/tests/format.rs
+expression: content
+---
+## Source
+
+```
+import { foo } from "bar";
+
+const { a, b: renamed } = foo;
+
+let count = 0;
+
+/**
+ * Adds two numbers.
+ * @param x - first operand
+ * @param y - second operand
+ */
+function add(x, y) {
+    return x + y;
+}
+
+/** A simple counter. */
+class Counter {
+    constructor(initial) {
+        this.value = initial;
+    }
+    increment() {
+        this.value++;
+    }
+}
+
+function outer() {
+    let local = 1;
+    return () => {
+        count++;
+        return local + count;
+    };
+}
+
+for (let i = 0; i < 10; i++) {
+    console.log(i);
+}
+
+try {
+    add(a, renamed);
+} catch (e) {
+    console.log(e);
+}
+
+export default outer;
+export { add, Counter };
+```
+
+## Semantic Model
+
+```
+Scope {
+  id: ScopeId(1) @ 1..636
+  children: [
+    Binding {
+      Id: BindingId(0) @ 10..13
+      Scope: ScopeId(1)
+      Imported: true
+      Exported: false
+      Kind: Import
+      ident: foo
+    }
+    Binding {
+      Id: BindingId(1) @ 37..38
+      Scope: ScopeId(1)
+      Imported: false
+      Exported: false
+      Kind: Value
+      ident: a
+    }
+    Binding {
+      Id: BindingId(2) @ 43..50
+      Scope: ScopeId(1)
+      Imported: false
+      Exported: false
+      Kind: Value
+      ident: renamed
+    }
+    Binding {
+      Id: BindingId(3) @ 65..70
+      Scope: ScopeId(1)
+      Imported: false
+      Exported: false
+      Kind: Value
+      ident: count
+    }
+    Scope {
+      id: ScopeId(2) @ 163..203
+      children: [
+        Binding {
+          Id: BindingId(5) @ 176..177
+          Scope: ScopeId(2)
+          Imported: false
+          Exported: false
+          Kind: Value
+          ident: x
+          JsDoc Comments: Adds two numbers.
+@param x - first operand
+@param y - second operand
+        }
+        Binding {
+          Id: BindingId(6) @ 179..180
+          Scope: ScopeId(2)
+          Imported: false
+          Exported: false
+          Kind: Value
+          ident: y
+          JsDoc Comments: Adds two numbers.
+@param x - first operand
+@param y - second operand
+        }
+        Scope {
+          id: ScopeId(3) @ 182..203
+          children: []
+        }
+      ]
+    }
+    Binding {
+      Id: BindingId(4) @ 172..175
+      Scope: ScopeId(2)
+      Imported: false
+      Exported: true
+      Kind: HoistedValue
+      ident: add
+      JsDoc Comments: Adds two numbers.
+@param x - first operand
+@param y - second operand
+    }
+    Scope {
+      id: ScopeId(4) @ 230..356
+      children: [
+        Scope {
+          id: ScopeId(5) @ 250..308
+          children: [
+            Binding {
+              Id: BindingId(8) @ 262..269
+              Scope: ScopeId(5)
+              Imported: false
+              Exported: false
+              Kind: Value
+              ident: initial
+              JsDoc Comments: A simple counter.
+            }
+            Scope {
+              id: ScopeId(6) @ 271..308
+              children: []
+            }
+          ]
+        }
+        Scope {
+          id: ScopeId(7) @ 313..354
+          children: [
+            Scope {
+              id: ScopeId(8) @ 325..354
+              children: []
+            }
+          ]
+        }
+      ]
+    }
+    Binding {
+      Id: BindingId(7) @ 236..243
+      Scope: ScopeId(4)
+      Imported: false
+      Exported: true
+      Kind: Class
+      ident: Counter
+      JsDoc Comments: A simple counter.
+    }
+    Scope {
+      id: ScopeId(9) @ 358..470
+      children: [
+        Scope {
+          id: ScopeId(10) @ 375..470
+          children: [
+            Binding {
+              Id: BindingId(10) @ 385..390
+              Scope: ScopeId(10)
+              Imported: false
+              Exported: false
+              Kind: Value
+              ident: local
+            }
+            Scope {
+              id: ScopeId(11) @ 407..467
+              children: [
+                Scope {
+                  id: ScopeId(12) @ 413..467
+                  children: []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    Binding {
+      Id: BindingId(9) @ 367..372
+      Scope: ScopeId(9)
+      Imported: false
+      Exported: true
+      Kind: HoistedValue
+      ident: outer
+    }
+    Scope {
+      id: ScopeId(13) @ 472..524
+      children: [
+        Binding {
+          Id: BindingId(11) @ 481..482
+          Scope: ScopeId(13)
+          Imported: false
+          Exported: false
+          Kind: Value
+          ident: i
+        }
+        Scope {
+          id: ScopeId(14) @ 501..524
+          children: []
+        }
+      ]
+    }
+    Scope {
+      id: ScopeId(15) @ 530..554
+      children: []
+    }
+    Scope {
+      id: ScopeId(16) @ 555..588
+      children: [
+        Binding {
+          Id: BindingId(12) @ 562..563
+          Scope: ScopeId(16)
+          Imported: false
+          Exported: false
+          Kind: Value
+          ident: e
+        }
+        Scope {
+          id: ScopeId(17) @ 565..588
+          children: []
+        }
+      ]
+    }
+  ]
+}
+```

--- a/crates/biome_js_semantic/src/snapshots/format_ts.snap
+++ b/crates/biome_js_semantic/src/snapshots/format_ts.snap
@@ -1,0 +1,173 @@
+---
+source: crates/biome_js_semantic/src/tests/format.rs
+expression: content
+---
+## Source
+
+```
+import { helper } from "./utils";
+
+/** The config shape. */
+interface Config {
+    name: string;
+    value: number;
+}
+
+type Pair<T> = { first: T; second: T };
+
+enum Status {
+    Active,
+    Inactive,
+}
+
+/**
+ * Creates a greeting.
+ * @param cfg - the configuration
+ */
+export function greet(cfg: Config): string {
+    return `Hello ${cfg.name}`;
+}
+
+/** The default config. */
+export const DEFAULT: Config = { name: "world", value: helper(0) };
+
+const s: Status = Status.Active;
+const p: Pair<number> = { first: 1, second: 2 };
+
+export { Status };
+```
+
+## Semantic Model
+
+```
+Scope {
+  id: ScopeId(1) @ 1..546
+  children: [
+    Binding {
+      Id: BindingId(0) @ 10..16
+      Scope: ScopeId(1)
+      Imported: true
+      Exported: false
+      Kind: Import
+      ident: helper
+    }
+    Scope {
+      id: ScopeId(2) @ 61..118
+      children: []
+    }
+    Binding {
+      Id: BindingId(1) @ 71..77
+      Scope: ScopeId(2)
+      Imported: false
+      Exported: false
+      Kind: Interface
+      ident: Config
+      JsDoc Comments: The config shape.
+    }
+    Scope {
+      id: ScopeId(3) @ 120..159
+      children: [
+        Binding {
+          Id: BindingId(3) @ 130..131
+          Scope: ScopeId(3)
+          Imported: false
+          Exported: false
+          Kind: Generic
+          ident: T
+        }
+      ]
+    }
+    Binding {
+      Id: BindingId(2) @ 125..129
+      Scope: ScopeId(3)
+      Imported: false
+      Exported: false
+      Kind: Type
+      ident: Pair
+    }
+    Scope {
+      id: ScopeId(4) @ 161..202
+      children: [
+        Binding {
+          Id: BindingId(5) @ 179..185
+          Scope: ScopeId(4)
+          Imported: false
+          Exported: false
+          Kind: Enum
+          ident: Active
+        }
+        Binding {
+          Id: BindingId(6) @ 191..199
+          Scope: ScopeId(4)
+          Imported: false
+          Exported: false
+          Kind: Enum
+          ident: Inactive
+        }
+      ]
+    }
+    Binding {
+      Id: BindingId(4) @ 166..172
+      Scope: ScopeId(4)
+      Imported: false
+      Exported: true
+      Kind: Enum
+      ident: Status
+    }
+    Scope {
+      id: ScopeId(5) @ 276..347
+      children: [
+        Binding {
+          Id: BindingId(8) @ 291..294
+          Scope: ScopeId(5)
+          Imported: false
+          Exported: false
+          Kind: Value
+          ident: cfg
+          JsDoc Comments: Creates a greeting.
+@param cfg - the configuration
+        }
+        Scope {
+          id: ScopeId(6) @ 312..347
+          children: []
+        }
+      ]
+    }
+    Binding {
+      Id: BindingId(7) @ 285..290
+      Scope: ScopeId(5)
+      Imported: false
+      Exported: true
+      Kind: HoistedValue
+      ident: greet
+      JsDoc Comments: Creates a greeting.
+@param cfg - the configuration
+    }
+    Binding {
+      Id: BindingId(9) @ 389..396
+      Scope: ScopeId(1)
+      Imported: false
+      Exported: true
+      Kind: Value
+      ident: DEFAULT
+      JsDoc Comments: The default config.
+    }
+    Binding {
+      Id: BindingId(10) @ 451..452
+      Scope: ScopeId(1)
+      Imported: false
+      Exported: false
+      Kind: Value
+      ident: s
+    }
+    Binding {
+      Id: BindingId(11) @ 484..485
+      Scope: ScopeId(1)
+      Imported: false
+      Exported: false
+      Kind: Value
+      ident: p
+    }
+  ]
+}
+```

--- a/crates/biome_js_semantic/src/tests/format.rs
+++ b/crates/biome_js_semantic/src/tests/format.rs
@@ -1,0 +1,118 @@
+use crate::{SemanticModelOptions, semantic_model};
+use biome_js_parser::JsParserOptions;
+use biome_js_syntax::JsFileSource;
+
+fn assert_format_snapshot(test_name: &str, source: &str, source_type: JsFileSource) {
+    let parsed = biome_js_parser::parse(source, source_type, JsParserOptions::default());
+    let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+    let formatted = model.to_string();
+
+    let mut content = String::new();
+    content.push_str("## Source\n\n```\n");
+    content.push_str(source.trim());
+    content.push_str("\n```\n\n## Semantic Model\n\n```\n");
+    content.push_str(formatted.trim());
+    content.push_str("\n```\n");
+
+    insta::with_settings!({
+        snapshot_path => "../snapshots",
+        prepend_module_to_snapshot => false,
+    }, {
+        insta::assert_snapshot!(test_name, content);
+    });
+}
+
+#[test]
+fn format_js() {
+    assert_format_snapshot(
+        "format_js",
+        r#"
+import { foo } from "bar";
+
+const { a, b: renamed } = foo;
+
+let count = 0;
+
+/**
+ * Adds two numbers.
+ * @param x - first operand
+ * @param y - second operand
+ */
+function add(x, y) {
+    return x + y;
+}
+
+/** A simple counter. */
+class Counter {
+    constructor(initial) {
+        this.value = initial;
+    }
+    increment() {
+        this.value++;
+    }
+}
+
+function outer() {
+    let local = 1;
+    return () => {
+        count++;
+        return local + count;
+    };
+}
+
+for (let i = 0; i < 10; i++) {
+    console.log(i);
+}
+
+try {
+    add(a, renamed);
+} catch (e) {
+    console.log(e);
+}
+
+export default outer;
+export { add, Counter };
+"#,
+        JsFileSource::js_module(),
+    );
+}
+
+#[test]
+fn format_ts() {
+    assert_format_snapshot(
+        "format_ts",
+        r#"
+import { helper } from "./utils";
+
+/** The config shape. */
+interface Config {
+    name: string;
+    value: number;
+}
+
+type Pair<T> = { first: T; second: T };
+
+enum Status {
+    Active,
+    Inactive,
+}
+
+/**
+ * Creates a greeting.
+ * @param cfg - the configuration
+ */
+export function greet(cfg: Config): string {
+    return `Hello ${cfg.name}`;
+}
+
+/** The default config. */
+export const DEFAULT: Config = { name: "world", value: helper(0) };
+
+const s: Status = Status.Active;
+const p: Pair<number> = { first: 1, second: 2 };
+
+export { Status };
+"#,
+        JsFileSource::tsx(),
+    );
+}

--- a/crates/biome_js_semantic/src/tests/mod.rs
+++ b/crates/biome_js_semantic/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod assertions;
 pub mod declarations;
+mod format;
 mod functions;
 mod infer;
 mod references;

--- a/crates/biome_jsdoc_comment/Cargo.toml
+++ b/crates/biome_jsdoc_comment/Cargo.toml
@@ -12,11 +12,10 @@ categories.workspace = true
 publish              = true
 
 [dependencies]
-biome_formatter    = { workspace = true }
-biome_js_parser    = { workspace = true }
-biome_js_syntax    = { workspace = true }
-biome_js_type_info = { workspace = true }
-biome_rowan        = { workspace = true }
+biome_formatter = { workspace = true }
+biome_js_parser = { workspace = true }
+biome_js_syntax = { workspace = true }
+biome_rowan     = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/biome_jsdoc_comment/src/format_jsdoc_comment.rs
+++ b/crates/biome_jsdoc_comment/src/format_jsdoc_comment.rs
@@ -1,15 +1,62 @@
 use crate::JsdocComment;
 use biome_formatter::prelude::*;
-use biome_formatter::{format_args, write};
-use biome_js_type_info::FormatTypeContext;
+use biome_formatter::{
+    FormatContext, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
+    SourceMapGeneration, TrailingNewline, TransformSourceMap, format_args, write,
+};
 use biome_rowan::TextSize;
 use std::ops::Deref;
 
-impl Format<FormatTypeContext> for JsdocComment {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
-    ) -> FormatResult<()> {
+pub struct JsDocFormatContext;
+
+impl FormatContext for JsDocFormatContext {
+    type Options = JsCommentFormatOptions;
+
+    fn options(&self) -> &Self::Options {
+        &JsCommentFormatOptions
+    }
+
+    fn source_map(&self) -> Option<&TransformSourceMap> {
+        None
+    }
+}
+
+pub struct JsCommentFormatOptions;
+
+impl FormatOptions for JsCommentFormatOptions {
+    fn indent_style(&self) -> IndentStyle {
+        IndentStyle::Space
+    }
+
+    fn indent_width(&self) -> IndentWidth {
+        IndentWidth::try_from(2).unwrap()
+    }
+
+    fn line_width(&self) -> LineWidth {
+        LineWidth::default()
+    }
+
+    fn line_ending(&self) -> LineEnding {
+        LineEnding::Lf
+    }
+
+    fn trailing_newline(&self) -> TrailingNewline {
+        TrailingNewline::default()
+    }
+
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions {
+            indent_width: self.indent_width(),
+            print_width: self.line_width().into(),
+            line_ending: self.line_ending(),
+            indent_style: self.indent_style(),
+            source_map_generation: SourceMapGeneration::default(),
+        }
+    }
+}
+
+impl Format<JsDocFormatContext> for JsdocComment {
+    fn fmt(&self, f: &mut Formatter<JsDocFormatContext>) -> FormatResult<()> {
         let comment = self.deref();
 
         let comment = format_with(|f| {

--- a/crates/biome_jsdoc_comment/src/jsdoc_comment.rs
+++ b/crates/biome_jsdoc_comment/src/jsdoc_comment.rs
@@ -1,5 +1,5 @@
 use biome_js_syntax::{JsSyntaxNode, JsSyntaxToken};
-use biome_rowan::TriviaPieceKind;
+use biome_rowan::{TextRange, TriviaPieceKind};
 use std::ops::Deref;
 
 /// Represents a normalised JSDoc comment.
@@ -24,11 +24,15 @@ use std::ops::Deref;
 ///
 /// See https://jsdoc.app/ for the JSDoc reference.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct JsdocComment(String);
+pub struct JsdocComment {
+    content: String,
+
+    range: TextRange,
+}
 
 impl JsdocComment {
     /// Creates a normalised JSDoc comment from the given comment `text`.
-    pub fn from_comment_text(text: &str) -> Self {
+    pub fn new(text: &str, range: TextRange) -> Self {
         debug_assert!(text.starts_with("/**") && text.ends_with("*/"));
 
         let mut result = text[3..text.len() - 2]
@@ -50,7 +54,10 @@ impl JsdocComment {
             result.truncate(result.len() - 1);
         }
 
-        Self(result)
+        Self {
+            content: result,
+            range,
+        }
     }
 
     /// Returns whether the given text is a valid JSDoc comment.
@@ -62,15 +69,6 @@ impl JsdocComment {
             && text.starts_with("/**")
             && text.as_bytes().get(3).is_some_and(|c| *c != b'*')
             && text.ends_with("*/")
-    }
-
-    /// Execute a callback on all JSDoc comments preceding the given node.
-    // TODO: Remove this and replace it since we now expose the raw iterator
-    pub fn for_each<F>(node: &JsSyntaxNode, mut func: F)
-    where
-        F: FnMut(&str),
-    {
-        Self::get_jsdocs(node).for_each(|str: String| func(str.as_str()))
     }
 
     /// Returns an iterator over the given node's serialized JSDoc comments.
@@ -94,7 +92,7 @@ impl JsdocComment {
 
 impl AsRef<str> for JsdocComment {
     fn as_ref(&self) -> &str {
-        self.0.as_str()
+        self.content.as_str()
     }
 }
 
@@ -102,7 +100,7 @@ impl Deref for JsdocComment {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        self.0.as_str()
+        self.content.as_str()
     }
 }
 
@@ -132,7 +130,7 @@ impl TryFrom<JsSyntaxToken> for JsdocComment {
             .find_map(|trivia| match trivia.kind() {
                 TriviaPieceKind::MultiLineComment | TriviaPieceKind::SingleLineComment => {
                     let text = trivia.text();
-                    Self::text_is_jsdoc_comment(text).then(|| Self::from_comment_text(text))
+                    Self::text_is_jsdoc_comment(text).then(|| Self::new(text, trivia.text_range()))
                 }
                 _ => None,
             })
@@ -184,7 +182,7 @@ mod tests {
         );
         assert_jsdoc_comments(
             r"
-            /** 
+            /**
              * multiline
              * yay
              * @param foo - the fooness of great
@@ -192,7 +190,7 @@ mod tests {
             export function fizzbuzz(foo: any) {};
             ",
             vec![
-                r"/** 
+                r"/**
              * multiline
              * yay
              * @param foo - the fooness of great

--- a/crates/biome_module_graph/src/format_module_graph.rs
+++ b/crates/biome_module_graph/src/format_module_graph.rs
@@ -3,7 +3,7 @@ use crate::{BindingTypeData, JsExport, JsImport, JsModuleInfo, JsOwnExport, JsRe
 use biome_formatter::prelude::*;
 use biome_formatter::{format_args, write};
 use biome_js_type_info::FormatTypeContext;
-use biome_rowan::{TextRange, TextSize};
+use biome_rowan::TextSize;
 use std::fmt::Formatter;
 use std::ops::Deref;
 
@@ -25,26 +25,6 @@ impl Format<FormatTypeContext> for BindingTypeData {
         &self,
         f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
-        let ranges: Vec<TypedRange> = self
-            .export_ranges
-            .iter()
-            .map(|range| range.into())
-            .collect();
-        let export_ranges = format_with(|f| {
-            let mut join = f.join();
-
-            for range in ranges.clone() {
-                join.entry(&range);
-            }
-            join.finish()
-        });
-
-        let jsdoc = format_with(|f| {
-            if self.jsdoc.is_some() {
-                write!(f, [&self.jsdoc, token(","), hard_line_break()])?;
-            };
-            Ok(())
-        });
         write!(
             f,
             [
@@ -54,9 +34,6 @@ impl Format<FormatTypeContext> for BindingTypeData {
                     &self.ty,
                     token(","),
                     hard_line_break(),
-                    jsdoc,
-                    token("Exported Ranges: "),
-                    &export_ranges
                 ])),
                 token("}")
             ]
@@ -266,23 +243,6 @@ impl Format<FormatTypeContext> for JsBindingData {
         &self,
         f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
-        let jsdoc_comment = format_with(|f| {
-            if let Some(jsdoc) = &self.jsdoc {
-                write!(
-                    f,
-                    [&format_args![
-                        token("JSDoc comment:"),
-                        space(),
-                        jsdoc,
-                        token(","),
-                        hard_line_break()
-                    ]]
-                )
-            } else {
-                Ok(())
-            }
-        });
-
         let content = format_with(|f| {
             write!(
                 f,
@@ -297,7 +257,6 @@ impl Format<FormatTypeContext> for JsBindingData {
                     &self.ty,
                     token(","),
                     hard_line_break(),
-                    jsdoc_comment,
                     token("Declaration kind:"),
                     space(),
                     text(
@@ -329,9 +288,10 @@ impl Format<FormatTypeContext> for JsReexport {
         let content = format_with(|f| {
             write!(f, [&format_args![&self.import]])?;
 
-            if let Some(comment) = &self.jsdoc_comment {
-                write!(f, [&format_args![&comment]])?;
-            }
+            // TODO: address this later
+            // if let Some(comment) = &self.jsdoc_comment {
+            //     write!(f, [&format_args![&comment]])?;
+            // }
 
             Ok(())
         });
@@ -420,50 +380,5 @@ impl Format<FormatTypeContext> for JsImport {
 
         write!(f, [hard_line_break()])?;
         Ok(())
-    }
-}
-#[derive(Clone)]
-struct TypedRange(TextRange);
-
-impl From<&TextRange> for TypedRange {
-    fn from(value: &TextRange) -> Self {
-        Self(*value)
-    }
-}
-
-#[derive(Clone)]
-struct TypedSize(TextSize);
-
-impl From<TextSize> for TypedSize {
-    fn from(value: TextSize) -> Self {
-        Self(value)
-    }
-}
-
-impl Format<FormatTypeContext> for TypedSize {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
-    ) -> FormatResult<()> {
-        let value = std::format!("{}", self.0);
-        write!(f, [text(&value, TextSize::default())])
-    }
-}
-
-impl Format<FormatTypeContext> for TypedRange {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
-    ) -> FormatResult<()> {
-        write!(
-            f,
-            [
-                token("("),
-                TypedSize::from(self.0.start()),
-                token(".."),
-                TypedSize::from(self.0.end()),
-                token(")")
-            ]
-        )
     }
 }

--- a/crates/biome_module_graph/src/format_module_graph.rs
+++ b/crates/biome_module_graph/src/format_module_graph.rs
@@ -3,7 +3,7 @@ use crate::{BindingTypeData, JsExport, JsImport, JsModuleInfo, JsOwnExport, JsRe
 use biome_formatter::prelude::*;
 use biome_formatter::{format_args, write};
 use biome_js_type_info::FormatTypeContext;
-use biome_rowan::TextSize;
+use biome_rowan::{TextRange, TextSize};
 use std::fmt::Formatter;
 use std::ops::Deref;
 
@@ -289,9 +289,12 @@ impl Format<FormatTypeContext> for JsReexport {
             write!(f, [&format_args![&self.import]])?;
 
             // TODO: address this later
-            // if let Some(comment) = &self.jsdoc_comment {
-            //     write!(f, [&format_args![&comment]])?;
-            // }
+            if let Some(export_range) = &self.export_range {
+                write!(
+                    f,
+                    [token("Exported range: "), TypedRange::from(export_range)]
+                )?;
+            }
 
             Ok(())
         });
@@ -380,5 +383,51 @@ impl Format<FormatTypeContext> for JsImport {
 
         write!(f, [hard_line_break()])?;
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct TypedRange(TextRange);
+
+impl From<&TextRange> for TypedRange {
+    fn from(value: &TextRange) -> Self {
+        Self(*value)
+    }
+}
+
+#[derive(Clone)]
+struct TypedSize(TextSize);
+
+impl From<TextSize> for TypedSize {
+    fn from(value: TextSize) -> Self {
+        Self(value)
+    }
+}
+
+impl Format<FormatTypeContext> for TypedSize {
+    fn fmt(
+        &self,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
+    ) -> FormatResult<()> {
+        let value = std::format!("{}", self.0);
+        write!(f, [text(&value, TextSize::default())])
+    }
+}
+
+impl Format<FormatTypeContext> for TypedRange {
+    fn fmt(
+        &self,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
+    ) -> FormatResult<()> {
+        write!(
+            f,
+            [
+                token("("),
+                TypedSize::from(self.0.start()),
+                token(".."),
+                TypedSize::from(self.0.end()),
+                token(")")
+            ]
+        )
     }
 }

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -38,12 +38,6 @@ pub(crate) use visitor::JsModuleVisitor;
 pub struct BindingTypeData {
     /// The inferred type of this binding.
     pub ty: TypeReference,
-
-    /// JSDoc comment associated with this binding, if any.
-    pub jsdoc: Option<JsdocComment>,
-
-    /// Ranges where this binding is exported.
-    pub export_ranges: Vec<TextRange>,
 }
 
 impl Display for BindingTypeData {
@@ -468,8 +462,8 @@ pub enum JsOwnExport {
 /// another module.
 #[derive(Clone, Debug, PartialEq)]
 pub struct JsReexport {
-    /// Optional JSDoc comment associated with the re-export statement.
-    pub jsdoc_comment: Option<JsdocComment>,
+    /// Where this export statement is located.
+    pub export_range: Option<TextRange>,
 
     /// Import from which the symbols are being re-exported.
     pub import: JsImport,

--- a/crates/biome_module_graph/src/js_module_info/binding.rs
+++ b/crates/biome_module_graph/src/js_module_info/binding.rs
@@ -1,11 +1,8 @@
-use std::sync::Arc;
-
 use biome_js_semantic::{JsDeclarationKind, ScopeId};
 use biome_js_syntax::TextRange;
 use biome_js_type_info::TypeReference;
-use biome_rowan::{Text, TextSize};
-
-use biome_jsdoc_comment::JsdocComment;
+use biome_rowan::Text;
+use std::sync::Arc;
 
 use super::{JsModuleInfoInner, scope::JsScope};
 
@@ -13,33 +10,10 @@ use super::{JsModuleInfoInner, scope::JsScope};
 #[derive(Clone, Debug)]
 pub struct JsBindingData {
     pub name: Text,
-    pub references: Vec<JsBindingReference>,
     pub scope_id: ScopeId,
     pub declaration_kind: JsDeclarationKind,
     pub ty: TypeReference,
-    pub jsdoc: Option<JsdocComment>,
-    pub export_ranges: Vec<TextRange>,
     pub range: TextRange,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum JsBindingReferenceKind {
-    Read { _hoisted: bool },
-    Write { _hoisted: bool },
-}
-
-/// Internal type with all the semantic data of a specific reference
-#[derive(Clone, Debug)]
-pub struct JsBindingReference {
-    pub range_start: TextSize,
-    pub kind: JsBindingReferenceKind,
-}
-
-impl JsBindingReference {
-    #[inline(always)]
-    pub fn is_write(&self) -> bool {
-        matches!(self.kind, JsBindingReferenceKind::Write { .. })
-    }
 }
 
 /// Provides access to all semantic data of a specific binding.
@@ -74,11 +48,7 @@ impl JsBinding {
     /// Returns whether the binding is exported.
     pub fn is_exported(&self) -> bool {
         // Check if there are export ranges in the type augmentation data
-        let binding_range = self.semantic_binding.syntax().text_trimmed_range();
-        self.data
-            .binding_type_data
-            .get(&binding_range)
-            .is_some_and(|data| !data.export_ranges.is_empty())
+        !self.semantic_binding.export_ranges().is_empty()
     }
 
     /// Returns whether the binding is imported.

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -684,10 +684,10 @@ impl JsModuleInfoCollector {
                 continue;
             }
 
-            let child_scope = &self.scopes[child_binding.scope_id.index()];
+            let child_scope = &self.semantic_model.scope_from_id(child_binding.scope_id);
             if child_scope
-                .parent
-                .is_some_and(|parent| parent == binding.scope_id)
+                .parent()
+                .is_some_and(|parent| parent.id() == binding.scope_id)
             {
                 exports
                     .entry(child_binding.name.clone())

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -1,14 +1,10 @@
 use std::{borrow::Cow, sync::Arc};
 
-use biome_js_semantic::{
-    BindingId, ScopeId, SemanticEvent, SemanticEventExtractor, TsBindingReference,
-};
+use biome_js_semantic::{Reference, ScopeId, SemanticModel, TsBindingReference};
 use biome_js_syntax::{
     AnyJsCombinedSpecifier, AnyJsDeclaration, AnyJsExportDefaultDeclaration, AnyJsExpression,
     AnyJsImportClause, JsAssignmentExpression, JsForVariableDeclaration, JsFormalParameter,
-    JsIdentifierBinding, JsRestParameter, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
-    JsVariableDeclaration, TsIdentifierBinding, TsTypeParameter, TsTypeParameterName,
-    inner_string_text,
+    JsRestParameter, JsSyntaxNode, JsVariableDeclaration, TsTypeParameter, inner_string_text,
 };
 use biome_js_type_info::{
     FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, GenericTypeParameter, MAX_FLATTEN_DEPTH,
@@ -16,22 +12,16 @@ use biome_js_type_info::{
     TypeImportQualifier, TypeMember, TypeMemberKind, TypeReference, TypeReferenceQualifier,
     TypeResolver, TypeResolverLevel, TypeStore, UnionCollector,
 };
-use biome_jsdoc_comment::JsdocComment;
-use biome_rowan::{AstNode, Text, TextRange, TextSize, TokenText};
+use biome_rowan::{AstNode, Text, TextRange, TokenText};
 use indexmap::IndexMap;
 use rustc_hash::FxHashMap;
 
 use super::{
     Exports, ImportSymbol, Imports, JsExport, JsImport, JsModuleInfo, JsModuleInfoDiagnostic,
     JsModuleInfoInner, JsOwnExport, JsReexport, ResolvedPath, binding::JsBindingData,
-    scope::JsScopeData,
 };
-use crate::js_module_info::{
-    binding::{JsBindingReference, JsBindingReferenceKind},
-    scope::TsBindingReferenceExt,
-    utils::reached_too_many_types,
-};
-use crate::{JsImportPath, JsImportPhase};
+use crate::js_module_info::{scope::TsBindingReferenceExt, utils::reached_too_many_types};
+use crate::{BindingTypeData, JsImportPath, JsImportPhase};
 
 /// Responsible for collecting all the information from which to build the
 /// [`JsModuleInfo`].
@@ -39,21 +29,10 @@ use crate::{JsImportPath, JsImportPhase};
 /// This collects a lot of fields with raw information, which then goes through
 /// another round of processing as we create the intermediate
 /// [`JsModuleInfoBag`], and finally the [`JsModuleInfo`] itself.
-#[derive(Default)]
 pub(super) struct JsModuleInfoCollector {
+    semantic_model: Arc<SemanticModel>,
+
     pub(super) bindings: Vec<JsBindingData>,
-
-    /// Maps a binding range start to its index inside the [Self::bindings]
-    /// vector.
-    bindings_by_start: FxHashMap<TextSize, BindingId>,
-
-    /// Binding and reference nodes indexed by their range start
-    binding_node_by_start: FxHashMap<TextSize, JsSyntaxNode>,
-
-    /// Creates semantic events from the full node traversal.
-    ///
-    /// Re-used from the semantic model in `biome_js_semantic`.
-    extractor: SemanticEventExtractor,
 
     /// Function parameters, both formal parameters as well as rest parameters.
     function_parameters: FxHashMap<JsSyntaxNode, FunctionParameter>,
@@ -63,14 +42,6 @@ pub(super) struct JsModuleInfoCollector {
 
     /// Map of parsed declarations, for caching purposes.
     parsed_expressions: FxHashMap<TextRange, ResolvedTypeId>,
-
-    /// Collection of all the scopes within the module.
-    ///
-    /// The first entry is always the module's global scope.
-    pub(super) scopes: Vec<JsScopeData>,
-
-    /// Used for tracking the scope we are currently in.
-    scope_stack: Vec<ScopeId>,
 
     /// Map with all static import paths, from the source specifier to the
     /// resolved path.
@@ -133,37 +104,48 @@ pub(super) enum JsCollectedExport {
 }
 
 impl JsModuleInfoCollector {
-    pub fn push_node(&mut self, node: &JsSyntaxNode) {
-        use JsSyntaxKind::*;
-        match node.kind() {
-            // Accessible from bindings and references
-            JS_IDENTIFIER_BINDING
-            | TS_IDENTIFIER_BINDING
-            | JS_REFERENCE_IDENTIFIER
-            | JSX_REFERENCE_IDENTIFIER
-            | TS_TYPE_PARAMETER_NAME
-            | TS_LITERAL_ENUM_MEMBER_NAME
-            | JS_IDENTIFIER_ASSIGNMENT => {
-                self.binding_node_by_start
-                    .insert(node.text_trimmed_range().start(), node.clone());
-            }
+    pub(super) fn new(semantic_model: Arc<SemanticModel>) -> Self {
+        let mut bindings = Vec::new();
 
-            _ => {}
+        for binding in semantic_model.all_bindings() {
+            let name = binding
+                .tree()
+                .name_token()
+                .ok()
+                .map(|t| t.token_text_trimmed().into())
+                .unwrap_or_default();
+            let range = binding.syntax().text_trimmed_range();
+
+            bindings.push(JsBindingData {
+                name,
+                scope_id: binding.scope().id(),
+                declaration_kind: binding.declaration_kind(),
+                ty: TypeReference::unknown(),
+                range,
+            });
         }
 
-        self.extractor.enter(node);
+        Self {
+            semantic_model,
+            bindings,
+            function_parameters: FxHashMap::default(),
+            variable_declarations: FxHashMap::default(),
+            parsed_expressions: FxHashMap::default(),
+            static_import_paths: IndexMap::new(),
+            dynamic_import_paths: IndexMap::new(),
+            exports: Vec::new(),
+            blanket_reexports: Vec::new(),
+            types: TypeStore::default(),
+            static_imports: IndexMap::new(),
+            diagnostics: Vec::new(),
+            infer_types: false,
+        }
     }
 
     pub fn leave_node(&mut self, node: &JsSyntaxNode) {
-        self.extractor.leave(node);
-
-        while let Some(event) = self.extractor.pop() {
-            self.push_event(event);
-        }
-
         if let Some(expr) = AnyJsExpression::cast_ref(node) {
             let range = expr.range();
-            let scope_id = *self.scope_stack.last().expect("there must be a scope");
+            let scope_id = self.semantic_model.scope(node).id();
             let ty = TypeData::from_any_js_expression(self, scope_id, &expr);
             let resolved_id = match GLOBAL_RESOLVER.find_type(&ty) {
                 Some(id) => ResolvedTypeId::new(TypeResolverLevel::Global, id),
@@ -175,24 +157,24 @@ impl JsModuleInfoCollector {
 
             self.parsed_expressions.insert(range, resolved_id);
         } else if let Some(decl) = JsForVariableDeclaration::cast_ref(node) {
-            let scope_id = *self.scope_stack.last().expect("there must be a scope");
+            let scope_id = self.semantic_model.scope(node).id();
             let type_bindings =
                 TypeData::typed_bindings_from_js_for_statement(self, scope_id, &decl)
                     .unwrap_or_default();
             self.variable_declarations
                 .insert(decl.syntax().clone(), type_bindings);
         } else if let Some(param) = JsFormalParameter::cast_ref(node) {
-            let scope_id = *self.scope_stack.last().expect("there must be a scope");
+            let scope_id = self.semantic_model.scope(node).id();
             let parsed_param = FunctionParameter::from_js_formal_parameter(self, scope_id, &param);
             self.function_parameters
                 .insert(param.syntax().clone(), parsed_param);
         } else if let Some(param) = JsRestParameter::cast_ref(node) {
-            let scope_id = *self.scope_stack.last().expect("there must be a scope");
+            let scope_id = self.semantic_model.scope(node).id();
             let parsed_param = FunctionParameter::from_js_rest_parameter(self, scope_id, &param);
             self.function_parameters
                 .insert(param.syntax().clone(), parsed_param);
         } else if let Some(decl) = JsVariableDeclaration::cast_ref(node) {
-            let scope_id = *self.scope_stack.last().expect("there must be a scope");
+            let scope_id = self.semantic_model.scope(node).id();
             let type_bindings =
                 TypeData::typed_bindings_from_js_variable_declaration(self, scope_id, &decl);
             self.variable_declarations
@@ -380,163 +362,9 @@ impl JsModuleInfoCollector {
         );
     }
 
-    fn push_event(&mut self, event: SemanticEvent) {
-        use SemanticEvent::*;
-        match event {
-            ScopeStarted {
-                range,
-                parent_scope_id,
-                ..
-            } => {
-                // Scopes will be raised in order
-                let scope_id = ScopeId::new(self.scopes.len());
-
-                self.scopes.push(JsScopeData {
-                    range,
-                    parent: parent_scope_id,
-                    children: Vec::new(),
-                    bindings: Vec::new(),
-                    bindings_by_name: FxHashMap::default(),
-                });
-
-                if let Some(parent_scope_id) = parent_scope_id {
-                    self.scopes[parent_scope_id.index()].children.push(scope_id);
-                }
-
-                self.scope_stack.push(scope_id);
-            }
-            ScopeEnded { .. } => {
-                self.scope_stack.pop();
-            }
-            DeclarationFound {
-                range,
-                scope_id,
-                hoisted_scope_id,
-                declaration_kind,
-            } => {
-                let binding_scope_id = hoisted_scope_id.unwrap_or(scope_id);
-
-                // SAFETY: this scope id is guaranteed to exist because they
-                //         were generated by the event extractor
-                debug_assert!((binding_scope_id.index()) < self.scopes.len());
-
-                let binding_id = BindingId::new(self.bindings.len());
-
-                // We must proceed and register the binding, even if the node
-                // cannot be found. Otherwise, later lookups for the binding
-                // may fail.
-                let node = self.binding_node_by_start.get(&range.start()).cloned();
-                let name_token = node.as_ref().and_then(|node| {
-                    if let Some(node) = JsIdentifierBinding::cast_ref(node) {
-                        node.name_token().ok()
-                    } else if let Some(node) = TsIdentifierBinding::cast_ref(node) {
-                        node.name_token().ok()
-                    } else if let Some(node) = TsTypeParameterName::cast_ref(node) {
-                        node.ident_token().ok()
-                    } else {
-                        None
-                    }
-                });
-
-                let name = name_token.as_ref().map(JsSyntaxToken::token_text_trimmed);
-                let scope_id = *self.scope_stack.last().expect("scope must be present");
-
-                self.bindings.push(JsBindingData {
-                    name: name
-                        .as_ref()
-                        .map(|name| name.clone().into())
-                        .unwrap_or_default(),
-                    references: Vec::new(),
-                    scope_id,
-                    declaration_kind,
-                    ty: TypeReference::unknown(),
-                    jsdoc: node.as_ref().and_then(find_jsdoc),
-                    export_ranges: Vec::new(),
-                    range,
-                });
-                self.bindings_by_start.insert(range.start(), binding_id);
-
-                let scope = &mut self.scopes[binding_scope_id.index()];
-
-                scope.bindings.push(binding_id);
-                if let Some(name) = name {
-                    let binding_reference = TsBindingReference::from_binding_and_declaration_kind(
-                        binding_id,
-                        declaration_kind,
-                    );
-
-                    scope
-                        .bindings_by_name
-                        .entry(name)
-                        .and_modify(|binding| {
-                            *binding = binding.union_with(binding_reference);
-                        })
-                        .or_insert(binding_reference);
-                }
-            }
-            Read {
-                range,
-                declaration_at,
-                ..
-            } => {
-                let binding_id = self.bindings_by_start[&declaration_at];
-                let binding = &mut self.bindings[binding_id.index()];
-                binding.references.push(JsBindingReference {
-                    range_start: range.start(),
-                    kind: JsBindingReferenceKind::Read { _hoisted: false },
-                });
-            }
-            HoistedRead {
-                range,
-                declaration_at,
-                ..
-            } => {
-                let binding_id = self.bindings_by_start[&declaration_at];
-                let binding = &mut self.bindings[binding_id.index()];
-                binding.references.push(JsBindingReference {
-                    range_start: range.start(),
-                    kind: JsBindingReferenceKind::Read { _hoisted: true },
-                });
-            }
-            Write {
-                range,
-                declaration_at,
-                ..
-            } => {
-                let binding_id = self.bindings_by_start[&declaration_at];
-                let binding = &mut self.bindings[binding_id.index()];
-                binding.references.push(JsBindingReference {
-                    range_start: range.start(),
-                    kind: JsBindingReferenceKind::Write { _hoisted: false },
-                });
-            }
-            HoistedWrite {
-                range,
-                declaration_at,
-                ..
-            } => {
-                let binding_id = self.bindings_by_start[&declaration_at];
-                let binding = &mut self.bindings[binding_id.index()];
-                binding.references.push(JsBindingReference {
-                    range_start: range.start(),
-                    kind: JsBindingReferenceKind::Write { _hoisted: true },
-                });
-            }
-            Export {
-                declaration_at,
-                range,
-            } => {
-                let binding_id = self.bindings_by_start[&declaration_at];
-                let binding = &mut self.bindings[binding_id.index()];
-                binding.export_ranges.push(range);
-            }
-            UnresolvedReference { .. } => {}
-        }
-    }
-
     fn finalise(
         &mut self,
-        semantic_model: &biome_js_semantic::SemanticModel,
+        semantic_model: &SemanticModel,
     ) -> (
         IndexMap<Text, JsExport>,
         FxHashMap<TextRange, super::BindingTypeData>,
@@ -566,28 +394,32 @@ impl JsModuleInfoCollector {
     fn infer_all_types(&mut self, semantic_model: &biome_js_semantic::SemanticModel) {
         for index in 0..self.bindings.len() {
             let binding = &self.bindings[index];
-            if let Some(node) = self.binding_node_by_start.get(&binding.range.start()) {
+            if let Some(node) = semantic_model
+                .as_binding_by_range(binding.range)
+                .map(|b| b.syntax().clone())
+            {
                 let scope_id = semantic_model.scope_for_range(binding.range).id();
-                let ty = self.infer_type(&node.clone(), binding.clone(), scope_id, semantic_model);
+                let ty = self.infer_type(&node, binding.clone(), scope_id, semantic_model);
                 self.bindings[index].ty = ty;
             }
         }
     }
 
-    fn has_writable_reference(&self, binding: &JsBindingData) -> bool {
-        binding
-            .references
-            .iter()
-            .any(|reference| reference.is_write())
+    fn has_writable_reference(&self, semantic_model: &SemanticModel, range: TextRange) -> bool {
+        semantic_model
+            .as_binding_by_range(range)
+            .is_some_and(|binding| binding.all_writes().next().is_some())
     }
 
-    fn get_writable_references(&self, binding: &JsBindingData) -> Vec<JsBindingReference> {
-        binding
-            .references
-            .iter()
-            .filter(|reference| reference.is_write())
-            .cloned()
-            .collect()
+    fn get_writable_references(
+        &self,
+        semantic_model: &SemanticModel,
+        range: TextRange,
+    ) -> Vec<Reference> {
+        semantic_model
+            .as_binding_by_range(range)
+            .map(|binding| binding.all_writes().collect())
+            .unwrap_or_default()
     }
 
     fn infer_type(
@@ -595,7 +427,7 @@ impl JsModuleInfoCollector {
         node: &JsSyntaxNode,
         binding: JsBindingData,
         scope_id: ScopeId,
-        semantic_model: &biome_js_semantic::SemanticModel,
+        semantic_model: &SemanticModel,
     ) -> TypeReference {
         let binding_name = &binding.name.clone();
 
@@ -621,7 +453,7 @@ impl JsModuleInfoCollector {
                         .find_map(|(name, ty)| (name == binding_name).then(|| ty.clone()))
                         .unwrap_or_default();
 
-                    if self.has_writable_reference(&binding) {
+                    if self.has_writable_reference(semantic_model, binding.range) {
                         self.widen_binding_from_writable_references(
                             scope_id,
                             &binding,
@@ -682,18 +514,14 @@ impl JsModuleInfoCollector {
         scope_id: ScopeId,
         binding: &JsBindingData,
         ty: &TypeReference,
-        semantic_model: &biome_js_semantic::SemanticModel,
+        semantic_model: &SemanticModel,
     ) -> TypeReference {
-        let references = self.get_writable_references(binding);
+        let references = self.get_writable_references(semantic_model, binding.range);
         let mut union_collector = UnionCollector::new();
         union_collector.add(ty.clone());
         for reference in references {
-            let Some(node) = self.binding_node_by_start.get(&reference.range_start) else {
-                continue;
-            };
-            let reference_scope = semantic_model
-                .scope_for_range(node.text_trimmed_range())
-                .id();
+            let node = reference.syntax();
+            let reference_scope = reference.scope().id();
 
             // We don't want to widen types inside the same scope
             if binding.scope_id == reference_scope {
@@ -799,18 +627,16 @@ impl JsModuleInfoCollector {
     }
 
     fn find_binding_in_scope(&self, name: &str, scope_id: ScopeId) -> Option<TsBindingReference> {
-        let mut scope = &self.scopes[scope_id.index()];
+        let mut scope = self.semantic_model.scope_from_id(scope_id);
         loop {
-            if let Some(binding_ref) = scope.bindings_by_name.get(name) {
-                return Some(*binding_ref);
+            if let Some(binding_ref) = scope.get_binding_reference(name) {
+                return Some(binding_ref);
             }
-
-            match &scope.parent {
-                Some(parent_id) => scope = &self.scopes[parent_id.index()],
+            match scope.parent() {
+                Some(parent) => scope = parent,
                 None => break,
             }
         }
-
         None
     }
 
@@ -818,10 +644,10 @@ impl JsModuleInfoCollector {
         self.bindings
             .iter()
             .filter(|binding| {
-                let scope = &self.scopes[binding.scope_id.index()];
+                let scope = self.semantic_model.scope_from_id(binding.scope_id);
                 scope
-                    .parent
-                    .is_some_and(|parent_scope_id| parent_scope_id == scope_id)
+                    .parent()
+                    .is_some_and(|parent_scope| parent_scope.id() == scope_id)
             })
             .map(|binding| TypeMember {
                 kind: TypeMemberKind::NamedStatic(binding.name.clone()),
@@ -1019,7 +845,10 @@ impl JsModuleInfoCollector {
     }
 
     fn get_export_for_local_name(&mut self, local_name: TokenText) -> Option<JsOwnExport> {
-        let binding_ref = self.scopes[0].bindings_by_name.get(&local_name)?;
+        let binding_ref = self
+            .semantic_model
+            .global_scope()
+            .get_binding_reference(&local_name)?;
 
         let export = match binding_ref {
             TsBindingReference::Merged {
@@ -1211,17 +1040,15 @@ impl JsModuleInfoCollector {
     /// Maps binding ranges to their type information and JSDoc comments.
     fn build_binding_type_data(
         &self,
-        _semantic_model: &biome_js_semantic::SemanticModel,
-    ) -> FxHashMap<TextRange, super::BindingTypeData> {
+        _semantic_model: &SemanticModel,
+    ) -> FxHashMap<TextRange, BindingTypeData> {
         let mut binding_type_data = FxHashMap::default();
 
         for binding in &self.bindings {
             binding_type_data.insert(
                 binding.range,
-                super::BindingTypeData {
+                BindingTypeData {
                     ty: binding.ty.clone(),
-                    jsdoc: binding.jsdoc.clone(),
-                    export_ranges: binding.export_ranges.clone(),
                 },
             );
         }
@@ -1253,16 +1080,4 @@ impl JsModuleInfo {
             infer_types: collector.infer_types,
         }))
     }
-}
-
-fn find_jsdoc(node: &JsSyntaxNode) -> Option<JsdocComment> {
-    node.ancestors().find_map(|ancestor| {
-        if let Some(export) = biome_js_syntax::JsExport::cast_ref(&ancestor) {
-            JsdocComment::try_from(export.syntax()).ok()
-        } else if let Some(decl) = AnyJsDeclaration::cast(ancestor) {
-            JsdocComment::try_from(decl.syntax()).ok()
-        } else {
-            None
-        }
-    })
 }

--- a/crates/biome_module_graph/src/js_module_info/scope.rs
+++ b/crates/biome_module_graph/src/js_module_info/scope.rs
@@ -1,27 +1,8 @@
-use std::{iter::FusedIterator, sync::Arc};
-
-use biome_js_semantic::{BindingId, ScopeId, TsBindingReference};
+use super::{JsModuleInfoInner, binding::JsBinding};
+use biome_js_semantic::{BindingId, TsBindingReference};
 use biome_js_syntax::TextRange;
 use biome_js_type_info::TypeReferenceQualifier;
-use biome_rowan::TokenText;
-use rustc_hash::FxHashMap;
-
-use super::{JsModuleInfoInner, binding::JsBinding};
-
-#[derive(Debug)]
-pub struct JsScopeData {
-    // The scope range
-    #[expect(dead_code, reason = "May be used in future for scope analysis")]
-    pub range: TextRange,
-    // The parent scope of this scope
-    pub parent: Option<ScopeId>,
-    // All children scope of this scope
-    pub children: Vec<ScopeId>,
-    // All bindings of this scope (points to SemanticModelData::bindings)
-    pub bindings: Vec<BindingId>,
-    // Map pointing to the [bindings] vec of each bindings by its name
-    pub bindings_by_name: FxHashMap<TokenText, TsBindingReference>,
-}
+use std::{iter::FusedIterator, sync::Arc};
 
 /// Extension trait for `TsBindingReference` that adds methods depending on
 /// `biome_js_type_info` types, which are not available in `biome_js_semantic`.

--- a/crates/biome_module_graph/src/js_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/js_module_info/visitor.rs
@@ -7,7 +7,6 @@ use biome_js_syntax::{
     JsIdentifierBinding, JsVariableDeclaratorList, TsExportAssignmentClause, unescape_js_string,
 };
 use biome_js_type_info::{ImportSymbol, TypeData, TypeReference, TypeResolver};
-use biome_jsdoc_comment::JsdocComment;
 use biome_resolver::{ResolveOptions, resolve};
 use biome_rowan::{AstNode, TokenText, WalkEvent};
 use camino::Utf8Path;
@@ -53,7 +52,7 @@ impl<'a> JsModuleVisitor<'a> {
     }
 
     pub fn collect_info(self) -> JsModuleInfo {
-        let mut collector = JsModuleInfoCollector::default();
+        let mut collector = JsModuleInfoCollector::new(self.semantic_model.clone());
 
         let iter = self.root.syntax().preorder();
         for event in iter {
@@ -64,8 +63,6 @@ impl<'a> JsModuleVisitor<'a> {
                     } else if let Some(export) = biome_js_syntax::JsExport::cast_ref(&node) {
                         self.visit_export(export, &mut collector);
                     }
-
-                    collector.push_node(&node);
                 }
                 WalkEvent::Leave(node) => {
                     collector.leave_node(&node);
@@ -276,11 +273,8 @@ impl<'a> JsModuleVisitor<'a> {
             specifier: specifier.into(),
             symbol: ImportSymbol::All,
         };
-        let jsdoc_comment = node
-            .syntax()
-            .parent()
-            .and_then(|parent| JsdocComment::try_from(parent).ok());
 
+        let export_range = node.syntax().parent().map(|p| p.text_trimmed_range());
         if let Some(export_as) = node.export_as() {
             let export_name = export_as
                 .exported_name()
@@ -291,13 +285,13 @@ impl<'a> JsModuleVisitor<'a> {
                 export_name,
                 reexport: JsReexport {
                     import,
-                    jsdoc_comment,
+                    export_range,
                 },
             });
         } else {
             collector.register_blanket_reexport(JsReexport {
                 import,
-                jsdoc_comment,
+                export_range,
             });
         }
 
@@ -339,7 +333,7 @@ impl<'a> JsModuleVisitor<'a> {
                         resolved_path: resolved_path.clone(),
                         symbol: ImportSymbol::Named(imported_name),
                     },
-                    jsdoc_comment: None,
+                    export_range: None,
                 },
             });
         }

--- a/crates/biome_module_graph/src/module_graph.rs
+++ b/crates/biome_module_graph/src/module_graph.rs
@@ -252,11 +252,17 @@ impl ModuleGraph {
 
         find_exported_symbol_with_seen_paths(&data, module, symbol_name, &mut seen_paths).and_then(
             |(module, export)| match export {
-                JsOwnExport::Binding(binding_range) => module
-                    .binding_type_data(*binding_range)
-                    .and_then(|data| data.jsdoc.clone()),
+                JsOwnExport::Binding(binding_range) => {
+                    // Find the binding at this range via the semantic model
+                    module
+                        .semantic_model
+                        .as_binding_by_range(*binding_range)
+                        .and_then(|binding| binding.jsdoc().cloned())
+                }
                 JsOwnExport::Type(_) => None,
-                JsOwnExport::Namespace(reexport) => reexport.jsdoc_comment.clone(),
+                JsOwnExport::Namespace(reexport) => reexport
+                    .export_range
+                    .and_then(|range| module.semantic_model.export_jsdoc(range).cloned()),
             },
         )
     }

--- a/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
@@ -33,11 +33,6 @@ Imports {
 ```
 Component => BindingTypeData {
   Types Module(0) TypeId(1),
-  JsDoc(
-    @public
-    @returns {JSX.Element}
-  ),
-  Exported Ranges: (130..139)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_export_default_imported_binding.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_default_imported_binding.snap
@@ -35,7 +35,6 @@ Imports {
 ```
 foo  => BindingTypeData {
   Types Import Symbol: foo from "/src/foo.ts",
-  Exported Ranges: (73..76)(73..76)
 }
 ```
 
@@ -76,10 +75,6 @@ Imports {
 ```
 foo => BindingTypeData {
   Types Module(0) TypeId(1),
-  JsDoc(
-    @returns {number}
-  ),
-  Exported Ranges: (94..97)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
@@ -34,10 +34,6 @@ Imports {
 ```
 foo => BindingTypeData {
   Types Module(0) TypeId(1),
-  JsDoc(
-    @returns {string}
-  ),
-  Exported Ranges: (118..121)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_namespace_reexport_type_inference.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_namespace_reexport_type_inference.snap
@@ -55,6 +55,7 @@ Exports {
       Specifier: "./source.ts"
       Resolved path: "/src/source.ts"
       Import Symbol: All
+      Exported range: (0..36)
     ))
   }
 }

--- a/crates/biome_module_graph/tests/snapshots/test_namespace_reexport_type_inference.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_namespace_reexport_type_inference.snap
@@ -96,11 +96,6 @@ Imports {
 ```
 alpha => BindingTypeData {
   Types Module(0) TypeId(1),
-  JsDoc(
-    @description
-    I am a jsdoc
-  ),
-  Exported Ranges: (114..119)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
@@ -39,7 +39,6 @@ Imports {
 ```
 returnPromiseResult => BindingTypeData {
   Types Module(0) TypeId(7),
-  Exported Ranges: (215..234)
 }
 ```
 
@@ -106,7 +105,6 @@ Imports {
 ```
 PromisedResult  => BindingTypeData {
   Types Module(0) TypeId(4),
-  Exported Ranges: (12..26)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -60,12 +60,10 @@ Imports {
 ```
 theAnswer  => BindingTypeData {
   Types Module(0) TypeId(0),
-  Exported Ranges: (26..35)
 }
 
 superComputer  => BindingTypeData {
   Types Module(0) TypeId(5),
-  Exported Ranges: (1077..1090)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -103,9 +103,6 @@ Exports {
       Specifier: "./renamed-reexports"
       Resolved path: "/src/renamed-reexports.ts"
       Import Symbol: All
-      JsDoc(
-        Hello, namespace 2.
-      )
     ))
   }
 }
@@ -119,65 +116,42 @@ Imports {
 ```
 foo => BindingTypeData {
   Types Module(0) TypeId(10),
-  JsDoc(
-    @returns {string}
-  ),
-  Exported Ranges: (118..121)
 }
 
 bar => BindingTypeData {
   Types Module(0) TypeId(11),
-  JsDoc(
-    @package
-  ),
-  Exported Ranges: (187..190)
 }
 
 quz  => BindingTypeData {
   Types Module(0) TypeId(0),
-  JsDoc(
-    @private
-  ),
-  Exported Ranges: (250..253)
 }
 
 baz => BindingTypeData {
   Types Module(0) TypeId(13),
-  Exported Ranges: (363..366)
 }
 
 qux  => BindingTypeData {
   Types Module(0) TypeId(1),
-  Exported Ranges: (123..126)
 }
 
 a => BindingTypeData {
   Types Module(0) TypeId(4),
-  Exported Ranges: (426..427)
 }
 
 b => BindingTypeData {
   Types Module(0) TypeId(5),
-  Exported Ranges: (429..430)
 }
 
 d => BindingTypeData {
   Types Module(0) TypeId(7),
-  Exported Ranges: (436..437)
 }
 
 e => BindingTypeData {
   Types Module(0) TypeId(8),
-  Exported Ranges: (439..440)
 }
 
 Component => BindingTypeData {
   Types Module(0) TypeId(17),
-  JsDoc(
-    @public
-    @returns {JSX.Element}
-  ),
-  Exported Ranges: (909..918)
 }
 ```
 
@@ -306,7 +280,6 @@ Imports {
 ```
 ohNo => BindingTypeData {
   Types Module(0) TypeId(1),
-  Exported Ranges: (29..33)
 }
 ```
 
@@ -344,9 +317,6 @@ Exports {
       Specifier: "./renamed-reexports"
       Resolved path: "/src/renamed-reexports.ts"
       Import Symbol: All
-      JsDoc(
-        Hello, namespace 1.
-      )
     ))
   }
 }

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -103,6 +103,7 @@ Exports {
       Specifier: "./renamed-reexports"
       Resolved path: "/src/renamed-reexports.ts"
       Import Symbol: All
+      Exported range: (1129..1177)
     ))
   }
 }
@@ -317,6 +318,7 @@ Exports {
       Specifier: "./renamed-reexports"
       Resolved path: "/src/renamed-reexports.ts"
       Import Symbol: All
+      Exported range: (80..127)
     ))
   }
 }

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value.snap
@@ -41,17 +41,14 @@ Imports {
 ```
 makePromise  => BindingTypeData {
   Types Module(0) TypeId(6),
-  Exported Ranges: (105..116)
 }
 
 makePromiseCb  => BindingTypeData {
   Types Module(0) TypeId(6),
-  Exported Ranges: (168..181)
 }
 
 promise  => BindingTypeData {
   Types Module(0) TypeId(7),
-  Exported Ranges: (224..231)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value_with_multiple_modules.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value_with_multiple_modules.snap
@@ -29,7 +29,6 @@ Imports {
 ```
 Bar  => BindingTypeData {
   Types Module(0) TypeId(1),
-  Exported Ranges: (21..24)
 }
 ```
 
@@ -132,7 +131,6 @@ Imports {
 ```
 foo => BindingTypeData {
   Types Module(0) TypeId(3),
-  Exported Ranges: 
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_import_as_namespace.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_import_as_namespace.snap
@@ -66,7 +66,6 @@ Imports {
 ```
 foo => BindingTypeData {
   Types Module(0) TypeId(1),
-  Exported Ranges: (25..28)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_merged_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_merged_types.snap
@@ -49,12 +49,10 @@ Imports {
 ```
 Union  => BindingTypeData {
   Types Module(0) TypeId(5),
-  Exported Ranges: (54..59)
 }
 
 Union2  => BindingTypeData {
   Types Module(0) TypeId(9),
-  Exported Ranges: (131..137)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_multiple_reexports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_multiple_reexports.snap
@@ -31,7 +31,6 @@ Imports {
 ```
 bar => BindingTypeData {
   Types Module(0) TypeId(1),
-  Exported Ranges: (25..28)
 }
 ```
 
@@ -123,7 +122,6 @@ Imports {
 ```
 foo => BindingTypeData {
   Types Module(0) TypeId(1),
-  Exported Ranges: (25..28)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_nested_function_call_with_namespace_in_return_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_nested_function_call_with_namespace_in_return_type.snap
@@ -66,7 +66,6 @@ Imports {
 ```
 foo => BindingTypeData {
   Types Module(0) TypeId(1),
-  Exported Ranges: (25..28)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
@@ -33,7 +33,6 @@ Imports {
 ```
 promise  => BindingTypeData {
   Types Module(0) TypeId(2),
-  Exported Ranges: (119..126)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -62,7 +62,6 @@ Imports {
 ```
 PromisedResult  => BindingTypeData {
   Types Module(0) TypeId(4),
-  Exported Ranges: (12..26)
 }
 ```
 
@@ -119,7 +118,6 @@ Imports {
 ```
 returnPromiseResult => BindingTypeData {
   Types Module(0) TypeId(7),
-  Exported Ranges: (215..234)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -88,7 +88,6 @@ Imports {
 ```
 PromisedResult  => BindingTypeData {
   Types Module(0) TypeId(4),
-  Exported Ranges: (12..26)
 }
 ```
 
@@ -145,7 +144,6 @@ Imports {
 ```
 returnPromiseResult => BindingTypeData {
   Types Module(0) TypeId(7),
-  Exported Ranges: (209..228)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
@@ -96,22 +96,18 @@ Imports {
 ```
 subdivision => BindingTypeData {
   Types Module(0) TypeId(15),
-  Exported Ranges: 
 }
 
 country => BindingTypeData {
   Types Module(0) TypeId(18),
-  Exported Ranges: 
 }
 
 data => BindingTypeData {
   Types Module(0) TypeId(1),
-  Exported Ranges: (1336..1340)
 }
 
 codes => BindingTypeData {
   Types Module(0) TypeId(2),
-  Exported Ranges: (1414..1419)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_single_reexport.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_single_reexport.snap
@@ -84,7 +84,6 @@ Imports {
 ```
 foo => BindingTypeData {
   Types Module(0) TypeId(1),
-  Exported Ranges: (25..28)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_type_of_this_in_class_export.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_type_of_this_in_class_export.snap
@@ -68,7 +68,6 @@ Imports {
 ```
 Foo  => BindingTypeData {
   Types Module(0) TypeId(23),
-  Exported Ranges: (21..24)
 }
 ```
 

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -13,7 +13,6 @@ use biome_deserialize::json::deserialize_from_json_str;
 use biome_fs::{BiomePath, FileSystem, MemoryFileSystem, OsFileSystem, normalize_path};
 use biome_js_semantic::ScopeId;
 use biome_js_type_info::{TypeData, TypeResolver};
-use biome_jsdoc_comment::JsdocComment;
 use biome_json_parser::{JsonParserOptions, parse_json};
 use biome_json_value::{JsonObject, JsonString};
 use biome_module_graph::{
@@ -22,7 +21,7 @@ use biome_module_graph::{
 };
 use biome_package::{Dependencies, PackageJson};
 use biome_project_layout::ProjectLayout;
-use biome_rowan::Text;
+use biome_rowan::{Text, TextRange, TextSize};
 use biome_test_utils::get_added_js_paths;
 use camino::{Utf8Path, Utf8PathBuf};
 use walkdir::WalkDir;
@@ -549,37 +548,35 @@ fn test_resolve_exports() {
     assert_eq!(
         exports.swap_remove(&Text::new_static("oh\nno")),
         Some(JsExport::Reexport(JsReexport {
+            export_range: None,
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
                 resolved_path: ResolvedPath::from_path("/src/renamed-reexports.ts"),
                 symbol: "ohNo".into()
             },
-            jsdoc_comment: None
         }))
     );
     assert_eq!(
         exports.swap_remove(&Text::new_static("renamed2")),
         Some(JsExport::Own(JsOwnExport::Namespace(JsReexport {
+            export_range: Some(TextRange::new(TextSize::from(1129), TextSize::from(1177))),
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
                 resolved_path: ResolvedPath::from_path("/src/renamed-reexports.ts"),
                 symbol: ImportSymbol::All,
             },
-            jsdoc_comment: Some(JsdocComment::from_comment_text(
-                "/**\n* Hello, namespace 2.\n*/"
-            )),
         })))
     );
 
     assert_eq!(
         data.blanket_reexports,
         &[JsReexport {
+            export_range: Some(TextRange::new(TextSize::from(950), TextSize::from(978))),
             import: JsImport {
                 specifier: "./reexports".into(),
                 resolved_path: ResolvedPath::from_path("/src/reexports.ts"),
                 symbol: ImportSymbol::All,
             },
-            jsdoc_comment: None
         }]
     );
 
@@ -591,14 +588,12 @@ fn test_resolve_exports() {
     assert_eq!(
         data.exports.get(&Text::new_static("renamed")),
         Some(&JsExport::Own(JsOwnExport::Namespace(JsReexport {
+            export_range: Some(TextRange::new(TextSize::from(80), TextSize::from(127))),
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
                 resolved_path: ResolvedPath::from_path("/src/renamed-reexports.ts"),
                 symbol: ImportSymbol::All,
             },
-            jsdoc_comment: Some(JsdocComment::from_comment_text(
-                "/**\n* Hello, namespace 1.\n*/"
-            )),
         })))
     );
 
@@ -2533,12 +2528,12 @@ fn test_namespace_reexport_is_own_export() {
     assert_eq!(
         barrel.exports.get(&Text::new_static("MyNs")),
         Some(&JsExport::Own(JsOwnExport::Namespace(JsReexport {
+            export_range: Some(TextRange::new(TextSize::from(0), TextSize::from(36))),
             import: JsImport {
                 specifier: "./source.ts".into(),
                 resolved_path: ResolvedPath::from_path("/src/source.ts"),
                 symbol: ImportSymbol::All,
             },
-            jsdoc_comment: None,
         }))),
         "`export * as MyNs` must produce JsExport::Own(JsOwnExport::Namespace(JsReexport {{ .. }}))"
     );

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_semantic_model.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_semantic_model.snap
@@ -9,13 +9,19 @@ Scope {
       id: ScopeId(2) @ 1..87
       children: [
         Binding {
-          id: BindingId(1) @ 14..18
-          scope: ScopeId(2)
+          Id: BindingId(1) @ 14..18
+          Scope: ScopeId(2)
+          Imported: false
+          Exported: false
+          Kind: Value
           ident: name
         }
         Binding {
-          id: BindingId(2) @ 28..31
-          scope: ScopeId(2)
+          Id: BindingId(2) @ 28..31
+          Scope: ScopeId(2)
+          Imported: false
+          Exported: false
+          Kind: Value
           ident: age
         }
         Scope {
@@ -25,8 +31,11 @@ Scope {
       ]
     }
     Binding {
-      id: BindingId(0) @ 10..13
-      scope: ScopeId(2)
+      Id: BindingId(0) @ 10..13
+      Scope: ScopeId(2)
+      Imported: false
+      Exported: false
+      Kind: HoistedValue
       ident: foo
     }
     Scope {
@@ -36,13 +45,19 @@ Scope {
           id: ScopeId(5) @ 142..240
           children: [
             Binding {
-              id: BindingId(4) @ 154..158
-              scope: ScopeId(5)
+              Id: BindingId(4) @ 154..158
+              Scope: ScopeId(5)
+              Imported: false
+              Exported: false
+              Kind: Value
               ident: name
             }
             Binding {
-              id: BindingId(5) @ 168..171
-              scope: ScopeId(5)
+              Id: BindingId(5) @ 168..171
+              Scope: ScopeId(5)
+              Imported: false
+              Exported: false
+              Kind: Value
               ident: age
             }
             Scope {
@@ -54,8 +69,11 @@ Scope {
       ]
     }
     Binding {
-      id: BindingId(3) @ 94..100
-      scope: ScopeId(4)
+      Id: BindingId(3) @ 94..100
+      Scope: ScopeId(4)
+      Imported: false
+      Exported: false
+      Kind: Class
       ident: Person
     }
   ]


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR finally finishes the refactor of using the semantic model inside our module graph.

There were still some parts that were ad hoc, and with this PR, now we use the semantic model for everything.

- JSDoc have been moved to the semantic model 
- Export ranges have been moved to the semantic model
- Some snapshots were updated, but that's expected because we moved data. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Updated the snapshots, updated unit tests.
Existing tests should still pass (module graph and JS rules)

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A
Changeset not needed, it's an internal refactor.

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
