### PR TITLE
fix(markdown_parser): mixed bullet markers and lazy continuation in lists

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -515,9 +515,17 @@ impl ParseNodeList for BulletList {
         // Check blank line at line start with indent awareness BEFORE
         // delegating to is_at_list_end_common (which uses non-indent-aware check).
         if p.at_line_start() && at_blank_line_start(p) {
-            let result = !has_bullet_item_after_blank_lines_at_indent(p, marker_indent);
-
-            return result;
+            let has_item = has_bullet_item_after_blank_lines_at_indent(p, marker_indent);
+            if !has_item {
+                return true;
+            }
+            // Per CommonMark §5.3, a change in bullet marker across a blank line
+            // starts a new list — even when the first item's content was a heading,
+            // thematic break, setext heading, or fenced code block.
+            if marker_changes_after_blank_lines(p, self.marker_kind) {
+                return true;
+            }
+            return false;
         }
 
         is_at_list_end_common(
@@ -2156,10 +2164,21 @@ fn check_continuation_indent(
     let indent = line_indent_from_current(p);
 
     if indent < state.marker_indent {
-        return ContinuationResult {
-            action: LoopAction::Break,
-            restore: VirtualLineRestore::None,
-        };
+        // Below the marker indent. Lazy continuation is still allowed for
+        // plain-text lines per CommonMark §5.2; list item starts and block
+        // interrupts must break.
+        let can_lazy = state.last_block_was_paragraph
+            && !at_bullet_list_item_with_base_indent(p, 0)
+            && !at_order_list_item_with_base_indent(p, 0)
+            && !at_block_interrupt(p);
+        if !can_lazy {
+            return ContinuationResult {
+                action: LoopAction::Break,
+                restore: VirtualLineRestore::None,
+            };
+        }
+        // Fall through: the insufficient-indent branch below handles the
+        // lazy continuation emit.
     }
 
     if indent >= state.required_indent {

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/header_in_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/header_in_list.md.snap
@@ -144,12 +144,16 @@ MdDocument {
                         },
                     ],
                 },
-                MdNewline {
-                    value_token: NEWLINE@39..40 "\n" [] [],
-                },
-                MdNewline {
-                    value_token: NEWLINE@40..41 "\n" [] [],
-                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@39..40 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@40..41 "\n" [] [],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
@@ -175,14 +179,18 @@ MdDocument {
                             },
                             after: MdHashList [],
                         },
-                        MdNewline {
-                            value_token: NEWLINE@54..55 "\n" [] [],
-                        },
                     ],
                 },
