### PR TITLE
test(formatter): retain formatter failures in prettier snapshots

### DIFF
--- a/crates/biome_formatter_test/src/check_reformat.rs
+++ b/crates/biome_formatter_test/src/check_reformat.rs
@@ -20,15 +20,15 @@ pub enum ReformatError {
 impl fmt::Display for ReformatError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ReformatError::SyntaxErrors(diagnostics) => {
+            Self::SyntaxErrors(diagnostics) => {
                 write!(
                     f,
                     "reformat: formatter output had syntax errors where input had none:\n{diagnostics}"
                 )
             }
-            ReformatError::Format(message) => write!(f, "reformat: {message}"),
-            ReformatError::Print(message) => write!(f, "reformat: {message}"),
-            ReformatError::OutputMismatch {
+            Self::Format(message) => write!(f, "reformat: {message}"),
+            Self::Print(message) => write!(f, "reformat: {message}"),
+            Self::OutputMismatch {
                 output_diff,
                 ir_diff,
             } => {

--- a/crates/biome_formatter_test/src/check_reformat.rs
+++ b/crates/biome_formatter_test/src/check_reformat.rs
@@ -4,6 +4,51 @@ use biome_diagnostics::console::markup;
 use biome_diagnostics::termcolor;
 use biome_diagnostics::{DiagnosticExt, PrintDiagnostic};
 use biome_rowan::SyntaxNode;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum ReformatError {
+    SyntaxErrors(String),
+    Format(String),
+    Print(String),
+    OutputMismatch {
+        output_diff: String,
+        ir_diff: Option<String>,
+    },
+}
+
+impl fmt::Display for ReformatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReformatError::SyntaxErrors(diagnostics) => {
+                write!(
+                    f,
+                    "reformat: formatter output had syntax errors where input had none:\n{diagnostics}"
+                )
+            }
+            ReformatError::Format(message) => write!(f, "reformat: {message}"),
+            ReformatError::Print(message) => write!(f, "reformat: {message}"),
+            ReformatError::OutputMismatch {
+                output_diff,
+                ir_diff,
+            } => {
+                writeln!(f, "reformat: output mismatch")?;
+                write!(f, "{output_diff}")?;
+
+                if let Some(ir_diff) = ir_diff {
+                    if !output_diff.ends_with('\n') {
+                        writeln!(f)?;
+                    }
+                    writeln!(f)?;
+                    writeln!(f, "IR differences:")?;
+                    write!(f, "{ir_diff}")?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
 
 /// Perform a second pass of formatting on a file, printing a diff if the
 /// output doesn't match the input
@@ -40,12 +85,11 @@ where
         }
     }
 
-    pub fn check_reformat(&self) {
+    pub fn check_reformat(&self) -> Result<(), ReformatError> {
         let re_parse = self.language.parse(self.text);
 
-        // Panic if the result from the formatter has syntax errors
         if re_parse.has_errors() {
-            let mut buffer = termcolor::Buffer::ansi();
+            let mut buffer = termcolor::Buffer::no_color();
 
             for diagnostic in re_parse.diagnostics() {
                 let error = diagnostic
@@ -59,51 +103,56 @@ where
                     .expect("failed to emit diagnostic");
             }
 
-            panic!(
-                "formatter output had syntax errors where input had none:\n{}",
-                std::str::from_utf8(buffer.as_slice()).expect("non utf8 in error buffer")
-            )
+            return Err(ReformatError::SyntaxErrors(
+                std::str::from_utf8(buffer.as_slice())
+                    .expect("non utf8 in error buffer")
+                    .to_string(),
+            ));
         }
 
-        let re_formatted = match self
+        let re_formatted = self
             .language
             .format_node(self.format_language.clone(), &re_parse.syntax())
-        {
-            Ok(formatted) => formatted,
-            Err(err) => {
-                panic!("failed to format: {err}");
-            }
-        };
+            .map_err(|err| ReformatError::Format(format!("failed to format: {err}")))?;
 
-        let re_printed = re_formatted.print().unwrap();
+        let re_printed = re_formatted
+            .print()
+            .map_err(|err| ReformatError::Print(format!("failed to print: {err}")))?;
 
         if self.text != re_printed.as_code() {
             let input_format_element = self
                 .language
                 .format_node(self.format_language.clone(), self.root)
-                .unwrap();
+                .map_err(|err| {
+                    ReformatError::Format(format!(
+                        "failed to format original input for IR comparison: {err}"
+                    ))
+                })?;
             let pretty_reformat_ir = format!("{}", re_formatted.into_document());
             let pretty_input_ir = format!("{}", input_format_element.into_document());
-
-            // Print a diff of the Formatter IR emitted for the input and the output
-            let diff = similar_asserts::SimpleDiff::from_str(
-                &pretty_input_ir,
-                &pretty_reformat_ir,
-                "input",
-                "output",
-            );
-            println!("{diff}");
-
-            similar_asserts::assert_eq!(
+            let output_diff = similar_asserts::SimpleDiff::from_str(
                 re_printed.as_code(),
                 self.text,
-                "left is the re-formatted"
-            );
-            similar_asserts::assert_eq!(
-                pretty_reformat_ir,
-                pretty_input_ir,
-                "left is the re-formatted"
-            );
+                "re-formatted",
+                "formatted",
+            )
+            .to_string();
+            let ir_diff = (pretty_reformat_ir != pretty_input_ir).then(|| {
+                similar_asserts::SimpleDiff::from_str(
+                    &pretty_reformat_ir,
+                    &pretty_input_ir,
+                    "re-formatted IR",
+                    "formatted IR",
+                )
+                .to_string()
+            });
+
+            return Err(ReformatError::OutputMismatch {
+                output_diff,
+                ir_diff,
+            });
         }
+
+        Ok(())
     }
 }

--- a/crates/biome_formatter_test/src/snapshot_builder.rs
+++ b/crates/biome_formatter_test/src/snapshot_builder.rs
@@ -170,6 +170,15 @@ impl<'a> SnapshotBuilder<'a> {
         self
     }
 
+    pub fn with_error(mut self, error: &str) -> Self {
+        writeln!(self.snapshot, "# Error").unwrap();
+        writeln!(self.snapshot, "```text").unwrap();
+        writeln!(self.snapshot, "{error}").unwrap();
+        writeln!(self.snapshot, "```").unwrap();
+        writeln!(self.snapshot).unwrap();
+        self
+    }
+
     /// Renders a `# Options` section with the raw JSON content of an options file.
     pub fn with_options_json(mut self, json_content: &str) -> Self {
         writeln!(self.snapshot, "# Options").unwrap();

--- a/crates/biome_formatter_test/src/test_prettier_snapshot.rs
+++ b/crates/biome_formatter_test/src/test_prettier_snapshot.rs
@@ -1,12 +1,12 @@
 use crate::TestFormatLanguage;
-use crate::check_reformat::CheckReformat;
+use crate::check_reformat::{CheckReformat, ReformatError};
 use crate::snapshot_builder::{SnapshotBuilder, SnapshotOutput};
 use crate::utils::{PrettierDiff, get_prettier_diff, strip_prettier_placeholders};
-use biome_formatter::{FormatLanguage, FormatOptions};
+use biome_formatter::{FormatLanguage, FormatOptions, Printed};
 use biome_parser::AnyParse;
 use biome_rowan::{TextRange, TextSize};
 use camino::Utf8Path;
-use std::{fs::read_to_string, ops::Range};
+use std::{fmt, fs::read_to_string, ops::Range};
 
 const PRETTIER_IGNORE: &str = "prettier-ignore";
 const BIOME_IGNORE: &str = "biome-ignore format: prettier ignore";
@@ -96,6 +96,26 @@ where
     format_language: L::FormatLanguage,
 }
 
+enum FormatAttempt {
+    Formatted(String),
+    Failed(PrettierSnapshotError),
+}
+
+#[derive(Debug)]
+enum PrettierSnapshotError {
+    Format(String),
+    Reformat(ReformatError),
+}
+
+impl fmt::Display for PrettierSnapshotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PrettierSnapshotError::Format(message) => write!(f, "format: {message}"),
+            PrettierSnapshotError::Reformat(error) => write!(f, "{error}"),
+        }
+    }
+}
+
 impl<'a, L> PrettierSnapshot<'a, L>
 where
     L: TestFormatLanguage,
@@ -112,98 +132,166 @@ where
         }
     }
 
