### PR TITLE
perf(lint): avoid string allocations in some lint rules

### DIFF
--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_custom_properties.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_custom_properties.rs
@@ -3,7 +3,7 @@ use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, decl
 use biome_console::markup;
 use biome_css_syntax::CssDeclarationOrRuleList;
 use biome_diagnostics::Severity;
-use biome_rowan::{AstNode, TextRange};
+use biome_rowan::{AstNode, TextRange, TokenText};
 use biome_rule_options::no_duplicate_custom_properties::NoDuplicateCustomPropertiesOptions;
 use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
@@ -47,7 +47,7 @@ declare_lint_rule! {
 
 impl Rule for NoDuplicateCustomProperties {
     type Query = Semantic<CssDeclarationOrRuleList>;
-    type State = (TextRange, (TextRange, String));
+    type State = (TextRange, (TextRange, TokenText));
     type Signals = Option<Self::State>;
     type Options = NoDuplicateCustomPropertiesOptions;
 
@@ -58,22 +58,22 @@ impl Rule for NoDuplicateCustomProperties {
 
         let rule = model.get_rule_by_range(node.range())?;
 
-        let mut seen: FxHashMap<Box<str>, TextRange> = FxHashMap::default();
+        let mut seen: FxHashMap<TokenText, TextRange> = FxHashMap::default();
 
         for declaration in rule.declarations() {
             let prop = declaration.property(&root);
-            let prop_name = prop.value().ok()?;
+            let prop_text = prop.value().ok()?;
             let prop_range = prop.range();
 
-            let is_custom_property = prop_name.starts_with("--");
+            let is_custom_property = prop_text.text().starts_with("--");
 
             if !is_custom_property {
                 continue;
             }
 
-            match seen.entry(prop_name.text().into()) {
+            match seen.entry(prop_text.clone()) {
                 Entry::Occupied(entry) => {
-                    return Some((*entry.get(), (prop_range, prop_name.to_string())));
+                    return Some((*entry.get(), (prop_range, prop_text)));
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(prop_range);
@@ -95,7 +95,7 @@ impl Rule for NoDuplicateCustomProperties {
                 },
             )
             .detail(first_occurrence_range, markup! {
-                <Emphasis>{duplicate_property_name}</Emphasis> " is already defined here."
+                <Emphasis>{duplicate_property_name.text()}</Emphasis> " is already defined here."
             })
             .note(markup! {
                 "Remove or rename the duplicate custom property to ensure consistent styling."

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_undefined_initialization.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_undefined_initialization.rs
@@ -6,7 +6,7 @@ use biome_diagnostics::Severity;
 use biome_js_factory::make::js_variable_declarator_list;
 use biome_js_semantic::CanBeImportedExported;
 use biome_js_syntax::{JsLanguage, JsSyntaxToken, JsVariableDeclarator, JsVariableStatement};
-use biome_rowan::{AstNode, BatchMutationExt, TextRange};
+use biome_rowan::{AstNode, BatchMutationExt};
 use biome_rowan::{SyntaxTriviaPiece, chain_trivia_pieces};
 use biome_rule_options::no_useless_undefined_initialization::NoUselessUndefinedInitializationOptions;
 
@@ -75,7 +75,7 @@ declare_lint_rule! {
 
 impl Rule for NoUselessUndefinedInitialization {
     type Query = Semantic<JsVariableStatement>;
-    type State = (Box<str>, TextRange);
+    type State = JsVariableDeclarator;
     type Signals = Box<[Self::State]>;
     type Options = NoUselessUndefinedInitializationOptions;
 
@@ -123,11 +123,7 @@ impl Rule for NoUselessUndefinedInitialization {
                     continue;
                 }
 
-                let decl_range = initializer.range();
-                let Some(binding_name) = decl.id().ok().map(|id| id.to_trimmed_text()) else {
-                    continue;
-                };
-                signals.push((binding_name.text().into(), decl_range));
+                signals.push(decl);
             }
         }
 
@@ -135,11 +131,21 @@ impl Rule for NoUselessUndefinedInitialization {
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let range = state.initializer()?.range();
+        let binding_name = state
+            .id()
+            .ok()?
+            .as_any_js_binding()?
+            .as_js_identifier_binding()?
+            .name_token()
+            .ok()?;
+        let binding_name_text = binding_name.text_trimmed();
+
         Some(RuleDiagnostic::new(
             rule_category!(),
-            state.1,
+            range,
             markup! {
-                "It's not necessary to initialize "<Emphasis>{state.0.as_ref()}</Emphasis>" to undefined."
+                "It's not necessary to initialize "<Emphasis>{binding_name_text}</Emphasis>" to undefined."
             }).note("A variable that is declared and not initialized to any value automatically gets the value of undefined.")
         )
     }
@@ -151,21 +157,7 @@ impl Rule for NoUselessUndefinedInitialization {
         let current_declaration_statement = node.clone().declaration().ok()?;
         let declarators = current_declaration_statement.declarators();
 
-        let current_declaration = declarators
-            .clone()
-            .into_iter()
-            .filter_map(|declarator| declarator.ok())
-            .find(|decl| {
-                decl.id()
-                    .ok()
-                    .and_then(|id| {
-                        id.as_any_js_binding()?
-                            .as_js_identifier_binding()?
-                            .name_token()
-                            .ok()
-                    })
-                    .is_some_and(|id| id.text_trimmed() == state.0.as_ref())
-            })?;
+        let current_declaration = state.clone();
 
         let current_initializer = current_declaration.initializer()?;
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_global_dirname_filename.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_global_dirname_filename.rs
@@ -60,7 +60,7 @@ declare_lint_rule! {
 
 impl Rule for NoGlobalDirnameFilename {
     type Query = Semantic<JsReferenceIdentifier>;
-    type State = (JsSyntaxToken, String);
+    type State = JsSyntaxToken;
     type Signals = Option<Self::State>;
     type Options = NoGlobalDirnameFilenameOptions;
 
@@ -76,7 +76,7 @@ impl Rule for NoGlobalDirnameFilename {
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
-        let syntax_token = &state.0;
+        let syntax_token = state;
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
@@ -94,8 +94,8 @@ impl Rule for NoGlobalDirnameFilename {
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
         let mut mutation = ctx.root().begin();
         let node = ctx.query();
-        let syntax_token = &state.0;
-        let dirname_or_filename = state.1.as_str();
+        let syntax_token = state;
+        let dirname_or_filename = maybe_text(syntax_token)?;
 
         if let Some(expr) = node.parent::<JsIdentifierExpression>() {
             mutation.replace_node::<AnyJsExpression>(
@@ -125,23 +125,23 @@ impl Rule for NoGlobalDirnameFilename {
 fn validate_dirname_filename(
     expr: &JsReferenceIdentifier,
     model: &SemanticModel,
-) -> Option<(JsSyntaxToken, String)> {
+) -> Option<JsSyntaxToken> {
     match model.binding(expr) {
         // Some binding exists, not global one
         Some(_) => None,
         // No binding exists, global one
         None => {
             let token = expr.value_token().ok()?;
-            let name = maybe_text(&token)?;
-            Some((token, name))
+            maybe_text(&token)?;
+            Some(token)
         }
     }
 }
 
-fn maybe_text(token: &JsSyntaxToken) -> Option<String> {
+fn maybe_text(token: &JsSyntaxToken) -> Option<&'static str> {
     match token.text_trimmed() {
-        "__dirname" => Some("dirname".to_string()),
-        "__filename" => Some("filename".to_string()),
+        "__dirname" => Some("dirname"),
+        "__filename" => Some("filename"),
         _ => None,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
@@ -6,7 +6,7 @@ use biome_analyze::{Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
-    AnyJsFunction, JsFileSource, Language, TextRange, TsAsExpression, TsReferenceType,
+    AnyJsFunction, JsFileSource, JsSyntaxToken, Language, TsAsExpression, TsReferenceType,
 };
 use biome_rowan::AstNode;
 use biome_rule_options::no_undeclared_variables::NoUndeclaredVariablesOptions;
@@ -64,7 +64,7 @@ declare_lint_rule! {
 
 impl Rule for NoUndeclaredVariables {
     type Query = SemanticServices;
-    type State = (TextRange, Box<str>);
+    type State = JsSyntaxToken;
     type Signals = Box<[Self::State]>;
     type Options = NoUndeclaredVariablesOptions;
 
@@ -121,20 +121,18 @@ impl Rule for NoUndeclaredVariables {
                     return None;
                 }
 
-                let span = token.text_trimmed_range();
-                let text = text.into();
-                Some((span, text))
+                Some(token)
             })
             .collect::<Vec<_>>()
             .into_boxed_slice()
     }
 
-    fn diagnostic(_ctx: &RuleContext<Self>, (span, name): &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(_ctx: &RuleContext<Self>, token: &Self::State) -> Option<RuleDiagnostic> {
         Some(RuleDiagnostic::new(
             rule_category!(),
-            *span,
+            token.text_trimmed_range(),
             markup! {
-                "The "<Emphasis>{name.as_ref()}</Emphasis>" variable is undeclared."
+                "The "<Emphasis>{token.text_trimmed()}</Emphasis>" variable is undeclared."
             },
         ).note(markup! {
             "By default, Biome recognizes browser and Node.js globals.\nYou can ignore more globals using the "<Hyperlink href="https://biomejs.dev/reference/configuration/#javascriptglobals">"javascript.globals"</Hyperlink>" configuration."

--- a/crates/biome_js_analyze/src/lint/nursery/no_duplicated_spread_props.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_duplicated_spread_props.rs
@@ -4,7 +4,7 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_js_syntax::AnyJsxAttribute;
 use biome_js_syntax::{JsxAttributeList, JsxOpeningElement, JsxSelfClosingElement};
-use biome_rowan::{AstNode, declare_node_union};
+use biome_rowan::{AstNode, TokenText, declare_node_union};
 use biome_rule_options::no_duplicated_spread_props::NoDuplicatedSpreadPropsOptions;
 use std::collections::HashSet;
 
@@ -41,7 +41,7 @@ declare_lint_rule! {
 
 impl Rule for NoDuplicatedSpreadProps {
     type Query = Ast<NoDuplicatedSpreadPropsQuery>;
-    type State = String;
+    type State = TokenText;
     type Signals = Option<Self::State>;
     type Options = NoDuplicatedSpreadPropsOptions;
 
@@ -67,7 +67,7 @@ impl Rule for NoDuplicatedSpreadProps {
                 rule_category!(),
                 node.range(),
                 markup! {
-                    "The expression "<Emphasis>{state}</Emphasis>" has spread more than once."
+                    "The expression "<Emphasis>{state.text()}</Emphasis>" has spread more than once."
                 },
             )
             .note(markup! {
@@ -83,7 +83,7 @@ declare_node_union! {
         | JsxSelfClosingElement
 }
 
-fn validate_attributes(list: &JsxAttributeList) -> Option<String> {
+fn validate_attributes(list: &JsxAttributeList) -> Option<TokenText> {
     let mut seen_spreads = HashSet::new();
 
     for attribute in list {
@@ -93,7 +93,7 @@ fn validate_attributes(list: &JsxAttributeList) -> Option<String> {
             && let Some(name) = express.name().ok()
             && let Some(value_token) = name.value_token().ok()
         {
-            let text = value_token.text_trimmed().to_string();
+            let text = value_token.token_text_trimmed();
             if !seen_spreads.insert(text.clone()) {
                 return Some(text);
             }

--- a/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
@@ -4,7 +4,7 @@ use biome_analyze::{Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_semantic::{Binding, BindingExtensions};
-use biome_js_syntax::{AnyJsIdentifierUsage, TextRange};
+use biome_js_syntax::{AnyJsIdentifierUsage, JsSyntaxToken};
 use biome_rowan::AstNode;
 use biome_rule_options::no_restricted_globals::NoRestrictedGlobalsOptions;
 use rustc_hash::FxHashMap;
@@ -64,7 +64,7 @@ const RESTRICTED_GLOBALS: [&str; 2] = ["event", "error"];
 
 impl Rule for NoRestrictedGlobals {
     type Query = SemanticServices;
-    type State = (TextRange, Box<str>, Option<Box<str>>);
+    type State = JsSyntaxToken;
     type Signals = Box<[Self::State]>;
     type Options = NoRestrictedGlobalsOptions;
 
@@ -97,27 +97,25 @@ impl Rule for NoRestrictedGlobals {
                 let token = token.ok()?;
                 let text = token.text_trimmed();
 
-                is_restricted(text, &binding, options.denied_globals.as_ref()).map(|message| {
-                    (
-                        token.text_trimmed_range(),
-                        text.to_string().into_boxed_str(),
-                        message.map(|m| m.into_boxed_str()),
-                    )
-                })
+                if is_restricted(text, &binding, options.denied_globals.as_ref()) {
+                    Some(token)
+                } else {
+                    None
+                }
             })
             .collect::<Vec<_>>()
             .into_boxed_slice()
     }
 
-    fn diagnostic(
-        _ctx: &RuleContext<Self>,
-        (span, text, message): &Self::State,
-    ) -> Option<RuleDiagnostic> {
+    fn diagnostic(_ctx: &RuleContext<Self>, token: &Self::State) -> Option<RuleDiagnostic> {
+        let text = token.text_trimmed();
+        let message = custom_restricted_message(text, _ctx.options().denied_globals.as_ref());
+
         let mut diag = RuleDiagnostic::new(
             rule_category!(),
-            *span,
+            token.text_trimmed_range(),
             markup! {
-                "Do not use the global variable "<Emphasis>{text.as_ref()}</Emphasis>"."
+                "Do not use the global variable "<Emphasis>{text}</Emphasis>"."
             },
         );
 
@@ -135,18 +133,23 @@ fn is_restricted(
     name: &str,
     binding: &Option<Binding>,
     denied_globals: Option<&FxHashMap<Box<str>, Box<str>>>,
-) -> Option<Option<String>> {
+) -> bool {
     if binding.is_some() {
-        return None;
+        return false;
     }
 
     if RESTRICTED_GLOBALS.contains(&name) {
-        return Some(None);
+        return true;
     }
 
-    if let Some(message) = denied_globals.and_then(|denied_globals| denied_globals.get(name)) {
-        return Some(Some(message.to_string()));
-    }
+    denied_globals.is_some_and(|denied_globals| denied_globals.contains_key(name))
+}
 
-    None
+fn custom_restricted_message<'a>(
+    name: &str,
+    denied_globals: Option<&'a FxHashMap<Box<str>, Box<str>>>,
+) -> Option<&'a str> {
+    denied_globals
+        .and_then(|denied_globals| denied_globals.get(name))
+        .map(|message| message.as_ref())
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_alert.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_alert.rs
@@ -4,7 +4,7 @@ use biome_console::markup;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, JsCallExpression, JsComputedMemberExpression,
-    JsStaticMemberExpression, global_identifier,
+    JsStaticMemberExpression, global_identifier, inner_string_text,
 };
 use biome_rowan::AstNode;
 use biome_rule_options::no_alert::NoAlertOptions;
@@ -67,7 +67,7 @@ declare_lint_rule! {
 
 impl Rule for NoAlert {
     type Query = Semantic<JsCallExpression>;
-    type State = String;
+    type State = &'static str;
     type Signals = Option<Self::State>;
     type Options = NoAlertOptions;
 
@@ -97,7 +97,7 @@ impl Rule for NoAlert {
     }
 }
 
-fn check_expression(expr: &AnyJsExpression, model: &SemanticModel) -> Option<String> {
+fn check_expression(expr: &AnyJsExpression, model: &SemanticModel) -> Option<&'static str> {
     match expr {
         AnyJsExpression::JsIdentifierExpression(_) => check_global_identifier(expr, model),
         AnyJsExpression::JsStaticMemberExpression(member_expr) => {
@@ -114,12 +114,14 @@ fn check_expression(expr: &AnyJsExpression, model: &SemanticModel) -> Option<Str
     }
 }
 
-fn check_global_identifier(expr: &AnyJsExpression, model: &SemanticModel) -> Option<String> {
+fn check_global_identifier(expr: &AnyJsExpression, model: &SemanticModel) -> Option<&'static str> {
     let (reference, name) = global_identifier(expr)?;
     let name_text = name.text();
 
-    if is_forbidden_function(name_text) && model.binding(&reference).is_none() {
-        Some(name_text.to_string())
+    if model.binding(&reference).is_none()
+        && let Some(forbidden) = forbidden_function(name_text)
+    {
+        Some(forbidden)
     } else {
         None
     }
@@ -128,7 +130,7 @@ fn check_global_identifier(expr: &AnyJsExpression, model: &SemanticModel) -> Opt
 fn check_static_member_expression(
     member_expr: &JsStaticMemberExpression,
     model: &SemanticModel,
-) -> Option<String> {
+) -> Option<&'static str> {
     let object = member_expr.object().ok()?;
     let (reference, object_name) = global_identifier(&object)?;
     let object_name_text = object_name.text();
@@ -138,11 +140,7 @@ fn check_static_member_expression(
         let member_token = member_name.value_token().ok()?;
         let member_name_text = member_token.text_trimmed();
 
-        if is_forbidden_function(member_name_text) {
-            Some(member_name_text.to_string())
-        } else {
-            None
-        }
+        forbidden_function(member_name_text)
     } else {
         None
     }
@@ -151,7 +149,7 @@ fn check_static_member_expression(
 fn check_computed_member_expression(
     computed_member_expr: &JsComputedMemberExpression,
     model: &SemanticModel,
-) -> Option<String> {
+) -> Option<&'static str> {
     let object = computed_member_expr.object().ok()?;
     let (reference, object_name) = global_identifier(&object)?;
     let object_name_text = object_name.text();
@@ -163,14 +161,9 @@ fn check_computed_member_expression(
         ) = member_expr
         {
             let string_token = string_literal.value_token().ok()?;
-            let string_text = string_token.text_trimmed();
-            let member_name = string_text.trim_matches('"').trim_matches('\'');
+            let member_name = inner_string_text(&string_token);
 
-            if is_forbidden_function(member_name) {
-                Some(member_name.to_string())
-            } else {
-                None
-            }
+            forbidden_function(&member_name)
         } else {
             None
         }
@@ -179,8 +172,12 @@ fn check_computed_member_expression(
     }
 }
 
-fn is_forbidden_function(name: &str) -> bool {
-    FORBIDDEN_FUNCTIONS.contains(&name)
+/// If the function name is in the list of forbidden functions, return it. Otherwise, return None.
+fn forbidden_function(name: &str) -> Option<&'static str> {
+    FORBIDDEN_FUNCTIONS
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == name)
 }
 
 fn is_global_object(name: &str) -> bool {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
@@ -3,10 +3,9 @@ use biome_analyze::{Ast, Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
-use biome_js_syntax::{AnyJsxAttribute, JsxAttribute};
-use biome_rowan::AstNode;
+use biome_js_syntax::{AnyJsxAttribute, AnyJsxAttributeName, JsxAttribute};
+use biome_rowan::{AstNode, TokenText};
 use biome_rule_options::no_duplicate_jsx_props::NoDuplicateJsxPropsOptions;
-use rustc_hash::FxHashMap;
 
 declare_lint_rule! {
     /// Prevents JSX properties to be assigned multiple times.
@@ -42,33 +41,64 @@ declare_lint_rule! {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum AttributeNameKey {
+    Name(TokenText),
+    Namespace(TokenText, TokenText),
+}
+
 impl Rule for NoDuplicateJsxProps {
     type Query = Ast<AnyJsxElement>;
-    type State = (Box<str>, Vec<JsxAttribute>);
-    type Signals = FxHashMap<Box<str>, Vec<JsxAttribute>>;
+    type State = Vec<JsxAttribute>;
+    type Signals = Vec<Self::State>;
     type Options = NoDuplicateJsxPropsOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
+        let attributes = node
+            .attributes()
+            .into_iter()
+            .filter_map(|attribute| match attribute {
+                AnyJsxAttribute::JsxAttribute(attr) => Some(attr),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
 
-        let mut defined_attributes: FxHashMap<Box<str>, Vec<JsxAttribute>> = FxHashMap::default();
-        for attribute in node.attributes() {
-            if let AnyJsxAttribute::JsxAttribute(attr) = attribute
-                && let Ok(name) = attr.name()
-            {
-                defined_attributes
-                    .entry(name.to_trimmed_text().text().into())
-                    .or_default()
-                    .push(attr);
+        let mut duplicated_attributes = Vec::new();
+        let mut processed_names = Vec::new();
+
+        for (index, attr) in attributes.iter().enumerate() {
+            let Some(name) = attribute_name_key(attr) else {
+                continue;
+            };
+
+            if processed_names.contains(&name) {
+                continue;
+            }
+
+            let mut duplicates = vec![attr.clone()];
+
+            for other in attributes.iter().skip(index + 1) {
+                let Some(other_name) = attribute_name_key(other) else {
+                    continue;
+                };
+
+                if name == other_name {
+                    duplicates.push(other.clone());
+                }
+            }
+
+            if duplicates.len() > 1 {
+                processed_names.push(name);
+                duplicated_attributes.push(duplicates);
             }
         }
 
-        defined_attributes.retain(|_, val| val.len() > 1);
-        defined_attributes
+        duplicated_attributes
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
-        let mut attributes = state.1.iter();
+        let mut attributes = state.iter();
 
         let mut diagnostic = RuleDiagnostic::new(
             rule_category!(),
@@ -84,5 +114,17 @@ impl Rule for NoDuplicateJsxProps {
         }
 
         Some(diagnostic)
+    }
+}
+
+fn attribute_name_key(attribute: &JsxAttribute) -> Option<AttributeNameKey> {
+    match attribute.name().ok()? {
+        AnyJsxAttributeName::JsxName(name) => {
+            Some(AttributeNameKey::Name(name.value_token().ok()?.token_text_trimmed()))
+        }
+        AnyJsxAttributeName::JsxNamespaceName(name) => Some(AttributeNameKey::Namespace(
+            name.namespace().ok()?.value_token().ok()?.token_text_trimmed(),
+            name.name().ok()?.value_token().ok()?.token_text_trimmed(),
+        )),
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_import_cycles.rs
@@ -160,7 +160,7 @@ declare_lint_rule! {
 
 impl Rule for NoImportCycles {
     type Query = ResolvedImports<AnyJsImportLike>;
-    type State = Vec<String>;
+    type State = Box<[ResolvedPath]>;
     type Signals = Option<Self::State>;
     type Options = NoImportCyclesOptions;
 
@@ -178,14 +178,14 @@ impl Rule for NoImportCycles {
             return None;
         }
 
-        let resolved_path = resolved_path.as_path()?;
+        let resolved_path_path = resolved_path.as_path()?;
 
         // Don't check for cycles through node_modules imports.
-        if is_node_modules_path(resolved_path) {
+        if is_node_modules_path(resolved_path_path) {
             return None;
         }
 
-        let imports = ctx.module_info_for_path(resolved_path)?;
+        let imports = ctx.module_info_for_path(resolved_path_path)?;
 
         find_cycle(ctx, resolved_path, imports)
     }
@@ -205,11 +205,15 @@ impl Rule for NoImportCycles {
                 note.extend_with(markup!("\n    ... which imports "));
             }
 
-            match Utf8Path::new(path).strip_prefix(&cwd) {
+            let Some(path) = path.as_path() else {
+                continue;
+            };
+
+            match path.strip_prefix(&cwd) {
                 Ok(relative_path) => {
                     note.extend_with(markup!(<Info>{relative_path.as_str()}</Info>))
                 }
-                Err(_) => note.extend_with(markup!(<Info>{path}</Info>)),
+                Err(_) => note.extend_with(markup!(<Info>{path.as_str()}</Info>)),
             }
         }
         note.extend_with(markup!("\n    ... which is the file we're importing from."));
@@ -237,9 +241,9 @@ impl Rule for NoImportCycles {
 /// the cycle, starting with `start_path` and ending with `ctx.file_path()`.
 fn find_cycle(
     ctx: &RuleContext<NoImportCycles>,
-    start_path: &Utf8Path,
+    start_path: &ResolvedPath,
     mut module_info: JsModuleInfo,
-) -> Option<Vec<String>> {
+) -> Option<Box<[ResolvedPath]>> {
     let options = ctx.options();
     let mut seen = FxHashSet::default();
     let mut stack: Vec<(ResolvedPath, JsModuleInfo)> = Vec::new();
@@ -270,21 +274,17 @@ fn find_cycle(
             if path == ctx.file_path() {
                 // https://github.com/biomejs/biome/issues/6569
                 // prevent flagging on import cycles when they are isolated to a single file
-                if stack.is_empty() && start_path == path {
+                if stack.is_empty() && start_path.as_path() == Some(path) {
                     continue;
                 }
 
                 // Return all the paths from `start_path` to `resolved_path`:
-                let paths = Some(start_path.to_string())
+                let paths = Some(start_path.clone())
                     .into_iter()
-                    .chain(
-                        stack
-                            .iter()
-                            .filter_map(|(path, _)| path.as_path())
-                            .map(ToString::to_string),
-                    )
-                    .chain(Some(path.to_string()))
-                    .collect();
+                    .chain(stack.iter().map(|(path, _)| path.clone()))
+                    .chain(Some(resolved_path.clone()))
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
 
                 return Some(paths);
             }

--- a/crates/biome_js_analyze/src/syntax/correctness/no_duplicate_private_class_members.rs
+++ b/crates/biome_js_analyze/src/syntax/correctness/no_duplicate_private_class_members.rs
@@ -1,6 +1,7 @@
 use biome_analyze::{Ast, Rule, RuleDiagnostic, context::RuleContext, declare_syntax_rule};
+use biome_console::markup;
 use biome_js_syntax::{AnyJsClassMember, JsClassMemberList, TextRange};
-use biome_rowan::AstNode;
+use biome_rowan::{AstNode, TokenText};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 declare_syntax_rule! {
@@ -30,12 +31,12 @@ enum MemberType {
 
 impl Rule for NoDuplicatePrivateClassMembers {
     type Query = Ast<JsClassMemberList>;
-    type State = (Box<str>, TextRange);
+    type State = (TokenText, TextRange);
     type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let mut defined_members: FxHashMap<Box<str>, FxHashSet<MemberType>> = FxHashMap::default();
+        let mut defined_members: FxHashMap<TokenText, FxHashSet<MemberType>> = FxHashMap::default();
         let node = ctx.query();
         node.into_iter()
             .filter_map(|member| {
@@ -45,9 +46,7 @@ impl Rule for NoDuplicatePrivateClassMembers {
                     .as_js_private_class_member_name()?
                     .id_token()
                     .ok()?
-                    .text_trimmed()
-                    .to_string()
-                    .into_boxed_str();
+                    .token_text_trimmed();
                 let member_type = match member {
                     AnyJsClassMember::JsGetterClassMember(_) => MemberType::Getter,
                     AnyJsClassMember::JsMethodClassMember(_) => MemberType::Normal,
@@ -83,7 +82,7 @@ impl Rule for NoDuplicatePrivateClassMembers {
         Some(RuleDiagnostic::new(
             rule_category!(),
             range,
-            format!("Duplicate private class member \"#{member_name}\""),
+            markup! { "Duplicate private class member \"#"{member_name.text()}"\"" },
         ))
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
A bunch of our older rules allocate strings more than they should. This is a quick attempt to resolve that for some of them. If there's a perf improvement, I'll add a changeset. There's also some cosmetic refactors to slightly realign some of these rules with our current patterns.

Generated initially by gpt 5.4, but i tweaked some things by hand.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
no snapshot updates.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
