### PR TITLE
fix(useConsistentTestIt): fix panic when applying code fix

### DIFF
--- a/.changeset/fair-otters-count.md
+++ b/.changeset/fair-otters-count.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9918](https://github.com/biomejs/biome/issues/9918): [`useConsistentTestIt`](https://biomejs.dev/linter/rules/use-consistent-test-it/) no longer panics when applying fixes to chained calls such as `test.for([])("x", () => {});`.

--- a/.changeset/sad-buttons-kneel.md
+++ b/.changeset/sad-buttons-kneel.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the safe fix for [`noSkippedTests`](https://biomejs.dev/linter/rules/no-skipped-tests/) so it no longer panics when rewriting skipped test function names such as `xit()`, `xtest()`, and `xdescribe()`.

--- a/.changeset/tidy-bags-draw.md
+++ b/.changeset/tidy-bags-draw.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the safe fix for [`noFocusedTests`](https://biomejs.dev/linter/rules/no-focused-tests/) so it no longer panics when rewriting focused test function names such as `fit()` and `fdescribe()`.

--- a/.claude/skills/changeset/SKILL.md
+++ b/.claude/skills/changeset/SKILL.md
@@ -25,6 +25,8 @@ Note that the file will *not* be literally empty. It will have this content:
 ---
 ```
 
+Do not simply append to the changeset description below the existing content, which creates an invalid changeset.
+
 > Requires `pnpm` — run `pnpm i` from repo root first.
 
 ## Choose the Correct Change Type

--- a/crates/biome_js_analyze/src/lint/nursery/use_consistent_test_it.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_consistent_test_it.rs
@@ -373,8 +373,7 @@ fn rename_base_identifier(
     mutation: &mut BatchMutation<JsLanguage>,
 ) -> Option<()> {
     let base = get_base_identifier(callee)?;
-    let new_ref = make::js_reference_identifier(make::ident(new_name.as_str()));
-    mutation.replace_element(base.into(), new_ref.into());
+    mutation.replace_token(base, make::ident(new_name.as_str()));
     Some(())
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
@@ -296,20 +296,17 @@ fn fix_function_name_pattern(
     match name {
         FDESCRIBE_KEYWORD => {
             // Replace fdescribe with describe
-            let replaced_function = make::js_reference_identifier(make::ident("describe"));
-            mutation.replace_element(function_name.into(), replaced_function.into());
+            mutation.replace_token(function_name, make::ident("describe"));
             Some(())
         }
         FIT_KEYWORD => {
             // Replace fit with it
-            let replaced_function = make::js_reference_identifier(make::ident("it"));
-            mutation.replace_element(function_name.into(), replaced_function.into());
+            mutation.replace_token(function_name, make::ident("it"));
             Some(())
         }
         "ftest" => {
             // Replace ftest with test
-            let replaced_function = make::js_reference_identifier(make::ident("test"));
-            mutation.replace_element(function_name.into(), replaced_function.into());
+            mutation.replace_token(function_name, make::ident("test"));
             Some(())
         }
         _ => None,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
@@ -137,16 +137,16 @@ impl Rule for NoSkippedTests {
                     )?;
                 }
                 "xdescribe" => {
-                    replaced_function = make::js_reference_identifier(make::ident("describe"));
-                    mutation.replace_element(function_name.into(), replaced_function.into());
+                    replaced_function = make::ident("describe");
+                    mutation.replace_token(function_name, replaced_function);
                 }
                 "xit" => {
-                    replaced_function = make::js_reference_identifier(make::ident("it"));
-                    mutation.replace_element(function_name.into(), replaced_function.into());
+                    replaced_function = make::ident("it");
+                    mutation.replace_token(function_name, replaced_function);
                 }
                 "xtest" => {
-                    replaced_function = make::js_reference_identifier(make::ident("test"));
-                    mutation.replace_element(function_name.into(), replaced_function.into());
+                    replaced_function = make::ident("test");
+                    mutation.replace_token(function_name, replaced_function);
                 }
                 _ => {}
             }

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentTestIt/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentTestIt/invalid.js
@@ -7,6 +7,7 @@ test.skip("foo", () => {});
 test.only("foo", () => {});
 test.concurrent("foo", () => {});
 test.each([])(foo, () => {});
+test.for([])("foo", () => {});
 xtest("foo", () => {});
 fit("foo", () => {});
 

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentTestIt/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentTestIt/invalid.js.snap
@@ -13,6 +13,7 @@ test.skip("foo", () => {});
 test.only("foo", () => {});
 test.concurrent("foo", () => {});
 test.each([])(foo, () => {});
+test.for([])("foo", () => {});
 xtest("foo", () => {});
 fit("foo", () => {});
 
@@ -120,7 +121,7 @@ invalid.js:8:1 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━�
    > 8 │ test.concurrent("foo", () => {});
        │ ^^^^
      9 │ test.each([])(foo, () => {});
-    10 │ xtest("foo", () => {});
+    10 │ test.for([])("foo", () => {});
   
   i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
   
@@ -133,7 +134,7 @@ invalid.js:8:1 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━�
      8    │ - test.concurrent("foo",·()·=>·{});
         8 │ + it.concurrent("foo",·()·=>·{});
      9  9 │   test.each([])(foo, () => {});
-    10 10 │   xtest("foo", () => {});
+    10 10 │   test.for([])("foo", () => {});
   
 
 ```
@@ -147,8 +148,8 @@ invalid.js:9:1 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━�
      8 │ test.concurrent("foo", () => {});
    > 9 │ test.each([])(foo, () => {});
        │ ^^^^
-    10 │ xtest("foo", () => {});
-    11 │ fit("foo", () => {});
+    10 │ test.for([])("foo", () => {});
+    11 │ xtest("foo", () => {});
   
   i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
   
@@ -160,8 +161,8 @@ invalid.js:9:1 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━�
      8  8 │   test.concurrent("foo", () => {});
      9    │ - test.each([])(foo,·()·=>·{});
         9 │ + it.each([])(foo,·()·=>·{});
-    10 10 │   xtest("foo", () => {});
-    11 11 │   fit("foo", () => {});
+    10 10 │   test.for([])("foo", () => {});
+    11 11 │   xtest("foo", () => {});
   
 
 ```
@@ -169,70 +170,14 @@ invalid.js:9:1 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━�
 ```
 invalid.js:10:1 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The test function xtest is inconsistent with the configured preferred function xit.
+  ! The test function test is inconsistent with the configured preferred function it.
   
      8 │ test.concurrent("foo", () => {});
      9 │ test.each([])(foo, () => {});
-  > 10 │ xtest("foo", () => {});
-       │ ^^^^^
-    11 │ fit("foo", () => {});
-    12 │ 
-  
-  i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
-  
-  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
-  
-  i Safe fix: Use xit instead.
-  
-     8  8 │   test.concurrent("foo", () => {});
-     9  9 │   test.each([])(foo, () => {});
-    10    │ - xtest("foo",·()·=>·{});
-       10 │ + xit("foo",·()·=>·{});
-    11 11 │   fit("foo", () => {});
-    12 12 │   
-  
-
-```
-
-```
-invalid.js:11:1 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The test function fit is inconsistent with the configured preferred function it.only.
-  
-     9 │ test.each([])(foo, () => {});
-    10 │ xtest("foo", () => {});
-  > 11 │ fit("foo", () => {});
-       │ ^^^
-    12 │ 
-    13 │ // Inside describe, should also use it() (default withinDescribe="it")
-  
-  i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
-  
-  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
-  
-  i Safe fix: Use it.only instead.
-  
-     9  9 │   test.each([])(foo, () => {});
-    10 10 │   xtest("foo", () => {});
-    11    │ - fit("foo",·()·=>·{});
-       11 │ + it.only("foo",·()·=>·{});
-    12 12 │   
-    13 13 │   // Inside describe, should also use it() (default withinDescribe="it")
-  
-
-```
-
-```
-invalid.js:15:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The test function test is inconsistent with the configured preferred function it.
-  
-    13 │ // Inside describe, should also use it() (default withinDescribe="it")
-    14 │ describe("suite", () => {
-  > 15 │   test("foo", () => {});
-       │   ^^^^
-    16 │   test.skip("foo", () => {});
-    17 │   test.only("foo", () => {});
+  > 10 │ test.for([])("foo", () => {});
+       │ ^^^^
+    11 │ xtest("foo", () => {});
+    12 │ fit("foo", () => {});
   
   i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
   
@@ -240,12 +185,68 @@ invalid.js:15:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━
   
   i Safe fix: Use it instead.
   
-    13 13 │   // Inside describe, should also use it() (default withinDescribe="it")
-    14 14 │   describe("suite", () => {
-    15    │ - ··test("foo",·()·=>·{});
-       15 │ + ··it("foo",·()·=>·{});
-    16 16 │     test.skip("foo", () => {});
-    17 17 │     test.only("foo", () => {});
+     8  8 │   test.concurrent("foo", () => {});
+     9  9 │   test.each([])(foo, () => {});
+    10    │ - test.for([])("foo",·()·=>·{});
+       10 │ + it.for([])("foo",·()·=>·{});
+    11 11 │   xtest("foo", () => {});
+    12 12 │   fit("foo", () => {});
+  
+
+```
+
+```
+invalid.js:11:1 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The test function xtest is inconsistent with the configured preferred function xit.
+  
+     9 │ test.each([])(foo, () => {});
+    10 │ test.for([])("foo", () => {});
+  > 11 │ xtest("foo", () => {});
+       │ ^^^^^
+    12 │ fit("foo", () => {});
+    13 │ 
+  
+  i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Use xit instead.
+  
+     9  9 │   test.each([])(foo, () => {});
+    10 10 │   test.for([])("foo", () => {});
+    11    │ - xtest("foo",·()·=>·{});
+       11 │ + xit("foo",·()·=>·{});
+    12 12 │   fit("foo", () => {});
+    13 13 │   
+  
+
+```
+
+```
+invalid.js:12:1 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The test function fit is inconsistent with the configured preferred function it.only.
+  
+    10 │ test.for([])("foo", () => {});
+    11 │ xtest("foo", () => {});
+  > 12 │ fit("foo", () => {});
+       │ ^^^
+    13 │ 
+    14 │ // Inside describe, should also use it() (default withinDescribe="it")
+  
+  i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Use it.only instead.
+  
+    10 10 │   test.for([])("foo", () => {});
+    11 11 │   xtest("foo", () => {});
+    12    │ - fit("foo",·()·=>·{});
+       12 │ + it.only("foo",·()·=>·{});
+    13 13 │   
+    14 14 │   // Inside describe, should also use it() (default withinDescribe="it")
   
 
 ```
@@ -255,12 +256,12 @@ invalid.js:16:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━
 
   ! The test function test is inconsistent with the configured preferred function it.
   
-    14 │ describe("suite", () => {
-    15 │   test("foo", () => {});
-  > 16 │   test.skip("foo", () => {});
+    14 │ // Inside describe, should also use it() (default withinDescribe="it")
+    15 │ describe("suite", () => {
+  > 16 │   test("foo", () => {});
        │   ^^^^
-    17 │   test.only("foo", () => {});
-    18 │   fit("foo", () => {});
+    17 │   test.skip("foo", () => {});
+    18 │   test.only("foo", () => {});
   
   i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
   
@@ -268,12 +269,12 @@ invalid.js:16:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━
   
   i Safe fix: Use it instead.
   
-    14 14 │   describe("suite", () => {
-    15 15 │     test("foo", () => {});
-    16    │ - ··test.skip("foo",·()·=>·{});
-       16 │ + ··it.skip("foo",·()·=>·{});
-    17 17 │     test.only("foo", () => {});
-    18 18 │     fit("foo", () => {});
+    14 14 │   // Inside describe, should also use it() (default withinDescribe="it")
+    15 15 │   describe("suite", () => {
+    16    │ - ··test("foo",·()·=>·{});
+       16 │ + ··it("foo",·()·=>·{});
+    17 17 │     test.skip("foo", () => {});
+    18 18 │     test.only("foo", () => {});
   
 
 ```
@@ -283,12 +284,12 @@ invalid.js:17:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━
 
   ! The test function test is inconsistent with the configured preferred function it.
   
-    15 │   test("foo", () => {});
-    16 │   test.skip("foo", () => {});
-  > 17 │   test.only("foo", () => {});
+    15 │ describe("suite", () => {
+    16 │   test("foo", () => {});
+  > 17 │   test.skip("foo", () => {});
        │   ^^^^
-    18 │   fit("foo", () => {});
-    19 │ });
+    18 │   test.only("foo", () => {});
+    19 │   fit("foo", () => {});
   
   i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
   
@@ -296,12 +297,12 @@ invalid.js:17:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━
   
   i Safe fix: Use it instead.
   
-    15 15 │     test("foo", () => {});
-    16 16 │     test.skip("foo", () => {});
-    17    │ - ··test.only("foo",·()·=>·{});
-       17 │ + ··it.only("foo",·()·=>·{});
-    18 18 │     fit("foo", () => {});
-    19 19 │   });
+    15 15 │   describe("suite", () => {
+    16 16 │     test("foo", () => {});
+    17    │ - ··test.skip("foo",·()·=>·{});
+       17 │ + ··it.skip("foo",·()·=>·{});
+    18 18 │     test.only("foo", () => {});
+    19 19 │     fit("foo", () => {});
   
 
 ```
@@ -309,14 +310,42 @@ invalid.js:17:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━
 ```
 invalid.js:18:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! The test function test is inconsistent with the configured preferred function it.
+  
+    16 │   test("foo", () => {});
+    17 │   test.skip("foo", () => {});
+  > 18 │   test.only("foo", () => {});
+       │   ^^^^
+    19 │   fit("foo", () => {});
+    20 │ });
+  
+  i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Use it instead.
+  
+    16 16 │     test("foo", () => {});
+    17 17 │     test.skip("foo", () => {});
+    18    │ - ··test.only("foo",·()·=>·{});
+       18 │ + ··it.only("foo",·()·=>·{});
+    19 19 │     fit("foo", () => {});
+    20 20 │   });
+  
+
+```
+
+```
+invalid.js:19:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   ! The test function fit is inconsistent with the configured preferred function it.only.
   
-    16 │   test.skip("foo", () => {});
-    17 │   test.only("foo", () => {});
-  > 18 │   fit("foo", () => {});
+    17 │   test.skip("foo", () => {});
+    18 │   test.only("foo", () => {});
+  > 19 │   fit("foo", () => {});
        │   ^^^
-    19 │ });
-    20 │ 
+    20 │ });
+    21 │ 
   
   i Using a consistent function for tests improves readability and makes it easier to search for tests in the codebase.
   
