### PR TITLE
fix(resolver): resolve typed package main entries

### DIFF
--- a/.changeset/long-boxes-walk.md
+++ b/.changeset/long-boxes-walk.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a resolver bug where packages that define a typed entry point through `package.json`'s `main` field but omit `types` were ignored during type-aware resolution. Type-aware rules such as [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-floating-promises/) can now inspect imports from those packages.

--- a/crates/biome_resolver/src/lib.rs
+++ b/crates/biome_resolver/src/lib.rs
@@ -668,10 +668,10 @@ fn resolve_package_path(
                     // points at TypeScript source or lets us discover a
                     // declaration file. Avoid returning untyped runtime
                     // JavaScript when no type entrypoint exists.
-                    if let Ok(path) = resolve_relative_path(target, &package_path, fs, &options)
-                        && is_type_resolution_path(&path)
-                    {
-                        return Ok(path);
+                    match resolve_relative_path(target, &package_path, fs, &options) {
+                        Ok(path) if is_type_resolution_path(&path) => return Ok(path),
+                        Ok(_) | Err(ResolveError::NotFound) => { /* fall through */ }
+                        Err(error) => return Err(error),
                     }
                 }
             } else if let Some(target) = &package_json.main {
@@ -732,6 +732,8 @@ fn definition_extension_for_js_extension(extension: &str) -> Option<&'static str
 }
 
 fn is_type_resolution_path(path: &Utf8Path) -> bool {
+    // `Utf8Path::extension()` returns the substring after the last dot, so
+    // declaration files such as `index.d.ts` match through `ts`.
     matches!(path.extension(), Some("ts" | "tsx" | "cts" | "mts"))
 }
 
@@ -882,7 +884,9 @@ pub struct ResolveOptions<'a> {
     /// - If no `"types"` export is found in a package, the `package.json`'s
     ///   `types` field  is used as a fallback.
     /// - If the `package.json`'s `types` field is not configured, the `main`
-    ///   field is used as a fallback if it resolves.
+    ///   field is used as a fallback only when it resolves to TypeScript source
+    ///   or a declaration file. Untyped runtime JavaScript is intentionally
+    ///   rejected.
     /// - Directories configured in [`Self::type_roots`] will be checked before
     ///   looking for dependencies in `node_modules/`.
     /// - For any import to a **JavaScript** file where an explicit extension is

--- a/crates/biome_resolver/src/lib.rs
+++ b/crates/biome_resolver/src/lib.rs
@@ -633,8 +633,8 @@ fn resolve_dependency(
 /// Resolves a dependency by its `package_path` and a `subpath`, by checking
 /// whether `package_path` exists, and resolving `subpath` inside it if it does.
 ///
-/// If `package.json` exists inside `package_path`, its `exports`, `main`,
-/// and `types` fields can be used for further resolution. Without a
+/// If `package.json` exists inside `package_path`, its `exports`, `types`,
+/// and `main` fields can be used for further resolution. Without a
 /// `package.json` file, only the `subpath` can be used for resolution.
 fn resolve_package_path(
     package_path: &Utf8Path,
@@ -656,12 +656,25 @@ fn resolve_package_path(
         }
 
         if subpath.is_empty() {
-            let field = if options.resolve_types {
-                &package_json.types
-            } else {
-                &package_json.main
-            };
-            if let Some(target) = field {
+            if options.resolve_types {
+                if let Some(target) = &package_json.types {
+                    let options = options.without_extensions_or_manifests();
+                    return resolve_relative_path(target, &package_path, fs, &options);
+                }
+
+                if let Some(target) = &package_json.main {
+                    let options = options.without_extensions_or_manifests();
+                    // In type-resolution mode, `main` is only useful if it
+                    // points at TypeScript source or lets us discover a
+                    // declaration file. Avoid returning untyped runtime
+                    // JavaScript when no type entrypoint exists.
+                    if let Ok(path) = resolve_relative_path(target, &package_path, fs, &options)
+                        && is_type_resolution_path(&path)
+                    {
+                        return Ok(path);
+                    }
+                }
+            } else if let Some(target) = &package_json.main {
                 let options = options.without_extensions_or_manifests();
                 return resolve_relative_path(target, &package_path, fs, &options);
             }
@@ -716,6 +729,17 @@ fn definition_extension_for_js_extension(extension: &str) -> Option<&'static str
         "mjs" => Some("d.mts"),
         _ => None,
     }
+}
+
+fn is_type_resolution_path(path: &Utf8Path) -> bool {
+    let path = path.as_str();
+    path.ends_with(".d.ts")
+        || path.ends_with(".d.cts")
+        || path.ends_with(".d.mts")
+        || matches!(
+            Utf8Path::new(path).extension(),
+            Some("ts" | "tsx" | "cts" | "mts")
+        )
 }
 
 pub fn is_relative_specifier(specifier: &str) -> bool {
@@ -864,7 +888,8 @@ pub struct ResolveOptions<'a> {
     /// TypeScript-like type resolution:
     /// - If no `"types"` export is found in a package, the `package.json`'s
     ///   `types` field  is used as a fallback.
-    /// - The `package.json`'s `main` field will be ignored.
+    /// - If the `package.json`'s `types` field is not configured, the `main`
+    ///   field is used as a fallback if it resolves.
     /// - Directories configured in [`Self::type_roots`] will be checked before
     ///   looking for dependencies in `node_modules/`.
     /// - For any import to a **JavaScript** file where an explicit extension is

--- a/crates/biome_resolver/src/lib.rs
+++ b/crates/biome_resolver/src/lib.rs
@@ -732,14 +732,7 @@ fn definition_extension_for_js_extension(extension: &str) -> Option<&'static str
 }
 
 fn is_type_resolution_path(path: &Utf8Path) -> bool {
-    let path = path.as_str();
-    path.ends_with(".d.ts")
-        || path.ends_with(".d.cts")
-        || path.ends_with(".d.mts")
-        || matches!(
-            Utf8Path::new(path).extension(),
-            Some("ts" | "tsx" | "cts" | "mts")
-        )
+    matches!(path.extension(), Some("ts" | "tsx" | "cts" | "mts"))
 }
 
 pub fn is_relative_specifier(specifier: &str) -> bool {

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/runtime-main/dist/index.d.ts
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/runtime-main/dist/index.d.ts
@@ -1,0 +1,1 @@
+export function runtimeMainFromMainField(): string;

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/runtime-main/dist/index.js
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/runtime-main/dist/index.js
@@ -1,0 +1,3 @@
+export function runtimeMain() {
+    return "runtime-main";
+}

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/runtime-main/package.json
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/runtime-main/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "runtime-main",
+  "main": "./dist/index.js"
+}

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/source-main/package.json
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/source-main/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "source-main",
+  "main": "./src/index.ts"
+}

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/source-main/src/index.ts
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/source-main/src/index.ts
@@ -1,0 +1,3 @@
+export function sourceMain(): string {
+    return "source-main";
+}

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/types-and-main/package.json
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/types-and-main/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "types-and-main",
+  "types": "./types/index.d.ts",
+  "main": "./src/index.ts"
+}

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/types-and-main/src/index.ts
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/types-and-main/src/index.ts
@@ -1,0 +1,3 @@
+export function mainEntry(): string {
+    return "main";
+}

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/types-and-main/types/index.d.ts
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/types-and-main/types/index.d.ts
@@ -1,0 +1,1 @@
+export function typesEntry(): string;

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/untyped-main/dist/index.js
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/untyped-main/dist/index.js
@@ -1,0 +1,3 @@
+export function untypedMain() {
+    return "untyped-main";
+}

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/untyped-main/package.json
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/untyped-main/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "untyped-main",
+  "main": "./dist/index.js"
+}

