### PR TITLE
fix(config): cli args should still override subprojects that don't extend the root config

### DIFF
--- a/.changeset/sad-days-wear.md
+++ b/.changeset/sad-days-wear.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7677](https://github.com/biomejs/biome/issues/7677): `--linter-enabled=false` now applies to nested monorepo projects that use `"root": false` without `"extends": "//"`.

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -11,7 +11,9 @@ use biome_configuration::analyzer::assist::{AssistConfiguration, AssistEnabled};
 use biome_configuration::css::CssParserConfiguration;
 use biome_configuration::formatter::{FormatWithErrorsEnabled, FormatterEnabled};
 use biome_configuration::json::JsonParserConfiguration;
-use biome_configuration::{Configuration, FormatterConfiguration, LinterConfiguration};
+use biome_configuration::{
+    Configuration, CssConfiguration, FormatterConfiguration, JsonConfiguration, LinterConfiguration,
+};
 use biome_console::{Console, MarkupBuf};
 use biome_deserialize::Merge;
 use biome_diagnostics::{Category, category};
@@ -166,6 +168,47 @@ impl TraversalCommand for CheckCommandPayload {
         None
     }
 
+    fn invocation_configuration(&self) -> Option<Configuration> {
+        let formatter = (self.formatter_enabled.is_some() || self.format_with_errors.is_some())
+            .then(|| FormatterConfiguration {
+                enabled: self.formatter_enabled,
+                format_with_errors: self.format_with_errors,
+                ..Default::default()
+            });
+        let linter = self.linter_enabled.is_some().then(|| LinterConfiguration {
+            enabled: self.linter_enabled,
+            ..Default::default()
+        });
+        let assist = self.assist_enabled.is_some().then(|| AssistConfiguration {
+            enabled: self.assist_enabled,
+            ..Default::default()
+        });
+
+        if formatter.is_none()
+            && linter.is_none()
+            && assist.is_none()
+            && self.json_parser.is_none()
+            && self.css_parser.is_none()
+        {
+            None
+        } else {
+            Some(Configuration {
+                formatter,
+                linter,
+                assist,
+                json: self.json_parser.clone().map(|parser| JsonConfiguration {
+                    parser: Some(parser),
+                    ..Default::default()
+                }),
+                css: self.css_parser.clone().map(|parser| CssConfiguration {
+                    parser: Some(parser),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+        }
+    }
+
     fn get_execution(
         &self,
         cli_options: &CliOptions,
@@ -206,43 +249,6 @@ impl TraversalCommand for CheckCommandPayload {
     ) -> Result<Configuration, WorkspaceError> {
         let mut configuration =
             self.combine_configuration(loaded_directory, loaded_configuration, fs)?;
-
-        let formatter = configuration
-            .formatter
-            .get_or_insert_with(FormatterConfiguration::default);
-
-        if self.formatter_enabled.is_some() {
-            formatter.enabled = self.formatter_enabled;
-        }
-        if self.format_with_errors.is_some() {
-            formatter.format_with_errors = self.format_with_errors;
-        }
-
-        let linter = configuration
-            .linter
-            .get_or_insert_with(LinterConfiguration::default);
-
-        if self.linter_enabled.is_some() {
-            linter.enabled = self.linter_enabled;
-        }
-
-        let assist = configuration
-            .assist
-            .get_or_insert_with(AssistConfiguration::default);
-
-        if self.assist_enabled.is_some() {
-            assist.enabled = self.assist_enabled;
-        }
-
-        let css = configuration.css.get_or_insert_with(Default::default);
-        if self.css_parser.is_some() {
-            css.parser.merge_with(self.css_parser.clone());
-        }
-
-        let json = configuration.json.get_or_insert_with(Default::default);
-        if self.json_parser.is_some() {
-            json.parser.merge_with(self.json_parser.clone())
-        }
 
         if let Some(mut conf) = self.configuration.clone() {
             if let Some(linter) = conf.linter.as_mut() {

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -146,6 +146,49 @@ impl TraversalCommand for CiCommandPayload {
         None
     }
 
+    fn invocation_configuration(&self) -> Option<Configuration> {
+        let formatter = self
+            .formatter_enabled
+            .is_some()
+            .then(|| FormatterConfiguration {
+                enabled: self.formatter_enabled,
+                format_with_errors: self.format_with_errors,
+                ..Default::default()
+            });
+        let linter = self.linter_enabled.is_some().then(|| LinterConfiguration {
+            enabled: self.linter_enabled,
+            ..Default::default()
+        });
+        let assist = self.assist_enabled.is_some().then(|| AssistConfiguration {
+            enabled: self.assist_enabled,
+            ..Default::default()
+        });
+
+        if formatter.is_none()
+            && linter.is_none()
+            && assist.is_none()
+            && self.json_parser.is_none()
+            && self.css_parser.is_none()
+        {
+            None
+        } else {
+            Some(Configuration {
+                formatter,
+                linter,
+                assist,
+                json: self.json_parser.clone().map(|parser| JsonConfiguration {
+                    parser: Some(parser),
+                    ..Default::default()
+                }),
+                css: self.css_parser.clone().map(|parser| CssConfiguration {
+                    parser: Some(parser),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+        }
+    }
+
     fn get_execution(
         &self,
         cli_options: &CliOptions,
@@ -179,45 +222,6 @@ impl TraversalCommand for CiCommandPayload {
     ) -> Result<Configuration, WorkspaceError> {
         let mut configuration =
             self.combine_configuration(loaded_directory, loaded_configuration, fs)?;
-
-        let formatter = configuration
-            .formatter
-            .get_or_insert_with(FormatterConfiguration::default);
-
-        if self.formatter_enabled.is_some() {
-            formatter.enabled = self.formatter_enabled;
-            formatter.format_with_errors = self.format_with_errors;
-        }
-
-        let linter = configuration
-            .linter
-            .get_or_insert_with(LinterConfiguration::default);
-
-        if self.linter_enabled.is_some() {
-            linter.enabled = self.linter_enabled;
-        }
-
-        let json = configuration
-            .json
-            .get_or_insert_with(JsonConfiguration::default);
-        if self.json_parser.is_some() {
-            json.parser.merge_with(self.json_parser.clone())
-        }
-
-        let css = configuration
-            .css
-            .get_or_insert_with(CssConfiguration::default);
-        if self.css_parser.is_some() {
-            css.parser.merge_with(self.css_parser.clone());
-        }
-
-        let assist = configuration
-            .assist
-            .get_or_insert_with(AssistConfiguration::default);
-
-        if self.assist_enabled.is_some() {
-            assist.enabled = self.assist_enabled;
-        }
 
         if let Some(mut conf) = self.configuration.clone() {
             if let Some(linter) = conf.linter.as_mut() {

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -12,7 +12,9 @@ use biome_configuration::graphql::GraphqlLinterConfiguration;
 use biome_configuration::javascript::JsLinterConfiguration;
 use biome_configuration::json::{JsonLinterConfiguration, JsonParserConfiguration};
 use biome_configuration::vcs::VcsConfiguration;
-use biome_configuration::{Configuration, FilesConfiguration, LinterConfiguration};
+use biome_configuration::{
+    Configuration, CssConfiguration, FilesConfiguration, JsonConfiguration, LinterConfiguration,
+};
 use biome_console::{Console, MarkupBuf};
 use biome_deserialize::Merge;
 use biome_diagnostics::{Category, category};
@@ -163,6 +165,30 @@ impl TraversalCommand for LintCommandPayload {
 
     fn minimal_scan_kind(&self) -> Option<ScanKind> {
         None
+    }
+
+    fn invocation_configuration(&self) -> Option<Configuration> {
+        let mut linter = self.linter_configuration.clone();
+        if let Some(linter) = linter.as_mut() {
+            linter.rules = None;
+        }
+
+        if linter.is_none() && self.json_parser.is_none() && self.css_parser.is_none() {
+            None
+        } else {
+            Some(Configuration {
+                linter,
+                json: self.json_parser.clone().map(|parser| JsonConfiguration {
+                    parser: Some(parser),
+                    ..Default::default()
+                }),
+                css: self.css_parser.clone().map(|parser| CssConfiguration {
+                    parser: Some(parser),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+        }
     }
 
     fn get_execution(

--- a/crates/biome_cli/src/runner/impls/commands/traversal.rs
+++ b/crates/biome_cli/src/runner/impls/commands/traversal.rs
@@ -98,6 +98,11 @@ pub(crate) trait TraversalCommand {
     /// Alias of [CommandRunner::minimal_scan_kind]
     fn minimal_scan_kind(&self) -> Option<ScanKind>;
 
+    /// Alias of [CommandRunner::invocation_configuration]
+    fn invocation_configuration(&self) -> Option<Configuration> {
+        None
+    }
+
     /// Alias of [CommandRunner::get_execution]
     fn get_execution(
         &self,
@@ -153,6 +158,10 @@ where
     /// The [ScanKind] to use for this command
     fn minimal_scan_kind(&self) -> Option<ScanKind> {
         self.deref().minimal_scan_kind()
+    }
+
+    fn invocation_configuration(&self) -> Option<Configuration> {
+        self.deref().invocation_configuration()
     }
 
     fn collector(

--- a/crates/biome_cli/src/runner/mod.rs
+++ b/crates/biome_cli/src/runner/mod.rs
@@ -207,6 +207,15 @@ pub(crate) trait CommandRunner {
     /// because it should be derived from the configuration.
     fn minimal_scan_kind(&self) -> Option<ScanKind>;
 
+    /// Optional, ad-hoc configuration that should apply across all resolved
+    /// project settings, including nested projects discovered during scan.
+    ///
+    /// Currently this means configuration supplied via CLI arguments that
+    /// needs to take precedence over configuration from disk.
+    fn invocation_configuration(&self) -> Option<Configuration> {
+        None
+    }
+
     /// Generates the collector to use for this command.
     fn collector(
         &self,
@@ -434,6 +443,7 @@ pub(crate) trait CommandRunner {
             project_key: open_project_result.project_key,
             workspace_directory: Some(BiomePath::new(project_dir)),
             configuration,
+            invocation_configuration: self.invocation_configuration(),
             extended_configurations: extended_configurations
                 .into_iter()
                 .map(|(path, config)| (BiomePath::from(path), config))

--- a/crates/biome_cli/tests/cases/monorepo.rs
+++ b/crates/biome_cli/tests/cases/monorepo.rs
@@ -386,6 +386,198 @@ fn should_not_lint_when_root_is_disabled_but_nested_is_enabled() {
     ));
 }
 
+/// `--linter-enabled=false` should disable linting for nested projects too, even
+/// when a nested `biome.json` uses `"root": false` without `"extends": "//"`.
+///
+/// Regression test for issue #7677:
+/// https://github.com/biomejs/biome/issues/7677
+#[test]
+fn should_disable_linter_via_cli_for_non_extending_nested_project() {
+    let mut console = BufferConsole::default();
+    let mut fs = TemporaryFs::new("should_disable_linter_via_cli_for_non_extending_nested_project");
+
+    fs.create_file(
+        "biome.json",
+        r#"{
+    "formatter": {
+        "enabled": false
+    },
+    "linter": {
+        "enabled": true,
+        "rules": {
+            "recommended": true
+        }
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "packages/extending/biome.json",
+        r#"{
+    "root": false,
+    "extends": "//"
+}"#,
+    );
+
+    fs.create_file(
+        "packages/non-extending/biome.json",
+        r#"{
+    "root": false,
+    "formatter": {
+        "enabled": false
+    }
+}"#,
+    );
+
+    fs.create_file("packages/extending/file.js", "const abc = 123;\n");
+    fs.create_file("packages/non-extending/file.js", "const abc = 123;\n");
+
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["check", "--linter-enabled=false", fs.cli_path()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_disable_linter_via_cli_for_non_extending_nested_project",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}
+
+/// `--formatter-enabled=false` should disable formatting for nested projects too,
+/// even when a nested `biome.json` uses `"root": false` without `"extends": "//"`.
+///
+/// Regression test for issue #7677:
+/// https://github.com/biomejs/biome/issues/7677
+#[test]
+fn should_disable_formatter_via_cli_for_non_extending_nested_project() {
+    let mut console = BufferConsole::default();
+    let mut fs =
+        TemporaryFs::new("should_disable_formatter_via_cli_for_non_extending_nested_project");
+
+    fs.create_file(
+        "biome.json",
+        r#"{
+    "formatter": {
+        "enabled": true
+    },
+    "linter": {
+        "enabled": false
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "packages/extending/biome.json",
+        r#"{
+    "root": false,
+    "extends": "//"
+}"#,
+    );
+
+    fs.create_file(
+        "packages/non-extending/biome.json",
+        r#"{
+    "root": false,
+    "linter": {
+        "enabled": false
+    }
+}"#,
+    );
+
+    fs.create_file("packages/extending/file.js", "let  abc  = 123 ;\n");
+    fs.create_file("packages/non-extending/file.js", "let  abc  = 123 ;\n");
+
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["check", "--formatter-enabled=false", fs.cli_path()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_disable_formatter_via_cli_for_non_extending_nested_project",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}
+
+/// `--assist-enabled=false` should disable assists for nested projects too,
+/// even when a nested `biome.json` uses `"root": false` without `"extends": "//"`.
+///
+/// Regression test for issue #7677:
+/// https://github.com/biomejs/biome/issues/7677
+#[test]
+fn should_disable_assist_via_cli_for_non_extending_nested_project() {
+    let mut console = BufferConsole::default();
+    let mut fs = TemporaryFs::new("should_disable_assist_via_cli_for_non_extending_nested_project");
+
+    fs.create_file(
+        "biome.json",
+        r#"{
+    "assist": {
+        "enabled": true
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "packages/extending/biome.json",
+        r#"{
+    "root": false,
+    "extends": "//"
+}"#,
+    );
+
+    fs.create_file(
+        "packages/non-extending/biome.json",
+        r#"{
+    "root": false
+}"#,
+    );
+
+    fs.create_file(
+        "packages/extending/file.js",
+        "import * as something from \"../something\";\nimport { lorem, foom, bar } from \"foo\";\n",
+    );
+    fs.create_file(
+        "packages/non-extending/file.js",
+        "import * as something from \"../something\";\nimport { lorem, foom, bar } from \"foo\";\n",
+    );
+
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(
+            [
+                "check",
+                "--assist-enabled=false",
+                &format!("{}/packages/extending/file.js", fs.cli_path()),
+                &format!("{}/packages/non-extending/file.js", fs.cli_path()),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_disable_assist_via_cli_for_non_extending_nested_project",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}
+
 #[test]
 fn should_find_settings_when_run_from_nested_dir() {
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_disable_assist_via_cli_for_non_extending_nested_project.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_disable_assist_via_cli_for_non_extending_nested_project.snap
@@ -1,0 +1,134 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 520
+expression: redactor(content)
+---
+## `packages/non-extending/biome.json`
+
+```json
+{
+  "root": false
+}
+```
+
+## `biome.json`
+
+```json
+{
+  "assist": {
+    "enabled": true
+  }
+}
+```
+
+## `packages/extending/biome.json`
+
+```json
+{
+  "root": false,
+  "extends": "//"
+}
+```
+
+## `packages/extending/file.js`
+
+```js
+import * as something from "../something";
+import { lorem, foom, bar } from "foo";
+
+```
+
+## `packages/non-extending/file.js`
+
+```js
+import * as something from "../something";
+import { lorem, foom, bar } from "foo";
+
+```
+
+# Emitted Messages
+
+```block
+packages/extending/file.js:1:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+  > 1 │ import * as something from "../something";
+      │             ^^^^^^^^^
+    2 │ import { lorem, foom, bar } from "foo";
+    3 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Unsafe fix: Remove the unused imports.
+  
+    1 │ import·*·as·something·from·"../something";
+      │ ------------------------------------------
+
+```
+
+```block
+packages/extending/file.js:2:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    1 │ import * as something from "../something";
+  > 2 │ import { lorem, foom, bar } from "foo";
+      │        ^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Unsafe fix: Remove the unused imports.
+  
+    1 1 │   import * as something from "../something";
+    2   │ - import·{·lorem,·foom,·bar·}·from·"foo";
+    3 2 │   
+  
+
+```
+
+```block
+packages/non-extending/file.js:1:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+  > 1 │ import * as something from "../something";
+      │             ^^^^^^^^^
+    2 │ import { lorem, foom, bar } from "foo";
+    3 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Unsafe fix: Remove the unused imports.
+  
+    1 │ import·*·as·something·from·"../something";
+      │ ------------------------------------------
+
+```
+
+```block
+packages/non-extending/file.js:2:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    1 │ import * as something from "../something";
+  > 2 │ import { lorem, foom, bar } from "foo";
+      │        ^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Unsafe fix: Remove the unused imports.
+  
+    1 1 │   import * as something from "../something";
+    2   │ - import·{·lorem,·foom,·bar·}·from·"foo";
+    3 2 │   
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+Found 4 warnings.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_disable_formatter_via_cli_for_non_extending_nested_project.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_disable_formatter_via_cli_for_non_extending_nested_project.snap
@@ -1,0 +1,57 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 520
+expression: redactor(content)
+---
+## `packages/non-extending/biome.json`
+
+```json
+{
+  "root": false,
+  "linter": {
+    "enabled": false
+  }
+}
+```
+
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": false
+  }
+}
+```
+
+## `packages/extending/biome.json`
+
+```json
+{
+  "root": false,
+  "extends": "//"
+}
+```
+
+## `packages/extending/file.js`
+
+```js
+let  abc  = 123 ;
+
+```
+
+## `packages/non-extending/file.js`
+
+```js
+let  abc  = 123 ;
+
+```
+
+# Emitted Messages
+
+```block
+Checked 5 files in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_disable_linter_via_cli_for_non_extending_nested_project.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_disable_linter_via_cli_for_non_extending_nested_project.snap
@@ -1,0 +1,60 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 520
+expression: redactor(content)
+---
+## `packages/non-extending/biome.json`
+
+```json
+{
+  "root": false,
+  "formatter": {
+    "enabled": false
+  }
+}
+```
+
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}
+```
+
+## `packages/extending/biome.json`
+
+```json
+{
+  "root": false,
+  "extends": "//"
+}
+```
+
+## `packages/extending/file.js`
+
+```js
+const abc = 123;
+
+```
+
+## `packages/non-extending/file.js`
+
+```js
+const abc = 123;
+
+```
+
+# Emitted Messages
+
+```block
+Checked 5 files in <TIME>. No fixes applied.
+```

--- a/crates/biome_formatter_test/src/spec.rs
+++ b/crates/biome_formatter_test/src/spec.rs
@@ -128,6 +128,7 @@ impl<'a> SpecSnapshot<'a> {
         workspace
             .update_settings(UpdateSettingsParams {
                 project_key,
+                invocation_configuration: None,
                 configuration: self.initial_configuration,
                 workspace_directory: None,
                 extended_configurations: vec![],
@@ -168,6 +169,7 @@ impl<'a> SpecSnapshot<'a> {
             workspace
                 .update_settings(UpdateSettingsParams {
                     project_key,
+                    invocation_configuration: None,
                     configuration: options_config,
                     workspace_directory: None,
                     extended_configurations: vec![],
@@ -230,6 +232,7 @@ impl<'a> SpecSnapshot<'a> {
                 workspace
                     .update_settings(UpdateSettingsParams {
                         project_key,
+                        invocation_configuration: None,
                         configuration: Configuration {
                             formatter: Some(
                                 biome_configuration::formatter::FormatterConfiguration {

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -1171,6 +1171,7 @@ impl Session {
                 .map(Utf8PathBuf::as_path)
                 .map(BiomePath::from),
             configuration,
+            invocation_configuration: None,
             extended_configurations: Default::default(),
             module_graph_resolution_kind: ModuleGraphResolutionKind::from(&scan_kind),
         });

--- a/crates/biome_service/src/projects.rs
+++ b/crates/biome_service/src/projects.rs
@@ -4,6 +4,7 @@ use crate::settings::{Settings, SettingsWithEditor};
 use crate::workspace::{
     DocumentFileSource, FeatureName, FeaturesSupported, FileFeaturesResult, IgnoreKind,
 };
+use biome_configuration::Configuration;
 use biome_fs::{ConfigName, FileSystem};
 use camino::{Utf8Path, Utf8PathBuf};
 use papaya::HashMap;
@@ -42,6 +43,10 @@ struct ProjectData {
     /// Optional nested settings, usually populated in monorepo
     /// projects.
     nested_settings: BTreeMap<Utf8PathBuf, Settings>,
+
+    /// Invocation-level configuration applied across the project, such as CLI
+    /// feature toggles.
+    invocation_configuration: Option<Configuration>,
 }
 
 /// Type that holds all the settings and information for different projects
@@ -79,6 +84,7 @@ impl Projects {
                 path,
                 root_settings: Settings::default(),
                 nested_settings: Default::default(),
+                invocation_configuration: None,
             },
         );
         key
@@ -135,6 +141,13 @@ impl Projects {
             .pin()
             .get(&project_key)
             .map(|data| data.root_settings.clone())
+    }
+
+    pub fn get_invocation_configuration(&self, project_key: ProjectKey) -> Option<Configuration> {
+        self.0
+            .pin()
+            .get(&project_key)
+            .and_then(|data| data.invocation_configuration.clone())
     }
 
     /// Returns whether a path is force-ignored using a forced negation (`!!`)
@@ -303,6 +316,20 @@ impl Projects {
             path: data.path.clone(),
             root_settings: settings.clone(),
             nested_settings: data.nested_settings.clone(),
+            invocation_configuration: data.invocation_configuration.clone(),
+        });
+    }
+
+    pub fn set_invocation_configuration(
+        &self,
+        project_key: ProjectKey,
+        configuration: Option<Configuration>,
+    ) {
+        self.0.pin().update(project_key, |data| ProjectData {
+            path: data.path.clone(),
+            root_settings: data.root_settings.clone(),
+            nested_settings: data.nested_settings.clone(),
+            invocation_configuration: configuration.clone(),
         });
     }
 
@@ -324,6 +351,7 @@ impl Projects {
                 path: data.path.clone(),
                 root_settings: data.root_settings.clone(),
                 nested_settings,
+                invocation_configuration: data.invocation_configuration.clone(),
             }
         });
     }

--- a/crates/biome_service/src/scanner.tests.rs
+++ b/crates/biome_service/src/scanner.tests.rs
@@ -61,6 +61,7 @@ fn scanner_only_loads_used_type_definitions_from_node_modules() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration: Default::default(),
             workspace_directory: Some(fixtures_path.clone().into()),
             extended_configurations: Default::default(),
@@ -142,6 +143,7 @@ fn scanner_ignored_files_are_not_loaded() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration,
             workspace_directory: Some(fixtures_path.clone().into()),
             extended_configurations: Default::default(),
@@ -196,6 +198,7 @@ fn scanner_required_files_are_only_ignored_in_ignored_directories() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration,
             workspace_directory: Some(fixtures_path.clone().into()),
             extended_configurations: Default::default(),

--- a/crates/biome_service/src/scanner/workspace_scanner_bridge.tests.rs
+++ b/crates/biome_service/src/scanner/workspace_scanner_bridge.tests.rs
@@ -191,6 +191,7 @@ fn should_not_index_an_ignored_file_inside_vcs_ignore_file() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: Some(BiomePath::new("/project")),
             configuration: Configuration {
                 vcs: Some(VcsConfiguration {
@@ -231,6 +232,7 @@ fn should_not_index_an_ignored_file_inside_file_includes() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: Some(BiomePath::new("/project")),
             configuration: Configuration {
                 files: Some(FilesConfiguration {
@@ -273,6 +275,7 @@ fn should_index_an_ignored_file_if_it_is_a_dependency_of_a_non_ignored_file() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: Some(BiomePath::new("/project")),
             configuration: Configuration {
                 files: Some(FilesConfiguration {
@@ -321,6 +324,7 @@ fn should_not_index_a_force_ignored_file_even_if_it_is_a_dependency() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: Some(BiomePath::new("/project")),
             configuration: Configuration {
                 files: Some(FilesConfiguration {
@@ -366,6 +370,7 @@ fn should_not_index_dependency_with_scan_kind_known_files() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: Some(BiomePath::new("/project")),
             configuration: Configuration {
                 files: Some(FilesConfiguration {
@@ -408,6 +413,7 @@ fn should_not_index_inside_an_ignored_folder_inside_file_includes() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: Some(BiomePath::new("/project")),
             configuration: Configuration {
                 files: Some(FilesConfiguration {
@@ -452,6 +458,7 @@ fn should_not_index_inside_an_ignored_folder_inside_vcs_ignore_file() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: Some(BiomePath::new(fs.cli_path())),
             configuration: Configuration {
                 vcs: Some(VcsConfiguration {

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -795,6 +795,8 @@ impl FeaturesBuilder {
 pub struct UpdateSettingsParams {
     pub project_key: ProjectKey,
     pub configuration: Configuration,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub invocation_configuration: Option<Configuration>,
     pub workspace_directory: Option<BiomePath>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub extended_configurations: Vec<(BiomePath, Configuration)>,

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -465,6 +465,7 @@ fn too_large_files_are_tracked_but_not_parsed() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration: Configuration {
                 files: Some(FilesConfiguration {
                     max_size: Some(NonZeroU64::new(10).unwrap().into()),
@@ -527,6 +528,7 @@ fn plugins_are_loaded_and_used_during_analysis() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration: Configuration {
                 plugins: Some(Plugins(vec![PluginConfiguration::Path(
                     "./plugin.grit".to_string(),
@@ -601,6 +603,7 @@ language css;
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration: Configuration {
                 plugins: Some(Plugins(vec![PluginConfiguration::Path(
                     "./plugin.grit".to_string(),
@@ -671,6 +674,7 @@ fn plugins_may_use_invalid_span() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration: Configuration {
                 plugins: Some(Plugins(vec![PluginConfiguration::Path(
                     "./plugin.grit".to_string(),
@@ -775,6 +779,7 @@ const hasOwn = Object.hasOwn({ foo: 'bar' }, 'foo');"#,
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration: Configuration {
                 plugins: Some(Plugins(vec![PluginConfiguration::Path(
                     "./plugin_a.grit".to_string(),

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1175,7 +1175,8 @@ impl Workspace for WorkspaceServer {
     ) -> Result<UpdateSettingsResult, WorkspaceError> {
         let UpdateSettingsParams {
             workspace_directory,
-            configuration,
+            mut configuration,
+            invocation_configuration,
             project_key,
             extended_configurations,
             module_graph_resolution_kind,
@@ -1201,6 +1202,10 @@ impl Workspace for WorkspaceServer {
                 .ok_or_else(WorkspaceError::no_project)?
         };
         settings.module_graph_resolution_kind = module_graph_resolution_kind;
+
+        if let Some(invocation_configuration) = invocation_configuration.clone() {
+            configuration.merge_with(invocation_configuration);
+        }
 
         settings.merge_with_configuration(
             configuration,
@@ -1238,6 +1243,8 @@ impl Workspace for WorkspaceServer {
                 settings,
             );
         } else {
+            self.projects
+                .set_invocation_configuration(project_key, invocation_configuration);
             // If the configuration is a root one, we also load the ignore files
             if settings.is_vcs_enabled() && settings.vcs_settings.should_use_ignore_file() {
                 let directory = settings
@@ -2620,12 +2627,20 @@ impl WorkspaceScannerBridge for WorkspaceServer {
                 nested_configuration
             };
 
-            let scan_kind = ProjectScanComputer::new(&nested_configuration).compute();
+            let mut scan_configuration = nested_configuration.clone();
+            if let Some(invocation_configuration) =
+                self.projects.get_invocation_configuration(project_key)
+            {
+                scan_configuration.merge_with(invocation_configuration);
+            }
+
+            let scan_kind = ProjectScanComputer::new(&scan_configuration).compute();
 
             let result = self.update_settings(UpdateSettingsParams {
                 project_key,
                 workspace_directory: nested_directory_path.map(BiomePath::from),
                 configuration: nested_configuration,
+                invocation_configuration: self.projects.get_invocation_configuration(project_key),
                 extended_configurations: extended_configurations
                     .into_iter()
                     .map(|(path, config)| (BiomePath::from(path), config))

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -239,6 +239,7 @@ function Foo({cond}) {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration,
             workspace_directory: Some(BiomePath::new("/project")),
             extended_configurations: Default::default(),
@@ -356,6 +357,7 @@ function Foo({cond}) {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration,
             workspace_directory: Some(BiomePath::new("/project")),
             extended_configurations: Default::default(),
@@ -648,6 +650,7 @@ const Bar = styled(Component)`
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: None,
             configuration: Configuration {
                 javascript: Some(JsConfiguration {
@@ -716,6 +719,7 @@ styled.div`
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: None,
             configuration: Configuration {
                 javascript: Some(JsConfiguration {
@@ -785,6 +789,7 @@ const PortfolioIcon = styled.div`
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: None,
             configuration: Configuration {
                 formatter: Some(FormatterConfiguration {
@@ -876,6 +881,7 @@ const Container = styled.div`
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: None,
             configuration: Configuration {
                 javascript: Some(JsConfiguration {
@@ -1000,6 +1006,7 @@ const Baz = graphql`
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: None,
             configuration: Configuration {
                 javascript: Some(JsConfiguration {
@@ -1086,6 +1093,7 @@ const highlight = foo`some tagged template` // unknown tagged template
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: None,
             configuration: Configuration {
                 javascript: Some(JsConfiguration {
@@ -1152,6 +1160,7 @@ graphql(`
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: None,
             configuration: Configuration {
                 javascript: Some(JsConfiguration {
@@ -1208,6 +1217,7 @@ fn issue_9484_propagate_expand_after_embed() {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: None,
             configuration: Configuration {
                 javascript: Some(JsConfiguration {
@@ -1274,6 +1284,7 @@ const Table = () => {
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             workspace_directory: None,
             configuration: Configuration {
                 javascript: Some(JsConfiguration {

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -905,6 +905,7 @@ pub fn analyze_with_workspace(
     workspace
         .update_settings(UpdateSettingsParams {
             project_key,
+            invocation_configuration: None,
             configuration: config,
             workspace_directory: Some(BiomePath::new(&project_root)),
             extended_configurations: vec![],

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8642,6 +8642,7 @@ export type SupportKind =
 export interface UpdateSettingsParams {
 	configuration: Configuration;
 	extendedConfigurations?: [BiomePath, Configuration][];
+	invocationConfiguration?: Configuration;
 	moduleGraphResolutionKind?: ModuleGraphResolutionKind;
 	projectKey: ProjectKey;
 	workspaceDirectory?: BiomePath;


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR makes it so that cli flags are respected for subprojects in a monorepo setup that don't extend the root config. The details of the bug are in the linked issue.

```
repo/
├── biome.json
│   └── linter.enabled = true
├── package-a/
│   ├── biome.json
│   │   ├── root = false
│   │   └── extends = "//"
│   └── index.ts
└── package-b/
    ├── biome.json
    │   └── root = false
    └── index.ts
```
Previously, if the linter was disabled by cli flag, `package-b` would not receive that configuration, and continue to emit linting diagnostics. This was because the cli flag configuration was merged into the root config immediately, and the information was lost by the time `package-b`'s config is loaded and applied.

This solution adds the concept of "Invocation configuration" to store configuration what is provided by CLI arguments. CLI configuration must always override disk configuration. This is stored separately so that configuration can be applied to all the child configs.

partially generated with gpt 5.4

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #7677
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added cli tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
