### PR TITLE
feat(css): support unquoted concatenation in SCSS interpolation expressions

### DIFF
--- a/crates/biome_css_formatter/src/scss/lists/expression_item_list.rs
+++ b/crates/biome_css_formatter/src/scss/lists/expression_item_list.rs
@@ -1,11 +1,62 @@
 use crate::prelude::*;
-use crate::utils::component_value_list::write_component_value_list;
-use biome_css_syntax::ScssExpressionItemList;
+use crate::utils::component_value_list::write_component_value_list_with_separator_rule;
+use biome_css_syntax::{AnyCssValue, AnyScssExpressionItem, ScssExpressionItemList};
+use biome_rowan::AstNode;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssExpressionItemList;
 impl FormatRule<ScssExpressionItemList> for FormatScssExpressionItemList {
     type Context = CssFormatContext;
     fn fmt(&self, node: &ScssExpressionItemList, f: &mut CssFormatter) -> FormatResult<()> {
-        write_component_value_list(node, f)
+        write_component_value_list_with_separator_rule(
+            node,
+            f,
+            omit_separator_between_unquoted_concatenation_parts,
+        )
     }
+}
+
+/// Preserves direct adjacency for the currently supported interpolation-bearing
+/// unquoted concatenation forms.
+///
+/// Examples:
+/// - `$variable#{something}`
+/// - `#{something}$variable`
+/// - `$a#{b}$c`
+///
+/// These forms currently parse as adjacent `ScssVariable` and
+/// `ScssInterpolation` expression items rather than a dedicated concatenation
+/// node, so the expression-item formatter must not insert a separator between
+/// those item pairs when the source had no trivia between them.
+fn omit_separator_between_unquoted_concatenation_parts(
+    left: &AnyScssExpressionItem,
+    right: &AnyScssExpressionItem,
+) -> bool {
+    has_no_trivia_between(left, right) && is_unquoted_concatenation_pair(left, right)
+}
+
+fn has_no_trivia_between(left: &AnyScssExpressionItem, right: &AnyScssExpressionItem) -> bool {
+    left.syntax()
+        .last_token()
+        .is_some_and(|token| token.trailing_trivia().is_empty())
+        && right
+            .syntax()
+            .first_token()
+            .is_some_and(|token| token.leading_trivia().is_empty())
+}
+
+fn is_unquoted_concatenation_pair(
+    left: &AnyScssExpressionItem,
+    right: &AnyScssExpressionItem,
+) -> bool {
+    matches!(
+        (left, right),
+        (
+            AnyScssExpressionItem::AnyCssValue(AnyCssValue::ScssVariable(_)),
+            AnyScssExpressionItem::ScssInterpolation(_),
+        ) | (
+            AnyScssExpressionItem::ScssInterpolation(_),
+            AnyScssExpressionItem::AnyCssValue(AnyCssValue::ScssVariable(_)),
+        )
+    )
 }

