### PR TITLE
fix: align HTML & JS a11y sources

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -357,6 +357,26 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "@html-eslint/no-aria-hidden-on-focusable" => {
+            if !options.include_inspired {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                return false;
+            }
+            let group = rules.a11y.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_aria_hidden_on_focusable
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
+        "@html-eslint/no-aria-hidden-on-focusable\t" => {
+            let group = rules.a11y.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_aria_hidden_on_focusable
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
         "@html-eslint/no-duplicate-attrs" => {
             if !options.include_nursery {
                 results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
@@ -389,6 +409,14 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "@html-eslint/no-invalid-role" => {
+            let group = rules.a11y.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_valid_aria_role
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
         "@html-eslint/no-positive-tabindex" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
@@ -410,6 +438,14 @@ pub(crate) fn migrate_eslint_any_rule(
             let rule = group
                 .unwrap_group_as_mut()
                 .use_button_type
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
+        "@html-eslint/require-frame-title" => {
+            let group = rules.a11y.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_iframe_title
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -358,18 +358,6 @@ pub(crate) fn migrate_eslint_any_rule(
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@html-eslint/no-aria-hidden-on-focusable" => {
-            if !options.include_inspired {
-                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
-                return false;
-            }
-            let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group
-                .unwrap_group_as_mut()
-                .no_aria_hidden_on_focusable
-                .get_or_insert(Default::default());
-            rule.set_level(rule.level().max(rule_severity.into()));
-        }
-        "@html-eslint/no-aria-hidden-on-focusable\t" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
                 .unwrap_group_as_mut()

--- a/crates/biome_html_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
@@ -51,7 +51,7 @@ declare_lint_rule! {
         version: "next",
         name: "noAriaHiddenOnFocusable",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("no-aria-hidden-on-focusable").same()],
+        sources: &[RuleSource::EslintJsxA11y("no-aria-hidden-on-focusable").inspired(), RuleSource::HtmlEslint("no-aria-hidden-on-focusable").same()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
@@ -42,7 +42,7 @@ declare_lint_rule! {
         version: "next",
         name: "noAriaUnsupportedElements",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("aria-unsupported-elements").same()],
+        sources: &[RuleSource::EslintJsxA11y("aria-unsupported-elements").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/no_autofocus.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_autofocus.rs
@@ -58,7 +58,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "noAutofocus",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("no-autofocus").same()],
+        sources: &[RuleSource::EslintJsxA11y("no-autofocus").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/no_distracting_elements.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_distracting_elements.rs
@@ -43,7 +43,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "noDistractingElements",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("no-distracting-elements").same()],
+        sources: &[RuleSource::EslintJsxA11y("no-distracting-elements").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/no_header_scope.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_header_scope.rs
@@ -44,7 +44,7 @@ declare_lint_rule! {
         version: "2.3.0",
         name: "noHeaderScope",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("scope").same()],
+        sources: &[RuleSource::EslintJsxA11y("scope").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
@@ -1,4 +1,6 @@
-use biome_analyze::{FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_analyze::{
+    FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+};
 use biome_aria_metadata::AriaRole;
 use biome_console::markup;
 use biome_diagnostics::Severity;
@@ -41,6 +43,7 @@ declare_lint_rule! {
         version: "next",
         name: "noInteractiveElementToNoninteractiveRole",
         language: "html",
+        sources: &[RuleSource::EslintJsxA11y("no-interactive-element-to-noninteractive-role").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
@@ -77,7 +77,7 @@ declare_lint_rule! {
         version: "next",
         name: "noLabelWithoutControl",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("label-has-associated-control").same()],
+        sources: &[RuleSource::EslintJsxA11y("label-has-associated-control").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/no_noninteractive_element_interactions.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_noninteractive_element_interactions.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_html_syntax::element_ext::AnyHtmlTagElement;
 use biome_rowan::AstNode;
@@ -70,6 +70,7 @@ declare_lint_rule! {
         version: "next",
         name: "noNoninteractiveElementInteractions",
         language: "html",
+        sources: &[RuleSource::EslintJsxA11y("no-noninteractive-element-interactions").inspired()],
         recommended: false,
     }
 }

--- a/crates/biome_html_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
@@ -1,4 +1,6 @@
-use biome_analyze::{FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_analyze::{
+    FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+};
 use biome_aria_metadata::AriaRole;
 use biome_console::markup;
 use biome_diagnostics::Severity;
@@ -50,6 +52,7 @@ declare_lint_rule! {
         version: "next",
         name: "noNoninteractiveElementToInteractiveRole",
         language: "html",
+        sources: &[RuleSource::EslintJsxA11y("no-noninteractive-element-to-interactive-role").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
@@ -50,7 +50,7 @@ declare_lint_rule! {
         version: "next",
         name: "noNoninteractiveTabindex",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("no-noninteractive-tabindex").same()],
+        sources: &[RuleSource::EslintJsxA11y("no-noninteractive-tabindex").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
@@ -143,4 +143,3 @@ impl Rule for NoNoninteractiveTabindex {
 fn is_negative_tabindex(number_like_string: &str) -> bool {
     matches!(number_like_string.trim().parse::<i64>(), Ok(n) if n < 0)
 }
-

--- a/crates/biome_html_analyze/src/lint/a11y/no_positive_tabindex.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_positive_tabindex.rs
@@ -44,7 +44,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "noPositiveTabindex",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("tabindex-no-positive").same(), RuleSource::HtmlEslint("no-positive-tabindex").same()],
+        sources: &[RuleSource::EslintJsxA11y("tabindex-no-positive").inspired(), RuleSource::HtmlEslint("no-positive-tabindex").same()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/no_redundant_alt.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_redundant_alt.rs
@@ -42,7 +42,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "noRedundantAlt",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("img-redundant-alt").same()],
+        sources: &[RuleSource::EslintJsxA11y("img-redundant-alt").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/no_redundant_roles.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_redundant_roles.rs
@@ -52,7 +52,7 @@ declare_lint_rule! {
         version: "next",
         name: "noRedundantRoles",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("no-redundant-roles").same(), RuleSource::HtmlEslint("no-redundant-role").same()],
+        sources: &[RuleSource::EslintJsxA11y("no-redundant-roles").inspired(), RuleSource::HtmlEslint("no-redundant-role").same()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/no_static_element_interactions.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_static_element_interactions.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_html_syntax::element_ext::AnyHtmlTagElement;
@@ -53,6 +53,7 @@ declare_lint_rule! {
         version: "next",
         name: "noStaticElementInteractions",
         language: "html",
+        sources: &[RuleSource::EslintJsxA11y("no-static-element-interactions").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/no_svg_without_title.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_svg_without_title.rs
@@ -5,8 +5,8 @@ use biome_html_syntax::{AnyHtmlElement, HtmlAttribute, HtmlElementList, HtmlFile
 use biome_rowan::AstNode;
 use biome_rule_options::no_svg_without_title::NoSvgWithoutTitleOptions;
 
-use crate::{a11y::is_aria_hidden_true, utils::is_html_tag};
 use crate::Aria;
+use crate::{a11y::is_aria_hidden_true, utils::is_html_tag};
 
 declare_lint_rule! {
     /// Enforces the usage of the `title` element for the `svg` element.

--- a/crates/biome_html_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_alt_text.rs
@@ -86,7 +86,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "useAltText",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("alt-text").same(), RuleSource::HtmlEslint("require-img-alt").same()],
+        sources: &[RuleSource::EslintJsxA11y("alt-text").inspired(), RuleSource::HtmlEslint("require-img-alt").same()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
@@ -83,7 +83,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "useAnchorContent",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("anchor-has-content").same()],
+        sources: &[RuleSource::EslintJsxA11y("anchor-has-content").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
@@ -58,7 +58,7 @@ declare_lint_rule! {
         version: "next",
         name: "useAriaActivedescendantWithTabindex",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("aria-activedescendant-has-tabindex").same()],
+        sources: &[RuleSource::EslintJsxA11y("aria-activedescendant-has-tabindex").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_aria_props_for_role.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_aria_props_for_role.rs
@@ -49,7 +49,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "useAriaPropsForRole",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("role-has-required-aria-props").same()],
+        sources: &[RuleSource::EslintJsxA11y("role-has-required-aria-props").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_aria_props_supported_by_role.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_aria_props_supported_by_role.rs
@@ -1,5 +1,5 @@
 use crate::services::aria::Aria;
-use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_aria_metadata::{AriaAttribute, AriaRole};
 use biome_console::markup;
 use biome_diagnostics::Severity;
@@ -37,6 +37,7 @@ declare_lint_rule! {
         version: "next",
         name: "useAriaPropsSupportedByRole",
         language: "html",
+        sources: &[RuleSource::EslintJsxA11y("role-supports-aria-props").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_button_type.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_button_type.rs
@@ -34,7 +34,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "useButtonType",
         language: "html",
-        sources: &[RuleSource::EslintReact("button-has-type").same(), RuleSource::HtmlEslint("require-button-type").same()],
+        sources: &[RuleSource::EslintReact("button-has-type").inspired(), RuleSource::EslintReactDom("no-missing-button-type").inspired(), RuleSource::EslintReactXyz("dom-no-missing-button-type").inspired(), RuleSource::HtmlEslint("require-button-type").same()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_focusable_interactive.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_focusable_interactive.rs
@@ -1,4 +1,4 @@
-use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_aria_metadata::AriaRole;
 use biome_console::markup;
 use biome_diagnostics::Severity;
@@ -43,6 +43,7 @@ declare_lint_rule! {
         version: "next",
         name: "useFocusableInteractive",
         language: "html",
+        sources: &[RuleSource::EslintJsxA11y("interactive-supports-focus").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
@@ -67,7 +67,7 @@ declare_lint_rule! {
         version: "next",
         name: "useHeadingContent",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("heading-has-content").same(), RuleSource::HtmlEslint("no-empty-headings").same()],
+    sources: &[RuleSource::EslintJsxA11y("heading-has-content").inspired(), RuleSource::HtmlEslint("no-empty-headings").same()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_html_lang.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_html_lang.rs
@@ -38,7 +38,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "useHtmlLang",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("html-has-lang").same(), RuleSource::HtmlEslint("require-lang").same()],
+        sources: &[RuleSource::EslintJsxA11y("html-has-lang").inspired(), RuleSource::HtmlEslint("require-lang").same()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_iframe_title.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_iframe_title.rs
@@ -45,7 +45,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "useIframeTitle",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("iframe-has-title").same()],
+        sources: &[RuleSource::EslintJsxA11y("iframe-has-title").inspired(), RuleSource::HtmlEslint("require-frame-title").same()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_key_with_click_events.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_key_with_click_events.rs
@@ -57,7 +57,7 @@ declare_lint_rule! {
         version: "next",
         name: "useKeyWithClickEvents",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("click-events-have-key-events").same()],
+        sources: &[RuleSource::EslintJsxA11y("click-events-have-key-events").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_key_with_mouse_events.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_key_with_mouse_events.rs
@@ -54,7 +54,7 @@ declare_lint_rule! {
         version: "next",
         name: "useKeyWithMouseEvents",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("mouse-events-have-key-events").same()],
+        sources: &[RuleSource::EslintJsxA11y("mouse-events-have-key-events").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_media_caption.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_media_caption.rs
@@ -64,7 +64,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "useMediaCaption",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("media-has-caption").same()],
+        sources: &[RuleSource::EslintJsxA11y("media-has-caption").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_semantic_elements.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_semantic_elements.rs
@@ -56,7 +56,7 @@ declare_lint_rule! {
         version: "next",
         name: "useSemanticElements",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("prefer-tag-over-role").same()],
+        sources: &[RuleSource::EslintJsxA11y("prefer-tag-over-role").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -65,7 +65,7 @@ declare_lint_rule! {
         version: "next",
         name: "useValidAnchor",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("anchor-is-valid").same(), RuleSource::EslintQwik("jsx-a").same()],
+        sources: &[RuleSource::EslintJsxA11y("anchor-is-valid").inspired(), RuleSource::EslintQwik("jsx-a").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_props.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_props.rs
@@ -41,7 +41,7 @@ declare_lint_rule! {
         version: "next",
         name: "useValidAriaProps",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("aria-props").same()],
+        sources: &[RuleSource::EslintJsxA11y("aria-props").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_role.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_role.rs
@@ -73,7 +73,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "useValidAriaRole",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("aria-role").same()],
+        sources: &[RuleSource::EslintJsxA11y("aria-role").inspired(), RuleSource::HtmlEslint("no-invalid-role").same()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_values.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_values.rs
@@ -49,7 +49,7 @@ declare_lint_rule! {
         version: "next",
         name: "useValidAriaValues",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("aria-proptypes").same()],
+        sources: &[RuleSource::EslintJsxA11y("aria-proptypes").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_autocomplete.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_autocomplete.rs
@@ -1,4 +1,6 @@
-use biome_analyze::{Ast, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_analyze::{
+    Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_html_syntax::{HtmlFileSource, element_ext::AnyHtmlTagElement};
@@ -54,6 +56,7 @@ declare_lint_rule! {
         version: "next",
         name: "useValidAutocomplete",
         language: "html",
+        sources: &[RuleSource::EslintJsxA11y("autocomplete-valid").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_lang.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_lang.rs
@@ -38,7 +38,7 @@ declare_lint_rule! {
         version: "2.4.0",
         name: "useValidLang",
         language: "html",
-        sources: &[RuleSource::EslintJsxA11y("lang").same()],
+        sources: &[RuleSource::EslintJsxA11y("lang").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
@@ -51,7 +51,7 @@ declare_lint_rule! {
         version: "1.4.0",
         name: "noAriaHiddenOnFocusable",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("no-aria-hidden-on-focusable").same()],
+        sources: &[RuleSource::EslintJsxA11y("no-aria-hidden-on-focusable").same(), RuleSource::HtmlEslint("no-aria-hidden-on-focusable").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
@@ -53,7 +53,7 @@ declare_lint_rule! {
         version: "1.0.0",
         name: "noPositiveTabindex",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("tabindex-no-positive").same()],
+        sources: &[RuleSource::EslintJsxA11y("tabindex-no-positive").same(), RuleSource::HtmlEslint("no-positive-tabindex").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
@@ -46,7 +46,7 @@ declare_lint_rule! {
         version: "1.0.0",
         name: "noRedundantRoles",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("no-redundant-roles").same()],
+        sources: &[RuleSource::EslintJsxA11y("no-redundant-roles").same(), RuleSource::HtmlEslint("no-redundant-role").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
@@ -51,7 +51,7 @@ declare_lint_rule! {
         version: "1.0.0",
         name: "useAltText",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("alt-text").same()],
+        sources: &[RuleSource::EslintJsxA11y("alt-text").same(), RuleSource::HtmlEslint("require-img-alt").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_button_type.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_button_type.rs
@@ -42,7 +42,7 @@ declare_lint_rule! {
         version: "1.0.0",
         name: "useButtonType",
         language: "jsx",
-        sources: &[RuleSource::EslintReact("button-has-type").same(), RuleSource::EslintReactDom("no-missing-button-type").same(), RuleSource::EslintReactXyz("dom-no-missing-button-type").same()],
+        sources: &[RuleSource::EslintReact("button-has-type").same(), RuleSource::EslintReactDom("no-missing-button-type").same(), RuleSource::EslintReactXyz("dom-no-missing-button-type").same(), RuleSource::HtmlEslint("require-button-type").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
@@ -61,7 +61,7 @@ declare_lint_rule! {
         version: "1.0.0",
         name: "useHeadingContent",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("heading-has-content").same()],
+        sources: &[RuleSource::EslintJsxA11y("heading-has-content").same(), RuleSource::HtmlEslint("no-empty-headings").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
@@ -60,7 +60,7 @@ declare_lint_rule! {
         version: "1.0.0",
         name: "useHtmlLang",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("html-has-lang").same()],
+        sources: &[RuleSource::EslintJsxA11y("html-has-lang").same(), RuleSource::HtmlEslint("require-lang").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
@@ -66,7 +66,7 @@ declare_lint_rule! {
         version: "1.0.0",
         name: "useIframeTitle",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("iframe-has-title").same()],
+        sources: &[RuleSource::EslintJsxA11y("iframe-has-title").same(), RuleSource::HtmlEslint("require-frame-title").inspired()],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
@@ -91,7 +91,7 @@ declare_lint_rule! {
         version: "1.4.0",
         name: "useValidAriaRole",
         language: "jsx",
-        sources: &[RuleSource::EslintJsxA11y("aria-role").same()],
+        sources: &[RuleSource::EslintJsxA11y("aria-role").same(), RuleSource::HtmlEslint("no-invalid-role").inspired()],
         recommended: true,
         severity: Severity::Error,
         fix_kind: FixKind::Unsafe,


### PR DESCRIPTION
## Summary

Add missing sources & link JS sources as inspired in HTML and html sources in JS.

No changeset needed as the only change in the migration script is related to a rule that has not yet been released

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
