### PR TITLE
fix: escape backslashes in JSON reporter file paths on Windows 🤖🤖🤖

### DIFF
--- a/.changeset/fix-json-reporter-path-separators.md
+++ b/.changeset/fix-json-reporter-path-separators.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9899](https://github.com/biomejs/biome/issues/9899): The JSON reporter now properly escapes backslashes in file paths on Windows, producing valid JSON output.

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -109,7 +109,9 @@ fn location_report_to_json(location: &LocationReport) -> AnyJsonValue {
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("path"))),
             token(T![:]),
-            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&location.path))),
+            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&json_escape(
+                &location.path,
+            )))),
         ),
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("start"))),


### PR DESCRIPTION
Fixes #9899

The JSON reporter was not escaping backslashes in file paths on Windows, producing invalid JSON output (e.g., `"path": "typescript\src\file.ts"`). Applied the existing `json_escape()` function to the `path` field in `location_report_to_json`, consistent with how `message` and `text` fields are already handled.

## Test Plan

Verified that the `json_escape` function correctly escapes `\` to `\\` in path strings, matching the behavior already applied to other string fields in the JSON output. The SARIF reporter already handles this with `.replace('\\', "/")` at `crates/biome_cli/src/reporter/sarif.rs:293`.

## Docs

No docs changes needed.

> This PR was created with AI assistance.