### PR TITLE
fix(analyzer): noDuplicateSelectors false positives with scope at-rule

### DIFF
--- a/.changeset/gentle-bars-drop.md
+++ b/.changeset/gentle-bars-drop.md
@@ -1,0 +1,19 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9997](https://github.com/biomejs/biome/issues/9997): [`noDuplicateSelectors`](https://biomejs.dev/linter/rules/no-duplicate-selectors/) no longer reports false positives for selectors inside `@scope` queries. Biome now treats `@scope` as a separate at-rule context, like `@media`, `@supports`, `@container`, and `@starting-style`.
+
+The following snippet is no longer flagged as a duplicate:
+
+```css
+.Example {
+  padding: 0;
+}
+
+@scope (.theme-dark) {
+  .Example {
+    color: white;
+  }
+}
+```

--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors.rs
@@ -146,6 +146,7 @@ impl Rule for NoDuplicateSelectors {
                         AnyRuleStart::CssMediaAtRule(_)
                             | AnyRuleStart::CssSupportsAtRule(_)
                             | AnyRuleStart::CssContainerAtRule(_)
+                            | AnyRuleStart::CssScopeAtRule(_)
                             | AnyRuleStart::CssStartingStyleAtRule(_)
                     );
 

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectors/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectors/invalid.css
@@ -82,3 +82,9 @@ h3 {
 #main {
   .content {}
 }
+
+/* 16. Duplicate inside the same @scope block */
+@scope (.theme-dark) {
+  .card {}
+  .card {}
+}

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectors/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectors/invalid.css.snap
@@ -89,6 +89,12 @@ h3 {
   .content {}
 }
 
+/* 16. Duplicate inside the same @scope block */
+@scope (.theme-dark) {
+  .card {}
+  .card {}
+}
+
 ```
 
 # Diagnostics
@@ -491,6 +497,34 @@ invalid.css:83:3 lint/nursery/noDuplicateSelectors ━━━━━━━━━�
        │ ^^^^^^^^^^^^^^^^^
     82 │ #main {
     83 │   .content {}
+  
+  i Remove or merge the duplicate rule to keep the stylesheet clean.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.css:89:3 lint/nursery/noDuplicateSelectors ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Duplicate selector list ".card".
+  
+    87 │ @scope (.theme-dark) {
+    88 │   .card {}
+  > 89 │   .card {}
+       │   ^^^^^^^^
+    90 │ }
+    91 │ 
+  
+  i It was first defined here.
+  
+    86 │ /* 16. Duplicate inside the same @scope block */
+    87 │ @scope (.theme-dark) {
+  > 88 │   .card {}
+       │   ^^^^^^^^
+    89 │   .card {}
+    90 │ }
   
   i Remove or merge the duplicate rule to keep the stylesheet clean.
   

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectors/valid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectors/valid.css
@@ -44,3 +44,28 @@
   .child {}
 }
 .other .child {}
+
+/* 9. Same selector inside @scope is NOT a duplicate of the one outside:
+   `@scope` defines its own at-rule context. */
+.Example {
+  padding: 0;
+}
+@scope (.theme-dark) {
+  .Example {
+    color: white;
+  }
+}
+
+/* 10. Same selector in different @scope blocks: each block is its own context. */
+@scope (.theme-dark) {
+  .card {}
+}
+@scope (.theme-light) {
+  .card {}
+}
+
+/* 11. @scope with `to`: inner selector is in its own context. */
+.note {}
+@scope (.doc) to (.footnote) {
+  .note {}
+}

--- a/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectors/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDuplicateSelectors/valid.css.snap
@@ -51,4 +51,29 @@ expression: valid.css
 }
 .other .child {}
 
+/* 9. Same selector inside @scope is NOT a duplicate of the one outside:
+   `@scope` defines its own at-rule context. */
+.Example {
+  padding: 0;
+}
+@scope (.theme-dark) {
+  .Example {
+    color: white;
+  }
+}
+
+/* 10. Same selector in different @scope blocks: each block is its own context. */
+@scope (.theme-dark) {
+  .card {}
+}
+@scope (.theme-light) {
+  .card {}
+}
+
+/* 11. @scope with `to`: inner selector is in its own context. */
+.note {}
+@scope (.doc) to (.footnote) {
+  .note {}
+}
+
 ```

--- a/crates/biome_css_semantic/src/events.rs
+++ b/crates/biome_css_semantic/src/events.rs
@@ -65,6 +65,7 @@ impl SemanticEventExtractor {
                 || kind == CSS_NESTED_QUALIFIED_RULE
                 || kind == CSS_CONTAINER_AT_RULE
                 || kind == CSS_MEDIA_AT_RULE
+                || kind == CSS_SCOPE_AT_RULE
                 || kind == CSS_STARTING_STYLE_AT_RULE
                 || kind == CSS_SUPPORTS_AT_RULE =>
             {
@@ -278,6 +279,7 @@ impl SemanticEventExtractor {
                 | CSS_NESTED_QUALIFIED_RULE
                 | CSS_CONTAINER_AT_RULE
                 | CSS_MEDIA_AT_RULE
+                | CSS_SCOPE_AT_RULE
                 | CSS_STARTING_STYLE_AT_RULE
                 | CSS_SUPPORTS_AT_RULE
         ) {

--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -53,7 +53,9 @@ impl SemanticModelBuilder {
                     let typed_node = rule.node.to_node(self.root.syntax());
                     if matches!(
                         typed_node,
-                        AnyRuleStart::CssMediaAtRule(_) | AnyRuleStart::CssSupportsAtRule(_)
+                        AnyRuleStart::CssMediaAtRule(_)
+                            | AnyRuleStart::CssScopeAtRule(_)
+                            | AnyRuleStart::CssSupportsAtRule(_)
                     ) {
                         current_parent_id = iterator
                             .next()
@@ -86,7 +88,9 @@ impl SemanticModelBuilder {
                     let typed_node = rule.node.to_node(self.root.syntax());
                     if matches!(
                         typed_node,
-                        AnyRuleStart::CssMediaAtRule(_) | AnyRuleStart::CssSupportsAtRule(_)
+                        AnyRuleStart::CssMediaAtRule(_)
+                            | AnyRuleStart::CssScopeAtRule(_)
+                            | AnyRuleStart::CssSupportsAtRule(_)
                     ) {
                         current_parent_id = iterator
                             .next()

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -1,7 +1,7 @@
 use biome_css_syntax::{
     AnyCssRoot, CssComplexSelector, CssComposesPropertyValue, CssCompoundSelector,
     CssContainerAtRule, CssDashedIdentifier, CssDeclaration, CssGenericComponentValueList,
-    CssIdentifier, CssMediaAtRule, CssNestedQualifiedRule, CssQualifiedRule,
+    CssIdentifier, CssMediaAtRule, CssNestedQualifiedRule, CssQualifiedRule, CssScopeAtRule,
     CssStartingStyleAtRule, CssSupportsAtRule, CssSyntaxKind, CssSyntaxToken, ScssExpression,
 };
 use biome_rowan::{
@@ -174,7 +174,7 @@ impl Rule {
 }
 
 declare_node_union! {
-    pub AnyRuleStart = CssQualifiedRule | CssNestedQualifiedRule | CssContainerAtRule | CssMediaAtRule | CssStartingStyleAtRule | CssSupportsAtRule
+    pub AnyRuleStart = CssQualifiedRule | CssNestedQualifiedRule | CssContainerAtRule | CssMediaAtRule | CssScopeAtRule | CssStartingStyleAtRule | CssSupportsAtRule
 }
 
 impl AnyRuleStart {
@@ -184,6 +184,7 @@ impl AnyRuleStart {
             Self::CssNestedQualifiedRule(node) => node.syntax().text_trimmed_range(),
             Self::CssContainerAtRule(node) => node.syntax().text_trimmed_range(),
             Self::CssMediaAtRule(node) => node.syntax().text_trimmed_range(),
+            Self::CssScopeAtRule(node) => node.syntax().text_trimmed_range(),
             Self::CssStartingStyleAtRule(node) => node.syntax().text_trimmed_range(),
             Self::CssSupportsAtRule(node) => node.syntax().text_trimmed_range(),
         }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->
Claude Code assist to writing code. I decide it and review code.

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #9997.

`noDuplicateSelectors` flagged identical selectors across `@scope` boundaries because `CssScopeAtRule` was not registered as a rule-context boundary in the CSS semantic model. Added `CssScopeAtRule` to `AnyRuleStart`, the event extractor, the parent-selector skip list, and the rule's `is_at_rule` check, mirroring how `@media` / `@supports` / `@container` / `@starting-style` are handled.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added cases to the rule's existing `valid.css` and `invalid.css` snapshot tests:

- valid: `@scope` outside vs inside, two different `@scope` blocks, `@scope ... to (...)`.
- invalid: same selector duplicated within the same `@scope` block.


<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
