### PR TITLE
fix(lint): detect misleading object returns for built-in class instances

### DIFF
--- a/.changeset/ripe-melons-rhyme.md
+++ b/.changeset/ripe-melons-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved [`noUnnecessaryConditions`](https://biomejs.dev/linter/rules/no-unnecessary-conditions/) to detect conditions that are always truthy because they check built-in global class instances such as `Date`, `Map`, `Set`, `WeakMap`, and `Error`.

--- a/.changeset/sour-hounds-bow.md
+++ b/.changeset/sour-hounds-bow.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved [`noMisleadingReturnType`](https://biomejs.dev/linter/rules/no-misleading-return-type/) to detect `object` return annotations that hide built-in global class instances such as `Date`, `Map`, `Set`, `WeakMap`, and `Error`.

--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
@@ -927,6 +927,10 @@ fn is_nonunion_wider(annotated: &Type, inferred: &Type) -> bool {
         }
 
         match (&*ann, &*inf) {
+            (TypeData::ObjectKeyword, TypeData::InstanceOf(_)) => {
+                found_wider = true;
+            }
+
             (TypeData::InstanceOf(ann_inst), TypeData::InstanceOf(inf_inst)) => {
                 let same_base = match (ann.resolve(&ann_inst.ty), inf.resolve(&inf_inst.ty)) {
                     (Some(a), Some(b)) => types_match(&a, &b),

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts
@@ -67,3 +67,9 @@ class GetterClass { get code(): number { if (Math.random() > 0.5) return 200; re
 const getterObj = { get code(): number { if (Math.random() > 0.5) return 200; return 404; } };
 
 class AsyncMethod { async getStatus(b: boolean): Promise<string> { if (b) return "loading"; return "idle"; } }
+
+function dateObject(): object { return new Date(); }
+function mapObject(): object { return new Map(); }
+function setObject(): object { return new Set(); }
+function weakMapObject(): object { return new WeakMap(); }
+function errorObject(): object { return new Error(); }

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts.snap
@@ -74,6 +74,12 @@ const getterObj = { get code(): number { if (Math.random() > 0.5) return 200; re
 
 class AsyncMethod { async getStatus(b: boolean): Promise<string> { if (b) return "loading"; return "idle"; } }
 
+function dateObject(): object { return new Date(); }
+function mapObject(): object { return new Map(); }
+function setObject(): object { return new Set(); }
+function weakMapObject(): object { return new WeakMap(); }
+function errorObject(): object { return new Error(); }
+
 ```
 
 # Diagnostics
@@ -796,10 +802,124 @@ invalid.ts:69:48 lint/nursery/noMisleadingReturnType ━━━━━━━━━
   > 69 │ class AsyncMethod { async getStatus(b: boolean): Promise<string> { if (b) return "loading"; return "idle"; } }
        │                                                ^^^^^^^^^^^^^^^^^
     70 │ 
+    71 │ function dateObject(): object { return new Date(); }
   
   i A wider return type hides the precise types that callers could rely on.
   
   i Consider using "loading" | "idle" as the return type.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:71:22 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    69 │ class AsyncMethod { async getStatus(b: boolean): Promise<string> { if (b) return "loading"; return "idle"; } }
+    70 │ 
+  > 71 │ function dateObject(): object { return new Date(); }
+       │                      ^^^^^^^^
+    72 │ function mapObject(): object { return new Map(); }
+    73 │ function setObject(): object { return new Set(); }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:72:21 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    71 │ function dateObject(): object { return new Date(); }
+  > 72 │ function mapObject(): object { return new Map(); }
+       │                     ^^^^^^^^
+    73 │ function setObject(): object { return new Set(); }
+    74 │ function weakMapObject(): object { return new WeakMap(); }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:73:21 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    71 │ function dateObject(): object { return new Date(); }
+    72 │ function mapObject(): object { return new Map(); }
+  > 73 │ function setObject(): object { return new Set(); }
+       │                     ^^^^^^^^
+    74 │ function weakMapObject(): object { return new WeakMap(); }
+    75 │ function errorObject(): object { return new Error(); }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:74:25 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    72 │ function mapObject(): object { return new Map(); }
+    73 │ function setObject(): object { return new Set(); }
+  > 74 │ function weakMapObject(): object { return new WeakMap(); }
+       │                         ^^^^^^^^
+    75 │ function errorObject(): object { return new Error(); }
+    76 │ 
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:75:23 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    73 │ function setObject(): object { return new Set(); }
+    74 │ function weakMapObject(): object { return new WeakMap(); }
+  > 75 │ function errorObject(): object { return new Error(); }
+       │                       ^^^^^^^^
+    76 │ 
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
   
   i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnnecessaryConditions/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnnecessaryConditions/invalid.ts
@@ -153,3 +153,6 @@ if (ro) console.log();
 
 declare const partialObj2: Partial<{a: string}>;
 if (partialObj2) console.log();
+
+const date = new Date();
+if (date) console.log(date);

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnnecessaryConditions/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnnecessaryConditions/invalid.ts.snap
@@ -160,6 +160,9 @@ if (ro) console.log();
 declare const partialObj2: Partial<{a: string}>;
 if (partialObj2) console.log();
 
+const date = new Date();
+if (date) console.log(date);
+
 ```
 
 # Diagnostics
@@ -884,6 +887,28 @@ invalid.ts:155:5 lint/nursery/noUnnecessaryConditions ━━━━━━━━�
   > 155 │ if (partialObj2) console.log();
         │     ^^^^^^^^^^^
     156 │ 
+    157 │ const date = new Date();
+  
+  i The type being checked can never be falsy, making this condition redundant.
+  
+  i Remove the condition.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/6611 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:158:5 lint/nursery/noUnnecessaryConditions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This condition is always truthy based on the type.
+  
+    157 │ const date = new Date();
+  > 158 │ if (date) console.log(date);
+        │     ^^^^
+    159 │ 
   
   i The type being checked can never be falsy, making this condition redundant.
   

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -100,6 +100,16 @@ pub fn global_type_name(id: TypeId) -> Option<&'static str> {
         DISPOSABLE_DISPOSE_ID => Some(DISPOSABLE_DISPOSE_ID_NAME),
         ASYNC_DISPOSABLE_ID => Some(ASYNC_DISPOSABLE_ID_NAME),
         ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID => Some(ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_NAME),
+        INSTANCEOF_DATE_ID => Some(INSTANCEOF_DATE_ID_NAME),
+        DATE_ID => Some(DATE_ID_NAME),
+        INSTANCEOF_MAP_ID => Some(INSTANCEOF_MAP_ID_NAME),
+        MAP_ID => Some(MAP_ID_NAME),
+        INSTANCEOF_SET_ID => Some(INSTANCEOF_SET_ID_NAME),
+        SET_ID => Some(SET_ID_NAME),
+        INSTANCEOF_WEAK_MAP_ID => Some(INSTANCEOF_WEAK_MAP_ID_NAME),
+        WEAK_MAP_ID => Some(WEAK_MAP_ID_NAME),
+        INSTANCEOF_ERROR_ID => Some(INSTANCEOF_ERROR_ID_NAME),
+        ERROR_ID => Some(ERROR_ID_NAME),
         _ => None,
     }
 }
@@ -123,6 +133,16 @@ impl Default for GlobalsResolver {
         let static_member = |name: &'static str, id: TypeId| TypeMember {
             kind: TypeMemberKind::NamedStatic(Text::new_static(name)),
             ty: ResolvedTypeId::new(TypeResolverLevel::Global, id).into(),
+        };
+
+        let class = |name: &'static str, type_parameters: Box<[TypeReference]>| {
+            TypeData::Class(Box::new(Class {
+                name: Some(Text::new_static(name)),
+                type_parameters,
+                extends: None,
+                implements: [].into(),
+                members: Box::default(),
+            }))
         };
 
         let array_method_definition =
@@ -414,6 +434,52 @@ impl Default for GlobalsResolver {
                 return_type: ReturnType::Type(GLOBAL_INSTANCEOF_REGEXP_ID.into()),
             }),
         );
+        builder.set_type_data(
+            INSTANCEOF_DATE_ID,
+            TypeData::instance_of(TypeReference::from(GLOBAL_DATE_ID)),
+        );
+        builder.set_type_data(DATE_ID, class(DATE_ID_NAME, Box::default()));
+        builder.set_type_data(
+            INSTANCEOF_MAP_ID,
+            TypeData::instance_of(TypeReference::from(GLOBAL_MAP_ID)),
+        );
+        builder.set_type_data(
+            MAP_ID,
+            class(
+                MAP_ID_NAME,
+                Box::new([
+                    TypeReference::from(GLOBAL_T_ID),
+                    TypeReference::from(GLOBAL_U_ID),
+                ]),
+            ),
+        );
+        builder.set_type_data(
+            INSTANCEOF_SET_ID,
+            TypeData::instance_of(TypeReference::from(GLOBAL_SET_ID)),
+        );
+        builder.set_type_data(
+            SET_ID,
+            class(SET_ID_NAME, Box::new([TypeReference::from(GLOBAL_T_ID)])),
+        );
+        builder.set_type_data(
+            INSTANCEOF_WEAK_MAP_ID,
+            TypeData::instance_of(TypeReference::from(GLOBAL_WEAK_MAP_ID)),
+        );
+        builder.set_type_data(
+            WEAK_MAP_ID,
+            class(
+                WEAK_MAP_ID_NAME,
+                Box::new([
+                    TypeReference::from(GLOBAL_T_ID),
+                    TypeReference::from(GLOBAL_U_ID),
+                ]),
+            ),
+        );
+        builder.set_type_data(
+            INSTANCEOF_ERROR_ID,
+            TypeData::instance_of(TypeReference::from(GLOBAL_ERROR_ID)),
+        );
+        builder.set_type_data(ERROR_ID, class(ERROR_ID_NAME, Box::default()));
         // Known symbols
         builder.set_type_data(
             INSTANCEOF_SYMBOL_ID,
@@ -568,6 +634,16 @@ impl TypeResolver for GlobalsResolver {
             Some(GLOBAL_REGEXP_ID)
         } else if qualifier.is_symbol() && !qualifier.has_known_type_parameters() {
             Some(GLOBAL_SYMBOL_ID)
+        } else if qualifier.is_date() && !qualifier.has_known_type_parameters() {
+            Some(GLOBAL_DATE_ID)
+        } else if qualifier.is_map() && !qualifier.has_known_type_parameters() {
+            Some(GLOBAL_MAP_ID)
+        } else if qualifier.is_set() && !qualifier.has_known_type_parameters() {
+            Some(GLOBAL_SET_ID)
+        } else if qualifier.is_weak_map() && !qualifier.has_known_type_parameters() {
+            Some(GLOBAL_WEAK_MAP_ID)
+        } else if qualifier.is_error() && !qualifier.has_known_type_parameters() {
+            Some(GLOBAL_ERROR_ID)
         } else if qualifier.is_disposable() && !qualifier.has_known_type_parameters() {
             Some(GLOBAL_DISPOSABLE_ID)
         } else if qualifier.is_async_disposable() && !qualifier.has_known_type_parameters() {

--- a/crates/biome_js_type_info/src/globals_ids.rs
+++ b/crates/biome_js_type_info/src/globals_ids.rs
@@ -221,10 +221,45 @@ define_global_type!(
     51,
     "AsyncDisposable[Symbol.asyncDispose]"
 );
+define_global_type!(
+    INSTANCEOF_DATE_ID,
+    INSTANCEOF_DATE_ID_NAME,
+    52,
+    "instanceof Date"
+);
+define_global_type!(DATE_ID, DATE_ID_NAME, 53, "Date");
+define_global_type!(
+    INSTANCEOF_MAP_ID,
+    INSTANCEOF_MAP_ID_NAME,
+    54,
+    "instanceof Map"
+);
+define_global_type!(MAP_ID, MAP_ID_NAME, 55, "Map");
+define_global_type!(
+    INSTANCEOF_SET_ID,
+    INSTANCEOF_SET_ID_NAME,
+    56,
+    "instanceof Set"
+);
+define_global_type!(SET_ID, SET_ID_NAME, 57, "Set");
+define_global_type!(
+    INSTANCEOF_WEAK_MAP_ID,
+    INSTANCEOF_WEAK_MAP_ID_NAME,
+    58,
+    "instanceof WeakMap"
+);
+define_global_type!(WEAK_MAP_ID, WEAK_MAP_ID_NAME, 59, "WeakMap");
+define_global_type!(
+    INSTANCEOF_ERROR_ID,
+    INSTANCEOF_ERROR_ID_NAME,
+    60,
+    "instanceof Error"
+);
+define_global_type!(ERROR_ID, ERROR_ID_NAME, 61, "Error");
 
 /// Total number of predefined types.
 /// Must be one more than the highest TypeId above.
-pub const NUM_PREDEFINED_TYPES: usize = 52;
+pub const NUM_PREDEFINED_TYPES: usize = 62;
 
 // Resolved type ID constants (TypeId wrapped with GlobalLevel)
 pub const GLOBAL_UNKNOWN_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, UNKNOWN_ID);
@@ -273,3 +308,8 @@ pub const GLOBAL_SYMBOL_ASYNC_DISPOSE_ID: ResolvedTypeId =
 pub const GLOBAL_DISPOSABLE_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, DISPOSABLE_ID);
 pub const GLOBAL_ASYNC_DISPOSABLE_ID: ResolvedTypeId =
     ResolvedTypeId::new(GLOBAL_LEVEL, ASYNC_DISPOSABLE_ID);
+pub const GLOBAL_DATE_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, DATE_ID);
+pub const GLOBAL_MAP_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, MAP_ID);
+pub const GLOBAL_SET_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, SET_ID);
+pub const GLOBAL_WEAK_MAP_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, WEAK_MAP_ID);
+pub const GLOBAL_ERROR_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, ERROR_ID);

