### PR TITLE
fix(markdown_parser): paragraph with trailing hard break absorbs following blank line

### DIFF
--- a/crates/biome_markdown_formatter/tests/specs/markdown/hard_line.md.snap
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/hard_line.md.snap
@@ -36,7 +36,8 @@ no hard line
 here
 
 foo  
-bar with empty line after  
+bar with empty line after
+
 foo  
 bar without empty line after
 

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -1080,6 +1080,7 @@ pub(crate) fn parse_inline_item_list(p: &mut MarkdownParser) {
     }
     let inline_start: usize = p.cur_range().start().into();
     let mut has_content = false;
+    let mut after_hard_break = false;
 
     loop {
         // EOF ends inline content
@@ -1089,6 +1090,13 @@ pub(crate) fn parse_inline_item_list(p: &mut MarkdownParser) {
 
         // NEWLINE handling: check for blank line (paragraph boundary)
         if p.at(NEWLINE) {
+            // After MD_HARD_LINE, a following bare NEWLINE is the blank-line separator.
+            // Container continuations do not appear as bare NEWLINE here: they start
+            // with quote/list continuation tokens first, so this only fires for
+            // paragraph breaks.
+            if after_hard_break {
+                break;
+            }
             if matches!(
                 handle_inline_newline(p, has_content),
                 InlineNewlineAction::Break
@@ -1134,14 +1142,11 @@ pub(crate) fn parse_inline_item_list(p: &mut MarkdownParser) {
         if parsed.is_absent() {
             break;
         }
-        let after_hard_break = matches!(&parsed, Present(cm) if cm.kind(p) == MD_HARD_LINE);
+        after_hard_break = matches!(&parsed, Present(cm) if cm.kind(p) == MD_HARD_LINE);
 
         // Per CommonMark §6.7: after a hard line break, leading spaces on the
         // next line are ignored. Consume as whitespace trivia (structural).
-        if after_hard_break
-            && p.at(MD_TEXTUAL_LITERAL)
-            && p.cur_text().chars().all(|c| c == ' ' || c == '\t')
-        {
+        if after_hard_break {
             while p.at(MD_TEXTUAL_LITERAL) && p.cur_text().chars().all(|c| c == ' ' || c == '\t') {
                 p.consume_as_whitespace_trivia();
             }

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break_paragraph_split.html
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break_paragraph_split.html
@@ -1,0 +1,4 @@
+<p>foo<br />
+bar with empty line after</p>
+<p>foo<br />
+bar without empty line after</p>

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break_paragraph_split.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break_paragraph_split.md
@@ -1,0 +1,5 @@
+foo  
+bar with empty line after  
+
+foo  
+bar without empty line after  

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break_paragraph_split.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break_paragraph_split.md.snap
@@ -1,0 +1,97 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```
+foo  
+bar with empty line after  
+
+foo  
+bar without empty line after  
+```
+
+
+## AST
+
+```
+MdDocument {
+    bom_token: missing (optional),
+    value: MdBlockList [
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@0..3 "foo" [] [],
+                },
+                MdHardLine {
+                    value_token: MD_HARD_LINE_LITERAL@3..6 "  \n" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@6..31 "bar with empty line after" [] [],
+                },
+                MdHardLine {
+                    value_token: MD_HARD_LINE_LITERAL@31..34 "  \n" [] [],
+                },
+            ],
+            hard_line: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@34..35 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@35..38 "foo" [] [],
+                },
+                MdHardLine {
+                    value_token: MD_HARD_LINE_LITERAL@38..41 "  \n" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@41..69 "bar without empty line after" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@69..71 "  " [] [],
+                },
+            ],
+            hard_line: missing (optional),
+        },
+    ],
+    eof_token: EOF@71..71 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_DOCUMENT@0..71
+  0: (empty)
+  1: MD_BLOCK_LIST@0..71
+    0: MD_PARAGRAPH@0..34
+      0: MD_INLINE_ITEM_LIST@0..34
+        0: MD_TEXTUAL@0..3
+          0: MD_TEXTUAL_LITERAL@0..3 "foo" [] []
+        1: MD_HARD_LINE@3..6
+          0: MD_HARD_LINE_LITERAL@3..6 "  \n" [] []
+        2: MD_TEXTUAL@6..31
+          0: MD_TEXTUAL_LITERAL@6..31 "bar with empty line after" [] []
+        3: MD_HARD_LINE@31..34
+          0: MD_HARD_LINE_LITERAL@31..34 "  \n" [] []
+      1: (empty)
+    1: MD_NEWLINE@34..35
+      0: NEWLINE@34..35 "\n" [] []
+    2: MD_PARAGRAPH@35..71
+      0: MD_INLINE_ITEM_LIST@35..71
+        0: MD_TEXTUAL@35..38
+          0: MD_TEXTUAL_LITERAL@35..38 "foo" [] []
+        1: MD_HARD_LINE@38..41
+          0: MD_HARD_LINE_LITERAL@38..41 "  \n" [] []
+        2: MD_TEXTUAL@41..69
+          0: MD_TEXTUAL_LITERAL@41..69 "bar without empty line after" [] []
+        3: MD_TEXTUAL@69..71
+          0: MD_TEXTUAL_LITERAL@69..71 "  " [] []
+      1: (empty)
+  2: EOF@71..71 "" [] []
+
+```


### PR DESCRIPTION
> [!NOTE]
> This PR was created with AI assistance (Claude Code).

## Summary

Fixes #9857.

When a paragraph ends with a hard line break (`  \n`) followed by a blank line and another paragraph, the parser incorrectly merged both paragraphs into a single `MD_PARAGRAPH` node. The root cause: `MD_HARD_LINE_LITERAL` already consumes the line-ending newline, so the following `NEWLINE` token *is* the blank-line separator, but the existing inline loop did not recognize it as a paragraph boundary.

The fix hoists `after_hard_break` state across loop iterations and breaks the paragraph when a bare `NEWLINE` follows a hard line break. Container continuations (blockquotes, list items) are unaffected because their continuation tokens (`>`, indent) appear before any `NEWLINE`.

Also simplifies the adjacent whitespace-trivia consumption by removing a redundant outer guard.

## Test Plan

- `just test-crate biome_markdown_parser`
- `just test-markdown-conformance`
- `just test-crate biome_markdown_formatter`
- `just lint`

## Docs

N/A