### PR TITLE
feat(lint/html): port noExcessiveLinesPerFile to html

### DIFF
--- a/.changeset/gentle-stars-do.md
+++ b/.changeset/gentle-stars-do.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added HTML support for [`noExcessiveLinesPerFile`](https://biomejs.dev/linter/rules/no-excessive-lines-per-file/). Biome now reports HTML files that exceed the configured line limit, including when `skipBlankLines` is enabled.

--- a/crates/biome_console/src/fmt.rs
+++ b/crates/biome_console/src/fmt.rs
@@ -1,4 +1,12 @@
-use std::{borrow::Cow, fmt, io, time::Duration};
+use std::{
+    borrow::Cow,
+    fmt, io,
+    num::{
+        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroU8,
+        NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
+    },
+    time::Duration,
+};
 
 pub use crate::write::{HTML, Termcolor, Write};
 use crate::{Markup, MarkupElement, markup};
@@ -211,6 +219,18 @@ impl_std_display!(u32);
 impl_std_display!(u64);
 impl_std_display!(u128);
 impl_std_display!(usize);
+impl_std_display!(NonZeroI8);
+impl_std_display!(NonZeroI16);
+impl_std_display!(NonZeroI32);
+impl_std_display!(NonZeroI64);
+impl_std_display!(NonZeroI128);
+impl_std_display!(NonZeroIsize);
+impl_std_display!(NonZeroU8);
+impl_std_display!(NonZeroU16);
+impl_std_display!(NonZeroU32);
+impl_std_display!(NonZeroU64);
+impl_std_display!(NonZeroU128);
+impl_std_display!(NonZeroUsize);
 
 impl Display for Duration {
     fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {

--- a/crates/biome_css_analyze/src/lint/nursery/no_excessive_lines_per_file.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_excessive_lines_per_file.rs
@@ -93,7 +93,7 @@ impl Rule for NoExcessiveLinesPerFile {
                 rule_category!(),
                 node.range(),
                 markup! {
-                    "This file has too many lines ("{state}"). Maximum allowed is "{options.max_lines().to_string()}"."
+                    "This file has too many lines ("{state}"). Maximum allowed is "{options.max_lines()}"."
                 },
             )
             .note(markup! {

--- a/crates/biome_html_analyze/src/lint/nursery/no_excessive_lines_per_file.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/no_excessive_lines_per_file.rs
@@ -2,7 +2,7 @@ use biome_analyze::{
     Ast, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule, utils::count_lines_in_file,
 };
 use biome_console::markup;
-use biome_graphql_syntax::{GraphqlRoot, GraphqlSyntaxKind};
+use biome_html_syntax::{HtmlRoot, HtmlSyntaxKind};
 use biome_rowan::AstNode;
 use biome_rule_options::no_excessive_lines_per_file::NoExcessiveLinesPerFileOptions;
 
@@ -25,17 +25,17 @@ declare_lint_rule! {
     ///     }
     /// }
     /// ```
-    /// ```graphql,expect_diagnostic,use_options
-    /// query Foo { id }
-    /// query Bar { id }
-    /// query Baz { id }
+    /// ```html,expect_diagnostic,use_options
+    /// <div></div>
+    /// <span></span>
+    /// <p></p>
     /// ```
     ///
     /// ### Valid
     ///
-    /// ```graphql
-    /// query Foo { id }
-    /// query Bar { id }
+    /// ```html
+    /// <div></div>
+    /// <span></span>
     /// ```
     ///
     /// ## Options
@@ -47,22 +47,82 @@ declare_lint_rule! {
     ///
     /// Default: `300`
     ///
+    /// #### Examples
+    ///
+    /// The default value for `maxLines` is `300`. The following example shows how to set the
+    /// `maxLines` option to a smaller value. It reports a diagnostic because the file has more
+    /// than 4 lines:
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "maxLines": 4
+    ///     }
+    /// }
+    /// ```
+    /// ```html,expect_diagnostic,use_options
+    /// <div>Line 1</div>
+    /// <div>Line 2</div>
+    /// <div>Line 3</div>
+    /// <div>Line 4</div>
+    /// <div>Line 5</div>
+    /// ```
+    ///
     /// ### `skipBlankLines`
     ///
     /// When this option is set to `true`, blank lines are not counted towards the maximum line limit.
     ///
     /// Default: `false`
     ///
+    /// #### Examples
+    ///
+    /// The following example shows how `skipBlankLines` can prevent a diagnostic by excluding blank
+    /// lines from the total count:
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "maxLines": 2,
+    ///         "skipBlankLines": true
+    ///     }
+    /// }
+    /// ```
+    /// ```html,use_options
+    /// <div></div>
+    ///
+    ///
+    /// <span></span>
+    /// ```
+    ///
+    /// ## Suppressions
+    ///
+    /// If you need to exceed the line limit in a specific file, you can suppress this rule
+    /// at the top of the file:
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "maxLines": 2
+    ///     }
+    /// }
+    /// ```
+    /// ```html,use_options
+    /// <!-- biome-ignore lint/nursery/noExcessiveLinesPerFile: generated file -->
+    /// <div></div>
+    /// <span></span>
+    /// <p></p>
+    /// ```
+    ///
     pub NoExcessiveLinesPerFile {
-        version: "2.3.12",
+        version: "next",
         name: "noExcessiveLinesPerFile",
-        language: "graphql",
+        language: "html",
         recommended: false,
     }
 }
 
 impl Rule for NoExcessiveLinesPerFile {
-    type Query = Ast<GraphqlRoot>;
+    type Query = Ast<HtmlRoot>;
     type State = usize;
     type Signals = Option<Self::State>;
     type Options = NoExcessiveLinesPerFileOptions;
@@ -73,7 +133,7 @@ impl Rule for NoExcessiveLinesPerFile {
 
         let file_lines_count = count_lines_in_file(
             node.syntax(),
-            |token| token.kind() == GraphqlSyntaxKind::EOF,
+            |token| token.kind() == HtmlSyntaxKind::EOF,
             options.skip_blank_lines(),
         );
 

--- a/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalid.html
@@ -1,0 +1,4 @@
+<!-- should generate diagnostics -->
+<div></div>
+<span></span>
+<p></p>

--- a/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalid.html.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+assertion_line: 77
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<div></div>
+<span></span>
+<p></p>
+
+```
+
+# Diagnostics
+```
+invalid.html:2:1 lint/nursery/noExcessiveLinesPerFile ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This file has too many lines (4). Maximum allowed is 2.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <div></div>
+      │ ^^^^^^^^^^^
+  > 3 │ <span></span>
+  > 4 │ <p></p>
+      │ ^^^^^^^
+    5 │ 
+  
+  i Consider splitting this file into smaller files.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalid.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noExcessiveLinesPerFile": {
+          "level": "error",
+          "options": {
+            "maxLines": 2
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalidSkipBlankLines.html
+++ b/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalidSkipBlankLines.html
@@ -1,0 +1,5 @@
+<!-- should generate diagnostics -->
+<div></div>
+
+<span></span>
+<p></p>

--- a/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalidSkipBlankLines.html.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalidSkipBlankLines.html.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+assertion_line: 77
+expression: invalidSkipBlankLines.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<div></div>
+
+<span></span>
+<p></p>
+
+```
+
+# Diagnostics
+```
+invalidSkipBlankLines.html:2:1 lint/nursery/noExcessiveLinesPerFile ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This file has too many lines (4). Maximum allowed is 2.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <div></div>
+      │ ^^^^^^^^^^^
+  > 3 │ 
+  > 4 │ <span></span>
+  > 5 │ <p></p>
+      │ ^^^^^^^
+    6 │ 
+  
+  i Consider splitting this file into smaller files.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalidSkipBlankLines.options.json
+++ b/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/invalidSkipBlankLines.options.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noExcessiveLinesPerFile": {
+          "level": "error",
+          "options": {
+            "maxLines": 2,
+            "skipBlankLines": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/valid.html
+++ b/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/valid.html
@@ -1,0 +1,3 @@
+<!-- should not generate diagnostics -->
+<div></div>
+<span></span>

--- a/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/valid.html.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+assertion_line: 77
+expression: valid.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<div></div>
+<span></span>
+
+```

--- a/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/nursery/noExcessiveLinesPerFile/valid.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noExcessiveLinesPerFile": {
+          "level": "error",
+          "options": {
+            "maxLines": 3
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/src/lint/complexity/no_excessive_lines_per_function.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_excessive_lines_per_function.rs
@@ -191,7 +191,7 @@ impl Rule for NoExcessiveLinesPerFunction {
                 rule_category!(),
                 node.range(),
                 markup! {
-                    "This function has too many lines ("{state.function_lines_count}"). Maximum allowed is "{options.max_lines().to_string()}"."
+                    "This function has too many lines ("{state.function_lines_count}"). Maximum allowed is "{options.max_lines()}"."
                 },
             )
             .note(markup! {

--- a/crates/biome_js_analyze/src/lint/nursery/no_excessive_lines_per_file.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_excessive_lines_per_file.rs
@@ -150,7 +150,7 @@ impl Rule for NoExcessiveLinesPerFile {
                 rule_category!(),
                 node.range(),
                 markup! {
-                    "This file has too many lines ("{state}"). Maximum allowed is "{options.max_lines().to_string()}"."
+                    "This file has too many lines ("{state}"). Maximum allowed is "{options.max_lines()}"."
                 },
             )
             .note(markup! {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This ports the noExcessiveLinesPerFile rule to HTML.

Also tried to reduce some string allocations in the other implementations.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
