### PR TITLE
fix(markdown_parser): stop nested lazy lists from swallowing fences

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -2247,6 +2247,10 @@ fn parse_first_line_blockquote(p: &mut MarkdownParser, state: &mut ListItemLoopS
     parsed
 }
 
+fn at_current_line_block_interrupt(p: &mut MarkdownParser) -> bool {
+    with_virtual_line_start(p, p.cur_range().start(), at_block_interrupt)
+}
+
 /// After the first line, verify indent level for continuation.
 ///
 /// Handles nested list detection at sufficient indent, sibling/block interrupt
@@ -2276,7 +2280,7 @@ fn check_continuation_indent(
         let can_lazy = state.last_block_was_paragraph
             && !at_bullet_list_item_with_base_indent(p, 0)
             && !at_order_list_item_with_base_indent(p, 0)
-            && !at_block_interrupt(p);
+            && !at_current_line_block_interrupt(p);
         if !can_lazy {
             return ContinuationResult {
                 action: LoopAction::Break,
@@ -2341,7 +2345,7 @@ fn check_continuation_indent(
             };
         }
 
-        if at_block_interrupt(p) {
+        if at_current_line_block_interrupt(p) {
             return ContinuationResult {
                 action: LoopAction::Break,
                 restore: VirtualLineRestore::None,

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_fence.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_fence.md
@@ -1,0 +1,6 @@
+* outer
+  * nested
+  lazy line
+```
+code here
+```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_fence.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_fence.md.snap
@@ -1,0 +1,202 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+assertion_line: 192
+expression: snapshot
+---
+
+## Input
+
+```
+* outer
+  * nested
+  lazy line
+```
+code here
+```
+
+```
+
+
+## AST
+
+```
+MdDocument {
+    bom_token: missing (optional),
+    value: MdBlockList [
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: STAR@0..1 "*" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@1..2 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@2..7 "outer" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
+                                },
+                            ],
+                            hard_line: missing (optional),
+                        },
+                        MdBulletListItem {
+                            md_bullet_list: MdBulletList [
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@8..9 " " [] [],
+                                            },
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@9..10 " " [] [],
+                                            },
+                                        ],
+                                        marker: STAR@10..11 "*" [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@11..12 " " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@12..18 "nested" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@18..19 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                        MdContinuationIndent {
+                                            indent: MdIndentTokenList [
+                                                MdIndentToken {
+                                                    md_indent_char_token: MD_INDENT_CHAR@19..20 " " [] [],
+                                                },
+                                                MdIndentToken {
+                                                    md_indent_char_token: MD_INDENT_CHAR@20..21 " " [] [],
+                                                },
+                                            ],
+                                        },
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        MdFencedCodeBlock {
+            indent: MdIndentTokenList [],
+            l_fence: TRIPLE_BACKTICK@31..34 "```" [] [],
+            code_list: MdCodeNameList [],
+            content: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@34..35 "\n" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@35..44 "code here" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@44..45 "\n" [] [],
+                },
+            ],
+            r_fence_indent: MdIndentTokenList [],
+            r_fence: TRIPLE_BACKTICK@45..48 "```" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@48..49 "\n" [] [],
+        },
+    ],
+    eof_token: EOF@49..49 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_DOCUMENT@0..49
+  0: (empty)
+  1: MD_BLOCK_LIST@0..49
+    0: MD_BULLET_LIST_ITEM@0..31
+      0: MD_BULLET_LIST@0..31
+        0: MD_BULLET@0..31
+          0: MD_LIST_MARKER_PREFIX@0..2
+            0: MD_INDENT_TOKEN_LIST@0..0
+            1: STAR@0..1 "*" [] []
+            2: MD_LIST_POST_MARKER_SPACE@1..2 " " [] []
+            3: MD_INDENT_TOKEN_LIST@2..2
+          1: MD_BLOCK_LIST@2..31
+            0: MD_PARAGRAPH@2..8
+              0: MD_INLINE_ITEM_LIST@2..8
+                0: MD_TEXTUAL@2..7
+                  0: MD_TEXTUAL_LITERAL@2..7 "outer" [] []
+                1: MD_TEXTUAL@7..8
+                  0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
+              1: (empty)
+            1: MD_BULLET_LIST_ITEM@8..31
+              0: MD_BULLET_LIST@8..31
+                0: MD_BULLET@8..31
+                  0: MD_LIST_MARKER_PREFIX@8..12
+                    0: MD_INDENT_TOKEN_LIST@8..10
+                      0: MD_INDENT_TOKEN@8..9
+                        0: MD_INDENT_CHAR@8..9 " " [] []
+                      1: MD_INDENT_TOKEN@9..10
+                        0: MD_INDENT_CHAR@9..10 " " [] []
+                    1: STAR@10..11 "*" [] []
+                    2: MD_LIST_POST_MARKER_SPACE@11..12 " " [] []
+                    3: MD_INDENT_TOKEN_LIST@12..12
+                  1: MD_BLOCK_LIST@12..31
+                    0: MD_PARAGRAPH@12..19
+                      0: MD_INLINE_ITEM_LIST@12..19
+                        0: MD_TEXTUAL@12..18
+                          0: MD_TEXTUAL_LITERAL@12..18 "nested" [] []
+                        1: MD_TEXTUAL@18..19
+                          0: MD_TEXTUAL_LITERAL@18..19 "\n" [] []
+                      1: (empty)
+                    1: MD_CONTINUATION_INDENT@19..21
+                      0: MD_INDENT_TOKEN_LIST@19..21
+                        0: MD_INDENT_TOKEN@19..20
+                          0: MD_INDENT_CHAR@19..20 " " [] []
+                        1: MD_INDENT_TOKEN@20..21
+                          0: MD_INDENT_CHAR@20..21 " " [] []
+                    2: MD_PARAGRAPH@21..31
+                      0: MD_INLINE_ITEM_LIST@21..31
+                        0: MD_TEXTUAL@21..30
+                          0: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] []
+                        1: MD_TEXTUAL@30..31
+                          0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
+                      1: (empty)
+    1: MD_FENCED_CODE_BLOCK@31..48
+      0: MD_INDENT_TOKEN_LIST@31..31
+      1: TRIPLE_BACKTICK@31..34 "```" [] []
+      2: MD_CODE_NAME_LIST@34..34
+      3: MD_INLINE_ITEM_LIST@34..45
+        0: MD_TEXTUAL@34..35
+          0: MD_TEXTUAL_LITERAL@34..35 "\n" [] []
+        1: MD_TEXTUAL@35..44
+          0: MD_TEXTUAL_LITERAL@35..44 "code here" [] []
+        2: MD_TEXTUAL@44..45
+          0: MD_TEXTUAL_LITERAL@44..45 "\n" [] []
+      4: MD_INDENT_TOKEN_LIST@45..45
+      5: TRIPLE_BACKTICK@45..48 "```" [] []
+    2: MD_NEWLINE@48..49
+      0: NEWLINE@48..49 "\n" [] []
+  2: EOF@49..49 "" [] []
+
+```

--- a/crates/biome_markdown_parser/tests/spec_test.rs
+++ b/crates/biome_markdown_parser/tests/spec_test.rs
@@ -553,3 +553,12 @@ fn fuzz_code_after_list_not_absorbed() {
         "<ul>\n<li>one</li>\n<li>two</li>\n</ul>\n<pre><code>code here\n</code></pre>\n",
     );
 }
+
+#[test]
+fn fuzz_nested_lazy_continuation_before_fence() {
+    fuzz_test_example(
+        9,
+        "* outer\n  * nested\n  lazy line\n```\ncode here\n```\n",
+        "<ul>\n<li>outer\n<ul>\n<li>nested\nlazy line</li>\n</ul>\n</li>\n</ul>\n<pre><code>code here\n</code></pre>\n",
+    );
+}


### PR DESCRIPTION
> [!NOTE]
> I used Codex to help investigate the fuzz mismatch and validate the fix.

## Summary

Fixes a markdown parser edge case where a top-level fenced code block after a nested list lazy-continuation line could be parsed as part of the nested list item.

The parser now checks block interrupts at less-indented physical lines relative to the current line, avoiding stale list-context virtual indentation when deciding whether lazy continuation is allowed.

## Test Plan

Added a regression test covering the fuzz-discovered nested-list lazy-continuation case where a following top-level fenced code block was incorrectly parsed inside the nested list item.

- `just test-crate biome_markdown_parser`
- `just fuzz-markdown-differential`

The differential fuzzer was used to discover the original mismatch against `commonmark.js`. The checked-in regression now verifies the fixed case directly.

## Docs

N/A