### PR TITLE
feat(js-api): add spanInBytesToSpanInCodeUnits in subpath exports

### DIFF
--- a/.changeset/add-span-conversion-helper-in-subpath.md
+++ b/.changeset/add-span-conversion-helper-in-subpath.md
@@ -1,0 +1,18 @@
+---
+"@biomejs/js-api": minor
+---
+
+Added `spanInBytesToSpanInCodeUnits` helper function in subpath exports of `@biomejs/js-api`.
+
+```js
+import { spanInBytesToSpanInCodeUnits } from "@biomejs/js-api/nodejs";
+// Or:
+// import { spanInBytesToSpanInCodeUnits } from "@biomejs/js-api/bundler";
+// import { spanInBytesToSpanInCodeUnits } from "@biomejs/js-api/web";
+
+const [start, end] = spanInBytesToSpanInCodeUnits(
+    diagnostic.location.span,
+    content
+);
+const text = content.slice(start, end); // Correctly extracts the text
+```

--- a/packages/@biomejs/js-api/README.md
+++ b/packages/@biomejs/js-api/README.md
@@ -22,8 +22,8 @@ You need to install one of the `@biomejs/wasm-*` package as a **peer dependency*
 ```js
 import { Biome } from "@biomejs/js-api/nodejs";
 // Or:
-// import { Biome, Distribution } from "@biomejs/js-api/bundler";
-// import { Biome, Distribution } from "@biomejs/js-api/web";
+// import { Biome } from "@biomejs/js-api/bundler";
+// import { Biome } from "@biomejs/js-api/web";
 
 const biome = new Biome();
 const { projectKey } = biome.openProject("path/to/project/dir");
@@ -51,6 +51,21 @@ const html = biome.printDiagnostics(result.diagnostics, {
 });
 
 console.log("Lint diagnostics: ", html);
+```
+
+If you want to work with diagnostics in your program, you can use the `spanInBytesToSpanInCodeUnits` helper function to convert byte-based segments from Biome diagnostics into UTF-16 code unit segments (used in JavaScript).
+
+```js
+import { Biome, spanInBytesToSpanInCodeUnits } from "@biomejs/js-api/nodejs";
+
+for (const diagnostic of result.diagnostics) {
+  const [start, end] = spanInBytesToSpanInCodeUnits(
+    diagnostic.location.span,
+    formatted.content,
+  );
+  // Correctly extracts the text
+  const text = formatted.content.slice(start, end);
+}
 ```
 
 ## Philosophy

--- a/packages/@biomejs/js-api/src/bundler.ts
+++ b/packages/@biomejs/js-api/src/bundler.ts
@@ -3,6 +3,7 @@ import * as moduleBundler from "@biomejs/wasm-bundler";
 import { BiomeCommon } from "./common";
 
 export type * from "./common";
+export { spanInBytesToSpanInCodeUnits } from "./common";
 export type { Configuration, Diagnostic };
 
 export class Biome extends BiomeCommon<Configuration, Diagnostic> {

--- a/packages/@biomejs/js-api/src/nodejs.ts
+++ b/packages/@biomejs/js-api/src/nodejs.ts
@@ -3,6 +3,7 @@ import * as moduleNodeJs from "@biomejs/wasm-nodejs";
 import { BiomeCommon } from "./common";
 
 export type * from "./common";
+export { spanInBytesToSpanInCodeUnits } from "./common";
 export type { Configuration, Diagnostic };
 
 export class Biome extends BiomeCommon<Configuration, Diagnostic> {

--- a/packages/@biomejs/js-api/src/web.ts
+++ b/packages/@biomejs/js-api/src/web.ts
@@ -3,6 +3,7 @@ import * as moduleWeb from "@biomejs/wasm-web";
 import { BiomeCommon } from "./common";
 
 export type * from "./common";
+export { spanInBytesToSpanInCodeUnits } from "./common";
 export type { Configuration, Diagnostic };
 
 export class Biome extends BiomeCommon<Configuration, Diagnostic> {


### PR DESCRIPTION
## Summary

Export the new `spanInBytesToSpanInCodeUnits` function (issue https://github.com/biomejs/biome/issues/4035 / PR https://github.com/biomejs/biome/pull/8944 / release [v6.0.0](https://github.com/biomejs/biome/releases/tag/%40biomejs%2Fjs-api%406.0.0)) to the [subpath exports](https://github.com/biomejs/biome/blob/3b334c05a7f6c5614e4046bb7e4363a98107081d/packages/%40biomejs/js-api/package.json#L36-L47) of the `@biomejs/js-api` package.

The goal is to have the same exports in both the main and the subpaths.

## Test Plan

n/a

## Docs

n/a