### PR TITLE
fix(linter): mark noThisInStatic auto-fix as unsafe

### DIFF
--- a/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
@@ -85,7 +85,7 @@ declare_lint_rule! {
         sources: &[RuleSource::EslintMysticatea("no-this-in-static").same()],
         recommended: true,
         severity: Severity::Warning,
-        fix_kind: FixKind::Safe,
+        fix_kind: FixKind::Unsafe,
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js.snap
@@ -60,7 +60,7 @@ invalid.js:2:14 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      1  1 │   export default class B extends A {
      2    │ - ····static·{·this.CONSTANT·+=·super.foo();·}
@@ -84,7 +84,7 @@ invalid.js:2:31 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      1  1 │   export default class B extends A {
      2    │ - ····static·{·this.CONSTANT·+=·super.foo();·}
@@ -108,7 +108,7 @@ invalid.js:8:19 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      6  6 │   
      7  7 │       static get property() {
@@ -134,7 +134,7 @@ invalid.js:9:26 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      7  7 │       static get property() {
      8  8 │           /*before*/this/*after*/;
@@ -159,7 +159,7 @@ invalid.js:13:15 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     11 11 │   
     12 12 │       static set property(x) {
@@ -185,7 +185,7 @@ invalid.js:14:15 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     12 12 │       static set property(x) {
     13 13 │           () => this;
@@ -210,7 +210,7 @@ invalid.js:18:16 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     16 16 │   
     17 17 │       static method() {
@@ -235,7 +235,7 @@ invalid.js:18:32 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     16 16 │   
     17 17 │       static method() {
@@ -261,7 +261,7 @@ invalid.js:24:16 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     22 22 │   class C extends A {
     23 23 │       static method() {
@@ -287,7 +287,7 @@ invalid.js:24:32 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     22 22 │   class C extends A {
     23 23 │       static method() {
@@ -313,7 +313,7 @@ invalid.js:30:16 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     28 28 │   const D = class D extends f() {
     29 29 │       static method() {


### PR DESCRIPTION
## Summary

Fixes #10011

The `noThisInStatic` rule's auto-fix currently replaces `this` with the class name, which is **not safe** when the static method is called on a subclass.

### Example of the problem

```ts
class Base {
  constructor(public name: string) {}
  static create<T extends typeof Base>(this: T, name: string): InstanceType<T> {
    // Biome's "safe fix" replaces `this` with `Base` — breaks at runtime
    return new this(name) as InstanceType<T>;
  }
}

class Sub extends Base {
  greet() { return `Hi, ${this.name}`; }
}

const sub = Sub.create("Alice");
console.log(sub instanceof Sub); // true with `this`, false with `Base`
sub.greet(); // runtime error with `Base`
```

### Change

Changed `fix_kind` from `FixKind::Safe` to `FixKind::Unsafe` so the fix is only applied with `--unsafe` flag.

This aligns with the rule's behavior in ESLint's original implementation, which also does not provide a safe auto-fix for this case.
