### PR TITLE
feat(html_analyze): implement useValidAutocomplete

### DIFF
--- a/.changeset/young-snails-melt.md
+++ b/.changeset/young-snails-melt.md
@@ -1,0 +1,9 @@
+---
+"@biomejs/biome": minor
+---
+
+Added the HTML lint rule [`useValidAutocomplete`](https://biomejs.dev/linter/rules/use-valid-autocomplete/), which enforces using valid values for the `autocomplete` attribute on `input` elements.
+
+```html
+<input autocomplete="incorrect"/>
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,7 @@ dependencies = [
  "phf 0.13.1",
  "schemars",
  "serde",
+ "smallvec",
  "tests_macros",
  "tikv-jemallocator",
 ]

--- a/crates/biome_html_analyze/Cargo.toml
+++ b/crates/biome_html_analyze/Cargo.toml
@@ -35,6 +35,7 @@ camino                   = { workspace = true }
 phf                      = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"] }
+smallvec                 = { workspace = true }
 
 [dev-dependencies]
 biome_html_parser = { path = "../biome_html_parser" }

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_autocomplete.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_autocomplete.rs
@@ -1,0 +1,227 @@
+use biome_analyze::{Ast, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_console::markup;
+use biome_diagnostics::Severity;
+use biome_html_syntax::{HtmlFileSource, element_ext::AnyHtmlTagElement};
+use biome_rowan::{AstNode, TextRange};
+use biome_rule_options::use_valid_autocomplete::UseValidAutocompleteOptions;
+
+use crate::utils::is_html_tag;
+
+declare_lint_rule! {
+    /// Use valid values for the `autocomplete` attribute on `input` elements.
+    ///
+    /// The HTML autocomplete attribute only accepts specific predefined values.
+    /// This allows for more detailed purpose definitions compared to the `type` attribute.
+    /// Using these predefined values, user agents and assistive technologies can present input purposes to users in different ways.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```html,expect_diagnostic
+    /// <input type="text" autocomplete="incorrect" />
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```html
+    /// <input type="text" autocomplete="name" />
+    /// ```
+    ///
+    /// ```vue
+    /// <MyInput autocomplete="incorrect" />
+    /// ```
+    ///
+    /// ## Options
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "inputComponents": ["MyInput"]
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ## Accessibility guidelines
+    /// - [WCAG 1.3.5](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose)
+    ///
+    /// ### Resources
+    /// - [HTML Living Standard autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill)
+    /// - [HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)
+    ///
+    pub UseValidAutocomplete {
+        version: "next",
+        name: "useValidAutocomplete",
+        language: "html",
+        recommended: true,
+        severity: Severity::Error,
+    }
+}
+
+impl Rule for UseValidAutocomplete {
+    type Query = Ast<AnyHtmlTagElement>;
+    type State = TextRange;
+    type Signals = Option<Self::State>;
+    type Options = UseValidAutocompleteOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        let source_type = ctx.source_type::<HtmlFileSource>();
+
+        let name = node.tag_name()?;
+        if !is_html_tag(node, source_type, "input")
+            && ctx
+                .options()
+                .input_components
+                .iter()
+                .flatten()
+                .all(|x| x.as_ref() != name)
+        {
+            return None;
+        }
+
+        let autocomplete_attribute = node.attributes().find_by_name("autocomplete")?;
+        let autocomplete_val = autocomplete_attribute
+            .initializer()?
+            .value()
+            .ok()?
+            .as_static_value()?;
+        let autocompletes = autocomplete_val
+            .as_string_constant()?
+            .split_ascii_whitespace()
+            .collect::<smallvec::SmallVec<[&str; 2]>>();
+        if (autocompletes.len() == 1 && autocompletes[0] == "none")
+            || is_valid_autocomplete(&autocompletes)
+        {
+            return None;
+        }
+
+        Some(autocomplete_attribute.range())
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                state,
+                markup! {
+                    "Use valid values for the "<Emphasis>"autocomplete"</Emphasis>" attribute."
+                },
+            )
+            .note(markup! {
+                "The autocomplete attribute only accepts a certain number of specific fixed values."
+        }).note(markup!{
+            "Follow the links for more information,
+  "<Hyperlink href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose">"WCAG 1.3.5"</Hyperlink>"
+  "<Hyperlink href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill">"HTML Living Standard autofill"</Hyperlink>"
+  "<Hyperlink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete">"HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN"</Hyperlink>""
+        })
+    )
+    }
+}
+
+// Sorted for binary search
+const VALID_AUTOCOMPLETE_VALUES: [&str; 55] = [
+    "additional-name",
+    "address-level1",
+    "address-level2",
+    "address-level3",
+    "address-level4",
+    "address-line1",
+    "address-line2",
+    "address-line3",
+    "bday",
+    "bday-day",
+    "bday-month",
+    "bday-year",
+    "cc-additional-name",
+    "cc-csc",
+    "cc-exp",
+    "cc-exp-month",
+    "cc-exp-year",
+    "cc-family-name",
+    "cc-given-name",
+    "cc-name",
+    "cc-number",
+    "cc-type",
+    "country",
+    "country-name",
+    "current-password",
+    "email",
+    "family-name",
+    "given-name",
+    "honorific-prefix",
+    "honorific-suffix",
+    "impp",
+    "language",
+    "name",
+    "new-password",
+    "nickname",
+    "off",
+    "on",
+    "one-time-code",
+    "organization",
+    "organization-title",
+    "photo",
+    "postal-code",
+    "sex",
+    "street-address",
+    "tel",
+    "tel-area-code",
+    "tel-country-code",
+    "tel-extension",
+    "tel-local",
+    "tel-national",
+    "transaction-amount",
+    "transaction-currency",
+    "url",
+    "username",
+    "webauthn",
+];
+
+// Sorted for binary search
+const BILLING_AND_SHIPPING_ADDRESS: &[&str; 11] = &[
+    "address-level1",
+    "address-level2",
+    "address-level3",
+    "address-level4",
+    "address-line1",
+    "address-line2",
+    "address-line3",
+    "country",
+    "country-name",
+    "postal-code",
+    "street-address",
+];
+
+/// Checks if the autocomplete attribute values are valid
+fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
+    match autocomplete_values.len() {
+        0 => true,
+        1 => {
+            // SAFETY: the size of the slice is superior or equal to `1`
+            let first = autocomplete_values[0];
+            first.is_empty()
+                || first.starts_with("section-")
+                || VALID_AUTOCOMPLETE_VALUES.binary_search(&first).is_ok()
+        }
+        2.. => {
+            // SAFETY: the size of the slice is superior or equal to `2`
+            let first = autocomplete_values[0];
+            let second = autocomplete_values[1];
+            first.starts_with("section-")
+                || ["billing", "shipping"].contains(&first)
+                    && (BILLING_AND_SHIPPING_ADDRESS.contains(&second)
+                        || VALID_AUTOCOMPLETE_VALUES.binary_search(&second).is_ok())
+                || autocomplete_values
+                    .iter()
+                    .all(|val| VALID_AUTOCOMPLETE_VALUES.binary_search(val).is_ok())
+        }
+    }
+}
+
+#[test]
+fn test_order() {
+    assert!(VALID_AUTOCOMPLETE_VALUES.is_sorted());
+    assert!(BILLING_AND_SHIPPING_ADDRESS.is_sorted());
+}

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_autocomplete.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_autocomplete.rs
@@ -4,6 +4,7 @@ use biome_diagnostics::Severity;
 use biome_html_syntax::{HtmlFileSource, element_ext::AnyHtmlTagElement};
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_valid_autocomplete::UseValidAutocompleteOptions;
+use phf::phf_set;
 
 use crate::utils::is_html_tag;
 
