### PR TITLE
feat(html): port noLabelWithoutControl to HTML

### DIFF
--- a/.changeset/add-no-label-without-control-html.md
+++ b/.changeset/add-no-label-without-control-html.md
@@ -1,0 +1,24 @@
+---
+"@biomejs/biome": minor
+---
+
+Added the HTML version of the [`noLabelWithoutControl`](https://biomejs.dev/linter/rules/no-label-without-control/) rule. The rule now enforces that `<label>` elements have accessible text content and are associated with a form control in HTML, Vue, Svelte, and Astro files.
+
+A label is valid when it either wraps a control (`input`, `select`, `textarea`, etc.) or has a `for` attribute pointing to a control's ID, and the label itself has non-empty text or an `aria-label`/`aria-labelledby` attribute.
+
+```html
+<!-- Invalid: empty label, no control -->
+<label></label>
+
+<!-- Invalid: has text but no control association -->
+<label>A label</label>
+
+<!-- Invalid: has `for` but no accessible text -->
+<label for="name"></label>
+
+<!-- Valid: text content + nested control -->
+<label>Full name <input /></label>
+
+<!-- Valid: `for` attribute + accessible text -->
+<label for="name">Full name</label>
+```

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -1717,6 +1717,18 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "jsx-a11y/label-has-associated-control" => {
+            if !options.include_inspired {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                return false;
+            }
+            let group = rules.a11y.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_label_without_control
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
         "jsx-a11y/lang" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -1717,18 +1717,6 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
-        "jsx-a11y/label-has-associated-control" => {
-            if !options.include_inspired {
-                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
-                return false;
-            }
-            let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group
-                .unwrap_group_as_mut()
-                .no_label_without_control
-                .get_or_insert(Default::default());
-            rule.set_level(rule.level().max(rule_severity.into()));
-        }
         "jsx-a11y/lang" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
@@ -1,0 +1,276 @@
+use biome_analyze::{Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
+use biome_console::markup;
+use biome_diagnostics::Severity;
+use biome_html_syntax::{
+    AnyHtmlContent, AnyHtmlElement, HtmlElementList, HtmlFileSource,
+};
+use biome_rowan::AstNode;
+use biome_rule_options::no_label_without_control::NoLabelWithoutControlOptions;
+
+use crate::a11y::{
+    has_accessible_name, html_element_has_truthy_aria_hidden,
+    html_self_closing_element_has_accessible_name,
+    html_self_closing_element_has_non_empty_attribute,
+};
+
+declare_lint_rule! {
+    /// Enforce that a label element has a text label and an associated control.
+    ///
+    /// A label element without a text label or an associated control is meaningless to users
+    /// who rely on assistive technologies such as screen readers.
+    ///
+    /// There are two supported ways to associate a label with a control:
+    /// - Wrapping a control inside a label element.
+    /// - Adding a `for` attribute to a label and assigning it the DOM ID of a control on the page.
+    ///
+    /// A label is considered to have accessible text content when it meets one of the following
+    /// conditions:
+    /// - Has non-whitespace text content.
+    /// - Has an `aria-label` attribute with a non-empty value.
+    /// - Has an `aria-labelledby` attribute with a non-empty value.
+    ///
+    /// :::note
+    /// In `.html` files, element names are matched case-insensitively.
+    /// In component-based frameworks (Vue, Svelte, Astro), only the lowercase `label` is checked.
+    /// PascalCase variants are assumed to be custom components and are ignored.
+    /// :::
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```html,expect_diagnostic
+    /// <label></label>
+    /// ```
+    ///
+    /// ```html,expect_diagnostic
+    /// <label>A label</label>
+    /// ```
+    ///
+    /// ```html,expect_diagnostic
+    /// <label for="js_id"></label>
+    /// ```
+    ///
+    /// ```html,expect_diagnostic
+    /// <label for="js_id"><input /></label>
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```html
+    /// <label for="js_id" aria-label="A label"></label>
+    /// ```
+    ///
+    /// ```html
+    /// <label for="js_id">A label</label>
+    /// ```
+    ///
+    /// ```html
+    /// <label>A label<input /></label>
+    /// ```
+    ///
+    /// ```html
+    /// <label>A label<textarea></textarea></label>
+    /// ```
+    ///
+    /// ## Accessibility guidelines
+    ///
+    /// - [WCAG 1.3.1](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
+    /// - [WCAG 3.3.2](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions)
+    ///
+    pub NoLabelWithoutControl {
+        version: "next",
+        name: "noLabelWithoutControl",
+        language: "html",
+        sources: &[RuleSource::EslintJsxA11y("label-has-associated-control").same()],
+        recommended: true,
+        severity: Severity::Error,
+    }
+}
+
+pub struct NoLabelWithoutControlState {
+    pub has_text_content: bool,
+    pub has_control_association: bool,
+}
+
+impl Rule for NoLabelWithoutControl {
+    type Query = Ast<AnyHtmlElement>;
+    type State = NoLabelWithoutControlState;
+    type Signals = Option<Self::State>;
+    type Options = NoLabelWithoutControlOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
+
+        let element_name = node.name()?;
+
+        // In HTML, tag names are case-insensitive; in framework files only lowercase matches
+        let is_label = if source_type.is_html() {
+            element_name.text().eq_ignore_ascii_case("label")
+        } else {
+            element_name.text() == "label"
+        };
+
+        if !is_label {
+            return None;
+        }
+
+        let is_html = source_type.is_html();
+
+        let has_text_content = element_has_accessible_label(node);
+        let has_control_association =
+            element_has_for_attribute(node) || element_has_nested_control(node, is_html);
+
+        if has_text_content && has_control_association {
+            return None;
+        }
+
+        Some(NoLabelWithoutControlState {
+            has_text_content,
+            has_control_association,
+        })
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let node = ctx.query();
+        let mut diagnostic = RuleDiagnostic::new(
+            rule_category!(),
+            node.syntax().text_trimmed_range(),
+            markup! {
+                "A form label must be associated with a control."
+            },
+        );
+
+        if !state.has_text_content {
+            diagnostic = diagnostic.note(
+                markup! { "Consider adding accessible text content to the label element." },
+            );
+        }
+
+        if !state.has_control_association {
+            diagnostic = diagnostic.note(
+                markup! { "Consider adding a `for` attribute to the label element or moving the control element inside the label." },
+            );
+        }
+
+        Some(diagnostic)
+    }
+}
+
+/// Returns `true` if the element has an accessible label: either via an aria-label/
+/// aria-labelledby attribute or via non-empty text content.
+fn element_has_accessible_label(element: &AnyHtmlElement) -> bool {
+    // Check aria-label / aria-labelledby / title on the element itself
+    if has_accessible_name(element) {
+        return true;
+    }
+
+    // For self-closing labels there can be no child content
+    let html_element = match element.as_html_element() {
+        Some(el) => el,
+        None => return false,
+    };
+
+    if html_element.opening_element().is_err() {
+        return false;
+    }
+
+    has_accessible_text_in_children(&html_element.children())
+}
+
+/// Returns `true` if the children contain non-empty accessible text content.
+fn has_accessible_text_in_children(children: &HtmlElementList) -> bool {
+    children.into_iter().any(|child| match &child {
+        AnyHtmlElement::AnyHtmlContent(content) => is_non_empty_text(content),
+        AnyHtmlElement::HtmlElement(element) => {
+            if html_element_has_truthy_aria_hidden(element) {
+                return false;
+            }
+            has_accessible_text_in_children(&element.children())
+        }
+        AnyHtmlElement::HtmlSelfClosingElement(element) => {
+            // A self-closing img with a non-empty alt attribute contributes accessible text
+            if let Some(tag_name) = element.tag_name() {
+                if tag_name.text().eq_ignore_ascii_case("img") {
+                    return html_self_closing_element_has_non_empty_attribute(element, "alt");
+                }
+            }
+            // Other self-closing elements with an accessible name (aria-label, etc.)
+            html_self_closing_element_has_accessible_name(element)
+        }
+        AnyHtmlElement::HtmlBogusElement(_) | AnyHtmlElement::HtmlCdataSection(_) => false,
+    })
+}
+
+/// Returns `true` if the content node contains non-empty, non-whitespace text.
+fn is_non_empty_text(content: &AnyHtmlContent) -> bool {
+    match content {
+        AnyHtmlContent::HtmlContent(html_content) => html_content
+            .value_token()
+            .is_ok_and(|token| !token.text_trimmed().is_empty()),
+        // Template expressions ({{ var }}, {expr}) are treated as accessible
+        AnyHtmlContent::AnyHtmlTextExpression(_) => true,
+        // Embedded script/style blocks are not text content
+        AnyHtmlContent::HtmlEmbeddedContent(_) => false,
+    }
+}
+
+/// Returns `true` if the element has a `for` attribute (HTML only, not `htmlFor`).
+fn element_has_for_attribute(element: &AnyHtmlElement) -> bool {
+    element.find_attribute_by_name("for").is_some()
+}
+
+/// Returns `true` if the element has a nested control element
+/// (`input`, `meter`, `output`, `progress`, `select`, `textarea`, `button`).
+fn element_has_nested_control(element: &AnyHtmlElement, is_html: bool) -> bool {
+    let html_element = match element.as_html_element() {
+        Some(el) => el,
+        None => return false,
+    };
+
+    if html_element.opening_element().is_err() {
+        return false;
+    }
+
+    children_have_control(&html_element.children(), is_html)
+}
+
+const CONTROL_ELEMENTS: [&str; 7] = [
+    "input", "meter", "output", "progress", "select", "textarea", "button",
+];
+
+/// Recursively checks whether the children contain a control element.
+fn children_have_control(children: &HtmlElementList, is_html: bool) -> bool {
+    children.into_iter().any(|child| match &child {
+        AnyHtmlElement::HtmlElement(element) => {
+            if let Some(tag_name) = element.tag_name() {
+                let is_control = if is_html {
+                    CONTROL_ELEMENTS
+                        .iter()
+                        .any(|&c| tag_name.text().eq_ignore_ascii_case(c))
+                } else {
+                    CONTROL_ELEMENTS.contains(&tag_name.text())
+                };
+                if is_control {
+                    return true;
+                }
+            }
+            children_have_control(&element.children(), is_html)
+        }
+        AnyHtmlElement::HtmlSelfClosingElement(element) => {
+            let tag_name = match element.tag_name() {
+                Some(name) => name,
+                None => return false,
+            };
+            if is_html {
+                CONTROL_ELEMENTS
+                    .iter()
+                    .any(|&c| tag_name.text().eq_ignore_ascii_case(c))
+            } else {
+                CONTROL_ELEMENTS.contains(&tag_name.text())
+            }
+        }
+        _ => false,
+    })
+}

--- a/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
@@ -199,10 +199,10 @@ fn has_accessible_text_in_children(children: &HtmlElementList) -> bool {
             // Other self-closing elements (input, br, etc.) do not provide label text
             // even if they carry aria-label/title — those attributes describe the control,
             // not the label's own text content.
-            if let Some(tag_name) = element.tag_name() {
-                if tag_name.text().eq_ignore_ascii_case("img") {
-                    return html_self_closing_element_has_non_empty_attribute(element, "alt");
-                }
+            if let Some(tag_name) = element.tag_name()
+                && tag_name.text().eq_ignore_ascii_case("img")
+            {
+                return html_self_closing_element_has_non_empty_attribute(element, "alt");
             }
             false
         }

--- a/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
@@ -8,8 +8,7 @@ use biome_rowan::AstNode;
 use biome_rule_options::no_label_without_control::NoLabelWithoutControlOptions;
 
 use crate::a11y::{
-    has_accessible_name, html_element_has_truthy_aria_hidden,
-    html_self_closing_element_has_accessible_name,
+    has_non_empty_attribute, html_element_has_truthy_aria_hidden,
     html_self_closing_element_has_non_empty_attribute,
 };
 
@@ -82,7 +81,7 @@ declare_lint_rule! {
         version: "next",
         name: "noLabelWithoutControl",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("label-has-associated-control").same()],
+        sources: &[RuleSource::EslintJsxA11y("label-has-associated-control").inspired()],
         recommended: true,
         severity: Severity::Error,
     }
@@ -158,11 +157,17 @@ impl Rule for NoLabelWithoutControl {
     }
 }
 
-/// Returns `true` if the element has an accessible label: either via an aria-label/
-/// aria-labelledby attribute or via non-empty text content.
+/// Returns `true` if the element has an accessible label: either via an explicit
+/// `aria-label`/`aria-labelledby` attribute or via non-empty text content.
+///
+/// Note: `title` is intentionally excluded here. While `title` can provide an
+/// accessible name for some elements, it is not a reliable substitute for visible
+/// label text on a `<label>` element.
 fn element_has_accessible_label(element: &AnyHtmlElement) -> bool {
-    // Check aria-label / aria-labelledby / title on the element itself
-    if has_accessible_name(element) {
+    // Check aria-label / aria-labelledby on the element itself (title excluded)
+    if has_non_empty_attribute(element, "aria-label")
+        || has_non_empty_attribute(element, "aria-labelledby")
+    {
         return true;
     }
 
@@ -190,14 +195,16 @@ fn has_accessible_text_in_children(children: &HtmlElementList) -> bool {
             has_accessible_text_in_children(&element.children())
         }
         AnyHtmlElement::HtmlSelfClosingElement(element) => {
-            // A self-closing img with a non-empty alt attribute contributes accessible text
+            // Only an img with a non-empty alt attribute contributes accessible text.
+            // Other self-closing elements (input, br, etc.) do not provide label text
+            // even if they carry aria-label/title — those attributes describe the control,
+            // not the label's own text content.
             if let Some(tag_name) = element.tag_name() {
                 if tag_name.text().eq_ignore_ascii_case("img") {
                     return html_self_closing_element_has_non_empty_attribute(element, "alt");
                 }
             }
-            // Other self-closing elements with an accessible name (aria-label, etc.)
-            html_self_closing_element_has_accessible_name(element)
+            false
         }
         AnyHtmlElement::HtmlBogusElement(_) | AnyHtmlElement::HtmlCdataSection(_) => false,
     })
@@ -216,9 +223,12 @@ fn is_non_empty_text(content: &AnyHtmlContent) -> bool {
     }
 }
 
