### PR TITLE
feat(organizeImports): allow grouping a subset of bare imports

### DIFF
--- a/.changeset/flat-beers-battle.md
+++ b/.changeset/flat-beers-battle.md
@@ -3,7 +3,7 @@
 ---
 
 Added the `sortBareImports` option to [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/),
-which allows bare imports to be sorted within other imports when set to `false`.
+which allows bare imports to be sorted within other imports when set to `true`.
 
 ```json
 {

--- a/.changeset/organize-imports-bare-matcher.md
+++ b/.changeset/organize-imports-bare-matcher.md
@@ -2,47 +2,46 @@
 "@biomejs/biome": minor
 ---
 
-Added a `kind` field to the `ImportMatcher` used by the [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/) assist action. The new field selects imports by their syntactic kind and currently supports `bare` (matching side-effect imports such as `import "polyfill"`) with optional `!` negation (`!bare`). The matcher composes with the existing `type` and `source` fields, so users can express patterns such as "only bare imports that import a CSS file" (`{ "kind": "bare", "source": "**/*.css" }`).
+Added an optional `kind` field to the import matchers used by the [`organizeImports`](https://biomejs.dev/assist/actions/organize-imports/) assist action.
+The new field selects imports by their syntactic kind and currently supports `bare` (matching side-effect imports such as `import "polyfill"`) with optional `!` negation (`!bare`).
+The matcher composes with the existing `type` and `source` fields, so users can express patterns such as "only bare imports that import style files" (`{ "kind": "bare", "source": ":STYLE:" }`).
 
 For example, with the following configuration:
 
 ```json
 {
-    "assist": {
-        "actions": {
-            "source": {
-                "organizeImports": {
-                    "level": "on",
-                    "options": {
-                        "sortBareImports": true,
-                        "groups": [
-                            { "kind": "!bare" },
-                            ":BLANK_LINE:",
-                            { "kind": "bare" }
-                        ]
-                    }
-                }
-            }
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              { "kind": "!bare" },
+              ":BLANK_LINE:",
+              { "kind": "bare", "source": ":STYLE:" }
+            ]
+          }
         }
+      }
     }
+  }
 }
 ```
 
 ...the following code:
 
 ```ts
-import "./register-my-component";
-import { render } from "react-dom";
-import "./polyfill";
-import { Button } from "@/components/Button";
+import "./b.css";
+import d from "./d.js";
+import "./a.css";
 ```
 
 ...is organized as:
 
 ```ts
-import { render } from "react-dom";
-import { Button } from "@/components/Button";
+import d from "./d.js";
 
-import "./polyfill";
-import "./register-my-component";
+import "./a.css";
+import "./b.css";
 ```

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -172,45 +172,6 @@ declare_source_rule! {
     /// - `:STYLE:`: paths ending with the following style extensions:
     ///   `.css`, `.less`, `.pcss`, `.sass`, `.scss`, `.sss` and `.styl`
     ///
-    /// #### Kind matcher
-    ///
-    /// Use a kind matcher to filter imports by their syntactic kind.
-    /// Currently, the only supported kind is `bare`, which matches
-    /// bare (side-effect) imports such as `import "polyfill"`.
-    /// Prefix the kind with `!` to match everything except that kind.
-    ///
-    /// ```json,options
-    /// {
-    ///     "options": {
-    ///         "sortBareImports": true,
-    ///         "groups": [
-    ///             { "kind": "!bare" },
-    ///             ":BLANK_LINE:",
-    ///             { "kind": "bare" }
-    ///         ]
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// The kind matcher composes with the `source` field,
-    /// allowing patterns such as "only bare imports that import a CSS file":
-    ///
-    /// ```json,options
-    /// {
-    ///     "options": {
-    ///         "sortBareImports": true,
-    ///         "groups": [
-    ///             { "kind": "bare", "source": "**/*.css" }
-    ///         ]
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// :::note
-    /// The `bare` kind requires [`sortBareImports`](#sortbareimports) to be `true`
-    /// for bare imports to participate in group matching.
-    /// :::
-    ///
     /// #### Type-only matcher
     ///
     /// Use a type-only matcher to separate `import type` from regular imports:
