### PR TITLE
fix(cli): normalize path separators in JSON reporter output

### DIFF
--- a/.changeset/fix-json-reporter-windows-paths.md
+++ b/.changeset/fix-json-reporter-windows-paths.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9899](https://github.com/biomejs/biome/issues/9899): `--reporter=json` now normalizes file paths to use forward slashes on Windows. Previously, paths were emitted with backslashes (e.g., `typescript\src\file.tsx`), which was inconsistent with other reporters and could break tooling that expects forward slashes.

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -446,7 +446,7 @@ mod tests {
     fn to_location_normalizes_backslashes() {
         let location = Location::builder()
             .resource(&r"typescript\src\account\setup-passkey.tsx")
-            .span(&(0..5))
+            .span(&(0u32..5u32))
             .source_code(&"hello")
             .build();
 
@@ -458,7 +458,7 @@ mod tests {
     fn to_location_preserves_unix_paths() {
         let location = Location::builder()
             .resource(&"typescript/src/account/setup-passkey.tsx")
-            .span(&(0..5))
+            .span(&(0u32..5u32))
             .source_code(&"hello")
             .build();
 
@@ -470,7 +470,7 @@ mod tests {
     fn to_location_handles_mixed_separators() {
         let location = Location::builder()
             .resource(&r"src\components/Button\index.tsx")
-            .span(&(0..5))
+            .span(&(0u32..5u32))
             .source_code(&"hello")
             .build();
 

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -436,3 +436,27 @@ impl Visit for SuggestionsVisitor {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn path_normalization_converts_backslashes() {
+        let windows_path = r"typescript\src\account\setup-passkey.tsx";
+        let normalized = windows_path.replace('\\', "/");
+        assert_eq!(normalized, "typescript/src/account/setup-passkey.tsx");
+    }
+
+    #[test]
+    fn path_normalization_preserves_unix_paths() {
+        let unix_path = "typescript/src/account/setup-passkey.tsx";
+        let normalized = unix_path.replace('\\', "/");
+        assert_eq!(normalized, unix_path);
+    }
+
+    #[test]
+    fn path_normalization_handles_mixed_separators() {
+        let mixed_path = r"src\components/Button\index.tsx";
+        let normalized = mixed_path.replace('\\', "/");
+        assert_eq!(normalized, "src/components/Button/index.tsx");
+    }
+}

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -477,4 +477,20 @@ mod tests {
         let report = to_location(&location).expect("expected LocationReport");
         assert_eq!(report.path, "src/components/Button/index.tsx");
     }
+
+    #[test]
+    fn fallback_path_normalizes_backslashes() {
+        // When to_location returns None (no span/source_code), the fallback
+        // in to_json_report should still normalize backslashes.
+        let location = Location::builder()
+            .resource(&r"views\admin\dashboard.tsx")
+            .build();
+
+        // to_location returns None here because there's no span
+        assert!(to_location(&location).is_none());
+
+        // Verify the normalization logic directly
+        let raw_path = r"views\admin\dashboard.tsx".to_string().replace('\\', "/");
+        assert_eq!(raw_path, "views/admin/dashboard.tsx");
+    }
 }

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -439,24 +439,42 @@ impl Visit for SuggestionsVisitor {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use biome_diagnostics::Location;
+
     #[test]
-    fn path_normalization_converts_backslashes() {
-        let windows_path = r"typescript\src\account\setup-passkey.tsx";
-        let normalized = windows_path.replace('\\', "/");
-        assert_eq!(normalized, "typescript/src/account/setup-passkey.tsx");
+    fn to_location_normalizes_backslashes() {
+        let location = Location::builder()
+            .resource(&r"typescript\src\account\setup-passkey.tsx")
+            .span(&(0..5))
+            .source_code(&"hello")
+            .build();
+
+        let report = to_location(&location).expect("expected LocationReport");
+        assert_eq!(report.path, "typescript/src/account/setup-passkey.tsx");
     }
 
     #[test]
-    fn path_normalization_preserves_unix_paths() {
-        let unix_path = "typescript/src/account/setup-passkey.tsx";
-        let normalized = unix_path.replace('\\', "/");
-        assert_eq!(normalized, unix_path);
+    fn to_location_preserves_unix_paths() {
+        let location = Location::builder()
+            .resource(&"typescript/src/account/setup-passkey.tsx")
+            .span(&(0..5))
+            .source_code(&"hello")
+            .build();
+
+        let report = to_location(&location).expect("expected LocationReport");
+        assert_eq!(report.path, "typescript/src/account/setup-passkey.tsx");
     }
 
     #[test]
-    fn path_normalization_handles_mixed_separators() {
-        let mixed_path = r"src\components/Button\index.tsx";
-        let normalized = mixed_path.replace('\\', "/");
-        assert_eq!(normalized, "src/components/Button/index.tsx");
+    fn to_location_handles_mixed_separators() {
+        let location = Location::builder()
+            .resource(&r"src\components/Button\index.tsx")
+            .span(&(0..5))
+            .source_code(&"hello")
+            .build();
+
+        let report = to_location(&location).expect("expected LocationReport");
+        assert_eq!(report.path, "src/components/Button/index.tsx");
     }
 }

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -298,7 +298,7 @@ fn to_json_report(diagnostic: &biome_diagnostics::Error) -> JsonReport {
     let location = to_location(&location).or_else(|| {
         let location = location
             .resource
-            .and_then(|location| location.as_file().map(|f| f.to_string()))?;
+            .and_then(|location| location.as_file().map(|f| f.to_string().replace('\\', "/")))?;
         Some(LocationReport {
             path: location,
             start: LocationSpan { column: 0, line: 0 },
@@ -337,8 +337,11 @@ fn to_location(location: &Location) -> Option<LocationReport> {
     let source = SourceFile::new(source_code);
     let start = source.location(span.start()).ok()?;
     let end = source.location(span.end()).ok()?;
+    // Normalize path separators to forward slashes for consistent JSON output
+    // across platforms (fixes backslash paths on Windows)
+    let path = resource.to_string().replace('\\', "/");
     Some(LocationReport {
-        path: resource.to_string(),
+        path,
         start: LocationSpan {
             column: start.column_number.get(),
             line: start.line_number.get(),


### PR DESCRIPTION
On Windows, the JSON reporter emits paths with backslashes (e.g. `typescript\srcile.tsx`). This normalizes them to forward slashes for consistency with other reporters.

Includes regression tests and a changeset.

Fixes #9899