### PR TITLE
chore: ignore rand unsoundness advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,3 +11,6 @@ multiple-versions = "allow"
 
 [advisories]
 unmaintained = "workspace"
+ignore = [
+	{ id = "RUSTSEC-2026-0097", reason = "Upgrading the `rand` crate to a newer version requires `grit-pattern-matcher` to also update the dependency. Also, the current version of Boa depends on a different version of `rand`, and its also affected by this advisory. It's more work than it's worth to fix it right now." }
+]


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Upgrading the `rand` crate to a newer version requires `grit-pattern-matcher` to also update the dependency. Also, the current version of Boa depends on a different version of `rand`, and its also affected by this advisory. It's more work than it's worth to fix it right now.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
green ci
## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
