### PR TITLE
chore: update rand & thin-vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
  "insta",
  "mimalloc",
  "path-absolutize",
- "rand 0.8.5",
+ "rand 0.9.3",
  "regex",
  "rustc-hash 2.1.2",
  "schemars",
@@ -1975,7 +1975,7 @@ dependencies = [
  "num_enum",
  "paste",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regress",
  "rustc-hash 2.1.2",
  "ryu-js",
@@ -4497,7 +4497,7 @@ checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4551,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4561,9 +4561,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "getrandom 0.4.2",
  "rand_core 0.10.0",
@@ -5377,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
  "insta",
  "mimalloc",
  "path-absolutize",
- "rand 0.9.3",
+ "rand 0.8.5",
  "regex",
  "rustc-hash 2.1.2",
  "schemars",


### PR DESCRIPTION
## Summary

The only one missing still is through grit-pattern-matcher, which uses rand 0.8.5, but it won't let me update that sub dependency

https://github.com/biomejs/biome/security

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
