### PR TITLE
feat(css_formatter): improve handling of SCSS `@while` rule formatting

### DIFF
--- a/crates/biome_css_formatter/src/scss/statements/while_at_rule.rs
+++ b/crates/biome_css_formatter/src/scss/statements/while_at_rule.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
+use crate::utils::scss_expression::single_expression_item;
 use biome_css_syntax::{ScssWhileAtRule, ScssWhileAtRuleFields};
-use biome_formatter::write;
+use biome_formatter::{format_args, write};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssWhileAtRule;
@@ -13,13 +14,36 @@ impl FormatNodeRule<ScssWhileAtRule> for FormatScssWhileAtRule {
             block,
         } = node.as_fields();
 
+        let is_parenthesized_condition = condition.as_ref().is_ok_and(|condition| {
+            single_expression_item(condition)
+                .is_some_and(|item| item.as_scss_parenthesized_expression().is_some())
+        });
+
+        if is_parenthesized_condition {
+            return write!(
+                f,
+                [
+                    while_token.format(),
+                    space(),
+                    condition.format(),
+                    space(),
+                    block.format()
+                ]
+            );
+        }
+
+        let header_group_id = f.group_id("scss_while_header");
+
         write!(
             f,
             [
                 while_token.format(),
                 space(),
-                condition.format(),
-                space(),
+                group(&format_args![
+                    indent_if_group_breaks(&condition.format(), header_group_id),
+                    soft_line_break_or_space()
+                ])
+                .with_group_id(Some(header_group_id)),
                 block.format()
             ]
         )

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/while.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/while.scss.snap
@@ -142,23 +142,7 @@ $i
  }
  @while ($i > 0) {
  }
-@@ -29,20 +29,17 @@
- @while ($i > 0) {
- }
- @while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
--  1
--{
-+1 {
- }
- @while 1 >
--  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
--{
-+$very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var {
- }
- @while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
--  $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
--{
-+$other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var {
+@@ -42,7 +42,7 @@
  }
  @while (($i) > (0)) {
  }
@@ -167,7 +151,7 @@ $i
  }
  @while (($i) > (0)) {
  }
-@@ -58,16 +55,16 @@
+@@ -58,16 +58,16 @@
  }
  @while (
    1 >
@@ -223,13 +207,16 @@ $i
 @while ($i > 0) {
 }
 @while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
-1 {
+  1
+{
 }
 @while 1 >
-$very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var {
+  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+{
 }
 @while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
-$other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var {
+  $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+{
 }
 @while (($i) > (0)) {
 }
@@ -267,11 +254,11 @@ $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-ver
 # Lines exceeding max width of 80 characters
 ```
    31: @while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
-   35: $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var {
-   37: @while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
-   38: $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var {
-   58:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
-   62:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
-   67:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
-   68:   $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   36:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   39: @while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
+   40:   $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   61:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   65:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
+   70:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
+   71:   $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/while.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/while.scss
@@ -9,3 +9,6 @@ gap:$gap;
 $gap:$gap - 0.25rem;
 }
 }
+
+@while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var > 1{
+}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/while.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/while.scss.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: css/scss/at-rule/while.scss
+info: scss/at-rule/while.scss
 ---
 
 # Input
@@ -16,6 +16,9 @@ $gap  >  0{
 gap:$gap;
 $gap:$gap - 0.25rem;
 }
+}
+
+@while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var > 1{
 }
 
 ```
@@ -35,4 +38,14 @@ $gap:$gap - 0.25rem;
 	}
 }
 
+@while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
+	1
+{
+}
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+   12: @while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
 ```


### PR DESCRIPTION
 > This PR was created with AI assistance (Codex).

  ## Summary

  Align SCSS `@while` formatting with Prettier for long non-parenthesized conditions.

  ## Test Plan

 cargo test -p biome_css_formatter
