### PR TITLE
fix(cli): normalize path separators to forward slashes in JSON reporters on Windows

### DIFF
--- a/.changeset/cool-rivers-flow.md
+++ b/.changeset/cool-rivers-flow.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fix `--reporter=json` and `--reporter=rdjson` producing invalid JSON on Windows due to unescaped backslashes in file paths. Path separators are now normalized to forward slashes in JSON output, making the output consistent across platforms.

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -23,6 +23,12 @@ fn json_escape(input: &str) -> String {
         .replace('\x0C', "\\f")
 }
 
+/// Normalizes path separators to forward slashes for cross-platform JSON output.
+/// On Windows, paths use backslashes which are not valid unescaped in JSON strings.
+fn normalize_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct JsonReporterVisitor {
     summary: TraversalSummary,
@@ -109,7 +115,9 @@ fn location_report_to_json(location: &LocationReport) -> AnyJsonValue {
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("path"))),
             token(T![:]),
-            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&location.path))),
+            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(
+                &normalize_path(&location.path),
+            ))),
         ),
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("start"))),

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -441,3 +441,45 @@ impl Visit for SuggestionsVisitor {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_path;
+
+    #[test]
+    fn normalize_path_converts_windows_backslashes() {
+        assert_eq!(
+            normalize_path("typescript\\src\\account\\setup-passkey.tsx"),
+            "typescript/src/account/setup-passkey.tsx"
+        );
+    }
+
+    #[test]
+    fn normalize_path_leaves_unix_paths_unchanged() {
+        assert_eq!(
+            normalize_path("src/components/App.tsx"),
+            "src/components/App.tsx"
+        );
+    }
+
+    #[test]
+    fn normalize_path_handles_mixed_separators() {
+        assert_eq!(
+            normalize_path("src\\components/App.tsx"),
+            "src/components/App.tsx"
+        );
+    }
+
+    #[test]
+    fn normalize_path_handles_empty_string() {
+        assert_eq!(normalize_path(""), "");
+    }
+
+    #[test]
+    fn normalize_path_handles_root_windows_path() {
+        assert_eq!(
+            normalize_path("C:\\Users\\user\\project\\file.ts"),
+            "C:/Users/user/project/file.ts"
+        );
+    }
+}

--- a/crates/biome_cli/src/reporter/rdjson.rs
+++ b/crates/biome_cli/src/reporter/rdjson.rs
@@ -122,7 +122,8 @@ fn to_rdjson_location(location: &Location<'_>) -> Option<RdJsonLocation> {
     let start = source.location(span.start()).ok()?;
     let end = source.location(span.end()).ok()?;
     Some(RdJsonLocation {
-        path: resource.to_string(),
+        // Normalize path separators to forward slashes for consistent JSON output across platforms
+        path: resource.to_string().replace('\\', "/"),
         range: Some(RdJsonRange {
             start: RdJsonLineColumn {
                 column: start.column_number.get(),


### PR DESCRIPTION
## Summary

Fixes #9899

On Windows, file paths use backslashes (`\`). The `--reporter=json` and `--reporter=rdjson` outputs included raw backslashes in the `path` field, producing **invalid JSON** because backslashes are escape characters in JSON strings.

### Root cause

In `json.rs`, the `location_report_to_json` function passed `location.path` directly to `json_string_literal` without escaping. While the file already had a `json_escape` helper (used for `message` and `suggestion.text`), it was not applied to `path`.

### Fix

Normalize path separators to forward slashes before serialization in both reporters:

```rust
// Before
path: resource.to_string()

// After  
path: resource.to_string().replace('\\', "/")
```

This approach:
- Produces **valid JSON** on Windows
- Makes output **consistent across platforms** (always forward slashes)
- Matches the first expected result from the issue reporter

### Files changed

- `crates/biome_cli/src/reporter/json.rs` — added `normalize_path()` helper, applied to `location.path` in `location_report_to_json`
- `crates/biome_cli/src/reporter/rdjson.rs` — same normalization applied to `path` in `to_rdjson_location`

### Before / After

**Before** (invalid JSON on Windows):
```json
{
  "location": {
    "path": "typescript\src\account\setup-passkey.tsx"
  }
}
```

**After** (valid, platform-consistent):
```json
{
  "location": {
    "path": "typescript/src/account/setup-passkey.tsx"
  }
}
```
