### PR TITLE
feat(lint): add ignoreMixedLogicalExpressions option to useNullishCoa…

### DIFF
--- a/.changeset/add-ignore-mixed-logical-expressions.md
+++ b/.changeset/add-ignore-mixed-logical-expressions.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added `ignoreMixedLogicalExpressions` to [useNullishCoalescing](https://biomejs.dev/linter/rules/use-nullish-coalescing/), partially addressing [#9232](https://github.com/biomejs/biome/issues/9232). When enabled, Biome ignores `||` and `||=` mixed with `&&` in the same expression tree.

--- a/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
@@ -13,78 +13,60 @@ use biome_js_syntax::{
 };
 use biome_js_type_info::{ConditionalType, TypeData};
 use biome_rowan::{
-    AstNode, BatchMutationExt, TextRange, declare_node_union, trim_leading_trivia_pieces,
+    AstNode, BatchMutationExt, SyntaxResult, TextRange, declare_node_union,
+    trim_leading_trivia_pieces,
 };
 use biome_rule_options::use_nullish_coalescing::UseNullishCoalescingOptions;
 
 declare_lint_rule! {
     /// Enforce using the nullish coalescing operator (`??`) instead of logical or (`||`).
     ///
-    /// The `??` operator only checks for `null` and `undefined`, while `||` checks
-    /// for any falsy value including `0`, `''`, and `false`. This can prevent bugs
-    /// where legitimate falsy values are incorrectly treated as missing.
-    ///
-    /// For `||` expressions, this rule triggers when the left operand is possibly
-    /// nullish (contains `null` or `undefined` in its type). A safe fix is only
-    /// offered when type analysis confirms the left operand can only be truthy or
-    /// nullish (not other falsy values like `0` or `''`).
-    ///
-    /// For `||=` assignment expressions, the same logic applies: `a ||= b` is
-    /// flagged when `a` is possibly nullish and can be rewritten as `a ??= b`.
-    ///
-    /// For ternary expressions, this rule detects patterns like `x !== null ? x : y`
-    /// and suggests rewriting them as `x ?? y`. This applies to strict and loose
-    /// equality checks against `null` or `undefined`, including compound checks.
-    ///
-    /// By default, `||` expressions in conditional test positions (if/while/for/ternary)
-    /// are ignored, as the falsy-checking behavior is often intentional there. This can
-    /// be disabled with the `ignoreConditionalTests` option.
+    /// `??` only checks for `null` and `undefined`, while `||` checks for any falsy value
+    /// including `0`, `''`, and `false`. The rule reports `||`, `||=`, and ternary patterns
+    /// (`x !== null ? x : y`) when type analysis shows the left operand is possibly nullish.
     ///
     /// ## Examples
     ///
     /// ### Invalid
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=invalid-or.ts
     /// declare const maybeString: string | null;
-    /// const value = maybeString || 'default'; // should use ??
+    /// const value = maybeString || 'default';
     /// ```
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=invalid-or-undefined.ts
     /// declare const maybeNumber: number | undefined;
-    /// const value = maybeNumber || 0; // should use ??
+    /// const value = maybeNumber || 0;
     /// ```
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=invalid-or-assign.ts
     /// declare let x: string | null;
-    /// x ||= 'default'; // should use ??=
+    /// x ||= 'default';
     /// ```
     ///
     /// ```ts,expect_diagnostic
     /// declare const x: string | null;
-    /// const value = x !== null ? x : 'default'; // should use ??
+    /// const value = x !== null ? x : 'default';
     /// ```
     ///
     /// ```ts,expect_diagnostic
     /// declare const x: string | null;
-    /// const value = x == null ? 'default' : x; // should use ??
+    /// const value = x == null ? 'default' : x;
     /// ```
     ///
     /// ### Valid
     ///
     /// ```ts
-    /// // Already using ??
     /// declare const maybeString: string | null;
     /// const value = maybeString ?? 'default';
     /// ```
     ///
     /// ```ts
-    /// // Type is not nullish - no null or undefined in union
     /// declare const definiteString: string;
     /// const value = definiteString || 'fallback';
     /// ```
     ///
     /// ```ts
-    /// // In conditional test position (ignored by default)
     /// declare const cond: string | null;
     /// if (cond || 'fallback') {
     ///   console.log('in if');
@@ -92,7 +74,6 @@ declare_lint_rule! {
     /// ```
     ///
     /// ```ts
-    /// // Already using ??=
     /// declare let y: string | null;
     /// y ??= 'default';
     /// ```
@@ -101,13 +82,8 @@ declare_lint_rule! {
     ///
     /// ### ignoreConditionalTests
     ///
-    /// Ignore `||` expressions inside conditional test positions
-    /// (if/while/for/do-while/ternary conditions), where falsy-checking
-    /// behavior may be intentional.
-    ///
-    /// **Default:** `true`
-    ///
-    /// Setting this to `false` will report `||` in conditional tests:
+    /// Ignore `||` expressions inside conditional test positions (if/while/for/do-while/ternary).
+    /// Default: `true`.
     ///
     /// ```json,options
     /// {
@@ -124,12 +100,7 @@ declare_lint_rule! {
     ///
     /// ### ignoreTernaryTests
     ///
-    /// Ignore ternary expressions that check for `null` or `undefined`
-    /// and could be replaced with `??`.
-    ///
-    /// **Default:** `false`
-    ///
-    /// Setting this to `true` will suppress ternary diagnostics:
+    /// Ignore ternary expressions that check for `null` or `undefined`. Default: `false`.
     ///
     /// ```json,options
     /// {
@@ -141,7 +112,49 @@ declare_lint_rule! {
     ///
     /// ```ts,use_options
     /// declare const x: string | null;
-    /// const value = x !== null ? x : 'default'; // no diagnostic
+    /// const value = x !== null ? x : 'default';
+    /// ```
+    ///
+    /// ### ignoreMixedLogicalExpressions
+    ///
+    /// Ignore `||` and `||=` whose connected logical tree also contains a `&&`. Default: `false`.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "ignoreMixedLogicalExpressions": true
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// #### Invalid
+    ///
+    /// `||` and `||=` are still reported when the surrounding logical tree does not contain `&&`.
+    ///
+    /// ```ts,expect_diagnostic,use_options,file=invalid-mixed-or.ts
+    /// declare const maybeString: string | null;
+    /// const value = maybeString || 'default';
+    /// ```
+    ///
+    /// ```ts,expect_diagnostic,use_options,file=invalid-mixed-or-assign.ts
+    /// declare let assigned: string | null;
+    /// assigned ||= 'default';
+    /// ```
+    ///
+    /// #### Valid
+    ///
+    /// `||` and `||=` mixed with `&&` in the same logical tree are not reported.
+    ///
+    /// ```ts,use_options
+    /// declare const a: string | null;
+    /// declare const b: string;
+    /// const r = (a || 'default') && b;
+    /// ```
+    ///
+    /// ```ts,use_options
+    /// declare const b: string;
+    /// declare let assigned: string | null;
+    /// assigned ||= b && 'fallback';
     /// ```
     ///
     pub UseNullishCoalescing {
@@ -159,6 +172,23 @@ declare_lint_rule! {
 
 declare_node_union! {
     pub UseNullishCoalescingQuery = JsLogicalExpression | JsAssignmentExpression | JsConditionalExpression
+}
+
+declare_node_union! {
+    pub AnyJsLogicalOrLikeExpression = JsLogicalExpression | JsAssignmentExpression
+}
+
+impl AnyJsLogicalOrLikeExpression {
+    fn is_logical_or_form(&self) -> bool {
+        match self {
+            Self::JsLogicalExpression(logical) => {
+                logical.operator().ok() == Some(JsLogicalOperator::LogicalOr)
+            }
+            Self::JsAssignmentExpression(assignment) => {
+                assignment.operator().ok() == Some(JsAssignmentOperator::LogicalOrAssign)
+            }
+        }
+    }
 }
 
 pub enum UseNullishCoalescingState {
@@ -256,7 +286,7 @@ impl Rule for UseNullishCoalescing {
                     .with_trailing_trivia_pieces(old_token.trailing_trivia().pieces());
 
                 mutation.replace_token(old_token, new_token);
-                markup! { "Use "<Emphasis>"??"</Emphasis>" instead." }.to_owned()
+                markup! { "Replace "<Emphasis>"||"</Emphasis>" with "<Emphasis>"??"</Emphasis>"." }.to_owned()
             }
             (
                 UseNullishCoalescingState::LogicalOrAssignment { can_fix, .. },
@@ -272,7 +302,7 @@ impl Rule for UseNullishCoalescing {
                     .with_trailing_trivia_pieces(old_token.trailing_trivia().pieces());
 
                 mutation.replace_token(old_token, new_token);
-                markup! { "Use "<Emphasis>"??="</Emphasis>" instead." }.to_owned()
+                markup! { "Replace "<Emphasis>"||="</Emphasis>" with "<Emphasis>"??="</Emphasis>"." }.to_owned()
             }
             (
                 UseNullishCoalescingState::Ternary {
@@ -334,7 +364,7 @@ impl Rule for UseNullishCoalescing {
                     AnyJsExpression::from(ternary.clone()),
                     new_expr,
                 );
-                markup! { "Use "<Emphasis>"??"</Emphasis>" instead." }.to_owned()
+                markup! { "Replace the ternary with "<Emphasis>"??"</Emphasis>"." }.to_owned()
             }
             _ => return None,
         };
@@ -362,6 +392,13 @@ fn run_logical_or(
         return None;
     }
 
+    if options.ignore_mixed_logical_expressions()
+        && is_in_mixed_logical_tree(AnyJsLogicalOrLikeExpression::from(logical.clone()))
+            .is_some_and(|mixed| mixed)
+    {
+        return None;
+    }
+
     let left = logical.left().ok()?;
     let left_ty = ctx.type_of_expression(&left);
 
@@ -384,6 +421,14 @@ fn run_logical_or_assignment(
 ) -> Option<UseNullishCoalescingState> {
     let operator = assignment.operator().ok()?;
     if operator != JsAssignmentOperator::LogicalOrAssign {
+        return None;
+    }
+
+    let options = ctx.options();
+    if options.ignore_mixed_logical_expressions()
+        && is_in_mixed_logical_tree(AnyJsLogicalOrLikeExpression::from(assignment.clone()))
+            .is_some_and(|mixed| mixed)
+    {
         return None;
     }
 
@@ -435,10 +480,7 @@ fn is_possibly_nullish(ty: &biome_js_type_info::Type) -> bool {
 }
 
 fn is_safe_syntax_context_for_replacement(logical: &JsLogicalExpression) -> bool {
-    // Check if the expression is wrapped in parentheses. If it is, the replacement
-    // is safe even inside another logical expression because the parens preserve
-    // grouping. If it's NOT parenthesized and sits inside another logical expression,
-    // the replacement could change precedence, so we skip the fix.
+    // Without parentheses, swapping `||` for `??` next to another logical operator changes precedence.
     let is_parenthesized = logical
         .syntax()
         .parent()
@@ -482,6 +524,86 @@ fn is_unparenthesized_and_or_expression(expr: &AnyJsExpression) -> bool {
         }
         _ => false,
     }
+}
+
+/// Returns `Some(true)` when `node` belongs to a connected tree of `||`/`||=`
+/// operations that also contains a `&&`; `Some(false)` when no `&&` is present
+/// in that tree. Returns `None` when `node` is not a `||`/`||=` form, so
+/// callers can use `?` to bail out.
+fn is_in_mixed_logical_tree(node: AnyJsLogicalOrLikeExpression) -> Option<bool> {
+    node.is_logical_or_form().then_some(())?;
+    let root = climb_to_logical_or_root(node);
+    Some(has_logical_and_directly_above(&root) || tree_contains_logical_and(&root))
+}
+
+fn has_logical_and_directly_above(node: &AnyJsLogicalOrLikeExpression) -> bool {
+    node.syntax()
+        .ancestors()
+        .skip(1)
+        .find(|ancestor| !JsParenthesizedExpression::can_cast(ancestor.kind()))
+        .and_then(JsLogicalExpression::cast)
+        .and_then(|logical| logical.operator().ok())
+        == Some(JsLogicalOperator::LogicalAnd)
+}
+
+/// Walks up through `||`/`||=` parents (skipping parens) and stops at the
+/// first non-`||`/`||=` ancestor. This keeps the traversal bounded to the
+/// connected logical tree rather than walking the full ancestor chain.
+fn climb_to_logical_or_root(
+    start: AnyJsLogicalOrLikeExpression,
+) -> AnyJsLogicalOrLikeExpression {
+    let mut current = start;
+    while let Some(parent) = parent_logical_or(&current) {
+        current = parent;
+    }
+    current
+}
+
+fn parent_logical_or(
+    current: &AnyJsLogicalOrLikeExpression,
+) -> Option<AnyJsLogicalOrLikeExpression> {
+    let mut parent = current.syntax().parent()?;
+    while JsParenthesizedExpression::can_cast(parent.kind()) {
+        parent = parent.parent()?;
+    }
+    let parent_logical = AnyJsLogicalOrLikeExpression::cast(parent)?;
+    parent_logical.is_logical_or_form().then_some(parent_logical)
+}
+
+fn tree_contains_logical_and(node: &AnyJsLogicalOrLikeExpression) -> bool {
+    match node {
+        AnyJsLogicalOrLikeExpression::JsLogicalExpression(logical) => {
+            match logical.operator() {
+                Ok(JsLogicalOperator::LogicalAnd) => true,
+                Ok(JsLogicalOperator::LogicalOr) => {
+                    operand_reaches_logical_and(logical.left())
+                        || operand_reaches_logical_and(logical.right())
+                }
+                _ => false,
+            }
+        }
+        AnyJsLogicalOrLikeExpression::JsAssignmentExpression(assignment) => {
+            // For `||=`, only the right-hand side is part of the logical tree.
+            operand_reaches_logical_and(assignment.right())
+        }
+    }
+}
+
+fn operand_reaches_logical_and(operand: SyntaxResult<AnyJsExpression>) -> bool {
+    operand.ok().is_some_and(|expr| {
+        match expr.omit_parentheses() {
+            AnyJsExpression::JsLogicalExpression(logical) => {
+                tree_contains_logical_and(&AnyJsLogicalOrLikeExpression::from(logical))
+            }
+            AnyJsExpression::JsAssignmentExpression(assignment)
+                if assignment.operator().ok()
+                    == Some(JsAssignmentOperator::LogicalOrAssign) =>
+            {
+                tree_contains_logical_and(&AnyJsLogicalOrLikeExpression::from(assignment))
+            }
+            _ => false,
+        }
+    })
 }
 
 fn is_in_test_position(logical: &JsLogicalExpression) -> bool {

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/assignmentCommentTrivia.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/assignmentCommentTrivia.ts.snap
@@ -38,7 +38,7 @@ assignmentCommentTrivia.ts:7:16 lint/nursery/useNullishCoalescing  FIXABLE  ━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ??= instead.
+  i Safe fix: Replace ||= with ??=.
   
      5  5 │   
      6  6 │   // Inline comment before operator
@@ -67,7 +67,7 @@ assignmentCommentTrivia.ts:10:3 lint/nursery/useNullishCoalescing  FIXABLE  ━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ??= instead.
+  i Safe fix: Replace ||= with ??=.
   
      8  8 │   
      9  9 │   // Inline comment after operator
@@ -95,7 +95,7 @@ assignmentCommentTrivia.ts:13:16 lint/nursery/useNullishCoalescing  FIXABLE  ━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ??= instead.
+  i Safe fix: Replace ||= with ??=.
   
     11 11 │   
     12 12 │   // Both sides

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/assignmentInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/assignmentInvalid.ts.snap
@@ -121,7 +121,7 @@ assignmentInvalid.ts:17:3 lint/nursery/useNullishCoalescing  FIXABLE  ━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ??= instead.
+  i Safe fix: Replace ||= with ??=.
   
     15 15 │   // Nullish literal
     16 16 │   let d: null = null;
@@ -150,7 +150,7 @@ assignmentInvalid.ts:20:3 lint/nursery/useNullishCoalescing  FIXABLE  ━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ??= instead.
+  i Safe fix: Replace ||= with ??=.
   
     18 18 │   
     19 19 │   let e: undefined = undefined;
@@ -180,7 +180,7 @@ assignmentInvalid.ts:24:5 lint/nursery/useNullishCoalescing  FIXABLE  ━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ??= instead.
+  i Safe fix: Replace ||= with ??=.
   
     22 22 │   // Object type with null (safe fix - objects are always truthy)
     23 23 │   declare let obj: { a: string } | null;

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/commentTrivia.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/commentTrivia.ts.snap
@@ -44,7 +44,7 @@ commentTrivia.ts:8:34 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
      6  6 │   
      7  7 │   // Comments should be preserved when replacing || with ??
@@ -74,7 +74,7 @@ commentTrivia.ts:9:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
      7  7 │   // Comments should be preserved when replacing || with ??
      8  8 │   const x = a /* inline comment */ || {};
@@ -104,7 +104,7 @@ commentTrivia.ts:10:26 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
      8  8 │   const x = a /* inline comment */ || {};
      9  9 │   const y = a || /* inline comment */ {};
@@ -134,7 +134,7 @@ commentTrivia.ts:15:3 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
     13 13 │   const w = b
     14 14 │     // line comment before
@@ -164,7 +164,7 @@ commentTrivia.ts:17:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
     15 15 │     || {};
     16 16 │   

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreConditionalTestsDisabled.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreConditionalTestsDisabled.ts.snap
@@ -49,7 +49,7 @@ ignoreConditionalTestsDisabled.ts:7:10 lint/nursery/useNullishCoalescing  FIXABL
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
      5  5 │   declare const c: boolean;
      6  6 │   
@@ -79,7 +79,7 @@ ignoreConditionalTestsDisabled.ts:11:13 lint/nursery/useNullishCoalescing  FIXAB
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
      9  9 │   }
     10 10 │   
@@ -109,7 +109,7 @@ ignoreConditionalTestsDisabled.ts:15:13 lint/nursery/useNullishCoalescing  FIXAB
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
     13 13 │   }
     14 14 │   
@@ -139,7 +139,7 @@ ignoreConditionalTestsDisabled.ts:21:15 lint/nursery/useNullishCoalescing  FIXAB
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
     19 19 │   do {
     20 20 │     break;
@@ -168,7 +168,7 @@ ignoreConditionalTestsDisabled.ts:23:22 lint/nursery/useNullishCoalescing  FIXAB
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
     21 21 │   } while (null || 'fallback');
     22 22 │   

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDefault.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDefault.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNullishCoalescing": {
+					"level": "error",
+					"options": {
+						"ignoreMixedLogicalExpressions": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDefault.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDefault.ts
@@ -1,0 +1,62 @@
+// Tests for ignoreMixedLogicalExpressions: true
+// These should NOT generate diagnostics because || is mixed with &&
+
+declare const a: string | null;
+declare const b: string;
+declare const c: string;
+
+// || as child of &&
+const r1 = (a || 'default') && b;
+
+// || with && child
+const r2 = a || (b && c);
+
+// || as left operand of &&
+const r3 = (a || b) && c;
+
+// Nested: || inside && inside another &&
+const r4 = (a || b) && c && b;
+
+// ||= mixed with && - should NOT generate diagnostic
+declare let assignMixed: string | null;
+assignMixed ||= b && c;
+
+// Chained || with && sibling: inner || should also be suppressed
+// In `(a || b) || (c && d)`, the inner `a || b` is part of the same
+// mixed expression tree and should not generate a diagnostic.
+declare const x: string | null;
+declare const y: string;
+declare const z: string;
+declare const w: string;
+const r5 = x || y || (z && w);
+
+// Three-way chain: a || b || c && d (without parens around &&)
+const r6 = x || y || z && w;
+
+// ||= chained with || containing && sibling
+// `a || (b && c)` as the RHS of ||=
+declare let chainAssign: string | null;
+chainAssign ||= y || (z && w);
+
+// Nested ||= where the inner ||= contains && in its RHS.
+// Both the outer and the inner ||= participate in the same connected
+// logical tree, so neither should be reported when the option is enabled.
+declare let outerAssign: string | null;
+declare let innerAssign: string | null;
+outerAssign ||= innerAssign ||= b && c;
+
+// Same nested ||= shape with explicit parens around the inner assignment.
+declare let parenOuter: string | null;
+declare let parenInner: string | null;
+parenOuter ||= (parenInner ||= b && c);
+
+// These SHOULD still generate diagnostics (no && mixing)
+declare const d: string | null;
+const r7 = d || 'default';
+
+declare const e: number | undefined;
+const r8 = e || 0;
+
+// ||= without && mixing - SHOULD generate diagnostic
+declare let assignPlain: string | null;
+assignPlain ||= 'default';

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDefault.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDefault.ts.snap
@@ -1,0 +1,132 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignoreMixedLogicalExpressionsDefault.ts
+---
+# Input
+```ts
+// Tests for ignoreMixedLogicalExpressions: true
+// These should NOT generate diagnostics because || is mixed with &&
+
+declare const a: string | null;
+declare const b: string;
+declare const c: string;
+
+// || as child of &&
+const r1 = (a || 'default') && b;
+
+// || with && child
+const r2 = a || (b && c);
+
+// || as left operand of &&
+const r3 = (a || b) && c;
+
+// Nested: || inside && inside another &&
+const r4 = (a || b) && c && b;
+
+// ||= mixed with && - should NOT generate diagnostic
+declare let assignMixed: string | null;
+assignMixed ||= b && c;
+
+// Chained || with && sibling: inner || should also be suppressed
+// In `(a || b) || (c && d)`, the inner `a || b` is part of the same
+// mixed expression tree and should not generate a diagnostic.
+declare const x: string | null;
+declare const y: string;
+declare const z: string;
+declare const w: string;
+const r5 = x || y || (z && w);
+
+// Three-way chain: a || b || c && d (without parens around &&)
+const r6 = x || y || z && w;
+
+// ||= chained with || containing && sibling
+// `a || (b && c)` as the RHS of ||=
+declare let chainAssign: string | null;
+chainAssign ||= y || (z && w);
+
+// Nested ||= where the inner ||= contains && in its RHS.
+// Both the outer and the inner ||= participate in the same connected
+// logical tree, so neither should be reported when the option is enabled.
+declare let outerAssign: string | null;
+declare let innerAssign: string | null;
+outerAssign ||= innerAssign ||= b && c;
+
+// Same nested ||= shape with explicit parens around the inner assignment.
+declare let parenOuter: string | null;
+declare let parenInner: string | null;
+parenOuter ||= (parenInner ||= b && c);
+
+// These SHOULD still generate diagnostics (no && mixing)
+declare const d: string | null;
+const r7 = d || 'default';
+
+declare const e: number | undefined;
+const r8 = e || 0;
+
+// ||= without && mixing - SHOULD generate diagnostic
+declare let assignPlain: string | null;
+assignPlain ||= 'default';
+
+```
+
+# Diagnostics
+```
+ignoreMixedLogicalExpressionsDefault.ts:55:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    53 │ // These SHOULD still generate diagnostics (no && mixing)
+    54 │ declare const d: string | null;
+  > 55 │ const r7 = d || 'default';
+       │              ^^
+    56 │ 
+    57 │ declare const e: number | undefined;
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDefault.ts:58:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    57 │ declare const e: number | undefined;
+  > 58 │ const r8 = e || 0;
+       │              ^^
+    59 │ 
+    60 │ // ||= without && mixing - SHOULD generate diagnostic
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDefault.ts:62:13 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    60 │ // ||= without && mixing - SHOULD generate diagnostic
+    61 │ declare let assignPlain: string | null;
+  > 62 │ assignPlain ||= 'default';
+       │             ^^^
+    63 │ 
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDisabled.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDisabled.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNullishCoalescing": {
+					"level": "error",
+					"options": {
+						"ignoreMixedLogicalExpressions": false
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDisabled.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDisabled.ts
@@ -1,0 +1,40 @@
+// Tests for ignoreMixedLogicalExpressions: false
+// Mixed || + && expressions SHOULD generate diagnostics
+
+declare const a: string | null;
+declare const b: string;
+declare const c: string;
+
+// || as child of &&
+const r1 = (a || 'default') && b;
+
+// || with && child
+const r2 = a || (b && c);
+
+// || as left operand of &&
+const r3 = (a || b) && c;
+
+// Nested: || inside && inside another &&
+const r4 = (a || b) && c && b;
+
+// ||= mixed with &&
+declare let assignMixed: string | null;
+assignMixed ||= b && c;
+
+// Chained || with && sibling
+declare const x: string | null;
+declare const y: string;
+declare const z: string;
+declare const w: string;
+const r5 = x || y || (z && w);
+
+// Nested ||= where the inner ||= contains && in its RHS.
+// With the option disabled, both ||= operations should be diagnosed.
+declare let outerAssign: string | null;
+declare let innerAssign: string | null;
+outerAssign ||= innerAssign ||= b && c;
+
+// Same nested ||= shape with explicit parens around the inner assignment.
+declare let parenOuter: string | null;
+declare let parenInner: string | null;
+parenOuter ||= (parenInner ||= b && c);

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDisabled.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreMixedLogicalExpressionsDisabled.ts.snap
@@ -1,0 +1,253 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignoreMixedLogicalExpressionsDisabled.ts
+---
+# Input
+```ts
+// Tests for ignoreMixedLogicalExpressions: false
+// Mixed || + && expressions SHOULD generate diagnostics
+
+declare const a: string | null;
+declare const b: string;
+declare const c: string;
+
+// || as child of &&
+const r1 = (a || 'default') && b;
+
+// || with && child
+const r2 = a || (b && c);
+
+// || as left operand of &&
+const r3 = (a || b) && c;
+
+// Nested: || inside && inside another &&
+const r4 = (a || b) && c && b;
+
+// ||= mixed with &&
+declare let assignMixed: string | null;
+assignMixed ||= b && c;
+
+// Chained || with && sibling
+declare const x: string | null;
+declare const y: string;
+declare const z: string;
+declare const w: string;
+const r5 = x || y || (z && w);
+
+// Nested ||= where the inner ||= contains && in its RHS.
+// With the option disabled, both ||= operations should be diagnosed.
+declare let outerAssign: string | null;
+declare let innerAssign: string | null;
+outerAssign ||= innerAssign ||= b && c;
+
+// Same nested ||= shape with explicit parens around the inner assignment.
+declare let parenOuter: string | null;
+declare let parenInner: string | null;
+parenOuter ||= (parenInner ||= b && c);
+
+```
+
+# Diagnostics
+```
+ignoreMixedLogicalExpressionsDisabled.ts:9:15 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+     8 │ // || as child of &&
+   > 9 │ const r1 = (a || 'default') && b;
+       │               ^^
+    10 │ 
+    11 │ // || with && child
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDisabled.ts:12:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    11 │ // || with && child
+  > 12 │ const r2 = a || (b && c);
+       │              ^^
+    13 │ 
+    14 │ // || as left operand of &&
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDisabled.ts:15:15 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    14 │ // || as left operand of &&
+  > 15 │ const r3 = (a || b) && c;
+       │               ^^
+    16 │ 
+    17 │ // Nested: || inside && inside another &&
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDisabled.ts:18:15 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    17 │ // Nested: || inside && inside another &&
+  > 18 │ const r4 = (a || b) && c && b;
+       │               ^^
+    19 │ 
+    20 │ // ||= mixed with &&
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDisabled.ts:22:13 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    20 │ // ||= mixed with &&
+    21 │ declare let assignMixed: string | null;
+  > 22 │ assignMixed ||= b && c;
+       │             ^^^
+    23 │ 
+    24 │ // Chained || with && sibling
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDisabled.ts:29:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    27 │ declare const z: string;
+    28 │ declare const w: string;
+  > 29 │ const r5 = x || y || (z && w);
+       │              ^^
+    30 │ 
+    31 │ // Nested ||= where the inner ||= contains && in its RHS.
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDisabled.ts:35:13 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    33 │ declare let outerAssign: string | null;
+    34 │ declare let innerAssign: string | null;
+  > 35 │ outerAssign ||= innerAssign ||= b && c;
+       │             ^^^
+    36 │ 
+    37 │ // Same nested ||= shape with explicit parens around the inner assignment.
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDisabled.ts:35:29 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    33 │ declare let outerAssign: string | null;
+    34 │ declare let innerAssign: string | null;
+  > 35 │ outerAssign ||= innerAssign ||= b && c;
+       │                             ^^^
+    36 │ 
+    37 │ // Same nested ||= shape with explicit parens around the inner assignment.
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDisabled.ts:40:12 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    38 │ declare let parenOuter: string | null;
+    39 │ declare let parenInner: string | null;
+  > 40 │ parenOuter ||= (parenInner ||= b && c);
+       │            ^^^
+    41 │ 
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreMixedLogicalExpressionsDisabled.ts:40:28 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    38 │ declare let parenOuter: string | null;
+    39 │ declare let parenInner: string | null;
+  > 40 │ parenOuter ||= (parenInner ||= b && c);
+       │                            ^^^
+    41 │ 
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/invalid.ts.snap
@@ -133,7 +133,7 @@ invalid.ts:5:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
       3   3 │   // Nullish literals
       4   4 │   const a: null = null;
@@ -162,7 +162,7 @@ invalid.ts:8:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
       6   6 │   
       7   7 │   const c: undefined = undefined;
@@ -548,7 +548,7 @@ invalid.ts:83:28 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace || with ??.
   
      81  81 │   // Nested nullable object in Pick
      82  82 │   declare const nestPick: Pick<{cfg: {name: string} | null}, "cfg">;

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ternaryCommentTrivia.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ternaryCommentTrivia.ts.snap
@@ -35,7 +35,7 @@ ternaryCommentTrivia.ts:3:11 lint/nursery/useNullishCoalescing  FIXABLE  ━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      1  1 │   // Comments around ternary parts should be preserved
      2  2 │   declare const x: string | null;
@@ -63,7 +63,7 @@ ternaryCommentTrivia.ts:7:23 lint/nursery/useNullishCoalescing  FIXABLE  ━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      5  5 │   // Comment before test
      6  6 │   declare const y: string | null;
@@ -90,7 +90,7 @@ ternaryCommentTrivia.ts:11:11 lint/nursery/useNullishCoalescing  FIXABLE  ━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      9  9 │   // Negative form with comments on both branches
     10 10 │   declare const z: string | null;

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ternaryInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ternaryInvalid.ts.snap
@@ -173,7 +173,7 @@ ternaryInvalid.ts:3:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
       1   1 │   // Strict !== null
       2   2 │   declare const a: string | null;
@@ -201,7 +201,7 @@ ternaryInvalid.ts:7:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
       5   5 │   // Strict !== undefined
       6   6 │   declare const b: string | undefined;
@@ -229,7 +229,7 @@ ternaryInvalid.ts:11:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
       9   9 │   // Loose != null
      10  10 │   declare const c: string | null;
@@ -257,7 +257,7 @@ ternaryInvalid.ts:15:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      13  13 │   // Inverted === null
      14  14 │   declare const d: string | null;
@@ -285,7 +285,7 @@ ternaryInvalid.ts:19:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      17  17 │   // Inverted === undefined
      18  18 │   declare const e: string | undefined;
@@ -313,7 +313,7 @@ ternaryInvalid.ts:23:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      21  21 │   // Inverted == null
      22  22 │   declare const f: string | null;
@@ -341,7 +341,7 @@ ternaryInvalid.ts:27:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      25  25 │   // Compound !== null && !== undefined
      26  26 │   declare const g: string | null | undefined;
@@ -369,7 +369,7 @@ ternaryInvalid.ts:31:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      29  29 │   // Compound === null || === undefined
      30  30 │   declare const h: string | null | undefined;
@@ -397,7 +397,7 @@ ternaryInvalid.ts:35:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      33  33 │   // Null on left side
      34  34 │   declare const i: string | null;
@@ -425,7 +425,7 @@ ternaryInvalid.ts:39:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      37  37 │   // Undefined on left side
      38  38 │   declare const j: string | undefined;
@@ -453,7 +453,7 @@ ternaryInvalid.ts:43:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      41  41 │   // Member access
      42  42 │   declare const obj: { prop: string | null };
@@ -481,7 +481,7 @@ ternaryInvalid.ts:47:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      45  45 │   // Loose != undefined
      46  46 │   declare const l: string | undefined;
@@ -509,7 +509,7 @@ ternaryInvalid.ts:51:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      49  49 │   // Inverted, null on left
      50  50 │   declare const n: string | null;
@@ -556,7 +556,7 @@ ternaryInvalid.ts:59:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      57  57 │   // Fallback is conditional (needs parens)
      58  58 │   declare const p: string | null;
@@ -584,7 +584,7 @@ ternaryInvalid.ts:63:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      61  61 │   // Fallback is logical OR (needs parens, ?? cannot mix with ||)
      62  62 │   declare const q: string | null;
@@ -633,7 +633,7 @@ ternaryInvalid.ts:67:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      65  65 │   // Fallback is logical AND (needs parens, ?? cannot mix with &&)
      66  66 │   declare const s: string | null;
@@ -699,7 +699,7 @@ ternaryInvalid.ts:79:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      77  77 │   // Undefined literal type
      78  78 │   const undef: undefined = undefined;
@@ -727,7 +727,7 @@ ternaryInvalid.ts:83:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      81  81 │   // Number | undefined (non-string union)
      82  82 │   declare const maybeNum: number | undefined;
@@ -755,7 +755,7 @@ ternaryInvalid.ts:87:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      85  85 │   // Loose != null with triple union (covers both null and undefined)
      86  86 │   declare const tripleUnion: string | null | undefined;
@@ -783,7 +783,7 @@ ternaryInvalid.ts:92:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      90  90 │   interface Config { timeout?: number; }
      91  91 │   declare const config: Config;
@@ -830,7 +830,7 @@ ternaryInvalid.ts:100:10 lint/nursery/useNullishCoalescing  FIXABLE  ━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
      98  98 │   // Function return context
      99  99 │   function getVal(x: string | null): string {
@@ -858,7 +858,7 @@ ternaryInvalid.ts:105:14 lint/nursery/useNullishCoalescing  FIXABLE  ━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
     103 103 │   // Nested in parentheses
     104 104 │   declare const paren: string | null;
@@ -962,7 +962,7 @@ ternaryInvalid.ts:127:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
     125 125 │   // Checks !== null, type has only null: fix IS safe
     126 126 │   declare const ss5: string | null;
@@ -990,7 +990,7 @@ ternaryInvalid.ts:131:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
     129 129 │   // Checks !== undefined, type has only undefined: fix IS safe
     130 130 │   declare const ss6: string | undefined;
@@ -1056,7 +1056,7 @@ ternaryInvalid.ts:145:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
     143 143 │   // Complementary: one null, one undefined: fix IS safe
     144 144 │   declare const cp2: string | null | undefined;
@@ -1083,7 +1083,7 @@ ternaryInvalid.ts:149:13 lint/nursery/useNullishCoalescing  FIXABLE  ━━━�
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
-  i Safe fix: Use ?? instead.
+  i Safe fix: Replace the ternary with ??.
   
     147 147 │   // Complementary reversed order: fix IS safe
     148 148 │   declare const cp3: string | null | undefined;

--- a/crates/biome_rule_options/src/use_nullish_coalescing.rs
+++ b/crates/biome_rule_options/src/use_nullish_coalescing.rs
@@ -1,24 +1,22 @@
 use biome_deserialize_macros::{Deserializable, Merge};
 use serde::{Deserialize, Serialize};
 
+/// Options for the `useNullishCoalescing` rule.
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct UseNullishCoalescingOptions {
-    /// Whether to ignore `||` expressions in conditional test positions
-    /// (if/while/for/do-while/ternary conditions).
-    ///
-    /// When `true` (the default), the rule will not report `||` expressions
-    /// that appear in places where the falsy-checking behavior may be intentional.
-    ///
-    /// Default: `true`
+    /// Ignore `||` expressions in conditional test positions (default: `true`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_conditional_tests: Option<bool>,
 
-    /// Whether to ignore ternary expressions that could be simplified
-    /// using the nullish coalescing operator.
-    ///
-    /// Default: `false`
+    /// Ignore ternary expressions that check for `null` or `undefined` (default: `false`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_ternary_tests: Option<bool>,
+
+    /// Whether to ignore `||` and `||=` binary operations that are part of a mixed logical expression with `&&` (default: `false`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore_mixed_logical_expressions: Option<bool>,
 }
 
 impl UseNullishCoalescingOptions {
@@ -28,5 +26,9 @@ impl UseNullishCoalescingOptions {
 
     pub fn ignore_ternary_tests(&self) -> bool {
         self.ignore_ternary_tests.unwrap_or(false)
+    }
+
+    pub fn ignore_mixed_logical_expressions(&self) -> bool {
+        self.ignore_mixed_logical_expressions.unwrap_or(false)
     }
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8201,22 +8201,20 @@ export type UseLoneAnonymousOperationOptions = {};
 export type UseLoneExecutableDefinitionOptions = {};
 export type UseMathMinMaxOptions = {};
 export type UseNamedCaptureGroupOptions = {};
+/**
+ * Options for the `useNullishCoalescing` rule.
+ */
 export interface UseNullishCoalescingOptions {
 	/**
-	* Whether to ignore `||` expressions in conditional test positions
-(if/while/for/do-while/ternary conditions).
-
-When `true` (the default), the rule will not report `||` expressions
-that appear in places where the falsy-checking behavior may be intentional.
-
-Default: `true` 
+	 * Ignore `||` expressions in conditional test positions (default: `true`).
 	 */
 	ignoreConditionalTests?: boolean;
 	/**
-	* Whether to ignore ternary expressions that could be simplified
-using the nullish coalescing operator.
-
-Default: `false` 
+	 * Whether to ignore `||` and `||=` binary operations that are part of a mixed logical expression with `&&` (default: `false`).
+	 */
+	ignoreMixedLogicalExpressions?: boolean;
+	/**
+	 * Ignore ternary expressions that check for `null` or `undefined` (default: `false`).
 	 */
 	ignoreTernaryTests?: boolean;
 }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -15273,17 +15273,20 @@
 			]
 		},
 		"UseNullishCoalescingOptions": {
+			"description": "Options for the `useNullishCoalescing` rule.",
 			"type": "object",
 			"properties": {
 				"ignoreConditionalTests": {
-					"description": "Whether to ignore `||` expressions in conditional test positions\n(if/while/for/do-while/ternary conditions).\n\nWhen `true` (the default), the rule will not report `||` expressions\nthat appear in places where the falsy-checking behavior may be intentional.\n\nDefault: `true`",
-					"type": ["boolean", "null"],
-					"default": null
+					"description": "Ignore `||` expressions in conditional test positions (default: `true`).",
+					"type": ["boolean", "null"]
+				},
+				"ignoreMixedLogicalExpressions": {
+					"description": "Whether to ignore `||` and `||=` binary operations that are part of a mixed logical expression with `&&` (default: `false`).",
+					"type": ["boolean", "null"]
 				},
 				"ignoreTernaryTests": {
-					"description": "Whether to ignore ternary expressions that could be simplified\nusing the nullish coalescing operator.\n\nDefault: `false`",
-					"type": ["boolean", "null"],
-					"default": null
+					"description": "Ignore ternary expressions that check for `null` or `undefined` (default: `false`).",
+					"type": ["boolean", "null"]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
This PR was developed with AI assistance.

## Summary

Partial fix for #9232.

Adds the `ignoreMixedLogicalExpressions` option to `useNullishCoalescing`. This is the first in a series of PRs to reach feature parity with ESLint's `prefer-nullish-coalescing` (split from #9841 per reviewer feedback to keep PRs scoped).

When `true`, suppresses diagnostics on `||` and `||=` expressions that are mixed with `&&` in the same expression tree. Defaults to `false` to match ESLint.

| option | type | default | what it does |
|--------|------|---------|--------------|
| `ignoreMixedLogicalExpressions` | `bool` | `false` | skip `\|\|` when mixed with `&&` in the same expression |

Implementation uses BFS to walk the connected tree of `||`/`||=` nodes (through parenthesized expressions) looking for any `&&` operator.

## Test Plan

Two test files, one per option value:

- `ignoreMixedLogicalExpressionsDefault.ts` — option `true`, verifies mixed expressions are suppressed and non-mixed expressions still diagnose
- `ignoreMixedLogicalExpressionsDisabled.ts` — option `false`, verifies all expressions diagnose normally

Covers: basic mixing (`(a || b) && c`), chained `||` with `&&` sibling (`x || y || (z && w)`), three-way chains without parens, `||=` with direct `&&`, and negative cases (no mixing, should still diagnose).

```
cargo test -p biome_js_analyze -- nursery::use_nullish_coalescing
```

## Docs

Option documented in rustdoc with `json,options` + `ts,use_options` examples. No website PR needed — rule is still in nursery.