--- a/crates/biome_js_type_info/src/type_data.rs
+++ b/crates/biome_js_type_info/src/type_data.rs
@@ -1532,6 +1532,31 @@ impl TypeReferenceQualifier {
         self.path.is_identifier("Symbol")
     }
 
+    /// Checks whether this type qualifier references the `Date` type.
+    pub fn is_date(&self) -> bool {
+        self.path.is_identifier("Date")
+    }
+
+    /// Checks whether this type qualifier references the `Map` type.
+    pub fn is_map(&self) -> bool {
+        self.path.is_identifier("Map")
+    }
+
+    /// Checks whether this type qualifier references the `Set` type.
+    pub fn is_set(&self) -> bool {
+        self.path.is_identifier("Set")
+    }
+
+    /// Checks whether this type qualifier references the `WeakMap` type.
+    pub fn is_weak_map(&self) -> bool {
+        self.path.is_identifier("WeakMap")
+    }
+
+    /// Checks whether this type qualifier references the `Error` type.
+    pub fn is_error(&self) -> bool {
+        self.path.is_identifier("Error")
+    }
+
     /// Checks whether this type qualifier references the `Disposable` type.
     ///
     /// This method simply checks whether the reference is for a literal

--- a/crates/biome_js_type_info/tests/flattening.rs
+++ b/crates/biome_js_type_info/tests/flattening.rs
@@ -300,6 +300,25 @@ fn infer_flattened_type_from_direct_promise_instance() {
 }
 
 #[test]
+fn infer_flattened_type_from_direct_builtin_class_instances() {
+    for (code, expected) in [
+        (r#"new Date()"#, "instanceof Date"),
+        (r#"new Map()"#, "instanceof Map"),
+        (r#"new Set()"#, "instanceof Set"),
+        (r#"new WeakMap()"#, "instanceof WeakMap"),
+        (r#"new Error()"#, "instanceof Error"),
+    ] {
+        let root = parse_ts(code);
+        let expr = get_expression(&root);
+        let mut resolver = GlobalsResolver::default();
+        let expr_ty = TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expr);
+        let expr_ty = expr_ty.inferred(&mut resolver);
+
+        assert_eq!(expr_ty.to_string(), expected);
+    }
+}
+
+#[test]
 fn infer_flattened_type_from_static_promise_function() {
     const CODE: &str = r#"Promise.resolve("value")"#;
 


### PR DESCRIPTION
This PR was implemented with AI assistance from Codex.

## Summary

Addresses items from https://github.com/biomejs/biome/issues/9810: Registers missing built-in global class instances in `biome_js_type_info` so `noMisleadingReturnType` can detect `object` return annotations that hide `Date`, `Map`, `Set`, `WeakMap`, and `Error`.


## Test Plan

Snapshot tests.