-/// Returns `true` if the element has a `for` attribute (HTML only, not `htmlFor`).
+/// Returns `true` if the element has a `for` attribute with a non-empty, non-whitespace value.
+///
+/// A `for=""` or `for="   "` attribute is treated as unassociated — an empty value cannot
+/// reference any control's DOM ID.
 fn element_has_for_attribute(element: &AnyHtmlElement) -> bool {
-    element.find_attribute_by_name("for").is_some()
+    has_non_empty_attribute(element, "for")
 }
 
 /// Returns `true` if the element has a nested control element

--- a/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
@@ -81,7 +81,7 @@ declare_lint_rule! {
         version: "next",
         name: "noLabelWithoutControl",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("label-has-associated-control").inspired()],
+        sources: &[RuleSource::EslintJsxA11y("label-has-associated-control").same()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/invalid.astro
@@ -1,0 +1,13 @@
+<!-- should generate diagnostics -->
+
+<!-- Empty label: no text, no control -->
+<label></label>
+
+<!-- Has text but no control association -->
+<label>A label</label>
+
+<!-- Has for attribute but no accessible text -->
+<label for="js_id"></label>
+
+<!-- Uppercase <INPUT> is NOT matched as a control in Astro (case-sensitive) -->
+<label>A label<INPUT /></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/invalid.astro.snap
@@ -1,0 +1,87 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.astro
+---
+# Input
+```astro
+<!-- should generate diagnostics -->
+
+<!-- Empty label: no text, no control -->
+<label></label>
+
+<!-- Has text but no control association -->
+<label>A label</label>
+
+<!-- Has for attribute but no accessible text -->
+<label for="js_id"></label>
+
+<!-- Uppercase <INPUT> is NOT matched as a control in Astro (case-sensitive) -->
+<label>A label<INPUT /></label>
+
+```
+
+# Diagnostics
+```
+invalid.astro:4:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    3 │ <!-- Empty label: no text, no control -->
+  > 4 │ <label></label>
+      │ ^^^^^^^^^^^^^^^
+    5 │ 
+    6 │ <!-- Has text but no control association -->
+  
+  i Consider adding accessible text content to the label element.
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.astro:7:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    6 │ <!-- Has text but no control association -->
+  > 7 │ <label>A label</label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ <!-- Has for attribute but no accessible text -->
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.astro:10:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+     9 │ <!-- Has for attribute but no accessible text -->
+  > 10 │ <label for="js_id"></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 
+    12 │ <!-- Uppercase <INPUT> is NOT matched as a control in Astro (case-sensitive) -->
+  
+  i Consider adding accessible text content to the label element.
+  
+
+```
+
+```
+invalid.astro:13:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    12 │ <!-- Uppercase <INPUT> is NOT matched as a control in Astro (case-sensitive) -->
+  > 13 │ <label>A label<INPUT /></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro
@@ -1,0 +1,13 @@
+<!-- should not generate diagnostics -->
+
+<!-- Basic valid: for + text -->
+<label for="js_id">A label</label>
+
+<!-- aria-labelledby as accessible text -->
+<label for="js_id" aria-labelledby="some-id"></label>
+
+<!-- Wraps a select with text content -->
+<label>A label<select><option>opt</option></select></label>
+
+<!-- PascalCase <Label> is a custom component — ignored entirely -->
+<Label></Label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+
+<!-- Basic valid: for + text -->
+<label for="js_id">A label</label>
+
+<!-- aria-labelledby as accessible text -->
+<label for="js_id" aria-labelledby="some-id"></label>
+
+<!-- Wraps a select with text content -->
+<label>A label<select><option>opt</option></select></label>
+
+<!-- PascalCase <Label> is a custom component — ignored entirely -->
+<Label></Label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html
@@ -26,3 +26,9 @@
 
 <!-- Whitespace-only `for` attribute is also unassociated -->
 <label for="   ">A label</label>
+
+<!-- img with empty alt does not contribute accessible text -->
+<label for="x"><img alt="" /></label>
+
+<!-- img with whitespace-only alt does not contribute accessible text -->
+<label for="x"><img alt="   " /></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html
@@ -1,0 +1,22 @@
+<!-- should generate diagnostics -->
+
+<!-- Empty label: no text, no control -->
+<label></label>
+
+<!-- Has text but no control association -->
+<label>A label</label>
+
+<!-- Has `for` attribute but no accessible text -->
+<label for="js_id"></label>
+
+<!-- Has `for` attribute, has nested input, but no accessible text -->
+<label for="js_id"><input /></label>
+
+<!-- Self-closing label (no content, no `for`) -->
+<label />
+
+<!-- Case-insensitive: uppercase LABEL, no text, no control -->
+<LABEL></LABEL>
+
+<!-- Whitespace-only text is not accessible -->
+<label>   <input /></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html
@@ -20,3 +20,9 @@
 
 <!-- Whitespace-only text is not accessible -->
 <label>   <input /></label>
+
+<!-- Empty `for` attribute cannot reference any control -->
+<label for="">A label</label>
+
+<!-- Whitespace-only `for` attribute is also unassociated -->
+<label for="   ">A label</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html.snap
@@ -1,0 +1,224 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+
+<!-- Empty label: no text, no control -->
+<label></label>
+
+<!-- Has text but no control association -->
+<label>A label</label>
+
+<!-- Has `for` attribute but no accessible text -->
+<label for="js_id"></label>
+
+<!-- Has `for` attribute, has nested input, but no accessible text -->
+<label for="js_id"><input /></label>
+
+<!-- Self-closing label (no content, no `for`) -->
+<label />
+
+<!-- Case-insensitive: uppercase LABEL, no text, no control -->
+<LABEL></LABEL>
+
+<!-- Whitespace-only text is not accessible -->
+<label>   <input /></label>
+
+<!-- Empty `for` attribute cannot reference any control -->
+<label for="">A label</label>
+
+<!-- Whitespace-only `for` attribute is also unassociated -->
+<label for="   ">A label</label>
+
+<!-- img with empty alt does not contribute accessible text -->
+<label for="x"><img alt="" /></label>
+
+<!-- img with whitespace-only alt does not contribute accessible text -->
+<label for="x"><img alt="   " /></label>
+
+```
+
+# Diagnostics
+```
+invalid.html:4:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    3 │ <!-- Empty label: no text, no control -->
+  > 4 │ <label></label>
+      │ ^^^^^^^^^^^^^^^
+    5 │ 
+    6 │ <!-- Has text but no control association -->
+  
+  i Consider adding accessible text content to the label element.
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.html:7:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    6 │ <!-- Has text but no control association -->
+  > 7 │ <label>A label</label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ <!-- Has `for` attribute but no accessible text -->
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.html:10:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+     9 │ <!-- Has `for` attribute but no accessible text -->
+  > 10 │ <label for="js_id"></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 
+    12 │ <!-- Has `for` attribute, has nested input, but no accessible text -->
+  
+  i Consider adding accessible text content to the label element.
+  
+
+```
+
+```
+invalid.html:13:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    12 │ <!-- Has `for` attribute, has nested input, but no accessible text -->
+  > 13 │ <label for="js_id"><input /></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+    15 │ <!-- Self-closing label (no content, no `for`) -->
+  
+  i Consider adding accessible text content to the label element.
+  
+
+```
+
+```
+invalid.html:16:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    15 │ <!-- Self-closing label (no content, no `for`) -->
+  > 16 │ <label />
+       │ ^^^^^^^^^
+    17 │ 
+    18 │ <!-- Case-insensitive: uppercase LABEL, no text, no control -->
+  
+  i Consider adding accessible text content to the label element.
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.html:19:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    18 │ <!-- Case-insensitive: uppercase LABEL, no text, no control -->
+  > 19 │ <LABEL></LABEL>
+       │ ^^^^^^^^^^^^^^^
+    20 │ 
+    21 │ <!-- Whitespace-only text is not accessible -->
+  
+  i Consider adding accessible text content to the label element.
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.html:22:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    21 │ <!-- Whitespace-only text is not accessible -->
+  > 22 │ <label>   <input /></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    23 │ 
+    24 │ <!-- Empty `for` attribute cannot reference any control -->
+  
+  i Consider adding accessible text content to the label element.
+  
+
+```
+
+```
+invalid.html:25:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    24 │ <!-- Empty `for` attribute cannot reference any control -->
+  > 25 │ <label for="">A label</label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    26 │ 
+    27 │ <!-- Whitespace-only `for` attribute is also unassociated -->
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.html:28:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    27 │ <!-- Whitespace-only `for` attribute is also unassociated -->
+  > 28 │ <label for="   ">A label</label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    29 │ 
+    30 │ <!-- img with empty alt does not contribute accessible text -->
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.html:31:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    30 │ <!-- img with empty alt does not contribute accessible text -->
+  > 31 │ <label for="x"><img alt="" /></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    32 │ 
+    33 │ <!-- img with whitespace-only alt does not contribute accessible text -->
+  
+  i Consider adding accessible text content to the label element.
+  
+
+```
+
+```
+invalid.html:34:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    33 │ <!-- img with whitespace-only alt does not contribute accessible text -->
+  > 34 │ <label for="x"><img alt="   " /></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    35 │ 
+  
+  i Consider adding accessible text content to the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/invalid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/invalid.svelte
@@ -1,0 +1,13 @@
+<!-- should generate diagnostics -->
+
+<!-- Empty label: no text, no control -->
+<label></label>
+
+<!-- Has text but no control association -->
+<label>A label</label>
+
+<!-- Has for attribute but no accessible text -->
+<label for="js_id"></label>
+
+<!-- Uppercase <INPUT> is NOT matched as a control in Svelte (case-sensitive) -->
+<label>A label<INPUT /></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/invalid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/invalid.svelte.snap
@@ -1,0 +1,87 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.svelte
+---
+# Input
+```svelte
+<!-- should generate diagnostics -->
+
+<!-- Empty label: no text, no control -->
+<label></label>
+
+<!-- Has text but no control association -->
+<label>A label</label>
+
+<!-- Has for attribute but no accessible text -->
+<label for="js_id"></label>
+
+<!-- Uppercase <INPUT> is NOT matched as a control in Svelte (case-sensitive) -->
+<label>A label<INPUT /></label>
+
+```
+
+# Diagnostics
+```
+invalid.svelte:4:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    3 │ <!-- Empty label: no text, no control -->
+  > 4 │ <label></label>
+      │ ^^^^^^^^^^^^^^^
+    5 │ 
+    6 │ <!-- Has text but no control association -->
+  
+  i Consider adding accessible text content to the label element.
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.svelte:7:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    6 │ <!-- Has text but no control association -->
+  > 7 │ <label>A label</label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ <!-- Has for attribute but no accessible text -->
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.svelte:10:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+     9 │ <!-- Has for attribute but no accessible text -->
+  > 10 │ <label for="js_id"></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 
+    12 │ <!-- Uppercase <INPUT> is NOT matched as a control in Svelte (case-sensitive) -->
+  
+  i Consider adding accessible text content to the label element.
+  
+
+```
+
+```
+invalid.svelte:13:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    12 │ <!-- Uppercase <INPUT> is NOT matched as a control in Svelte (case-sensitive) -->
+  > 13 │ <label>A label<INPUT /></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte
@@ -1,0 +1,16 @@
+<!-- should not generate diagnostics -->
+
+<!-- Basic valid: for + text -->
+<label for="js_id">A label</label>
+
+<!-- aria-label as accessible text -->
+<label for="js_id" aria-label="A label"></label>
+
+<!-- Wraps a textarea with text content -->
+<label>A label<textarea></textarea></label>
+
+<!-- Svelte expression counts as accessible text -->
+<label>{labelText}<input /></label>
+
+<!-- PascalCase <Label> is a custom component — ignored entirely -->
+<Label></Label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+
+<!-- Basic valid: for + text -->
+<label for="js_id">A label</label>
+
+<!-- aria-label as accessible text -->
+<label for="js_id" aria-label="A label"></label>
+
+<!-- Wraps a textarea with text content -->
+<label>A label<textarea></textarea></label>
+
+<!-- Svelte expression counts as accessible text -->
+<label>{labelText}<input /></label>
+
+<!-- PascalCase <Label> is a custom component — ignored entirely -->
+<Label></Label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html
@@ -30,3 +30,5 @@
 <!-- Deeply nested input still counts as associated control -->
 <label>A label<span><input /></span></label>
 
+<!-- img with non-empty alt provides accessible text for the label -->
+<label><img alt="A label" /><input /></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html
@@ -1,0 +1,34 @@
+<!-- should not generate diagnostics -->
+
+<!-- Has `for` attribute and accessible text -->
+<label for="js_id">A label</label>
+
+<!-- Has `for` and aria-label -->
+<label for="js_id" aria-label="A label"></label>
+
+<!-- Has `for` and aria-labelledby -->
+<label for="js_id" aria-labelledby="some-id"></label>
+
+<!-- Wraps an input with text content -->
+<label>A label<input /></label>
+
+<!-- Wraps a textarea with text content -->
+<label>A label<textarea></textarea></label>
+
+<!-- Wraps a select with text content -->
+<label>A label<select><option>opt</option></select></label>
+
+<!-- Wraps a button with text content -->
+<label>A label<button>Click</button></label>
+
+<!-- Nested control with aria-label on the label -->
+<label aria-label="A label"><input /></label>
+
+<!-- Case-insensitive match for control -->
+<label>A label<INPUT /></label>
+
+<!-- Deeply nested input still counts as associated control -->
+<label>A label<span><input /></span></label>
+
+<!-- Text expression is accessible content -->
+<label>{{ labelText }}<input /></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html.snap
@@ -1,3 +1,9 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.html
+---
+# Input
+```html
 <!-- should not generate diagnostics -->
 
 <!-- Has `for` attribute and accessible text -->
@@ -30,3 +36,5 @@
 <!-- Deeply nested input still counts as associated control -->
 <label>A label<span><input /></span></label>
 
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html.snap
@@ -36,5 +36,7 @@ expression: valid.html
 <!-- Deeply nested input still counts as associated control -->
 <label>A label<span><input /></span></label>
 
+<!-- img with non-empty alt provides accessible text for the label -->
+<label><img alt="A label" /><input /></label>
 
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/invalid.vue
@@ -1,0 +1,16 @@
+<!-- should generate diagnostics -->
+
+<!-- Empty label: no text, no control -->
+<label></label>
+
+<!-- Has text but no control association -->
+<label>A label</label>
+
+<!-- Has for attribute but no accessible text -->
+<label for="js_id"></label>
+
+<!-- Uppercase <INPUT> is NOT matched as a control in Vue (case-sensitive) -->
+<label>A label<INPUT /></label>
+
+<!-- PascalCase <Input> is treated as a custom component, not a control -->
+<label>A label<Input /></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/invalid.vue.snap
@@ -1,0 +1,106 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+
+<!-- Empty label: no text, no control -->
+<label></label>
+
+<!-- Has text but no control association -->
+<label>A label</label>
+
+<!-- Has for attribute but no accessible text -->
+<label for="js_id"></label>
+
+<!-- Uppercase <INPUT> is NOT matched as a control in Vue (case-sensitive) -->
+<label>A label<INPUT /></label>
+
+<!-- PascalCase <Input> is treated as a custom component, not a control -->
+<label>A label<Input /></label>
+
+```
+
+# Diagnostics
+```
+invalid.vue:4:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    3 │ <!-- Empty label: no text, no control -->
+  > 4 │ <label></label>
+      │ ^^^^^^^^^^^^^^^
+    5 │ 
+    6 │ <!-- Has text but no control association -->
+  
+  i Consider adding accessible text content to the label element.
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.vue:7:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    6 │ <!-- Has text but no control association -->
+  > 7 │ <label>A label</label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ <!-- Has for attribute but no accessible text -->
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.vue:10:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+     9 │ <!-- Has for attribute but no accessible text -->
+  > 10 │ <label for="js_id"></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 
+    12 │ <!-- Uppercase <INPUT> is NOT matched as a control in Vue (case-sensitive) -->
+  
+  i Consider adding accessible text content to the label element.
+  
+
+```
+
+```
+invalid.vue:13:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    12 │ <!-- Uppercase <INPUT> is NOT matched as a control in Vue (case-sensitive) -->
+  > 13 │ <label>A label<INPUT /></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+    15 │ <!-- PascalCase <Input> is treated as a custom component, not a control -->
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```
+
+```
+invalid.vue:16:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with a control.
+  
+    15 │ <!-- PascalCase <Input> is treated as a custom component, not a control -->
+  > 16 │ <label>A label<Input /></label>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    17 │ 
+  
+  i Consider adding a `for` attribute to the label element or moving the control element inside the label.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue
@@ -1,0 +1,23 @@
+<!-- should not generate diagnostics -->
+
+<!-- Basic valid: for + text -->
+<label for="js_id">A label</label>
+
+<!-- aria-label as accessible text -->
+<label for="js_id" aria-label="A label"></label>
+
+<!-- aria-labelledby as accessible text -->
+<label for="js_id" aria-labelledby="some-id"></label>
+
+<!-- Wraps an input with text content -->
+<label>A label<input /></label>
+
+<!-- Template expression counts as accessible text -->
+<label>{{ labelText }}<input /></label>
+
+<!-- PascalCase <Label> is a custom component — ignored entirely -->
+<Label></Label>
+<Label for="js_id"></Label>
+
+<!-- Lowercase <input> matches as a control in Vue/Svelte/Astro -->
+<label>A label<input /></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+
+<!-- Basic valid: for + text -->
+<label for="js_id">A label</label>
+
+<!-- aria-label as accessible text -->
+<label for="js_id" aria-label="A label"></label>
+
+<!-- aria-labelledby as accessible text -->
+<label for="js_id" aria-labelledby="some-id"></label>
+
+<!-- Wraps an input with text content -->
+<label>A label<input /></label>
+
+<!-- Template expression counts as accessible text -->
+<label>{{ labelText }}<input /></label>
+
+<!-- PascalCase <Label> is a custom component — ignored entirely -->
+<Label></Label>
+<Label for="js_id"></Label>
+
+<!-- Lowercase <input> matches as a control in Vue/Svelte/Astro -->
+<label>A label<input /></label>
+
+```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1313,7 +1313,7 @@ See https://biomejs.dev/linter/rules/no-interactive-element-to-noninteractive-ro
 	 */
 	noInteractiveElementToNoninteractiveRole?: NoInteractiveElementToNoninteractiveRoleConfiguration;
 	/**
-	* Enforce that a label element or component has a text label and an associated input.
+	* Enforce that a label element has a text label and an associated control.
 See https://biomejs.dev/linter/rules/no-label-without-control 
 	 */
 	noLabelWithoutControl?: NoLabelWithoutControlConfiguration;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -130,7 +130,7 @@
 					]
 				},
 				"noLabelWithoutControl": {
-					"description": "Enforce that a label element or component has a text label and an associated input.\nSee https://biomejs.dev/linter/rules/no-label-without-control",
+					"description": "Enforce that a label element has a text label and an associated control.\nSee https://biomejs.dev/linter/rules/no-label-without-control",
 					"anyOf": [
 						{ "$ref": "#/$defs/NoLabelWithoutControlConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
## Summary

Ports the `noLabelWithoutControl` a11y lint rule to HTML, resolving the relevant item in the umbrella issue #8155.

The rule now fires on `<label>` elements in `.html`, `.vue`, `.svelte`, and `.astro` files using the same two-condition check as the existing JSX version:

1. The label must have **accessible text content** (non-whitespace text, `aria-label`, `aria-labelledby`, or a nested `<img alt="...">`)
2. The label must have a **control association** via a `for` attribute *or* a nested control element (`input`, `select`, `textarea`, `button`, `meter`, `output`, `progress`)

### Key differences from the JSX rule

- Only checks `for` (not `htmlFor` — that's JSX-specific React mapping)
- Element names are matched case-insensitively in `.html` files and case-sensitively in component framework files (`.vue`, `.svelte`, `.astro`), consistent with the pattern used in `useHeadingContent`, `useAnchorContent`, etc.
- The `inputComponents` and `labelComponents` options from `NoLabelWithoutControlOptions` are not wired up for HTML (they're JSX-specific custom component names), but the shared options struct is retained so no schema changes are needed

## Test plan

- [ ] `crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html` — cases that should emit a diagnostic
- [ ] `crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html` — cases that should pass cleanly
- Snapshot files (`.snap`) will be generated by running `cargo test -p biome_html_analyze`
- Run `just gen-analyzer` to regenerate the JSON configuration schema and documentation

## Files changed

- `crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs` — new rule implementation
- `crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.html` — invalid test fixtures
- `crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/valid.html` — valid test fixtures
- `.changeset/add-no-label-without-control-html.md` — minor changeset

Closes part of #8155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)