@@ -245,6 +206,86 @@ declare_source_rule! {
     /// ```
     ///
     /// The `source` field accepts predefined groups and glob patterns.
+    ///
+    /// #### Kind matcher
+    ///
+    /// Use a kind matcher to filter imports by their syntactic kind.
+    /// Currently, the only supported kind is `bare`, which matches
+    /// bare (side-effect) imports such as `import "polyfill"`.
+    /// The kind matcher composes with the `source` field,
+    /// allowing patterns such as "only bare imports that import a style file":
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "groups": [
+    ///             { "kind": "bare", "source": ":STYLE:" }
+    ///         ]
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```js,use_options,expect_diagnostic
+    /// import "./b.css";
+    /// import d from "./d.js";
+    /// import "./a.css";
+    /// ```
+    ///
+    /// If you don't set [`sortBareImports`](#sortbareimports) to `true`,
+    /// then bare imports that are not matched are not sorted with other imports.
+    /// Using the previous configuration, the following code...
+    ///
+    /// ```ts,ignore
+    /// import "./e.css";
+    /// import d from "./d.js";
+    /// import "./c.css";
+    /// import "./x.js";
+    /// import "./b.css";
+    /// import "./a.css";
+    /// ```
+    ///
+    /// ...is sorted as:
+    ///
+    /// ```ts,ignore
+    /// import "./c.css";
+    /// import "./e.css";
+    /// import d from "./d.js";
+    /// import "./x.js";
+    /// import "./a.css";
+    /// import "./b.css";
+    /// ```
+    ///
+    /// Another subtlety of not setting [`sortBareImports`](#sortbareimports) to `true`
+    /// is that the following configuration doesn't group bare imports at the end:
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "groups": [{ "kind": "!bare" }]
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// If you want to group bare imports last,
+    /// you have to create a group that explicitly matches bare imports:
+    ///
+    /// ```jsonc,options
+    /// {
+    ///     "options": {
+    ///         "groups": [
+    ///             { "kind": "!bare" },
+    ///             ":BLANK_LINE:",
+    ///             { "kind": "bare" }
+    ///         ]
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```js,use_options,expect_diagnostic
+    /// import "./b.css";
+    /// import d from "./d.js";
+    /// import "./a.css";
+    /// ```
     ///
     /// ### `sortBareImports`
     ///

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -1055,7 +1055,7 @@ impl Rule for OrganizeImports {
                     && let Some(groups) = groups
                     && let Some(import_group) = groups.get(key.group)
                 {
-                    import_group.matches_bare()
+                    import_group.matches_bare(&(&key).into())
                 } else {
                     false
                 };
@@ -1289,8 +1289,8 @@ impl Rule for OrganizeImports {
                             .take(slot_indexes.len())
                             .filter_map(|item| {
                                 let info = ImportInfo::from_module_item(&item)?.0;
-                                let item = organized_items.remove(&info.slot_index).unwrap_or(item);
                                 let key = ImportKey::new(info, groups);
+                                let item = organized_items.remove(&key.slot_index).unwrap_or(item);
                                 Some(KeyedItem {
                                     key,
                                     was_merged: false,

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -999,28 +999,43 @@ impl Rule for OrganizeImports {
         let sort_order = options.identifier_order.unwrap_or_default();
         let sort_bare_imports = options.sort_bare_imports.unwrap_or_default();
         let mut chunk: Option<ChunkBuilder> = None;
-        let mut prev_kind: Option<JsSyntaxKind> = None;
-        let mut prev_is_bare_import = false;
+        let mut prev_stmt_kind: Option<JsSyntaxKind> = None;
+        let mut prev_is_unmatched_bare_import = false;
         let mut prev_group = None;
         for item in root.items() {
-            let current_kind = item.syntax().kind();
+            let current_stmt_kind = item.syntax().kind();
             if let Some((info, specifiers, attributes)) = ImportInfo::from_module_item(&item) {
-                let prev_is_distinct = prev_kind.is_some_and(|kind| kind != current_kind);
+                let key = ImportKey::new(info, groups);
+                let prev_is_distinct_stmt_kind =
+                    prev_stmt_kind.is_some_and(|kind| kind != current_stmt_kind);
+                // Is this a bare import that is explicitly matched by its group?
+                // Explicitly means that it is a bare import matcher such as `{ "kind": "bare" }`.
+                let is_matched_bare_import = if key.kind == ImportStatementKind::Bare
+                    && let Some(groups) = groups
+                    && let Some(import_group) = groups.get(key.group)
+                {
+                    import_group.matches_bare()
+                } else {
+                    false
+                };
                 // switching of kind (import/statement/export) marks the start of a new chunk.
-                if prev_is_distinct
+                if prev_is_distinct_stmt_kind
                     // A detached comment marks the start of a new chunk
                     || has_detached_leading_comment(item.syntax())
                     // bare imports marks the start of a new chunk if they are ignored in the sort.
                     || (!sort_bare_imports && (
-                        prev_is_bare_import || info.kind == ImportStatementKind::Bare
+                        // bare imports that are explicitly matched are ignored.
+                        prev_is_unmatched_bare_import || (
+                            !is_matched_bare_import && key.kind == ImportStatementKind::Bare
+                        )
                     ))
                 {
                     // The chunk ends, here
                     report_unsorted_chunk(chunk.take(), &mut result);
                     prev_group = None;
                 }
-                prev_is_bare_import = info.kind == ImportStatementKind::Bare;
-                let key = ImportKey::new(info, groups);
+                prev_is_unmatched_bare_import =
+                    key.kind == ImportStatementKind::Bare && !is_matched_bare_import;
                 let blank_line_separated_groups = groups.is_some_and(|groups| {
                     prev_group.is_some_and(|prev_group| {
                         groups.separated_by_blank_line(prev_group, key.group)
@@ -1037,7 +1052,7 @@ impl Rule for OrganizeImports {
                 let newline_issue = if leading_newline_count == 1
                     // A chunk must start with a blank line (two newlines)
                     // if a distinct kind (import/statement/export) precedes it.
-                    && ((starts_chunk && prev_is_distinct) ||
+                    && ((starts_chunk && prev_is_distinct_stmt_kind) ||
                     // Some groups must be separated by a blank line
                     blank_line_separated_groups)
                 {
@@ -1096,9 +1111,9 @@ impl Rule for OrganizeImports {
                         slot_index: statement.syntax().index() as u32,
                     });
                 }
-                prev_is_bare_import = false;
+                prev_is_unmatched_bare_import = false;
             }
-            prev_kind = Some(current_kind);
+            prev_stmt_kind = Some(current_stmt_kind);
         }
         // Report the last chunk
         report_unsorted_chunk(chunk.take(), &mut result);

--- a/crates/biome_js_analyze/src/assist/source/organize_imports/import_key.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports/import_key.rs
@@ -26,7 +26,7 @@ pub struct ImportKey {
 impl ImportKey {
     pub fn new(info: ImportInfo, groups: Option<&ImportGroups>) -> Self {
         Self {
-            group: groups.map_or(0, |groups| groups.index(&((&info).into()))),
+            group: groups.map_or(0, |groups| groups.index(&(&info).into())),
             source: info.source,
             has_no_attributes: info.has_no_attributes,
             kind: info.kind,
@@ -70,6 +70,15 @@ impl Ord for ImportKey {
 impl PartialOrd for ImportKey {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+impl<'a> From<&'a ImportKey> for ImportCandidate<'a> {
+    fn from(value: &'a ImportKey) -> Self {
+        Self {
+            has_type_token: value.kind.has_type_token(),
+            is_bare: value.kind == ImportStatementKind::Bare,
+            source: value.source.as_ref().map(ImportSourceCandidate::new),
+        }
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-end.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-end.js
@@ -1,0 +1,6 @@
+import "./e.css";
+import d from "./d.js";
+import "./c.css";
+import "./x.js";
+import "./b.css";
+import "./a.css";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-end.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-end.js.snap
@@ -1,0 +1,68 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: bare-selective-matching-end.js
+---
+# Input
+```js
+import "./e.css";
+import d from "./d.js";
+import "./c.css";
+import "./x.js";
+import "./b.css";
+import "./a.css";
+
+```
+
+# Diagnostics
+```
+bare-selective-matching-end.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Some imports or exports are not organized.
+  
+  > 1 │ import "./e.css";
+      │ ^^^^^^^^^^^^^^^^^
+  > 2 │ import d from "./d.js";
+  > 3 │ import "./c.css";
+  > 4 │ import "./x.js";
+  > 5 │ import "./b.css";
+  > 6 │ import "./a.css";
+      │ ^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i Sort these imports.
+  
+  > 1 │ import "./e.css";
+      │ ^^^^^^^^^^^^^^^^^
+  > 2 │ import d from "./d.js";
+  > 3 │ import "./c.css";
+      │ ^^^^^^^^^^^^^^^^^
+    4 │ import "./x.js";
+    5 │ import "./b.css";
+  
+  i Sort these imports.
+  
+    3 │ import "./c.css";
+    4 │ import "./x.js";
+  > 5 │ import "./b.css";
+      │ ^^^^^^^^^^^^^^^^^
+  > 6 │ import "./a.css";
+      │ ^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
+  
+    1   │ - import·"./e.css";
+    2   │ - import·d·from·"./d.js";
+    3   │ - import·"./c.css";
+      1 │ + import·d·from·"./d.js";
+      2 │ + import·"./c.css";
+      3 │ + import·"./e.css";
+    4 4 │   import "./x.js";
+    5   │ - import·"./b.css";
+    6   │ - import·"./a.css";
+      5 │ + import·"./a.css";
+      6 │ + import·"./b.css";
+    7 7 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-end.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-end.options.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-end.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-end.options.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              { "kind": "!bare" },
+              { "kind": "bare", "source": ":STYLE:" }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-list.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-list.js
@@ -1,0 +1,6 @@
+import "./e.css";
+import d from "./d.js";
+import "./c.css";
+import "package";
+import "./b.css";
+import "./a.css";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-list.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-list.js.snap
@@ -1,0 +1,68 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: bare-selective-matching-list.js
+---
+# Input
+```js
+import "./e.css";
+import d from "./d.js";
+import "./c.css";
+import "package";
+import "./b.css";
+import "./a.css";
+
+```
+
+# Diagnostics
+```
+bare-selective-matching-list.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Some imports or exports are not organized.
+  
+  > 1 │ import "./e.css";
+      │ ^^^^^^^^^^^^^^^^^
+  > 2 │ import d from "./d.js";
+  > 3 │ import "./c.css";
+  > 4 │ import "package";
+  > 5 │ import "./b.css";
+  > 6 │ import "./a.css";
+      │ ^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i Sort these imports.
+  
+  > 1 │ import "./e.css";
+      │ ^^^^^^^^^^^^^^^^^
+  > 2 │ import d from "./d.js";
+  > 3 │ import "./c.css";
+      │ ^^^^^^^^^^^^^^^^^
+    4 │ import "package";
+    5 │ import "./b.css";
+  
+  i Sort these imports.
+  
+    3 │ import "./c.css";
+    4 │ import "package";
+  > 5 │ import "./b.css";
+      │ ^^^^^^^^^^^^^^^^^
+  > 6 │ import "./a.css";
+      │ ^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
+  
+    1   │ - import·"./e.css";
+    2   │ - import·d·from·"./d.js";
+    3   │ - import·"./c.css";
+      1 │ + import·"./c.css";
+      2 │ + import·"./e.css";
+      3 │ + import·d·from·"./d.js";
+    4 4 │   import "package";
+    5   │ - import·"./b.css";
+    6   │ - import·"./a.css";
+      5 │ + import·"./a.css";
+      6 │ + import·"./b.css";
+    7 7 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-list.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching-list.options.json
@@ -7,7 +7,7 @@
           "level": "on",
           "options": {
             "groups": [
-              { "kind": "bare", "source": ":STYLE:" }
+              [{ "kind": "bare", "source": ":STYLE:" }, ":PACKAGE:"]
             ]
           }
         }

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching.js
@@ -1,0 +1,6 @@
+import "./e.css";
+import d from "./d.js";
+import "./c.css";
+import "./x.js";
+import "./b.css";
+import "./a.css";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching.js.snap
@@ -1,0 +1,68 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: bare-selective-matching.js
+---
+# Input
+```js
+import "./e.css";
+import d from "./d.js";
+import "./c.css";
+import "./x.js";
+import "./b.css";
+import "./a.css";
+
+```
+
+# Diagnostics
+```
+bare-selective-matching.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Some imports or exports are not organized.
+  
+  > 1 │ import "./e.css";
+      │ ^^^^^^^^^^^^^^^^^
+  > 2 │ import d from "./d.js";
+  > 3 │ import "./c.css";
+  > 4 │ import "./x.js";
+  > 5 │ import "./b.css";
+  > 6 │ import "./a.css";
+      │ ^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i Sort these imports.
+  
+  > 1 │ import "./e.css";
+      │ ^^^^^^^^^^^^^^^^^
+  > 2 │ import d from "./d.js";
+  > 3 │ import "./c.css";
+      │ ^^^^^^^^^^^^^^^^^
+    4 │ import "./x.js";
+    5 │ import "./b.css";
+  
+  i Sort these imports.
+  
+    3 │ import "./c.css";
+    4 │ import "./x.js";
+  > 5 │ import "./b.css";
+      │ ^^^^^^^^^^^^^^^^^
+  > 6 │ import "./a.css";
+      │ ^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i Safe fix: Organize imports and exports (Biome)
+  
+    1   │ - import·"./e.css";
+    2   │ - import·d·from·"./d.js";
+    3   │ - import·"./c.css";
+      1 │ + import·"./c.css";
+      2 │ + import·"./e.css";
+      3 │ + import·d·from·"./d.js";
+    4 4 │   import "./x.js";
+    5   │ - import·"./b.css";
+    6   │ - import·"./a.css";
+      5 │ + import·"./a.css";
+      6 │ + import·"./b.css";
+    7 7 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-selective-matching.options.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              { "kind": "bare", "source": ":STYLE:" }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_rule_options/src/organize_imports/import_groups.rs
+++ b/crates/biome_rule_options/src/organize_imports/import_groups.rs
@@ -38,6 +38,11 @@ impl ImportGroups {
                     .any(|group| matches!(group, ImportGroup::BlankLine,))
             })
     }
+
+    /// Returns the explicit import group at `index` if any.
+    pub fn get(&self, index: u16) -> Option<&ImportGroup> {
+        self.0.get(index as usize)
+    }
 }
 impl biome_deserialize::Merge for ImportGroups {
     fn merge_with(&mut self, other: Self) {
@@ -72,18 +77,29 @@ impl ImportCandidate<'_> {
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
-enum ImportGroup {
+pub enum ImportGroup {
     #[serde(rename = ":BLANK_LINE:")]
     BlankLine,
     Matcher(GroupMatcher),
     MatcherList(Box<[GroupMatcher]>),
 }
 impl ImportGroup {
-    fn contains(&self, candidate: &ImportCandidate<'_>) -> bool {
+    pub fn contains(&self, candidate: &ImportCandidate<'_>) -> bool {
         match self {
             Self::BlankLine => false,
             Self::Matcher(matcher) => matcher.is_match(candidate),
             Self::MatcherList(matchers) => candidate.matches_with_exceptions(matchers.iter()),
+        }
+    }
+
+    /// Returns `true` if it matches bare imports.
+    pub fn matches_bare(&self) -> bool {
+        match self {
+            Self::BlankLine => false,
+            Self::Matcher(group_matcher) => group_matcher.matches_bare(),
+            Self::MatcherList(group_matchers) => group_matchers
+                .iter()
+                .any(|group_matcher| group_matcher.matches_bare()),
         }
     }
 }
@@ -150,6 +166,15 @@ impl GroupMatcher {
                 .is_some_and(|src| matcher.is_raw_match(src)),
         }
     }
+
+    /// Returns `true` if it matches bare imports.
+    pub fn matches_bare(&self) -> bool {
+        if let Self::Import(import_matcher) = self {
+            import_matcher.matches_bare()
+        } else {
+            false
+        }
+    }
 }
 impl Deserializable for GroupMatcher {
     fn deserialize(
@@ -192,20 +217,30 @@ impl ImportMatcher {
                     .is_some_and(|candidate_source| src.is_match(candidate_source))
             })
     }
+
+    /// Returns `true` if it matches bare imports.
+    pub fn matches_bare(&self) -> bool {
+        self.kind.is_some_and(|kind| kind.is_bare())
+    }
 }
 
 /// Kind matcher for [`ImportMatcher::kind`].
 ///
 /// Accepts a plain kind (e.g. `"bare"`) or a negated kind (e.g. `"!bare"`).
-#[derive(Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct NegatableImportKindMatcher {
     is_negated: bool,
     kind: ImportKindMatcher,
 }
 impl NegatableImportKindMatcher {
-    pub fn is_match(&self, candidate: &ImportCandidate<'_>) -> bool {
+    pub fn is_match(self, candidate: &ImportCandidate<'_>) -> bool {
         self.kind.is_match(candidate) != self.is_negated
+    }
+
+    /// Returns `true` if it matches bare import kind.
+    pub const fn is_bare(self) -> bool {
+        !self.is_negated && self.kind.is_bare()
     }
 }
 impl biome_deserialize::Deserializable for NegatableImportKindMatcher {
@@ -286,17 +321,23 @@ impl schemars::JsonSchema for NegatableImportKindMatcher {
     }
 }
 
-#[derive(Clone, Debug, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize,
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum ImportKindMatcher {
     #[serde(rename = "bare")]
     Bare,
 }
 impl ImportKindMatcher {
-    fn is_match(&self, candidate: &ImportCandidate<'_>) -> bool {
+    pub fn is_match(self, candidate: &ImportCandidate<'_>) -> bool {
         match self {
             Self::Bare => candidate.is_bare,
         }
+    }
+
+    pub const fn is_bare(self) -> bool {
+        matches!(self, Self::Bare)
     }
 }
 impl std::fmt::Display for ImportKindMatcher {
@@ -413,24 +454,24 @@ impl biome_deserialize::Deserializable for SourceMatcher {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct NegatablePredefinedSourceMatcher {
     is_negated: bool,
     matcher: PredefinedSourceMatcher,
 }
 impl NegatablePredefinedSourceMatcher {
-    pub fn is_negated(&self) -> bool {
+    pub fn is_negated(self) -> bool {
         self.is_negated
     }
 
     /// Tests whether the given `candidate` matches this matcher.
-    pub fn is_match(&self, candidate: &ImportSourceCandidate) -> bool {
+    pub fn is_match(self, candidate: &ImportSourceCandidate) -> bool {
         self.is_raw_match(candidate) != self.is_negated
     }
 
     /// Tests whether the given `candidate` matches this matcher, ignoring the negation.
-    pub fn is_raw_match(&self, candidate: &ImportSourceCandidate) -> bool {
+    pub fn is_raw_match(self, candidate: &ImportSourceCandidate) -> bool {
         self.matcher.is_match(candidate)
     }
 }
@@ -498,7 +539,9 @@ impl schemars::JsonSchema for NegatablePredefinedSourceMatcher {
     }
 }
 
-#[derive(Clone, Debug, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize,
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum PredefinedSourceMatcher {
     #[serde(rename = ":ALIAS:")]
@@ -519,7 +562,7 @@ pub enum PredefinedSourceMatcher {
     Url,
 }
 impl PredefinedSourceMatcher {
-    fn is_match(&self, candidate: &ImportSourceCandidate) -> bool {
+    fn is_match(self, candidate: &ImportSourceCandidate) -> bool {
         let source_kind = candidate.source_kund();
         let source = candidate.as_str();
         match self {

--- a/crates/biome_rule_options/src/organize_imports/import_groups.rs
+++ b/crates/biome_rule_options/src/organize_imports/import_groups.rs
@@ -92,14 +92,21 @@ impl ImportGroup {
         }
     }
 
-    /// Returns `true` if it matches bare imports.
-    pub fn matches_bare(&self) -> bool {
+    /// Returns `true` if it matches the bare import `candidate`.
+    pub fn matches_bare(&self, candidate: &ImportCandidate<'_>) -> bool {
         match self {
             Self::BlankLine => false,
-            Self::Matcher(group_matcher) => group_matcher.matches_bare(),
-            Self::MatcherList(group_matchers) => group_matchers
-                .iter()
-                .any(|group_matcher| group_matcher.matches_bare()),
+            Self::Matcher(group_matcher) => {
+                group_matcher.matches_bare() && group_matcher.is_match(candidate)
+            }
+            Self::MatcherList(group_matchers) => {
+                // It is not possible to have exceptions
+                // because import matcher hasno exceptions and
+                // glob patterns (that can have exceptions) cannot explicitly match bare imports.
+                group_matchers.iter().any(|group_matcher| {
+                    group_matcher.matches_bare() && group_matcher.is_match(candidate)
+                })
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

We recently added two features:

- the `sortBareImports` option that allows sorting **all** bare imports within other imports.
- the kind group matcher (e.g., `{ "kind": "bare" }`) that allows to group bare imports.
  This **requires** to turn on `sortBareImports`, otherwise these matchers are useless.

They impose two limitations:
- It is not possible to group a subset of bare imports.
  For example, a user might want to group bare style imports only.
- This can create some confusion if the user forgets to turn on `sortBareImports` and use bare import matchers.

This PR solves these two limitations by allowing to group bare imports matched by a bare import matcher without requiring to turn on `sortBareImports`.

Given the following config...

```json
{ "groups": [
    { "kind": "bare", "source": ":STYLE:" }
  ]
}
```

We get the following sorting:

```diff
+ import "./c.css";
  import "./e.css";
  import d from "./d.js";
- import "./c.css";
  import "./x.js";
+ import "./a.css";
  import "./b.css";
- import "./a.css";
```

Because `import "./x.js"` is not matched, it still acts as an import chunk breaker.

A limitation of this system is that it doesn't play well with the implicit group.
For example if we want to group bare style imports at the end, a user could think it is enough to write the following config:

```json5
{ "groups": [
    // Note the negated kind using the exclamation mark `!`
    { "kind": "!bare", "source": ":STYLE:" }
  ]
}
```

Unfortunately, it is not the case because the implicit group doesn't match explicitly bare imports.
Thus, the user has to write:


```json
{ "groups": [
    { "kind": "!bare" },
    { "kind": "bare", "source": ":STYLE:" }
  ]
}
```

Also, I took the opportunity to do some renaming to make the code easier to read.

## Docs

TODO

- [x] changeset
- [x] Rule docs
