### PR TITLE
fix(migrate): enable multi-rule eslint mappings 🤖🤖🤖

### DIFF
--- a/.changeset/fix-eslint-migrate-multi-rule.md
+++ b/.changeset/fix-eslint-migrate-multi-rule.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10024](https://github.com/biomejs/biome/issues/10024): `biome migrate eslint` now enables all matching Biome rules when a single ESLint rule maps to multiple rule sources.

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -618,20 +618,43 @@ pub(crate) fn migrate_eslint_any_rule(
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/explicit-function-return-type" => {
+            let mut migrated = false;
+            let mut skipped_inspired = false;
+            let mut skipped_nursery = false;
             if !options.include_inspired {
-                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                skipped_inspired = true;
+            } else if !options.include_nursery {
+                skipped_nursery = true;
+            } else {
+                let group = rules.nursery.get_or_insert_with(Default::default);
+                let rule = group
+                    .unwrap_group_as_mut()
+                    .use_explicit_return_type
+                    .get_or_insert(Default::default());
+                rule.set_level(rule.level().max(rule_severity.into()));
+                migrated = true;
+            }
+            if !options.include_inspired {
+                skipped_inspired = true;
+            } else if !options.include_nursery {
+                skipped_nursery = true;
+            } else {
+                let group = rules.nursery.get_or_insert_with(Default::default);
+                let rule = group
+                    .unwrap_group_as_mut()
+                    .use_explicit_type
+                    .get_or_insert(Default::default());
+                rule.set_level(rule.level().max(rule_severity.into()));
+                migrated = true;
+            }
+            if !migrated {
+                if skipped_inspired {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                } else if skipped_nursery {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                }
                 return false;
             }
-            if !options.include_nursery {
-                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
-                return false;
-            }
-            let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group
-                .unwrap_group_as_mut()
-                .use_explicit_type
-                .get_or_insert(Default::default());
-            rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/explicit-member-accessibility" => {
             let group = rules.style.get_or_insert_with(Default::default);
@@ -1470,16 +1493,41 @@ pub(crate) fn migrate_eslint_any_rule(
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "e18e/prefer-spread-syntax" => {
+            let mut migrated = false;
+            let mut skipped_inspired = false;
+            let mut skipped_nursery = false;
             if !options.include_inspired {
-                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                skipped_inspired = true;
+            } else if !options.include_nursery {
+                skipped_nursery = true;
+            } else {
+                let group = rules.nursery.get_or_insert_with(Default::default);
+                let rule = group
+                    .unwrap_group_as_mut()
+                    .use_spread
+                    .get_or_insert(Default::default());
+                rule.set_level(rule.level().max(rule_severity.into()));
+                migrated = true;
+            }
+            if !options.include_inspired {
+                skipped_inspired = true;
+            } else {
+                let group = rules.style.get_or_insert_with(Default::default);
+                let rule = group
+                    .unwrap_group_as_mut()
+                    .use_object_spread
+                    .get_or_insert(Default::default());
+                rule.set_level(rule.level().max(rule_severity.into()));
+                migrated = true;
+            }
+            if !migrated {
+                if skipped_inspired {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                } else if skipped_nursery {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                }
                 return false;
             }
-            let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group
-                .unwrap_group_as_mut()
-                .use_object_spread
-                .get_or_insert(Default::default());
-            rule.set_level(rule.level().max(rule_severity.into()));
         }
         "eqeqeq" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);

--- a/crates/biome_cli/tests/specs/migrate_eslint/e18ePreferSpreadSyntax/basic.jsonc
+++ b/crates/biome_cli/tests/specs/migrate_eslint/e18ePreferSpreadSyntax/basic.jsonc
@@ -1,0 +1,8 @@
+{
+  "biome": {},
+  "eslint": {
+    "rules": {
+      "e18e/prefer-spread-syntax": "error"
+    }
+  }
+}

--- a/crates/biome_cli/tests/specs/migrate_eslint/e18ePreferSpreadSyntax/basic.jsonc.snap
+++ b/crates/biome_cli/tests/specs/migrate_eslint/e18ePreferSpreadSyntax/basic.jsonc.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+expression: basic.jsonc
+---
+## ESLint Config
+
+```json
+{ "rules": { "e18e/prefer-spread-syntax": "error" } }
+
+```
+
+## Biome Config Before Migration
+
+```json
+{}
+
+```
+
+## Biome Config After Migration
+
+```json
+{
+	"linter": {
+		"rules": {
+			"recommended": false,
+			"nursery": { "useSpread": "error" },
+			"style": { "useObjectSpread": "error" }
+		}
+	}
+}
+
+```

--- a/crates/biome_cli/tests/specs/migrate_eslint/typescriptExplicitFunctionReturnType/basic.jsonc
+++ b/crates/biome_cli/tests/specs/migrate_eslint/typescriptExplicitFunctionReturnType/basic.jsonc
@@ -1,0 +1,8 @@
+{
+  "biome": {},
+  "eslint": {
+    "rules": {
+      "@typescript-eslint/explicit-function-return-type": "error"
+    }
+  }
+}

--- a/crates/biome_cli/tests/specs/migrate_eslint/typescriptExplicitFunctionReturnType/basic.jsonc.snap
+++ b/crates/biome_cli/tests/specs/migrate_eslint/typescriptExplicitFunctionReturnType/basic.jsonc.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+expression: basic.jsonc
+---
+## ESLint Config
+
+```json
+{ "rules": { "@typescript-eslint/explicit-function-return-type": "error" } }
+
+```
+
+## Biome Config Before Migration
+
+```json
+{}
+
+```
+
+## Biome Config After Migration
+
+```json
+{
+	"linter": {
+		"rules": {
+			"recommended": false,
+			"nursery": {
+				"useExplicitReturnType": "error",
+				"useExplicitType": "error"
+			}
+		}
+	}
+}
+
+```

--- a/xtask/codegen/src/generate_migrate_eslint.rs
+++ b/xtask/codegen/src/generate_migrate_eslint.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{
-    GroupCategory, Queryable, RegistryVisitor, Rule, RuleCategory, RuleGroup, RuleMetadata,
-    RuleSourceKind, RuleSourceWithKind,
+    GroupCategory, Queryable, RegistryVisitor, Rule, RuleCategory, RuleGroup, RuleSourceKind,
+    RuleSourceWithKind,
 };
 use biome_rowan::syntax::Language;
 use biome_string_case::Case;
@@ -17,37 +17,109 @@ pub(crate) fn generate_migrate_eslint(mode: Mode) -> Result<()> {
     biome_css_analyze::visit_registry(&mut visitor);
     biome_html_analyze::visit_registry(&mut visitor);
     let mut lines = Vec::with_capacity(visitor.0.len());
-    for ((eslint_name, source_kind), (group_name, rule_metadata)) in visitor.0 {
-        let name = rule_metadata.name;
-        let name_ident = format_ident!("{}", Case::Snake.convert(name));
-        let group_ident = format_ident!("{group_name}");
-        let check_inspired = if source_kind.is_inspired() {
-            quote! {
-                if !options.include_inspired {
-                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
-                    return false;
+    for (eslint_name, mut mappings) in visitor.0 {
+        mappings.sort_by_key(|mapping| {
+            (
+                mapping.group_name,
+                mapping.rule_name,
+                mapping.source_kind.is_inspired(),
+            )
+        });
+        mappings.dedup_by(|left, right| {
+            left.group_name == right.group_name
+                && left.rule_name == right.rule_name
+                && left.source_kind == right.source_kind
+        });
+
+        if let [mapping] = mappings.as_slice() {
+            let name_ident = format_ident!("{}", Case::Snake.convert(mapping.rule_name));
+            let group_ident = format_ident!("{}", mapping.group_name);
+            let check_inspired = if mapping.source_kind.is_inspired() {
+                quote! {
+                    if !options.include_inspired {
+                        results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                        return false;
+                    }
                 }
-            }
-        } else {
-            quote! {}
-        };
-        let check_nursery = if group_name == "nursery" {
-            quote! {
-                if !options.include_nursery {
-                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
-                    return false;
+            } else {
+                quote! {}
+            };
+            let check_nursery = if mapping.group_name == "nursery" {
+                quote! {
+                    if !options.include_nursery {
+                        results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                        return false;
+                    }
                 }
-            }
-        } else {
-            quote! {}
-        };
+            } else {
+                quote! {}
+            };
+            lines.push(quote! {
+                #eslint_name => {
+                    #check_inspired
+                    #check_nursery
+                    let group = rules.#group_ident.get_or_insert_with(Default::default);
+                    let rule = group
+                        .unwrap_group_as_mut()
+                        .#name_ident
+                        .get_or_insert(Default::default());
+                    rule.set_level(rule.level().max(rule_severity.into()));
+                }
+            });
+            continue;
+        }
+
+        let mut migrations = Vec::with_capacity(mappings.len());
+        for mapping in mappings {
+            let name_ident = format_ident!("{}", Case::Snake.convert(mapping.rule_name));
+            let group_ident = format_ident!("{}", mapping.group_name);
+            let skip_inspired = if mapping.source_kind.is_inspired() {
+                quote! {
+                    if !options.include_inspired {
+                        skipped_inspired = true;
+                    } else
+                }
+            } else {
+                quote! {}
+            };
+            let skip_nursery = if mapping.group_name == "nursery" {
+                quote! {
+                    if !options.include_nursery {
+                        skipped_nursery = true;
+                    } else
+                }
+            } else {
+                quote! {}
+            };
+            migrations.push(quote! {
+                #skip_inspired
+                #skip_nursery
+                {
+                    let group = rules.#group_ident.get_or_insert_with(Default::default);
+                    let rule = group
+                        .unwrap_group_as_mut()
+                        .#name_ident
+                        .get_or_insert(Default::default());
+                    rule.set_level(rule.level().max(rule_severity.into()));
+                    migrated = true;
+                }
+            });
+        }
+
         lines.push(quote! {
             #eslint_name => {
-                #check_inspired
-                #check_nursery
-                let group = rules.#group_ident.get_or_insert_with(Default::default);
-                let rule = group.unwrap_group_as_mut().#name_ident.get_or_insert(Default::default());
-                rule.set_level(rule.level().max(rule_severity.into()));
+                let mut migrated = false;
+                let mut skipped_inspired = false;
+                let mut skipped_nursery = false;
+                #( #migrations )*
+                if !migrated {
+                    if skipped_inspired {
+                        results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                    } else if skipped_nursery {
+                        results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                    }
+                    return false;
+                }
             }
         });
     }
@@ -78,7 +150,14 @@ pub(crate) fn generate_migrate_eslint(mode: Mode) -> Result<()> {
 }
 
 #[derive(Default)]
-struct EslintLintRulesVisitor(BTreeMap<(Box<str>, RuleSourceKind), (&'static str, RuleMetadata)>);
+struct EslintLintRulesVisitor(BTreeMap<Box<str>, Vec<RuleMapping>>);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RuleMapping {
+    group_name: &'static str,
+    rule_name: &'static str,
+    source_kind: RuleSourceKind,
+}
 
 impl<L: Language> RegistryVisitor<L> for EslintLintRulesVisitor {
     fn record_category<C: GroupCategory<Language = L>>(&mut self) {
@@ -94,10 +173,14 @@ impl<L: Language> RegistryVisitor<L> for EslintLintRulesVisitor {
     {
         for RuleSourceWithKind { kind, source } in R::METADATA.sources {
             if source.is_eslint() || source.is_eslint_plugin() {
-                self.0.insert(
-                    (source.to_namespaced_rule_name().into_boxed_str(), *kind),
-                    (<R::Group as RuleGroup>::NAME, R::METADATA),
-                );
+                self.0
+                    .entry(source.to_namespaced_rule_name().into_boxed_str())
+                    .or_default()
+                    .push(RuleMapping {
+                        group_name: <R::Group as RuleGroup>::NAME,
+                        rule_name: R::METADATA.name,
+                        source_kind: *kind,
+                    });
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes #10024

`biome migrate eslint` now applies every matching Biome rule when a single ESLint rule source maps to multiple Biome rules, instead of only keeping one generated mapping. This adds regression specs for `e18e/prefer-spread-syntax` and `@typescript-eslint/explicit-function-return-type`.

> This PR was created with AI assistance (Codex). I reviewed and validated the resulting changes.

## Test Plan
- `cargo test -p biome_cli migrate_eslint`
- `cargo fmt --all --check`
- Manual repro: run `/tmp/fix-biome-10024/target/debug/biome migrate eslint --include-inspired --include-nursery --write` against a temp ESLint config containing `e18e/prefer-spread-syntax` and confirm both `nursery.useSpread` and `style.useObjectSpread` are written.

## Docs
- Added a changeset for the user-facing migration fix.