--- a/crates/biome_resolver/tests/spec_tests.rs
+++ b/crates/biome_resolver/tests/spec_tests.rs
@@ -463,6 +463,32 @@ fn test_resolve_type_definitions() {
     );
 
     assert_eq!(
+        resolve("types-and-main", &base_dir, &fs, &options),
+        Ok(Utf8PathBuf::from(format!(
+            "{base_dir}/node_modules/types-and-main/types/index.d.ts"
+        )))
+    );
+
+    assert_eq!(
+        resolve("source-main", &base_dir, &fs, &options),
+        Ok(Utf8PathBuf::from(format!(
+            "{base_dir}/node_modules/source-main/src/index.ts"
+        )))
+    );
+
+    assert_eq!(
+        resolve("runtime-main", &base_dir, &fs, &options),
+        Ok(Utf8PathBuf::from(format!(
+            "{base_dir}/node_modules/runtime-main/dist/index.d.ts"
+        )))
+    );
+
+    assert_eq!(
+        resolve("untyped-main", &base_dir, &fs, &options),
+        Err(ResolveError::DirectoryWithoutDefault)
+    );
+
+    assert_eq!(
         resolve("react", &base_dir.join("src"), &fs, &options),
         Ok(Utf8PathBuf::from(format!(
             "{base_dir}/node_modules/@types/react/index.d.ts"


### PR DESCRIPTION
## Summary

Fixes type-aware package resolution for packages that omit `types` but point `package.json`'s `main` field at a typed entry point.

Before this change, type-resolution mode ignored `main` entirely when `types` was absent. That meant workspace/source packages such as packages with `main: "./src/index.ts"` could not be resolved by type-aware rules. The resolver now still prefers `types`, but can fall back to `main` when it resolves to TypeScript source or a declaration file, while avoiding untyped runtime JavaScript.

> This PR was implemented with AI assistance. The solution and tests were reviewed and validated by the contributor.

## Context

`types` is recommended for published packages, but TypeScript does not require it for package resolution.

The TypeScript docs describe package type resolution as checking optional `types`, then `main`, then root `index.d.ts`: https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html#editing-the-packagejson. Extension substitution also explains why a JavaScript `main` can resolve to a sibling `.d.ts`: https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution.

This matters for pnpm workspaces because local workspace packages can be linked into `node_modules` via `workspace:*`, so TypeScript sees them as packages and applies package resolution. In a large private pnpm workspace I checked, many internal packages use `main: "./src/index.ts"` without `types`.

This PR keeps Biome narrower than TypeScript: it only accepts the `main` fallback when it resolves to TypeScript source or declarations, and still rejects untyped runtime JavaScript.

## Test Plan

Added resolver coverage for typed `main` fallback, `types` precedence, JavaScript `main` declaration discovery, and untyped JavaScript rejection.

- `cargo test -p biome_resolver`


## Related

Builds on a related improvement I made recently:
- https://github.com/biomejs/biome/pull/9835

Potentially related issue:
- https://github.com/biomejs/biome/issues/7354


## Docs

N/A