### PR TITLE
feat(html_analyze): implement useFocusableInteractive

### DIFF
--- a/.changeset/vast-islands-clap.md
+++ b/.changeset/vast-islands-clap.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": minor
+---
+
+Added the HTML lint rule [`useFocusableInteractive`](https://biomejs.dev/linter/rules/use-focusable-interactive/), which enforces elements with an interactive role and interaction handler to be focusable.
+
+**Invalid**:
+
+```html
+<div role="button"></div>
+```

--- a/.changeset/vast-islands-clap.md
+++ b/.changeset/vast-islands-clap.md
@@ -2,7 +2,7 @@
 "@biomejs/biome": minor
 ---
 
-Added the HTML lint rule [`useFocusableInteractive`](https://biomejs.dev/linter/rules/use-focusable-interactive/), which enforces elements with an interactive role and interaction handler to be focusable.
+Added the lint rule [`useFocusableInteractive`](https://biomejs.dev/linter/rules/use-focusable-interactive/) to HTML, which enforces elements with an interactive role and interaction handler to be focusable.
 
 **Invalid**:
 

--- a/crates/biome_html_analyze/src/lint/a11y/use_focusable_interactive.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_focusable_interactive.rs
@@ -1,0 +1,95 @@
+use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_aria_metadata::AriaRole;
+use biome_console::markup;
+use biome_diagnostics::Severity;
+use biome_html_syntax::element_ext::AnyHtmlTagElement;
+use biome_rowan::AstNode;
+use biome_rule_options::use_focusable_interactive::UseFocusableInteractiveOptions;
+
+use crate::Aria;
+
+declare_lint_rule! {
+    /// Elements with an interactive role and interaction handlers must be focusable.
+    ///
+    /// HTML elements with interactive roles must have `tabindex` defined to ensure they are
+    /// focusable. Without `tabindex`, assistive technologies may not recognize these elements as
+    /// interactive.
+    /// You could also consider switching from an interactive role to its semantic HTML element
+    /// instead.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```html,expect_diagnostic
+    /// <div role="button"></div>
+    /// ```
+    ///
+    /// ```html,expect_diagnostic
+    /// <div role="tab"></div>
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```html
+    /// <div role="button" tabindex="0"></div>
+    /// ```
+    ///
+    /// ```html
+    /// <div></div>
+    /// ```
+    ///
+    pub UseFocusableInteractive {
+        version: "next",
+        name: "useFocusableInteractive",
+        language: "html",
+        recommended: true,
+        severity: Severity::Error,
+    }
+}
+
+impl Rule for UseFocusableInteractive {
+    type Query = Aria<AnyHtmlTagElement>;
+    type State = Box<str>;
+    type Signals = Option<Self::State>;
+    type Options = UseFocusableInteractiveOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+
+        if node.is_custom_component() {
+            return None;
+        }
+
+        if ctx.aria_roles().is_not_interactive_element(node) {
+            let role_attribute = node.find_attribute_by_name("role");
+            if let Some(role_attribute) = role_attribute {
+                let tabindex_attribute = node.find_attribute_by_name("tabindex");
+                let role_attribute_value = role_attribute.initializer()?.value().ok()?;
+                let role = AriaRole::from_roles(role_attribute_value.as_static_value()?.text())?;
+                if role.is_interactive() && !role.is_composite() && tabindex_attribute.is_none() {
+                    return Some(role_attribute_value.to_trimmed_text().text().into());
+                }
+            }
+        }
+        None
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let node = ctx.query();
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                node.range(),
+                markup! {
+                    "The HTML element with the interactive role "<Emphasis>{state}</Emphasis>" is not focusable."
+                },
+            ).note(markup! {
+                "A non-interactive HTML element that is not focusable may not be reachable for users that rely on keyboard navigation, even with an added role like "<Emphasis>{state}</Emphasis>"."
+            })
+            .note(markup! {
+                "Add a "<Emphasis>"tabindex"</Emphasis>" attribute to make this element focusable."
+            }),
+        )
+    }
+}

--- a/crates/biome_html_analyze/src/lint/a11y/use_focusable_interactive.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_focusable_interactive.rs
@@ -50,7 +50,7 @@ declare_lint_rule! {
 
 impl Rule for UseFocusableInteractive {
     type Query = Aria<AnyHtmlTagElement>;
-    type State = Box<str>;
+    type State = ();
     type Signals = Option<Self::State>;
     type Options = UseFocusableInteractiveOptions;
 
@@ -68,24 +68,26 @@ impl Rule for UseFocusableInteractive {
                 let role_attribute_value = role_attribute.initializer()?.value().ok()?;
                 let role = AriaRole::from_roles(role_attribute_value.as_static_value()?.text())?;
                 if role.is_interactive() && !role.is_composite() && tabindex_attribute.is_none() {
-                    return Some(role_attribute_value.to_trimmed_text().text().into());
+                    return Some(());
                 }
             }
         }
         None
     }
 
-    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
         let node = ctx.query();
