### PR TITLE
feat(css_formatter): improve handling of SCSS parenthesized binary expressions formatting

### DIFF
--- a/crates/biome_css_formatter/src/scss/auxiliary/binary_expression.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/binary_expression.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::{ScssBinaryExpression, ScssBinaryExpressionFields};
+use biome_css_syntax::{
+    ScssBinaryExpression, ScssBinaryExpressionFields, ScssParenthesizedExpression,
+};
 use biome_formatter::{format_args, write};
 
 #[derive(Debug, Clone, Default)]
@@ -12,15 +14,36 @@ impl FormatNodeRule<ScssBinaryExpression> for FormatScssBinaryExpression {
             operator,
             right,
         } = node.as_fields();
+        let should_indent_right = is_nested_in_parenthesized_expression(node);
+        let formatted_right = format_with(|f| {
+            if should_indent_right {
+                write!(
+                    f,
+                    [indent(&format_args![
+                        soft_line_break_or_space(),
+                        right.format()
+                    ])]
+                )
+            } else {
+                write!(f, [soft_line_break_or_space(), right.format()])
+            }
+        });
+
         write!(
             f,
             [group(&format_args![
                 left.format(),
                 space(),
                 operator.format(),
-                soft_line_break_or_space(),
-                right.format()
+                formatted_right
             ])]
         )
     }
+}
+
+fn is_nested_in_parenthesized_expression(node: &ScssBinaryExpression) -> bool {
+    node.syntax()
+        .ancestors()
+        .skip(1)
+        .any(|ancestor| ScssParenthesizedExpression::can_cast(ancestor.kind()))
 }

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/for.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/for.scss.snap
@@ -71,20 +71,6 @@ through
  @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
    from ($var1 + $var1)
    through ($var-2 + $var-2)
-@@ -45,11 +41,11 @@
- @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
-   from (
-     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
--      $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
-+    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
-   )
-   through (
-     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
--      $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
-+    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
-   )
- {
- }
 ```
 
 # Output
@@ -133,11 +119,11 @@ through
 @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
   from (
     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
-    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
+      $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
   )
   through (
     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
-    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+      $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
   )
 {
 }
@@ -173,7 +159,7 @@ for.scss:41:273 parse ━━━━━━━━━━━━━━━━━━━�
    36: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
    41: @for $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
    43:     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1 +
-   44:     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
+   44:       $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1
    47:     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 +
-   48:     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+   48:       $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/while.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/while.scss.snap
@@ -151,26 +151,6 @@ $i
  }
  @while (($i) > (0)) {
  }
-@@ -58,16 +58,16 @@
- }
- @while (
-   1 >
--    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
-+  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
- ) {
- }
- @while (
-   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
--    1
-+  1
- ) {
- }
- @while (
-   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
--    $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
-+  $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
- ) {
- }
 ```
 
 # Output
@@ -236,17 +216,17 @@ $i
 }
 @while (
   1 >
-  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+    $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
 ) {
 }
 @while (
   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
-  1
+    1
 ) {
 }
 @while (
   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
-  $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+    $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
 ) {
 }
 ```
@@ -257,8 +237,8 @@ $i
    36:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
    39: @while $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
    40:   $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
-   61:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   61:     $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
    65:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
    70:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var >
-   71:   $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   71:     $other-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/parens/parens.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/parens/parens.scss.snap
@@ -309,16 +309,7 @@ a {
 ```diff
 --- Prettier
 +++ Biome
-@@ -58,7 +58,7 @@
-   padding-right: (100% * $info-width / (1 - $image-width));
-   padding-bottom: (
-     100% * $image-height /
--      ($image-width-responsive + $image-margin-responsive * 2)
-+    ($image-width-responsive + $image-margin-responsive * 2)
-   );
- }
- 
-@@ -67,15 +67,15 @@
+@@ -67,7 +67,7 @@
    content: attr(data-title);
    color: var(--main-bg-color);
    background-color: rgb(255, 0, 0);
@@ -327,8 +318,7 @@ a {
    width: calc(100% - (#{var(--g-spacing)} - #{$iframe-x-padding}) * 2);
    padding-bottom: (
      100% * $image-height /
--      ($image-width-responsive + $image-margin-responsive * 2)
-+    ($image-width-responsive + $image-margin-responsive * 2)
+@@ -75,7 +75,7 @@
    );
    padding-top: var(--paddingC);
    margin: 1 * 1 (1) * 1 1 * (1) (1) * (1);
@@ -497,7 +487,7 @@ a {
   padding-right: (100% * $info-width / (1 - $image-width));
   padding-bottom: (
     100% * $image-height /
-    ($image-width-responsive + $image-margin-responsive * 2)
+      ($image-width-responsive + $image-margin-responsive * 2)
   );
 }
 
@@ -510,7 +500,7 @@ a {
   width: calc(100% - (#{var(--g-spacing)} - #{$iframe-x-padding}) * 2);
   padding-bottom: (
     100% * $image-height /
-    ($image-width-responsive + $image-margin-responsive * 2)
+      ($image-width-responsive + $image-margin-responsive * 2)
   );
   padding-top: var(--paddingC);
   margin: 1 * 1 (1) * 1 1 * (1) (1) * (1);

--- a/crates/biome_css_formatter/tests/specs/scss/expression/parenthesized-binary.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/parenthesized-binary.scss
@@ -1,0 +1,1 @@
+$value:(1 > $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var);

--- a/crates/biome_css_formatter/tests/specs/scss/expression/parenthesized-binary.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/parenthesized-binary.scss.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/expression/parenthesized-binary.scss
+---
+
+# Input
+
+```scss
+$value:(1 > $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var);
+
+```
+
+
+# Formatted
+
+```scss
+$value: (
+	1 >
+		$very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+);
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    3: 		$very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+```


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

  ## Summary

  Align SCSS parenthesized binary expression indentation with Prettier.

  Biome now formats long parenthesized binary expressions as:

  ```scss
  $value: (
  	1 >
  		$very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
  );
```
  ## Test Plan

  cargo test -p biome_css_formatter