--- a/crates/biome_css_formatter/src/utils/component_value_list.rs
+++ b/crates/biome_css_formatter/src/utils/component_value_list.rs
@@ -141,6 +141,25 @@ where
     N: AstNodeList<Language = CssLanguage, Node = I> + AstNode<Language = CssLanguage>,
     I: AstNode<Language = CssLanguage> + IntoFormat<CssFormatContext>,
 {
+    write_component_value_list_with_separator_rule(node, f, |_, _| false)
+}
+
+/// Formats a component value list while allowing callers to suppress the
+/// normally inserted separator between specific adjacent items.
+///
+/// This is used for syntax families where adjacency itself is semantically
+/// significant and the formatter must preserve the no-space boundary instead of
+/// normalizing it to `soft_line_break_or_space()`.
+pub(crate) fn write_component_value_list_with_separator_rule<N, I, P>(
+    node: &N,
+    f: &mut CssFormatter,
+    omit_separator_between: P,
+) -> FormatResult<()>
+where
+    N: AstNodeList<Language = CssLanguage, Node = I> + AstNode<Language = CssLanguage>,
+    I: AstNode<Language = CssLanguage> + IntoFormat<CssFormatContext>,
+    P: Fn(&I, &I) -> bool + Copy,
+{
     let layout = get_value_list_layout(node, f.context().comments(), f);
 
     // Check if any of the elements in the list have a leading newline.
@@ -176,8 +195,13 @@ where
 
             let mut fill = f.fill();
             let mut at_group_boundary = false;
+            let mut previous_element: Option<I> = None;
 
             for (element, formatted) in node.iter().zip(node.iter().formatted()) {
+                let omit_separator = previous_element
+                    .as_ref()
+                    .is_some_and(|previous| omit_separator_between(previous, &element));
+
                 fill.entry(
                     &format_once(|f| {
                         // If the current element is not a comma, insert a soft line break or a space.
@@ -186,7 +210,7 @@ where
                         // A separator should not be added before the comma because the comma acts as a `CssGenericDelimiter`.
                         let is_comma = is_comma_delimiter(&element);
 
-                        if !is_comma {
+                        if !is_comma && !omit_separator {
                             if matches!(
                                 layout,
                                 ValueListLayout::PreserveInline | ValueListLayout::OnePerLine
@@ -238,6 +262,8 @@ where
                     }),
                     &formatted,
                 );
+
+                previous_element = Some(element);
             }
 
             fill.finish()

--- a/crates/biome_css_formatter/tests/specs/css/scss/declaration/unquoted-concatenation.scss
+++ b/crates/biome_css_formatter/tests/specs/css/scss/declaration/unquoted-concatenation.scss
@@ -1,0 +1,8 @@
+$variable:alpha;
+$a:beta;
+$b:gamma;
+$c:delta;
+
+$test-1:#{something}$variable;
+$test-2:$a#{b}$c;
+$test-3:#{a}$b#{c};

--- a/crates/biome_css_formatter/tests/specs/css/scss/declaration/unquoted-concatenation.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/css/scss/declaration/unquoted-concatenation.scss.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/scss/declaration/unquoted-concatenation.scss
+---
+
+# Input
+
+```scss
+$variable:alpha;
+$a:beta;
+$b:gamma;
+$c:delta;
+
+$test-1:#{something}$variable;
+$test-2:$a#{b}$c;
+$test-3:#{a}$b#{c};
+
+```
+
+
+# Formatted
+
+```scss
+$variable: alpha;
+$a: beta;
+$b: gamma;
+$c: delta;
+
+$test-1: #{something}$variable;
+$test-2: $a#{b}$c;
+$test-3: #{a}$b#{c};
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/list.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/list.scss
@@ -2,7 +2,6 @@ $mylist: (alpha, beta, gamma, );
 $my-single-item-list: (alpha,);
 $box-shadow-first-two: 0 0.5em $background, 0 -0.5em $background;
 $list2: (1px solid,);
-// TODO(interpolation support): $no-whitespaces: $variable#{something};
-
+$no-whitespaces: $variable#{something};
 
 

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/list.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/list.scss.snap
@@ -10,8 +10,7 @@ $mylist: (alpha, beta, gamma, );
 $my-single-item-list: (alpha,);
 $box-shadow-first-two: 0 0.5em $background, 0 -0.5em $background;
 $list2: (1px solid,);
-// TODO(interpolation support): $no-whitespaces: $variable#{something};
-
+$no-whitespaces: $variable#{something};
 
 
 
@@ -208,17 +207,50 @@ CssRoot {
             modifiers: ScssVariableModifierList [],
             semicolon_token: SEMICOLON@151..152 ";" [] [],
         },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@152..154 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@154..168 "no-whitespaces" [] [],
+                },
+            },
+            colon_token: COLON@168..170 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    ScssVariable {
+                        dollar_token: DOLLAR@170..171 "$" [] [],
+                        name: CssIdentifier {
+                            value_token: IDENT@171..179 "variable" [] [],
+                        },
+                    },
+                    ScssInterpolation {
+                        hash_token: HASH@179..180 "#" [] [],
+                        l_curly_token: L_CURLY@180..181 "{" [] [],
+                        value: ScssExpression {
+                            items: ScssExpressionItemList [
+                                CssIdentifier {
+                                    value_token: IDENT@181..190 "something" [] [],
+                                },
+                            ],
+                        },
+                        r_curly_token: R_CURLY@190..191 "}" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@191..192 ";" [] [],
+        },
     ],
-    eof_token: EOF@152..228 "" [Newline("\n"), Comments("// TODO(interpolation ..."), Newline("\n"), Newline("\n"), Newline("\n"), Newline("\n")] [],
+    eof_token: EOF@192..195 "" [Newline("\n"), Newline("\n"), Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..228
+0: CSS_ROOT@0..195
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..152
+  1: CSS_ROOT_ITEM_LIST@0..192
     0: SCSS_VARIABLE_DECLARATION@0..32
       0: SCSS_VARIABLE@0..7
         0: DOLLAR@0..1 "$" [] []
@@ -336,6 +368,28 @@ CssRoot {
             2: R_PAREN@150..151 ")" [] []
       3: SCSS_VARIABLE_MODIFIER_LIST@151..151
       4: SEMICOLON@151..152 ";" [] []
-  2: EOF@152..228 "" [Newline("\n"), Comments("// TODO(interpolation ..."), Newline("\n"), Newline("\n"), Newline("\n"), Newline("\n")] []
+    4: SCSS_VARIABLE_DECLARATION@152..192
+      0: SCSS_VARIABLE@152..168
+        0: DOLLAR@152..154 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@154..168
+          0: IDENT@154..168 "no-whitespaces" [] []
+      1: COLON@168..170 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@170..191
+        0: SCSS_EXPRESSION_ITEM_LIST@170..191
+          0: SCSS_VARIABLE@170..179
+            0: DOLLAR@170..171 "$" [] []
+            1: CSS_IDENTIFIER@171..179
+              0: IDENT@171..179 "variable" [] []
+          1: SCSS_INTERPOLATION@179..191
+            0: HASH@179..180 "#" [] []
+            1: L_CURLY@180..181 "{" [] []
+            2: SCSS_EXPRESSION@181..190
+              0: SCSS_EXPRESSION_ITEM_LIST@181..190
+                0: CSS_IDENTIFIER@181..190
+                  0: IDENT@181..190 "something" [] []
+            3: R_CURLY@190..191 "}" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@191..191
+      4: SEMICOLON@191..192 ";" [] []
+  2: EOF@192..195 "" [Newline("\n"), Newline("\n"), Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/unquoted-concatenation.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/unquoted-concatenation.scss
@@ -1,0 +1,8 @@
+$variable: alpha;
+$a: beta;
+$b: gamma;
+$c: delta;
+
+$test-1: #{something}$variable;
+$test-2: $a#{b}$c;
+$test-3: #{a}$b#{c};

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/unquoted-concatenation.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/unquoted-concatenation.scss.snap
@@ -1,0 +1,355 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+$variable: alpha;
+$a: beta;
+$b: gamma;
+$c: delta;
+
+$test-1: #{something}$variable;
+$test-2: $a#{b}$c;
+$test-3: #{a}$b#{c};
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@0..1 "$" [] [],
+                name: CssIdentifier {
+                    value_token: IDENT@1..9 "variable" [] [],
+                },
+            },
+            colon_token: COLON@9..11 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssIdentifier {
+                        value_token: IDENT@11..16 "alpha" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@16..17 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@17..19 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@19..20 "a" [] [],
+                },
+            },
+            colon_token: COLON@20..22 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssIdentifier {
+                        value_token: IDENT@22..26 "beta" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@26..27 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@27..29 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@29..30 "b" [] [],
+                },
+            },
+            colon_token: COLON@30..32 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssIdentifier {
+                        value_token: IDENT@32..37 "gamma" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@37..38 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@38..40 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@40..41 "c" [] [],
+                },
+            },
+            colon_token: COLON@41..43 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssIdentifier {
+                        value_token: IDENT@43..48 "delta" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@48..49 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@49..52 "$" [Newline("\n"), Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@52..58 "test-1" [] [],
+                },
+            },
+            colon_token: COLON@58..60 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    ScssInterpolation {
+                        hash_token: HASH@60..61 "#" [] [],
+                        l_curly_token: L_CURLY@61..62 "{" [] [],
+                        value: ScssExpression {
+                            items: ScssExpressionItemList [
+                                CssIdentifier {
+                                    value_token: IDENT@62..71 "something" [] [],
+                                },
+                            ],
+                        },
+                        r_curly_token: R_CURLY@71..72 "}" [] [],
+                    },
+                    ScssVariable {
+                        dollar_token: DOLLAR@72..73 "$" [] [],
+                        name: CssIdentifier {
+                            value_token: IDENT@73..81 "variable" [] [],
+                        },
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@81..82 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@82..84 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@84..90 "test-2" [] [],
+                },
+            },
+            colon_token: COLON@90..92 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    ScssVariable {
+                        dollar_token: DOLLAR@92..93 "$" [] [],
+                        name: CssIdentifier {
+                            value_token: IDENT@93..94 "a" [] [],
+                        },
+                    },
+                    ScssInterpolation {
+                        hash_token: HASH@94..95 "#" [] [],
+                        l_curly_token: L_CURLY@95..96 "{" [] [],
+                        value: ScssExpression {
+                            items: ScssExpressionItemList [
+                                CssIdentifier {
+                                    value_token: IDENT@96..97 "b" [] [],
+                                },
+                            ],
+                        },
+                        r_curly_token: R_CURLY@97..98 "}" [] [],
+                    },
+                    ScssVariable {
+                        dollar_token: DOLLAR@98..99 "$" [] [],
+                        name: CssIdentifier {
+                            value_token: IDENT@99..100 "c" [] [],
+                        },
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@100..101 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@101..103 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@103..109 "test-3" [] [],
+                },
+            },
+            colon_token: COLON@109..111 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    ScssInterpolation {
+                        hash_token: HASH@111..112 "#" [] [],
+                        l_curly_token: L_CURLY@112..113 "{" [] [],
+                        value: ScssExpression {
+                            items: ScssExpressionItemList [
+                                CssIdentifier {
+                                    value_token: IDENT@113..114 "a" [] [],
+                                },
+                            ],
+                        },
+                        r_curly_token: R_CURLY@114..115 "}" [] [],
+                    },
+                    ScssVariable {
+                        dollar_token: DOLLAR@115..116 "$" [] [],
+                        name: CssIdentifier {
+                            value_token: IDENT@116..117 "b" [] [],
+                        },
+                    },
+                    ScssInterpolation {
+                        hash_token: HASH@117..118 "#" [] [],
+                        l_curly_token: L_CURLY@118..119 "{" [] [],
+                        value: ScssExpression {
+                            items: ScssExpressionItemList [
+                                CssIdentifier {
+                                    value_token: IDENT@119..120 "c" [] [],
+                                },
+                            ],
+                        },
+                        r_curly_token: R_CURLY@120..121 "}" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@121..122 ";" [] [],
+        },
+    ],
+    eof_token: EOF@122..123 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..123
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..122
+    0: SCSS_VARIABLE_DECLARATION@0..17
+      0: SCSS_VARIABLE@0..9
+        0: DOLLAR@0..1 "$" [] []
+        1: CSS_IDENTIFIER@1..9
+          0: IDENT@1..9 "variable" [] []
+      1: COLON@9..11 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@11..16
+        0: SCSS_EXPRESSION_ITEM_LIST@11..16
+          0: CSS_IDENTIFIER@11..16
+            0: IDENT@11..16 "alpha" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@16..16
+      4: SEMICOLON@16..17 ";" [] []
+    1: SCSS_VARIABLE_DECLARATION@17..27
+      0: SCSS_VARIABLE@17..20
+        0: DOLLAR@17..19 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@19..20
+          0: IDENT@19..20 "a" [] []
+      1: COLON@20..22 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@22..26
+        0: SCSS_EXPRESSION_ITEM_LIST@22..26
+          0: CSS_IDENTIFIER@22..26
+            0: IDENT@22..26 "beta" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@26..26
+      4: SEMICOLON@26..27 ";" [] []
+    2: SCSS_VARIABLE_DECLARATION@27..38
+      0: SCSS_VARIABLE@27..30
+        0: DOLLAR@27..29 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@29..30
+          0: IDENT@29..30 "b" [] []
+      1: COLON@30..32 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@32..37
+        0: SCSS_EXPRESSION_ITEM_LIST@32..37
+          0: CSS_IDENTIFIER@32..37
+            0: IDENT@32..37 "gamma" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@37..37
+      4: SEMICOLON@37..38 ";" [] []
+    3: SCSS_VARIABLE_DECLARATION@38..49
+      0: SCSS_VARIABLE@38..41
+        0: DOLLAR@38..40 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@40..41
+          0: IDENT@40..41 "c" [] []
+      1: COLON@41..43 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@43..48
+        0: SCSS_EXPRESSION_ITEM_LIST@43..48
+          0: CSS_IDENTIFIER@43..48
+            0: IDENT@43..48 "delta" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@48..48
+      4: SEMICOLON@48..49 ";" [] []
+    4: SCSS_VARIABLE_DECLARATION@49..82
+      0: SCSS_VARIABLE@49..58
+        0: DOLLAR@49..52 "$" [Newline("\n"), Newline("\n")] []
+        1: CSS_IDENTIFIER@52..58
+          0: IDENT@52..58 "test-1" [] []
+      1: COLON@58..60 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@60..81
+        0: SCSS_EXPRESSION_ITEM_LIST@60..81
+          0: SCSS_INTERPOLATION@60..72
+            0: HASH@60..61 "#" [] []
+            1: L_CURLY@61..62 "{" [] []
+            2: SCSS_EXPRESSION@62..71
+              0: SCSS_EXPRESSION_ITEM_LIST@62..71
+                0: CSS_IDENTIFIER@62..71
+                  0: IDENT@62..71 "something" [] []
+            3: R_CURLY@71..72 "}" [] []
+          1: SCSS_VARIABLE@72..81
+            0: DOLLAR@72..73 "$" [] []
+            1: CSS_IDENTIFIER@73..81
+              0: IDENT@73..81 "variable" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@81..81
+      4: SEMICOLON@81..82 ";" [] []
+    5: SCSS_VARIABLE_DECLARATION@82..101
+      0: SCSS_VARIABLE@82..90
+        0: DOLLAR@82..84 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@84..90
+          0: IDENT@84..90 "test-2" [] []
+      1: COLON@90..92 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@92..100
+        0: SCSS_EXPRESSION_ITEM_LIST@92..100
+          0: SCSS_VARIABLE@92..94
+            0: DOLLAR@92..93 "$" [] []
+            1: CSS_IDENTIFIER@93..94
+              0: IDENT@93..94 "a" [] []
+          1: SCSS_INTERPOLATION@94..98
+            0: HASH@94..95 "#" [] []
+            1: L_CURLY@95..96 "{" [] []
+            2: SCSS_EXPRESSION@96..97
+              0: SCSS_EXPRESSION_ITEM_LIST@96..97
+                0: CSS_IDENTIFIER@96..97
+                  0: IDENT@96..97 "b" [] []
+            3: R_CURLY@97..98 "}" [] []
+          2: SCSS_VARIABLE@98..100
+            0: DOLLAR@98..99 "$" [] []
+            1: CSS_IDENTIFIER@99..100
+              0: IDENT@99..100 "c" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@100..100
+      4: SEMICOLON@100..101 ";" [] []
+    6: SCSS_VARIABLE_DECLARATION@101..122
+      0: SCSS_VARIABLE@101..109
+        0: DOLLAR@101..103 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@103..109
+          0: IDENT@103..109 "test-3" [] []
+      1: COLON@109..111 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@111..121
+        0: SCSS_EXPRESSION_ITEM_LIST@111..121
+          0: SCSS_INTERPOLATION@111..115
+            0: HASH@111..112 "#" [] []
+            1: L_CURLY@112..113 "{" [] []
+            2: SCSS_EXPRESSION@113..114
+              0: SCSS_EXPRESSION_ITEM_LIST@113..114
+                0: CSS_IDENTIFIER@113..114
+                  0: IDENT@113..114 "a" [] []
+            3: R_CURLY@114..115 "}" [] []
+          1: SCSS_VARIABLE@115..117
+            0: DOLLAR@115..116 "$" [] []
+            1: CSS_IDENTIFIER@116..117
+              0: IDENT@116..117 "b" [] []
+          2: SCSS_INTERPOLATION@117..121
+            0: HASH@117..118 "#" [] []
+            1: L_CURLY@118..119 "{" [] []
+            2: SCSS_EXPRESSION@119..120
+              0: SCSS_EXPRESSION_ITEM_LIST@119..120
+                0: CSS_IDENTIFIER@119..120
+                  0: IDENT@119..120 "c" [] []
+            3: R_CURLY@120..121 "}" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@121..121
+      4: SEMICOLON@121..122 ";" [] []
+  2: EOF@122..123 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
 > This PR was created with AI assistance (Codex).

  ## Summary

  Fixes SCSS formatting for unquoted interpolation concatenation.

  Biome no longer inserts spaces into forms such as `$variable#{something}`, `#{something}$variable`, `$a#{b}$c`, and
  `#{a}$b#{c}`. These values now keep their direct adjacency when formatted.
  
  ## Test Plan
  
  new snapshots