### PR TITLE
feat(html_analyze): port noLabelWithoutControl

### DIFF
--- a/.changeset/shiny-parts-make.md
+++ b/.changeset/shiny-parts-make.md
@@ -1,0 +1,9 @@
+---
+"@biomejs/biome": minor
+---
+
+Added the lint rule [`noLabelWithoutControl`](https://biomejs.dev/linter/rules/no-label-without-control/) to HTML, which enforces that a label element or component has a text label and an associated input.
+
+```html
+<label></label>
+```

--- a/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
@@ -10,8 +10,6 @@ use biome_html_syntax::{
 use biome_rowan::{AstNode, WalkEvent};
 use biome_rule_options::no_label_without_control::NoLabelWithoutControlOptions;
 
-use crate::utils::is_html_tag;
-
 declare_lint_rule! {
     /// Enforce that a label element or component has a text label and an associated input.
     ///
@@ -98,11 +96,7 @@ impl Rule for NoLabelWithoutControl {
 
         let element_name = node.name()?;
         let element_name = element_name.trim();
-        let tag_element = node.clone().as_any_html_tag_element()?;
-        let is_allowed_element = has_element_name(options, element_name)
-            || DEFAULT_LABEL_COMPONENTS
-                .iter()
-                .any(|label_component| is_html_tag(&tag_element, source_type, label_component));
+        let is_allowed_element = has_element_name(options, element_name, source_type);
 
         if !is_allowed_element {
             return None;
@@ -158,12 +152,10 @@ fn has_label_attribute(options: &NoLabelWithoutControlOptions, attribute: &HtmlA
     let Some(attribute_name) = attribute_name.token_text_trimmed() else {
         return false;
     };
-    if !DEFAULT_LABEL_ATTRIBUTES.contains(&attribute_name.text())
-        && !options
-            .label_attributes
-            .iter()
-            .flatten()
-            .any(|name| name.as_ref() == attribute_name)
+    if !options
+        .label_attributes()
+        .iter()
+        .any(|name| *name == attribute_name)
     {
         return false;
     }
@@ -234,18 +226,13 @@ fn has_nested_control(
                         continue;
                     };
                     let element_name = element_name.text();
-                    if DEFAULT_INPUT_COMPONENTS.iter().any(|input_component| {
+                    if options.input_components().iter().any(|name| {
                         if source_type.is_html() {
-                            element_name.eq_ignore_ascii_case(input_component)
+                            element_name.eq_ignore_ascii_case(name)
                         } else {
-                            &element_name == input_component
+                            &element_name == name
                         }
-                    }) || options
-                        .input_components
-                        .iter()
-                        .flatten()
-                        .any(|name| name.as_ref() == element_name)
-                    {
+                    }) {
                         return true;
                     }
                 }
@@ -256,24 +243,27 @@ fn has_nested_control(
     false
 }
 
-fn has_element_name(options: &NoLabelWithoutControlOptions, element_name: &str) -> bool {
+fn has_element_name(
+    options: &NoLabelWithoutControlOptions,
+    element_name: &str,
+    source_type: &HtmlFileSource,
+) -> bool {
     options
-        .label_components
+        .label_components()
         .iter()
-        .flatten()
-        .any(|label_component_name| label_component_name.as_ref() == element_name)
+        .any(|label_component_name| {
+            if source_type.is_html() {
+                element_name.eq_ignore_ascii_case(label_component_name)
+            } else {
+                &element_name == label_component_name
+            }
+        })
 }
 
 pub struct NoLabelWithoutControlState {
     pub has_text_content: bool,
     pub has_control_association: bool,
 }
-
-const DEFAULT_LABEL_ATTRIBUTES: [&str; 3] = ["aria-label", "aria-labelledby", "alt"];
-const DEFAULT_LABEL_COMPONENTS: [&str; 1] = ["label"];
-const DEFAULT_INPUT_COMPONENTS: [&str; 7] = [
-    "input", "meter", "output", "progress", "select", "textarea", "button",
-];
 
 /// Returns true whether the passed `AnyHtmlElement` has a `for` attribute
 fn has_for_attribute(html_element: &AnyHtmlElement) -> bool {

--- a/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
@@ -3,12 +3,14 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{
-    AnyJsxAttribute, AnyJsxAttributeName, AnyJsxAttributeValue, AnyJsxElementName, AnyJsxTag,
-    JsSyntaxKind, JsxAttribute,
+use biome_html_syntax::{
+    AnyHtmlAttribute, AnyHtmlAttributeInitializer, AnyHtmlElement, AnyHtmlTagName, HtmlAttribute,
+    HtmlFileSource, HtmlSyntaxKind,
 };
 use biome_rowan::{AstNode, WalkEvent};
 use biome_rule_options::no_label_without_control::NoLabelWithoutControlOptions;
+
+use crate::utils::is_html_tag;
 
 declare_lint_rule! {
     /// Enforce that a label element or component has a text label and an associated input.
@@ -28,40 +30,30 @@ declare_lint_rule! {
     ///
     /// ### Invalid
     ///
-    /// ```jsx,expect_diagnostic
-    /// <label for="js_id" />;
+    /// ```html,expect_diagnostic
+    /// <label for="html_id"></label>
     /// ```
     ///
-    /// ```jsx,expect_diagnostic
-    /// <label for="js_id"><input /></label>;
+    /// ```html,expect_diagnostic
+    /// <label for="html_id"><input /></label>
     /// ```
     ///
-    /// ```jsx,expect_diagnostic
-    /// <label htmlFor="js_id" />;
+    /// ```html,expect_diagnostic
+    /// <label>A label</label>
     /// ```
     ///
-    /// ```jsx,expect_diagnostic
-    /// <label htmlFor="js_id"><input /></label>;
-    /// ```
-    ///
-    /// ```jsx,expect_diagnostic
-    /// <label>A label</label>;
-    /// ```
-    ///
-    /// ```jsx,expect_diagnostic
-    /// <div><label /><input /></div>;
+    /// ```html,expect_diagnostic
+    /// <div><label></label><input /></div>
     /// ```
     ///
     /// ### Valid
     ///
-    /// ```jsx
-    /// <label for="js_id" aria-label="A label" />;
-    /// <label for="js_id" aria-labelledby="A label" />;
-    /// <label htmlFor="js_id" aria-label="A label" />;
-    /// <label htmlFor="js_id" aria-labelledby="A label" />;
-    /// <label>A label<input /></label>;
-    /// <label>A label<textarea /></label>;
-    /// <label><img alt="A label" /><input /></label>;
+    /// ```html
+    /// <label for="html_id" aria-label="A label"></label>
+    /// <label for="html_id" aria-labelledby="A label"></label>
+    /// <label>A label<input /></label>
+    /// <label>A label<textarea></textarea></label>
+    /// <label><img alt="A label" /><input /></label>
     /// ```
     ///
     /// ## Options
@@ -84,9 +76,9 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoLabelWithoutControl {
-        version: "1.8.0",
+        version: "next",
         name: "noLabelWithoutControl",
-        language: "jsx",
+        language: "html",
         sources: &[RuleSource::EslintJsxA11y("label-has-associated-control").same()],
         recommended: true,
         severity: Severity::Error,
@@ -94,7 +86,7 @@ declare_lint_rule! {
 }
 
 impl Rule for NoLabelWithoutControl {
-    type Query = Ast<AnyJsxTag>;
+    type Query = Ast<AnyHtmlElement>;
     type State = NoLabelWithoutControlState;
     type Signals = Option<Self::State>;
     type Options = NoLabelWithoutControlOptions;
@@ -102,17 +94,23 @@ impl Rule for NoLabelWithoutControl {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let options = ctx.options();
-        let element_name = node.name()?.name_value_token().ok()?;
-        let element_name = element_name.text_trimmed();
+        let source_type = ctx.source_type::<HtmlFileSource>();
+
+        let element_name = node.name()?;
+        let element_name = element_name.trim();
+        let tag_element = node.clone().as_any_html_tag_element()?;
         let is_allowed_element = has_element_name(options, element_name)
-            || DEFAULT_LABEL_COMPONENTS.contains(&element_name);
+            || DEFAULT_LABEL_COMPONENTS
+                .iter()
+                .any(|label_component| is_html_tag(&tag_element, source_type, label_component));
 
         if !is_allowed_element {
             return None;
         }
 
         let has_text_content = has_accessible_label(options, node);
-        let has_control_association = has_for_attribute(node) || has_nested_control(options, node);
+        let has_control_association =
+            has_for_attribute(node) || has_nested_control(options, node, source_type);
 
         if has_text_content && has_control_association {
             return None;
@@ -142,7 +140,7 @@ impl Rule for NoLabelWithoutControl {
 
         if !state.has_control_association {
             diagnostic = diagnostic.note(
-                markup! { "Consider adding a \""<Emphasis>"for"</Emphasis>"\" or \""<Emphasis>"htmlFor"</Emphasis>"\" attribute to the label element or moving the input element to inside the label element." },
+                markup! { "Consider adding a \""<Emphasis>"for"</Emphasis>"\" attribute to the label element or moving the input element to inside the label element." },
             );
         }
 
@@ -153,12 +151,14 @@ impl Rule for NoLabelWithoutControl {
 /// Returns `true` whether the passed `attribute` meets one of the following conditions:
 /// - Has a label attribute that corresponds to the `label_attributes` parameter
 /// - Has a label among `DEFAULT_LABEL_ATTRIBUTES`
-fn has_label_attribute(options: &NoLabelWithoutControlOptions, attribute: &JsxAttribute) -> bool {
-    let Ok(attribute_name) = attribute.name().and_then(|name| name.name_token()) else {
+fn has_label_attribute(options: &NoLabelWithoutControlOptions, attribute: &HtmlAttribute) -> bool {
+    let Ok(attribute_name) = attribute.name() else {
         return false;
     };
-    let attribute_name = attribute_name.text_trimmed();
-    if !DEFAULT_LABEL_ATTRIBUTES.contains(&attribute_name)
+    let Some(attribute_name) = attribute_name.token_text_trimmed() else {
+        return false;
+    };
+    if !DEFAULT_LABEL_ATTRIBUTES.contains(&attribute_name.text())
         && !options
             .label_attributes
             .iter()
@@ -173,27 +173,28 @@ fn has_label_attribute(options: &NoLabelWithoutControlOptions, attribute: &JsxAt
         .is_some_and(|v| has_label_attribute_value(&v))
 }
 
-/// Returns `true` whether the passed `jsx_tag` meets one of the following conditions:
+/// Returns `true` whether the passed `html_element` meets one of the following conditions:
 /// - Has a label attribute that corresponds to the `label_attributes` parameter
 /// - Has a label among `DEFAULT_LABEL_ATTRIBUTES`
 /// - Has a child that acts as a label
-fn has_accessible_label(options: &NoLabelWithoutControlOptions, jsx_tag: &AnyJsxTag) -> bool {
-    let mut child_iter = jsx_tag.syntax().preorder();
+fn has_accessible_label(
+    options: &NoLabelWithoutControlOptions,
+    html_element: &AnyHtmlElement,
+) -> bool {
+    let mut child_iter = html_element.syntax().preorder();
     while let Some(event) = child_iter.next() {
         match event {
             WalkEvent::Enter(child) => match child.kind() {
-                JsSyntaxKind::JSX_EXPRESSION_CHILD
-                | JsSyntaxKind::JSX_SPREAD_CHILD
-                | JsSyntaxKind::JSX_TEXT => {
+                HtmlSyntaxKind::HTML_TEXT_EXPRESSION | HtmlSyntaxKind::HTML_CONTENT => {
                     return true;
                 }
-                JsSyntaxKind::JSX_ELEMENT
-                | JsSyntaxKind::JSX_OPENING_ELEMENT
-                | JsSyntaxKind::JSX_CHILD_LIST
-                | JsSyntaxKind::JSX_SELF_CLOSING_ELEMENT
-                | JsSyntaxKind::JSX_ATTRIBUTE_LIST => {}
-                JsSyntaxKind::JSX_ATTRIBUTE => {
-                    let attribute = JsxAttribute::unwrap_cast(child);
+                HtmlSyntaxKind::HTML_ELEMENT
+                | HtmlSyntaxKind::HTML_OPENING_ELEMENT
+                | HtmlSyntaxKind::HTML_ELEMENT_LIST
+                | HtmlSyntaxKind::HTML_SELF_CLOSING_ELEMENT
+                | HtmlSyntaxKind::HTML_ATTRIBUTE_LIST => {}
+                HtmlSyntaxKind::HTML_ATTRIBUTE => {
+                    let attribute = HtmlAttribute::unwrap_cast(child);
                     if has_label_attribute(options, &attribute) {
                         return true;
                     }
@@ -209,32 +210,41 @@ fn has_accessible_label(options: &NoLabelWithoutControlOptions, jsx_tag: &AnyJsx
     false
 }
 
-/// Returns whether the passed `AnyJsxTag` have a child that is considered an input component
+/// Returns whether the passed `AnyHtmlElement` have a child that is considered an input component
 /// according to the passed `input_components` parameter
-fn has_nested_control(options: &NoLabelWithoutControlOptions, jsx_tag: &AnyJsxTag) -> bool {
-    let mut child_iter = jsx_tag.syntax().preorder();
+fn has_nested_control(
+    options: &NoLabelWithoutControlOptions,
+    html_element: &AnyHtmlElement,
+    source_type: &HtmlFileSource,
+) -> bool {
+    let mut child_iter = html_element.syntax().preorder();
     while let Some(event) = child_iter.next() {
         match event {
             WalkEvent::Enter(child) => match child.kind() {
-                JsSyntaxKind::JSX_ELEMENT
-                | JsSyntaxKind::JSX_OPENING_ELEMENT
-                | JsSyntaxKind::JSX_CHILD_LIST
-                | JsSyntaxKind::JSX_SELF_CLOSING_ELEMENT => {}
+                HtmlSyntaxKind::HTML_ELEMENT
+                | HtmlSyntaxKind::HTML_OPENING_ELEMENT
+                | HtmlSyntaxKind::HTML_ELEMENT_LIST
+                | HtmlSyntaxKind::HTML_SELF_CLOSING_ELEMENT => {}
                 _ => {
-                    let Some(element_name) = AnyJsxElementName::cast(child) else {
+                    let Some(element_name) = AnyHtmlTagName::cast(child) else {
                         child_iter.skip_subtree();
                         continue;
                     };
-                    let Ok(element_name) = element_name.name_value_token() else {
+                    let Some(element_name) = element_name.token_text_trimmed() else {
                         continue;
                     };
-                    let element_name = element_name.text_trimmed();
-                    if DEFAULT_INPUT_COMPONENTS.contains(&element_name)
-                        || options
-                            .input_components
-                            .iter()
-                            .flatten()
-                            .any(|name| name.as_ref() == element_name)
+                    let element_name = element_name.text();
+                    if DEFAULT_INPUT_COMPONENTS.iter().any(|input_component| {
+                        if source_type.is_html() {
+                            element_name.eq_ignore_ascii_case(input_component)
+                        } else {
+                            &element_name == input_component
+                        }
+                    }) || options
+                        .input_components
+                        .iter()
+                        .flatten()
+                        .any(|name| name.as_ref() == element_name)
                     {
                         return true;
                     }
@@ -265,39 +275,27 @@ const DEFAULT_INPUT_COMPONENTS: [&str; 7] = [
     "input", "meter", "output", "progress", "select", "textarea", "button",
 ];
 
-/// Returns whether the passed `AnyJsxTag` have a `for` or `htmlFor` attribute
-fn has_for_attribute(jsx_tag: &AnyJsxTag) -> bool {
-    let for_attributes = ["for", "htmlFor"];
-    let Some(attributes) = jsx_tag.attributes() else {
+/// Returns true whether the passed `AnyHtmlElement` has a `for` attribute
+fn has_for_attribute(html_element: &AnyHtmlElement) -> bool {
+    let Some(attributes) = html_element.attributes() else {
         return false;
     };
+
     attributes.into_iter().any(|attribute| match attribute {
-        AnyJsxAttribute::JsxAttribute(jsx_attribute) => jsx_attribute
+        AnyHtmlAttribute::HtmlAttribute(html_attribute) => html_attribute
             .name()
             .ok()
-            .and_then(|jsx_name| {
-                if let AnyJsxAttributeName::JsxName(jsx_name) = jsx_name {
-                    jsx_name.value_token().ok()
-                } else {
-                    None
-                }
-            })
-            .is_some_and(|jsx_name| for_attributes.contains(&jsx_name.text_trimmed())),
-        AnyJsxAttribute::JsxShorthandAttribute(attribute) => attribute
-            .name()
-            .ok()
-            .and_then(|name| name.value_token().ok())
-            .is_some_and(|name| for_attributes.contains(&name.text_trimmed())),
-        AnyJsxAttribute::JsxSpreadAttribute(_) | AnyJsxAttribute::JsMetavariable(_) => false,
+            .and_then(|attribute_name| attribute_name.token_text_trimmed())
+            .is_some_and(|text| text.eq_ignore_ascii_case("for")),
+        _ => false,
     })
 }
 
-/// Returns whether the passed `jsx_attribute_value` has a valid value inside it
-fn has_label_attribute_value(jsx_attribute_value: &AnyJsxAttributeValue) -> bool {
-    match jsx_attribute_value {
-        AnyJsxAttributeValue::AnyJsxTag(_) => false,
-        AnyJsxAttributeValue::JsxExpressionAttributeValue(_) => true,
-        AnyJsxAttributeValue::JsxString(jsx_string) => !jsx_string
+/// Returns whether the passed `html_attribute_value` has a valid value inside it
+fn has_label_attribute_value(html_attribute_value: &AnyHtmlAttributeInitializer) -> bool {
+    match html_attribute_value {
+        AnyHtmlAttributeInitializer::HtmlAttributeSingleTextExpression(_) => true,
+        AnyHtmlAttributeInitializer::HtmlString(html_string) => !html_string
             .inner_string_text()
             .is_ok_and(|text| text.text().trim().is_empty()),
     }

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/invalid.astro
@@ -1,0 +1,7 @@
+<!-- should generate diagnostics -->
+<CustomLabel>
+	<span>
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/invalid.astro.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.astro
+---
+# Input
+```astro
+<!-- should generate diagnostics -->
+<CustomLabel>
+	<span>
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel aria-label="A label" />
+
+```
+
+# Diagnostics
+```
+invalid.astro:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <CustomLabel>
+      │ ^^^^^^^^^^^^^
+  > 3 │ 	<span>
+  > 4 │ 		<CustomInput />
+  > 5 │ 	</span>
+  > 6 │ </CustomLabel>
+      │ ^^^^^^^^^^^^^^
+    7 │ <CustomLabel aria-label="A label" />
+    8 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.astro:7:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    5 │ 	</span>
+    6 │ </CustomLabel>
+  > 7 │ <CustomLabel aria-label="A label" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/invalid.options.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/valid.astro
@@ -1,0 +1,13 @@
+<!-- should not generate diagnostics -->
+<CustomLabel>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel>
+	<span label="A label">
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel for="js_id" label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/valid.astro.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+<CustomLabel>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel>
+	<span label="A label">
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel for="js_id" label="A label" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/all/valid.options.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/invalid.astro
@@ -1,0 +1,6 @@
+<!-- should generate diagnostics -->
+<label>
+	<span>
+		<CustomInput />
+	</span>
+</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/invalid.astro.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.astro
+---
+# Input
+```astro
+<!-- should generate diagnostics -->
+<label>
+	<span>
+		<CustomInput />
+	</span>
+</label>
+
+```
+
+# Diagnostics
+```
+invalid.astro:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label>
+      │ ^^^^^^^
+  > 3 │ 	<span>
+  > 4 │ 		<CustomInput />
+  > 5 │ 	</span>
+  > 6 │ </label>
+      │ ^^^^^^^^
+    7 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/valid.astro
@@ -1,0 +1,7 @@
+<!-- should not generate diagnostics -->
+<label>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/valid.astro.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+<label>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/inputComponents/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/invalid.astro
@@ -1,0 +1,8 @@
+<!-- should generate diagnostics -->
+<label for="js_id"></label>
+<label for="js_id"><input /></label>
+<label for="js_id"><textarea></textarea></label>
+<label></label>
+<label>A label</label>
+<div><label></label><input /></div>
+<div><label>A label</label><input /></div>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/invalid.astro.snap
@@ -1,0 +1,138 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.astro
+---
+# Input
+```astro
+<!-- should generate diagnostics -->
+<label for="js_id"></label>
+<label for="js_id"><input /></label>
+<label for="js_id"><textarea></textarea></label>
+<label></label>
+<label>A label</label>
+<div><label></label><input /></div>
+<div><label>A label</label><input /></div>
+
+```
+
+# Diagnostics
+```
+invalid.astro:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label for="js_id"></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ <label for="js_id"><input /></label>
+    4 │ <label for="js_id"><textarea></textarea></label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.astro:3:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <label for="js_id"></label>
+  > 3 │ <label for="js_id"><input /></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <label for="js_id"><textarea></textarea></label>
+    5 │ <label></label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.astro:4:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    2 │ <label for="js_id"></label>
+    3 │ <label for="js_id"><input /></label>
+  > 4 │ <label for="js_id"><textarea></textarea></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ <label></label>
+    6 │ <label>A label</label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.astro:5:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    3 │ <label for="js_id"><input /></label>
+    4 │ <label for="js_id"><textarea></textarea></label>
+  > 5 │ <label></label>
+      │ ^^^^^^^^^^^^^^^
+    6 │ <label>A label</label>
+    7 │ <div><label></label><input /></div>
+  
+  i Consider adding an accessible text content to the label element.
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.astro:6:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    4 │ <label for="js_id"><textarea></textarea></label>
+    5 │ <label></label>
+  > 6 │ <label>A label</label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    7 │ <div><label></label><input /></div>
+    8 │ <div><label>A label</label><input /></div>
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.astro:7:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    5 │ <label></label>
+    6 │ <label>A label</label>
+  > 7 │ <div><label></label><input /></div>
+      │      ^^^^^^^^^^^^^^^
+    8 │ <div><label>A label</label><input /></div>
+    9 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.astro:8:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    6 │ <label>A label</label>
+    7 │ <div><label></label><input /></div>
+  > 8 │ <div><label>A label</label><input /></div>
+      │      ^^^^^^^^^^^^^^^^^^^^^^
+    9 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/invalid.astro
@@ -1,0 +1,2 @@
+<!-- should generate diagnostics -->
+<label label="A label"></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/invalid.astro.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.astro
+---
+# Input
+```astro
+<!-- should generate diagnostics -->
+<label label="A label"></label>
+
+```
+
+# Diagnostics
+```
+invalid.astro:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label label="A label"></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/valid.astro
@@ -1,0 +1,2 @@
+<!-- should not generate diagnostics -->
+<label for="js_id" label="A label"></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/valid.astro.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+<label for="js_id" label="A label"></label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelAttributes/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/invalid.astro
@@ -1,0 +1,2 @@
+<!-- should generate diagnostics -->
+<CustomLabel aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/invalid.astro.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.astro
+---
+# Input
+```astro
+<!-- should generate diagnostics -->
+<CustomLabel aria-label="A label" />
+
+```
+
+# Diagnostics
+```
+invalid.astro:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <CustomLabel aria-label="A label" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/valid.astro
@@ -1,0 +1,2 @@
+<!-- should not generate diagnostics -->
+<CustomLabel for="js_id" aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/valid.astro.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+<CustomLabel for="js_id" aria-label="A label" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/labelComponents/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro
@@ -1,0 +1,34 @@
+<!-- should not generate diagnostics -->
+<!-- Always valid -->
+<div></div>
+<CustomElement />
+<input type="hidden" />
+
+<!-- For element -->
+<label for="js_id"><span><span><span>A label</span></span></span></label>
+<label for="js_id" aria-label="A label"></label>
+<label for="js_id" aria-labelledby="A label"></label>
+
+<!-- Nesting valid -->
+<label>A label<input /></label>
+<label>A label<textarea></textarea></label>
+<label><img alt="A label" /><input /></label>
+<label><img aria-label="A label" /><input /></label>
+<label><span>A label<input /></span></label>
+<label><span><span>A label<input /></span></span></label>
+<label><span><span><span>A label<input /></span></span></span></label>
+<label><span><span><span><span>A label</span><input /></span></span></span></label>
+<label><span><span><span><span aria-label="A label"></span><input /></span></span></span></label>
+<label><span><span><span><input aria-label="A label" /></span></span></span></label>
+
+<!-- Other controls -->
+<label>foo<meter></meter></label>
+<label>foo<output></output></label>
+<label>foo<progress></progress></label>
+<label>foo<textarea></textarea></label>
+
+<label for="btn_id"><button id="btn_id">Button</button></label>
+<label>A label<button></button></label>
+
+<button type="button" id="burger">Menu</button>
+<label for="burger">Menu</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+<!-- Always valid -->
+<div></div>
+<CustomElement />
+<input type="hidden" />
+
+<!-- For element -->
+<label for="js_id"><span><span><span>A label</span></span></span></label>
+<label for="js_id" aria-label="A label"></label>
+<label for="js_id" aria-labelledby="A label"></label>
+
+<!-- Nesting valid -->
+<label>A label<input /></label>
+<label>A label<textarea></textarea></label>
+<label><img alt="A label" /><input /></label>
+<label><img aria-label="A label" /><input /></label>
+<label><span>A label<input /></span></label>
+<label><span><span>A label<input /></span></span></label>
+<label><span><span><span>A label<input /></span></span></span></label>
+<label><span><span><span><span>A label</span><input /></span></span></span></label>
+<label><span><span><span><span aria-label="A label"></span><input /></span></span></span></label>
+<label><span><span><span><input aria-label="A label" /></span></span></span></label>
+
+<!-- Other controls -->
+<label>foo<meter></meter></label>
+<label>foo<output></output></label>
+<label>foo<progress></progress></label>
+<label>foo<textarea></textarea></label>
+
+<label for="btn_id"><button id="btn_id">Button</button></label>
+<label>A label<button></button></label>
+
+<button type="button" id="burger">Menu</button>
+<label for="burger">Menu</label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/invalid.html
@@ -1,0 +1,7 @@
+<!-- should generate diagnostics -->
+<CustomLabel>
+	<span>
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/invalid.html.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<CustomLabel>
+	<span>
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel aria-label="A label" />
+
+```
+
+# Diagnostics
+```
+invalid.html:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <CustomLabel>
+      │ ^^^^^^^^^^^^^
+  > 3 │ 	<span>
+  > 4 │ 		<CustomInput />
+  > 5 │ 	</span>
+  > 6 │ </CustomLabel>
+      │ ^^^^^^^^^^^^^^
+    7 │ <CustomLabel aria-label="A label" />
+    8 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.html:7:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    5 │ 	</span>
+    6 │ </CustomLabel>
+  > 7 │ <CustomLabel aria-label="A label" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/invalid.options.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/valid.html
@@ -1,0 +1,13 @@
+<!-- should not generate diagnostics -->
+<CustomLabel>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel>
+	<span label="A label">
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel for="js_id" label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/valid.html.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<CustomLabel>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel>
+	<span label="A label">
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel for="js_id" label="A label" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/all/valid.options.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/invalid.html
@@ -1,0 +1,6 @@
+<!-- should generate diagnostics -->
+<label>
+	<span>
+		<CustomInput />
+	</span>
+</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/invalid.html.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<label>
+	<span>
+		<CustomInput />
+	</span>
+</label>
+
+```
+
+# Diagnostics
+```
+invalid.html:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label>
+      │ ^^^^^^^
+  > 3 │ 	<span>
+  > 4 │ 		<CustomInput />
+  > 5 │ 	</span>
+  > 6 │ </label>
+      │ ^^^^^^^^
+    7 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/valid.html
@@ -1,0 +1,7 @@
+<!-- should not generate diagnostics -->
+<label>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/valid.html.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<label>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/inputComponents/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/invalid.html
@@ -1,0 +1,8 @@
+<!-- should generate diagnostics -->
+<label for="js_id"></label>
+<label for="js_id"><input /></label>
+<label for="js_id"><textarea></textarea></label>
+<label></label>
+<label>A label</label>
+<div><label></label><input /></div>
+<div><label>A label</label><input /></div>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/invalid.html.snap
@@ -1,0 +1,138 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<label for="js_id"></label>
+<label for="js_id"><input /></label>
+<label for="js_id"><textarea></textarea></label>
+<label></label>
+<label>A label</label>
+<div><label></label><input /></div>
+<div><label>A label</label><input /></div>
+
+```
+
+# Diagnostics
+```
+invalid.html:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label for="js_id"></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ <label for="js_id"><input /></label>
+    4 │ <label for="js_id"><textarea></textarea></label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.html:3:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <label for="js_id"></label>
+  > 3 │ <label for="js_id"><input /></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <label for="js_id"><textarea></textarea></label>
+    5 │ <label></label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.html:4:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    2 │ <label for="js_id"></label>
+    3 │ <label for="js_id"><input /></label>
+  > 4 │ <label for="js_id"><textarea></textarea></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ <label></label>
+    6 │ <label>A label</label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.html:5:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    3 │ <label for="js_id"><input /></label>
+    4 │ <label for="js_id"><textarea></textarea></label>
+  > 5 │ <label></label>
+      │ ^^^^^^^^^^^^^^^
+    6 │ <label>A label</label>
+    7 │ <div><label></label><input /></div>
+  
+  i Consider adding an accessible text content to the label element.
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.html:6:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    4 │ <label for="js_id"><textarea></textarea></label>
+    5 │ <label></label>
+  > 6 │ <label>A label</label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    7 │ <div><label></label><input /></div>
+    8 │ <div><label>A label</label><input /></div>
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.html:7:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    5 │ <label></label>
+    6 │ <label>A label</label>
+  > 7 │ <div><label></label><input /></div>
+      │      ^^^^^^^^^^^^^^^
+    8 │ <div><label>A label</label><input /></div>
+    9 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.html:8:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    6 │ <label>A label</label>
+    7 │ <div><label></label><input /></div>
+  > 8 │ <div><label>A label</label><input /></div>
+      │      ^^^^^^^^^^^^^^^^^^^^^^
+    9 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/invalid.html
@@ -1,0 +1,2 @@
+<!-- should generate diagnostics -->
+<label label="A label"></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/invalid.html.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<label label="A label"></label>
+
+```
+
+# Diagnostics
+```
+invalid.html:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label label="A label"></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/valid.html
@@ -1,0 +1,2 @@
+<!-- should not generate diagnostics -->
+<label for="js_id" label="A label"></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/valid.html.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<label for="js_id" label="A label"></label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelAttributes/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/invalid.html
@@ -1,0 +1,2 @@
+<!-- should generate diagnostics -->
+<CustomLabel aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/invalid.html.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<CustomLabel aria-label="A label" />
+
+```
+
+# Diagnostics
+```
+invalid.html:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <CustomLabel aria-label="A label" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/valid.html
@@ -1,0 +1,2 @@
+<!-- should not generate diagnostics -->
+<CustomLabel for="js_id" aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/valid.html.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<CustomLabel for="js_id" aria-label="A label" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/labelComponents/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/valid.html
@@ -1,0 +1,34 @@
+<!-- should not generate diagnostics -->
+<!-- Always valid -->
+<div></div>
+<CustomElement />
+<input type="hidden" />
+
+<!-- For element -->
+<label for="js_id"><span><span><span>A label</span></span></span></label>
+<label for="js_id" aria-label="A label"></label>
+<label for="js_id" aria-labelledby="A label"></label>
+
+<!-- Nesting valid -->
+<label>A label<input /></label>
+<label>A label<textarea></textarea></label>
+<label><img alt="A label" /><input /></label>
+<label><img aria-label="A label" /><input /></label>
+<label><span>A label<input /></span></label>
+<label><span><span>A label<input /></span></span></label>
+<label><span><span><span>A label<input /></span></span></span></label>
+<label><span><span><span><span>A label</span><input /></span></span></span></label>
+<label><span><span><span><span aria-label="A label"></span><input /></span></span></span></label>
+<label><span><span><span><input aria-label="A label" /></span></span></span></label>
+
+<!-- Other controls -->
+<label>foo<meter></meter></label>
+<label>foo<output></output></label>
+<label>foo<progress></progress></label>
+<label>foo<textarea></textarea></label>
+
+<label for="btn_id"><button id="btn_id">Button</button></label>
+<label>A label<button></button></label>
+
+<button type="button" id="burger">Menu</button>
+<label for="burger">Menu</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/html/valid.html.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<!-- Always valid -->
+<div></div>
+<CustomElement />
+<input type="hidden" />
+
+<!-- For element -->
+<label for="js_id"><span><span><span>A label</span></span></span></label>
+<label for="js_id" aria-label="A label"></label>
+<label for="js_id" aria-labelledby="A label"></label>
+
+<!-- Nesting valid -->
+<label>A label<input /></label>
+<label>A label<textarea></textarea></label>
+<label><img alt="A label" /><input /></label>
+<label><img aria-label="A label" /><input /></label>
+<label><span>A label<input /></span></label>
+<label><span><span>A label<input /></span></span></label>
+<label><span><span><span>A label<input /></span></span></span></label>
+<label><span><span><span><span>A label</span><input /></span></span></span></label>
+<label><span><span><span><span aria-label="A label"></span><input /></span></span></span></label>
+<label><span><span><span><input aria-label="A label" /></span></span></span></label>
+
+<!-- Other controls -->
+<label>foo<meter></meter></label>
+<label>foo<output></output></label>
+<label>foo<progress></progress></label>
+<label>foo<textarea></textarea></label>
+
+<label for="btn_id"><button id="btn_id">Button</button></label>
+<label>A label<button></button></label>
+
+<button type="button" id="burger">Menu</button>
+<label for="burger">Menu</label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/invalid.options.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/invalid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/invalid.svelte
@@ -1,0 +1,7 @@
+<!-- should generate diagnostics -->
+<CustomLabel>
+	<span>
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/invalid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/invalid.svelte.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.svelte
+---
+# Input
+```svelte
+<!-- should generate diagnostics -->
+<CustomLabel>
+	<span>
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel aria-label="A label" />
+
+```
+
+# Diagnostics
+```
+invalid.svelte:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <CustomLabel>
+      │ ^^^^^^^^^^^^^
+  > 3 │ 	<span>
+  > 4 │ 		<CustomInput />
+  > 5 │ 	</span>
+  > 6 │ </CustomLabel>
+      │ ^^^^^^^^^^^^^^
+    7 │ <CustomLabel aria-label="A label" />
+    8 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.svelte:7:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    5 │ 	</span>
+    6 │ </CustomLabel>
+  > 7 │ <CustomLabel aria-label="A label" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/valid.options.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/valid.svelte
@@ -1,0 +1,13 @@
+<!-- should not generate diagnostics -->
+<CustomLabel>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel>
+	<span label="A label">
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel for="js_id" label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/all/valid.svelte.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<CustomLabel>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel>
+	<span label="A label">
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel for="js_id" label="A label" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/invalid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/invalid.svelte
@@ -1,0 +1,6 @@
+<!-- should generate diagnostics -->
+<label>
+	<span>
+		<CustomInput />
+	</span>
+</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/invalid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/invalid.svelte.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.svelte
+---
+# Input
+```svelte
+<!-- should generate diagnostics -->
+<label>
+	<span>
+		<CustomInput />
+	</span>
+</label>
+
+```
+
+# Diagnostics
+```
+invalid.svelte:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label>
+      │ ^^^^^^^
+  > 3 │ 	<span>
+  > 4 │ 		<CustomInput />
+  > 5 │ 	</span>
+  > 6 │ </label>
+      │ ^^^^^^^^
+    7 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/valid.svelte
@@ -1,0 +1,7 @@
+<!-- should not generate diagnostics -->
+<label>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/inputComponents/valid.svelte.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<label>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/invalid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/invalid.svelte
@@ -1,0 +1,8 @@
+<!-- should generate diagnostics -->
+<label for="js_id"></label>
+<label for="js_id"><input /></label>
+<label for="js_id"><textarea></textarea></label>
+<label></label>
+<label>A label</label>
+<div><label></label><input /></div>
+<div><label>A label</label><input /></div>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/invalid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/invalid.svelte.snap
@@ -1,0 +1,138 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.svelte
+---
+# Input
+```svelte
+<!-- should generate diagnostics -->
+<label for="js_id"></label>
+<label for="js_id"><input /></label>
+<label for="js_id"><textarea></textarea></label>
+<label></label>
+<label>A label</label>
+<div><label></label><input /></div>
+<div><label>A label</label><input /></div>
+
+```
+
+# Diagnostics
+```
+invalid.svelte:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label for="js_id"></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ <label for="js_id"><input /></label>
+    4 │ <label for="js_id"><textarea></textarea></label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.svelte:3:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <label for="js_id"></label>
+  > 3 │ <label for="js_id"><input /></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <label for="js_id"><textarea></textarea></label>
+    5 │ <label></label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.svelte:4:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    2 │ <label for="js_id"></label>
+    3 │ <label for="js_id"><input /></label>
+  > 4 │ <label for="js_id"><textarea></textarea></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ <label></label>
+    6 │ <label>A label</label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.svelte:5:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    3 │ <label for="js_id"><input /></label>
+    4 │ <label for="js_id"><textarea></textarea></label>
+  > 5 │ <label></label>
+      │ ^^^^^^^^^^^^^^^
+    6 │ <label>A label</label>
+    7 │ <div><label></label><input /></div>
+  
+  i Consider adding an accessible text content to the label element.
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.svelte:6:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    4 │ <label for="js_id"><textarea></textarea></label>
+    5 │ <label></label>
+  > 6 │ <label>A label</label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    7 │ <div><label></label><input /></div>
+    8 │ <div><label>A label</label><input /></div>
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.svelte:7:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    5 │ <label></label>
+    6 │ <label>A label</label>
+  > 7 │ <div><label></label><input /></div>
+      │      ^^^^^^^^^^^^^^^
+    8 │ <div><label>A label</label><input /></div>
+    9 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.svelte:8:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    6 │ <label>A label</label>
+    7 │ <div><label></label><input /></div>
+  > 8 │ <div><label>A label</label><input /></div>
+      │      ^^^^^^^^^^^^^^^^^^^^^^
+    9 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/invalid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/invalid.svelte
@@ -1,0 +1,2 @@
+<!-- should generate diagnostics -->
+<label label="A label"></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/invalid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/invalid.svelte.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.svelte
+---
+# Input
+```svelte
+<!-- should generate diagnostics -->
+<label label="A label"></label>
+
+```
+
+# Diagnostics
+```
+invalid.svelte:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label label="A label"></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/valid.svelte
@@ -1,0 +1,2 @@
+<!-- should not generate diagnostics -->
+<label for="js_id" label="A label"></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelAttributes/valid.svelte.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<label for="js_id" label="A label"></label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/invalid.html
@@ -1,0 +1,2 @@
+<!-- should generate diagnostics -->
+<CustomLabel aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/invalid.html.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<CustomLabel aria-label="A label" />
+
+```
+
+# Diagnostics
+```
+invalid.html:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <CustomLabel aria-label="A label" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/valid.svelte
@@ -1,0 +1,2 @@
+<!-- should not generate diagnostics -->
+<CustomLabel for="js_id" aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/labelComponents/valid.svelte.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<CustomLabel for="js_id" aria-label="A label" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte
@@ -1,0 +1,34 @@
+<!-- should not generate diagnostics -->
+<!-- Always valid -->
+<div></div>
+<CustomElement />
+<input type="hidden" />
+
+<!-- For element -->
+<label for="js_id"><span><span><span>A label</span></span></span></label>
+<label for="js_id" aria-label="A label"></label>
+<label for="js_id" aria-labelledby="A label"></label>
+
+<!-- Nesting valid -->
+<label>A label<input /></label>
+<label>A label<textarea></textarea></label>
+<label><img alt="A label" /><input /></label>
+<label><img aria-label="A label" /><input /></label>
+<label><span>A label<input /></span></label>
+<label><span><span>A label<input /></span></span></label>
+<label><span><span><span>A label<input /></span></span></span></label>
+<label><span><span><span><span>A label</span><input /></span></span></span></label>
+<label><span><span><span><span aria-label="A label"></span><input /></span></span></span></label>
+<label><span><span><span><input aria-label="A label" /></span></span></span></label>
+
+<!-- Other controls -->
+<label>foo<meter></meter></label>
+<label>foo<output></output></label>
+<label>foo<progress></progress></label>
+<label>foo<textarea></textarea></label>
+
+<label for="btn_id"><button id="btn_id">Button</button></label>
+<label>A label<button></button></label>
+
+<button type="button" id="burger">Menu</button>
+<label for="burger">Menu</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<!-- Always valid -->
+<div></div>
+<CustomElement />
+<input type="hidden" />
+
+<!-- For element -->
+<label for="js_id"><span><span><span>A label</span></span></span></label>
+<label for="js_id" aria-label="A label"></label>
+<label for="js_id" aria-labelledby="A label"></label>
+
+<!-- Nesting valid -->
+<label>A label<input /></label>
+<label>A label<textarea></textarea></label>
+<label><img alt="A label" /><input /></label>
+<label><img aria-label="A label" /><input /></label>
+<label><span>A label<input /></span></label>
+<label><span><span>A label<input /></span></span></label>
+<label><span><span><span>A label<input /></span></span></span></label>
+<label><span><span><span><span>A label</span><input /></span></span></span></label>
+<label><span><span><span><span aria-label="A label"></span><input /></span></span></span></label>
+<label><span><span><span><input aria-label="A label" /></span></span></span></label>
+
+<!-- Other controls -->
+<label>foo<meter></meter></label>
+<label>foo<output></output></label>
+<label>foo<progress></progress></label>
+<label>foo<textarea></textarea></label>
+
+<label for="btn_id"><button id="btn_id">Button</button></label>
+<label>A label<button></button></label>
+
+<button type="button" id="burger">Menu</button>
+<label for="burger">Menu</label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/invalid.options.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/invalid.vue
@@ -1,0 +1,7 @@
+<!-- should generate diagnostics -->
+<CustomLabel>
+	<span>
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/invalid.vue.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<CustomLabel>
+	<span>
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel aria-label="A label" />
+
+```
+
+# Diagnostics
+```
+invalid.vue:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <CustomLabel>
+      │ ^^^^^^^^^^^^^
+  > 3 │ 	<span>
+  > 4 │ 		<CustomInput />
+  > 5 │ 	</span>
+  > 6 │ </CustomLabel>
+      │ ^^^^^^^^^^^^^^
+    7 │ <CustomLabel aria-label="A label" />
+    8 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.vue:7:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    5 │ 	</span>
+    6 │ </CustomLabel>
+  > 7 │ <CustomLabel aria-label="A label" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/valid.options.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/valid.vue
@@ -1,0 +1,13 @@
+<!-- should not generate diagnostics -->
+<CustomLabel>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel>
+	<span label="A label">
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel for="js_id" label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/all/valid.vue.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<CustomLabel>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel>
+	<span label="A label">
+		<CustomInput />
+	</span>
+</CustomLabel>
+<CustomLabel for="js_id" label="A label" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/invalid.vue
@@ -1,0 +1,6 @@
+<!-- should generate diagnostics -->
+<label>
+	<span>
+		<CustomInput />
+	</span>
+</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/invalid.vue.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<label>
+	<span>
+		<CustomInput />
+	</span>
+</label>
+
+```
+
+# Diagnostics
+```
+invalid.vue:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label>
+      │ ^^^^^^^
+  > 3 │ 	<span>
+  > 4 │ 		<CustomInput />
+  > 5 │ 	</span>
+  > 6 │ </label>
+      │ ^^^^^^^^
+    7 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [
+              "CustomInput"
+            ],
+            "labelAttributes": [],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/valid.vue
@@ -1,0 +1,7 @@
+<!-- should not generate diagnostics -->
+<label>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/inputComponents/valid.vue.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<label>
+	<span>
+		A label
+		<CustomInput />
+	</span>
+</label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/invalid.vue
@@ -1,0 +1,8 @@
+<!-- should generate diagnostics -->
+<label for="js_id"></label>
+<label for="js_id"><input /></label>
+<label for="js_id"><textarea></textarea></label>
+<label></label>
+<label>A label</label>
+<div><label></label><input /></div>
+<div><label>A label</label><input /></div>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/invalid.vue.snap
@@ -1,0 +1,138 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<label for="js_id"></label>
+<label for="js_id"><input /></label>
+<label for="js_id"><textarea></textarea></label>
+<label></label>
+<label>A label</label>
+<div><label></label><input /></div>
+<div><label>A label</label><input /></div>
+
+```
+
+# Diagnostics
+```
+invalid.vue:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label for="js_id"></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ <label for="js_id"><input /></label>
+    4 │ <label for="js_id"><textarea></textarea></label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.vue:3:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <label for="js_id"></label>
+  > 3 │ <label for="js_id"><input /></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <label for="js_id"><textarea></textarea></label>
+    5 │ <label></label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.vue:4:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    2 │ <label for="js_id"></label>
+    3 │ <label for="js_id"><input /></label>
+  > 4 │ <label for="js_id"><textarea></textarea></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ <label></label>
+    6 │ <label>A label</label>
+  
+  i Consider adding an accessible text content to the label element.
+  
+
+```
+
+```
+invalid.vue:5:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    3 │ <label for="js_id"><input /></label>
+    4 │ <label for="js_id"><textarea></textarea></label>
+  > 5 │ <label></label>
+      │ ^^^^^^^^^^^^^^^
+    6 │ <label>A label</label>
+    7 │ <div><label></label><input /></div>
+  
+  i Consider adding an accessible text content to the label element.
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.vue:6:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    4 │ <label for="js_id"><textarea></textarea></label>
+    5 │ <label></label>
+  > 6 │ <label>A label</label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    7 │ <div><label></label><input /></div>
+    8 │ <div><label>A label</label><input /></div>
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.vue:7:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    5 │ <label></label>
+    6 │ <label>A label</label>
+  > 7 │ <div><label></label><input /></div>
+      │      ^^^^^^^^^^^^^^^
+    8 │ <div><label>A label</label><input /></div>
+    9 │ 
+  
+  i Consider adding an accessible text content to the label element.
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```
+
+```
+invalid.vue:8:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    6 │ <label>A label</label>
+    7 │ <div><label></label><input /></div>
+  > 8 │ <div><label>A label</label><input /></div>
+      │      ^^^^^^^^^^^^^^^^^^^^^^
+    9 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/invalid.vue
@@ -1,0 +1,2 @@
+<!-- should generate diagnostics -->
+<label label="A label"></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/invalid.vue.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<label label="A label"></label>
+
+```
+
+# Diagnostics
+```
+invalid.vue:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <label label="A label"></label>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [
+              "label"
+            ],
+            "labelComponents": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/valid.vue
@@ -1,0 +1,2 @@
+<!-- should not generate diagnostics -->
+<label for="js_id" label="A label"></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelAttributes/valid.vue.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<label for="js_id" label="A label"></label>
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/invalid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/invalid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/invalid.vue
@@ -1,0 +1,2 @@
+<!-- should generate diagnostics -->
+<CustomLabel aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/invalid.vue.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<CustomLabel aria-label="A label" />
+
+```
+
+# Diagnostics
+```
+invalid.vue:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A form label must be associated with an input.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <CustomLabel aria-label="A label" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Consider adding a "for" attribute to the label element or moving the input element to inside the label element.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/valid.options.json
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/valid.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "a11y": {
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": [],
+            "labelAttributes": [],
+            "labelComponents": [
+              "CustomLabel"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/valid.vue
@@ -1,0 +1,2 @@
+<!-- should not generate diagnostics -->
+<CustomLabel for="js_id" aria-label="A label" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/labelComponents/valid.vue.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<CustomLabel for="js_id" aria-label="A label" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue
@@ -1,0 +1,34 @@
+<!-- should not generate diagnostics -->
+<!-- Always valid -->
+<div></div>
+<CustomElement />
+<input type="hidden" />
+
+<!-- For element -->
+<label for="js_id"><span><span><span>A label</span></span></span></label>
+<label for="js_id" aria-label="A label"></label>
+<label for="js_id" aria-labelledby="A label"></label>
+
+<!-- Nesting valid -->
+<label>A label<input /></label>
+<label>A label<textarea></textarea></label>
+<label><img alt="A label" /><input /></label>
+<label><img aria-label="A label" /><input /></label>
+<label><span>A label<input /></span></label>
+<label><span><span>A label<input /></span></span></label>
+<label><span><span><span>A label<input /></span></span></span></label>
+<label><span><span><span><span>A label</span><input /></span></span></span></label>
+<label><span><span><span><span aria-label="A label"></span><input /></span></span></span></label>
+<label><span><span><span><input aria-label="A label" /></span></span></span></label>
+
+<!-- Other controls -->
+<label>foo<meter></meter></label>
+<label>foo<output></output></label>
+<label>foo<progress></progress></label>
+<label>foo<textarea></textarea></label>
+
+<label for="btn_id"><button id="btn_id">Button</button></label>
+<label>A label<button></button></label>
+
+<button type="button" id="burger">Menu</button>
+<label for="burger">Menu</label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<!-- Always valid -->
+<div></div>
+<CustomElement />
+<input type="hidden" />
+
+<!-- For element -->
+<label for="js_id"><span><span><span>A label</span></span></span></label>
+<label for="js_id" aria-label="A label"></label>
+<label for="js_id" aria-labelledby="A label"></label>
+
+<!-- Nesting valid -->
+<label>A label<input /></label>
+<label>A label<textarea></textarea></label>
+<label><img alt="A label" /><input /></label>
+<label><img aria-label="A label" /><input /></label>
+<label><span>A label<input /></span></label>
+<label><span><span>A label<input /></span></span></label>
+<label><span><span><span>A label<input /></span></span></span></label>
+<label><span><span><span><span>A label</span><input /></span></span></span></label>
+<label><span><span><span><span aria-label="A label"></span><input /></span></span></span></label>
+<label><span><span><span><input aria-label="A label" /></span></span></span></label>
+
+<!-- Other controls -->
+<label>foo<meter></meter></label>
+<label>foo<output></output></label>
+<label>foo<progress></progress></label>
+<label>foo<textarea></textarea></label>
+
+<label for="btn_id"><button id="btn_id">Button</button></label>
+<label>A label<button></button></label>
+
+<button type="button" id="burger">Menu</button>
+<label for="burger">Menu</label>
+
+```

--- a/crates/biome_js_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_label_without_control.rs
@@ -102,10 +102,10 @@ impl Rule for NoLabelWithoutControl {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let options = ctx.options();
+
         let element_name = node.name()?.name_value_token().ok()?;
         let element_name = element_name.text_trimmed();
-        let is_allowed_element = has_element_name(options, element_name)
-            || DEFAULT_LABEL_COMPONENTS.contains(&element_name);
+        let is_allowed_element = has_element_name(options, element_name);
 
         if !is_allowed_element {
             return None;
@@ -158,13 +158,7 @@ fn has_label_attribute(options: &NoLabelWithoutControlOptions, attribute: &JsxAt
         return false;
     };
     let attribute_name = attribute_name.text_trimmed();
-    if !DEFAULT_LABEL_ATTRIBUTES.contains(&attribute_name)
-        && !options
-            .label_attributes
-            .iter()
-            .flatten()
-            .any(|name| name.as_ref() == attribute_name)
-    {
+    if !options.label_attributes().contains(&attribute_name) {
         return false;
     }
     attribute
@@ -229,13 +223,7 @@ fn has_nested_control(options: &NoLabelWithoutControlOptions, jsx_tag: &AnyJsxTa
                         continue;
                     };
                     let element_name = element_name.text_trimmed();
-                    if DEFAULT_INPUT_COMPONENTS.contains(&element_name)
-                        || options
-                            .input_components
-                            .iter()
-                            .flatten()
-                            .any(|name| name.as_ref() == element_name)
-                    {
+                    if options.input_components().contains(&element_name) {
                         return true;
                     }
                 }
@@ -247,11 +235,7 @@ fn has_nested_control(options: &NoLabelWithoutControlOptions, jsx_tag: &AnyJsxTa
 }
 
 fn has_element_name(options: &NoLabelWithoutControlOptions, element_name: &str) -> bool {
-    options
-        .label_components
-        .iter()
-        .flatten()
-        .any(|label_component_name| label_component_name.as_ref() == element_name)
+    options.label_components().contains(&element_name)
 }
 
 pub struct NoLabelWithoutControlState {
@@ -259,15 +243,10 @@ pub struct NoLabelWithoutControlState {
     pub has_control_association: bool,
 }
 
-const DEFAULT_LABEL_ATTRIBUTES: [&str; 3] = ["aria-label", "aria-labelledby", "alt"];
-const DEFAULT_LABEL_COMPONENTS: [&str; 1] = ["label"];
-const DEFAULT_INPUT_COMPONENTS: [&str; 7] = [
-    "input", "meter", "output", "progress", "select", "textarea", "button",
-];
+const FOR_ATTRIBUTES: [&str; 2] = ["for", "htmlFor"];
 
 /// Returns whether the passed `AnyJsxTag` have a `for` or `htmlFor` attribute
 fn has_for_attribute(jsx_tag: &AnyJsxTag) -> bool {
-    let for_attributes = ["for", "htmlFor"];
     let Some(attributes) = jsx_tag.attributes() else {
         return false;
     };
@@ -282,12 +261,12 @@ fn has_for_attribute(jsx_tag: &AnyJsxTag) -> bool {
                     None
                 }
             })
-            .is_some_and(|jsx_name| for_attributes.contains(&jsx_name.text_trimmed())),
+            .is_some_and(|jsx_name| FOR_ATTRIBUTES.contains(&jsx_name.text_trimmed())),
         AnyJsxAttribute::JsxShorthandAttribute(attribute) => attribute
             .name()
             .ok()
             .and_then(|name| name.value_token().ok())
-            .is_some_and(|name| for_attributes.contains(&name.text_trimmed())),
+            .is_some_and(|name| FOR_ATTRIBUTES.contains(&name.text_trimmed())),
         AnyJsxAttribute::JsxSpreadAttribute(_) | AnyJsxAttribute::JsMetavariable(_) => false,
     })
 }

--- a/crates/biome_js_analyze/tests/specs/a11y/noLabelWithoutControl/all/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noLabelWithoutControl/all/invalid.jsx.snap
@@ -38,7 +38,7 @@ invalid.jsx:3:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━�
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ 
   
-  i Consider adding a `for` or `htmlFor` attribute to the label element or moving the input element to inside the label element.
+  i Consider adding a "for" or "htmlFor" attribute to the label element or moving the input element to inside the label element.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noLabelWithoutControl/invalid.jsx.snap
@@ -134,7 +134,7 @@ invalid.jsx:8:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━�
   
   i Consider adding an accessible text content to the label element.
   
-  i Consider adding a `for` or `htmlFor` attribute to the label element or moving the input element to inside the label element.
+  i Consider adding a "for" or "htmlFor" attribute to the label element or moving the input element to inside the label element.
   
 
 ```
@@ -151,7 +151,7 @@ invalid.jsx:9:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━�
     10 │ <div><label /><input /></div>;
     11 │ <div><label>A label</label><input /></div>;
   
-  i Consider adding a `for` or `htmlFor` attribute to the label element or moving the input element to inside the label element.
+  i Consider adding a "for" or "htmlFor" attribute to the label element or moving the input element to inside the label element.
   
 
 ```
@@ -170,7 +170,7 @@ invalid.jsx:10:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━�
   
   i Consider adding an accessible text content to the label element.
   
-  i Consider adding a `for` or `htmlFor` attribute to the label element or moving the input element to inside the label element.
+  i Consider adding a "for" or "htmlFor" attribute to the label element or moving the input element to inside the label element.
   
 
 ```
@@ -186,7 +186,7 @@ invalid.jsx:11:6 lint/a11y/noLabelWithoutControl ━━━━━━━━━━�
        │      ^^^^^^^^^^^^^^^^^^^^^^
     12 │ 
   
-  i Consider adding a `for` or `htmlFor` attribute to the label element or moving the input element to inside the label element.
+  i Consider adding a "for" or "htmlFor" attribute to the label element or moving the input element to inside the label element.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/a11y/noLabelWithoutControl/labelAttributes/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noLabelWithoutControl/labelAttributes/invalid.jsx.snap
@@ -20,7 +20,7 @@ invalid.jsx:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━�
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
     3 │ 
   
-  i Consider adding a `for` or `htmlFor` attribute to the label element or moving the input element to inside the label element.
+  i Consider adding a "for" or "htmlFor" attribute to the label element or moving the input element to inside the label element.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/a11y/noLabelWithoutControl/labelComponents/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noLabelWithoutControl/labelComponents/invalid.jsx.snap
@@ -20,7 +20,7 @@ invalid.jsx:2:1 lint/a11y/noLabelWithoutControl ━━━━━━━━━━�
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     3 │ 
   
-  i Consider adding a `for` or `htmlFor` attribute to the label element or moving the input element to inside the label element.
+  i Consider adding a "for" or "htmlFor" attribute to the label element or moving the input element to inside the label element.
   
 
 ```

--- a/crates/biome_rule_options/src/no_label_without_control.rs
+++ b/crates/biome_rule_options/src/no_label_without_control.rs
@@ -28,3 +28,38 @@ impl biome_deserialize::Merge for NoLabelWithoutControlOptions {
         }
     }
 }
+
+impl NoLabelWithoutControlOptions {
+    const DEFAULT_INPUT_COMPONENTS: [&str; 7] = [
+        "input", "meter", "output", "progress", "select", "textarea", "button",
+    ];
+    const DEFAULT_LABEL_ATTRIBUTES: [&str; 3] = ["aria-label", "aria-labelledby", "alt"];
+    const DEFAULT_LABEL_COMPONENTS: [&str; 1] = ["label"];
+
+    /// Returns [`Self::input_components`] merged with [`Self::DEFAULT_INPUT_COMPONENTS`].
+    pub fn input_components(&self) -> Vec<&str> {
+        let mut result = Self::DEFAULT_INPUT_COMPONENTS.to_vec();
+        if let Some(input) = &self.input_components {
+            result.extend(input.iter().map(|s| s.as_ref()));
+        }
+        result
+    }
+
+    /// Returns [`Self::label_attributes`] merged with [`Self::DEFAULT_LABEL_ATTRIBUTES`].
+    pub fn label_attributes(&self) -> Vec<&str> {
+        let mut result = Self::DEFAULT_LABEL_ATTRIBUTES.to_vec();
+        if let Some(input) = &self.label_attributes {
+            result.extend(input.iter().map(|s| s.as_ref()));
+        }
+        result
+    }
+
+    /// Returns [`Self::label_components`] merged with [`Self::DEFAULT_LABEL_COMPONENTS`].
+    pub fn label_components(&self) -> Vec<&str> {
+        let mut result = Self::DEFAULT_LABEL_COMPONENTS.to_vec();
+        if let Some(input) = &self.label_components {
+            result.extend(input.iter().map(|s| s.as_ref()));
+        }
+        result
+    }
+}


### PR DESCRIPTION
## Summary

Port [noLabelWithoutControl](https://biomejs.dev/linter/rules/no-label-without-control/) to the HTML analyzer

Related #8155 

## Test Plan

Unit tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
