### PR TITLE
fix(lint): fix false positive in noMisleadingReturnType for mutable bindings

### DIFF
--- a/.changeset/shaggy-planets-yawn.md
+++ b/.changeset/shaggy-planets-yawn.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed `noMisleadingReturnType` incorrectly flagging functions with reassigned `let` variables.

--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
@@ -394,7 +394,19 @@ fn is_intersection_with_type_param(ty: &Type) -> bool {
 }
 
 fn is_literal_of_primitive(ty: &Type) -> bool {
-    matches!(&**ty, TypeData::Literal(lit) if lit.is_primitive())
+    match &**ty {
+        TypeData::Literal(lit) => lit.is_primitive(),
+        // The type resolver may wrap a single literal in a Union for mutable
+        // bindings.  Treat a one-element union of a primitive literal the same.
+        TypeData::Union(_) => {
+            let mut iter = ty.flattened_union_variants();
+            matches!(
+                (iter.next(), iter.next()),
+                (Some(v), None) if matches!(&*v, TypeData::Literal(lit) if lit.is_primitive())
+            )
+        }
+        _ => false,
+    }
 }
 
 /// Checks whether annotation differs from returns only by property-level
@@ -1035,12 +1047,26 @@ fn is_wider_than(annotated: &Type, inferred: &Type) -> bool {
 
         (TypeData::Union(_), _) => is_union_wider(annotated, &current),
         (_, TypeData::Union(_)) => {
-            current
-                .flattened_union_variants()
-                .all(|v| types_match(annotated, &v) || is_nonunion_wider(annotated, &v))
-                && current
-                    .flattened_union_variants()
-                    .any(|v| is_nonunion_wider(annotated, &v))
+            let variants: Vec<_> = current.flattened_union_variants().collect();
+
+            // When the annotation's base type already appears as a variant in the
+            // inferred union, any literal subtypes are subsumed by it — the union
+            // collapses to the base type (e.g., 0 | number = number).  In that
+            // case the annotation is not wider than the inferred type.
+            if variants.iter().any(|v| types_match(annotated, v))
+                && variants
+                    .iter()
+                    .all(|v| types_match(annotated, v) || is_base_type_of_literal(annotated, v))
+            {
+                return false;
+            }
+
+            variants
+                .iter()
+                .all(|v| types_match(annotated, v) || is_nonunion_wider(annotated, v))
+                && variants
+                    .iter()
+                    .any(|v| is_nonunion_wider(annotated, v))
         }
         _ => is_nonunion_wider(annotated, &current),
     }

