### PR TITLE
feat(markdown_formatter): enable formatter ir debugger

### DIFF
--- a/crates/biome_service/src/file_handlers/md.rs
+++ b/crates/biome_service/src/file_handlers/md.rs
@@ -237,7 +237,7 @@ impl ExtensionHandler for MarkdownFileHandler {
             debug: DebugCapabilities {
                 debug_syntax_tree: Some(debug_syntax_tree),
                 debug_control_flow: None,
-                debug_formatter_ir: None,
+                debug_formatter_ir: Some(debug_formatter_ir),
                 debug_type_info: None,
                 debug_registered_types: None,
                 debug_semantic_model: None,
@@ -291,6 +291,21 @@ fn debug_syntax_tree(_biome_path: &BiomePath, parse: AnyParse) -> GetSyntaxTreeR
         cst: format!("{syntax:#?}"),
         ast: format!("{tree:#?}"),
     }
+}
+
+fn debug_formatter_ir(
+    biome_path: &BiomePath,
+    document_file_source: &DocumentFileSource,
+    parse: AnyParse,
+    settings: &SettingsWithEditor,
+) -> Result<String, WorkspaceError> {
+    let options = settings.format_options::<MarkdownLanguage>(biome_path, document_file_source);
+
+    let tree = parse.syntax();
+    let formatted = format_node(options, &tree)?;
+
+    let root_element = formatted.into_document();
+    Ok(root_element.to_string())
 }
 
 pub(crate) fn format(


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

I started using `prettier-compare` per @dyc3 's [suggestion](https://github.com/biomejs/website/pull/4194#issuecomment-4330789039). We need to enable this capability before `prettier-compare` can work with Markdown.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

```
$ bun run packages/prettier-compare/bin/prettier-compare.js --rebuild -l md '**foo* *'
Rebuilding WASM...
Starting WASM rebuild...
WASM rebuilt successfully.

=== Formatted Output ===  [DIFF]

--- Biome ---
*_foo_ *

--- Prettier ---
\*_foo_ \*

=== IR (Intermediate Representation) ===

--- Biome ---
["*_foo_ *", hard_line_break]

--- Prettier ---
[fill([["\\*", "_", "foo", "_", " ", "\\*"]]), hardline]

Language: Markdown | Prettier parser: markdown
```
