### PR TITLE
feat(css_formatter): improve handling of SCSS list trailing separator comments

### DIFF
--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -1,11 +1,12 @@
 use crate::prelude::*;
 use crate::utils::scss_include_comments::{
-    place_map_trailing_separator_comment, place_separated_list_comment,
+    place_list_trailing_separator_comment, place_map_trailing_separator_comment,
+    place_separated_list_comment,
 };
 use biome_css_syntax::{
     AnyCssDeclarationName, AnyCssRoot, CssComplexSelector, CssFunction, CssGenericProperty,
-    CssIdentifier, CssLanguage, CssSyntaxKind, ScssMapExpression, ScssMapExpressionPair, TextLen,
-    TextSize,
+    CssIdentifier, CssLanguage, CssSyntaxKind, ScssListExpression, ScssListExpressionElement,
+    ScssMapExpression, ScssMapExpressionPair, TextLen, TextSize,
 };
 use biome_diagnostics::category;
 use biome_formatter::comments::{
@@ -103,6 +104,7 @@ impl CommentStyle for CssCommentStyle {
     ) -> CommentPlacement<Self::Language> {
         handle_scss_map_trailing_separator_comment(comment)
             .or_else(place_separated_list_comment)
+            .or_else(handle_scss_list_trailing_separator_comment)
             .or_else(handle_function_comment)
             .or_else(handle_generic_property_comment)
             .or_else(handle_declaration_name_comment)
@@ -133,6 +135,27 @@ fn handle_scss_map_trailing_separator_comment(
     };
 
     place_map_trailing_separator_comment(&map_expression, &preceding_pair, comment)
+}
+
+fn handle_scss_list_trailing_separator_comment(
+    comment: DecoratedComment<CssLanguage>,
+) -> CommentPlacement<CssLanguage> {
+    let Some(preceding_element) = comment
+        .preceding_node()
+        .and_then(ScssListExpressionElement::cast_ref)
+    else {
+        return CommentPlacement::Default(comment);
+    };
+
+    let Some(list_expression) = preceding_element
+        .syntax()
+        .ancestors()
+        .find_map(ScssListExpression::cast)
+    else {
+        return CommentPlacement::Default(comment);
+    };
+
+    place_list_trailing_separator_comment(&list_expression, &preceding_element, comment)
 }
 
 fn handle_function_comment(

--- a/crates/biome_css_formatter/src/utils/scss_include_comments.rs
+++ b/crates/biome_css_formatter/src/utils/scss_include_comments.rs
@@ -1,7 +1,7 @@
-//! Comment placement rules for SCSS `@include` arguments.
+//! Comment placement rules for SCSS separated forms.
 //!
-//! Separator-path comments are attached before formatting so renderers only
-//! need to print leading, trailing, or dangling comments.
+//! Separator comments are attached before formatting so renderers only need to
+//! print leading, trailing, or dangling comments.
 
 use crate::utils::scss_context::is_in_scss_include_arguments;
 use crate::utils::scss_expression::{
@@ -10,7 +10,8 @@ use crate::utils::scss_expression::{
 };
 use biome_css_syntax::{
     CssLanguage, CssParameterList, CssSyntaxKind, CssSyntaxNode, ScssIncludeArgumentList,
-    ScssKeywordArgument, ScssListExpression, ScssMapExpression, ScssMapExpressionPair,
+    ScssKeywordArgument, ScssListExpression, ScssListExpressionElement, ScssMapExpression,
+    ScssMapExpressionPair,
 };
 use biome_formatter::comments::{CommentPlacement, DecoratedComment};
 use biome_rowan::AstNode;
@@ -24,6 +25,18 @@ pub(crate) fn place_map_trailing_separator_comment(
     comment: DecoratedComment<CssLanguage>,
 ) -> CommentPlacement<CssLanguage> {
     classify_map_trailing_separator_comment(map_expression, preceding_pair, &comment)
+        .into_comment_placement(comment)
+}
+
+/// Places comments that follow a list separator.
+///
+/// Example: `$list: a, // next\nb;`.
+pub(crate) fn place_list_trailing_separator_comment(
+    list_expression: &ScssListExpression,
+    preceding_element: &ScssListExpressionElement,
+    comment: DecoratedComment<CssLanguage>,
+) -> CommentPlacement<CssLanguage> {
+    classify_list_trailing_separator_comment(list_expression, preceding_element, &comment)
         .into_comment_placement(comment)
 }
 
@@ -102,6 +115,29 @@ fn classify_map_trailing_separator_comment(
     }
 
     attachment_before_next_or_closing(comment, map_expression.syntax().clone())
+}
+
+/// Classifies comments after list separators before attaching them.
+fn classify_list_trailing_separator_comment(
+    list_expression: &ScssListExpression,
+    preceding_element: &ScssListExpressionElement,
+    comment: &DecoratedComment<CssLanguage>,
+) -> IncludeCommentAttachment {
+    if is_in_scss_include_arguments(list_expression.syntax()) {
+        return IncludeCommentAttachment::Default;
+    }
+
+    let is_separator_comment = is_trailing_separator_comment(preceding_element.syntax(), comment);
+
+    if comment.kind().is_line()
+        && comment.text_position().is_end_of_line()
+        && is_separator_comment
+        && comment.following_node().is_some()
+    {
+        attachment_before_next_or_closing(comment, list_expression.syntax().clone())
+    } else {
+        IncludeCommentAttachment::Default
+    }
 }
 
 /// Classifies comments after include-owned list separators.

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/comments/4594.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/comments/4594.scss.snap
@@ -55,7 +55,7 @@ $my-map: (
 @@ -20,8 +20,10 @@
    "baz": 4, // Baz
  );
-
+ 
 -[href]:hover &, // Comment
 -[href]:focus &, // Comment
 +[href]:hover

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/comments/4594.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/comments/4594.scss.snap
@@ -52,20 +52,10 @@ $my-map: (
 ```diff
 --- Prettier
 +++ Biome
-@@ -6,8 +6,7 @@
- }
- 
- $my-list:
--  "foo",
--  // Comment
-+  "foo", // Comment
-   "bar"; // Comment
- 
- $my-map: (
-@@ -20,8 +19,10 @@
+@@ -20,8 +20,10 @@
    "baz": 4, // Baz
  );
- 
+
 -[href]:hover &, // Comment
 -[href]:focus &, // Comment
 +[href]:hover
@@ -75,7 +65,7 @@ $my-map: (
  [href]:active & {
    .tooltip {
      opacity: 1;
-@@ -33,7 +34,8 @@
+@@ -33,7 +35,8 @@
    "variables",
    // Comment
    "reset",
@@ -98,7 +88,8 @@ $my-map: (
 }
 
 $my-list:
-  "foo", // Comment
+  "foo",
+  // Comment
   "bar"; // Comment
 
 $my-map: (

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/comments/lists.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/comments/lists.scss.snap
@@ -23,10 +23,10 @@ $my-list2:
 reformat: output mismatch
 --- re-formatted
 +++ formatted
-@@ -2,4 +2,5 @@
-   "foo", // Foo
+@@ -3,4 +3,5 @@
+   // Foo
    "bar"; // Bar
- 
+
 -$my-list2: a b c; // a
 +$my-list2: // a
 +  a b c;
@@ -34,7 +34,7 @@ reformat: output mismatch
 IR differences:
 --- re-formatted IR
 +++ formatted IR
-@@ -15,14 +15,11 @@
+@@ -14,14 +14,11 @@
    line_suffix([" // Bar"]),
    expand_parent,
    empty_line,

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/comments/lists.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/comments/lists.scss.snap
@@ -26,7 +26,7 @@ reformat: output mismatch
 @@ -3,4 +3,5 @@
    // Foo
    "bar"; // Bar
-
+ 
 -$my-list2: a b c; // a
 +$my-list2: // a
 +  a b c;

--- a/crates/biome_css_formatter/tests/specs/scss/expression/separator-line-comments.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/separator-line-comments.scss
@@ -2,3 +2,7 @@ $map-after-source-comma: (
 a:1px, // after comma
 b:2px
 );
+
+$list-after-source-comma:
+a, // after comma
+b;

--- a/crates/biome_css_formatter/tests/specs/scss/expression/separator-line-comments.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/separator-line-comments.scss.snap
@@ -12,6 +12,10 @@ a:1px, // after comma
 b:2px
 );
 
+$list-after-source-comma:
+a, // after comma
+b;
+
 ```
 
 
@@ -23,5 +27,10 @@ $map-after-source-comma: (
 	// after comma
 	b: 2px,
 );
+
+$list-after-source-comma:
+	a,
+	// after comma
+	b;
 
 ```


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

  ## Summary

  Aligns SCSS list separator line comments with Prettier.

```scss
  $list-after-source-comma:
    a,
    // after comma
    b;
```

  ## Test Plan

cargo test -p biome_css_formatter

