### PR TITLE
feat(css_formatter): improve handling of SCSS `@for` rule formatting

### DIFF
--- a/crates/biome_css_formatter/src/scss/statements/for_at_rule.rs
+++ b/crates/biome_css_formatter/src/scss/statements/for_at_rule.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use biome_css_syntax::{ScssForAtRule, ScssForAtRuleFields};
-use biome_formatter::write;
+use biome_formatter::{format_args, write};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssForAtRule;
@@ -22,16 +22,20 @@ impl FormatNodeRule<ScssForAtRule> for FormatScssForAtRule {
             [
                 for_token.format(),
                 space(),
-                variable.format(),
-                space(),
-                from_token.format(),
-                space(),
-                lower_bound.format(),
-                space(),
-                operator.format(),
-                space(),
-                upper_bound.format(),
-                space(),
+                group(&format_args![
+                    variable.format(),
+                    indent(&format_args![
+                        soft_line_break_or_space(),
+                        from_token.format(),
+                        space(),
+                        lower_bound.format(),
+                        soft_line_break_or_space(),
+                        operator.format(),
+                        space(),
+                        upper_bound.format()
+                    ]),
+                    soft_line_break_or_space()
+                ]),
                 block.format()
             ]
         )

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/for.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/for.scss.snap
@@ -58,65 +58,32 @@ through
 ```diff
 --- Prettier
 +++ Biome
-@@ -12,44 +12,24 @@
- }
- @for $i from 1 through 8 {
- }
--@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
--  from 1
--  through 5
--{
-+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from 1 through 5 {
- }
--@for $i
--  from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
--  through 5
--{
-+@for $i from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 through 5 {
- }
--@for $i
--  from 1
--  through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
--{
-+@for $i from 1 through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {
- }
--@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
--  from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
--  through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
--{
-+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {
+@@ -32,11 +32,7 @@
+   through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+ {
  }
 -@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
 -  from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
 -  end $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
 -{
-+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 end $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {}
-+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from (
-+  $var1 + $var1
-+) through ($var-2 + $var-2) {
- }
--@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
--  from ($var1 + $var1)
--  through ($var-2 + $var-2)
--{
 -}
--@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
--  from (
--    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
++@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 end $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {}
+ @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   from ($var1 + $var1)
+   through ($var-2 + $var-2)
+@@ -45,11 +41,11 @@
+ @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   from (
+     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
 -      $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
--  )
--  through (
--    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
++    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
+   )
+   through (
+     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
 -      $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
--  )
--{
-+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from (
-+  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
-+  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
-+) through (
-+  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
-+  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
-+) {
++    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+   )
+ {
  }
 ```
 
@@ -137,26 +104,42 @@ through
 }
 @for $i from 1 through 8 {
 }
-@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from 1 through 5 {
+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+  from 1
+  through 5
+{
 }
-@for $i from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 through 5 {
+@for $i
+  from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
+  through 5
+{
 }
-@for $i from 1 through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {
+@for $i
+  from 1
+  through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+{
 }
-@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {
+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+  from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
+  through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+{
 }
 @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 end $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {}
-@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from (
-  $var1 + $var1
-) through ($var-2 + $var-2) {
+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+  from ($var1 + $var1)
+  through ($var-2 + $var-2)
+{
 }
-@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from (
-  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
-  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
-) through (
-  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
-  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
-) {
+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+  from (
+    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
+    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
+  )
+  through (
+    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
+    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+  )
+{
 }
 ```
 
@@ -180,15 +163,17 @@ for.scss:41:273 parse ━━━━━━━━━━━━━━━━━━━�
 
 # Lines exceeding max width of 80 characters
 ```
-   15: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from 1 through 5 {
-   17: @for $i from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 through 5 {
-   19: @for $i from 1 through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {
-   21: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {
-   23: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 end $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {}
-   24: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from (
-   28: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from (
-   29:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
-   30:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
-   32:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
-   33:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+   15: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   21:   from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
+   27:   through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+   30: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   31:   from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
+   32:   through $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+   35: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 end $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 {}
+   36: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   41: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   43:     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
+   44:     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
+   47:     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
+   48:     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/for.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/for.scss
@@ -15,3 +15,6 @@ $end - 1
 margin:$step;
 }
 }
+
+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from 1 through 5{
+}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/for.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/for.scss.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: css/scss/at-rule/for.scss
+info: scss/at-rule/for.scss
 ---
 
 # Input
@@ -24,6 +24,9 @@ margin:$step;
 }
 }
 
+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var from 1 through 5{
+}
+
 ```
 
 
@@ -42,4 +45,15 @@ margin:$step;
 	}
 }
 
+@for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+	from 1
+	through 5
+{
+}
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+   13: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
 ```


### PR DESCRIPTION
 > This PR was created with AI assistance (Codex).

  ## Summary

  Align SCSS `@for` long-header formatting with Prettier.

  ```scss
  @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
  	from 1
  	through 5
  {
  }
```

  ## Test Plan

  cargo test -p biome_css_formatter