### PR TITLE
fix(css_formatter): avoid double indenting pseudo classes 🤖🤖🤖

### DIFF
--- a/.changeset/fix-css-functional-pseudo-indent.md
+++ b/.changeset/fix-css-functional-pseudo-indent.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10045](https://github.com/biomejs/biome/issues/10045): CSS formatter no longer over-indents nested functional pseudo-classes such as `:not(:where(...))` when wrapping selector lists.

--- a/crates/biome_css_formatter/src/css/lists/selector_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/selector_list.rs
@@ -80,17 +80,26 @@ impl FormatRule<CssSelectorList> for FormatCssSelectorList {
                 }
             }
 
-            // Each selector gets `indent` added in case it breaks over multiple
-            // lines. The break is added here rather than in each selector both
-            // for simplicity and to avoid recursively adding indents when
-            // selectors are nested within other rules. The group is then added
-            // around the indent to ensure that it tries using a flat layout
-            // first and only expands when the single selector can't fit the line.
-            //
-            // For example, a selector like `div span a` is structured like
-            // `[div, [span, [a]]]`, so `a` would end up double-indented if it
-            // was handled by the selector rather than here.
-            joiner.entry(&group(&indent(&formatted)));
+            if formatted.node()?.as_css_complex_selector().is_some() {
+                // Each complex selector gets `indent` added in case it breaks over
+                // multiple lines. The break is added here rather than in each
+                // selector both for simplicity and to avoid recursively adding
+                // indents when selectors are nested within other rules. The group
+                // is then added around the indent to ensure that it tries using a
+                // flat layout first and only expands when the single selector can't
+                // fit the line.
+                //
+                // For example, a selector like `div span a` is structured like
+                // `[div, [span, [a]]]`, so `a` would end up double-indented if it
+                // was handled by the selector rather than here.
+                joiner.entry(&group(&indent(&formatted)));
+            } else {
+                // Compound selectors can break internally, for example in nested
+                // functional pseudo-classes like `:not(:where(...))`. Those nodes
+                // already add their own block indentation, so adding a selector-list
+                // indent here would double-indent their contents.
+                joiner.entry(&group(&formatted));
+            }
         }
 
         joiner.finish()

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/not.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/not.css
@@ -10,3 +10,7 @@ div:not(
      #id:hover
      
      ) {}
+
+input:not(:where([type='submit'], [type='checkbox'], [type='radio'], [type='button'], [type='reset'])) {
+	inline-size: 100%;
+}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/not.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/not.css.snap
@@ -18,6 +18,11 @@ div:not(
      #id:hover
      
      ) {}
+
+input:not(:where([type='submit'], [type='checkbox'], [type='radio'], [type='button'], [type='reset'])) {
+	inline-size: 100%;
+}
+
 ```
 
 
@@ -28,6 +33,18 @@ div:not(:last-child) {
 }
 
 :not(div + #id:hover) {
+}
+
+input:not(
+	:where(
+		[type="submit"],
+		[type="checkbox"],
+		[type="radio"],
+		[type="button"],
+		[type="reset"]
+	)
+) {
+	inline-size: 100%;
 }
 
 ```


### PR DESCRIPTION
## Summary

Fixes #10045

The CSS formatter now avoids adding an extra selector-list indent around compound selectors, so nested functional pseudo-classes such as `:not(:where(...))` wrap at the expected indentation.

> This PR was created with AI assistance.

## Test Plan

- `cargo test -p biome_css_formatter --test spec_tests formatter::css_module::css::pseudo::not_css`
- `git diff --check`

Note: `just f` was attempted; the Rust formatting step completed, but the repo-level `pnpm format` step could not run in this environment because `tombi`/node dependencies were not installed.

## Docs

No documentation changes needed for this formatter bug fix.