+        let role_attribute = node.find_attribute_by_name("role")?;
+        let role_attribute_value = role_attribute.initializer()?.value().ok()?;
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
                 node.range(),
                 markup! {
-                    "The HTML element with the interactive role "<Emphasis>{state}</Emphasis>" is not focusable."
+                    "The HTML element with the interactive role "<Emphasis>{role_attribute_value.to_trimmed_string()}</Emphasis>" is not focusable."
                 },
             ).note(markup! {
-                "A non-interactive HTML element that is not focusable may not be reachable for users that rely on keyboard navigation, even with an added role like "<Emphasis>{state}</Emphasis>"."
+                "A non-interactive HTML element that is not focusable may not be reachable for users that rely on keyboard navigation, even with an added role like "<Emphasis>{role_attribute_value.to_trimmed_string()}</Emphasis>"."
             })
             .note(markup! {
                 "Add a "<Emphasis>"tabindex"</Emphasis>" attribute to make this element focusable."

--- a/crates/biome_html_analyze/tests/specs/a11y/useFocusableInteractive/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/useFocusableInteractive/invalid.html
@@ -1,0 +1,5 @@
+<!-- should generate diagnostics -->
+<div>
+	<div role="button"></div>
+	<div role="tab"></div>
+</div>

--- a/crates/biome_html_analyze/tests/specs/a11y/useFocusableInteractive/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useFocusableInteractive/invalid.html.snap
@@ -1,0 +1,52 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<div>
+	<div role="button"></div>
+	<div role="tab"></div>
+</div>
+
+```
+
+# Diagnostics
+```
+invalid.html:3:2 lint/a11y/useFocusableInteractive ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The HTML element with the interactive role "button" is not focusable.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <div>
+  > 3 │ 	<div role="button"></div>
+      │ 	^^^^^^^^^^^^^^^^^^^
+    4 │ 	<div role="tab"></div>
+    5 │ </div>
+  
+  i A non-interactive HTML element that is not focusable may not be reachable for users that rely on keyboard navigation, even with an added role like "button".
+  
+  i Add a tabindex attribute to make this element focusable.
+  
+
+```
+
+```
+invalid.html:4:2 lint/a11y/useFocusableInteractive ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The HTML element with the interactive role "tab" is not focusable.
+  
+    2 │ <div>
+    3 │ 	<div role="button"></div>
+  > 4 │ 	<div role="tab"></div>
+      │ 	^^^^^^^^^^^^^^^^
+    5 │ </div>
+    6 │ 
+  
+  i A non-interactive HTML element that is not focusable may not be reachable for users that rely on keyboard navigation, even with an added role like "tab".
+  
+  i Add a tabindex attribute to make this element focusable.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/useFocusableInteractive/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/useFocusableInteractive/valid.html
@@ -1,0 +1,18 @@
+<!-- should not generate diagnostics -->
+<div>
+	<div role="button" tabindex="0"></div>
+
+	<div role="menu">
+		<div role="menuitem" tabindex="0">
+			Open
+		</div>
+		<div role="menuitem" tabindex="-1">
+			Save
+		</div>
+		<div role="menuitem" tabindex="-1">
+			Close
+		</div>
+	</div>
+	<button></button>
+	<div role="h1"></div>
+</div>

--- a/crates/biome_html_analyze/tests/specs/a11y/useFocusableInteractive/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useFocusableInteractive/valid.html.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<div>
+	<div role="button" tabindex="0"></div>
+
+	<div role="menu">
+		<div role="menuitem" tabindex="0">
+			Open
+		</div>
+		<div role="menuitem" tabindex="-1">
+			Save
+		</div>
+		<div role="menuitem" tabindex="-1">
+			Close
+		</div>
+	</div>
+	<button></button>
+	<div role="h1"></div>
+</div>
+
+```

--- a/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
@@ -51,7 +51,7 @@ declare_lint_rule! {
 
 impl Rule for UseFocusableInteractive {
     type Query = Aria<AnyJsxElement>;
-    type State = Box<str>;
+    type State = ();
     type Signals = Option<Self::State>;
     type Options = UseFocusableInteractiveOptions;
 
@@ -69,24 +69,26 @@ impl Rule for UseFocusableInteractive {
                 if attribute_has_interactive_role(&role_attribute_value)?
                     && tabindex_attribute.is_none()
                 {
-                    return Some(role_attribute_value.to_trimmed_text().text().into());
+                    return Some(());
                 }
             }
         }
         None
     }
 
-    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
         let node = ctx.query();
+        let role_attribute = node.find_attribute_by_name("role")?;
+        let role_attribute_value = role_attribute.initializer()?.value().ok()?;
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
                 node.range(),
                 markup! {
-                    "The HTML element with the interactive role "<Emphasis>{state}</Emphasis>" is not focusable."
+                    "The HTML element with the interactive role "<Emphasis>{role_attribute_value.to_trimmed_string()}</Emphasis>" is not focusable."
                 },
             ).note(markup! {
-                "A non-interactive HTML element that is not focusable may not be reachable for users that rely on keyboard navigation, even with an added role like "<Emphasis>{state}</Emphasis>"."
+                "A non-interactive HTML element that is not focusable may not be reachable for users that rely on keyboard navigation, even with an added role like "<Emphasis>{role_attribute_value.to_trimmed_string()}</Emphasis>"."
             })
             .note(markup! {
                 "Add a "<Emphasis>"tabIndex"</Emphasis>" attribute to make this element focusable."


### PR DESCRIPTION
## Summary

Port useFocusableInteractive over to the HTML analyzer

Related #8155 

## Test Plan

Unit tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
