### PR TITLE
fix(organizeImports): sorts imports in ts modules and declaration files

### DIFF
--- a/.changeset/moody-waves-bake.md
+++ b/.changeset/moody-waves-bake.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10038](https://github.com/biomejs/biome/issues/10038): [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/) now sorts imports in TypeScript modules and declaration files.
+
+```diff
+  declare module "mymodule" {
+-  	import type { B } from "b";
+  	import type { A } from "a";
++  	import type { B } from "b";
+  }
+```

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -12,9 +12,11 @@ use biome_diagnostics::category;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsCombinedSpecifier, AnyJsExportClause, AnyJsImportClause, AnyJsModuleItem, JsModule,
-    JsSyntaxKind, T,
+    JsModuleItemList, JsSyntaxKind, T, TsDeclarationModule, TsModuleBlock,
 };
-use biome_rowan::{AstNode, BatchMutationExt, TextRange, TriviaPieceKind, chain_trivia_pieces};
+use biome_rowan::{
+    AstNode, BatchMutationExt, TextRange, TriviaPieceKind, chain_trivia_pieces, declare_node_union,
+};
 use biome_rule_options::{organize_imports::OrganizeImportsOptions, sort_order::SortOrder};
 use import_key::{ImportInfo, ImportKey};
 use rustc_hash::FxHashMap;
@@ -706,7 +708,7 @@ declare_source_rule! {
 }
 
 impl Rule for OrganizeImports {
-    type Query = Ast<JsModule>;
+    type Query = Ast<AnyJsModule>;
     type State = Box<[Issue]>;
     type Signals = Option<Self::State>;
     type Options = OrganizeImportsOptions;
@@ -1109,6 +1111,19 @@ impl Rule for OrganizeImports {
             "Organize Imports (Biome)",
             mutation,
         ))
+    }
+}
+
+declare_node_union! {
+    pub AnyJsModule = JsModule | TsDeclarationModule | TsModuleBlock
+}
+impl AnyJsModule {
+    pub fn items(&self) -> JsModuleItemList {
+        match self {
+            Self::JsModule(js_module) => js_module.items(),
+            Self::TsDeclarationModule(ts_declaration_module) => ts_declaration_module.items(),
+            Self::TsModuleBlock(ts_module_block) => ts_module_block.items(),
+        }
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts
@@ -1,0 +1,4 @@
+import B from "b";
+import A from "a";
+
+export { A, B };

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-declaration.d.ts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ts-declaration.d.ts
+---
+# Input
+```ts
+import B from "b";
+import A from "a";
+
+export { A, B };
+
+```
+
+# Diagnostics
+```
+ts-declaration.d.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The imports and exports are not sorted.
+  
+  > 1 │ import B from "b";
+      │ ^^^^^^^^^^^^^^^^^^
+    2 │ import A from "a";
+    3 │ 
+  
+  i Safe fix: Organize Imports (Biome)
+  
+    1   │ - import·B·from·"b";
+    2   │ - import·A·from·"a";
+      1 │ + import·A·from·"a";
+      2 │ + import·B·from·"b";
+    3 3 │   
+    4 4 │   export { A, B };
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts
@@ -1,0 +1,6 @@
+declare module "module" {
+	import type { B } from "b";
+	import type { A } from "a";
+
+	type X = [A, B];
+}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/ts-module.ts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ts-module.ts
+---
+# Input
+```ts
+declare module "module" {
+	import type { B } from "b";
+	import type { A } from "a";
+
+	type X = [A, B];
+}
+
+```
+
+# Diagnostics
+```
+ts-module.ts:2:2 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The imports and exports are not sorted.
+  
+    1 │ declare module "module" {
+  > 2 │ 	import type { B } from "b";
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 	import type { A } from "a";
+    4 │ 
+  
+  i Safe fix: Organize Imports (Biome)
+  
+    1 1 │   declare module "module" {
+    2   │ - → import·type·{·B·}·from·"b";
+    3   │ - → import·type·{·A·}·from·"a";
+      2 │ + → import·type·{·A·}·from·"a";
+      3 │ + → import·type·{·B·}·from·"b";
+    4 4 │   
+    5 5 │     type X = [A, B];
+  
+
+```


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/10038

The import organizer sorted only imports at the root of JavaScript and TypeScript files.
It now sorts imports in TypeScript modules and declaration files.

Here is an example:

```diff
  declare module "mymodule" {
-  	import type { B } from "b";
  	import type { A } from "a";
+  	import type { B } from "b";
  }
```

## Test Plan

I added a test for sorting imports in a TypeScript module and another one for sorting imports in declaration files.

## Docs

I added a changeset.