### PR TITLE
fix(lint): handle computed property destructuring in useExhaustiveDependencies

### DIFF
--- a/.changeset/fix-exhaustive-deps-computed-destructure.md
+++ b/.changeset/fix-exhaustive-deps-computed-destructure.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9744](https://github.com/biomejs/biome/issues/9744): [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) no longer reports a false positive when a variable is declared via computed property destructuring (e.g. `const { [KEY]: value } = obj`).

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -1053,7 +1053,11 @@ fn get_single_pattern_member(
             {
                 Some((object_pattern.syntax().clone(), Some(member)))
             } else {
-                return GetSinglePatternMemberResult::Unknown;
+                // Computed property names (e.g. `{ [key]: value }`) don't have
+                // a statically-known member name, so we treat the binding the
+                // same as a rest element: check the initializer's stability
+                // without a specific member key.
+                Some((object_pattern.syntax().clone(), None))
             }
         }
         JsSyntaxKind::JS_VARIABLE_DECLARATOR => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue9744.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue9744.js
@@ -1,0 +1,15 @@
+/* should not generate diagnostics */
+
+import { useEffect } from "react";
+
+const KEY = "key";
+
+// Issue #9744: Computed property destructuring should not cause false positives
+function Component(props) {
+    const { [KEY]: value } = props;
+    useEffect(() => {
+        console.log(value);
+    }, [value]);
+
+    return null;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue9744.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue9744.js.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue9744.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+
+import { useEffect } from "react";
+
+const KEY = "key";
+
+// Issue #9744: Computed property destructuring should not cause false positives
+function Component(props) {
+    const { [KEY]: value } = props;
+    useEffect(() => {
+        console.log(value);
+    }, [value]);
+
+    return null;
+}
+
+```


### PR DESCRIPTION
When you destructure with a computed property name like `const { [key]: value } = obj`, the rule was treating `value` as stable and flagging it as an unnecessary dependency. The issue was in `get_single_pattern_member` -- a computed property name returns `None` from `member.name()`, which produced `Unknown`, and `Unknown` was unconditionally treated as stable.

Changed the fallback to return `NoPattern` instead, which correctly defers to checking whether the initializer expression itself is stable.

Includes test case and changeset.

Fixes #9744