### PR TITLE
fix(organizeImports): doesn't add a blank line between a never-matched group and a matched group

### DIFF
--- a/.changeset/deep-beans-pick.md
+++ b/.changeset/deep-beans-pick.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/)
+that added an extra newline at the start of a file when `:BLANK_LINE:` is used.

--- a/.changeset/deep-beans-pick.md
+++ b/.changeset/deep-beans-pick.md
@@ -2,5 +2,47 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/)
-that added an extra newline at the start of a file when `:BLANK_LINE:` is used.
+Fixed [#9097](https://github.com/biomejs/biome/issues/9097): [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/) no longer adds a blank line between a never-matched group and a matched group.
+
+Given the following `organizeImports` options:
+
+```json
+{
+  "groups": [
+    ":NODE:",
+    ":BLANK_LINE:",
+    ":PACKAGE:",
+    ":BLANK_LINE:",
+    ":PATH:"
+  ]
+}
+```
+
+The following code...
+
+```js
+// Comment
+import "package";
+import "./file.js";
+```
+
+...was organized as:
+
+```diff
++
+  // Comment
+  import "package";
++
+  import "./file.js";
+```
+
+A blank line was added even though the group ':NODE:' doesn't match any imports here.
+`:BLANK_LINE:` between never-matched groups and matched groups are now ignored.
+The code is now organized as:
+
+```diff
+  // Comment
+  import "package";
++
+  import "./file.js";
+```

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -767,7 +767,7 @@ impl Rule for OrganizeImports {
         let sort_order = options.identifier_order.unwrap_or_default();
         let mut chunk: Option<ChunkBuilder> = None;
         let mut prev_kind: Option<JsSyntaxKind> = None;
-        let mut prev_group = 0;
+        let mut prev_group = None;
         for item in root.items() {
             if let Some((info, specifiers, attributes)) = ImportInfo::from_module_item(&item) {
                 let prev_is_distinct = prev_kind.is_some_and(|kind| kind != item.syntax().kind());
@@ -775,11 +775,14 @@ impl Rule for OrganizeImports {
                 if prev_is_distinct || has_detached_leading_comment(item.syntax()) {
                     // The chunk ends, here
                     report_unsorted_chunk(chunk.take(), &mut result);
-                    prev_group = 0;
+                    prev_group = None;
                 }
                 let key = ImportKey::new(info, groups);
-                let blank_line_separated_groups = groups
-                    .is_some_and(|groups| groups.separated_by_blank_line(prev_group, key.group));
+                let blank_line_separated_groups = groups.is_some_and(|groups| {
+                    prev_group.is_some_and(|prev_group| {
+                        groups.separated_by_blank_line(prev_group, key.group)
+                    })
+                });
                 let starts_chunk = chunk.is_none();
                 let leading_newline_count = leading_newlines(item.syntax()).count();
                 let are_specifiers_unsorted =
@@ -825,12 +828,12 @@ impl Rule for OrganizeImports {
                     if chunk.max_key > key || chunk.max_key.is_mergeable(&key) {
                         chunk.slot_indexes.end = key.slot_index + 1;
                     } else {
-                        prev_group = key.group;
+                        prev_group = Some(key.group);
                         chunk.max_key = key;
                     }
                 } else {
                     // New chunk
-                    prev_group = key.group;
+                    prev_group = Some(key.group);
                     chunk = Some(ChunkBuilder::new(key));
                 }
             } else if chunk.is_some() {
@@ -841,7 +844,7 @@ impl Rule for OrganizeImports {
                 //
                 // In any case, the chunk ends here
                 report_unsorted_chunk(chunk.take(), &mut result);
-                prev_group = 0;
+                prev_group = None;
                 // A statement must be separated of a chunk with a blank line
                 if let AnyJsModuleItem::AnyJsStatement(statement) = &item
                     && leading_newlines(statement.syntax()).count() == 1

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/no-leaading-extra-newline.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/no-leaading-extra-newline.js
@@ -1,0 +1,4 @@
+/* should not generate diagnostics */
+import A from "a";
+import "chunked";
+import B from "b";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/no-leaading-extra-newline.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/no-leaading-extra-newline.js.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: no-leaading-extra-newline.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+import A from "a";
+import "chunked";
+import B from "b";
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/no-leaading-extra-newline.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/no-leaading-extra-newline.options.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              ":NODE:",
+              ":BLANK_LINE:"
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/9097.
Fix https://github.com/biomejs/biome/issues/8596.

Given the following configuration...

```json
{
  "assist": {
    "actions": {
      "source": {
        "organizeImports": {
          "level": "on",
          "options": { "groups": [":NODE:", ":BLANK_LINE:", ":PACKAGE:", ":BLANK_LINE:", ":PATH:"] }
        }
      }
    }
  }
}
```

The import organizer was adding two blank lines to the following code:

```diff
+
  // Comment
  import "package";
+
  import "./file.js";
```

A blank line was added even though the group ':NODE:' doesn't match any imports here.
`:BLANK_LINE:` between never-matched groups and matched groups are now ignored.
The code is now organized as:

```diff
  // Comment
  import "package";
+
  import "./file.js";
```

## Test Plan

I added a test

## Docs

I added a changeset.