### PR TITLE
fix(lsp): inform clients that .biome.json(c) should also be watched

### DIFF
--- a/.changeset/fine-sites-fail.md
+++ b/.changeset/fine-sites-fail.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug in the LSP file watcher registration so Biome now watches `.biome.json` and `.biome.jsonc` configuration files and reloads workspace settings when they change.

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -147,6 +147,13 @@ impl LSPServer {
                             },
                             FileSystemWatcher {
                                 glob_pattern: GlobPattern::Relative(RelativePattern {
+                                    pattern: "**/.biome.{json,jsonc}".to_string(),
+                                    base_uri: OneOf::Left(folder.clone()),
+                                }),
+                                kind: Some(WatchKind::all()),
+                            },
+                            FileSystemWatcher {
+                                glob_pattern: GlobPattern::Relative(RelativePattern {
                                     pattern: ".editorconfig".to_string(),
                                     base_uri: OneOf::Left(folder.clone()),
                                 }),
@@ -179,6 +186,13 @@ impl LSPServer {
                         FileSystemWatcher {
                             glob_pattern: GlobPattern::Relative(RelativePattern {
                                 pattern: "**/biome.{json,jsonc}".to_string(),
+                                base_uri: OneOf::Right(base_uri.clone()),
+                            }),
+                            kind: Some(WatchKind::all()),
+                        },
+                        FileSystemWatcher {
+                            glob_pattern: GlobPattern::Relative(RelativePattern {
+                                pattern: "**/.biome.{json,jsonc}".to_string(),
                                 base_uri: OneOf::Right(base_uri),
                             }),
                             kind: Some(WatchKind::all()),
@@ -386,6 +400,20 @@ impl LanguageServer for LSPServer {
                         || watched_file.ends_with(".gitignore")
                         || watched_file.ends_with(".ignore"))
                 {
+                    info!(
+                        path = %watched_file.display(),
+                        "Received watched file change notification"
+                    );
+                    self.session
+                        .client
+                        .log_message(
+                            MessageType::INFO,
+                            format!(
+                                "Received watched file change notification: {}",
+                                watched_file.display()
+                            ),
+                        )
+                        .await;
                     self.session.load_extension_settings(None).await;
                     self.session.load_workspace_settings(true).await;
                     self.setup_capabilities().await;


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This makes it so that biome will tell lsp clients to inform us when `.biome.json`/`jsonc` changes.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
The LSP spec lists this syntax as valid. I tested this manually, and the logs indicated that the watchers include these new patterns.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
