### PR TITLE
fix(lint): resolve false positive in noAssignInExpressions for Svelte {@const} blocks

### DIFF
--- a/.changeset/fix-svelte-const-false-positive.md
+++ b/.changeset/fix-svelte-const-false-positive.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed false positive in `noAssignInExpressions` for Svelte `{@const}` blocks. Assignments in `{@const name = value}` are now correctly recognized as declarations rather than accidental assignments in expressions.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_assign_in_expressions.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_assign_in_expressions.rs
@@ -72,6 +72,12 @@ impl Rule for NoAssignInExpressions {
             return None;
         }
 
+        // Skip assignments in Svelte const blocks ({@const name = value})
+        // These are declaration statements, not accidental assignments in expressions
+        if file_source.is_svelte_const_block() {
+            return None;
+        }
+
         let assign = ctx.query();
         let mut ancestor = assign
             .syntax()

--- a/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const.svelte
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const.svelte
@@ -1,0 +1,9 @@
+<!-- should not generate diagnostics -->
+<script lang="ts">
+  const numbers = [1, 2, 3, 4];
+</script>
+
+{#each numbers as number, index (number)}
+  {@const n = number + 1}
+  <p>{n}</p>
+{/each}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const.svelte.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: valid-svelte-const.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script lang="ts">
+  const numbers = [1, 2, 3, 4];
+</script>
+
+{#each numbers as number, index (number)}
+  {@const n = number + 1}
+  <p>{n}</p>
+{/each}
+
+```

--- a/crates/biome_js_parser/tests/spec_test.rs
+++ b/crates/biome_js_parser/tests/spec_test.rs
@@ -89,6 +89,7 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_
             is_source: false,
             is_function_signature: false,
             kind: biome_js_syntax::SvelteFileKind::Component,
+            is_const_block: false,
         });
     }
 

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -165,6 +165,9 @@ pub enum EmbeddingKind {
 
         /// Whether this is the declaration of a function, usually declared in `#snippet`
         is_function_signature: bool,
+
+        /// Whether this is a `{@const name = value}` block.
+        is_const_block: bool,
     },
     #[default]
     None,
@@ -218,6 +221,15 @@ impl EmbeddingKind {
             self,
             Self::Svelte {
                 kind: SvelteFileKind::SourceModule,
+                ..
+            }
+        )
+    }
+    pub const fn is_svelte_const_block(&self) -> bool {
+        matches!(
+            self,
+            Self::Svelte {
+                is_const_block: true,
                 ..
             }
         )
@@ -315,6 +327,7 @@ impl JsFileSource {
             is_source: true,
             is_function_signature: false,
             kind: SvelteFileKind::Component,
+            is_const_block: false,
         })
     }
 
@@ -421,6 +434,11 @@ impl JsFileSource {
         self.embedding_kind.is_vue_event_handler()
     }
 
+    /// Returns true if this is a Svelte `{@const}` block
+    pub const fn is_svelte_const_block(&self) -> bool {
+        self.embedding_kind.is_svelte_const_block()
+    }
+
     pub const fn as_embedding_kind(&self) -> &EmbeddingKind {
         &self.embedding_kind
     }
@@ -510,6 +528,7 @@ impl JsFileSource {
                 is_source: true,
                 is_function_signature: false,
                 kind: SvelteFileKind::SourceModule,
+                is_const_block: false,
             }));
         }
 

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
@@ -790,6 +790,7 @@ fn parse_matched_embed(
                             is_source: true,
                             is_function_signature: false,
                             kind: SvelteFileKind::Component,
+                            is_const_block: false,
                         });
                     } else if ctx.host_file_source.is_vue() {
                         js_source = js_source.with_embedding_kind(EmbeddingKind::Vue {
@@ -813,6 +814,10 @@ fn parse_matched_embed(
                             is_source: false,
                             is_function_signature,
                             kind: SvelteFileKind::Component,
+                            is_const_block: matches!(
+                                block_kind,
+                                EmbedBlockKind::Svelte(SvelteBlockKind::Const)
+                            ),
                         });
                     } else if ctx.host_file_source.is_vue() {
                         js_source = js_source.with_embedding_kind(EmbeddingKind::Vue {
@@ -846,6 +851,7 @@ fn parse_matched_embed(
                                 is_source: false,
                                 is_function_signature: false,
                                 kind: SvelteFileKind::Component,
+                                is_const_block: false,
                             });
                         }
                     }

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -82,6 +82,7 @@ impl SvelteFileHandler {
                             is_source: true,
                             is_function_signature: false,
                             kind: SvelteFileKind::Component,
+                            is_const_block: false,
                         }),
                 )
             })

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -9650,6 +9650,10 @@ Source-level embeds (`<script>`) use `true`; directives and text expressions use
 	| {
 			Svelte: {
 				/**
+				 * Whether this is a `{@const name = value}` block.
+				 */
+				is_const_block: boolean;
+				/**
 				 * Whether this is the declaration of a function, usually declared in `#snippet`
 				 */
 				is_function_signature: boolean;


### PR DESCRIPTION
This PR was written primarily by qwen3.6-plus and kimi-k2.6 using opencode.

## Summary

Closes #10082 

Currently biome flag as `lint/suspicious/noAssignInExpressions` Svelte {@const} blocks.

```
{@const n = number + 1}
```

Here a link to the [playground](https://biomejs.dev/playground/?lineWidth=120&tab=formatter&pane=Diagnostics&code=PABzAGMAcgBpAHAAdAAgAGwAYQBuAGcAPQAiAHQAcwAiAD4ACgAgACAAYwBvAG4AcwB0ACAAbgB1AG0AYgBlAHIAcwAgAD0AIABbADEALAAgADIALAAgADMALAAgADQAXQA7AAoAPAAvAHMAYwByAGkAcAB0AD4ACgAKAHsAIwBlAGEAYwBoACAAbgB1AG0AYgBlAHIAcwAgAGEAcwAgAG4AdQBtAGIAZQByACwAIABpAG4AZABlAHgAIAAoAG4AdQBtAGIAZQByACkAfQAKACAAIAB7AEAAYwBvAG4AcwB0ACAAbgAgAD0AIABuAHUAbQBiAGUAcgAgACsAIAAxAH0ACgAgACAAPABwAD4AewBuAH0APAAvAHAAPgAKAHsALwBlAGEAYwBoAH0A&language=svelte) where there is the false positive.

## Test Plan

I added a test: `valid-svelte-const` similar to the `valid-vue-v-on` test.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
