### PR TITLE
fix(markdown_parser): keep lazy link references as text

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -44,7 +44,6 @@ use crate::lexer::MarkdownReLexContext;
 use crate::syntax::fenced_code_block::parse_fenced_code_block;
 use crate::syntax::header::{parse_header_content, parse_trailing_hashes};
 use crate::syntax::html_block::{at_html_block, parse_html_block};
-use crate::syntax::parse_any_block_with_indent_code_policy;
 use crate::syntax::parse_error::list_nesting_too_deep;
 use crate::syntax::quote::{
     at_quote_indented_code_start, consume_quote_prefix, consume_quote_prefix_without_virtual,
@@ -56,6 +55,7 @@ use crate::syntax::{
     INDENT_CODE_BLOCK_SPACES, MAX_BLOCK_PREFIX_INDENT, TAB_STOP_SPACES, at_block_interrupt,
     at_indent_code_block, is_paragraph_like, is_whitespace_only,
 };
+use crate::syntax::{parse_any_block_with_indent_code_policy, parse_paragraph};
 use biome_rowan::{TextRange, TextSize};
 
 /// Tokens that start a new block (used for recovery)
@@ -1463,11 +1463,18 @@ enum VirtualLineRestore {
     Restore(Option<TextSize>),
 }
 
+/// How the current continuation line should be parsed after indentation checks.
+enum ContinuationParseMode {
+    AnyBlock,
+    Paragraph,
+}
+
 /// Result of the continuation-indent check.
 struct ContinuationResult {
     action: LoopAction,
     /// Whether virtual_line_start must be restored after parsing the block.
     restore: VirtualLineRestore,
+    parse_mode: ContinuationParseMode,
 }
 
 /// Mutable loop state for `parse_list_item_block_content`.
@@ -2268,6 +2275,7 @@ fn check_continuation_indent(
         return ContinuationResult {
             action: LoopAction::FallThrough,
             restore: VirtualLineRestore::None,
+            parse_mode: ContinuationParseMode::AnyBlock,
         };
     }
 
@@ -2285,6 +2293,7 @@ fn check_continuation_indent(
             return ContinuationResult {
                 action: LoopAction::Break,
                 restore: VirtualLineRestore::None,
+                parse_mode: ContinuationParseMode::AnyBlock,
             };
         }
         // Fall through: the insufficient-indent branch below handles the
@@ -2307,6 +2316,7 @@ fn check_continuation_indent(
                 return ContinuationResult {
                     action: LoopAction::Continue,
                     restore: VirtualLineRestore::None,
+                    parse_mode: ContinuationParseMode::AnyBlock,
                 };
             }
             if at_order_list_item(p) {
@@ -2317,6 +2327,7 @@ fn check_continuation_indent(
                 return ContinuationResult {
                     action: LoopAction::Continue,
                     restore: VirtualLineRestore::None,
+                    parse_mode: ContinuationParseMode::AnyBlock,
                 };
             }
 
@@ -2332,6 +2343,7 @@ fn check_continuation_indent(
             return ContinuationResult {
                 action: LoopAction::FallThrough,
                 restore: VirtualLineRestore::Restore(prev_virtual),
+                parse_mode: ContinuationParseMode::AnyBlock,
             };
         }
     } else {
@@ -2342,6 +2354,7 @@ fn check_continuation_indent(
             return ContinuationResult {
                 action: LoopAction::Break,
                 restore: VirtualLineRestore::None,
+                parse_mode: ContinuationParseMode::AnyBlock,
             };
         }
 
@@ -2349,6 +2362,7 @@ fn check_continuation_indent(
             return ContinuationResult {
                 action: LoopAction::Break,
                 restore: VirtualLineRestore::None,
+                parse_mode: ContinuationParseMode::AnyBlock,
             };
         }
 
@@ -2357,6 +2371,7 @@ fn check_continuation_indent(
             return ContinuationResult {
                 action: LoopAction::Break,
                 restore: VirtualLineRestore::None,
+                parse_mode: ContinuationParseMode::AnyBlock,
             };
         }
 
@@ -2373,12 +2388,14 @@ fn check_continuation_indent(
         return ContinuationResult {
             action: LoopAction::FallThrough,
             restore: VirtualLineRestore::Restore(prev_virtual),
+            parse_mode: ContinuationParseMode::Paragraph,
         };
     }
 
     ContinuationResult {
         action: LoopAction::FallThrough,
         restore: VirtualLineRestore::None,
+        parse_mode: ContinuationParseMode::AnyBlock,
     }
 }
 
@@ -2388,6 +2405,7 @@ fn parse_continuation_block(
     p: &mut MarkdownParser,
     state: &mut ListItemLoopState,
     prev_was_blank: bool,
+    parse_mode: ContinuationParseMode,
     restore: VirtualLineRestore,
 ) {
     let is_blank_line = p.at_blank_line();
@@ -2443,7 +2461,12 @@ fn parse_continuation_block(
     state.first_line = false;
 
     let allow_indent_code_block = !state.last_block_was_paragraph || prev_was_blank;
-    let parsed = parse_any_block_with_indent_code_policy(p, allow_indent_code_block);
+    let parsed = match parse_mode {
+        ContinuationParseMode::AnyBlock => {
+            parse_any_block_with_indent_code_policy(p, allow_indent_code_block)
+        }
+        ContinuationParseMode::Paragraph => parse_paragraph(p),
+    };
     state.last_block_was_paragraph = if let Present(ref marker) = parsed {
         is_paragraph_like(marker.kind(p))
     } else {
@@ -2531,7 +2554,7 @@ fn parse_list_item_block_content(
         }
 
         // Parse block content
-        parse_continuation_block(p, &mut state, prev_was_blank, cont.restore);
+        parse_continuation_block(p, &mut state, prev_was_blank, cont.parse_mode, cont.restore);
     }
 
     m.complete(p, MD_BLOCK_LIST);

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_link_reference.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_link_reference.md
@@ -1,0 +1,4 @@
+- outer
+  - nested
+  lazy line
+[valid]: /url

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_link_reference.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_link_reference.md.snap
@@ -1,0 +1,207 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+assertion_line: 192
+expression: snapshot
+---
+
+## Input
+
+```
+- outer
+  - nested
+  lazy line
+[valid]: /url
+
+```
+
+
+## AST
+
+```
+MdDocument {
+    bom_token: missing (optional),
+    value: MdBlockList [
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@0..1 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@1..2 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@2..7 "outer" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
+                                },
+                            ],
+                            hard_line: missing (optional),
+                        },
+                        MdBulletListItem {
+                            md_bullet_list: MdBulletList [
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@8..9 " " [] [],
+                                            },
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@9..10 " " [] [],
+                                            },
+                                        ],
+                                        marker: MINUS@10..11 "-" [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@11..12 " " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@12..18 "nested" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@18..19 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                        MdContinuationIndent {
+                                            indent: MdIndentTokenList [
+                                                MdIndentToken {
+                                                    md_indent_char_token: MD_INDENT_CHAR@19..20 " " [] [],
+                                                },
+                                                MdIndentToken {
+                                                    md_indent_char_token: MD_INDENT_CHAR@20..21 " " [] [],
+                                                },
+                                            ],
+                                        },
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                        MdContinuationIndent {
+                                            indent: MdIndentTokenList [],
+                                        },
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@31..32 "[" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@32..37 "valid" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@37..38 "]" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@38..39 ":" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@39..44 " /url" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@44..45 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@45..45 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_DOCUMENT@0..45
+  0: (empty)
+  1: MD_BLOCK_LIST@0..45
+    0: MD_BULLET_LIST_ITEM@0..45
+      0: MD_BULLET_LIST@0..45
+        0: MD_BULLET@0..45
+          0: MD_LIST_MARKER_PREFIX@0..2
+            0: MD_INDENT_TOKEN_LIST@0..0
+            1: MINUS@0..1 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@1..2 " " [] []
+            3: MD_INDENT_TOKEN_LIST@2..2
+          1: MD_BLOCK_LIST@2..45
+            0: MD_PARAGRAPH@2..8
+              0: MD_INLINE_ITEM_LIST@2..8
+                0: MD_TEXTUAL@2..7
+                  0: MD_TEXTUAL_LITERAL@2..7 "outer" [] []
+                1: MD_TEXTUAL@7..8
+                  0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
+              1: (empty)
+            1: MD_BULLET_LIST_ITEM@8..45
+              0: MD_BULLET_LIST@8..45
+                0: MD_BULLET@8..45
+                  0: MD_LIST_MARKER_PREFIX@8..12
+                    0: MD_INDENT_TOKEN_LIST@8..10
+                      0: MD_INDENT_TOKEN@8..9
+                        0: MD_INDENT_CHAR@8..9 " " [] []
+                      1: MD_INDENT_TOKEN@9..10
+                        0: MD_INDENT_CHAR@9..10 " " [] []
+                    1: MINUS@10..11 "-" [] []
+                    2: MD_LIST_POST_MARKER_SPACE@11..12 " " [] []
+                    3: MD_INDENT_TOKEN_LIST@12..12
+                  1: MD_BLOCK_LIST@12..45
+                    0: MD_PARAGRAPH@12..19
+                      0: MD_INLINE_ITEM_LIST@12..19
+                        0: MD_TEXTUAL@12..18
+                          0: MD_TEXTUAL_LITERAL@12..18 "nested" [] []
+                        1: MD_TEXTUAL@18..19
+                          0: MD_TEXTUAL_LITERAL@18..19 "\n" [] []
+                      1: (empty)
+                    1: MD_CONTINUATION_INDENT@19..21
+                      0: MD_INDENT_TOKEN_LIST@19..21
+                        0: MD_INDENT_TOKEN@19..20
+                          0: MD_INDENT_CHAR@19..20 " " [] []
+                        1: MD_INDENT_TOKEN@20..21
+                          0: MD_INDENT_CHAR@20..21 " " [] []
+                    2: MD_PARAGRAPH@21..31
+                      0: MD_INLINE_ITEM_LIST@21..31
+                        0: MD_TEXTUAL@21..30
+                          0: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] []
+                        1: MD_TEXTUAL@30..31
+                          0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
+                      1: (empty)
+                    3: MD_CONTINUATION_INDENT@31..31
+                      0: MD_INDENT_TOKEN_LIST@31..31
+                    4: MD_PARAGRAPH@31..45
+                      0: MD_INLINE_ITEM_LIST@31..45
+                        0: MD_TEXTUAL@31..32
+                          0: MD_TEXTUAL_LITERAL@31..32 "[" [] []
+                        1: MD_TEXTUAL@32..37
+                          0: MD_TEXTUAL_LITERAL@32..37 "valid" [] []
+                        2: MD_TEXTUAL@37..38
+                          0: MD_TEXTUAL_LITERAL@37..38 "]" [] []
+                        3: MD_TEXTUAL@38..39
+                          0: MD_TEXTUAL_LITERAL@38..39 ":" [] []
+                        4: MD_TEXTUAL@39..44
+                          0: MD_TEXTUAL_LITERAL@39..44 " /url" [] []
+                        5: MD_TEXTUAL@44..45
+                          0: MD_TEXTUAL_LITERAL@44..45 "\n" [] []
+                      1: (empty)
+  2: EOF@45..45 "" [] []
+
+```

--- a/crates/biome_markdown_parser/tests/spec_test.rs
+++ b/crates/biome_markdown_parser/tests/spec_test.rs
@@ -562,3 +562,12 @@ fn fuzz_nested_lazy_continuation_before_fence() {
         "<ul>\n<li>outer\n<ul>\n<li>nested\nlazy line</li>\n</ul>\n</li>\n</ul>\n<pre><code>code here\n</code></pre>\n",
     );
 }
+
+#[test]
+fn fuzz_nested_lazy_continuation_before_link_reference() {
+    fuzz_test_example(
+        10,
+        "- outer\n  - nested\n  lazy line\n[valid]: /url\n",
+        "<ul>\n<li>outer\n<ul>\n<li>nested\nlazy line\n[valid]: /url</li>\n</ul>\n</li>\n</ul>\n",
+    );
+}


### PR DESCRIPTION
> [!NOTE]
> I used Codex to help investigate the fuzz mismatch and validate the fix.

## Summary

Fixes a markdown parser edge case where a link reference-looking line after a nested list lazy-continuation line could be parsed as a link reference definition instead of remaining part of the nested list item text.

The parser now keeps accepted lazy continuation lines in paragraph parsing mode, avoiding block-level parsing when the line belongs to the continued paragraph.

## Test Plan

Added a regression test covering the fuzz-discovered nested-list lazy-continuation case where a following link reference-looking line was incorrectly parsed as a link reference definition.

- `just test-crate biome_markdown_parser`
- `just fuzz-markdown-differential`

The differential fuzzer was used to discover the original mismatch against `commonmark.js`. The checked-in regression now verifies the fixed case directly.

## Docs

N/A