### PR TITLE
fix(parser/css): nested selectors in embedded snippets

### DIFF
--- a/.changeset/fix-styled-nested-selectors.md
+++ b/.changeset/fix-styled-nested-selectors.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9975](https://github.com/biomejs/biome/issues/9975): Biome now parses nested CSS selectors correctly inside embedded snippets without requiring an explicit `&`.

--- a/crates/biome_css_parser/src/lib.rs
+++ b/crates/biome_css_parser/src/lib.rs
@@ -252,7 +252,7 @@ pub fn parse_css_with_offset_and_cache(
 mod tests {
     use crate::{CssParserOptions, parse_css};
     use crate::{parse_css_with_cache, parse_css_with_offset};
-    use biome_css_syntax::CssFileSource;
+    use biome_css_syntax::{CssFileSource, EmbeddingKind};
     use biome_rowan::TextSize;
 
     #[test]
@@ -331,5 +331,25 @@ mod tests {
             offset_parse.syntax().inner().text_with_trivia().to_string(),
             normal_parse.syntax().text_with_trivia().to_string()
         );
+    }
+
+    #[test]
+    fn styled_embedding_accepts_nested_selectors_without_ampersand() {
+        for css in [
+            "svg:first-of-type {\n  margin-left: 0;\n}\n",
+            "div:not(:last-child) {\n  border-bottom: 1px solid black;\n}\n",
+        ] {
+            let parse = parse_css(
+                css,
+                CssFileSource::css().with_embedding_kind(EmbeddingKind::Styled),
+                CssParserOptions::default(),
+            );
+
+            assert!(
+                !parse.has_errors(),
+                "styled embedded CSS should accept nested selectors without &: {:#?}",
+                parse.diagnostics()
+            );
+        }
     }
 }

--- a/crates/biome_css_parser/src/syntax/block/declaration_or_rule_list_block.rs
+++ b/crates/biome_css_parser/src/syntax/block/declaration_or_rule_list_block.rs
@@ -186,7 +186,7 @@ impl ParseNodeList for DeclarationOrRuleList {
                 // Check if the *last* token parsed is a closing brace (}).
                 // Indicates the end of a rule block.
                 // If true, the nested qualified rule is considered valid.
-                if p.last().is_some_and(|kind| kind == self.end_kind) {
+                if p.last().is_some_and(|kind| kind == self.end_kind) || p.at(self.end_kind) {
                     Ok(rule)
                 } else {
                     // If the condition is not met, return an error to indicate parsing failure.

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -694,6 +694,77 @@ const Bar = styled(Component)`
 }
 
 #[test]
+fn issue_9975() {
+    const FILE_PATH: &str = "/project/file.ts";
+    const FILE_CONTENT: &str = r#"styled.div`
+  svg:first-of-type {
+    margin-left: 0;
+  }
+`;
+
+styled.div`
+  div:not(:last-child) {
+    border-bottom: 1px solid black;
+  }
+`;"#;
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from(FILE_PATH), FILE_CONTENT);
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
+
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            workspace_directory: None,
+            configuration: Configuration {
+                javascript: Some(JsConfiguration {
+                    experimental_embedded_snippets_enabled: Some(true.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            extended_configurations: vec![],
+            module_graph_resolution_kind: ModuleGraphResolutionKind::None,
+        })
+        .unwrap();
+
+    workspace
+        .open_file(OpenFileParams {
+            project_key,
+            path: BiomePath::new(FILE_PATH),
+            content: FileContent::FromServer,
+            document_file_source: None,
+            persist_node_cache: false,
+            inline_config: None,
+        })
+        .unwrap();
+
+    let result = workspace
+        .pull_diagnostics(PullDiagnosticsParams {
+            project_key,
+            path: BiomePath::new(FILE_PATH),
+            categories: RuleCategories::default(),
+            only: vec![],
+            skip: vec![],
+            enabled_rules: vec![],
+            include_code_fix: false,
+            inline_config: None,
+            max_diagnostics: None,
+            diagnostic_level: Severity::Hint,
+            enforce_assist: false,
+        })
+        .unwrap();
+
+    assert_eq!(result.parse_errors, 0);
+    assert!(
+        result.diagnostics.is_empty(),
+        "Expected no diagnostics for styled nested selectors, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn issue_9625() {
     const FILE_PATH: &str = "/project/file.js";
     const FILE_CONTENT: &str = r#"const Portfolio = styled.div`


### PR DESCRIPTION
## Summary

> [!NOTE]
> **AI Assistance Disclosure**: I used the Codex agent to investigate the problem, and create regression tests. All changes and output are reviewed by a human (me).

Fixes #9975

Nested selectors without `&` (SCSS style) are now correctly parsed inside embedded CSS snippets.

## Test Plan

Added a parser test and an integration test.

## Docs

N/A