-                MdNewline {
-                    value_token: NEWLINE@55..56 "\n" [] [],
-                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@54..55 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@55..56 "\n" [] [],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
@@ -330,8 +338,8 @@ MdDocument {
 0: MD_DOCUMENT@0..138
   0: (empty)
   1: MD_BLOCK_LIST@0..138
-    0: MD_BULLET_LIST_ITEM@0..93
-      0: MD_BULLET_LIST@0..93
+    0: MD_BULLET_LIST_ITEM@0..39
+      0: MD_BULLET_LIST@0..39
         0: MD_BULLET@0..8
           0: MD_LIST_MARKER_PREFIX@0..2
             0: MD_INDENT_TOKEN_LIST@0..0
@@ -405,17 +413,19 @@ MdDocument {
                     0: MD_TEXTUAL_LITERAL@31..39 " Level 2" [] []
                 1: (empty)
               3: MD_HASH_LIST@39..39
-        3: MD_NEWLINE@39..40
-          0: NEWLINE@39..40 "\n" [] []
-        4: MD_NEWLINE@40..41
-          0: NEWLINE@40..41 "\n" [] []
-        5: MD_BULLET@41..55
+    1: MD_NEWLINE@39..40
+      0: NEWLINE@39..40 "\n" [] []
+    2: MD_NEWLINE@40..41
+      0: NEWLINE@40..41 "\n" [] []
+    3: MD_BULLET_LIST_ITEM@41..54
+      0: MD_BULLET_LIST@41..54
+        0: MD_BULLET@41..54
           0: MD_LIST_MARKER_PREFIX@41..43
             0: MD_INDENT_TOKEN_LIST@41..41
             1: STAR@41..42 "*" [] []
             2: MD_LIST_POST_MARKER_SPACE@42..43 " " [] []
             3: MD_INDENT_TOKEN_LIST@43..43
-          1: MD_BLOCK_LIST@43..55
+          1: MD_BLOCK_LIST@43..54
             0: MD_HEADER@43..54
               0: MD_INDENT_TOKEN_LIST@43..43
               1: MD_HASH_LIST@43..46
@@ -427,11 +437,13 @@ MdDocument {
                     0: MD_TEXTUAL_LITERAL@46..54 " Level 3" [] []
                 1: (empty)
               3: MD_HASH_LIST@54..54
-            1: MD_NEWLINE@54..55
-              0: NEWLINE@54..55 "\n" [] []
-        6: MD_NEWLINE@55..56
-          0: NEWLINE@55..56 "\n" [] []
-        7: MD_BULLET@56..73
+    4: MD_NEWLINE@54..55
+      0: NEWLINE@54..55 "\n" [] []
+    5: MD_NEWLINE@55..56
+      0: NEWLINE@55..56 "\n" [] []
+    6: MD_BULLET_LIST_ITEM@56..93
+      0: MD_BULLET_LIST@56..93
+        0: MD_BULLET@56..73
           0: MD_LIST_MARKER_PREFIX@56..58
             0: MD_INDENT_TOKEN_LIST@56..56
             1: MINUS@56..57 "-" [] []
@@ -451,9 +463,9 @@ MdDocument {
               3: MD_HASH_LIST@72..72
             1: MD_NEWLINE@72..73
               0: NEWLINE@72..73 "\n" [] []
-        8: MD_NEWLINE@73..74
+        1: MD_NEWLINE@73..74
           0: NEWLINE@73..74 "\n" [] []
-        9: MD_BULLET@74..93
+        2: MD_BULLET@74..93
           0: MD_LIST_MARKER_PREFIX@74..76
             0: MD_INDENT_TOKEN_LIST@74..74
             1: MINUS@74..75 "-" [] []
@@ -473,11 +485,11 @@ MdDocument {
               3: MD_HASH_LIST@91..93
                 0: MD_HASH@91..93
                   0: HASH@91..93 "#" [Whitespace(" ")] []
-    1: MD_NEWLINE@93..94
+    7: MD_NEWLINE@93..94
       0: NEWLINE@93..94 "\n" [] []
-    2: MD_NEWLINE@94..95
+    8: MD_NEWLINE@94..95
       0: NEWLINE@94..95 "\n" [] []
-    3: MD_ORDERED_LIST_ITEM@95..137
+    9: MD_ORDERED_LIST_ITEM@95..137
       0: MD_BULLET_LIST@95..137
         0: MD_BULLET@95..116
           0: MD_LIST_MARKER_PREFIX@95..98
@@ -517,7 +529,7 @@ MdDocument {
                     0: MD_TEXTUAL_LITERAL@121..137 " Ordered level 2" [] []
                 1: (empty)
               3: MD_HASH_LIST@137..137
-    4: MD_NEWLINE@137..138
+    10: MD_NEWLINE@137..138
       0: NEWLINE@137..138 "\n" [] []
   2: EOF@138..138 "" [] []
 

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/thematic_break_in_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/thematic_break_in_list.md.snap
@@ -120,12 +120,16 @@ MdDocument {
                         },
                     ],
                 },
-                MdNewline {
-                    value_token: NEWLINE@21..22 "\n" [] [],
-                },
-                MdNewline {
-                    value_token: NEWLINE@22..23 "\n" [] [],
-                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@21..22 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@22..23 "\n" [] [],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
@@ -147,14 +151,18 @@ MdDocument {
                                 },
                             ],
                         },
-                        MdNewline {
-                            value_token: NEWLINE@28..29 "\n" [] [],
-                        },
                     ],
                 },
-                MdNewline {
-                    value_token: NEWLINE@29..30 "\n" [] [],
-                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@28..29 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@29..30 "\n" [] [],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
@@ -340,8 +348,8 @@ MdDocument {
       0: NEWLINE@14..15 "\n" [] []
     5: MD_NEWLINE@15..16
       0: NEWLINE@15..16 "\n" [] []
-    6: MD_BULLET_LIST_ITEM@16..62
-      0: MD_BULLET_LIST@16..62
+    6: MD_BULLET_LIST_ITEM@16..21
+      0: MD_BULLET_LIST@16..21
         0: MD_BULLET@16..21
           0: MD_LIST_MARKER_PREFIX@16..18
             0: MD_INDENT_TOKEN_LIST@16..16
@@ -357,17 +365,19 @@ MdDocument {
                   0: UNDERSCORE@19..20 "_" [] []
                 2: MD_THEMATIC_BREAK_CHAR@20..21
                   0: UNDERSCORE@20..21 "_" [] []
-        1: MD_NEWLINE@21..22
-          0: NEWLINE@21..22 "\n" [] []
-        2: MD_NEWLINE@22..23
-          0: NEWLINE@22..23 "\n" [] []
-        3: MD_BULLET@23..29
+    7: MD_NEWLINE@21..22
+      0: NEWLINE@21..22 "\n" [] []
+    8: MD_NEWLINE@22..23
+      0: NEWLINE@22..23 "\n" [] []
+    9: MD_BULLET_LIST_ITEM@23..28
+      0: MD_BULLET_LIST@23..28
+        0: MD_BULLET@23..28
           0: MD_LIST_MARKER_PREFIX@23..25
             0: MD_INDENT_TOKEN_LIST@23..23
             1: STAR@23..24 "*" [] []
             2: MD_LIST_POST_MARKER_SPACE@24..25 " " [] []
             3: MD_INDENT_TOKEN_LIST@25..25
-          1: MD_BLOCK_LIST@25..29
+          1: MD_BLOCK_LIST@25..28
             0: MD_THEMATIC_BREAK_BLOCK@25..28
               0: MD_THEMATIC_BREAK_PART_LIST@25..28
                 0: MD_THEMATIC_BREAK_CHAR@25..26
@@ -376,11 +386,13 @@ MdDocument {
                   0: MINUS@26..27 "-" [] []
                 2: MD_THEMATIC_BREAK_CHAR@27..28
                   0: MINUS@27..28 "-" [] []
-            1: MD_NEWLINE@28..29
-              0: NEWLINE@28..29 "\n" [] []
-        4: MD_NEWLINE@29..30
-          0: NEWLINE@29..30 "\n" [] []
-        5: MD_BULLET@30..37
+    10: MD_NEWLINE@28..29
+      0: NEWLINE@28..29 "\n" [] []
+    11: MD_NEWLINE@29..30
+      0: NEWLINE@29..30 "\n" [] []
+    12: MD_BULLET_LIST_ITEM@30..62
+      0: MD_BULLET_LIST@30..62
+        0: MD_BULLET@30..37
           0: MD_LIST_MARKER_PREFIX@30..32
             0: MD_INDENT_TOKEN_LIST@30..30
             1: MINUS@30..31 "-" [] []
@@ -399,9 +411,9 @@ MdDocument {
                   0: STAR@35..36 "*" [] []
             1: MD_NEWLINE@36..37
               0: NEWLINE@36..37 "\n" [] []
-        6: MD_NEWLINE@37..38
+        1: MD_NEWLINE@37..38
           0: NEWLINE@37..38 "\n" [] []
-        7: MD_BULLET@38..45
+        2: MD_BULLET@38..45
           0: MD_LIST_MARKER_PREFIX@38..40
             0: MD_INDENT_TOKEN_LIST@38..38
             1: MINUS@38..39 "-" [] []
@@ -420,9 +432,9 @@ MdDocument {
                   0: UNDERSCORE@43..44 "_" [] []
             1: MD_NEWLINE@44..45
               0: NEWLINE@44..45 "\n" [] []
-        8: MD_NEWLINE@45..46
+        3: MD_NEWLINE@45..46
           0: NEWLINE@45..46 "\n" [] []
-        9: MD_BULLET@46..54
+        4: MD_BULLET@46..54
           0: MD_LIST_MARKER_PREFIX@46..48
             0: MD_INDENT_TOKEN_LIST@46..46
             1: MINUS@46..47 "-" [] []
@@ -443,9 +455,9 @@ MdDocument {
                   0: STAR@52..53 "*" [] []
             1: MD_NEWLINE@53..54
               0: NEWLINE@53..54 "\n" [] []
-        10: MD_NEWLINE@54..55
+        5: MD_NEWLINE@54..55
           0: NEWLINE@54..55 "\n" [] []
-        11: MD_BULLET@55..62
+        6: MD_BULLET@55..62
           0: MD_LIST_MARKER_PREFIX@55..57
             0: MD_INDENT_TOKEN_LIST@55..55
             1: MINUS@55..56 "-" [] []
@@ -464,7 +476,7 @@ MdDocument {
                   0: UNDERSCORE@60..61 "_" [] []
                 4: MD_THEMATIC_BREAK_CHAR@61..62
                   0: UNDERSCORE@61..62 "_" [] []
-    7: MD_NEWLINE@62..63
+    13: MD_NEWLINE@62..63
       0: NEWLINE@62..63 "\n" [] []
   2: EOF@63..63 "" [] []
 

--- a/crates/biome_markdown_parser/tests/spec_test.rs
+++ b/crates/biome_markdown_parser/tests/spec_test.rs
@@ -393,4 +393,154 @@ pub fn quick_test() {
         "* item one\n\n- item two\n",
         "<ul>\n<li>item one</li>\n</ul>\n<ul>\n<li>item two</li>\n</ul>\n",
     );
+
+    // Fuzzer: mixed markers after heading-in-list — 3 markers
+    test_example(
+        30001,
+        "- # Bar\n\n+ item one\n\n* item two\n",
+        "<ul>\n<li>\n<h1>Bar</h1>\n</li>\n</ul>\n<ul>\n<li>item one</li>\n</ul>\n<ul>\n<li>item two</li>\n</ul>\n",
+    );
+    // Reduce: heading in list then different marker
+    test_example(
+        30011,
+        "- # Bar\n\n+ item\n",
+        "<ul>\n<li>\n<h1>Bar</h1>\n</li>\n</ul>\n<ul>\n<li>item</li>\n</ul>\n",
+    );
+    // Reduce: paragraph in list then different marker (should work like 10006)
+    test_example(
+        30012,
+        "- bar\n\n+ item\n",
+        "<ul>\n<li>bar</li>\n</ul>\n<ul>\n<li>item</li>\n</ul>\n",
+    );
+    // Reduce: thematic break in list then different marker
+    // NOTE: `- ---` is a pre-existing Biome bug where it parses as a top-level
+    // thematic break instead of a list item containing <hr />.
+    test_example(
+        30013,
+        "- ---\n\n+ item\n",
+        "<hr />\n<ul>\n<li>item</li>\n</ul>\n",
+    );
+    // Reduce: setext heading in list then different marker
+    test_example(
+        30014,
+        "- Foo\n  ---\n\n+ item\n",
+        "<ul>\n<li>\n<h2>Foo</h2>\n</li>\n</ul>\n<ul>\n<li>item</li>\n</ul>\n",
+    );
+
+    // Fuzzer: lazy continuation with trailing paragraph
+    test_example(
+        30002,
+        "- outer\n  * nested\n  lazy line\nhello\n",
+        "<ul>\n<li>outer\n<ul>\n<li>nested\nlazy line\nhello</li>\n</ul>\n</li>\n</ul>\n",
+    );
+
+    // Fuzzer: fenced code after list not absorbed
+    test_example(
+        30003,
+        "* one\n* two\n```\ncode here\n```\n",
+        "<ul>\n<li>one</li>\n<li>two</li>\n</ul>\n<pre><code>code here\n</code></pre>\n",
+    );
+
+    // Fuzzer: mixed markers after fenced code in list item
+    test_example(
+        30004,
+        "- item\n\n  ```\n  code\n  ```\n\n+ other\n",
+        "<ul>\n<li>\n<p>item</p>\n<pre><code>code\n</code></pre>\n</li>\n</ul>\n<ul>\n<li>other</li>\n</ul>\n",
+    );
+
+    // Fuzzer: lazy continuation absorbs following non-indented line
+    test_example(
+        30005,
+        "- outer\n  - nested\n  lazy line\nhello\n",
+        "<ul>\n<li>outer\n<ul>\n<li>nested\nlazy line\nhello</li>\n</ul>\n</li>\n</ul>\n",
+    );
+}
+
+fn fuzz_test_example(num: u32, input: &str, expected: &str) {
+    let root = parse_markdown(input);
+    let doc =
+        MdDocument::cast(root.syntax()).unwrap_or_else(|| panic!("Fuzz {:03}: parse failed", num));
+    let html = document_to_html(
+        &doc,
+        root.list_tightness(),
+        root.list_item_indents(),
+        root.quote_indents(),
+    );
+    similar_asserts::assert_eq!(expected, html, "Fuzz {:03} failed\nInput: {:?}", num, input);
+}
+
+#[test]
+fn fuzz_mixed_markers_heading() {
+    fuzz_test_example(
+        1,
+        "- # Bar\n\n+ item\n",
+        "<ul>\n<li>\n<h1>Bar</h1>\n</li>\n</ul>\n<ul>\n<li>item</li>\n</ul>\n",
+    );
+}
+
+#[test]
+fn fuzz_mixed_markers_paragraph() {
+    fuzz_test_example(
+        2,
+        "- bar\n\n+ item\n",
+        "<ul>\n<li>bar</li>\n</ul>\n<ul>\n<li>item</li>\n</ul>\n",
+    );
+}
+
+/// NOTE: `- ---` is parsed by Biome as a top-level thematic break rather than
+/// a list item containing `<hr />`. This is a separate pre-existing bug
+/// (thematic break precedence over list marker) unrelated to the mixed-marker
+/// list-split fix. The expected value here matches Biome's current behavior.
+#[test]
+fn fuzz_mixed_markers_thematic_break() {
+    fuzz_test_example(
+        3,
+        "- ---\n\n+ item\n",
+        "<hr />\n<ul>\n<li>item</li>\n</ul>\n",
+    );
+}
+
+#[test]
+fn fuzz_mixed_markers_setext() {
+    fuzz_test_example(
+        4,
+        "- Foo\n  ---\n\n+ item\n",
+        "<ul>\n<li>\n<h2>Foo</h2>\n</li>\n</ul>\n<ul>\n<li>item</li>\n</ul>\n",
+    );
+}
+
+#[test]
+fn fuzz_mixed_markers_fenced_code() {
+    fuzz_test_example(
+        5,
+        "- item\n\n  ```\n  code\n  ```\n\n+ other\n",
+        "<ul>\n<li>\n<p>item</p>\n<pre><code>code\n</code></pre>\n</li>\n</ul>\n<ul>\n<li>other</li>\n</ul>\n",
+    );
+}
+
+#[test]
+fn fuzz_lazy_cont_nested_trailing() {
+    fuzz_test_example(
+        6,
+        "- outer\n  * nested\n  lazy line\nhello\n",
+        "<ul>\n<li>outer\n<ul>\n<li>nested\nlazy line\nhello</li>\n</ul>\n</li>\n</ul>\n",
+    );
+}
+
+#[test]
+fn fuzz_lazy_cont_nested_same_marker() {
+    fuzz_test_example(
+        7,
+        "- outer\n  - nested\n  lazy line\nhello\n",
+        "<ul>\n<li>outer\n<ul>\n<li>nested\nlazy line\nhello</li>\n</ul>\n</li>\n</ul>\n",
+    );
+}
+
+#[test]
+fn fuzz_code_after_list_not_absorbed() {
+    fuzz_test_example(
+        8,
+        "* one\n* two\n```\ncode here\n```\n",
+        "<ul>\n<li>one</li>\n<li>two</li>\n</ul>\n<pre><code>code here\n</code></pre>\n",
+    );
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was created with AI assistance (Claude Code).

## Summary

Two fixes in `crates/biome_markdown_parser/src/syntax/list.rs`:

1. **Mixed bullet markers don't split lists after non-paragraph content.** `BulletList::is_at_list_end` had an early return that checked `has_bullet_item_after_blank_lines_at_indent` without checking whether the bullet marker changed. After headings, setext headings, and fenced code blocks, the item loop broke at a blank-introducing NEWLINE that hit this path, so `- # H\n\n+ x` merged into one `<ul>` instead of two. Added `marker_changes_after_blank_lines` to the early return.

2. **Lazy continuation lines not absorbed into nested list items.** `check_continuation_indent` returned `Break` unconditionally when `indent < marker_indent`, preventing lazy continuation below the marker column. Per CommonMark §5.2, `- a\n  - b\n  lazy\nhello` should keep `hello` inside the nested item. Now checks for lazy eligibility before breaking.

Note: `- ---` is a pre-existing markdown parser bug where it parses as a top-level thematic break instead of a list item containing `<hr />`; not addressed here.

## Test Plan

- `just test-crate biome_markdown_parser`
- `just test-markdown-conformance`
- 8 targeted fuzz regression tests added to `spec_test.rs`
- 2 CST snapshots updated (`header_in_list.md`, `thematic_break_in_list.md`)

## Docs

N/A