### PR TITLE
fix(js_analyze): flag useIframeSandbox non initializer value

### DIFF
--- a/.changeset/cool-memes-juggle.md
+++ b/.changeset/cool-memes-juggle.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10032](https://github.com/biomejs/biome/issues/10032): [useIframeSandbox](https://biomejs.dev/linter/rules/use-iframe-sandbox/) now flags if there's no initializer value.

--- a/crates/biome_js_analyze/src/lint/nursery/use_iframe_sandbox.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_iframe_sandbox.rs
@@ -64,7 +64,7 @@ impl Rule for UseIframeSandbox {
                     return true;
                 };
 
-                init.value().ok().is_none()
+                init.value().ok().is_none() || sandbox_attribute.is_value_null_or_undefined()
             })
             && !element.has_spread_prop()
         {

--- a/crates/biome_js_analyze/src/lint/nursery/use_iframe_sandbox.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_iframe_sandbox.rs
@@ -59,7 +59,13 @@ impl Rule for UseIframeSandbox {
 
         if element
             .find_attribute_by_name("sandbox")
-            .is_none_or(|sandbox_attribute| sandbox_attribute.as_static_value().is_none())
+            .is_none_or(|sandbox_attribute| {
+                let Some(init) = sandbox_attribute.initializer() else {
+                    return true;
+                };
+
+                init.value().ok().is_none()
+            })
             && !element.has_spread_prop()
         {
             return Some(());

--- a/crates/biome_js_analyze/tests/specs/nursery/useIframeSandbox/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIframeSandbox/invalid.jsx
@@ -1,4 +1,9 @@
 /* should generate diagnostics */
-const Invalid1 = () => <iframe />;
-
-const Invalid2 = () => <iframe sandbox />;
+const Invalid = () => (
+	<>
+		<iframe />
+		<iframe sandbox />
+		<iframe sandbox={undefined} />
+		<iframe sandbox={null} />
+	</>
+);

--- a/crates/biome_js_analyze/tests/specs/nursery/useIframeSandbox/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIframeSandbox/invalid.jsx.snap
@@ -5,23 +5,29 @@ expression: invalid.jsx
 # Input
 ```jsx
 /* should generate diagnostics */
-const Invalid1 = () => <iframe />;
-
-const Invalid2 = () => <iframe sandbox />;
+const Invalid = () => (
+	<>
+		<iframe />
+		<iframe sandbox />
+		<iframe sandbox={undefined} />
+		<iframe sandbox={null} />
+	</>
+);
 
 ```
 
 # Diagnostics
 ```
-invalid.jsx:2:24 lint/nursery/useIframeSandbox ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.jsx:4:3 lint/nursery/useIframeSandbox ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Iframe doesn't have the sandbox attribute.
   
-    1 │ /* should generate diagnostics */
-  > 2 │ const Invalid1 = () => <iframe />;
-      │                        ^^^^^^^^^^
-    3 │ 
-    4 │ const Invalid2 = () => <iframe sandbox />;
+    2 │ const Invalid = () => (
+    3 │ 	<>
+  > 4 │ 		<iframe />
+      │ 		^^^^^^^^^^
+    5 │ 		<iframe sandbox />
+    6 │ 		<iframe sandbox={undefined} />
   
   i The sandbox attribute enables an extra set of restrictions for the content in the iframe, protecting against malicious scripts and other security threats.
   
@@ -33,15 +39,58 @@ invalid.jsx:2:24 lint/nursery/useIframeSandbox ━━━━━━━━━━━
 ```
 
 ```
-invalid.jsx:4:24 lint/nursery/useIframeSandbox ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.jsx:5:3 lint/nursery/useIframeSandbox ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Iframe doesn't have the sandbox attribute.
   
-    2 │ const Invalid1 = () => <iframe />;
-    3 │ 
-  > 4 │ const Invalid2 = () => <iframe sandbox />;
-      │                        ^^^^^^^^^^^^^^^^^^
-    5 │ 
+    3 │ 	<>
+    4 │ 		<iframe />
+  > 5 │ 		<iframe sandbox />
+      │ 		^^^^^^^^^^^^^^^^^^
+    6 │ 		<iframe sandbox={undefined} />
+    7 │ 		<iframe sandbox={null} />
+  
+  i The sandbox attribute enables an extra set of restrictions for the content in the iframe, protecting against malicious scripts and other security threats.
+  
+  i Provide a sandbox attribute when using iframe elements.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.jsx:6:3 lint/nursery/useIframeSandbox ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Iframe doesn't have the sandbox attribute.
+  
+    4 │ 		<iframe />
+    5 │ 		<iframe sandbox />
+  > 6 │ 		<iframe sandbox={undefined} />
+      │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 		<iframe sandbox={null} />
+    8 │ 	</>
+  
+  i The sandbox attribute enables an extra set of restrictions for the content in the iframe, protecting against malicious scripts and other security threats.
+  
+  i Provide a sandbox attribute when using iframe elements.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.jsx:7:3 lint/nursery/useIframeSandbox ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Iframe doesn't have the sandbox attribute.
+  
+    5 │ 		<iframe sandbox />
+    6 │ 		<iframe sandbox={undefined} />
+  > 7 │ 		<iframe sandbox={null} />
+      │ 		^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 	</>
+    9 │ );
   
   i The sandbox attribute enables an extra set of restrictions for the content in the iframe, protecting against malicious scripts and other security threats.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useIframeSandbox/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIframeSandbox/valid.jsx
@@ -11,10 +11,10 @@ const Valid1 = () => (
 	</>
 );
 
+const prop = "allow-downloads allow-scripts allow-forms"
+const Valid2 = () => <iframe sandbox={prop} />;
+
 const props = {
 	sandbox: "allow-downloads",
 };
-
-const Invalid2 = () => {
-	return <iframe {...props} />;
-}
+const Valid3 = () => <iframe {...props} />;

--- a/crates/biome_js_analyze/tests/specs/nursery/useIframeSandbox/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIframeSandbox/valid.jsx.snap
@@ -17,12 +17,12 @@ const Valid1 = () => (
 	</>
 );
 
+const prop = "allow-downloads allow-scripts allow-forms"
+const Valid2 = () => <iframe sandbox={prop} />;
+
 const props = {
 	sandbox: "allow-downloads",
 };
-
-const Invalid2 = () => {
-	return <iframe {...props} />;
-}
+const Valid3 = () => <iframe {...props} />;
 
 ```


### PR DESCRIPTION
## Summary

Fixed #10032, flag useIframeSandbox if there's no initializer value instead of only no static string value

## Test Plan

Added test case

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
