### PR TITLE
fix(analyzer): respect overrides that disable rules when using --only

### DIFF
--- a/.changeset/fix-suppress-only-overrides.md
+++ b/.changeset/fix-suppress-only-overrides.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10113](https://github.com/biomejs/biome/issues/10113): `--suppress` with `--only` no longer ignores overrides that disable a rule.
+
+Previously, running `biome lint --suppress --only=lint/suspicious/noDebugger` would add suppression comments to files where the rule was disabled by an override. Now, overrides that set a rule to `"off"` are always respected, regardless of whether `--only` is active.

--- a/crates/biome_cli/tests/cases/suppressions.rs
+++ b/crates/biome_cli/tests/cases/suppressions.rs
@@ -279,6 +279,93 @@ fn custom_explanation_with_reason() {
 }
 
 #[test]
+fn suppress_only_respects_override_disabling_rule() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // Config: noDebugger enabled at root, disabled for foo/**
+    let config_path = Utf8Path::new("biome.json");
+    fs.insert(
+        config_path.into(),
+        r#"{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noDebugger": "error"
+      }
+    }
+  },
+  "overrides": [{
+    "includes": ["foo/**"],
+    "linter": {
+      "rules": {
+        "suspicious": {
+          "noDebugger": "off"
+        }
+      }
+    }
+  }]
+}"#
+        .as_bytes(),
+    );
+
+    // File in normal path: should get suppression
+    let regular_path = Utf8Path::new("src/regular.js");
+    fs.insert(regular_path.into(), b"debugger;" as &[u8]);
+
+    // File in overridden path: should NOT get suppression (rule is off)
+    let overridden_path = Utf8Path::new("foo/overridden.js");
+    fs.insert(overridden_path.into(), b"debugger;" as &[u8]);
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "lint",
+                "--suppress",
+                "--only=lint/suspicious/noDebugger",
+                regular_path.as_str(),
+                overridden_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    // The overridden file should be unchanged (no suppression comment added)
+    let mut overridden_content = String::new();
+    fs.open(overridden_path)
+        .unwrap()
+        .read_to_string(&mut overridden_content)
+        .unwrap();
+    assert_eq!(
+        overridden_content, "debugger;",
+        "override-disabled file should not receive a suppression comment"
+    );
+
+    // The regular file should have the suppression comment
+    let mut regular_content = String::new();
+    fs.open(regular_path)
+        .unwrap()
+        .read_to_string(&mut regular_content)
+        .unwrap();
+    assert!(
+        regular_content.contains("biome-ignore"),
+        "regular file should receive a suppression comment"
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "suppress_only_respects_override_disabling_rule",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn unused_suppression_after_top_level() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/cases/suppressions.rs
+++ b/crates/biome_cli/tests/cases/suppressions.rs
@@ -352,8 +352,8 @@ fn suppress_only_respects_override_disabling_rule() {
         .read_to_string(&mut regular_content)
         .unwrap();
     assert!(
-        regular_content.contains("biome-ignore"),
-        "regular file should receive a suppression comment"
+        regular_content.contains("biome-ignore lint/suspicious/noDebugger"),
+        "regular file should receive a noDebugger suppression comment"
     );
 
     assert_cli_snapshot(SnapshotPayload::new(

--- a/crates/biome_cli/tests/snapshots/main_cases_suppressions/suppress_only_respects_override_disabling_rule.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_suppressions/suppress_only_respects_override_disabling_rule.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 520
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noDebugger": "error"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["foo/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noDebugger": "off"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+## `foo/overridden.js`
+
+```js
+debugger;
+```
+
+## `src/regular.js`
+
+```js
+// biome-ignore lint/suspicious/noDebugger: ignored using `--suppress`
+debugger;
+```
+
+# Emitted Messages
+
+```block
+Checked 2 files in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -1700,8 +1700,11 @@ impl<'a, 'b> LintVisitor<'a, 'b> {
             .unwrap_or_default();
         if !has_only_filter {
             self.enabled_rules.extend(rules.as_enabled_rules());
-            self.disabled_rules.extend(rules.as_disabled_rules());
         }
+        // Always respect overrides that disable rules, even when --only is active.
+        // Without this, --suppress with --only would add suppression comments to
+        // files where the rule is disabled by an override.
+        self.disabled_rules.extend(rules.as_disabled_rules());
         let fixable_rules = self
             .enabled_rules
             .iter()
@@ -1988,8 +1991,11 @@ impl<'a, 'b> AssistsVisitor<'a, 'b> {
             .unwrap_or_default();
         if !has_only_filter {
             self.enabled_rules.extend(rules.as_enabled_rules());
-            self.disabled_rules.extend(rules.as_disabled_rules());
         }
+        // Always respect overrides that disable rules, even when --only is active.
+        // Without this, --suppress with --only would add suppression comments to
+        // files where the rule is disabled by an override.
+        self.disabled_rules.extend(rules.as_disabled_rules());
         let fixable_rules = self
             .enabled_rules
             .iter()


### PR DESCRIPTION
## Summary

Fixes #10113. When `--only` was specified, `LintVisitor::finish()` and `AssistsVisitor::finish()` skipped populating `disabled_rules` from the merged override configuration. This caused `--suppress` with `--only` to add suppression comments to files where the target rule was disabled by an override.

## Root cause

In `crates/biome_service/src/file_handlers/mod.rs`, both `LintVisitor::finish()` and `AssistsVisitor::finish()` had:

```rust
if !has_only_filter {
    self.enabled_rules.extend(rules.as_enabled_rules());
    self.disabled_rules.extend(rules.as_disabled_rules());
}
```

When `--only` is active, `has_only_filter` is `true`, so the entire block is skipped. This means `disabled_rules` never receives the override-disabled rules from the merged config. Since `AnalysisFilter::match_rule` gives `disabled_rules` precedence over `enabled_rules`, the missing entries allow the rule to fire on files where it should be off.

## Fix

Move `disabled_rules.extend(rules.as_disabled_rules())` outside the `!has_only_filter` guard. The `enabled_rules` population stays gated (we don't want all enabled rules when `--only` is set), but disabled rules from overrides should always be respected.

Applied to both `LintVisitor::finish()` and `AssistsVisitor::finish()` for consistency.

## Test plan

- All 18 existing suppression tests pass (`cargo test --package biome_cli -- suppressions`)
- Verified with the reproduction repo from #10113: the override-disabled file no longer receives a suppression comment