### PR TITLE
feat(linter): add allowConditional option to noSkippedTests (#8998) 🤖🤖🤖

### DIFF
--- a/.changeset/add-no-skipped-tests-allow-conditional.md
+++ b/.changeset/add-no-skipped-tests-allow-conditional.md
@@ -1,0 +1,25 @@
+---
+"@biomejs/biome": minor
+---
+
+Added the `allowConditional` option to [`noSkippedTests`](https://biomejs.dev/linter/rules/no-skipped-tests/). When enabled, conditional skip patterns are allowed:
+
+- `test.skip()` / `test.fixme()` calls inside an `if` statement.
+- `test.skip(condition)` / `test.skip(condition, "reason")` with a non-string first argument.
+
+```json
+{
+    "linter": {
+        "rules": {
+            "suspicious": {
+                "noSkippedTests": {
+                    "level": "error",
+                    "options": {
+                        "allowConditional": true
+                    }
+                }
+            }
+        }
+    }
+}
+```

--- a/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
@@ -5,8 +5,8 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_factory::make;
-use biome_js_syntax::{AnyJsExpression, JsCallExpression};
-use biome_rowan::{AstSeparatedList, BatchMutationExt, TextRange};
+use biome_js_syntax::{AnyJsExpression, JsCallExpression, JsSyntaxKind};
+use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TextRange};
 use biome_rule_options::no_skipped_tests::NoSkippedTestsOptions;
 
 use crate::JsRuleAction;
@@ -48,6 +48,37 @@ declare_lint_rule! {
     /// ```js
     /// test.only("test", () => {});
     /// test("test", () => {});
+    /// ```
+    ///
+    /// ## Options
+    ///
+    /// ### `allowConditional`
+    ///
+    /// When enabled, conditional skip patterns are allowed:
+    ///
+    /// - `test.skip()` / `test.fixme()` calls inside an `if` statement.
+    /// - `test.skip(condition)` / `test.skip(condition, "reason")` with a non-string first argument.
+    ///
+    /// Default: `false`.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "allowConditional": true
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```js,use_options
+    /// test("conditional skip inside if", () => {
+    ///     if (someCondition) {
+    ///         test.skip();
+    ///     }
+    /// });
+    ///
+    /// test("conditional skip with arg", () => {
+    ///     test.skip(someCondition);
+    /// });
     /// ```
     ///
     pub NoSkippedTests {
@@ -99,7 +130,8 @@ impl Rule for NoSkippedTests {
 
         // Path 2: Bare skip/fixme calls (e.g., test.skip() or test.fixme() with 0 args),
         // bracket notation (test["skip"]), and Playwright describe/step patterns
-        if let Some(skip_state) = detect_bare_skip_call(node, &callee) {
+        let allow_conditional = ctx.options().allow_conditional();
+        if let Some(skip_state) = detect_bare_skip_call(node, &callee, allow_conditional) {
             return Some(skip_state);
         }
 
@@ -181,6 +213,7 @@ pub struct SkipState {
 fn detect_bare_skip_call(
     call_expr: &JsCallExpression,
     callee: &AnyJsExpression,
+    allow_conditional: bool,
 ) -> Option<SkipState> {
     // Collect the member names from the callee chain
     let names = collect_callee_names(callee)?;
@@ -242,6 +275,10 @@ fn detect_bare_skip_call(
             }
             // 0-arg bare skip/fixme
             if arg_count == 0 {
+                // When `allowConditional` is enabled, allow bare skip/fixme inside an `if` block.
+                if allow_conditional && is_inside_if_block(call_expr) {
+                    return None;
+                }
                 return Some(SkipState {
                     range: name_range,
                     annotation,
@@ -249,6 +286,10 @@ fn detect_bare_skip_call(
             }
             // 1-2 arg conditional skip
             if (arg_count == 1 || arg_count == 2) && !has_string_first_arg(call_expr) {
+                // When `allowConditional` is enabled, allow conditional skip patterns.
+                if allow_conditional {
+                    return None;
+                }
                 return Some(SkipState {
                     range: name_range,
                     annotation,
@@ -334,6 +375,19 @@ fn collect_callee_names_rec(
         }
         _ => None,
     }
+}
+
+/// Checks if a call expression is inside an `if` statement, before hitting a function boundary.
+fn is_inside_if_block(call_expr: &JsCallExpression) -> bool {
+    for ancestor in call_expr.syntax().ancestors() {
+        if ancestor.kind() == JsSyntaxKind::JS_IF_STATEMENT {
+            return true;
+        }
+        if crate::ast_utils::is_function_boundary(ancestor.kind()) {
+            break;
+        }
+    }
+    false
 }
 
 /// Checks if the first argument of a call expression is a string literal or template literal.

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalInvalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalInvalid.js
@@ -1,0 +1,23 @@
+// Standard skip with string first arg — still reported even with allowConditional: true
+test.skip("standard skip", () => {});
+it.skip("standard skip", () => {});
+describe.skip("standard skip", () => {});
+
+// 0-arg bare skip OUTSIDE an `if` block — still reported
+test('outside-if', () => {
+    test.skip();
+});
+
+// describe.skip with non-string first arg — still reported (option only allows test/it)
+describe('describe-conditional', () => {
+    describe.skip(someCondition);
+});
+
+// x-prefix variants are not conditional patterns — still reported
+xtest('x-prefix', () => {});
+xit('x-prefix', () => {});
+xdescribe('x-prefix', () => {});
+
+// Playwright describe/step skip — still reported
+test.describe.skip("playwright", () => {});
+test.step.skip("playwright", () => {});

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalInvalid.js.snap
@@ -1,0 +1,306 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: conditionalInvalid.js
+---
+# Input
+```js
+// Standard skip with string first arg — still reported even with allowConditional: true
+test.skip("standard skip", () => {});
+it.skip("standard skip", () => {});
+describe.skip("standard skip", () => {});
+
+// 0-arg bare skip OUTSIDE an `if` block — still reported
+test('outside-if', () => {
+    test.skip();
+});
+
+// describe.skip with non-string first arg — still reported (option only allows test/it)
+describe('describe-conditional', () => {
+    describe.skip(someCondition);
+});
+
+// x-prefix variants are not conditional patterns — still reported
+xtest('x-prefix', () => {});
+xit('x-prefix', () => {});
+xdescribe('x-prefix', () => {});
+
+// Playwright describe/step skip — still reported
+test.describe.skip("playwright", () => {});
+test.step.skip("playwright", () => {});
+
+```
+
+# Diagnostics
+```
+conditionalInvalid.js:2:6 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    1 │ // Standard skip with string first arg — still reported even with allowConditional: true
+  > 2 │ test.skip("standard skip", () => {});
+      │      ^^^^
+    3 │ it.skip("standard skip", () => {});
+    4 │ describe.skip("standard skip", () => {});
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+     1  1 │   // Standard skip with string first arg — still reported even with allowConditional: true
+     2    │ - test.skip("standard·skip",·()·=>·{});
+        2 │ + test("standard·skip",·()·=>·{});
+     3  3 │   it.skip("standard skip", () => {});
+     4  4 │   describe.skip("standard skip", () => {});
+  
+
+```
+
+```
+conditionalInvalid.js:3:4 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    1 │ // Standard skip with string first arg — still reported even with allowConditional: true
+    2 │ test.skip("standard skip", () => {});
+  > 3 │ it.skip("standard skip", () => {});
+      │    ^^^^
+    4 │ describe.skip("standard skip", () => {});
+    5 │ 
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+     1  1 │   // Standard skip with string first arg — still reported even with allowConditional: true
+     2  2 │   test.skip("standard skip", () => {});
+     3    │ - it.skip("standard·skip",·()·=>·{});
+        3 │ + it("standard·skip",·()·=>·{});
+     4  4 │   describe.skip("standard skip", () => {});
+     5  5 │   
+  
+
+```
+
+```
+conditionalInvalid.js:4:10 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    2 │ test.skip("standard skip", () => {});
+    3 │ it.skip("standard skip", () => {});
+  > 4 │ describe.skip("standard skip", () => {});
+      │          ^^^^
+    5 │ 
+    6 │ // 0-arg bare skip OUTSIDE an `if` block — still reported
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+     2  2 │   test.skip("standard skip", () => {});
+     3  3 │   it.skip("standard skip", () => {});
+     4    │ - describe.skip("standard·skip",·()·=>·{});
+        4 │ + describe("standard·skip",·()·=>·{});
+     5  5 │   
+     6  6 │   // 0-arg bare skip OUTSIDE an `if` block — still reported
+  
+
+```
+
+```
+conditionalInvalid.js:8:10 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+     6 │ // 0-arg bare skip OUTSIDE an `if` block — still reported
+     7 │ test('outside-if', () => {
+   > 8 │     test.skip();
+       │          ^^^^
+     9 │ });
+    10 │ 
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+     6  6 │   // 0-arg bare skip OUTSIDE an `if` block — still reported
+     7  7 │   test('outside-if', () => {
+     8    │ - ····test.skip();
+        8 │ + ····test();
+     9  9 │   });
+    10 10 │   
+  
+
+```
+
+```
+conditionalInvalid.js:13:14 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    11 │ // describe.skip with non-string first arg — still reported (option only allows test/it)
+    12 │ describe('describe-conditional', () => {
+  > 13 │     describe.skip(someCondition);
+       │              ^^^^
+    14 │ });
+    15 │ 
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    11 11 │   // describe.skip with non-string first arg — still reported (option only allows test/it)
+    12 12 │   describe('describe-conditional', () => {
+    13    │ - ····describe.skip(someCondition);
+       13 │ + ····describe(someCondition);
+    14 14 │   });
+    15 15 │   
+  
+
+```
+
+```
+conditionalInvalid.js:17:1 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    16 │ // x-prefix variants are not conditional patterns — still reported
+  > 17 │ xtest('x-prefix', () => {});
+       │ ^^^^^
+    18 │ xit('x-prefix', () => {});
+    19 │ xdescribe('x-prefix', () => {});
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    15 15 │   
+    16 16 │   // x-prefix variants are not conditional patterns — still reported
+    17    │ - xtest('x-prefix',·()·=>·{});
+       17 │ + test('x-prefix',·()·=>·{});
+    18 18 │   xit('x-prefix', () => {});
+    19 19 │   xdescribe('x-prefix', () => {});
+  
+
+```
+
+```
+conditionalInvalid.js:18:1 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    16 │ // x-prefix variants are not conditional patterns — still reported
+    17 │ xtest('x-prefix', () => {});
+  > 18 │ xit('x-prefix', () => {});
+       │ ^^^
+    19 │ xdescribe('x-prefix', () => {});
+    20 │ 
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    16 16 │   // x-prefix variants are not conditional patterns — still reported
+    17 17 │   xtest('x-prefix', () => {});
+    18    │ - xit('x-prefix',·()·=>·{});
+       18 │ + it('x-prefix',·()·=>·{});
+    19 19 │   xdescribe('x-prefix', () => {});
+    20 20 │   
+  
+
+```
+
+```
+conditionalInvalid.js:19:1 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    17 │ xtest('x-prefix', () => {});
+    18 │ xit('x-prefix', () => {});
+  > 19 │ xdescribe('x-prefix', () => {});
+       │ ^^^^^^^^^
+    20 │ 
+    21 │ // Playwright describe/step skip — still reported
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    17 17 │   xtest('x-prefix', () => {});
+    18 18 │   xit('x-prefix', () => {});
+    19    │ - xdescribe('x-prefix',·()·=>·{});
+       19 │ + describe('x-prefix',·()·=>·{});
+    20 20 │   
+    21 21 │   // Playwright describe/step skip — still reported
+  
+
+```
+
+```
+conditionalInvalid.js:22:15 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    21 │ // Playwright describe/step skip — still reported
+  > 22 │ test.describe.skip("playwright", () => {});
+       │               ^^^^
+    23 │ test.step.skip("playwright", () => {});
+    24 │ 
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    20 20 │   
+    21 21 │   // Playwright describe/step skip — still reported
+    22    │ - test.describe.skip("playwright",·()·=>·{});
+       22 │ + test.describe("playwright",·()·=>·{});
+    23 23 │   test.step.skip("playwright", () => {});
+    24 24 │   
+  
+
+```
+
+```
+conditionalInvalid.js:23:11 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    21 │ // Playwright describe/step skip — still reported
+    22 │ test.describe.skip("playwright", () => {});
+  > 23 │ test.step.skip("playwright", () => {});
+       │           ^^^^
+    24 │ 
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    21 21 │   // Playwright describe/step skip — still reported
+    22 22 │   test.describe.skip("playwright", () => {});
+    23    │ - test.step.skip("playwright",·()·=>·{});
+       23 │ + test.step("playwright",·()·=>·{});
+    24 24 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalInvalid.options.json
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalInvalid.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"suspicious": {
+				"noSkippedTests": {
+					"level": "error",
+					"options": {
+						"allowConditional": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalValid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalValid.js
@@ -1,0 +1,37 @@
+/* should not generate diagnostics */
+
+// 0-arg bare skip inside an `if` block
+test('a', () => {
+    if (someCondition) {
+        test.skip();
+    }
+});
+
+// 0-arg bare fixme inside an `if` block
+test('b', () => {
+    if (someCondition) {
+        test.fixme();
+    }
+});
+
+// 1-arg conditional skip (non-string first arg)
+test('c', () => {
+    test.skip(someCondition);
+});
+
+// 2-arg conditional skip (non-string first arg, string reason)
+test('d', () => {
+    test.skip(someCondition, 'reason');
+});
+
+// it variant: 0-arg bare skip inside if
+it('e', () => {
+    if (cond) {
+        it.skip();
+    }
+});
+
+// fixme conditional with non-string first arg
+test('f', () => {
+    test.fixme(someCondition);
+});

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalValid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalValid.js.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: conditionalValid.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+
+// 0-arg bare skip inside an `if` block
+test('a', () => {
+    if (someCondition) {
+        test.skip();
+    }
+});
+
+// 0-arg bare fixme inside an `if` block
+test('b', () => {
+    if (someCondition) {
+        test.fixme();
+    }
+});
+
+// 1-arg conditional skip (non-string first arg)
+test('c', () => {
+    test.skip(someCondition);
+});
+
+// 2-arg conditional skip (non-string first arg, string reason)
+test('d', () => {
+    test.skip(someCondition, 'reason');
+});
+
+// it variant: 0-arg bare skip inside if
+it('e', () => {
+    if (cond) {
+        it.skip();
+    }
+});
+
+// fixme conditional with non-string first arg
+test('f', () => {
+    test.fixme(someCondition);
+});
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalValid.options.json
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/conditionalValid.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"suspicious": {
+				"noSkippedTests": {
+					"level": "error",
+					"options": {
+						"allowConditional": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_rule_options/src/no_skipped_tests.rs
+++ b/crates/biome_rule_options/src/no_skipped_tests.rs
@@ -1,6 +1,21 @@
 use biome_deserialize_macros::{Deserializable, Merge};
 use serde::{Deserialize, Serialize};
+
 #[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
-pub struct NoSkippedTestsOptions {}
+pub struct NoSkippedTestsOptions {
+    /// Allows conditional skipping inside test bodies.
+    /// When enabled, `test.skip(condition)` and `test.skip()` inside `if` statements are allowed.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub allow_conditional: Option<bool>,
+}
+
+impl NoSkippedTestsOptions {
+    pub const DEFAULT_ALLOW_CONDITIONAL: bool = false;
+
+    pub fn allow_conditional(&self) -> bool {
+        self.allow_conditional
+            .unwrap_or(Self::DEFAULT_ALLOW_CONDITIONAL)
+    }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8794,7 +8794,13 @@ export type NoRedundantUseStrictOptions = {};
 export type NoSelfCompareOptions = {};
 export type NoShadowRestrictedNamesOptions = {};
 export type NoShorthandPropertyOverridesOptions = {};
-export type NoSkippedTestsOptions = {};
+export interface NoSkippedTestsOptions {
+	/**
+	* Allows conditional skipping inside test bodies.
+When enabled, `test.skip(condition)` and `test.skip()` inside `if` statements are allowed. 
+	 */
+	allowConditional?: boolean;
+}
 export type NoSparseArrayOptions = {};
 export type NoSuspiciousSemicolonInJsxOptions = {};
 export type NoTemplateCurlyInStringOptions = {};

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -5146,6 +5146,12 @@
 		},
 		"NoSkippedTestsOptions": {
 			"type": "object",
+			"properties": {
+				"allowConditional": {
+					"description": "Allows conditional skipping inside test bodies.\nWhen enabled, `test.skip(condition)` and `test.skip()` inside `if` statements are allowed.",
+					"type": ["boolean", "null"]
+				}
+			},
 			"additionalProperties": false
 		},
 		"NoSolidDestructuredPropsConfiguration": {


### PR DESCRIPTION
## Summary

Closes #8998. Re-adds the `allowConditional` option to the [`noSkippedTests`](https://biomejs.dev/linter/rules/no-skipped-tests/) rule, originally landed in #8960 and reverted because user-facing options cannot ship in a patch release. Targets `next` per the issue spec.

When `allowConditional: true`, two patterns are allowed for `test` / `it`:

- 0-arg bare `test.skip()` / `test.fixme()` calls **inside an `if` statement**.
- 1-2 arg conditional skips with a non-string first argument (e.g. `test.skip(condition)`, `test.skip(condition, "reason")`).

Default is `false`, preserving current behaviour. Standard `test.skip("name", fn)`, `describe.skip(...)`, x-prefix variants, and Playwright `test.describe.skip` / `test.step.skip` patterns are still flagged.

```js
// allowed when allowConditional: true
test('a', () => {
    if (someCondition) {
        test.skip();
    }
});

// allowed when allowConditional: true
test('b', () => {
    test.skip(someCondition);
});

// still flagged regardless
test.skip("name", () => {});
```

## Test Plan

New fixtures under `crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/`:

- `conditionalValid.js` (option on, expects no diagnostics): bare-skip-in-if, fixme-in-if, 1-arg conditional, 2-arg conditional with reason, `it.skip` variant, `fixme` conditional.
- `conditionalInvalid.js` (option on, expects diagnostics): standard `test.skip("name", fn)` / `it.skip(...)` / `describe.skip(...)`, bare-skip outside `if`, `describe.skip(condition)` (option only allows test/it), x-prefix variants, Playwright `test.describe.skip` and `test.step.skip`.

`cargo test -p biome_js_analyze no_skipped_tests` — green (6 passed; 0 failed).

Code generation ran via `cargo codegen-configuration`, `cargo codegen-schema`, and `gen-bindings`; the resulting `configuration_schema.json` and `workspace.ts` updates are committed.

## Docs

The `## Options` block is included inline in the rule source so it renders to the website via codegen.

## AI Assistance Disclosure

This PR was authored with AI assistance (Claude Opus 4.7) following Biome's [contributor guide](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md), the implementation spec in #8998, and the conventions of the existing `detect_bare_skip_call` function in this rule. Tests, schema regen, and the changeset were verified locally.