@@ -120,8 +121,7 @@ impl Rule for UseValidAutocomplete {
     }
 }
 
-// Sorted for binary search
-const VALID_AUTOCOMPLETE_VALUES: [&str; 55] = [
+const VALID_AUTOCOMPLETE_VALUES: phf::Set<&'static str> = phf_set! {
     "additional-name",
     "address-level1",
     "address-level2",
@@ -177,10 +177,9 @@ const VALID_AUTOCOMPLETE_VALUES: [&str; 55] = [
     "url",
     "username",
     "webauthn",
-];
+};
 
-// Sorted for binary search
-const BILLING_AND_SHIPPING_ADDRESS: &[&str; 11] = &[
+const BILLING_AND_SHIPPING_ADDRESS: phf::Set<&'static str> = phf_set! {
     "address-level1",
     "address-level2",
     "address-level3",
@@ -192,7 +191,7 @@ const BILLING_AND_SHIPPING_ADDRESS: &[&str; 11] = &[
     "country-name",
     "postal-code",
     "street-address",
-];
+};
 
 /// Checks if the autocomplete attribute values are valid
 fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
@@ -203,7 +202,7 @@ fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
             let first = autocomplete_values[0];
             first.is_empty()
                 || first.starts_with("section-")
-                || VALID_AUTOCOMPLETE_VALUES.binary_search(&first).is_ok()
+                || VALID_AUTOCOMPLETE_VALUES.contains(first)
         }
         2.. => {
             // SAFETY: the size of the slice is superior or equal to `2`
@@ -211,17 +210,11 @@ fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
             let second = autocomplete_values[1];
             first.starts_with("section-")
                 || ["billing", "shipping"].contains(&first)
-                    && (BILLING_AND_SHIPPING_ADDRESS.contains(&second)
-                        || VALID_AUTOCOMPLETE_VALUES.binary_search(&second).is_ok())
+                    && (BILLING_AND_SHIPPING_ADDRESS.contains(second)
+                        || VALID_AUTOCOMPLETE_VALUES.contains(second))
                 || autocomplete_values
                     .iter()
-                    .all(|val| VALID_AUTOCOMPLETE_VALUES.binary_search(val).is_ok())
+                    .all(|val| VALID_AUTOCOMPLETE_VALUES.contains(val))
         }
     }
