### PR TITLE
fix(noThisInStatic): don't report `new this()`

### DIFF
--- a/.changeset/fix-no-this-in-static-new-this.md
+++ b/.changeset/fix-no-this-in-static-new-this.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10011](https://github.com/biomejs/biome/issues/10011): The `noThisInStatic` rule no longer reports `this` when it is used as the constructor target in `new this(...)`, which is required for inherited static factory methods.

--- a/.changeset/fix-no-this-in-static-new-this.md
+++ b/.changeset/fix-no-this-in-static-new-this.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10011](https://github.com/biomejs/biome/issues/10011): The `noThisInStatic` rule no longer reports `this` when it is used as the constructor target in `new this(...)`, which is required for inherited static factory methods.
+Fixed [#10011](https://github.com/biomejs/biome/issues/10011): The [`noThisInStatic`](https://biomejs.dev/linter/rules/no-this-in-static/) rule no longer reports `this` when it is used as the constructor target in `new this(...)`, which is required for inherited static factory methods.

--- a/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
@@ -5,8 +5,8 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
-    AnyJsClass, AnyJsClassMember, AnyJsExpression, JsArrowFunctionExpression, JsSuperExpression,
-    JsSyntaxToken, JsThisExpression,
+    AnyJsClass, AnyJsClassMember, AnyJsExpression, JsArrowFunctionExpression, JsNewExpression,
+    JsSuperExpression, JsSyntaxToken, JsThisExpression,
 };
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, SyntaxResult, declare_node_union};
 use biome_rule_options::no_this_in_static::NoThisInStaticOptions;
@@ -97,6 +97,10 @@ impl Rule for NoThisInStatic {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let this_super_expression = ctx.query();
+        if this_super_expression.is_new_this_callee() {
+            return None;
+        }
+
         let static_method = this_super_expression
             .syntax()
             .ancestors()
@@ -192,5 +196,18 @@ impl JsThisSuperExpression {
             Self::JsSuperExpression(expr) => expr.super_token(),
             Self::JsThisExpression(expr) => expr.this_token(),
         }
+    }
+
+    fn is_new_this_callee(&self) -> bool {
+        matches!(self, Self::JsThisExpression(_))
+            && self
+                .syntax()
+                .parent()
+                .and_then(JsNewExpression::cast)
+                .is_some_and(|new_expression| {
+                    new_expression.callee().is_ok_and(|callee| {
+                        callee.syntax() == self.syntax()
+                    })
+                })
     }
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js
@@ -37,3 +37,11 @@ const E = class extends f() {
         return this.CONSTANT + super.ANOTHER_CONSTANT;
     }
 }
+
+class FactoryCases {
+    static method() {
+        new this(this);
+        new Foo(this);
+        new this.Factory();
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js.snap
@@ -44,6 +44,14 @@ const E = class extends f() {
     }
 }
 
+class FactoryCases {
+    static method() {
+        new this(this);
+        new Foo(this);
+        new this.Factory();
+    }
+}
+
 ```
 
 # Diagnostics
@@ -372,6 +380,84 @@ invalid.js:37:32 lint/complexity/noThisInStatic ━━━━━━━━━━�
     39 │ }
   
   i super refers to a parent class.
+  
+
+```
+
+```
+invalid.js:43:18 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Using this in a static context can be confusing.
+  
+    41 │ class FactoryCases {
+    42 │     static method() {
+  > 43 │         new this(this);
+       │                  ^^^^
+    44 │         new Foo(this);
+    45 │         new this.Factory();
+  
+  i this refers to the class.
+  
+  i Safe fix: Use the class name instead.
+  
+    41 41 │   class FactoryCases {
+    42 42 │       static method() {
+    43    │ - ········new·this(this);
+       43 │ + ········new·this(FactoryCases);
+    44 44 │           new Foo(this);
+    45 45 │           new this.Factory();
+  
+
+```
+
+```
+invalid.js:44:17 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Using this in a static context can be confusing.
+  
+    42 │     static method() {
+    43 │         new this(this);
+  > 44 │         new Foo(this);
+       │                 ^^^^
+    45 │         new this.Factory();
+    46 │     }
+  
+  i this refers to the class.
+  
+  i Safe fix: Use the class name instead.
+  
+    42 42 │       static method() {
+    43 43 │           new this(this);
+    44    │ - ········new·Foo(this);
+       44 │ + ········new·Foo(FactoryCases);
+    45 45 │           new this.Factory();
+    46 46 │       }
+  
+
+```
+
+```
+invalid.js:45:13 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Using this in a static context can be confusing.
+  
+    43 │         new this(this);
+    44 │         new Foo(this);
+  > 45 │         new this.Factory();
+       │             ^^^^
+    46 │     }
+    47 │ }
+  
+  i this refers to the class.
+  
+  i Safe fix: Use the class name instead.
+  
+    43 43 │           new this(this);
+    44 44 │           new Foo(this);
+    45    │ - ········new·this.Factory();
+       45 │ + ········new·FactoryCases.Factory();
+    46 46 │       }
+    47 47 │   }
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/valid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/valid.js
@@ -4,3 +4,18 @@ function foo() { this }
 class A { constructor() { this } }
 class A { foo() { this } }
 class A { static foo() { function foo() { this } } }
+
+class Base {
+    static create(name) {
+        return new this(name);
+    }
+
+    static field = new this();
+
+    static {
+        new this();
+    }
+}
+
+class Sub extends Base {}
+Sub.create("Alice");

--- a/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/valid.js.snap
@@ -10,4 +10,20 @@ function foo() { this }
 class A { constructor() { this } }
 class A { foo() { this } }
 class A { static foo() { function foo() { this } } }
+
+class Base {
+    static create(name) {
+        return new this(name);
+    }
+
+    static field = new this();
+
+    static {
+        new this();
+    }
+}
+
+class Sub extends Base {}
+Sub.create("Alice");
+
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Pretty simple fix to not trigger the rule on `new this()` usages. I couldn't decide whether or not to mark the fix as unsafe, considering the rule has been around for so long, and not getting too many bugs for it.

generated by gpt 5.5

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
closes #10011
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots
## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
