### PR TITLE
fix(10024): eslint generation

### DIFF
--- a/.changeset/weak-kiwis-post.md
+++ b/.changeset/weak-kiwis-post.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10024](https://github.com/biomejs/biome/issues/10024): `biome migrate eslint` now correctly maps a single Eslint rule to multiple Biome rules (if applicable).
+Fixed [#10024](https://github.com/biomejs/biome/issues/10024): `biome migrate eslint` correctly migrates `eslint` rules that belong to multiple Biome rules.

--- a/.changeset/weak-kiwis-post.md
+++ b/.changeset/weak-kiwis-post.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10024](https://github.com/biomejs/biome/issues/10024): `biome migrate eslint` now correctly maps a single Eslint rule to multiple Biome rules (if applicable).

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -630,20 +630,50 @@ pub(crate) fn migrate_eslint_any_rule(
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/explicit-function-return-type" => {
-            if !options.include_inspired {
-                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+            let mut migrated = false;
+            {
+                let mut blocked = false;
+                if !options.include_inspired {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                    blocked = true;
+                }
+                if !options.include_nursery {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                    blocked = true;
+                }
+                if !blocked {
+                    let group = rules.nursery.get_or_insert_with(Default::default);
+                    let rule = group
+                        .unwrap_group_as_mut()
+                        .use_explicit_return_type
+                        .get_or_insert(Default::default());
+                    rule.set_level(rule.level().max(rule_severity.into()));
+                    migrated = true;
+                }
+            }
+            {
+                let mut blocked = false;
+                if !options.include_inspired {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                    blocked = true;
+                }
+                if !options.include_nursery {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                    blocked = true;
+                }
+                if !blocked {
+                    let group = rules.nursery.get_or_insert_with(Default::default);
+                    let rule = group
+                        .unwrap_group_as_mut()
+                        .use_explicit_type
+                        .get_or_insert(Default::default());
+                    rule.set_level(rule.level().max(rule_severity.into()));
+                    migrated = true;
+                }
+            }
+            if !migrated {
                 return false;
             }
-            if !options.include_nursery {
-                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
-                return false;
-            }
-            let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group
-                .unwrap_group_as_mut()
-                .use_explicit_type
-                .get_or_insert(Default::default());
-            rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/explicit-member-accessibility" => {
             let group = rules.style.get_or_insert_with(Default::default);
@@ -1554,16 +1584,46 @@ pub(crate) fn migrate_eslint_any_rule(
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "e18e/prefer-spread-syntax" => {
-            if !options.include_inspired {
-                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+            let mut migrated = false;
+            {
+                let mut blocked = false;
+                if !options.include_inspired {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                    blocked = true;
+                }
+                if !options.include_nursery {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                    blocked = true;
+                }
+                if !blocked {
+                    let group = rules.nursery.get_or_insert_with(Default::default);
+                    let rule = group
+                        .unwrap_group_as_mut()
+                        .use_spread
+                        .get_or_insert(Default::default());
+                    rule.set_level(rule.level().max(rule_severity.into()));
+                    migrated = true;
+                }
+            }
+            {
+                let mut blocked = false;
+                if !options.include_inspired {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                    blocked = true;
+                }
+                if !blocked {
+                    let group = rules.style.get_or_insert_with(Default::default);
+                    let rule = group
+                        .unwrap_group_as_mut()
+                        .use_object_spread
+                        .get_or_insert(Default::default());
+                    rule.set_level(rule.level().max(rule_severity.into()));
+                    migrated = true;
+                }
+            }
+            if !migrated {
                 return false;
             }
-            let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group
-                .unwrap_group_as_mut()
-                .use_object_spread
-                .get_or_insert(Default::default());
-            rule.set_level(rule.level().max(rule_severity.into()));
         }
         "eqeqeq" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);

--- a/crates/biome_cli/tests/specs/migrate_eslint/typescriptExplicitFunctionReturnType/basic.jsonc
+++ b/crates/biome_cli/tests/specs/migrate_eslint/typescriptExplicitFunctionReturnType/basic.jsonc
@@ -1,0 +1,8 @@
+{
+  "biome": {},
+  "eslint": {
+    "rules": {
+      "@typescript-eslint/explicit-function-return-type": "error"
+    }
+  }
+}

--- a/crates/biome_cli/tests/specs/migrate_eslint/typescriptExplicitFunctionReturnType/basic.jsonc.snap
+++ b/crates/biome_cli/tests/specs/migrate_eslint/typescriptExplicitFunctionReturnType/basic.jsonc.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+expression: basic.jsonc
+---
+## ESLint Config
+
+```json
+{ "rules": { "@typescript-eslint/explicit-function-return-type": "error" } }
+
+```
+
+## Biome Config Before Migration
+
+```json
+{}
+
+```
+
+## Biome Config After Migration
+
+```json
+{
+	"linter": {
+		"rules": {
+			"recommended": false,
+			"nursery": {
+				"useExplicitReturnType": "error",
+				"useExplicitType": "error"
+			}
+		}
+	}
+}
+
+```

--- a/crates/biome_html_analyze/src/lint/a11y/no_access_key.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_access_key.rs
@@ -42,7 +42,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "noAccessKey",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("no-access-key").same(), RuleSource::HtmlEslint("no-accesskey-attrs").same()],
+        sources: &[RuleSource::EslintJsxA11y("no-access-key").inspired(), RuleSource::HtmlEslint("no-accesskey-attrs").same()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
@@ -41,7 +41,7 @@ declare_lint_rule! {
         version: "1.0.0",
         name: "noAccessKey",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("no-access-key").same()],
+        sources: &[RuleSource::EslintJsxA11y("no-access-key").same(), RuleSource::HtmlEslint("no-accesskey-attrs").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/xtask/codegen/src/generate_migrate_eslint.rs
+++ b/xtask/codegen/src/generate_migrate_eslint.rs
@@ -1,13 +1,128 @@
 use biome_analyze::{
-    GroupCategory, Queryable, RegistryVisitor, Rule, RuleCategory, RuleGroup, RuleMetadata,
-    RuleSourceKind, RuleSourceWithKind,
+    GroupCategory, Queryable, RegistryVisitor, Rule, RuleCategory, RuleGroup, RuleSourceKind,
+    RuleSourceWithKind,
 };
 use biome_rowan::syntax::Language;
 use biome_string_case::Case;
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::BTreeMap;
 use xtask_codegen::update;
 use xtask_glue::*;
+
+fn generate_multi_mapping(eslint_name: Box<str>, mapped_rules: Vec<RuleMapping>) -> TokenStream {
+    let rules = mapped_rules.iter().map(|RuleMapping{source_kind, rule_name, group_name}| {
+        let name_ident = format_ident!("{}", Case::Snake.convert(rule_name));
+        let group_ident = format_ident!("{group_name}");
+        let blocked_set = if source_kind.is_inspired() || *group_name == "nursery" {
+            quote! {
+                let mut blocked = false;
+            }
+        } else {
+            quote! {}
+        };
+        let check_inspired = if source_kind.is_inspired() {
+            quote! {
+                if !options.include_inspired {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                    blocked = true;
+                }
+            }
+        } else {
+            quote! {}
+        };
+        let check_nursery = if *group_name == "nursery" {
+            quote! {
+                if !options.include_nursery {
+                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                    blocked = true;
+                }
+            }
+        } else {
+            quote! {}
+        };
+        let migrate = if source_kind.is_inspired() || *group_name == "nursery" {
+            quote! {
+                if !blocked {
+                    let group = rules.#group_ident.get_or_insert_with(Default::default);
+                    let rule = group.unwrap_group_as_mut().#name_ident.get_or_insert(Default::default());
+                    rule.set_level(rule.level().max(rule_severity.into()));
+                    migrated = true;
+                }
+            }
+        } else {
+            quote! {
+                let group = rules.#group_ident.get_or_insert_with(Default::default);
+                let rule = group.unwrap_group_as_mut().#name_ident.get_or_insert(Default::default());
+                rule.set_level(rule.level().max(rule_severity.into()));
+                migrated = true;
+            }
+        };
+
+        quote! {
+            {
+                #blocked_set
+                #check_inspired
+                #check_nursery
+                #migrate
+            }
+        }
+    });
+
+    quote! {
+        #eslint_name => {
+            let mut migrated = false;
+            #( #rules )*
+            if !migrated {
+                return false;
+            }
+        }
+    }
+}
+
+fn generate_single_mapping(eslint_name: Box<str>, mapped_rules: Vec<RuleMapping>) -> TokenStream {
+    let Some(RuleMapping {
+        source_kind,
+        rule_name,
+        group_name,
+    }) = mapped_rules.first()
+    else {
+        return quote! {};
+    };
+
+    let name_ident = format_ident!("{}", Case::Snake.convert(rule_name));
+    let group_ident = format_ident!("{group_name}");
+    let check_inspired = if source_kind.is_inspired() {
+        quote! {
+            if !options.include_inspired {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                return false;
+            }
+        }
+    } else {
+        quote! {}
+    };
+    let check_nursery = if *group_name == "nursery" {
+        quote! {
+            if !options.include_nursery {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                return false;
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    quote! {
+        #eslint_name => {
+            #check_inspired
+            #check_nursery
+            let group = rules.#group_ident.get_or_insert_with(Default::default);
+            let rule = group.unwrap_group_as_mut().#name_ident.get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
+    }
+}
 
 pub(crate) fn generate_migrate_eslint(mode: Mode) -> Result<()> {
     let mut visitor = EslintLintRulesVisitor::default();
@@ -17,38 +132,15 @@ pub(crate) fn generate_migrate_eslint(mode: Mode) -> Result<()> {
     biome_css_analyze::visit_registry(&mut visitor);
     biome_html_analyze::visit_registry(&mut visitor);
     let mut lines = Vec::with_capacity(visitor.0.len());
-    for ((eslint_name, source_kind), (group_name, rule_metadata)) in visitor.0 {
-        let name = rule_metadata.name;
-        let name_ident = format_ident!("{}", Case::Snake.convert(name));
-        let group_ident = format_ident!("{group_name}");
-        let check_inspired = if source_kind.is_inspired() {
-            quote! {
-                if !options.include_inspired {
-                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
-                    return false;
-                }
-            }
+    for (eslint_name, mapped_rules) in visitor.0 {
+        if mapped_rules.is_empty() {
+            continue;
+        }
+
+        lines.push(if mapped_rules.len() > 1 {
+            generate_multi_mapping(eslint_name, mapped_rules)
         } else {
-            quote! {}
-        };
-        let check_nursery = if group_name == "nursery" {
-            quote! {
-                if !options.include_nursery {
-                    results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
-                    return false;
-                }
-            }
-        } else {
-            quote! {}
-        };
-        lines.push(quote! {
-            #eslint_name => {
-                #check_inspired
-                #check_nursery
-                let group = rules.#group_ident.get_or_insert_with(Default::default);
-                let rule = group.unwrap_group_as_mut().#name_ident.get_or_insert(Default::default());
-                rule.set_level(rule.level().max(rule_severity.into()));
-            }
+            generate_single_mapping(eslint_name, mapped_rules)
         });
     }
     let tokens = xtask_glue::reformat(quote! {
@@ -78,7 +170,14 @@ pub(crate) fn generate_migrate_eslint(mode: Mode) -> Result<()> {
 }
 
 #[derive(Default)]
-struct EslintLintRulesVisitor(BTreeMap<(Box<str>, RuleSourceKind), (&'static str, RuleMetadata)>);
+struct EslintLintRulesVisitor(BTreeMap<Box<str>, Vec<RuleMapping>>);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RuleMapping {
+    group_name: &'static str,
+    rule_name: &'static str,
+    source_kind: RuleSourceKind,
+}
 
 impl<L: Language> RegistryVisitor<L> for EslintLintRulesVisitor {
     fn record_category<C: GroupCategory<Language = L>>(&mut self) {
@@ -93,11 +192,29 @@ impl<L: Language> RegistryVisitor<L> for EslintLintRulesVisitor {
         <R::Query as Queryable>::Output: Clone,
     {
         for RuleSourceWithKind { kind, source } in R::METADATA.sources {
-            if source.is_eslint() || source.is_eslint_plugin() {
-                self.0.insert(
-                    (source.to_namespaced_rule_name().into_boxed_str(), *kind),
-                    (<R::Group as RuleGroup>::NAME, R::METADATA),
-                );
+            if !source.is_eslint() && !source.is_eslint_plugin() {
+                continue;
+            }
+
+            let mapped_rules = self
+                .0
+                .entry(source.to_namespaced_rule_name().into_boxed_str())
+                .or_default();
+
+            let existing = mapped_rules
+                .iter_mut()
+                .find(|mapped_rule| mapped_rule.rule_name == R::METADATA.name);
+
+            if let Some(existing) = existing {
+                if existing.source_kind.is_inspired() && !kind.is_inspired() {
+                    existing.source_kind = *kind;
+                }
+            } else {
+                mapped_rules.push(RuleMapping {
+                    source_kind: *kind,
+                    group_name: <R::Group as RuleGroup>::NAME,
+                    rule_name: R::METADATA.name,
+                });
             }
         }
     }


### PR DESCRIPTION
## Summary

- Support migrating a single Eslint rule to multiple Biome rules (if there are multiple sources) 
- Correctly generate the mapping file if the same Eslint source is mentioned as inspired & same in the same Biome rule, but different language analyzers. Prefer same over inspired

Closes #10024 

Ref [Discord](https://discord.com/channels/1132231889290285117/1132602754276274216/1496993681327263854)

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
