### PR TITLE
fix(lint/a11y/noStaticElementInteractions): exclude custom elements

### DIFF
--- a/.changeset/proud-trams-feel.md
+++ b/.changeset/proud-trams-feel.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Now the rule [`noStaticElementInteractions`](https://biomejs.dev/linter/rules/no-static-element-interactions/) doesn't trigger custom elements.

--- a/crates/biome_js_analyze/src/lint/a11y/no_static_element_interactions.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_static_element_interactions.rs
@@ -101,8 +101,8 @@ impl Rule for NoStaticElementInteractions {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
-        // Custom components are not checked because we do not know what DOM will be used.
-        if node.is_custom_component() {
+        // Custom components and elements are not checked because we do not know what DOM will be used.
+        if node.is_custom_component() || node.is_custom_element() {
             return None;
         }
 

--- a/crates/biome_js_analyze/tests/specs/a11y/noStaticElementInteractions/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noStaticElementInteractions/valid.jsx
@@ -4,7 +4,7 @@
 	<Button onClick={doFoo} />
 	<Button onClick={doFoo} />
 	<div />
-	<custom-element />
+	<custom-element onClick={doFoo} />
 	<div className="foo" />
 	<div className="foo" {...props} />
 	<div onClick={() => void 0} aria-hidden />

--- a/crates/biome_js_analyze/tests/specs/a11y/noStaticElementInteractions/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noStaticElementInteractions/valid.jsx
@@ -4,6 +4,7 @@
 	<Button onClick={doFoo} />
 	<Button onClick={doFoo} />
 	<div />
+	<custom-element />
 	<div className="foo" />
 	<div className="foo" {...props} />
 	<div onClick={() => void 0} aria-hidden />

--- a/crates/biome_js_analyze/tests/specs/a11y/noStaticElementInteractions/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noStaticElementInteractions/valid.jsx.snap
@@ -10,6 +10,7 @@ expression: valid.jsx
 	<Button onClick={doFoo} />
 	<Button onClick={doFoo} />
 	<div />
+	<custom-element />
 	<div className="foo" />
 	<div className="foo" {...props} />
 	<div onClick={() => void 0} aria-hidden />

--- a/crates/biome_js_analyze/tests/specs/a11y/noStaticElementInteractions/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noStaticElementInteractions/valid.jsx.snap
@@ -10,7 +10,7 @@ expression: valid.jsx
 	<Button onClick={doFoo} />
 	<Button onClick={doFoo} />
 	<div />
-	<custom-element />
+	<custom-element onClick={doFoo} />
 	<div className="foo" />
 	<div className="foo" {...props} />
 	<div onClick={() => void 0} aria-hidden />


### PR DESCRIPTION
> [!NOTE]
> Claude Sonnet 4.6 has been used for determining the root cause of the false positive generated by the rule when using custom elements.

## Summary

Similar to #7348, `a11y.noStaticElementInteractions` was producing false positives with `<custom-element>`s during linting, due to the fact that just like custom components, the attributes used cannot be determined.

This PR fixes the rule by checking if the node is a custom element and excludes it if that's the case.

Has also been mentioned on https://github.com/biomejs/biome/issues/2862#issuecomment-4154139513.

## Test Plan

Added excluded element to the test specs.

## Docs

N/A