### PR TITLE
feat(css_formatter): improve handling of SCSS `@each` rule formatting

### DIFF
--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -1,15 +1,17 @@
 use crate::prelude::*;
 use crate::utils::comment_trivia::is_trailing_comment_on_node;
 use crate::utils::scss_context::is_in_scss_include_arguments;
+use crate::utils::scss_expression::single_expression_item;
 use crate::utils::scss_include_comments::{
     place_list_trailing_separator_comment, place_map_trailing_separator_comment,
     place_separated_list_comment,
 };
 use biome_css_syntax::{
-    AnyCssDeclarationName, AnyCssRoot, CssComplexSelector, CssDeclarationOrRuleBlock, CssFunction,
-    CssGenericProperty, CssIdentifier, CssLanguage, CssSyntaxKind, ScssAtRootAtRule,
-    ScssAtRootSelector, ScssExpressionItemList, ScssIfAtRule, ScssListExpression,
-    ScssListExpressionElement, ScssMapExpression, ScssMapExpressionPair, T, TextLen, TextSize,
+    AnyCssDeclarationName, AnyCssRoot, AnyScssExpressionItem, CssComplexSelector,
+    CssDeclarationOrRuleBlock, CssFunction, CssGenericProperty, CssIdentifier, CssLanguage,
+    CssSyntaxKind, ScssAtRootAtRule, ScssAtRootSelector, ScssEachAtRule, ScssExpression,
+    ScssExpressionItemList, ScssIfAtRule, ScssListExpression, ScssListExpressionElement,
+    ScssMapExpression, ScssMapExpressionPair, T, TextLen, TextSize,
 };
 use biome_diagnostics::category;
 use biome_formatter::comments::{
@@ -108,6 +110,7 @@ impl CommentStyle for CssCommentStyle {
         handle_scss_map_trailing_separator_comment(comment)
             .or_else(place_separated_list_comment)
             .or_else(handle_scss_list_trailing_separator_comment)
+            .or_else(handle_scss_each_iterable_comment)
             .or_else(handle_scss_expression_item_trailing_line_comment)
             .or_else(handle_scss_at_root_selector_comment)
             .or_else(handle_scss_else_clause_comment)
@@ -162,6 +165,30 @@ fn handle_scss_list_trailing_separator_comment(
     };
 
     place_list_trailing_separator_comment(&list_expression, &preceding_element, comment)
+}
+
+/// Keeps `@each ... in /* comment */ (a, b)` comments with the list.
+fn handle_scss_each_iterable_comment(
+    comment: DecoratedComment<CssLanguage>,
+) -> CommentPlacement<CssLanguage> {
+    let Some(expression) = comment.following_node().and_then(ScssExpression::cast_ref) else {
+        return CommentPlacement::Default(comment);
+    };
+
+    if !expression
+        .syntax()
+        .parent()
+        .is_some_and(|parent| ScssEachAtRule::can_cast(parent.kind()))
+    {
+        return CommentPlacement::Default(comment);
+    }
+
+    let Some(AnyScssExpressionItem::ScssListExpression(list)) = single_expression_item(&expression)
+    else {
+        return CommentPlacement::Default(comment);
+    };
+
+    CommentPlacement::leading(list.into_syntax(), comment)
 }
 
 fn handle_scss_expression_item_trailing_line_comment(

--- a/crates/biome_css_formatter/src/scss/auxiliary/expression.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/expression.rs
@@ -1,7 +1,15 @@
+mod each_iterable_list;
+
 use crate::prelude::*;
+use crate::utils::scss_expression::single_expression_item;
 use crate::utils::scss_separator_comments::FormatScssSeparatorComments;
-use biome_css_syntax::{ScssExpression, ScssExpressionFields};
-use biome_formatter::{FormatResult, write};
+use biome_css_syntax::{
+    AnyScssExpressionItem, CssSyntaxToken, ScssEachAtRule, ScssEachBindingList, ScssExpression,
+    ScssExpressionFields, ScssListExpression,
+};
+use biome_formatter::{FormatOwnedWithRule, FormatResult, write};
+use biome_rowan::AstSeparatedList;
+use each_iterable_list::FormatScssEachIterableList;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssExpression;
@@ -12,6 +20,23 @@ impl FormatNodeRule<ScssExpression> for FormatScssExpression {
 
     fn fmt_fields(&self, node: &ScssExpression, f: &mut CssFormatter) -> FormatResult<()> {
         let ScssExpressionFields { items } = node.as_fields();
+
+        if let Some(header) = each_iterable_header(node) {
+            let ScssEachIterableHeader {
+                bindings,
+                in_token,
+                list,
+            } = header;
+
+            return write!(
+                f,
+                [FormatOwnedWithRule::new(
+                    list,
+                    FormatScssEachIterableList::new(bindings, in_token)
+                )]
+            );
+        }
+
         write!(f, [items.format()])
     }
 
@@ -20,6 +45,47 @@ impl FormatNodeRule<ScssExpression> for FormatScssExpression {
         node: &ScssExpression,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
+        if each_iterable_header(node).is_some() {
+            // In `@each $x in /* list */ a, b`, the list prints the comment.
+            return Ok(());
+        }
+
         self.fmt_leading_scss_separator_comments(node, f)
     }
+}
+
+/// Header pieces for `@each $x, $y in (a, b), (c, d)`.
+struct ScssEachIterableHeader {
+    bindings: ScssEachBindingList,
+    in_token: CssSyntaxToken,
+    list: ScssListExpression,
+}
+
+/// Matches only direct list iterables in `@each`, like `@each $x in a, b`.
+fn each_iterable_header(node: &ScssExpression) -> Option<ScssEachIterableHeader> {
+    let Some(AnyScssExpressionItem::ScssListExpression(list)) = single_expression_item(node) else {
+        return None;
+    };
+
+    let each = node.syntax().parent().and_then(ScssEachAtRule::cast)?;
+    let bindings = each.bindings();
+
+    if bindings.len() == 0 {
+        return None;
+    }
+
+    let iterable = each.iterable().ok()?;
+
+    // Only the actual `@each` iterable owns the header layout.
+    if iterable.syntax() != node.syntax() {
+        return None;
+    }
+
+    let in_token = each.in_token().ok()?;
+
+    Some(ScssEachIterableHeader {
+        bindings,
+        in_token,
+        list,
+    })
 }

--- a/crates/biome_css_formatter/src/scss/auxiliary/expression/each_iterable_list.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/expression/each_iterable_list.rs
@@ -1,0 +1,143 @@
+use crate::prelude::*;
+use biome_css_syntax::{CssSyntaxToken, ScssEachBindingList, ScssListExpression};
+use biome_formatter::{FormatRule, format_args, write};
+use biome_rowan::AstSeparatedList;
+
+/// Formats `@each $x in a, b` so bindings and list items share one fill group.
+pub(super) struct FormatScssEachIterableList {
+    bindings: ScssEachBindingList,
+    in_token: CssSyntaxToken,
+}
+
+impl FormatScssEachIterableList {
+    pub(super) fn new(bindings: ScssEachBindingList, in_token: CssSyntaxToken) -> Self {
+        Self { bindings, in_token }
+    }
+}
+
+impl FormatRule<ScssListExpression> for FormatScssEachIterableList {
+    type Context = CssFormatContext;
+
+    fn fmt(&self, node: &ScssListExpression, f: &mut CssFormatter) -> FormatResult<()> {
+        FormatNodeRule::<ScssListExpression>::fmt(self, node, f)
+    }
+}
+
+impl FormatNodeRule<ScssListExpression> for FormatScssEachIterableList {
+    fn fmt_fields(&self, node: &ScssListExpression, f: &mut CssFormatter) -> FormatResult<()> {
+        write_each_iterable(&self.bindings, &self.in_token, node, f)
+    }
+
+    fn fmt_leading_comments(
+        &self,
+        _node: &ScssListExpression,
+        _f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        // The `@each` fill group prints list comments after `in`.
+        Ok(())
+    }
+}
+
+/// Formats an `@each` header and list iterable in one fill group.
+///
+/// This matches Prettier wrapping for `@each $a, $b in (x, y), (z, w)`.
+fn write_each_iterable(
+    bindings: &ScssEachBindingList,
+    in_token: &CssSyntaxToken,
+    iterable: &ScssListExpression,
+    f: &mut CssFormatter,
+) -> FormatResult<()> {
+    let elements = iterable.elements();
+    let mut iterable_elements = elements.elements();
+    let Some(first_iterable) = iterable_elements.next() else {
+        return write!(
+            f,
+            [
+                bindings.format(),
+                soft_line_break_or_space(),
+                in_token.format()
+            ]
+        );
+    };
+
+    let separator = soft_line_break_or_space();
+    let has_iterable_line_comment = f
+        .comments()
+        .leading_comments(iterable.syntax())
+        .iter()
+        .any(|comment| comment.kind().is_line());
+    let mut fill = f.fill();
+    let binding_count = bindings.len();
+    let mut break_after_first_iterable = false;
+
+    for (index, binding) in bindings.elements().enumerate() {
+        if index + 1 == binding_count {
+            // The final binding owns `in` and the first iterable item.
+            if has_iterable_line_comment {
+                // `@each $x in // list\n a, b` breaks before the first item.
+                fill.entry(
+                    &separator,
+                    &group(&indent(&format_args![
+                        binding.node()?.format(),
+                        soft_line_break_or_space(),
+                        in_token.format(),
+                        space(),
+                        format_leading_comments(iterable.syntax())
+                    ])),
+                );
+
+                fill.entry(
+                    &separator,
+                    &format_args![
+                        first_iterable.node()?.format(),
+                        first_iterable.trailing_separator()?.format()
+                    ],
+                );
+                break_after_first_iterable = true;
+                continue;
+            }
+
+            fill.entry(
+                &separator,
+                &group(&indent(&format_args![
+                    binding.node()?.format(),
+                    soft_line_break_or_space(),
+                    in_token.format(),
+                    space(),
+                    format_leading_comments(iterable.syntax()),
+                    format_args![
+                        first_iterable.node()?.format(),
+                        first_iterable.trailing_separator()?.format()
+                    ]
+                ])),
+            );
+        } else {
+            fill.entry(
+                &separator,
+                &format_args![
+                    binding.node()?.format(),
+                    binding.trailing_separator()?.format()
+                ],
+            );
+        }
+    }
+
+    for iterable in iterable_elements {
+        let item_separator = if break_after_first_iterable {
+            break_after_first_iterable = false;
+            hard_line_break()
+        } else {
+            separator
+        };
+
+        fill.entry(
+            &item_separator,
+            &format_args![
+                iterable.node()?.format(),
+                iterable.trailing_separator()?.format()
+            ],
+        );
+    }
+
+    fill.finish()
+}

--- a/crates/biome_css_formatter/src/scss/statements/each_at_rule.rs
+++ b/crates/biome_css_formatter/src/scss/statements/each_at_rule.rs
@@ -1,6 +1,12 @@
 use crate::prelude::*;
-use biome_css_syntax::{ScssEachAtRule, ScssEachAtRuleFields};
-use biome_formatter::write;
+use crate::utils::scss_expression::single_expression_item;
+use biome_css_syntax::{
+    CssLanguage, CssSyntaxNode, CssSyntaxToken, ScssEachAtRule, ScssEachAtRuleFields,
+    ScssEachBindingList, ScssExpression, ScssListExpression, ScssListExpressionElement,
+    ScssVariable,
+};
+use biome_formatter::{format_args, write};
+use biome_rowan::{AstNode, AstSeparatedElement, AstSeparatedList};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssEachAtRule;
@@ -14,6 +20,30 @@ impl FormatNodeRule<ScssEachAtRule> for FormatScssEachAtRule {
             iterable,
             block,
         } = node.as_fields();
+
+        if let (Ok(in_token), Ok(iterable)) = (in_token.as_ref(), iterable.as_ref())
+            && let Some(iterable_list) = each_iterable_list(iterable)
+        {
+            let has_iterable_suppression =
+                has_suppression(iterable.syntax(), f) || has_suppression(iterable_list.syntax(), f);
+
+            if !has_iterable_suppression {
+                return write!(
+                    f,
+                    [
+                        each_token.format(),
+                        group(&format_args![
+                            space(),
+                            indent(&group(&format_with(|f| {
+                                write_each_list_header(&bindings, in_token, &iterable_list, f)
+                            }))),
+                            soft_line_break_or_space()
+                        ]),
+                        block.format()
+                    ]
+                );
+            }
+        }
 
         write!(
             f,
@@ -29,5 +59,108 @@ impl FormatNodeRule<ScssEachAtRule> for FormatScssEachAtRule {
                 block.format()
             ]
         )
+    }
+}
+
+fn each_iterable_list(iterable: &ScssExpression) -> Option<ScssListExpression> {
+    single_expression_item(iterable).and_then(|item| item.as_scss_list_expression().cloned())
+}
+
+fn has_suppression(node: &CssSyntaxNode, f: &CssFormatter) -> bool {
+    f.comments().is_suppressed(node) || f.comments().is_global_suppressed(node)
+}
+
+fn write_each_list_header(
+    bindings: &ScssEachBindingList,
+    in_token: &CssSyntaxToken,
+    iterable: &ScssListExpression,
+    f: &mut CssFormatter,
+) -> FormatResult<()> {
+    let mut binding_elements: Vec<_> = bindings.elements().collect();
+    let Some(last_binding) = binding_elements.pop() else {
+        return Ok(());
+    };
+
+    let elements = iterable.elements();
+    let mut iterable_elements = elements.elements();
+    let Some(first_iterable) = iterable_elements.next() else {
+        return write!(
+            f,
+            [
+                bindings.format(),
+                space(),
+                in_token.format(),
+                space(),
+                iterable.format()
+            ]
+        );
+    };
+
+    let separator = soft_line_break_or_space();
+    let mut fill = f.fill();
+
+    for binding in binding_elements {
+        fill.entry(
+            &separator,
+            &format_with(|f| write_separated_binding(&binding, f)),
+        );
+    }
+
+    fill.entry(
+        &separator,
+        &group(&indent(&format_with(|f| {
+            write_last_binding_with_first_iterable(&last_binding, in_token, &first_iterable, f)
+        }))),
+    );
+
+    for iterable in iterable_elements {
+        fill.entry(
+            &separator,
+            &format_with(|f| write_separated_iterable(&iterable, f)),
+        );
+    }
+
+    fill.finish()
+}
+
+fn write_last_binding_with_first_iterable(
+    binding: &AstSeparatedElement<CssLanguage, ScssVariable>,
+    in_token: &CssSyntaxToken,
+    iterable: &AstSeparatedElement<CssLanguage, ScssListExpressionElement>,
+    f: &mut CssFormatter,
+) -> FormatResult<()> {
+    write!(
+        f,
+        [
+            binding.node()?.format(),
+            soft_line_break_or_space(),
+            in_token.format(),
+            space(),
+            format_with(|f| write_separated_iterable(iterable, f))
+        ]
+    )
+}
+
+fn write_separated_binding(
+    binding: &AstSeparatedElement<CssLanguage, ScssVariable>,
+    f: &mut CssFormatter,
+) -> FormatResult<()> {
+    write!(f, [binding.node()?.format()])?;
+    write_separator(binding.trailing_separator()?, f)
+}
+
+fn write_separated_iterable(
+    iterable: &AstSeparatedElement<CssLanguage, ScssListExpressionElement>,
+    f: &mut CssFormatter,
+) -> FormatResult<()> {
+    write!(f, [iterable.node()?.format()])?;
+    write_separator(iterable.trailing_separator()?, f)
+}
+
+fn write_separator(separator: Option<&CssSyntaxToken>, f: &mut CssFormatter) -> FormatResult<()> {
+    if let Some(separator) = separator {
+        write!(f, [separator.format()])
+    } else {
+        Ok(())
     }
 }