@@ -324,12 +353,12 @@ invalid.js:18:3 lint/nursery/useConsistentTestIt  FIXABLE  ━━━━━━━
   
   i Safe fix: Use it.only instead.
   
-    16 16 │     test.skip("foo", () => {});
-    17 17 │     test.only("foo", () => {});
-    18    │ - ··fit("foo",·()·=>·{});
-       18 │ + ··it.only("foo",·()·=>·{});
-    19 19 │   });
-    20 20 │   
+    17 17 │     test.skip("foo", () => {});
+    18 18 │     test.only("foo", () => {});
+    19    │ - ··fit("foo",·()·=>·{});
+       19 │ + ··it.only("foo",·()·=>·{});
+    20 20 │   });
+    21 21 │   
   
 
 ```

--- a/crates/biome_rowan/src/ast/batch.rs
+++ b/crates/biome_rowan/src/ast/batch.rs
@@ -102,6 +102,81 @@ impl<L> BatchMutation<L>
 where
     L: Language,
 {
+    #[cfg(debug_assertions)]
+    fn debug_assert_slot_compatibility(
+        parent: Option<&SyntaxNode<L>>,
+        slot_index: usize,
+        prev_element: &SyntaxElement<L>,
+        next_element: Option<&SyntaxElement<L>>,
+    ) {
+        let Some(parent) = parent else {
+            return;
+        };
+
+        let Some(slot) = parent.slots().nth(slot_index) else {
+            debug_assert!(
+                false,
+                "batch mutation targeted missing slot {slot_index} in parent kind {:?}: {parent:?}",
+                parent.kind()
+            );
+            return;
+        };
+
+        let prev_is_node = matches!(prev_element, SyntaxElement::Node(_));
+        let prev_kind = match prev_element {
+            SyntaxElement::Node(node) => format!("{:?}", node.kind()),
+            SyntaxElement::Token(token) => format!("{:?}", token.kind()),
+        };
+        let slot_is_node = matches!(slot, SyntaxSlot::Node(_));
+        let slot_is_token = matches!(slot, SyntaxSlot::Token(_));
+        let slot_kind = match &slot {
+            SyntaxSlot::Node(node) => Some(format!("{:?}", node.kind())),
+            SyntaxSlot::Token(token) => Some(format!("{:?}", token.kind())),
+            SyntaxSlot::Empty { .. } => None,
+        };
+
+        debug_assert!(
+            (prev_is_node && slot_is_node) || (!prev_is_node && slot_is_token),
+            "batch mutation targeted a {} {:?} in slot {slot_index} of parent kind {:?}, but the current slot contains a {} {:?}: {parent:?}",
+            if prev_is_node { "node" } else { "token" },
+            prev_kind,
+            parent.kind(),
+            match &slot {
+                SyntaxSlot::Node(_) => "node",
+                SyntaxSlot::Token(_) => "token",
+                SyntaxSlot::Empty { .. } => "missing element",
+            },
+            slot_kind
+        );
+
+        let Some(next_element) = next_element else {
+            return;
+        };
+
+        let next_kind = match next_element {
+            SyntaxElement::Node(node) => format!("{:?}", node.kind()),
+            SyntaxElement::Token(token) => format!("{:?}", token.kind()),
+        };
+
+        debug_assert!(
+            matches!(
+                (prev_element, next_element),
+                (SyntaxElement::Node(_), SyntaxElement::Node(_))
+                    | (SyntaxElement::Token(_), SyntaxElement::Token(_))
+            ),
+            "batch mutation attempted to replace a {} {:?} with a {} {:?} in parent kind {:?}; use the matching token/node replacement API",
+            if prev_is_node { "node" } else { "token" },
+            prev_kind,
+            if matches!(next_element, SyntaxElement::Node(_)) {
+                "node"
+            } else {
+                "token"
+            },
+            next_kind,
+            parent.kind()
+        );
+    }
+
     pub fn new(root: SyntaxNode<L>) -> Self {
         Self {
             root,
@@ -368,6 +443,13 @@ where
     ) {
         let new_node_slot = prev_element.index();
         let parent = prev_element.parent();
+        #[cfg(debug_assertions)]
+        Self::debug_assert_slot_compatibility(
+            parent.as_ref(),
+            new_node_slot,
+            &prev_element,
+            next_element.as_ref(),
+        );
         let parent_range: Option<(u32, u32)> = parent.as_ref().map(|p| {
             let range = p.text_range_with_trivia();
             (range.start().into(), range.end().into())


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The rule was using the wrong method to replace the token, which caused the panic.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #9918

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added debug assertions to the batch mutation API, so snapshot tests will be able to detect it now
tested manually on the repro

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
