### PR TITLE
fix(cli): escape backslashes in JSON reporter path output

### DIFF
--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -109,7 +109,9 @@ fn location_report_to_json(location: &LocationReport) -> AnyJsonValue {
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("path"))),
             token(T![:]),
-            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&location.path))),
+            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&json_escape(
+                &location.path,
+            )))),
         ),
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("start"))),


### PR DESCRIPTION
## Summary

Fixes #9899

On Windows, the JSON reporter emits diagnostic paths with unescaped backslashes, producing invalid JSON:

```json
"path": "typescript\src\account\setup-passkey.tsx"
```

The `json_escape()` helper already exists and is applied to `message` and `suggestion.text`, but the `path` field in `location_report_to_json` was missed.

## Fix

One-line change: wrap `location.path` with `json_escape()` before passing it to `json_string_literal()`.

## Test Plan

The fix uses the same escaping function (`json_escape`) already tested via the message and suggestion fields. The backslash case only manifests on Windows where path separators are backslashes.