### PR TITLE
fix(linter): `useExhaustiveDependencies` proper handling of computed keys when destructuring, fixes #9556

### DIFF
--- a/.changeset/green-buckets-love.md
+++ b/.changeset/green-buckets-love.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9556](https://github.com/biomejs/biome/issues/9556): [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) no longer reports false positives for variables obtained via object destructuring with computed keys, e.g. `const { [KEY]: key1 } = props`.

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -800,7 +800,7 @@ fn is_stable_binding(
                     depth + 1,
                 ),
                 GetSinglePatternMemberResult::TooDeep => false,
-                GetSinglePatternMemberResult::Unknown => true,
+                GetSinglePatternMemberResult::Unknown => false,
             }
         }
 
@@ -1075,6 +1075,7 @@ fn get_single_pattern_member(
     }
 }
 
+#[derive(Debug)]
 enum GetSinglePatternMemberResult {
     /// The binding is part of a pattern 1 level deep
     Member(ReactHookResultMember),

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -233,7 +233,7 @@ impl StableReactHookConfiguration {
 }
 
 /// Represents a potentially stable React hook result member.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ReactHookResultMember {
     Key(TokenText),
     Index(u8),

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue9556.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue9556.ts
@@ -1,0 +1,20 @@
+/* should not generate diagnostics */
+import {useEffect} from 'react';
+
+const KEY = "key";
+
+interface ComponentProps {
+    key: string;
+}
+
+function Component(props: ComponentProps) {
+    const { [KEY]: key1 } = props;
+    const { key: key2 } = props;
+    useEffect(() => {
+        console.log(key1)
+    }, [key1]);
+    useEffect(() => {
+        console.log(key2)
+    }, [key2]);
+    return null;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue9556.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue9556.ts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: issue9556.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+import {useEffect} from 'react';
+
+const KEY = "key";
+
+interface ComponentProps {
+    key: string;
+}
+
+function Component(props: ComponentProps) {
+    const { [KEY]: key1 } = props;
+    const { key: key2 } = props;
+    useEffect(() => {
+        console.log(key1)
+    }, [key1]);
+    useEffect(() => {
+        console.log(key2)
+    }, [key2]);
+    return null;
+}
+
+```


### PR DESCRIPTION


<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixed [#9556](https://github.com/biomejs/biome/issues/9556): [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) no longer reports false positives for variables obtained via object destructuring with computed keys, e.g. `const { [KEY]: key1 } = props`.

## Test Plan

Test is included.

<!-- What demonstrates that your implementation is correct? -->

## Docs

Changeset is included.

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