-}
-
-#[test]
-fn test_order() {
-    assert!(VALID_AUTOCOMPLETE_VALUES.is_sorted());
-    assert!(BILLING_AND_SHIPPING_ADDRESS.is_sorted());
 }

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.astro
@@ -1,0 +1,7 @@
+<!-- should generate diagnostics -->
+<input type="text" autocomplete="foo" />
+<input type="text" autocomplete="name invalid" />
+<input type="text" autocomplete="invalid name" />
+<input type="text" autocomplete="home url" />
+<Bar autocomplete="baz"></Bar>
+<Input type="text" autocomplete="baz" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.astro.snap
@@ -1,0 +1,146 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.astro
+---
+# Input
+```astro
+<!-- should generate diagnostics -->
+<input type="text" autocomplete="foo" />
+<input type="text" autocomplete="name invalid" />
+<input type="text" autocomplete="invalid name" />
+<input type="text" autocomplete="home url" />
+<Bar autocomplete="baz"></Bar>
+<Input type="text" autocomplete="baz" />
+
+```
+
+# Diagnostics
+```
+invalid.astro:2:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <input type="text" autocomplete="foo" />
+      │                    ^^^^^^^^^^^^^^^^^^
+    3 │ <input type="text" autocomplete="name invalid" />
+    4 │ <input type="text" autocomplete="invalid name" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.astro:3:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <input type="text" autocomplete="foo" />
+  > 3 │ <input type="text" autocomplete="name invalid" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <input type="text" autocomplete="invalid name" />
+    5 │ <input type="text" autocomplete="home url" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.astro:4:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    2 │ <input type="text" autocomplete="foo" />
+    3 │ <input type="text" autocomplete="name invalid" />
+  > 4 │ <input type="text" autocomplete="invalid name" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ <input type="text" autocomplete="home url" />
+    6 │ <Bar autocomplete="baz"></Bar>
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.astro:5:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    3 │ <input type="text" autocomplete="name invalid" />
+    4 │ <input type="text" autocomplete="invalid name" />
+  > 5 │ <input type="text" autocomplete="home url" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ <Bar autocomplete="baz"></Bar>
+    7 │ <Input type="text" autocomplete="baz" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.astro:6:6 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    4 │ <input type="text" autocomplete="invalid name" />
+    5 │ <input type="text" autocomplete="home url" />
+  > 6 │ <Bar autocomplete="baz"></Bar>
+      │      ^^^^^^^^^^^^^^^^^^
+    7 │ <Input type="text" autocomplete="baz" />
+    8 │ 
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.astro:7:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    5 │ <input type="text" autocomplete="home url" />
+    6 │ <Bar autocomplete="baz"></Bar>
+  > 7 │ <Input type="text" autocomplete="baz" />
+      │                    ^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.html
@@ -1,0 +1,5 @@
+<!-- should generate diagnostics -->
+<input type="text" autocomplete="foo" />
+<input type="text" autocomplete="name invalid" />
+<input type="text" autocomplete="invalid name" />
+<input type="text" autocomplete="home url" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.html.snap
@@ -1,0 +1,100 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<input type="text" autocomplete="foo" />
+<input type="text" autocomplete="name invalid" />
+<input type="text" autocomplete="invalid name" />
+<input type="text" autocomplete="home url" />
+
+```
+
+# Diagnostics
+```
+invalid.html:2:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <input type="text" autocomplete="foo" />
+      │                    ^^^^^^^^^^^^^^^^^^
+    3 │ <input type="text" autocomplete="name invalid" />
+    4 │ <input type="text" autocomplete="invalid name" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.html:3:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <input type="text" autocomplete="foo" />
+  > 3 │ <input type="text" autocomplete="name invalid" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <input type="text" autocomplete="invalid name" />
+    5 │ <input type="text" autocomplete="home url" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.html:4:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    2 │ <input type="text" autocomplete="foo" />
+    3 │ <input type="text" autocomplete="name invalid" />
+  > 4 │ <input type="text" autocomplete="invalid name" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ <input type="text" autocomplete="home url" />
+    6 │ 
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.html:5:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    3 │ <input type="text" autocomplete="name invalid" />
+    4 │ <input type="text" autocomplete="invalid name" />
+  > 5 │ <input type="text" autocomplete="home url" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"a11y": {
+				"useValidAutocomplete": {
+					"level": "error",
+					"options": {
+						"inputComponents": ["Foo", "Bar", "Input"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.svelte
@@ -1,0 +1,7 @@
+<!-- should generate diagnostics -->
+<input type="text" autocomplete="foo" />
+<input type="text" autocomplete="name invalid" />
+<input type="text" autocomplete="invalid name" />
+<input type="text" autocomplete="home url" />
+<Bar autocomplete="baz"></Bar>
+<Input type="text" autocomplete="baz" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.svelte.snap
@@ -1,0 +1,146 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.svelte
+---
+# Input
+```svelte
+<!-- should generate diagnostics -->
+<input type="text" autocomplete="foo" />
+<input type="text" autocomplete="name invalid" />
+<input type="text" autocomplete="invalid name" />
+<input type="text" autocomplete="home url" />
+<Bar autocomplete="baz"></Bar>
+<Input type="text" autocomplete="baz" />
+
+```
+
+# Diagnostics
+```
+invalid.svelte:2:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <input type="text" autocomplete="foo" />
+      │                    ^^^^^^^^^^^^^^^^^^
+    3 │ <input type="text" autocomplete="name invalid" />
+    4 │ <input type="text" autocomplete="invalid name" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.svelte:3:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <input type="text" autocomplete="foo" />
+  > 3 │ <input type="text" autocomplete="name invalid" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <input type="text" autocomplete="invalid name" />
+    5 │ <input type="text" autocomplete="home url" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.svelte:4:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    2 │ <input type="text" autocomplete="foo" />
+    3 │ <input type="text" autocomplete="name invalid" />
+  > 4 │ <input type="text" autocomplete="invalid name" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ <input type="text" autocomplete="home url" />
+    6 │ <Bar autocomplete="baz"></Bar>
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.svelte:5:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    3 │ <input type="text" autocomplete="name invalid" />
+    4 │ <input type="text" autocomplete="invalid name" />
+  > 5 │ <input type="text" autocomplete="home url" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ <Bar autocomplete="baz"></Bar>
+    7 │ <Input type="text" autocomplete="baz" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.svelte:6:6 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    4 │ <input type="text" autocomplete="invalid name" />
+    5 │ <input type="text" autocomplete="home url" />
+  > 6 │ <Bar autocomplete="baz"></Bar>
+      │      ^^^^^^^^^^^^^^^^^^
+    7 │ <Input type="text" autocomplete="baz" />
+    8 │ 
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.svelte:7:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    5 │ <input type="text" autocomplete="home url" />
+    6 │ <Bar autocomplete="baz"></Bar>
+  > 7 │ <Input type="text" autocomplete="baz" />
+      │                    ^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.vue
@@ -1,0 +1,7 @@
+<!-- should generate diagnostics -->
+<input type="text" autocomplete="foo" />
+<input type="text" autocomplete="name invalid" />
+<input type="text" autocomplete="invalid name" />
+<input type="text" autocomplete="home url" />
+<Bar autocomplete="baz"></Bar>
+<Input type="text" autocomplete="baz" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/invalid.vue.snap
@@ -1,0 +1,146 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<input type="text" autocomplete="foo" />
+<input type="text" autocomplete="name invalid" />
+<input type="text" autocomplete="invalid name" />
+<input type="text" autocomplete="home url" />
+<Bar autocomplete="baz"></Bar>
+<Input type="text" autocomplete="baz" />
+
+```
+
+# Diagnostics
+```
+invalid.vue:2:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <input type="text" autocomplete="foo" />
+      │                    ^^^^^^^^^^^^^^^^^^
+    3 │ <input type="text" autocomplete="name invalid" />
+    4 │ <input type="text" autocomplete="invalid name" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.vue:3:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <input type="text" autocomplete="foo" />
+  > 3 │ <input type="text" autocomplete="name invalid" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <input type="text" autocomplete="invalid name" />
+    5 │ <input type="text" autocomplete="home url" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.vue:4:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    2 │ <input type="text" autocomplete="foo" />
+    3 │ <input type="text" autocomplete="name invalid" />
+  > 4 │ <input type="text" autocomplete="invalid name" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ <input type="text" autocomplete="home url" />
+    6 │ <Bar autocomplete="baz"></Bar>
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.vue:5:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    3 │ <input type="text" autocomplete="name invalid" />
+    4 │ <input type="text" autocomplete="invalid name" />
+  > 5 │ <input type="text" autocomplete="home url" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ <Bar autocomplete="baz"></Bar>
+    7 │ <Input type="text" autocomplete="baz" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.vue:6:6 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    4 │ <input type="text" autocomplete="invalid name" />
+    5 │ <input type="text" autocomplete="home url" />
+  > 6 │ <Bar autocomplete="baz"></Bar>
+      │      ^^^^^^^^^^^^^^^^^^
+    7 │ <Input type="text" autocomplete="baz" />
+    8 │ 
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.vue:7:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    5 │ <input type="text" autocomplete="home url" />
+    6 │ <Bar autocomplete="baz"></Bar>
+  > 7 │ <Input type="text" autocomplete="baz" />
+      │                    ^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.astro
@@ -1,0 +1,17 @@
+<!-- should not generate diagnostics -->
+<input type="text" />
+<input type="text" autocomplete="name" />
+<input type="text" autocomplete="" />
+<input type="text" autocomplete="off" />
+<input type="text" autocomplete="on" />
+<input type="text" autocomplete="billing family-name" />
+<input type="text" autocomplete="section-blue shipping street-address" />
+<input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete />
+<input type="text" autocomplete={autocompl} />
+<input type="text" autocomplete={autocompl || "name" } />
+<input type="text" autocomplete={autocompl || "foo" } />
+<input type={isEmail ? "email" : "text" } autocomplete="none" />
+<Foo autocomplete="bar"></Foo>
+<Input type="text" autocomplete="name" />
+<Input type="text" autocomplete="baz" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.astro.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+<input type="text" />
+<input type="text" autocomplete="name" />
+<input type="text" autocomplete="" />
+<input type="text" autocomplete="off" />
+<input type="text" autocomplete="on" />
+<input type="text" autocomplete="billing family-name" />
+<input type="text" autocomplete="section-blue shipping street-address" />
+<input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete />
+<input type="text" autocomplete={autocompl} />
+<input type="text" autocomplete={autocompl || "name" } />
+<input type="text" autocomplete={autocompl || "foo" } />
+<input type={isEmail ? "email" : "text" } autocomplete="none" />
+<Foo autocomplete="bar"></Foo>
+<Input type="text" autocomplete="name" />
+<Input type="text" autocomplete="baz" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.html
@@ -1,0 +1,10 @@
+<!-- should not generate diagnostics -->
+<input type="text" />
+<input type="text" autocomplete="name" />
+<input type="text" autocomplete="" />
+<input type="text" autocomplete="off" />
+<input type="text" autocomplete="on" />
+<input type="text" autocomplete="billing family-name" />
+<input type="text" autocomplete="section-blue shipping street-address" />
+<input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.html.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<input type="text" />
+<input type="text" autocomplete="name" />
+<input type="text" autocomplete="" />
+<input type="text" autocomplete="off" />
+<input type="text" autocomplete="on" />
+<input type="text" autocomplete="billing family-name" />
+<input type="text" autocomplete="section-blue shipping street-address" />
+<input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"a11y": {
+				"useValidAutocomplete": {
+					"level": "error",
+					"options": {
+						"inputComponents": []
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.svelte
@@ -1,0 +1,17 @@
+<!-- should not generate diagnostics -->
+<input type="text" />
+<input type="text" autocomplete="name" />
+<input type="text" autocomplete="" />
+<input type="text" autocomplete="off" />
+<input type="text" autocomplete="on" />
+<input type="text" autocomplete="billing family-name" />
+<input type="text" autocomplete="section-blue shipping street-address" />
+<input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete />
+<input type="text" autocomplete={autocompl} />
+<input type="text" autocomplete={autocompl || "name" } />
+<input type="text" autocomplete={autocompl || "foo" } />
+<input type={isEmail ? "email" : "text" } autocomplete="none" />
+<Foo autocomplete="bar"></Foo>
+<Input type="text" autocomplete="name" />
+<Input type="text" autocomplete="baz" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.svelte.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<input type="text" />
+<input type="text" autocomplete="name" />
+<input type="text" autocomplete="" />
+<input type="text" autocomplete="off" />
+<input type="text" autocomplete="on" />
+<input type="text" autocomplete="billing family-name" />
+<input type="text" autocomplete="section-blue shipping street-address" />
+<input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete />
+<input type="text" autocomplete={autocompl} />
+<input type="text" autocomplete={autocompl || "name" } />
+<input type="text" autocomplete={autocompl || "foo" } />
+<input type={isEmail ? "email" : "text" } autocomplete="none" />
+<Foo autocomplete="bar"></Foo>
+<Input type="text" autocomplete="name" />
+<Input type="text" autocomplete="baz" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.vue
@@ -1,0 +1,13 @@
+<!-- should not generate diagnostics -->
+<input type="text" />
+<input type="text" autocomplete="name" />
+<input type="text" autocomplete="" />
+<input type="text" autocomplete="off" />
+<input type="text" autocomplete="on" />
+<input type="text" autocomplete="billing family-name" />
+<input type="text" autocomplete="section-blue shipping street-address" />
+<input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete />
+<Foo autocomplete="bar"></Foo>
+<Input type="text" autocomplete="name" />
+<Input type="text" autocomplete="baz" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/valid.vue.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<input type="text" />
+<input type="text" autocomplete="name" />
+<input type="text" autocomplete="" />
+<input type="text" autocomplete="off" />
+<input type="text" autocomplete="on" />
+<input type="text" autocomplete="billing family-name" />
+<input type="text" autocomplete="section-blue shipping street-address" />
+<input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete />
+<Foo autocomplete="bar"></Foo>
+<Input type="text" autocomplete="name" />
+<Input type="text" autocomplete="baz" />
+
+```


### PR DESCRIPTION
## Summary

Port useValidAutocomplete to the HTML analyzer

Related https://github.com/biomejs/biome/issues/8155

## Test Plan

Unit tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