--- a/crates/biome_css_formatter/src/scss/statements/each_at_rule.rs
+++ b/crates/biome_css_formatter/src/scss/statements/each_at_rule.rs
@@ -1,12 +1,8 @@
 use crate::prelude::*;
 use crate::utils::scss_expression::single_expression_item;
-use biome_css_syntax::{
-    CssLanguage, CssSyntaxNode, CssSyntaxToken, ScssEachAtRule, ScssEachAtRuleFields,
-    ScssEachBindingList, ScssExpression, ScssListExpression, ScssListExpressionElement,
-    ScssVariable,
-};
+use biome_css_syntax::{ScssEachAtRule, ScssEachAtRuleFields, ScssExpression};
 use biome_formatter::{format_args, write};
-use biome_rowan::{AstNode, AstSeparatedElement, AstSeparatedList};
+use biome_rowan::AstSeparatedList;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssEachAtRule;
@@ -21,28 +17,22 @@ impl FormatNodeRule<ScssEachAtRule> for FormatScssEachAtRule {
             block,
         } = node.as_fields();
 
-        if let (Ok(in_token), Ok(iterable)) = (in_token.as_ref(), iterable.as_ref())
-            && let Some(iterable_list) = each_iterable_list(iterable)
-        {
-            let has_iterable_suppression =
-                has_suppression(iterable.syntax(), f) || has_suppression(iterable_list.syntax(), f);
+        let in_token = in_token?;
+        let iterable = iterable?;
 
-            if !has_iterable_suppression {
-                return write!(
-                    f,
-                    [
-                        each_token.format(),
-                        group(&format_args![
-                            space(),
-                            indent(&group(&format_with(|f| {
-                                write_each_list_header(&bindings, in_token, &iterable_list, f)
-                            }))),
-                            soft_line_break_or_space()
-                        ]),
-                        block.format()
-                    ]
-                );
-            }
+        if is_each_list_iterable(&iterable) && bindings.len() > 0 {
+            return write!(
+                f,
+                [
+                    each_token.format(),
+                    group(&format_args![
+                        space(),
+                        indent(&group(&iterable.format())),
+                        soft_line_break_or_space()
+                    ]),
+                    block.format()
+                ]
+            );
         }
 
         write!(
@@ -62,105 +52,7 @@ impl FormatNodeRule<ScssEachAtRule> for FormatScssEachAtRule {
     }
 }
 
-fn each_iterable_list(iterable: &ScssExpression) -> Option<ScssListExpression> {
-    single_expression_item(iterable).and_then(|item| item.as_scss_list_expression().cloned())
-}
-
-fn has_suppression(node: &CssSyntaxNode, f: &CssFormatter) -> bool {
-    f.comments().is_suppressed(node) || f.comments().is_global_suppressed(node)
-}
-
-fn write_each_list_header(
-    bindings: &ScssEachBindingList,
-    in_token: &CssSyntaxToken,
-    iterable: &ScssListExpression,
-    f: &mut CssFormatter,
-) -> FormatResult<()> {
-    let mut binding_elements: Vec<_> = bindings.elements().collect();
-    let Some(last_binding) = binding_elements.pop() else {
-        return Ok(());
-    };
-
-    let elements = iterable.elements();
-    let mut iterable_elements = elements.elements();
-    let Some(first_iterable) = iterable_elements.next() else {
-        return write!(
-            f,
-            [
-                bindings.format(),
-                space(),
-                in_token.format(),
-                space(),
-                iterable.format()
-            ]
-        );
-    };
-
-    let separator = soft_line_break_or_space();
-    let mut fill = f.fill();
-
-    for binding in binding_elements {
-        fill.entry(
-            &separator,
-            &format_with(|f| write_separated_binding(&binding, f)),
-        );
-    }
-
-    fill.entry(
-        &separator,
-        &group(&indent(&format_with(|f| {
-            write_last_binding_with_first_iterable(&last_binding, in_token, &first_iterable, f)
-        }))),
-    );
-
-    for iterable in iterable_elements {
-        fill.entry(
-            &separator,
-            &format_with(|f| write_separated_iterable(&iterable, f)),
-        );
-    }
-
-    fill.finish()
-}
-
-fn write_last_binding_with_first_iterable(
-    binding: &AstSeparatedElement<CssLanguage, ScssVariable>,
-    in_token: &CssSyntaxToken,
-    iterable: &AstSeparatedElement<CssLanguage, ScssListExpressionElement>,
-    f: &mut CssFormatter,
-) -> FormatResult<()> {
-    write!(
-        f,
-        [
-            binding.node()?.format(),
-            soft_line_break_or_space(),
-            in_token.format(),
-            space(),
-            format_with(|f| write_separated_iterable(iterable, f))
-        ]
-    )
-}
-
-fn write_separated_binding(
-    binding: &AstSeparatedElement<CssLanguage, ScssVariable>,
-    f: &mut CssFormatter,
-) -> FormatResult<()> {
-    write!(f, [binding.node()?.format()])?;
-    write_separator(binding.trailing_separator()?, f)
-}
-
-fn write_separated_iterable(
-    iterable: &AstSeparatedElement<CssLanguage, ScssListExpressionElement>,
-    f: &mut CssFormatter,
-) -> FormatResult<()> {
-    write!(f, [iterable.node()?.format()])?;
-    write_separator(iterable.trailing_separator()?, f)
-}
-
-fn write_separator(separator: Option<&CssSyntaxToken>, f: &mut CssFormatter) -> FormatResult<()> {
-    if let Some(separator) = separator {
-        write!(f, [separator.format()])
-    } else {
-        Ok(())
-    }
+/// Returns `true` for list iterables that need the shared `@each` fill group.
+fn is_each_list_iterable(iterable: &ScssExpression) -> bool {
+    single_expression_item(iterable).is_some_and(|item| item.as_scss_list_expression().is_some())
 }

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/each.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/atrule/each.scss.snap
@@ -241,61 +241,9 @@ h3
  }
  @each $animal in ((puma), (sea-slug), (egret), (salamander)) {
  }
-@@ -26,50 +26,86 @@
- }
- @each $animal in ((puma), (sea-slug), (egret), (salamander)) {
- }
--@each $animal, $color, $cursor in (puma, black, default),
--  (sea-slug, blue, pointer), (egret, white, move)
--{
-+@each $animal,
-+$color,
-+$cursor in
-+  (puma, black, default),
-+  (sea-slug, blue, pointer),
-+  (egret, white, move) {
- }
--@each $animal, $color, $cursor in (puma, black, default),
--  (sea-slug, blue, pointer), (egret, white, move)
--{
-+@each $animal,
-+$color,
-+$cursor in
-+  (puma, black, default),
-+  (sea-slug, blue, pointer),
-+  (egret, white, move) {
- }
--@each $animal, $color, $cursor in (puma, black, default),
--  (sea-slug, blue, pointer), (egret, white, move)
--{
-+@each $animal,
-+$color,
-+$cursor in
-+  (puma, black, default),
-+  (sea-slug, blue, pointer),
-+  (egret, white, move) {
- }
--@each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
--    in puma,
--  sea-slug, egret, salamander
--{
-+@each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var in
-+  puma,
-+  sea-slug,
-+  egret,
-+  salamander {
- }
- @each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var,
--  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1,
--  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
--    in (puma, black, default),
--  (sea-slug, blue, pointer), (egret, white, move)
--{
-+$very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1,
-+$very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 in
-+  (puma, black, default),
-+  (sea-slug, blue, pointer),
-+  (egret, white, move) {
+@@ -50,26 +50,52 @@
+   (sea-slug, blue, pointer), (egret, white, move)
+ {
  }
 -@each $element, $size in (h1: 20px, h2: 16px, h3: 14px) {
 +@each $element,
@@ -394,39 +342,29 @@ h3
 }
 @each $animal in ((puma), (sea-slug), (egret), (salamander)) {
 }
-@each $animal,
-$color,
-$cursor in
-  (puma, black, default),
-  (sea-slug, blue, pointer),
-  (egret, white, move) {
+@each $animal, $color, $cursor in (puma, black, default),
+  (sea-slug, blue, pointer), (egret, white, move)
+{
 }
-@each $animal,
-$color,
-$cursor in
-  (puma, black, default),
-  (sea-slug, blue, pointer),
-  (egret, white, move) {
+@each $animal, $color, $cursor in (puma, black, default),
+  (sea-slug, blue, pointer), (egret, white, move)
+{
 }
-@each $animal,
-$color,
-$cursor in
-  (puma, black, default),
-  (sea-slug, blue, pointer),
-  (egret, white, move) {
+@each $animal, $color, $cursor in (puma, black, default),
+  (sea-slug, blue, pointer), (egret, white, move)
+{
 }
-@each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var in
-  puma,
-  sea-slug,
-  egret,
-  salamander {
+@each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+    in puma,
+  sea-slug, egret, salamander
+{
 }
 @each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var,
-$very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1,
-$very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 in
-  (puma, black, default),
-  (sea-slug, blue, pointer),
-  (egret, white, move) {
+  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1,
+  $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
+    in (puma, black, default),
+  (sea-slug, blue, pointer), (egret, white, move)
+{
 }
 @each $element,
 $size in (
@@ -481,8 +419,8 @@ $size in (
 
 # Lines exceeding max width of 80 characters
 ```
-   50: @each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var in
-   56: @each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var,
-   57: $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1,
-   58: $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2 in
+   41: @each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+   46: @each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var,
+   47:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var1,
+   48:   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var-2
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/each.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/each.scss
@@ -20,3 +20,9 @@ font-size:$value;
 color:red;
 }
 }
+
+@each $animal,$color,$cursor in (puma,black,default),(sea-slug,blue,pointer),(egret,white,move){
+}
+
+@each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var in puma,sea-slug,egret,salamander{
+}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/each.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/each.scss
@@ -26,3 +26,17 @@ color:red;
 
 @each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var in puma,sea-slug,egret,salamander{
 }
+
+@each $animal in /* animals */ puma,sea-slug,egret,salamander{
+}
+
+@each $animal in
+// animals
+puma,sea-slug,egret,salamander{
+}
+
+@each $animal,$color,$cursor in /* animals */ (puma,black,default),(sea-slug,blue,pointer){
+}
+
+@each $animal in /* animals */ $animals{
+}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/each.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/each.scss.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: css/scss/at-rule/each.scss
+info: scss/at-rule/each.scss
 ---
 
 # Input
@@ -27,6 +27,12 @@ font-size:$value;
 @each $animal in puma,sea-slug,egret,salamander{
 color:red;
 }
+}
+
+@each $animal,$color,$cursor in (puma,black,default),(sea-slug,blue,pointer),(egret,white,move){
+}
+
+@each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var in puma,sea-slug,egret,salamander{
 }
 
 ```
@@ -57,4 +63,20 @@ color:red;
 	}
 }
 
+@each $animal, $color, $cursor in (puma, black, default),
+	(sea-slug, blue, pointer), (egret, white, move)
+{
+}
+
+@each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
+		in puma,
+	sea-slug, egret, salamander
+{
+}
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+   28: @each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/each.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/each.scss.snap
@@ -35,6 +35,20 @@ color:red;
 @each $very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-var in puma,sea-slug,egret,salamander{
 }
 
+@each $animal in /* animals */ puma,sea-slug,egret,salamander{
+}
+
+@each $animal in
+// animals
+puma,sea-slug,egret,salamander{
+}
+
+@each $animal,$color,$cursor in /* animals */ (puma,black,default),(sea-slug,blue,pointer){
+}
+
+@each $animal in /* animals */ $animals{
+}
+
 ```
 
 
@@ -72,6 +86,24 @@ color:red;
 		in puma,
 	sea-slug, egret, salamander
 {
+}
+
+@each $animal in /* animals */ puma, sea-slug, egret, salamander {
+}
+
+@each $animal
+		in // animals
+	puma,
+	sea-slug, egret, salamander
+{
+}
+
+@each $animal, $color, $cursor in /* animals */ (puma, black, default),
+	(sea-slug, blue, pointer)
+{
+}
+
+@each $animal in /* animals */ $animals {
 }
 
 ```


### PR DESCRIPTION
> This PR was implemented with assistance from Codex.

  ## Summary

  Aligns SCSS `@each` list iterable formatting with Prettier.


  ```scss
  @each $animal in /* animals */ puma, sea-slug, egret, salamander {
  }

  @each $animal
  		in // animals
  	puma,
  	sea-slug, egret, salamander
  {
  }

  @each $animal, $color, $cursor in /* animals */ (puma, black, default),
  	(sea-slug, blue, pointer)
  {
  }

  @each $animal in /* animals */ $animals {
  }
```

  ## Test Plan

 cargo test -p biome_css_formatter