--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
@@ -1053,16 +1053,19 @@ fn is_wider_than(annotated: &Type, inferred: &Type) -> bool {
             // case the annotation is not wider than the inferred type.
             let (has_base_variant, all_subsumed, all_covered, any_wider) = current
                 .flattened_union_variants()
-                .fold((false, true, true, false), |(hb, asum, acov, aw), v| {
-                    let matches = types_match(annotated, &v);
-                    let wider = is_nonunion_wider(annotated, &v);
-                    (
-                        hb || matches,
-                        asum && (matches || is_base_type_of_literal(annotated, &v)),
-                        acov && (matches || wider),
-                        aw || wider,
-                    )
-                });
+                .fold(
+                    (false, true, true, false),
+                    |(has_base_variant, all_subsumed, all_covered, any_wider), v| {
+                        let matches = types_match(annotated, &v);
+                        let wider = is_nonunion_wider(annotated, &v);
+                        (
+                            has_base_variant || matches,
+                            all_subsumed && (matches || is_base_type_of_literal(annotated, &v)),
+                            all_covered && (matches || wider),
+                            any_wider || wider,
+                        )
+                    },
+                );
             if has_base_variant && all_subsumed {
                 return false;
             }

--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
@@ -1047,26 +1047,26 @@ fn is_wider_than(annotated: &Type, inferred: &Type) -> bool {
 
         (TypeData::Union(_), _) => is_union_wider(annotated, &current),
         (_, TypeData::Union(_)) => {
-            let variants: Vec<_> = current.flattened_union_variants().collect();
-
             // When the annotation's base type already appears as a variant in the
             // inferred union, any literal subtypes are subsumed by it — the union
             // collapses to the base type (e.g., 0 | number = number).  In that
             // case the annotation is not wider than the inferred type.
-            if variants.iter().any(|v| types_match(annotated, v))
-                && variants
-                    .iter()
-                    .all(|v| types_match(annotated, v) || is_base_type_of_literal(annotated, v))
-            {
+            let (has_base_variant, all_subsumed, all_covered, any_wider) = current
+                .flattened_union_variants()
+                .fold((false, true, true, false), |(hb, asum, acov, aw), v| {
+                    let matches = types_match(annotated, &v);
+                    let wider = is_nonunion_wider(annotated, &v);
+                    (
+                        hb || matches,
+                        asum && (matches || is_base_type_of_literal(annotated, &v)),
+                        acov && (matches || wider),
+                        aw || wider,
+                    )
+                });
+            if has_base_variant && all_subsumed {
                 return false;
             }
-
-            variants
-                .iter()
-                .all(|v| types_match(annotated, v) || is_nonunion_wider(annotated, v))
-                && variants
-                    .iter()
-                    .any(|v| is_nonunion_wider(annotated, v))
+            all_covered && any_wider
         }
         _ => is_nonunion_wider(annotated, &current),
     }

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts
@@ -143,3 +143,9 @@ class OverloadedMethods {
         return "idle";
     }
 }
+
+// Mutable bindings where inferred union contains base type + literal (not misleading)
+declare function getStr(): string;
+function letReassignStr(): string { let s = "default"; if (Math.random() > 0.5) s = getStr(); return s; }
+declare function getNum(): number;
+const arrowLetReassign = (): number => { let n = 0; if (Math.random() > 0.5) n = getNum(); return n; };

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts.snap
@@ -150,4 +150,10 @@ class OverloadedMethods {
     }
 }
 
+// Mutable bindings where inferred union contains base type + literal (not misleading)
+declare function getStr(): string;
+function letReassignStr(): string { let s = "default"; if (Math.random() > 0.5) s = getStr(); return s; }
+declare function getNum(): number;
+const arrowLetReassign = (): number => { let n = 0; if (Math.random() > 0.5) n = getNum(); return n; };
+
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->


I used Claude Code to assist with this implementation.


## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

[Sandbox](https://biomejs.dev/playground/?lineWidth=120&indentStyle=space&whitespaceSensitivity=strict&indentScriptAndStyle=true&lintRules=noMisleadingReturnType&analyzerFixMode=safeAndUnsafeFixes&tab=formatter&pane=Console&code=YwBvAG4AcwB0ACAAZwBlAHQATgB1AG0AIAA9ACAAKAApADoAIABuAHUAbQBiAGUAcgAgAD0APgAgAE0AYQB0AGgALgByAGEAbgBkAG8AbQAoACkAOwAKAAoAYwBvAG4AcwB0ACAAZwBlAHQAQQBkAGQAaQB0AGkAbwBuAGEAbABTAEwAQQBEAGEAeQBzACAAPQAgACgAbwByAGQAZQByAEkAdABlAG0AcwA6ACAAQQByAHIAYQB5ADwATwByAGQAZQByAEkAdABlAG0ARgBvAHIAUwBMAEEAPgApADoAIABuAHUAbQBiAGUAcgAgAD0APgAgAHsACgAgACAAbABlAHQAIABzAG8AbQBlAFYAYQByACAAPQAgADAAOwAKAAoAIAAgAGkAZgAgACgATQBhAHQAaAAuAHIAYQBuAGQAbwBtACgAKQAgAD4AIAAwAC4ANQApACAAewAKACAAIAAgACAAcwBvAG0AZQBWAGEAcgAgAD0AIABnAGUAdABOAHUAbQAoACkAOwAKACAAIAB9AAoACgAgACAAcgBlAHQAdQByAG4AIABzAG8AbQBlAFYAYQByADsACgB9ADsA&ruleDomains.react=all&ruleDomains.test=all&ruleDomains.solid=all&ruleDomains.next=all&ruleDomains.project=all)

Addresses items from https://github.com/biomejs/biome/issues/9810: Mutable binding with reassignment



## Test Plan

Snapshot tests.