-    fn formatted(&self, parsed: &AnyParse) -> Option<String> {
-        let has_errors = parsed.has_errors();
+    fn format_for_snapshot(&self, parsed: &AnyParse) -> Option<FormatAttempt> {
         let syntax = parsed.syntax();
+        let printed = match self.run_formatter(&syntax) {
+            Some(Ok(printed)) => printed,
+            Some(Err(error)) => return Some(FormatAttempt::Failed(error)),
+            None => return None,
+        };
 
-        let range = self.test_file.range();
+        let formatted = match self.finish_formatted_output(parsed, &syntax, printed) {
+            Ok(formatted) => formatted,
+            Err(error) => return Some(FormatAttempt::Failed(error)),
+        };
 
-        let result = match range {
-            (Some(start), Some(end)) => {
-                // Skip the reversed range tests as its impossible
-                // to create a reversed TextRange anyway
-                if end < start {
-                    return None;
-                }
+        Some(FormatAttempt::Formatted(
+            formatted.replace(BIOME_IGNORE, PRETTIER_IGNORE),
+        ))
+    }
 
-                self.language.format_range(
+    fn run_formatter(
+        &self,
+        syntax: &biome_rowan::SyntaxNode<L::ServiceLanguage>,
+    ) -> Option<Result<Printed, PrettierSnapshotError>> {
+        match self.test_file.range() {
+            (Some(start), Some(end)) => self.format_range_once(syntax, start, end),
+            _ => Some(self.format_node_once(syntax)),
+        }
+    }
+
+    fn format_range_once(
+        &self,
+        syntax: &biome_rowan::SyntaxNode<L::ServiceLanguage>,
+        start: usize,
+        end: usize,
+    ) -> Option<Result<Printed, PrettierSnapshotError>> {
+        // Skip reversed range tests because TextRange cannot represent them.
+        if end < start {
+            return None;
+        }
+
+        Some(
+            self.language
+                .format_range(
                     self.format_language.clone(),
-                    &syntax,
+                    syntax,
                     TextRange::new(
                         TextSize::try_from(start).unwrap(),
                         TextSize::try_from(end).unwrap(),
                     ),
                 )
-            }
-            _ => self
-                .language
-                .format_node(self.format_language.clone(), &syntax)
-                .map(|formatted| formatted.print().unwrap()),
-        };
+                .map_err(|err| PrettierSnapshotError::Format(err.to_string())),
+        )
+    }
 
-        let formatted = result.expect("formatting failed");
-        let formatted = match range {
-            (Some(_), Some(_)) => {
-                let range = formatted
-                    .range()
-                    .expect("the result of format_range should have a range");
-
-                let formatted = formatted.as_code();
-                let mut output_code = self.test_file.parse_input.clone();
-                output_code.replace_range(Range::<usize>::from(range), formatted);
-                output_code
-            }
-            _ => {
-                let formatted = formatted.into_code();
-
-                if !has_errors {
-                    let check_reformat = CheckReformat::new(
-                        &syntax,
-                        &formatted,
-                        self.test_file.file_name(),
-                        &self.language,
-                        self.format_language.clone(),
-                    );
-                    check_reformat.check_reformat();
-                }
-
+    fn format_node_once(
+        &self,
+        syntax: &biome_rowan::SyntaxNode<L::ServiceLanguage>,
+    ) -> Result<Printed, PrettierSnapshotError> {
+        self.language
+            .format_node(self.format_language.clone(), syntax)
+            .map_err(|err| PrettierSnapshotError::Format(err.to_string()))
+            .and_then(|formatted| {
                 formatted
-            }
-        };
+                    .print()
+                    .map_err(|err| PrettierSnapshotError::Format(err.to_string()))
+            })
+    }
 
-        let formatted = formatted.replace(BIOME_IGNORE, PRETTIER_IGNORE);
+    fn finish_formatted_output(
+        &self,
+        parsed: &AnyParse,
+        syntax: &biome_rowan::SyntaxNode<L::ServiceLanguage>,
+        printed: Printed,
+    ) -> Result<String, PrettierSnapshotError> {
+        match self.test_file.range() {
+            (Some(_), Some(_)) => Ok(self.apply_range_format(printed)),
+            _ => self.finish_file_format(parsed, syntax, printed),
+        }
+    }
 
-        Some(formatted)
+    fn apply_range_format(&self, printed: Printed) -> String {
+        let range = printed
+            .range()
+            .expect("the result of format_range should have a range");
+
+        let formatted = printed.as_code();
+        let mut output_code = self.test_file.parse_input.clone();
+        output_code.replace_range(Range::<usize>::from(range), formatted);
+        output_code
+    }
+
+    fn finish_file_format(
+        &self,
+        parsed: &AnyParse,
+        syntax: &biome_rowan::SyntaxNode<L::ServiceLanguage>,
+        printed: Printed,
+    ) -> Result<String, PrettierSnapshotError> {
+        let formatted = printed.into_code();
+
+        if !parsed.has_errors() {
+            self.verify_reformat(syntax, &formatted)?;
+        }
+
+        Ok(formatted)
+    }
+
+    fn verify_reformat(
+        &self,
+        syntax: &biome_rowan::SyntaxNode<L::ServiceLanguage>,
+        formatted: &str,
+    ) -> Result<(), PrettierSnapshotError> {
+        let check_reformat = CheckReformat::new(
+            syntax,
+            formatted,
+            self.test_file.file_name(),
+            &self.language,
+            self.format_language.clone(),
+        );
+
+        check_reformat
+            .check_reformat()
+            .map_err(PrettierSnapshotError::Reformat)
     }
 
     pub fn test(self) {
         let parsed = self.language.parse(self.test_file().parse_input());
-
-        let formatted = match self.formatted(&parsed) {
-            Some(formatted) => formatted,
+        let attempt = match self.format_for_snapshot(&parsed) {
+            Some(attempt) => attempt,
             None => return,
         };
 
         let relative_file_name = self.test_file().relative_file_name();
         let input_file = self.test_file().input_file();
 
-        let prettier_diff = get_prettier_diff(input_file, relative_file_name, &formatted);
+        match attempt {
+            FormatAttempt::Formatted(formatted) => {
+                let prettier_diff = get_prettier_diff(input_file, relative_file_name, &formatted);
+                let prettier_diff = match prettier_diff {
+                    PrettierDiff::Diff(prettier_diff) => prettier_diff,
+                    PrettierDiff::Same => return,
+                };
 
-        let prettier_diff = match prettier_diff {
-            PrettierDiff::Diff(prettier_diff) => prettier_diff,
-            PrettierDiff::Same => return,
-        };
+                let mut builder = SnapshotBuilder::new(input_file)
+                    .with_input(&self.test_file().input_code)
+                    .with_prettier_diff(&prettier_diff)
+                    .with_output(SnapshotOutput::new(&formatted))
+                    .with_errors(&parsed, &self.test_file().parse_input);
 
-        let mut builder = SnapshotBuilder::new(input_file)
-            .with_input(&self.test_file().input_code)
-            .with_prettier_diff(&prettier_diff)
-            .with_output(SnapshotOutput::new(&formatted))
-            .with_errors(&parsed, &self.test_file().parse_input);
+                let max_width = self.format_language.options().line_width().value() as usize;
+                builder = builder.with_lines_exceeding_max_width(&formatted, max_width);
 
-        let max_width = self.format_language.options().line_width().value() as usize;
-        builder = builder.with_lines_exceeding_max_width(&formatted, max_width);
-
-        builder.finish(relative_file_name);
+                builder.finish(relative_file_name);
+            }
+            FormatAttempt::Failed(error) => {
+                SnapshotBuilder::new(input_file)
+                    .with_input(&self.test_file().input_code)
+                    .with_errors(&parsed, &self.test_file().parse_input)
+                    .with_error(&error.to_string())
+                    .finish(relative_file_name);
+            }
+        }
     }
 
     fn test_file(&self) -> &PrettierTestFile<'_> {

--- a/crates/biome_formatter_test/src/test_prettier_snapshot.rs
+++ b/crates/biome_formatter_test/src/test_prettier_snapshot.rs
@@ -110,8 +110,8 @@ enum PrettierSnapshotError {
 impl fmt::Display for PrettierSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            PrettierSnapshotError::Format(message) => write!(f, "format: {message}"),
-            PrettierSnapshotError::Reformat(error) => write!(f, "{error}"),
+            Self::Format(message) => write!(f, "format: {message}"),
+            Self::Reformat(error) => write!(f, "{error}"),
         }
     }
 }


### PR DESCRIPTION
  ## Summary

  Importing SCSS fixtures from Prettier exposed cases where `PrettierSnapshot` can panic during formatting or
  reformat verification. I don't want to delete those fixtures just because they panic today, so this change keeps
  them as reviewable snapshot artifacts instead of aborting the test run.

  Regular spec snapshots are unchanged and still fail fast.

  ## Test Plan

Green CI
