### PR TITLE
chore: abstract html tag matcher

### DIFF
--- a/.changeset/frogs-like-green.md
+++ b/.changeset/frogs-like-green.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Tweaked the diagnostics range for [useAltText](https://biomejs.dev/linter/rules/use-alt-text), [useButtonType](https://biomejs.dev/linter/rules/use-button-type), [useHtmlLang](https://biomejs.dev/linter/rules/use-html-lang), [useIframeTitle](https://biomejs.dev/linter/rules/use-iframe-title), [useValidAriaRole](https://biomejs.dev/linter/rules/use-valid-aria-role) & [useIfameSandbox](https://biomejs.dev/linter/rules/use-iframe-sandbox) to report on the opening tag instead of the full tag.

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/full_support.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/full_support.snap
@@ -167,14 +167,8 @@ file.astro:41:1 lint/a11y/useHtmlLang ━━━━━━━━━━━━━━
     40 │ 
   > 41 │ <html>
        │ ^^^^^^
-  > 42 │ 	<head>
-  > 43 │ 		<title>Astro</title>
-  > 44 │ 	</head>
-  > 45 │ 	<body></body>
-  > 46 │ </html>
-       │ ^^^^^^^
-    47 │ 
-    48 │ <style>
+    42 │ 	<head>
+    43 │ 		<title>Astro</title>
   
   i Setting a lang attribute on HTML document elements configures the language used by screen readers when no user default is specified.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/full_support.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/full_support.snap
@@ -69,14 +69,8 @@ file.svelte:10:1 lint/a11y/useHtmlLang ━━━━━━━━━━━━━�
      9 │ 
   > 10 │ <html>
        │ ^^^^^^
-  > 11 │ 	<head>
-  > 12 │ 		<title>Svelte</title>
-  > 13 │ 	</head>
-  > 14 │ 	<body></body>
-  > 15 │ </html>
-       │ ^^^^^^^
-    16 │ 
-    17 │ <style>
+    11 │ 	<head>
+    12 │ 		<title>Svelte</title>
   
   i Setting a lang attribute on HTML document elements configures the language used by screen readers when no user default is specified.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/full_support_ts.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/full_support_ts.snap
@@ -71,14 +71,8 @@ file.svelte:15:1 lint/a11y/useHtmlLang ━━━━━━━━━━━━━�
     14 │ 
   > 15 │ <html>
        │ ^^^^^^
-  > 16 │ 	<head>
-  > 17 │ 		<title>Svelte</title>
-  > 18 │ 	</head>
-  > 19 │ 	<body></body>
-  > 20 │ </html>
-       │ ^^^^^^^
-    21 │ 
-    22 │ <style>
+    16 │ 	<head>
+    17 │ 		<title>Svelte</title>
   
   i Setting a lang attribute on HTML document elements configures the language used by screen readers when no user default is specified.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/full_support.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/full_support.snap
@@ -72,14 +72,8 @@ file.vue:10:1 lint/a11y/useHtmlLang ━━━━━━━━━━━━━━�
      9 │ 
   > 10 │ <html>
        │ ^^^^^^
-  > 11 │ 	<head>
-  > 12 │ 		<title>Svelte</title>
-  > 13 │ 	</head>
-  > 14 │ 	<body></body>
-  > 15 │ </html>
-       │ ^^^^^^^
-    16 │ 
-    17 │ <style>
+    11 │ 	<head>
+    12 │ 		<title>Svelte</title>
   
   i Setting a lang attribute on HTML document elements configures the language used by screen readers when no user default is specified.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/full_support_ts.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/full_support_ts.snap
@@ -71,14 +71,8 @@ file.vue:15:1 lint/a11y/useHtmlLang ━━━━━━━━━━━━━━�
     14 │ 
   > 15 │ <html>
        │ ^^^^^^
-  > 16 │ 	<head>
-  > 17 │ 		<title>Svelte</title>
-  > 18 │ 	</head>
-  > 19 │ 	<body></body>
-  > 20 │ </html>
-       │ ^^^^^^^
-    21 │ 
-    22 │ <style>
+    16 │ 	<head>
+    17 │ 		<title>Svelte</title>
   
   i Setting a lang attribute on HTML document elements configures the language used by screen readers when no user default is specified.
   

--- a/crates/biome_html_analyze/src/a11y.rs
+++ b/crates/biome_html_analyze/src/a11y.rs
@@ -7,8 +7,8 @@
 //! 2. **Element helpers** (public): Higher-level checks on HTML elements
 //! 3. **Type-specific variants** (public): Optimized versions that avoid cloning
 
+use biome_html_syntax::HtmlAttribute;
 use biome_html_syntax::element_ext::AnyHtmlTagElement;
-use biome_html_syntax::{AnyHtmlElement, HtmlAttribute};
 
 // ============================================================================
 // Core attribute value helpers (private)
@@ -90,7 +90,7 @@ pub(crate) fn is_hidden_from_screen_reader(element: &AnyHtmlTagElement) -> bool 
 /// Unlike [`is_aria_hidden_value_truthy`], this only matches the exact string `"true"`.
 ///
 /// Ref: <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden>
-pub(crate) fn is_aria_hidden_true(element: &AnyHtmlElement) -> bool {
+pub(crate) fn is_aria_hidden_true(element: &AnyHtmlTagElement) -> bool {
     element
         .find_attribute_by_name("aria-hidden")
         .is_some_and(|attr| is_strict_true_value(&attr))
@@ -102,7 +102,9 @@ pub(crate) fn is_aria_hidden_true(element: &AnyHtmlElement) -> bool {
 /// Useful for code fixes that need to reference the attribute node.
 ///
 /// Ref: <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden>
-pub(crate) fn get_truthy_aria_hidden_attribute(element: &AnyHtmlElement) -> Option<HtmlAttribute> {
+pub(crate) fn get_truthy_aria_hidden_attribute(
+    element: &AnyHtmlTagElement,
+) -> Option<HtmlAttribute> {
     let attribute = element.find_attribute_by_name("aria-hidden")?;
     if is_aria_hidden_value_truthy(&attribute) {
         Some(attribute)
@@ -114,7 +116,7 @@ pub(crate) fn get_truthy_aria_hidden_attribute(element: &AnyHtmlElement) -> Opti
 /// Returns `true` if the element has the named attribute with a non-empty value.
 ///
 /// Whitespace-only values are considered empty.
-pub(crate) fn has_non_empty_attribute(element: &AnyHtmlElement, name: &str) -> bool {
+pub(crate) fn has_non_empty_attribute(element: &AnyHtmlTagElement, name: &str) -> bool {
     element
         .find_attribute_by_name(name)
         .is_some_and(|attr| has_non_empty_value(&attr))
@@ -122,7 +124,7 @@ pub(crate) fn has_non_empty_attribute(element: &AnyHtmlElement, name: &str) -> b
 
 /// Returns `true` if the element has an accessible name via `aria-label`,
 /// `aria-labelledby`, or `title` attributes.
-pub(crate) fn has_accessible_name(element: &AnyHtmlElement) -> bool {
+pub(crate) fn has_accessible_name(element: &AnyHtmlTagElement) -> bool {
     has_non_empty_attribute(element, "aria-label")
         || has_non_empty_attribute(element, "aria-labelledby")
         || has_non_empty_attribute(element, "title")

--- a/crates/biome_html_analyze/src/a11y_tests.rs
+++ b/crates/biome_html_analyze/src/a11y_tests.rs
@@ -1,16 +1,18 @@
 use super::*;
 use biome_html_parser::parse_html;
-use biome_html_syntax::HtmlRoot;
+use biome_html_syntax::{AnyHtmlElement, HtmlRoot};
 use biome_rowan::AstNode;
 
 /// Helper to parse HTML and extract the first element
-fn parse_first_element(html: &str) -> AnyHtmlElement {
+fn parse_first_element(html: &str) -> AnyHtmlTagElement {
     let parsed = parse_html(html, Default::default());
     let root = HtmlRoot::cast(parsed.syntax()).unwrap();
     root.syntax()
         .descendants()
         .find_map(AnyHtmlElement::cast)
         .expect("No element found in parsed HTML")
+        .as_any_html_tag_element()
+        .expect("No opening or self-closing element found")
 }
 
 // ============================================================================

--- a/crates/biome_html_analyze/src/lib.rs
+++ b/crates/biome_html_analyze/src/lib.rs
@@ -6,6 +6,7 @@ mod lint;
 pub mod options;
 mod registry;
 mod suppression_action;
+mod utils;
 
 pub use crate::registry::visit_registry;
 use crate::suppression_action::HtmlSuppressionAction;

--- a/crates/biome_html_analyze/src/lint/a11y/no_autofocus.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_autofocus.rs
@@ -4,11 +4,12 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_html_syntax::element_ext::AnyHtmlTagElement;
-use biome_html_syntax::{HtmlAttribute, HtmlElement, HtmlSelfClosingElement};
+use biome_html_syntax::{HtmlAttribute, HtmlElement, HtmlFileSource, HtmlSelfClosingElement};
 use biome_rowan::{AstNode, BatchMutationExt};
 use biome_rule_options::no_autofocus::NoAutofocusOptions;
 
 use crate::HtmlRuleAction;
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Enforce that the `autofocus` attribute is not used on elements.
@@ -72,6 +73,7 @@ impl Rule for NoAutofocus {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
         // Check if this is an autofocus attribute
         if !is_autofocus_attribute(node) {
@@ -79,7 +81,7 @@ impl Rule for NoAutofocus {
         }
 
         // Check if element is inside a dialog or has popover attribute in ancestors
-        if is_inside_allowed_context(node).unwrap_or(false) {
+        if is_inside_allowed_context(node, source_type).unwrap_or(false) {
             return None;
         }
 
@@ -128,7 +130,7 @@ fn is_autofocus_attribute(node: &HtmlAttribute) -> bool {
 /// Note: We skip the first [HtmlElement] (the one containing the autofocus attribute)
 /// because we only want to check if it's *inside* a dialog/popover, not if
 /// it *is* the dialog/popover itself.
-fn is_inside_allowed_context(attr: &HtmlAttribute) -> Option<bool> {
+fn is_inside_allowed_context(attr: &HtmlAttribute, source_type: &HtmlFileSource) -> Option<bool> {
     let mut skip_first_element = true;
 
     // Walk up the ancestors to find if we're inside a dialog or popover
@@ -142,7 +144,7 @@ fn is_inside_allowed_context(attr: &HtmlAttribute) -> Option<bool> {
             continue;
         }
 
-        if is_dialog_or_popover(&tag_element) {
+        if is_dialog_or_popover(&tag_element, source_type) {
             return Some(true);
         }
     }
@@ -161,12 +163,7 @@ fn get_tag_element(node: &biome_html_syntax::HtmlSyntaxNode) -> Option<AnyHtmlTa
 }
 
 /// Check if the tag element is a dialog or has popover attribute
-fn is_dialog_or_popover(tag_element: &AnyHtmlTagElement) -> bool {
-    let is_dialog = tag_element
-        .name()
-        .ok()
-        .and_then(|n| n.token_text_trimmed())
-        .is_some_and(|text| text.eq_ignore_ascii_case("dialog"));
-
-    is_dialog || tag_element.find_attribute_by_name("popover").is_some()
+fn is_dialog_or_popover(element: &AnyHtmlTagElement, source_type: &HtmlFileSource) -> bool {
+    is_html_tag(element, source_type, "dialog")
+        || element.find_attribute_by_name("popover").is_some()
 }

--- a/crates/biome_html_analyze/src/lint/a11y/no_distracting_elements.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_distracting_elements.rs
@@ -2,12 +2,13 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{Ast, FixKind, Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::AnyHtmlElement;
+use biome_html_syntax::{AnyHtmlElement, HtmlFileSource};
 use biome_rowan::BatchMutationExt;
 use biome_rowan::{AstNode, TokenText};
 use biome_rule_options::no_distracting_elements::NoDistractingElementsOptions;
 
 use crate::HtmlRuleAction;
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Enforces that no distracting elements are used.
@@ -57,10 +58,16 @@ impl Rule for NoDistractingElements {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
-        let element_name = element.name()?;
-        if is_marquee_or_blink_element(element_name.text()) {
+        let source_type = ctx.source_type::<HtmlFileSource>();
+
+        let tag_element = element.clone().as_any_html_tag_element()?;
+        let element_name = tag_element.tag_name()?;
+        if is_html_tag(&tag_element, source_type, "marquee")
+            || is_html_tag(&tag_element, source_type, "blink")
+        {
             return Some(element_name);
         }
+
         None
     }
 
@@ -90,8 +97,4 @@ impl Rule for NoDistractingElements {
             mutation,
         ))
     }
-}
-
-fn is_marquee_or_blink_element(element_name: &str) -> bool {
-    element_name.eq_ignore_ascii_case("marquee") || element_name.eq_ignore_ascii_case("blink")
 }

--- a/crates/biome_html_analyze/src/lint/a11y/no_header_scope.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_header_scope.rs
@@ -2,11 +2,13 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{Ast, FixKind, Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlElement, HtmlAttribute};
+use biome_html_syntax::element_ext::AnyHtmlTagElement;
+use biome_html_syntax::{HtmlAttribute, HtmlFileSource};
 use biome_rowan::{AstNode, BatchMutationExt};
 use biome_rule_options::no_header_scope::NoHeaderScopeOptions;
 
 use crate::HtmlRuleAction;
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// The scope prop should be used only on `<th>` elements.
@@ -50,16 +52,17 @@ declare_lint_rule! {
 }
 
 impl Rule for NoHeaderScope {
-    type Query = Ast<AnyHtmlElement>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = HtmlAttribute;
     type Signals = Option<Self::State>;
     type Options = NoHeaderScopeOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
         // Check if element is NOT a th element and has a scope attribute
-        if is_th_element(element)? {
+        if is_html_tag(element, source_type, "th") {
             return None;
         }
 
@@ -96,9 +99,4 @@ impl Rule for NoHeaderScope {
             mutation,
         ))
     }
-}
-
-// Helper function to check if element is a th element
-fn is_th_element(element: &AnyHtmlElement) -> Option<bool> {
-    Some(element.name()?.text().eq_ignore_ascii_case("th"))
 }

--- a/crates/biome_html_analyze/src/lint/a11y/no_positive_tabindex.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_positive_tabindex.rs
@@ -2,7 +2,8 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{Ast, FixKind, Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlElement, HtmlAttribute};
+use biome_html_syntax::HtmlAttribute;
+use biome_html_syntax::element_ext::AnyHtmlTagElement;
 use biome_rowan::{AstNode, BatchMutationExt, TextRange};
 use biome_rule_options::no_positive_tabindex::NoPositiveTabindexOptions;
 
@@ -56,7 +57,7 @@ pub struct NoPositiveTabindexState {
 }
 
 impl Rule for NoPositiveTabindex {
-    type Query = Ast<AnyHtmlElement>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = NoPositiveTabindexState;
     type Signals = Option<Self::State>;
     type Options = NoPositiveTabindexOptions;

--- a/crates/biome_html_analyze/src/lint/a11y/no_redundant_alt.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_redundant_alt.rs
@@ -9,6 +9,8 @@ use biome_rowan::AstNode;
 use biome_rule_options::is_redundant_alt;
 use biome_rule_options::no_redundant_alt::NoRedundantAltOptions;
 
+use crate::utils::is_html_tag;
+
 declare_lint_rule! {
     /// Enforce `img` alt prop does not contain the word "image", "picture", or "photo".
     ///
@@ -54,12 +56,9 @@ impl Rule for NoRedundantAlt {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let file_source = ctx.source_type::<HtmlFileSource>();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        let name = node.name().ok()?.token_text_trimmed()?;
-        if (file_source.is_html() && !name.eq_ignore_ascii_case("img"))
-            || (!file_source.is_html() && name != "img")
-        {
+        if !is_html_tag(node, source_type, "img") {
             return None;
         }
 

--- a/crates/biome_html_analyze/src/lint/a11y/no_svg_without_title.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_svg_without_title.rs
@@ -1,12 +1,12 @@
 use biome_analyze::{Ast, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlElement, HtmlAttribute, HtmlElementList};
+use biome_html_syntax::{AnyHtmlElement, HtmlAttribute, HtmlElementList, HtmlFileSource};
 use biome_rowan::AstNode;
 use biome_rule_options::no_svg_without_title::NoSvgWithoutTitleOptions;
 use biome_string_case::StrLikeExtension;
 
-use crate::a11y::is_aria_hidden_true;
+use crate::{a11y::is_aria_hidden_true, utils::is_html_tag};
 
 const NAME_REQUIRED_ROLES: &[&str] = &["img", "image", "graphics-document", "graphics-symbol"];
 
@@ -128,12 +128,14 @@ impl Rule for NoSvgWithoutTitle {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        if node.name()? != "svg" {
+        let tag_element = node.clone().as_any_html_tag_element()?;
+        if !is_html_tag(&tag_element, source_type, "svg") {
             return None;
         }
 
-        if is_aria_hidden_true(node) {
+        if is_aria_hidden_true(&tag_element) {
             return None;
         }
 

--- a/crates/biome_html_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_alt_text.rs
@@ -3,12 +3,13 @@ use biome_analyze::{
 };
 use biome_console::{fmt::Display, fmt::Formatter, markup};
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlElement, HtmlFileSource};
+use biome_html_syntax::{HtmlFileSource, element_ext::AnyHtmlTagElement};
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_alt_text::UseAltTextOptions;
 
-use crate::a11y::{
-    attribute_value_equals_ignore_case, has_non_empty_attribute, is_aria_hidden_true,
+use crate::{
+    a11y::{attribute_value_equals_ignore_case, has_non_empty_attribute, is_aria_hidden_true},
+    utils::is_html_tag,
 };
 
 declare_lint_rule! {
@@ -109,32 +110,21 @@ impl Display for ValidatedElement {
 }
 
 impl Rule for UseAltText {
-    type Query = Ast<AnyHtmlElement>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = (ValidatedElement, TextRange);
     type Signals = Option<Self::State>;
     type Options = UseAltTextOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
-        let file_source = ctx.source_type::<HtmlFileSource>();
-
-        let element_name = element.name()?;
-        let is_html_file = file_source.is_html();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
         let has_alt = has_valid_alt_text(element);
         let has_aria_label = has_non_empty_attribute(element, "aria-label");
         let has_aria_labelledby = has_non_empty_attribute(element, "aria-labelledby");
         let aria_hidden = is_aria_hidden_true(element);
 
-        let name_matches = |name: &str| -> bool {
-            if is_html_file {
-                element_name.eq_ignore_ascii_case(name)
-            } else {
-                element_name.text() == name
-            }
-        };
-
-        if name_matches("object") {
+        if is_html_tag(element, source_type, "object") {
             let has_title = has_non_empty_attribute(element, "title");
 
             if !has_title && !has_aria_label && !has_aria_labelledby && !aria_hidden {
@@ -146,18 +136,18 @@ impl Rule for UseAltText {
                     element.syntax().text_trimmed_range(),
                 ));
             }
-        } else if name_matches("img") {
+        } else if is_html_tag(element, source_type, "img") {
             if !has_alt && !has_aria_label && !has_aria_labelledby && !aria_hidden {
                 return Some((ValidatedElement::Img, element.syntax().text_trimmed_range()));
             }
-        } else if name_matches("area") {
+        } else if is_html_tag(element, source_type, "area") {
             if !has_alt && !has_aria_label && !has_aria_labelledby && !aria_hidden {
                 return Some((
                     ValidatedElement::Area,
                     element.syntax().text_trimmed_range(),
                 ));
             }
-        } else if name_matches("input")
+        } else if is_html_tag(element, source_type, "input")
             && has_type_image_attribute(element)
             && !has_alt
             && !has_aria_label
@@ -192,13 +182,13 @@ impl Rule for UseAltText {
 }
 
 /// Check if the element has a type="image" attribute
-fn has_type_image_attribute(element: &AnyHtmlElement) -> bool {
+fn has_type_image_attribute(element: &AnyHtmlTagElement) -> bool {
     element
         .find_attribute_by_name("type")
         .is_some_and(|attr| attribute_value_equals_ignore_case(&attr, "image"))
 }
 
 /// Check if the element has a valid alt attribute
-fn has_valid_alt_text(element: &AnyHtmlElement) -> bool {
+fn has_valid_alt_text(element: &AnyHtmlTagElement) -> bool {
     element.find_attribute_or_vue_binding("alt").is_some()
 }

--- a/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
@@ -16,6 +16,7 @@ use crate::a11y::{
     html_self_closing_element_has_non_empty_attribute,
     html_self_closing_element_has_truthy_aria_hidden,
 };
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Enforce that anchors have content and that the content is accessible to screen readers.
@@ -102,30 +103,23 @@ impl Rule for UseAnchorContent {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
         // Check if element is an anchor tag
-        // In HTML files, tag names are case-insensitive
-        // In component frameworks (Vue, Svelte, Astro), only lowercase is checked
-        let element_name = node.name()?;
-        let source_type = ctx.source_type::<HtmlFileSource>();
-        let is_anchor = if source_type.is_html() {
-            element_name.text().eq_ignore_ascii_case("a")
-        } else {
-            element_name.text() == "a"
-        };
-        if !is_anchor {
+        let tag_element = node.clone().as_any_html_tag_element()?;
+        if !is_html_tag(&tag_element, source_type, "a") {
             return None;
         }
 
         // Check if the anchor itself has aria-hidden attribute
-        if let Some(aria_hidden_attr) = get_truthy_aria_hidden_attribute(node) {
+        if let Some(aria_hidden_attr) = get_truthy_aria_hidden_attribute(&tag_element) {
             return Some(UseAnchorContentState {
                 aria_hidden_attribute: Some(aria_hidden_attr),
             });
         }
 
         // Check if anchor has accessible name via aria-label or title
-        if has_accessible_name(node) {
+        if has_accessible_name(&tag_element) {
             return None;
         }
 
@@ -213,10 +207,7 @@ fn has_accessible_content(html_child_list: &HtmlElementList, is_astro: bool) -> 
             let tag_text = element.name().ok().and_then(|n| n.token_text_trimmed());
 
             match tag_text.as_ref().map(|t| t.as_ref()) {
-                Some(name)
-                    if name.eq_ignore_ascii_case("img")
-                        || (is_astro && name == "Image") =>
-                {
+                Some(name) if name.eq_ignore_ascii_case("img") || (is_astro && name == "Image") => {
                     html_self_closing_element_has_non_empty_attribute(element, "alt")
                 }
                 Some(name)

--- a/crates/biome_html_analyze/src/lint/a11y/use_aria_props_for_role.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_aria_props_for_role.rs
@@ -4,7 +4,8 @@ use biome_analyze::{Ast, Rule, RuleDiagnostic, declare_lint_rule};
 use biome_aria_metadata::AriaRole;
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlElement, HtmlAttribute};
+use biome_html_syntax::HtmlAttribute;
+use biome_html_syntax::element_ext::AnyHtmlTagElement;
 use biome_rowan::{AstNode, Text};
 use biome_rule_options::use_aria_props_for_role::UseAriaPropsForRoleOptions;
 
@@ -61,7 +62,7 @@ pub struct UseAriaPropsForRoleState {
 }
 
 impl Rule for UseAriaPropsForRole {
-    type Query = Ast<AnyHtmlElement>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = UseAriaPropsForRoleState;
     type Signals = Option<Self::State>;
     type Options = UseAriaPropsForRoleOptions;

--- a/crates/biome_html_analyze/src/lint/a11y/use_button_type.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_button_type.rs
@@ -2,9 +2,12 @@ use biome_analyze::RuleSource;
 use biome_analyze::{Ast, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlElement, HtmlFileSource};
+use biome_html_syntax::HtmlFileSource;
+use biome_html_syntax::element_ext::AnyHtmlTagElement;
 use biome_rowan::{AstNode, AstNodeList};
 use biome_rule_options::use_button_type::UseButtonTypeOptions;
+
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Enforces the usage and validity of the attribute `type` for the element `button`
@@ -44,15 +47,16 @@ pub struct UseButtonTypeState {
 }
 
 impl Rule for UseButtonType {
-    type Query = Ast<AnyHtmlElement>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = UseButtonTypeState;
     type Signals = Option<Self::State>;
     type Options = UseButtonTypeOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        if !is_button_element(element, ctx) {
+        if !is_html_tag(element, source_type, "button") {
             return None;
         }
 
@@ -125,31 +129,11 @@ impl Rule for UseButtonType {
     }
 }
 
-fn is_button_element(element: &AnyHtmlElement, ctx: &RuleContext<UseButtonType>) -> bool {
-    let Some(element_name) = element.name() else {
-        return false;
-    };
-
-    let source_type = ctx.source_type::<HtmlFileSource>();
-
-    // In HTML files: case-insensitive (BUTTON, Button, button all match)
-    // In component frameworks (Vue, Svelte, Astro): case-sensitive (only "button" matches)
-    // This means <Button> in Vue/Svelte is treated as a component and ignored
-    if source_type.is_html() {
-        element_name.text().eq_ignore_ascii_case("button")
-    } else {
-        element_name.text() == "button"
-    }
-}
-
 /// Checks if a dynamic attribute (shorthand or directive) exists for the given name.
 /// For example, `<button {type}>` (Svelte), `<button :type="foo">` (Vue), or `<button v-bind:type="foo">` (Vue).
-fn has_dynamic_attribute(element: &AnyHtmlElement, name: &str) -> bool {
-    let Some(attributes) = element.attributes() else {
-        return false;
-    };
-
-    attributes
+fn has_dynamic_attribute(element: &AnyHtmlTagElement, name: &str) -> bool {
+    element
+        .attributes()
         .iter()
         .find_map(|attr| {
             // Check if this is a HtmlSingleTextExpression (Svelte shorthand syntax)

--- a/crates/biome_html_analyze/src/lint/a11y/use_html_lang.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_html_lang.rs
@@ -3,11 +3,11 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::AnyHtmlElement;
-use biome_rowan::{AstNode, TextRange};
+use biome_html_syntax::{HtmlFileSource, element_ext::AnyHtmlTagElement};
+use biome_rowan::AstNode;
 use biome_rule_options::use_html_lang::UseHtmlLangOptions;
 
-use crate::a11y::has_non_empty_attribute;
+use crate::{a11y::has_non_empty_attribute, utils::is_html_tag};
 
 declare_lint_rule! {
     /// Enforce that `html` element has `lang` attribute.
@@ -45,15 +45,16 @@ declare_lint_rule! {
 }
 
 impl Rule for UseHtmlLang {
-    type Query = Ast<AnyHtmlElement>;
-    type State = TextRange;
+    type Query = Ast<AnyHtmlTagElement>;
+    type State = ();
     type Signals = Option<Self::State>;
     type Options = UseHtmlLangOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        if !is_html_element(element) {
+        if !is_html_tag(element, source_type, "html") {
             return None;
         }
 
@@ -61,13 +62,13 @@ impl Rule for UseHtmlLang {
             return None;
         }
 
-        Some(element.syntax().text_trimmed_range())
+        Some(())
     }
 
-    fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
         Some(RuleDiagnostic::new(
             rule_category!(),
-            state,
+            ctx.query().range(),
             markup! {
                 "Provide a "<Emphasis>"lang"</Emphasis>" attribute when using the "<Emphasis>"html"</Emphasis>" element."
             }
@@ -78,10 +79,4 @@ impl Rule for UseHtmlLang {
             }
         ))
     }
-}
-
-fn is_html_element(element: &AnyHtmlElement) -> bool {
-    element
-        .name()
-        .is_some_and(|token_text| token_text.eq_ignore_ascii_case("html"))
 }

--- a/crates/biome_html_analyze/src/lint/a11y/use_iframe_title.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_iframe_title.rs
@@ -3,11 +3,11 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlElement, HtmlFileSource};
+use biome_html_syntax::{HtmlFileSource, element_ext::AnyHtmlTagElement};
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_iframe_title::UseIframeTitleOptions;
 
-use crate::a11y::has_non_empty_attribute;
+use crate::{a11y::has_non_empty_attribute, utils::is_html_tag};
 
 declare_lint_rule! {
     /// Enforces the usage of the attribute `title` for the element `iframe`.
@@ -52,15 +52,16 @@ declare_lint_rule! {
 }
 
 impl Rule for UseIframeTitle {
-    type Query = Ast<AnyHtmlElement>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = TextRange;
     type Signals = Option<Self::State>;
     type Options = UseIframeTitleOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        if !is_iframe_element(element, ctx) {
+        if !is_html_tag(element, source_type, "iframe") {
             return None;
         }
 
@@ -84,22 +85,5 @@ impl Rule for UseIframeTitle {
                 "Screen readers rely on the title set on an iframe to describe the content being displayed."
             }),
         )
-    }
-}
-
-fn is_iframe_element(element: &AnyHtmlElement, ctx: &RuleContext<UseIframeTitle>) -> bool {
-    let Some(element_name) = element.name() else {
-        return false;
-    };
-
-    let source_type = ctx.source_type::<HtmlFileSource>();
-
-    // In HTML files: case-insensitive (IFRAME, Iframe, iframe all match)
-    // In component frameworks (Vue, Svelte, Astro): case-sensitive (only "iframe" matches)
-    // This means <Iframe> in Vue/Svelte is treated as a component and ignored
-    if source_type.is_html() {
-        element_name.text().eq_ignore_ascii_case("iframe")
-    } else {
-        element_name.text() == "iframe"
     }
 }

--- a/crates/biome_html_analyze/src/lint/a11y/use_media_caption.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_media_caption.rs
@@ -7,6 +7,8 @@ use biome_html_syntax::{AnyHtmlElement, HtmlElementList, HtmlFileSource};
 use biome_rowan::AstNode;
 use biome_rule_options::use_media_caption::UseMediaCaptionOptions;
 
+use crate::utils::is_html_tag;
+
 declare_lint_rule! {
     /// Enforces that `audio` and `video` elements must have a `track` for captions.
     ///
@@ -79,17 +81,9 @@ impl Rule for UseMediaCaption {
         let source_type = ctx.source_type::<HtmlFileSource>();
 
         // Check if element is audio or video
-        let element_name = node.name()?;
-        let is_audio = if source_type.is_html() {
-            element_name.text().eq_ignore_ascii_case("audio")
-        } else {
-            element_name.text() == "audio"
-        };
-        let is_video = if source_type.is_html() {
-            element_name.text().eq_ignore_ascii_case("video")
-        } else {
-            element_name.text() == "video"
-        };
+        let tag_element = node.clone().as_any_html_tag_element()?;
+        let is_audio = is_html_tag(&tag_element, source_type, "audio");
+        let is_video = is_html_tag(&tag_element, source_type, "video");
 
         if !is_audio && !is_video {
             return None;
@@ -106,7 +100,7 @@ impl Rule for UseMediaCaption {
         if html_element.opening_element().is_err() {
             return None;
         }
-        if has_caption_track(&html_element.children(), *source_type) {
+        if has_caption_track(&html_element.children(), source_type) {
             return None;
         }
 
@@ -132,16 +126,12 @@ impl Rule for UseMediaCaption {
 }
 
 /// Checks if the given `HtmlElementList` has a `track` element with `kind="captions"`.
-fn has_caption_track(html_child_list: &HtmlElementList, source_type: HtmlFileSource) -> bool {
+fn has_caption_track(html_child_list: &HtmlElementList, source_type: &HtmlFileSource) -> bool {
     html_child_list
         .into_iter()
         .find_map(|child| {
-            let name = child.name()?;
-            let is_track = if source_type.is_html() {
-                name.text().eq_ignore_ascii_case("track")
-            } else {
-                name.text() == "track"
-            };
+            let tag_element = child.clone().as_any_html_tag_element()?;
+            let is_track = is_html_tag(&tag_element, source_type, "track");
             if !is_track {
                 return None;
             }

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_role.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_role.rs
@@ -4,7 +4,7 @@ use biome_analyze::{
 use biome_aria_metadata::AriaRole;
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::AnyHtmlElement;
+use biome_html_syntax::element_ext::AnyHtmlTagElement;
 use biome_rowan::{AstNode, BatchMutationExt};
 use biome_rule_options::use_valid_aria_role::UseValidAriaRoleOptions;
 
@@ -81,7 +81,7 @@ declare_lint_rule! {
 }
 
 impl Rule for UseValidAriaRole {
-    type Query = Ast<AnyHtmlElement>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = ();
     type Signals = Option<Self::State>;
     type Options = UseValidAriaRoleOptions;

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_lang.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_lang.rs
@@ -8,6 +8,8 @@ use biome_html_syntax::element_ext::AnyHtmlTagElement;
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_valid_lang::UseValidLangOptions;
 
+use crate::utils::is_html_tag;
+
 declare_lint_rule! {
     /// Ensure that the attribute passed to the `lang` attribute is a correct ISO language and/or country.
     ///
@@ -62,14 +64,9 @@ impl Rule for UseValidLang {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let element_text = node.name().ok()?.token_text_trimmed()?;
         let source_type = ctx.source_type::<HtmlFileSource>();
-        let matches_tag = if source_type.is_html() {
-            element_text.eq_ignore_ascii_case("html")
-        } else {
-            element_text == "html"
-        };
-        if !matches_tag {
+
+        if !is_html_tag(node, source_type, "html") {
             return None;
         }
 

--- a/crates/biome_html_analyze/src/lint/nursery/no_ambiguous_anchor_text.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/no_ambiguous_anchor_text.rs
@@ -3,14 +3,14 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_html_syntax::{
-    AnyHtmlContent, AnyHtmlElement, HtmlElement, HtmlOpeningElement,
+    AnyHtmlContent, AnyHtmlElement, HtmlElement, HtmlFileSource, HtmlOpeningElement,
     element_ext::AnyHtmlTagElement, inner_string_text,
 };
 use biome_rowan::AstNode;
 use biome_rule_options::no_ambiguous_anchor_text::NoAmbiguousAnchorTextOptions;
 use biome_string_case::StrOnlyExtension;
 
-use crate::a11y::is_hidden_from_screen_reader;
+use crate::{a11y::is_hidden_from_screen_reader, utils::is_html_tag};
 
 declare_lint_rule! {
     /// Disallow ambiguous anchor descriptions.
@@ -73,15 +73,14 @@ impl Rule for NoAmbiguousAnchorText {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let binding = ctx.query();
         let words = ctx.options().words();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        let name = binding.name().ok()?;
-        let name_text = name.token_text_trimmed()?;
-        if name_text != "a" {
+        if !is_html_tag(&AnyHtmlTagElement::from(binding.clone()), source_type, "a") {
             return None;
         }
 
         let parent = HtmlElement::cast(binding.syntax().parent()?)?;
-        let text = get_accessible_child_text(&parent);
+        let text = get_accessible_child_text(&parent, source_type);
 
         if words.contains(&text) {
             return Some(());
@@ -118,10 +117,8 @@ fn get_aria_label(node: &AnyHtmlTagElement) -> Option<String> {
     Some(text.to_string())
 }
 
-fn get_img_alt(node: &AnyHtmlTagElement) -> Option<String> {
-    let name = node.name().ok()?;
-    let name_text = name.token_text_trimmed()?;
-    if name_text != "img" {
+fn get_img_alt(node: &AnyHtmlTagElement, source_type: &HtmlFileSource) -> Option<String> {
+    if !is_html_tag(node, source_type, "img") {
         return None;
     }
 
@@ -145,7 +142,7 @@ fn standardize_space_and_case(input: &str) -> String {
         .join(" ")
 }
 
-fn get_accessible_text(node: &AnyHtmlTagElement) -> Option<String> {
+fn get_accessible_text(node: &AnyHtmlTagElement, source_type: &HtmlFileSource) -> Option<String> {
     if is_hidden_from_screen_reader(node) {
         return Some(String::new());
     }
@@ -154,17 +151,17 @@ fn get_accessible_text(node: &AnyHtmlTagElement) -> Option<String> {
         return Some(standardize_space_and_case(&aria_label));
     }
 
-    if let Some(alt) = get_img_alt(node) {
+    if let Some(alt) = get_img_alt(node, source_type) {
         return Some(standardize_space_and_case(&alt));
     }
 
     None
 }
 
-fn get_accessible_child_text(node: &HtmlElement) -> String {
+fn get_accessible_child_text(node: &HtmlElement, source_type: &HtmlFileSource) -> String {
     if let Ok(opening) = node.opening_element() {
         let any_jsx_element: AnyHtmlTagElement = opening.clone().into();
-        if let Some(accessible_text) = get_accessible_text(&any_jsx_element) {
+        if let Some(accessible_text) = get_accessible_text(&any_jsx_element, source_type) {
             return accessible_text;
         }
     };
@@ -180,10 +177,12 @@ fn get_accessible_child_text(node: &HtmlElement) -> String {
                     String::new()
                 }
             }
-            AnyHtmlElement::HtmlElement(element) => get_accessible_child_text(&element),
+            AnyHtmlElement::HtmlElement(element) => {
+                get_accessible_child_text(&element, source_type)
+            }
             AnyHtmlElement::HtmlSelfClosingElement(element) => {
                 let any_jsx_element: AnyHtmlTagElement = element.clone().into();
-                get_accessible_text(&any_jsx_element).unwrap_or_default()
+                get_accessible_text(&any_jsx_element, source_type).unwrap_or_default()
             }
             _ => String::new(),
         })

--- a/crates/biome_html_analyze/src/lint/nursery/no_inline_styles.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/no_inline_styles.rs
@@ -2,7 +2,9 @@ use biome_analyze::{
     Ast, FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
-use biome_html_syntax::{AnyHtmlElement, HtmlAttribute, HtmlAttributeList, HtmlFileSource};
+use biome_html_syntax::{
+    HtmlAttribute, HtmlAttributeList, HtmlFileSource, element_ext::AnyHtmlTagElement,
+};
 use biome_rowan::{AstNode, BatchMutationExt, TextRange, TokenText};
 use biome_rule_options::no_inline_styles::NoInlineStylesOptions;
 use biome_string_case::StrOnlyExtension;
@@ -57,7 +59,7 @@ declare_lint_rule! {
 }
 
 impl Rule for NoInlineStyles {
-    type Query = Ast<AnyHtmlElement>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = TextRange;
     type Signals = Option<Self::State>;
     type Options = NoInlineStylesOptions;
@@ -66,18 +68,16 @@ impl Rule for NoInlineStyles {
         let node = ctx.query();
 
         match node {
-            AnyHtmlElement::HtmlElement(element) => {
-                let opening = element.opening_element().ok()?;
-
-                if let Some(name) = opening.tag_name()
+            AnyHtmlTagElement::HtmlOpeningElement(element) => {
+                if let Some(name) = element.tag_name()
                     && is_custom_component(name, ctx)
                 {
                     return None;
                 }
 
-                find_style_attribute(opening.attributes()).map(|attribute| attribute.range())
+                find_style_attribute(element.attributes()).map(|attribute| attribute.range())
             }
-            AnyHtmlElement::HtmlSelfClosingElement(self_closing_element) => {
+            AnyHtmlTagElement::HtmlSelfClosingElement(self_closing_element) => {
                 if let Some(name) = self_closing_element.tag_name()
                     && is_custom_component(name, ctx)
                 {
@@ -87,7 +87,6 @@ impl Rule for NoInlineStyles {
                 find_style_attribute(self_closing_element.attributes())
                     .map(|attribute| attribute.range())
             }
-            _ => None,
         }
     }
 
@@ -111,13 +110,11 @@ impl Rule for NoInlineStyles {
         let mut mutation = ctx.root().begin();
 
         match node {
-            AnyHtmlElement::HtmlElement(element) => {
-                let opening = element.opening_element().ok()?;
-                mutation.remove_node(find_style_attribute(opening.attributes()).unwrap())
+            AnyHtmlTagElement::HtmlOpeningElement(opening_element) => {
+                mutation.remove_node(find_style_attribute(opening_element.attributes()).unwrap())
             }
-            AnyHtmlElement::HtmlSelfClosingElement(self_closing_element) => mutation
+            AnyHtmlTagElement::HtmlSelfClosingElement(self_closing_element) => mutation
                 .remove_node(find_style_attribute(self_closing_element.attributes()).unwrap()),
-            _ => {}
         }
 
         Some(HtmlRuleAction::new(

--- a/crates/biome_html_analyze/src/lint/nursery/no_script_url.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/no_script_url.rs
@@ -3,10 +3,15 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlAttributeInitializer, HtmlOpeningElement, inner_string_text};
+use biome_html_syntax::{
+    AnyHtmlAttributeInitializer, HtmlFileSource, HtmlOpeningElement,
+    element_ext::AnyHtmlTagElement, inner_string_text,
+};
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::no_script_url::NoScriptUrlOptions;
 use biome_string_case::StrOnlyExtension;
+
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Disallow `javascript:` URLs in HTML.
@@ -61,11 +66,9 @@ impl Rule for NoScriptUrl {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let element = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        // Only check <a> elements for HTML (unlike JSX where components/custom elements exist)
-        let name = element.name().ok()?;
-        let tag = name.token_text_trimmed()?;
-        if !tag.eq_ignore_ascii_case("a") {
+        if !is_html_tag(&AnyHtmlTagElement::from(element.clone()), source_type, "a") {
             return None;
         }
 

--- a/crates/biome_html_analyze/src/lint/nursery/no_sync_scripts.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/no_sync_scripts.rs
@@ -2,9 +2,11 @@ use biome_analyze::{
     Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
-use biome_html_syntax::{HtmlFileSource, HtmlOpeningElement};
+use biome_html_syntax::{HtmlFileSource, HtmlOpeningElement, element_ext::AnyHtmlTagElement};
 use biome_rowan::AstNode;
 use biome_rule_options::no_sync_scripts::NoSyncScriptsOptions;
+
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Prevent the usage of synchronous scripts.
@@ -44,15 +46,13 @@ impl Rule for NoSyncScripts {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let binding = ctx.query();
-        let file_source = ctx.source_type::<HtmlFileSource>();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        let name = binding.name().ok()?;
-        let name_text = name.token_text_trimmed()?;
-
-        if file_source.is_html() && !name_text.eq_ignore_ascii_case("script") {
-            return None;
-        }
-        if !file_source.is_html() && name_text != "script" {
+        if !is_html_tag(
+            &AnyHtmlTagElement::from(binding.clone()),
+            source_type,
+            "script",
+        ) {
             return None;
         }
 

--- a/crates/biome_html_analyze/src/lint/nursery/use_iframe_sandbox.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_iframe_sandbox.rs
@@ -1,9 +1,11 @@
 use biome_analyze::{Ast, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlElement, HtmlFileSource};
+use biome_html_syntax::{HtmlFileSource, element_ext::AnyHtmlTagElement};
 use biome_rowan::AstNode;
 use biome_rule_options::use_iframe_sandbox::UseIframeSandboxOptions;
+
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Enforce the 'sandbox' attribute for 'iframe' elements.
@@ -37,15 +39,16 @@ declare_lint_rule! {
 }
 
 impl Rule for UseIframeSandbox {
-    type Query = Ast<AnyHtmlElement>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = ();
     type Signals = Option<Self::State>;
     type Options = UseIframeSandboxOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        if !is_iframe_element(element, ctx) {
+        if !is_html_tag(element, source_type, "iframe") {
             return None;
         }
 
@@ -73,22 +76,5 @@ impl Rule for UseIframeSandbox {
                 "Provide a "<Emphasis>"sandbox"</Emphasis>" attribute when using iframe elements."
             }),
         )
-    }
-}
-
-fn is_iframe_element(element: &AnyHtmlElement, ctx: &RuleContext<UseIframeSandbox>) -> bool {
-    let Some(element_name) = element.name() else {
-        return false;
-    };
-
-    let source_type = ctx.source_type::<HtmlFileSource>();
-
-    // In HTML files: case-insensitive (IFRAME, Iframe, iframe all match)
-    // In component frameworks (Vue, Svelte, Astro): case-sensitive (only "iframe" matches)
-    // This means <Iframe> in Vue/Svelte is treated as a component and ignored
-    if source_type.is_html() {
-        element_name.text().eq_ignore_ascii_case("iframe")
-    } else {
-        element_name.text() == "iframe"
     }
 }

--- a/crates/biome_html_analyze/src/lint/nursery/use_scoped_styles.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_scoped_styles.rs
@@ -106,7 +106,7 @@ impl Rule for UseScopedStyles {
             } else {
                 return Some(GlobalStylesKind::Vue);
             }
-        } else if ctx.source_type::<HtmlFileSource>().is_astro() {
+        } else if source_type.is_astro() {
             let is_directives = attributes
                 .iter()
                 .filter_map(|attr| attr.syntax().clone().cast::<AstroIsDirective>());

--- a/crates/biome_html_analyze/src/lint/nursery/use_scoped_styles.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_scoped_styles.rs
@@ -97,7 +97,7 @@ impl Rule for UseScopedStyles {
         }
 
         let attributes = opening.attributes();
-        if ctx.source_type::<HtmlFileSource>().is_vue() {
+        if source_type.is_vue() {
             let has_scoped = attributes.find_by_name("scoped").is_some();
             let has_module = attributes.find_by_name("module").is_some();
 

--- a/crates/biome_html_analyze/src/lint/nursery/use_scoped_styles.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_scoped_styles.rs
@@ -6,10 +6,12 @@ use biome_console::markup;
 use biome_html_factory::make;
 use biome_html_syntax::{
     AnyHtmlAttribute, AstroIsDirective, HtmlFileSource, HtmlOpeningElement, HtmlSyntaxKind,
-    HtmlSyntaxToken,
+    HtmlSyntaxToken, element_ext::AnyHtmlTagElement,
 };
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, SyntaxNodeCast};
 use biome_rule_options::use_scoped_styles::UseScopedStylesOptions;
+
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Enforce that `<style>` blocks in Vue SFCs have the `scoped` attribute and that `<style>` blocks in Astro components do not have the `is:global` directive.
@@ -78,17 +80,19 @@ impl Rule for UseScopedStyles {
     type Options = UseScopedStylesOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        if !ctx.source_type::<HtmlFileSource>().is_vue()
-            && !ctx.source_type::<HtmlFileSource>().is_astro()
-        {
+        let source_type = ctx.source_type::<HtmlFileSource>();
+
+        if !source_type.is_vue() && !source_type.is_astro() {
             return None;
         }
 
         let opening = ctx.query();
 
-        let name = opening.name().ok()?;
-        let name_text = name.token_text_trimmed()?;
-        if !name_text.eq_ignore_ascii_case("style") {
+        if !is_html_tag(
+            &AnyHtmlTagElement::from(opening.clone()),
+            source_type,
+            "style",
+        ) {
             return None;
         }
 

--- a/crates/biome_html_analyze/src/lint/nursery/use_vue_hyphenated_attributes.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_vue_hyphenated_attributes.rs
@@ -3,10 +3,8 @@ use biome_analyze::{
     declare_lint_rule,
 };
 use biome_console::markup;
-use biome_html_syntax::{
-    AnyHtmlAttribute, AnyHtmlTagName, HtmlAttributeList, HtmlOpeningElement, HtmlSelfClosingElement,
-};
-use biome_rowan::{AstNode, AstNodeList, SyntaxResult, TokenText, declare_node_union};
+use biome_html_syntax::{AnyHtmlAttribute, element_ext::AnyHtmlTagElement};
+use biome_rowan::{AstNode, AstNodeList, TokenText};
 use biome_rule_options::use_vue_hyphenated_attributes::UseVueHyphenatedAttributesOptions;
 use biome_string_case::Case;
 
@@ -99,12 +97,8 @@ declare_lint_rule! {
     }
 }
 
-declare_node_union! {
-    pub AnyTagWithAttributes = HtmlOpeningElement | HtmlSelfClosingElement
-}
-
 impl Rule for UseVueHyphenatedAttributes {
-    type Query = Ast<AnyTagWithAttributes>;
+    type Query = Ast<AnyHtmlTagElement>;
     type State = AnyHtmlAttribute;
     type Signals = Box<[Self::State]>;
     type Options = UseVueHyphenatedAttributesOptions;
@@ -224,22 +218,6 @@ impl Rule for UseVueHyphenatedAttributes {
             markup! { "Rename the attribute to "<Emphasis>{suggested}</Emphasis>"." }.to_owned(),
             mutation,
         ))
-    }
-}
-
-impl AnyTagWithAttributes {
-    fn name(&self) -> SyntaxResult<AnyHtmlTagName> {
-        match self {
-            Self::HtmlOpeningElement(node) => node.name(),
-            Self::HtmlSelfClosingElement(node) => node.name(),
-        }
-    }
-
-    fn attributes(&self) -> HtmlAttributeList {
-        match self {
-            Self::HtmlOpeningElement(node) => node.attributes(),
-            Self::HtmlSelfClosingElement(node) => node.attributes(),
-        }
     }
 }
 

--- a/crates/biome_html_analyze/src/lint/nursery/use_vue_valid_template_root.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_vue_valid_template_root.rs
@@ -3,9 +3,11 @@ use biome_analyze::{
     declare_lint_rule,
 };
 use biome_console::markup;
-use biome_html_syntax::{HtmlElement, HtmlRoot};
+use biome_html_syntax::{HtmlElement, HtmlFileSource, HtmlRoot};
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt};
 use biome_rule_options::use_vue_valid_template_root::UseVueValidTemplateRootOptions;
+
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Enforce valid Vue `<template>` root usage.
@@ -60,19 +62,17 @@ impl Rule for UseVueValidTemplateRoot {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let root = ctx.query();
-        // Find top-level `<template>` elements only
-        let element = root
-            .html()
-            .into_iter()
-            .filter_map(|el| HtmlElement::cast(el.into_syntax()))
-            .find(|el| {
-                el.opening_element()
-                    .ok()
-                    .and_then(|op| op.name().ok())
-                    .and_then(|name| name.token_text_trimmed())
-                    .is_some_and(|text| text == "template")
-            })?;
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
+        // Find top-level `<template>` elements only
+        let element = root.html().into_iter().find(|el| {
+            if let Some(element) = el.clone().as_any_html_tag_element() {
+                return is_html_tag(&element, source_type, "template");
+            }
+            false
+        })?;
+
+        let element = HtmlElement::cast(element.into_syntax())?;
         let has_src = element.find_attribute_by_name("src").is_some();
         let has_non_whitespace_content = !element.children().is_empty();
 

--- a/crates/biome_html_analyze/src/lint/nursery/use_vue_vapor.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_vue_vapor.rs
@@ -4,10 +4,13 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_html_factory::make;
 use biome_html_syntax::{
-    AnyHtmlAttribute, HtmlAttributeList, HtmlOpeningElement, HtmlSyntaxKind, HtmlSyntaxToken,
+    AnyHtmlAttribute, HtmlAttributeList, HtmlFileSource, HtmlOpeningElement, HtmlSyntaxKind,
+    HtmlSyntaxToken, element_ext::AnyHtmlTagElement,
 };
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, TriviaPiece};
 use biome_rule_options::use_vue_vapor::UseVueVaporOptions;
+
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Enforce opting in to Vue Vapor mode in `<script setup>` blocks.
@@ -58,10 +61,13 @@ impl Rule for UseVueVapor {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let opening = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
 
-        let name = opening.name().ok()?;
-        let name_text = name.token_text_trimmed()?;
-        if !name_text.eq_ignore_ascii_case("script") {
+        if !is_html_tag(
+            &AnyHtmlTagElement::from(opening.clone()),
+            source_type,
+            "script",
+        ) {
             return None;
         }
 

--- a/crates/biome_html_analyze/src/utils.rs
+++ b/crates/biome_html_analyze/src/utils.rs
@@ -1,0 +1,16 @@
+use biome_html_syntax::{HtmlFileSource, element_ext::AnyHtmlTagElement};
+
+// In HTML files: case-insensitive (TAG, Tag, tag all match)
+// In component frameworks (Vue, Svelte, Astro): case-sensitive (only "tag" matches)
+// This means <Tag> in Vue/Svelte is treated as a component and ignored
+pub fn is_html_tag(element: &AnyHtmlTagElement, source_type: &HtmlFileSource, name: &str) -> bool {
+    let Some(element_name) = element.tag_name() else {
+        return false;
+    };
+
+    if source_type.is_html() {
+        element_name.eq_ignore_ascii_case(name)
+    } else {
+        element_name.text() == name
+    }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/useAltText/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAltText/invalid.html.snap
@@ -143,7 +143,7 @@ invalid.html:16:1 lint/a11y/useAltText ━━━━━━━━━━━━━�
   
     15 │ <!-- object without title -->
   > 16 │ <object data="movie.swf"></object>
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
     17 │ <object data="document.pdf" type="application/pdf"></object>
     18 │ 
   
@@ -162,7 +162,7 @@ invalid.html:17:1 lint/a11y/useAltText ━━━━━━━━━━━━━�
     15 │ <!-- object without title -->
     16 │ <object data="movie.swf"></object>
   > 17 │ <object data="document.pdf" type="application/pdf"></object>
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     18 │ 
   
   i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.

--- a/crates/biome_html_analyze/tests/specs/a11y/useButtonType/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useButtonType/invalid.html.snap
@@ -24,7 +24,7 @@ invalid.html:2:1 lint/a11y/useButtonType ━━━━━━━━━━━━━
   
     1 │ <!-- should generate diagnostics -->
   > 2 │ <button>Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^
     3 │ <button type="incorrectType">Do something</button>
     4 │ <button type>Do something</button>
   
@@ -43,7 +43,7 @@ invalid.html:3:1 lint/a11y/useButtonType ━━━━━━━━━━━━━
     1 │ <!-- should generate diagnostics -->
     2 │ <button>Do something</button>
   > 3 │ <button type="incorrectType">Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ <button type>Do something</button>
     5 │ <button type="">Do something</button>
   
@@ -62,7 +62,7 @@ invalid.html:4:1 lint/a11y/useButtonType ━━━━━━━━━━━━━
     2 │ <button>Do something</button>
     3 │ <button type="incorrectType">Do something</button>
   > 4 │ <button type>Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^
     5 │ <button type="">Do something</button>
     6 │ <button />
   
@@ -81,7 +81,7 @@ invalid.html:5:1 lint/a11y/useButtonType ━━━━━━━━━━━━━
     3 │ <button type="incorrectType">Do something</button>
     4 │ <button type>Do something</button>
   > 5 │ <button type="">Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^
     6 │ <button />
     7 │ <button type="incorrectType" />
   

--- a/crates/biome_html_analyze/tests/specs/a11y/useButtonType/invalid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useButtonType/invalid.svelte.snap
@@ -24,7 +24,7 @@ invalid.svelte:3:1 lint/a11y/useButtonType ━━━━━━━━━━━━�
     1 │ <!-- should generate diagnostics -->
     2 │ 
   > 3 │ <button>Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^
     4 │ <button />
     5 │ <button type="incorrectType">Do something</button>
   
@@ -61,7 +61,7 @@ invalid.svelte:5:1 lint/a11y/useButtonType ━━━━━━━━━━━━�
     3 │ <button>Do something</button>
     4 │ <button />
   > 5 │ <button type="incorrectType">Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     6 │ <button type="incorrectType" />
     7 │ <button type>Do something</button>
   
@@ -99,7 +99,7 @@ invalid.svelte:7:1 lint/a11y/useButtonType ━━━━━━━━━━━━�
     5 │ <button type="incorrectType">Do something</button>
     6 │ <button type="incorrectType" />
   > 7 │ <button type>Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^
     8 │ <button type="" />
     9 │ 
   

--- a/crates/biome_html_analyze/tests/specs/a11y/useButtonType/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useButtonType/invalid.vue.snap
@@ -24,7 +24,7 @@ invalid.vue:3:1 lint/a11y/useButtonType ━━━━━━━━━━━━━�
     1 │ <!-- should generate diagnostics -->
     2 │ 
   > 3 │ <button>Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^
     4 │ <button />
     5 │ <button type="incorrectType">Do something</button>
   
@@ -61,7 +61,7 @@ invalid.vue:5:1 lint/a11y/useButtonType ━━━━━━━━━━━━━�
     3 │ <button>Do something</button>
     4 │ <button />
   > 5 │ <button type="incorrectType">Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     6 │ <button type="incorrectType" />
     7 │ <button type>Do something</button>
   
@@ -99,7 +99,7 @@ invalid.vue:7:1 lint/a11y/useButtonType ━━━━━━━━━━━━━�
     5 │ <button type="incorrectType">Do something</button>
     6 │ <button type="incorrectType" />
   > 7 │ <button type>Do something</button>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^
     8 │ <button type="" />
     9 │ 
   

--- a/crates/biome_html_analyze/tests/specs/a11y/useHtmlLang/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHtmlLang/invalid.html.snap
@@ -37,7 +37,7 @@ invalid.html:3:1 lint/a11y/useHtmlLang ━━━━━━━━━━━━━�
     1 │ <!-- should generate diagnostics -->
     2 │ <html />
   > 3 │ <html></html>
-      │ ^^^^^^^^^^^^^
+      │ ^^^^^^
     4 │ <html lang></html>
     5 │ <html lang=""></html>
   
@@ -54,7 +54,7 @@ invalid.html:4:1 lint/a11y/useHtmlLang ━━━━━━━━━━━━━�
     2 │ <html />
     3 │ <html></html>
   > 4 │ <html lang></html>
-      │ ^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^
     5 │ <html lang=""></html>
     6 │ 
   
@@ -71,7 +71,7 @@ invalid.html:5:1 lint/a11y/useHtmlLang ━━━━━━━━━━━━━�
     3 │ <html></html>
     4 │ <html lang></html>
   > 5 │ <html lang=""></html>
-      │ ^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^
     6 │ 
   
   i Setting a lang attribute on HTML document elements configures the language used by screen readers when no user default is specified.

--- a/crates/biome_html_analyze/tests/specs/a11y/useIframeTitle/astro/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useIframeTitle/astro/invalid.astro.snap
@@ -36,7 +36,7 @@ invalid.astro:3:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━�
     1 │ <!-- should generate diagnostics -->
     2 │ <iframe />
   > 3 │ <iframe></iframe>
-      │ ^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^
     4 │ <iframe title=""></iframe>
     5 │ 
   
@@ -53,7 +53,7 @@ invalid.astro:4:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━�
     2 │ <iframe />
     3 │ <iframe></iframe>
   > 4 │ <iframe title=""></iframe>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^
     5 │ 
   
   i Screen readers rely on the title set on an iframe to describe the content being displayed.

--- a/crates/biome_html_analyze/tests/specs/a11y/useIframeTitle/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useIframeTitle/invalid.html.snap
@@ -38,7 +38,7 @@ invalid.html:3:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━�
     1 │ <!-- should generate diagnostics -->
     2 │ <iframe />
   > 3 │ <iframe></iframe>
-      │ ^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^
     4 │ <iframe title></iframe>
     5 │ <iframe title=""></iframe>
   
@@ -55,7 +55,7 @@ invalid.html:4:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━�
     2 │ <iframe />
     3 │ <iframe></iframe>
   > 4 │ <iframe title></iframe>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^
     5 │ <iframe title=""></iframe>
     6 │ <IFRAME></IFRAME>
   
@@ -72,7 +72,7 @@ invalid.html:5:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━�
     3 │ <iframe></iframe>
     4 │ <iframe title></iframe>
   > 5 │ <iframe title=""></iframe>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^
     6 │ <IFRAME></IFRAME>
     7 │ 
   
@@ -89,7 +89,7 @@ invalid.html:6:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━�
     4 │ <iframe title></iframe>
     5 │ <iframe title=""></iframe>
   > 6 │ <IFRAME></IFRAME>
-      │ ^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^
     7 │ 
   
   i Screen readers rely on the title set on an iframe to describe the content being displayed.

--- a/crates/biome_html_analyze/tests/specs/a11y/useIframeTitle/svelte/invalid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useIframeTitle/svelte/invalid.svelte.snap
@@ -36,7 +36,7 @@ invalid.svelte:3:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━
     1 │ <!-- should generate diagnostics -->
     2 │ <iframe />
   > 3 │ <iframe></iframe>
-      │ ^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^
     4 │ <iframe title=""></iframe>
     5 │ 
   
@@ -53,7 +53,7 @@ invalid.svelte:4:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━
     2 │ <iframe />
     3 │ <iframe></iframe>
   > 4 │ <iframe title=""></iframe>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^
     5 │ 
   
   i Screen readers rely on the title set on an iframe to describe the content being displayed.

--- a/crates/biome_html_analyze/tests/specs/a11y/useIframeTitle/vue/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useIframeTitle/vue/invalid.vue.snap
@@ -36,7 +36,7 @@ invalid.vue:3:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━━
     1 │ <!-- should generate diagnostics -->
     2 │ <iframe />
   > 3 │ <iframe></iframe>
-      │ ^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^
     4 │ <iframe title=""></iframe>
     5 │ 
   
@@ -53,7 +53,7 @@ invalid.vue:4:1 lint/a11y/useIframeTitle ━━━━━━━━━━━━━
     2 │ <iframe />
     3 │ <iframe></iframe>
   > 4 │ <iframe title=""></iframe>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^
     5 │ 
   
   i Screen readers rely on the title set on an iframe to describe the content being displayed.

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAriaRole/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAriaRole/invalid.html.snap
@@ -23,7 +23,7 @@ invalid.html:2:1 lint/a11y/useValidAriaRole  FIXABLE  ━━━━━━━━�
   
     1 │ <!-- should generate diagnostics -->
   > 2 │ <div role="range"></div>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^
     3 │ <div role="datepicker"></div>
     4 │ <div role=""></div>
   
@@ -45,7 +45,7 @@ invalid.html:3:1 lint/a11y/useValidAriaRole  FIXABLE  ━━━━━━━━�
     1 │ <!-- should generate diagnostics -->
     2 │ <div role="range"></div>
   > 3 │ <div role="datepicker"></div>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
     4 │ <div role=""></div>
     5 │ <div role="datepicker" />
   
@@ -67,7 +67,7 @@ invalid.html:4:1 lint/a11y/useValidAriaRole  FIXABLE  ━━━━━━━━�
     2 │ <div role="range"></div>
     3 │ <div role="datepicker"></div>
   > 4 │ <div role=""></div>
-      │ ^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^
     5 │ <div role="datepicker" />
     6 │ <div role="unknown-invalid-role" />
   
@@ -133,7 +133,7 @@ invalid.html:7:1 lint/a11y/useValidAriaRole  FIXABLE  ━━━━━━━━�
     5 │ <div role="datepicker" />
     6 │ <div role="unknown-invalid-role" />
   > 7 │ <div role="tabpanel row foobar"></div>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     8 │ <div role="doc-endnotes range"></div>
     9 │ 
   
@@ -155,7 +155,7 @@ invalid.html:8:1 lint/a11y/useValidAriaRole  FIXABLE  ━━━━━━━━�
     6 │ <div role="unknown-invalid-role" />
     7 │ <div role="tabpanel row foobar"></div>
   > 8 │ <div role="doc-endnotes range"></div>
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     9 │ 
   
   i Check WAI-ARIA for valid roles or provide options accordingly.

--- a/crates/biome_html_analyze/tests/specs/nursery/useIframeSandbox/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/useIframeSandbox/invalid.html.snap
@@ -17,7 +17,7 @@ invalid.html:2:1 lint/nursery/useIframeSandbox ━━━━━━━━━━━
   
     1 │ <!-- should generate diagnostics -->
   > 2 │ <iframe></iframe>
-      │ ^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^
     3 │ 
   
   i The sandbox attribute enables an extra set of restrictions for the content in the iframe, protecting against malicious scripts and other security threats.

--- a/crates/biome_html_syntax/src/element_ext.rs
+++ b/crates/biome_html_syntax/src/element_ext.rs
@@ -115,6 +115,17 @@ impl AnyHtmlElement {
         }
     }
 
+    pub fn as_any_html_tag_element(self) -> Option<AnyHtmlTagElement> {
+        match &self {
+            Self::HtmlElement(element) => {
+                let opening = element.opening_element().ok()?;
+                Some(AnyHtmlTagElement::from(opening))
+            }
+            Self::HtmlSelfClosingElement(element) => Some(AnyHtmlTagElement::from(element.clone())),
+            _ => None,
+        }
+    }
+
     /// Returns the list of attributes for this element, if it has any.
     pub fn attributes(&self) -> Option<HtmlAttributeList> {
         match self {
@@ -123,58 +134,6 @@ impl AnyHtmlElement {
             // Other variants don't have attributes
             _ => None,
         }
-    }
-
-    /// Check if the element has a given HTML attribute or a Vue v-bind binding
-    /// targeting the same attribute name.
-    ///
-    /// Handles:
-    /// - `name="..."` — standard HTML attribute
-    /// - `:name="..."` — Vue v-bind shorthand (`VueVBindShorthandDirective`)
-    /// - `v-bind:name="..."` — explicit Vue v-bind (`VueDirective`)
-    pub fn find_attribute_or_vue_binding(&self, name_to_lookup: &str) -> Option<AnyHtmlAttribute> {
-        let attrs = self.attributes()?;
-
-        attrs.iter().find_map(|attr| {
-            let matches = match &attr {
-                AnyHtmlAttribute::HtmlAttribute(a) => a
-                    .name()
-                    .ok()
-                    .and_then(|n| n.value_token().ok())
-                    .is_some_and(|t| t.text_trimmed().eq_ignore_ascii_case(name_to_lookup)),
-
-                AnyHtmlAttribute::AnyVueDirective(vue) => match vue {
-                    // :name="..."
-                    AnyVueDirective::VueVBindShorthandDirective(d) => d
-                        .arg()
-                        .ok()
-                        .and_then(|arg| arg.arg().ok())
-                        .and_then(|arg| arg.as_vue_static_argument().cloned())
-                        .and_then(|s| s.name_token().ok())
-                        .is_some_and(|t| t.text_trimmed().eq_ignore_ascii_case(name_to_lookup)),
-
-                    // v-bind:name="..."
-                    AnyVueDirective::VueDirective(d) => {
-                        let is_bind = d
-                            .name_token()
-                            .is_ok_and(|t| t.text_trimmed().eq_ignore_ascii_case("v-bind"));
-                        is_bind
-                            && d.arg()
-                                .and_then(|arg| arg.arg().ok())
-                                .and_then(|arg| arg.as_vue_static_argument().cloned())
-                                .and_then(|s| s.name_token().ok())
-                                .is_some_and(|t| {
-                                    t.text_trimmed().eq_ignore_ascii_case(name_to_lookup)
-                                })
-                    }
-
-                    _ => false,
-                },
-
-                _ => false,
-            };
-            if matches { Some(attr) } else { None }
-        })
     }
 }
 
@@ -377,6 +336,13 @@ declare_node_union! {
 }
 
 impl AnyHtmlTagElement {
+    pub fn tag_name(&self) -> Option<TokenText> {
+        match self {
+            Self::HtmlOpeningElement(element) => element.tag_name(),
+            Self::HtmlSelfClosingElement(element) => element.tag_name(),
+        }
+    }
+
     pub fn name(&self) -> SyntaxResult<AnyHtmlTagName> {
         match self {
             Self::HtmlOpeningElement(element) => element.name(),
@@ -416,6 +382,56 @@ impl AnyHtmlTagElement {
                     .and_then(|value| value.string_value())
                     .is_none_or(|value| value != "false")
             })
+    }
+
+    /// Check if the element has a given HTML attribute or a Vue v-bind binding
+    /// targeting the same attribute name.
+    ///
+    /// Handles:
+    /// - `name="..."` — standard HTML attribute
+    /// - `:name="..."` — Vue v-bind shorthand (`VueVBindShorthandDirective`)
+    /// - `v-bind:name="..."` — explicit Vue v-bind (`VueDirective`)
+    pub fn find_attribute_or_vue_binding(&self, name_to_lookup: &str) -> Option<AnyHtmlAttribute> {
+        self.attributes().iter().find_map(|attr| {
+            let matches = match &attr {
+                AnyHtmlAttribute::HtmlAttribute(a) => a
+                    .name()
+                    .ok()
+                    .and_then(|n| n.value_token().ok())
+                    .is_some_and(|t| t.text_trimmed().eq_ignore_ascii_case(name_to_lookup)),
+
+                AnyHtmlAttribute::AnyVueDirective(vue) => match vue {
+                    // :name="..."
+                    AnyVueDirective::VueVBindShorthandDirective(d) => d
+                        .arg()
+                        .ok()
+                        .and_then(|arg| arg.arg().ok())
+                        .and_then(|arg| arg.as_vue_static_argument().cloned())
+                        .and_then(|s| s.name_token().ok())
+                        .is_some_and(|t| t.text_trimmed().eq_ignore_ascii_case(name_to_lookup)),
+
+                    // v-bind:name="..."
+                    AnyVueDirective::VueDirective(d) => {
+                        let is_bind = d
+                            .name_token()
+                            .is_ok_and(|t| t.text_trimmed().eq_ignore_ascii_case("v-bind"));
+                        is_bind
+                            && d.arg()
+                                .and_then(|arg| arg.arg().ok())
+                                .and_then(|arg| arg.as_vue_static_argument().cloned())
+                                .and_then(|s| s.name_token().ok())
+                                .is_some_and(|t| {
+                                    t.text_trimmed().eq_ignore_ascii_case(name_to_lookup)
+                                })
+                    }
+
+                    _ => false,
+                },
+
+                _ => false,
+            };
+            if matches { Some(attr) } else { None }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

- Abstracted checking for regular html tags
- Used a smaller union query for certain rules (which affects diagnostic ranges; now only opening & self-closing instead the full open till close, which is better honestly)

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
