### PR TITLE
fix(analyzer): skip noAssignInExpressions inside Svelte const blocks

### DIFF
--- a/.changeset/kind-moles-hide.md
+++ b/.changeset/kind-moles-hide.md
@@ -1,0 +1,14 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10082](https://github.com/biomejs/biome/issues/10082): [`noAssignInExpressions`](https://biomejs.dev/linter/rules/no-assign-in-expressions/) no longer flags assignments inside Svelte `{@const name = value}` blocks. Those assignments are declarations scoped to the enclosing block, not accidental side effects.
+
+The following pattern is now considered valid:
+
+```svelte
+{#each items as item}
+  {@const doubled = item * 2}
+  <div>{doubled}</div>
+{/each}
+```

--- a/crates/biome_js_analyze/src/lint/suspicious/no_assign_in_expressions.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_assign_in_expressions.rs
@@ -71,6 +71,12 @@ impl Rule for NoAssignInExpressions {
         if file_source.is_vue_event_handler() {
             return None;
         }
+        // Skip assignments in Svelte `{@const name = value}` blocks.
+        // These are declarations (scoped to the enclosing block), not
+        // accidental uses of `=` in place of a comparison.
+        if file_source.is_svelte_const_block() {
+            return None;
+        }
 
         let assign = ctx.query();
         let mut ancestor = assign

--- a/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/invalid-svelte-interpolation.svelte
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/invalid-svelte-interpolation.svelte
@@ -1,0 +1,6 @@
+<!-- should generate diagnostics -->
+<script>
+  let counter = 0;
+</script>
+
+<p>{counter = counter + 1}</p>

--- a/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/invalid-svelte-interpolation.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/invalid-svelte-interpolation.svelte.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-svelte-interpolation.svelte
+---
+# Input
+```svelte
+<!-- should generate diagnostics -->
+<script>
+  let counter = 0;
+</script>
+
+<p>{counter = counter + 1}</p>
+
+```
+
+# Diagnostics
+```
+invalid-svelte-interpolation.svelte:6:5 lint/suspicious/noAssignInExpressions ━━━━━━━━━━━━━━━━━━━━━━
+
+  × The assignment should not be in an expression.
+  
+    4 │ </script>
+    5 │ 
+  > 6 │ <p>{counter = counter + 1}</p>
+      │     ^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i The use of assignments in expressions is confusing.
+    Expressions are often considered as side-effect free.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const-block.svelte
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const-block.svelte
@@ -1,0 +1,10 @@
+<!-- should not generate diagnostics -->
+<!-- https://github.com/biomejs/biome/issues/10082 -->
+<script>
+  const foo = [1, 2, 3, 4];
+</script>
+
+{#each foo as f}
+  {@const bar = f ** 2}
+  <div>{bar}</div>
+{/each}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const-block.svelte
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const-block.svelte
@@ -2,9 +2,15 @@
 <!-- https://github.com/biomejs/biome/issues/10082 -->
 <script>
   const foo = [1, 2, 3, 4];
+  const enabled = true;
 </script>
 
 {#each foo as f}
-  {@const bar = f ** 2}
-  <div>{bar}</div>
+  {@const doubled = f ** 2}
+  <div>{doubled}</div>
 {/each}
+
+{#if enabled}
+  {@const message = "hello"}
+  <p>{message}</p>
+{/if}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const-block.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const-block.svelte.snap
@@ -8,11 +8,17 @@ expression: valid-svelte-const-block.svelte
 <!-- https://github.com/biomejs/biome/issues/10082 -->
 <script>
   const foo = [1, 2, 3, 4];
+  const enabled = true;
 </script>
 
 {#each foo as f}
-  {@const bar = f ** 2}
-  <div>{bar}</div>
+  {@const doubled = f ** 2}
+  <div>{doubled}</div>
 {/each}
+
+{#if enabled}
+  {@const message = "hello"}
+  <p>{message}</p>
+{/if}
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const-block.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noAssignInExpressions/valid-svelte-const-block.svelte.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-svelte-const-block.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<!-- https://github.com/biomejs/biome/issues/10082 -->
+<script>
+  const foo = [1, 2, 3, 4];
+</script>
+
+{#each foo as f}
+  {@const bar = f ** 2}
+  <div>{bar}</div>
+{/each}
+
+```

--- a/crates/biome_js_parser/tests/spec_test.rs
+++ b/crates/biome_js_parser/tests/spec_test.rs
@@ -88,6 +88,7 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_
         file_source = file_source.with_embedding_kind(biome_js_syntax::EmbeddingKind::Svelte {
             is_source: false,
             is_function_signature: false,
+            const_block: false,
         });
     }
 

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -142,6 +142,11 @@ pub enum EmbeddingKind {
 
         /// Whether this is the declaration of a function, usually declared in `#snippet`
         is_function_signature: bool,
+
+        /// Whether this embed is the expression of a `{@const name = value}`
+        /// block. Those assignments are declarations, not accidental side
+        /// effects, so rules like `noAssignInExpressions` should skip them.
+        const_block: bool,
     },
     #[default]
     None,
@@ -177,6 +182,15 @@ impl EmbeddingKind {
             self,
             Self::Svelte {
                 is_function_signature: true,
+                ..
+            }
+        )
+    }
+    pub const fn is_svelte_const_block(&self) -> bool {
+        matches!(
+            self,
+            Self::Svelte {
+                const_block: true,
                 ..
             }
         )
@@ -273,6 +287,7 @@ impl JsFileSource {
         Self::js_module().with_embedding_kind(EmbeddingKind::Svelte {
             is_source: true,
             is_function_signature: false,
+            const_block: false,
         })
     }
 
@@ -377,6 +392,12 @@ impl JsFileSource {
     /// Returns true if this is a Vue event handler (v-on directive)
     pub const fn is_vue_event_handler(&self) -> bool {
         self.embedding_kind.is_vue_event_handler()
+    }
+
+    /// Returns true if this embed is the expression of a Svelte
+    /// `{@const name = value}` block.
+    pub const fn is_svelte_const_block(&self) -> bool {
+        self.embedding_kind.is_svelte_const_block()
     }
 
     pub const fn as_embedding_kind(&self) -> &EmbeddingKind {

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
@@ -789,6 +789,7 @@ fn parse_matched_embed(
                         js_source = js_source.with_embedding_kind(EmbeddingKind::Svelte {
                             is_source: true,
                             is_function_signature: false,
+                            const_block: false,
                         });
                     } else if ctx.host_file_source.is_vue() {
                         js_source = js_source.with_embedding_kind(EmbeddingKind::Vue {
@@ -808,9 +809,12 @@ fn parse_matched_embed(
                     } else if ctx.host_file_source.is_svelte() {
                         let is_function_signature =
                             matches!(block_kind, EmbedBlockKind::Svelte(SvelteBlockKind::Snippet));
+                        let const_block =
+                            matches!(block_kind, EmbedBlockKind::Svelte(SvelteBlockKind::Const));
                         js_source = js_source.with_embedding_kind(EmbeddingKind::Svelte {
                             is_source: false,
                             is_function_signature,
+                            const_block,
                         });
                     } else if ctx.host_file_source.is_vue() {
                         js_source = js_source.with_embedding_kind(EmbeddingKind::Vue {
@@ -843,6 +847,7 @@ fn parse_matched_embed(
                             js_source = js_source.with_embedding_kind(EmbeddingKind::Svelte {
                                 is_source: false,
                                 is_function_signature: false,
+                                const_block: false,
                             });
                         }
                     }

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -79,6 +79,7 @@ impl SvelteFileHandler {
                         .with_embedding_kind(EmbeddingKind::Svelte {
                             is_source: true,
                             is_function_signature: false,
+                            const_block: false,
                         }),
                 )
             })

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -9650,6 +9650,12 @@ Source-level embeds (`<script>`) use `true`; directives and text expressions use
 	| {
 			Svelte: {
 				/**
+	* Whether this embed is the expression of a `{@const name = value}`
+block. Those assignments are declarations, not accidental side
+effects, so rules like `noAssignInExpressions` should skip them. 
+	 */
+				const_block: boolean;
+				/**
 				 * Whether this is the declaration of a function, usually declared in `#snippet`
 				 */
 				is_function_signature: boolean;


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->
Claude Code assist writing code. I decide design decision and review code.

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #10082.

Mirrors the Vue `v-on` fix from #9164: add a `const_block` flag to `EmbeddingKind::Svelte` so the embed-extraction layer can tell the rule whether the JS originated from a `{@const}` block. The rule short-circuits when the flag is set, exactly like it does for Vue event handlers via `is_vue_event_handler()`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Two fixtures added under `tests/specs/suspicious/noAssignInExpressions/`:

- `valid-svelte-const-block.svelte` — asserts no diagnostic on the issue's exact reproduction.
- `invalid-svelte-interpolation.svelte` — asserts plain `{counter = counter + 1}` still triggers the rule, preventing an over-eager exemption.


## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
