### PR TITLE
feat(type-info): preserve object-literal as const properties

### DIFF
--- a/.changeset/no-misleading-return-type-as-const-property.md
+++ b/.changeset/no-misleading-return-type-as-const-property.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+[`noMisleadingReturnType`](https://biomejs.dev/linter/rules/no-misleading-return-type/) now detects misleading return type annotations when object literal properties are initialized with `as const`.
+
+This function is now reported because the return annotation widens a property initialized with `as const`:
+
+```ts
+function f(): { value: string } {
+	return { value: "text" as const };
+}
+```

--- a/.changeset/no-useless-type-conversion-as-const-property.md
+++ b/.changeset/no-useless-type-conversion-as-const-property.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+[`noUselessTypeConversion`](https://biomejs.dev/linter/rules/no-useless-type-conversion/) now detects redundant conversions on object literal properties initialized with `as const`.
+
+This conversion is now reported because `message.value` is inferred as a string literal:
+
+```ts
+const message = { value: "text" as const };
+String(message.value);
+```

--- a/.changeset/use-exhaustive-switch-cases-as-const-property.md
+++ b/.changeset/use-exhaustive-switch-cases-as-const-property.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+[`useExhaustiveSwitchCases`](https://biomejs.dev/linter/rules/use-exhaustive-switch-cases/) now checks switch statements over object literal properties initialized with `as const`.
+
+This switch is now reported because `status.kind` is inferred as the string literal `"ready"` but no case handles it:
+
+```ts
+const status = { kind: "ready" as const };
+switch (status.kind) {}
+```

--- a/.changeset/use-string-starts-ends-with-as-const-property.md
+++ b/.changeset/use-string-starts-ends-with-as-const-property.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+[`useStringStartsEndsWith`](https://biomejs.dev/linter/rules/use-string-starts-ends-with/) now detects string index comparisons on object literal properties initialized with `as const`.
+
+This comparison is now reported because `message.value` is inferred as a string literal:
+
+```ts
+const message = { value: "hello" as const };
+message.value[0] === "h";
+```

--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
@@ -551,6 +551,9 @@ fn is_only_property_literal_widening(annotation: &Type, returns: &[Type]) -> boo
             {
                 let mut index_signature_has_widening = false;
                 let all_inferred_covered = inferred_members.iter().all(|inferred_member| {
+                    if inferred_member.is_const_asserted() {
+                        return false;
+                    }
                     if let Some(inferred_type) = inferred.resolve(&inferred_member.ty) {
                         if types_match(&index_signature_value_type, &inferred_type) {
                             return true;
@@ -581,6 +584,9 @@ fn is_only_property_literal_widening(annotation: &Type, returns: &[Type]) -> boo
                 else {
                     return false;
                 };
+                if inferred_member.is_const_asserted() {
+                    return false;
+                }
                 match (
                     annotated.resolve(&annotated_member.ty),
                     inferred.resolve(&inferred_member.ty),
@@ -1489,15 +1495,9 @@ fn class_type_has_instance_shape(class: &Class) -> bool {
 
 /// Whether a type-info member contributes instance shape.
 fn type_member_affects_instance_shape(member: &biome_js_type_info::TypeMember) -> bool {
-    match &member.kind {
-        TypeMemberKind::Constructor
-        | TypeMemberKind::Getter(_)
-        | TypeMemberKind::NamedStatic(_)
-        | TypeMemberKind::IndexSignature(_) => false,
-        TypeMemberKind::CallSignature
-        | TypeMemberKind::Named(_)
-        | TypeMemberKind::NamedOptional(_) => true,
-    }
+    !member.is_static()
+        && !member.is_getter()
+        && !member.is_index_signature_with_ty(|_| true)
 }
 
 /// Compares non-union type pairs using a work stack. Compound types

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts
@@ -136,3 +136,32 @@ function ternaryObjectBranch(b: boolean): object { return b ? {} : { a: 1 }; }
 class InheritedBase { y = 1; }
 class ClassWithInheritedMembers extends InheritedBase {}
 function inheritedClassInstance(): object { return new ClassWithInheritedMembers(); }
+
+function objectPropertyAsConst(): { a: string } {
+    return { a: "x" as const };
+}
+
+function parenthesizedObjectPropertyAsConst(): { a: string } {
+    return { a: ("x" as const) };
+}
+
+function objectPropertyNegativeNumberAsConst(): { a: number } {
+    return { a: -1 as const };
+}
+
+function objectPropertyTupleAsConst(): { a: [number, number] } {
+    return { a: [1, 2] as const };
+}
+
+function objectPropertyAsConstWithSibling(): { a: string; b: number } {
+    return { a: "x" as const, b: 1 };
+}
+
+function nestedObjectPropertyAsConst(): { outer: { a: string } } {
+    return { outer: { a: "x" as const } };
+}
+
+function objectWithConstPropertyFromIdentifier(): { a: string } {
+    const result = { a: "x" as const };
+    return result;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts.snap
@@ -143,6 +143,35 @@ class InheritedBase { y = 1; }
 class ClassWithInheritedMembers extends InheritedBase {}
 function inheritedClassInstance(): object { return new ClassWithInheritedMembers(); }
 
+function objectPropertyAsConst(): { a: string } {
+    return { a: "x" as const };
+}
+
+function parenthesizedObjectPropertyAsConst(): { a: string } {
+    return { a: ("x" as const) };
+}
+
+function objectPropertyNegativeNumberAsConst(): { a: number } {
+    return { a: -1 as const };
+}
+
+function objectPropertyTupleAsConst(): { a: [number, number] } {
+    return { a: [1, 2] as const };
+}
+
+function objectPropertyAsConstWithSibling(): { a: string; b: number } {
+    return { a: "x" as const, b: 1 };
+}
+
+function nestedObjectPropertyAsConst(): { outer: { a: string } } {
+    return { outer: { a: "x" as const } };
+}
+
+function objectWithConstPropertyFromIdentifier(): { a: string } {
+    const result = { a: "x" as const };
+    return result;
+}
+
 ```
 
 # Diagnostics
@@ -1707,6 +1736,168 @@ invalid.ts:138:34 lint/nursery/noMisleadingReturnType ━━━━━━━━�
   > 138 │ function inheritedClassInstance(): object { return new ClassWithInheritedMembers(); }
         │                                  ^^^^^^^^
     139 │ 
+    140 │ function objectPropertyAsConst(): { a: string } {
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:140:33 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    138 │ function inheritedClassInstance(): object { return new ClassWithInheritedMembers(); }
+    139 │ 
+  > 140 │ function objectPropertyAsConst(): { a: string } {
+        │                                 ^^^^^^^^^^^^^^^
+    141 │     return { a: "x" as const };
+    142 │ }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:144:46 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    142 │ }
+    143 │ 
+  > 144 │ function parenthesizedObjectPropertyAsConst(): { a: string } {
+        │                                              ^^^^^^^^^^^^^^^
+    145 │     return { a: ("x" as const) };
+    146 │ }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:148:47 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    146 │ }
+    147 │ 
+  > 148 │ function objectPropertyNegativeNumberAsConst(): { a: number } {
+        │                                               ^^^^^^^^^^^^^^^
+    149 │     return { a: -1 as const };
+    150 │ }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:152:38 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    150 │ }
+    151 │ 
+  > 152 │ function objectPropertyTupleAsConst(): { a: [number, number] } {
+        │                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
+    153 │     return { a: [1, 2] as const };
+    154 │ }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:156:44 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    154 │ }
+    155 │ 
+  > 156 │ function objectPropertyAsConstWithSibling(): { a: string; b: number } {
+        │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    157 │     return { a: "x" as const, b: 1 };
+    158 │ }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:160:39 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    158 │ }
+    159 │ 
+  > 160 │ function nestedObjectPropertyAsConst(): { outer: { a: string } } {
+        │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    161 │     return { outer: { a: "x" as const } };
+    162 │ }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:164:49 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    162 │ }
+    163 │ 
+  > 164 │ function objectWithConstPropertyFromIdentifier(): { a: string } {
+        │                                                 ^^^^^^^^^^^^^^^
+    165 │     const result = { a: "x" as const };
+    166 │     return result;
   
   i A wider return type hides the precise types that callers could rely on.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts
@@ -61,6 +61,14 @@ function objectNoConst(): { a: string; b: string } {
     return { a: "x", b: "y" };
 }
 
+function propertyLiteralWithoutAsConst(): { a: string } {
+    return { a: "x" };
+}
+
+function propertyAsConstExact(): { a: "x" } {
+    return { a: "x" as const };
+}
+
 function asConstMatch(): "hello" { return "hello" as const; }
 
 function bareReturn(): void { return; }

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts.snap
@@ -67,6 +67,14 @@ function objectNoConst(): { a: string; b: string } {
     return { a: "x", b: "y" };
 }
 
+function propertyLiteralWithoutAsConst(): { a: string } {
+    return { a: "x" };
+}
+
+function propertyAsConstExact(): { a: "x" } {
+    return { a: "x" as const };
+}
+
 function asConstMatch(): "hello" { return "hello" as const; }
 
 function bareReturn(): void { return; }

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessTypeConversion/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessTypeConversion/invalid.ts
@@ -70,3 +70,6 @@ function reqStr(x: Required<{s?: string}>) { return String(x.s); }
 function reqNum(x: Required<{n?: number}>) { return Number(x.n); }
 function reqBig(x: Required<{b?: bigint}>) { return BigInt(x.b); }
 function roStr(x: Readonly<{s: string}>) { return String(x.s); }
+
+const wrappedStringContainer = { value: "wrapped" as const };
+String(wrappedStringContainer.value);

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessTypeConversion/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessTypeConversion/invalid.ts.snap
@@ -77,6 +77,9 @@ function reqNum(x: Required<{n?: number}>) { return Number(x.n); }
 function reqBig(x: Required<{b?: bigint}>) { return BigInt(x.b); }
 function roStr(x: Readonly<{s: string}>) { return String(x.s); }
 
+const wrappedStringContainer = { value: "wrapped" as const };
+String(wrappedStringContainer.value);
+
 ```
 
 # Diagnostics
@@ -903,6 +906,30 @@ invalid.ts:72:51 lint/nursery/noUselessTypeConversion ━━━━━━━━�
   > 72 │ function roStr(x: Readonly<{s: string}>) { return String(x.s); }
        │                                                   ^^^^^^
     73 │ 
+    74 │ const wrappedStringContainer = { value: "wrapped" as const };
+  
+  i This expression already evaluates to a string.
+  
+  i Remove the conversion and use the value directly.
+  
+  i Redundant conversions make it harder to see that the value already has the expected string type.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9752 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:75:1 lint/nursery/noUselessTypeConversion ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Avoid calling `String()` on a string value.
+  
+    74 │ const wrappedStringContainer = { value: "wrapped" as const };
+  > 75 │ String(wrappedStringContainer.value);
+       │ ^^^^^^
+    76 │ 
   
   i This expression already evaluates to a string.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalid.ts
@@ -114,3 +114,9 @@ function switchAliasedBoolean(value: boolean | AliasedBoolean): number {
 			return 1;
 	}
 }
+
+function exhaustiveSwitchOnAsConstStringDiscriminant(): void {
+	const wrappedSwitch = { kind: "wrapped" as const };
+	switch (wrappedSwitch.kind) {
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalid.ts.snap
@@ -121,6 +121,12 @@ function switchAliasedBoolean(value: boolean | AliasedBoolean): number {
 	}
 }
 
+function exhaustiveSwitchOnAsConstStringDiscriminant(): void {
+	const wrappedSwitch = { kind: "wrapped" as const };
+	switch (wrappedSwitch.kind) {
+	}
+}
+
 ```
 
 # Diagnostics
@@ -688,5 +694,34 @@ invalid.ts:112:2 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━
     115 116 │     }
     116 117 │   }
   
+
+```
+
+```
+invalid.ts:120:2 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The switch statement is not exhaustive.
+  
+    118 │ function exhaustiveSwitchOnAsConstStringDiscriminant(): void {
+    119 │ 	const wrappedSwitch = { kind: "wrapped" as const };
+  > 120 │ 	switch (wrappedSwitch.kind) {
+        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 121 │ 	}
+        │ 	^
+    122 │ }
+    123 │ 
+  
+  i Some variants of the union type are not handled here.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i These cases are missing:
+  
+  - "wrapped"
+  
+  i Unsafe fix: Add the missing cases to the switch statement.
+  
+    120 │ → switch·(wrappedSwitch.kind)·{case·"wrapped":·throw·new·Error("TODO:·Not·implemented·yet");
+        │                                +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useStringStartsEndsWith/invalidIndex.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStringStartsEndsWith/invalidIndex.ts
@@ -9,3 +9,6 @@ text[0] !== "a";
 text[0] === other;
 text[text.length - 1] === "z";
 "z" === text[text.length - 1];
+
+const greeting = { value: "hello" as const };
+greeting.value[0] === "h";

--- a/crates/biome_js_analyze/tests/specs/nursery/useStringStartsEndsWith/invalidIndex.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useStringStartsEndsWith/invalidIndex.ts.snap
@@ -16,6 +16,9 @@ text[0] === other;
 text[text.length - 1] === "z";
 "z" === text[text.length - 1];
 
+const greeting = { value: "hello" as const };
+greeting.value[0] === "h";
+
 ```
 
 # Diagnostics
@@ -161,6 +164,7 @@ invalidIndex.ts:11:1 lint/nursery/useStringStartsEndsWith  FIXABLE  ━━━━
   > 11 │ "z" === text[text.length - 1];
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     12 │ 
+    13 │ const greeting = { value: "hello" as const };
   
   i Using the built-in string method is clearer and easier to read.
   
@@ -173,6 +177,32 @@ invalidIndex.ts:11:1 lint/nursery/useStringStartsEndsWith  FIXABLE  ━━━━
     11    │ - "z"·===·text[text.length·-·1];
        11 │ + text.endsWith("z");
     12 12 │   
+    13 13 │   const greeting = { value: "hello" as const };
+  
+
+```
+
+```
+invalidIndex.ts:14:1 lint/nursery/useStringStartsEndsWith  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This index access comparison looks like you're checking a string prefix.
+  
+    13 │ const greeting = { value: "hello" as const };
+  > 14 │ greeting.value[0] === "h";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ 
+  
+  i Using the built-in string method is clearer and easier to read.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Use startsWith() instead.
+  
+    12 12 │   
+    13 13 │   const greeting = { value: "hello" as const };
+    14    │ - greeting.value[0]·===·"h";
+       14 │ + greeting.value.startsWith("h");
+    15 15 │   
   
 
 ```

--- a/crates/biome_js_type_info/src/flattening/intersections.rs
+++ b/crates/biome_js_type_info/src/flattening/intersections.rs
@@ -144,6 +144,12 @@ impl MergedType {
                                         kind: TypeMemberKind::Named(name),
                                         ty: member.ty,
                                     }),
+                                    TypeMemberKind::ConstAssertedNamedStatic(name) => {
+                                        Some(TypeMember {
+                                            kind: TypeMemberKind::ConstAssertedNamed(name),
+                                            ty: member.ty,
+                                        })
+                                    }
                                     _ => None,
                                 })
                                 .collect(),

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -340,28 +340,33 @@ impl Format<FormatTypeContext> for TypeMember {
 }
 
 impl Format<FormatTypeContext> for TypeMemberKind {
-    fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
+    fn fmt(&self, formatter: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
         match self {
-            Self::CallSignature => write!(f, [token("()")]),
-            Self::Constructor => write!(f, [token("constructor")]),
-            Self::Getter(name) => {
+            Self::CallSignature | Self::ConstAssertedCallSignature => {
+                write!(formatter, [token("()")])
+            }
+            Self::Constructor | Self::ConstAssertedConstructor => {
+                write!(formatter, [token("constructor")])
+            }
+            Self::Getter(name) | Self::ConstAssertedGetter(name) => {
                 let quoted = std::format!("get \"{name}\"");
-                write!(f, [text(&quoted, TextSize::default())])
+                write!(formatter, [text(&quoted, TextSize::default())])
             }
-            Self::IndexSignature(ty) => {
-                write!(f, [token("["), ty, token("]")])
+            Self::IndexSignature(index_signature_type)
+            | Self::ConstAssertedIndexSignature(index_signature_type) => {
+                write!(formatter, [token("["), index_signature_type, token("]")])
             }
-            Self::Named(name) => {
+            Self::Named(name) | Self::ConstAssertedNamed(name) => {
                 let quoted = std::format!("\"{name}\"");
-                write!(f, [text(&quoted, TextSize::default())])
+                write!(formatter, [text(&quoted, TextSize::default())])
             }
-            Self::NamedOptional(name) => {
+            Self::NamedOptional(name) | Self::ConstAssertedNamedOptional(name) => {
                 let quoted = std::format!("\"{name}\"?");
-                write!(f, [text(&quoted, TextSize::default())])
+                write!(formatter, [text(&quoted, TextSize::default())])
             }
-            Self::NamedStatic(name) => {
+            Self::NamedStatic(name) | Self::ConstAssertedNamedStatic(name) => {
                 let quoted = std::format!("static \"{name}\"");
-                write!(f, [text(&quoted, TextSize::default())])
+                write!(formatter, [text(&quoted, TextSize::default())])
             }
         }
     }

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -46,6 +46,8 @@ use crate::{
     TypeofTypeofExpression, TypeofUnaryMinusExpression, TypeofValue,
 };
 
+const MAX_CONST_ASSERTION_DEPTH: usize = 50;
+
 impl TypeData {
     /// Applies the given `pattern` and returns the named bindings, and their
     /// associated types.
@@ -594,6 +596,32 @@ impl TypeData {
             AnyJsExpression::JsThisExpression(_) => Self::from(TypeofExpression::This(
                 TypeofThisOrSuperExpression::from_any_js_expression(scope_id, expr),
             )),
+            AnyJsExpression::TsAsExpression(expr) => {
+                let Ok(annotation) = expr.ty() else {
+                    return Self::unknown();
+                };
+                let Ok(inner) = expr.expression() else {
+                    return Self::unknown();
+                };
+                if is_const_reference_type(&annotation) {
+                    type_data_from_const_assertion_expression(resolver, scope_id, &inner)
+                } else {
+                    Self::unknown()
+                }
+            }
+            AnyJsExpression::TsTypeAssertionExpression(expr) => {
+                let Ok(annotation) = expr.ty() else {
+                    return Self::unknown();
+                };
+                let Ok(inner) = expr.expression() else {
+                    return Self::unknown();
+                };
+                if is_const_reference_type(&annotation) {
+                    type_data_from_const_assertion_expression(resolver, scope_id, &inner)
+                } else {
+                    Self::unknown()
+                }
+            }
             AnyJsExpression::JsUnaryExpression(expr) => {
                 Self::from_js_unary_expression(resolver, scope_id, expr)
             }
@@ -2071,12 +2099,21 @@ impl TypeMember {
                         .map(|name| TypeMemberKind::Named(name.into())),
                     _ => None,
                 })
-                .map(|kind| Self {
-                    kind,
-                    ty: member
-                        .value()
-                        .map(|value| resolver.reference_to_resolved_expression(scope_id, &value))
-                        .unwrap_or_default(),
+                .map(|kind| {
+                    let value = member.value().ok();
+                    let kind = if value.as_ref().is_some_and(expression_is_const_assertion) {
+                        kind.with_const_asserted()
+                    } else {
+                        kind
+                    };
+                    Self {
+                        kind,
+                        ty: value
+                            .map(|value| {
+                                resolver.reference_to_resolved_expression(scope_id, &value)
+                            })
+                            .unwrap_or_default(),
+                    }
                 }),
             AnyJsObjectMember::JsSetterObjectMember(_) => {
                 // TODO: Handle setters
@@ -2091,7 +2128,7 @@ impl TypeMember {
                     ty: resolver.reference_to_owned_data(TypeData::from(TypeofValue {
                         identifier: name,
                         ty: TypeReference::unknown(),
-                        scope_id: None,
+                        scope_id: Some(scope_id),
                     })),
                 }),
             AnyJsObjectMember::JsSpread(_) => {
@@ -2841,6 +2878,144 @@ fn type_from_function_body(
             TypeData::union_of(resolver, return_types)
         }
     }
+}
+
+/// Checks for TypeScript's special `const` assertion target.
+fn is_const_reference_type(type_annotation: &AnyTsType) -> bool {
+    let Some(reference_type) = type_annotation.as_ts_reference_type() else {
+        return false;
+    };
+
+    reference_type.type_arguments().is_none()
+        && reference_type.name().ok().is_some_and(|name| {
+            name.as_js_reference_identifier()
+                .and_then(|identifier| identifier.value_token().ok())
+                .is_some_and(|token| token.text_trimmed() == "const")
+        })
+}
+
+/// Recognizes direct `as const` and `<const>` assertions, allowing parentheses around them.
+fn expression_is_const_assertion(expression: &AnyJsExpression) -> bool {
+    let mut current = expression.clone();
+    loop {
+        match &current {
+            AnyJsExpression::TsAsExpression(expression) => {
+                return expression.ty().is_ok_and(|ty| is_const_reference_type(&ty));
+            }
+            AnyJsExpression::TsTypeAssertionExpression(expression) => {
+                return expression.ty().is_ok_and(|ty| is_const_reference_type(&ty));
+            }
+            AnyJsExpression::JsParenthesizedExpression(expression) => match expression.expression()
+            {
+                Ok(inner) => current = inner,
+                Err(_) => return false,
+            },
+            _ => return false,
+        }
+    }
+}
+
+/// Builds the type produced by a const assertion expression.
+fn type_data_from_const_assertion_expression(
+    resolver: &mut dyn TypeResolver,
+    scope_id: ScopeId,
+    expression: &AnyJsExpression,
+) -> TypeData {
+    let expression = expression.clone().omit_parentheses();
+    if let AnyJsExpression::JsUnaryExpression(unary) = &expression
+        && unary.operator().ok() == Some(JsUnaryOperator::Minus)
+        && let Ok(argument) = unary.argument()
+    {
+        match argument.omit_parentheses() {
+            AnyJsExpression::AnyJsLiteralExpression(
+                AnyJsLiteralExpression::JsBigintLiteralExpression(literal),
+            ) => {
+                if let Some(text) = text_from_token(literal.value_token()) {
+                    return TypeData::Literal(Box::new(Literal::BigInt(format!("-{text}").into())));
+                }
+            }
+            AnyJsExpression::AnyJsLiteralExpression(
+                AnyJsLiteralExpression::JsNumberLiteralExpression(literal),
+            ) => {
+                if let Some(text) = text_from_token(literal.value_token()) {
+                    return TypeData::Literal(Box::new(Literal::Number(NumberLiteral::new(
+                        format!("-{text}").into(),
+                    ))));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let inner_type = resolver
+        .resolve_expression(scope_id, &expression)
+        .into_owned();
+    apply_deep_const(resolver, inner_type)
+}
+
+/// Applies const assertion conversion to inferred tuple and object types.
+fn apply_deep_const(resolver: &mut dyn TypeResolver, inner_type: TypeData) -> TypeData {
+    apply_deep_const_inner(resolver, inner_type, 0)
+}
+
+/// Recursively applies `as const` to tuple elements and object members.
+fn apply_deep_const_inner(
+    resolver: &mut dyn TypeResolver,
+    inner_type: TypeData,
+    depth: usize,
+) -> TypeData {
+    if depth >= MAX_CONST_ASSERTION_DEPTH {
+        return inner_type;
+    }
+
+    match inner_type {
+        TypeData::Tuple(tuple) => {
+            let elements = tuple
+                .elements()
+                .iter()
+                .map(|element| TupleElementType {
+                    ty: apply_deep_const_reference(resolver, &element.ty, depth + 1),
+                    name: element.name.clone(),
+                    is_optional: element.is_optional,
+                    is_rest: element.is_rest,
+                })
+                .collect();
+            TypeData::Tuple(Box::new(Tuple(elements)))
+        }
+        TypeData::Object(object) => TypeData::Object(Box::new(Object {
+            prototype: object.prototype.clone(),
+            members: object
+                .members
+                .iter()
+                .map(|member| TypeMember {
+                    kind: member.kind.clone().with_const_asserted(),
+                    ty: apply_deep_const_reference(resolver, &member.ty, depth + 1),
+                })
+                .collect(),
+        })),
+        _ => inner_type,
+    }
+}
+
+/// Resolves a type reference, applies const assertion conversion, and stores the result.
+fn apply_deep_const_reference(
+    resolver: &mut dyn TypeResolver,
+    type_reference: &TypeReference,
+    depth: usize,
+) -> TypeReference {
+    if depth >= MAX_CONST_ASSERTION_DEPTH {
+        return type_reference.clone();
+    }
+
+    let Some(inner_type) = resolver
+        .resolve_and_get(type_reference)
+        .map(|resolved| resolved.to_data())
+    else {
+        return type_reference.clone();
+    };
+
+    let inner_type = apply_deep_const_inner(resolver, inner_type, depth);
+    resolver.reference_to_owned_data(inner_type)
 }
 
 #[inline]

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -875,31 +875,30 @@ impl Resolvable for TypeReference {
                                         .map(|member| {
                                             let was_optional = member.is_optional();
                                             let kind = match &member.kind {
-                                                TypeMemberKind::IndexSignature(key_ref) => {
-                                                    TypeMemberKind::IndexSignature(
-                                                        resolved
-                                                            .apply_module_id_to_reference(key_ref)
-                                                            .into_owned(),
-                                                    )
+                                                TypeMemberKind::IndexSignature(key_reference)
+                                                | TypeMemberKind::ConstAssertedIndexSignature(
+                                                    key_reference,
+                                                ) => {
+                                                    let resolved_index_signature_kind =
+                                                        TypeMemberKind::IndexSignature(
+                                                            resolved
+                                                                .apply_module_id_to_reference(
+                                                                    key_reference,
+                                                                )
+                                                                .into_owned(),
+                                                        );
+                                                    if member.kind.is_const_asserted() {
+                                                        resolved_index_signature_kind
+                                                            .with_const_asserted()
+                                                    } else {
+                                                        resolved_index_signature_kind
+                                                    }
                                                 }
                                                 other => {
                                                     if is_partial {
-                                                        match other {
-                                                            TypeMemberKind::Named(name) => {
-                                                                TypeMemberKind::NamedOptional(
-                                                                    name.clone(),
-                                                                )
-                                                            }
-                                                            _ => other.clone(),
-                                                        }
+                                                        other.clone().with_optional()
                                                     } else {
-                                                        // Required: make optional members non-optional
-                                                        match other {
-                                                            TypeMemberKind::NamedOptional(name) => {
-                                                                TypeMemberKind::Named(name.clone())
-                                                            }
-                                                            _ => other.clone(),
-                                                        }
+                                                        other.clone().without_optional()
                                                     }
                                                 }
                                             };
@@ -920,8 +919,9 @@ impl Resolvable for TypeReference {
                                     .into_iter()
                                     .map(|(mut member, was_optional)| {
                                         if is_partial && !was_optional {
-                                            let id = resolver.optional(member.ty.clone());
-                                            member.ty = resolver.reference_to_id(id);
+                                            let optional_type_id =
+                                                resolver.optional(member.ty.clone());
+                                            member.ty = resolver.reference_to_id(optional_type_id);
                                         } else if !is_partial && was_optional {
                                             strip_undefined_from_member(resolver, &mut member);
                                         }
@@ -954,12 +954,24 @@ impl Resolvable for TypeReference {
                                         .own_members()
                                         .map(|member| {
                                             let kind = match &member.kind {
-                                                TypeMemberKind::IndexSignature(key_ref) => {
-                                                    TypeMemberKind::IndexSignature(
-                                                        resolved
-                                                            .apply_module_id_to_reference(key_ref)
-                                                            .into_owned(),
-                                                    )
+                                                TypeMemberKind::IndexSignature(key_reference)
+                                                | TypeMemberKind::ConstAssertedIndexSignature(
+                                                    key_reference,
+                                                ) => {
+                                                    let resolved_index_signature_kind =
+                                                        TypeMemberKind::IndexSignature(
+                                                            resolved
+                                                                .apply_module_id_to_reference(
+                                                                    key_reference,
+                                                                )
+                                                                .into_owned(),
+                                                        );
+                                                    if member.kind.is_const_asserted() {
+                                                        resolved_index_signature_kind
+                                                            .with_const_asserted()
+                                                    } else {
+                                                        resolved_index_signature_kind
+                                                    }
                                                 }
                                                 other => other.clone(),
                                             };

--- a/crates/biome_js_type_info/src/type_data.rs
+++ b/crates/biome_js_type_info/src/type_data.rs
@@ -12,7 +12,7 @@
 pub mod literal;
 
 use std::borrow::Cow;
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Formatter, Result as FormatResult};
 use std::str::FromStr;
 
 use biome_js_type_info_macros::Resolvable;
@@ -646,7 +646,7 @@ pub struct Interface {
 }
 
 impl Debug for Interface {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Interface")
             .field("name", &self.name)
             .field("type_parameters", &self.type_parameters)
@@ -919,10 +919,23 @@ pub struct TupleElementType {
 }
 
 /// Members of a definition, such as an object, namespace or module.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Resolvable)]
+#[derive(Clone, Eq, Hash, PartialEq, Resolvable)]
 pub struct TypeMember {
     pub kind: TypeMemberKind,
     pub ty: TypeReference,
+}
+
+impl Debug for TypeMember {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FormatResult {
+        let mut debug_struct = formatter.debug_struct("TypeMember");
+        debug_struct
+            .field("kind", &self.kind.without_const_asserted())
+            .field("ty", &self.ty);
+        if self.is_const_asserted() {
+            debug_struct.field("is_const_asserted", &true);
+        }
+        debug_struct.finish()
+    }
 }
 
 impl TypeMember {
@@ -930,6 +943,12 @@ impl TypeMember {
     #[inline]
     pub fn is_optional(&self) -> bool {
         self.kind.is_optional()
+    }
+
+    /// Returns whether this member carries `as const` provenance.
+    #[inline]
+    pub fn is_const_asserted(&self) -> bool {
+        self.kind.is_const_asserted()
     }
 
     /// Returns a reference to the type of the member if we dereference it.
@@ -964,7 +983,10 @@ impl TypeMember {
 
     pub fn is_index_signature_with_ty(&self, predicate: impl Fn(&TypeReference) -> bool) -> bool {
         match &self.kind {
-            TypeMemberKind::IndexSignature(ty) => predicate(ty),
+            TypeMemberKind::IndexSignature(index_signature_type)
+            | TypeMemberKind::ConstAssertedIndexSignature(index_signature_type) => {
+                predicate(index_signature_type)
+            }
             _ => false,
         }
     }
@@ -989,6 +1011,13 @@ impl TypeMember {
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Resolvable)]
 pub enum TypeMemberKind {
     CallSignature,
+    ConstAssertedCallSignature,
+    ConstAssertedConstructor,
+    ConstAssertedGetter(Text),
+    ConstAssertedIndexSignature(TypeReference),
+    ConstAssertedNamed(Text),
+    ConstAssertedNamedOptional(Text),
+    ConstAssertedNamedStatic(Text),
     Constructor,
     Getter(Text),
     IndexSignature(TypeReference),
@@ -1000,49 +1029,144 @@ pub enum TypeMemberKind {
 impl TypeMemberKind {
     pub fn has_name(&self, name: &str) -> bool {
         match self {
-            Self::CallSignature | Self::IndexSignature(_) => false,
-            Self::Constructor => name == "constructor",
+            Self::CallSignature
+            | Self::ConstAssertedCallSignature
+            | Self::IndexSignature(_)
+            | Self::ConstAssertedIndexSignature(_) => false,
+            Self::Constructor | Self::ConstAssertedConstructor => name == "constructor",
             Self::Getter(own_name)
+            | Self::ConstAssertedGetter(own_name)
             | Self::Named(own_name)
+            | Self::ConstAssertedNamed(own_name)
             | Self::NamedOptional(own_name)
-            | Self::NamedStatic(own_name) => *own_name == name,
+            | Self::ConstAssertedNamedOptional(own_name)
+            | Self::NamedStatic(own_name)
+            | Self::ConstAssertedNamedStatic(own_name) => *own_name == name,
         }
     }
 
     /// Returns whether this member kind represents an optional member.
     #[inline]
     pub fn is_optional(&self) -> bool {
-        matches!(self, Self::NamedOptional(_))
+        matches!(
+            self,
+            Self::NamedOptional(_) | Self::ConstAssertedNamedOptional(_)
+        )
     }
 
     #[inline]
     pub fn is_call_signature(&self) -> bool {
-        matches!(self, Self::CallSignature)
+        matches!(self, Self::CallSignature | Self::ConstAssertedCallSignature)
     }
 
     #[inline]
     pub fn is_constructor(&self) -> bool {
-        matches!(self, Self::Constructor)
+        matches!(self, Self::Constructor | Self::ConstAssertedConstructor)
     }
 
     #[inline]
     pub fn is_getter(&self) -> bool {
-        matches!(self, Self::Getter(_))
+        matches!(self, Self::Getter(_) | Self::ConstAssertedGetter(_))
     }
 
     #[inline]
     pub fn is_static(&self) -> bool {
-        matches!(self, Self::Constructor | Self::NamedStatic(_))
+        matches!(
+            self,
+            Self::Constructor
+                | Self::ConstAssertedConstructor
+                | Self::NamedStatic(_)
+                | Self::ConstAssertedNamedStatic(_)
+        )
+    }
+
+    #[inline]
+    pub fn is_const_asserted(&self) -> bool {
+        matches!(
+            self,
+            Self::ConstAssertedCallSignature
+                | Self::ConstAssertedConstructor
+                | Self::ConstAssertedGetter(_)
+                | Self::ConstAssertedIndexSignature(_)
+                | Self::ConstAssertedNamed(_)
+                | Self::ConstAssertedNamedOptional(_)
+                | Self::ConstAssertedNamedStatic(_)
+        )
+    }
+
+    /// Marks the member kind with `as const` provenance without growing `TypeMember`.
+    pub fn with_const_asserted(self) -> Self {
+        match self {
+            Self::CallSignature | Self::ConstAssertedCallSignature => {
+                Self::ConstAssertedCallSignature
+            }
+            Self::Constructor | Self::ConstAssertedConstructor => Self::ConstAssertedConstructor,
+            Self::Getter(name) | Self::ConstAssertedGetter(name) => Self::ConstAssertedGetter(name),
+            Self::IndexSignature(index_signature_type)
+            | Self::ConstAssertedIndexSignature(index_signature_type) => {
+                Self::ConstAssertedIndexSignature(index_signature_type)
+            }
+            Self::Named(name) | Self::ConstAssertedNamed(name) => Self::ConstAssertedNamed(name),
+            Self::NamedOptional(name) | Self::ConstAssertedNamedOptional(name) => {
+                Self::ConstAssertedNamedOptional(name)
+            }
+            Self::NamedStatic(name) | Self::ConstAssertedNamedStatic(name) => {
+                Self::ConstAssertedNamedStatic(name)
+            }
+        }
+    }
+
+    /// Returns the structural member kind without `as const` provenance.
+    pub fn without_const_asserted(&self) -> Self {
+        match self {
+            Self::ConstAssertedCallSignature => Self::CallSignature,
+            Self::ConstAssertedConstructor => Self::Constructor,
+            Self::ConstAssertedGetter(name) => Self::Getter(name.clone()),
+            Self::ConstAssertedIndexSignature(index_signature_type) => {
+                Self::IndexSignature(index_signature_type.clone())
+            }
+            Self::ConstAssertedNamed(name) => Self::Named(name.clone()),
+            Self::ConstAssertedNamedOptional(name) => Self::NamedOptional(name.clone()),
+            Self::ConstAssertedNamedStatic(name) => Self::NamedStatic(name.clone()),
+            other => other.clone(),
+        }
+    }
+
+    /// Makes named properties optional while preserving `as const` provenance.
+    pub fn with_optional(self) -> Self {
+        match self {
+            Self::Named(name) => Self::NamedOptional(name),
+            Self::ConstAssertedNamed(name) => Self::ConstAssertedNamedOptional(name),
+            other => other,
+        }
+    }
+
+    /// Makes optional named properties required while preserving `as const` provenance.
+    pub fn without_optional(self) -> Self {
+        match self {
+            Self::NamedOptional(name) => Self::Named(name),
+            Self::ConstAssertedNamedOptional(name) => Self::ConstAssertedNamed(name),
+            other => other,
+        }
     }
 
     pub fn name(&self) -> Option<Text> {
         match self {
-            Self::CallSignature | Self::IndexSignature(_) => None,
-            Self::Constructor => Some(Text::new_static("constructor")),
+            Self::CallSignature
+            | Self::ConstAssertedCallSignature
+            | Self::IndexSignature(_)
+            | Self::ConstAssertedIndexSignature(_) => None,
+            Self::Constructor | Self::ConstAssertedConstructor => {
+                Some(Text::new_static("constructor"))
+            }
             Self::Getter(name)
+            | Self::ConstAssertedGetter(name)
             | Self::Named(name)
+            | Self::ConstAssertedNamed(name)
             | Self::NamedOptional(name)
-            | Self::NamedStatic(name) => Some(name.clone()),
+            | Self::ConstAssertedNamedOptional(name)
+            | Self::NamedStatic(name)
+            | Self::ConstAssertedNamedStatic(name) => Some(name.clone()),
         }
     }
 }

--- a/crates/biome_js_type_info/tests/local_inference.rs
+++ b/crates/biome_js_type_info/tests/local_inference.rs
@@ -1,7 +1,7 @@
 mod utils;
 
 use biome_js_semantic::ScopeId;
-use biome_js_type_info::{GlobalsResolver, TypeData};
+use biome_js_type_info::{GlobalsResolver, TypeData, TypeResolver};
 
 use utils::{
     assert_type_data_snapshot, assert_typed_bindings_snapshot, get_expression,
@@ -66,6 +66,123 @@ fn infer_type_of_typeof_expression() {
     let mut resolver = GlobalsResolver::default();
     let ty = TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expr);
     assert_type_data_snapshot(CODE, &ty, &resolver, "infer_type_of_typeof_expression");
+}
+
+#[test]
+fn infer_type_of_const_assertion() {
+    const CODE: &str = r#""value" as const"#;
+
+    let syntax_tree = parse_ts(CODE);
+    let expression = get_expression(&syntax_tree);
+    let mut resolver = GlobalsResolver::default();
+    let expression_type =
+        TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expression);
+    assert_eq!(expression_type.to_string(), "string: value");
+}
+
+#[test]
+fn const_assertion_marks_object_property_as_const_asserted() {
+    const CODE: &str =
+        r#"({ value: "x" as const, nested: { flag: true as const }, paren: ("y" as const) })"#;
+
+    let syntax_tree = parse_ts(CODE);
+    let expression = get_expression(&syntax_tree);
+    let mut resolver = GlobalsResolver::default();
+    let expression_type =
+        TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expression);
+    let TypeData::Object(object) = expression_type else {
+        panic!("expected object type");
+    };
+
+    let value = object
+        .members
+        .iter()
+        .find(|member| member.has_name("value"))
+        .expect("value member");
+    assert!(value.is_const_asserted());
+    let value_type = resolver
+        .resolve_and_get(&value.ty)
+        .expect("value type")
+        .to_data();
+    assert_eq!(value_type.to_string(), "string: x");
+
+    let nested = object
+        .members
+        .iter()
+        .find(|member| member.has_name("nested"))
+        .expect("nested member");
+    assert!(!nested.is_const_asserted());
+    let nested_type = resolver
+        .resolve_and_get(&nested.ty)
+        .expect("nested type")
+        .to_data();
+    let TypeData::Object(nested_object) = nested_type else {
+        panic!("expected nested object type");
+    };
+    let flag = nested_object
+        .members
+        .iter()
+        .find(|member| member.has_name("flag"))
+        .expect("flag member");
+    assert!(flag.is_const_asserted());
+    let flag_type = resolver
+        .resolve_and_get(&flag.ty)
+        .expect("flag type")
+        .to_data();
+    assert_eq!(flag_type.to_string(), "bool: true");
+
+    let parenthesized = object
+        .members
+        .iter()
+        .find(|member| member.has_name("paren"))
+        .expect("paren member");
+    assert!(parenthesized.is_const_asserted());
+}
+
+#[test]
+fn const_assertion_marks_nested_object_members_as_const_asserted() {
+    const CODE: &str = r#"({ value: { inner: "x" } } as const)"#;
+
+    let syntax_tree = parse_ts(CODE);
+    let expression = get_expression(&syntax_tree);
+    let mut resolver = GlobalsResolver::default();
+    let expression_type =
+        TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expression);
+    let TypeData::Object(object) = expression_type else {
+        panic!("expected object type");
+    };
+
+    let value = object
+        .members
+        .iter()
+        .find(|member| member.has_name("value"))
+        .expect("value member");
+    assert!(value.is_const_asserted());
+    let value_type = resolver
+        .resolve_and_get(&value.ty)
+        .expect("value type")
+        .to_data();
+    let TypeData::Object(value_object) = value_type else {
+        panic!("expected nested object type");
+    };
+    let inner = value_object
+        .members
+        .iter()
+        .find(|member| member.has_name("inner"))
+        .expect("inner member");
+    assert!(inner.is_const_asserted());
+}
+
+#[test]
+fn const_assertion_preserves_negative_number_literal() {
+    const CODE: &str = r#"-1 as const"#;
+
+    let syntax_tree = parse_ts(CODE);
+    let expression = get_expression(&syntax_tree);
+    let mut resolver = GlobalsResolver::default();
+    let expression_type =
+        TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expression);
+    assert_eq!(expression_type.to_string(), "number: -1");
 }
 
 #[test]

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -2691,3 +2691,38 @@ fn test_optional_and_readonly_members() {
 
     snapshot.assert_snapshot("test_optional_and_readonly_members");
 }
+
+#[test]
+fn test_property_const_assertion_flows_through_module_resolver() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"const object = { value: "x" as const };"#,
+    );
+
+    let added_paths = [BiomePath::new("/src/index.ts")];
+    let added_paths = get_added_js_paths(&fs, &added_paths);
+
+    let module_graph = Arc::new(ModuleGraph::default());
+    module_graph.update_graph_for_js_paths(&fs, &ProjectLayout::default(), &added_paths, true);
+
+    let index_module = module_graph
+        .js_module_info_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let resolver = Arc::new(ModuleResolver::for_module(index_module, module_graph));
+    let object = resolver.resolved_type_of_named_value(TextRange::default(), "object");
+    let TypeData::Object(object) = object.deref() else {
+        panic!("expected object type");
+    };
+    let value = object
+        .members
+        .iter()
+        .find(|member| member.has_name("value"))
+        .expect("value member");
+    assert!(value.is_const_asserted());
+    let value_type = resolver
+        .resolve_and_get(&value.ty)
+        .expect("value type")
+        .to_data();
+    assert_eq!(value_type.to_string(), "string: x");
+}


### PR DESCRIPTION
This PR was implemented with AI assistance from Codex.

## Summary

Addresses the property-level `as const` case from #9810.

`biome_js_type_info` now preserves const-assertion information for object-literal members such as `{ a: "x" as const }`, so type-aware rules can distinguish const-asserted properties from widened object properties without adding ad-hoc AST checks in individual rules.


## Test Plan

Snapshot tests.