### PR TITLE
perf(noMagicNumbers): reduce allocations

### DIFF
--- a/.changeset/odd-wasps-fly.md
+++ b/.changeset/odd-wasps-fly.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved performance of `noMagicNumbers`, and updated it's source rule metadata.

--- a/.changeset/odd-wasps-fly.md
+++ b/.changeset/odd-wasps-fly.md
@@ -2,4 +2,5 @@
 "@biomejs/biome": patch
 ---
 
-Improved performance of `noMagicNumbers`, and updated it's source rule metadata.
+Improved performance of [noMagicNumbers](https://biomejs.dev/linter/rules/no-magic-numbers/).
+Biome now maps ESLint `no-magic-numbers` sources more accurately during `biome migrate eslint`.

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -2521,6 +2521,18 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "no-magic-numbers" => {
+            if !options.include_inspired {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                return false;
+            }
+            let group = rules.style.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_magic_numbers
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
         "no-misleading-character-class" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
@@ -55,7 +55,7 @@ declare_lint_rule! {
         version: "2.1.0",
         name: "noMagicNumbers",
         language: "ts",
-        sources: &[RuleSource::EslintTypeScript("no-magic-numbers").same()],
+        sources: &[RuleSource::Eslint("no-magic-numbers").inspired(), RuleSource::EslintTypeScript("no-magic-numbers").same()],
         recommended: false,
     }
 }
@@ -407,5 +407,9 @@ const ALWAYS_IGNORED_IN_ARITHMETIC_OPERATIONS: &[&str] = &[
 ];
 
 fn is_allowed_number(numeric_literal: &AnyJsNumericLiteral) -> bool {
-    ALWAYS_IGNORED_IN_ARITHMETIC_OPERATIONS.contains(&numeric_literal.to_trimmed_string().as_str())
+    match numeric_literal {
+        AnyJsNumericLiteral::JsNumberLiteralExpression(expr) => expr.value_token(),
+        AnyJsNumericLiteral::JsBigintLiteralExpression(expr) => expr.value_token(),
+    }
+    .is_ok_and(|token| ALWAYS_IGNORED_IN_ARITHMETIC_OPERATIONS.contains(&token.text_trimmed()))
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
A small tweak to reduce string allocations, and a fix for the rule's sources.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
green ci
## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
