### PR TITLE
fix(markdown_parser): parse quoted ordered list interrupts

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -932,6 +932,17 @@ fn at_order_list_item_with_base_indent(p: &mut MarkdownParser, base_indent: usiz
     })
 }
 
+fn at_order_list_item_textual_with_base_indent(p: &mut MarkdownParser, base_indent: usize) -> bool {
+    p.lookahead(|p| {
+        if !list_item_within_indent(p, base_indent) {
+            return false;
+        }
+
+        skip_leading_whitespace_tokens(p);
+        p.at(MD_TEXTUAL_LITERAL) && textual_starts_with_ordered_marker(p.cur_text())
+    })
+}
+
 /// Struct implementing `ParseNodeList` for ordered lists.
 struct OrderedList {
     /// A list is tight if there are no blank lines between items or inside items.
@@ -2288,6 +2299,7 @@ fn check_continuation_indent(
         let can_lazy = state.last_block_was_paragraph
             && !at_bullet_list_item_with_base_indent(p, 0)
             && !at_order_list_item_with_base_indent(p, 0)
+            && !at_order_list_item_textual_with_base_indent(p, 0)
             && !at_current_line_block_interrupt(p);
         if !can_lazy {
             return ContinuationResult {
@@ -2330,6 +2342,20 @@ fn check_continuation_indent(
                     parse_mode: ContinuationParseMode::AnyBlock,
                 };
             }
+            if at_order_list_item_textual_with_base_indent(p, p.state().list_item_required_indent) {
+                p.set_force_ordered_list_marker(true);
+                p.force_relex_regular();
+                let _ = parse_order_list_item(p);
+                p.set_force_ordered_list_marker(false);
+                state.last_block_was_paragraph = false;
+                state.first_line = false;
+                p.state_mut().virtual_line_start = prev_virtual;
+                return ContinuationResult {
+                    action: LoopAction::Continue,
+                    restore: VirtualLineRestore::None,
+                    parse_mode: ContinuationParseMode::AnyBlock,
+                };
+            }
 
             // Emit the indentation for a continuation line inside a list item
             // as an explicit MdContinuationIndent node so it appears in the
@@ -2350,6 +2376,7 @@ fn check_continuation_indent(
         // Insufficient indentation - check for block interrupts
         if at_bullet_list_item_with_base_indent(p, state.marker_indent)
             || at_order_list_item_with_base_indent(p, state.marker_indent)
+            || at_order_list_item_textual_with_base_indent(p, state.marker_indent)
         {
             return ContinuationResult {
                 action: LoopAction::Break,

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_list_interrupt.html
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_list_interrupt.html
@@ -1,0 +1,8 @@
+<blockquote>
+<ul>
+<li>baz <strong>bold</strong> <strong>bold</strong> baz</li>
+</ul>
+<ol>
+<li><b>tag</i></li>
+</ol>
+</blockquote>

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_list_interrupt.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_list_interrupt.md
@@ -1,0 +1,2 @@
+> * baz **bold** **bold** baz
+> 1. <b>tag</i>

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_list_interrupt.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_list_interrupt.md.snap
@@ -1,0 +1,222 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```
+> * baz **bold** **bold** baz
+> 1. <b>tag</i>
+
+```
+
+
+## AST
+
+```
+MdDocument {
+    bom_token: missing (optional),
+    value: MdBlockList [
+        MdQuote {
+            prefix: MdQuotePrefix {
+                pre_marker_indent: MdQuoteIndentList [],
+                marker_token: R_ANGLE@0..1 ">" [] [],
+                post_marker_space_token: MD_QUOTE_POST_MARKER_SPACE@1..2 " " [] [],
+            },
+            content: MdBlockList [
+                MdBulletListItem {
+                    md_bullet_list: MdBulletList [
+                        MdBullet {
+                            prefix: MdListMarkerPrefix {
+                                pre_marker_indent: MdIndentTokenList [],
+                                marker: STAR@2..3 "*" [] [],
+                                post_marker_space_token: MD_LIST_POST_MARKER_SPACE@3..4 " " [] [],
+                                content_indent: MdIndentTokenList [],
+                            },
+                            content: MdBlockList [
+                                MdParagraph {
+                                    list: MdInlineItemList [
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@4..8 "baz " [] [],
+                                        },
+                                        MdInlineEmphasis {
+                                            l_fence: DOUBLE_STAR@8..10 "**" [] [],
+                                            content: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@10..14 "bold" [] [],
+                                                },
+                                            ],
+                                            r_fence: DOUBLE_STAR@14..16 "**" [] [],
+                                        },
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@16..17 " " [] [],
+                                        },
+                                        MdInlineEmphasis {
+                                            l_fence: DOUBLE_STAR@17..19 "**" [] [],
+                                            content: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@19..23 "bold" [] [],
+                                                },
+                                            ],
+                                            r_fence: DOUBLE_STAR@23..25 "**" [] [],
+                                        },
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@25..29 " baz" [] [],
+                                        },
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@29..30 "\n" [] [],
+                                        },
+                                    ],
+                                    hard_line: missing (optional),
+                                },
+                                MdQuotePrefix {
+                                    pre_marker_indent: MdQuoteIndentList [],
+                                    marker_token: R_ANGLE@30..31 ">" [] [],
+                                    post_marker_space_token: MD_QUOTE_POST_MARKER_SPACE@31..32 " " [] [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                MdOrderedListItem {
+                    md_bullet_list: MdBulletList [
+                        MdBullet {
+                            prefix: MdListMarkerPrefix {
+                                pre_marker_indent: MdIndentTokenList [],
+                                marker: MD_ORDERED_LIST_MARKER@32..34 "1." [] [],
+                                post_marker_space_token: MD_LIST_POST_MARKER_SPACE@34..35 " " [] [],
+                                content_indent: MdIndentTokenList [],
+                            },
+                            content: MdBlockList [
+                                MdParagraph {
+                                    list: MdInlineItemList [
+                                        MdInlineHtml {
+                                            value: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@35..36 "<" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@36..37 "b" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@37..38 ">" [] [],
+                                                },
+                                            ],
+                                        },
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@38..41 "tag" [] [],
+                                        },
+                                        MdInlineHtml {
+                                            value: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@41..42 "<" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@42..44 "/i" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@44..45 ">" [] [],
+                                                },
+                                            ],
+                                        },
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@45..46 "\n" [] [],
+                                        },
+                                    ],
+                                    hard_line: missing (optional),
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@46..46 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_DOCUMENT@0..46
+  0: (empty)
+  1: MD_BLOCK_LIST@0..46
+    0: MD_QUOTE@0..46
+      0: MD_QUOTE_PREFIX@0..2
+        0: MD_QUOTE_INDENT_LIST@0..0
+        1: R_ANGLE@0..1 ">" [] []
+        2: MD_QUOTE_POST_MARKER_SPACE@1..2 " " [] []
+      1: MD_BLOCK_LIST@2..46
+        0: MD_BULLET_LIST_ITEM@2..32
+          0: MD_BULLET_LIST@2..32
+            0: MD_BULLET@2..32
+              0: MD_LIST_MARKER_PREFIX@2..4
+                0: MD_INDENT_TOKEN_LIST@2..2
+                1: STAR@2..3 "*" [] []
+                2: MD_LIST_POST_MARKER_SPACE@3..4 " " [] []
+                3: MD_INDENT_TOKEN_LIST@4..4
+              1: MD_BLOCK_LIST@4..32
+                0: MD_PARAGRAPH@4..30
+                  0: MD_INLINE_ITEM_LIST@4..30
+                    0: MD_TEXTUAL@4..8
+                      0: MD_TEXTUAL_LITERAL@4..8 "baz " [] []
+                    1: MD_INLINE_EMPHASIS@8..16
+                      0: DOUBLE_STAR@8..10 "**" [] []
+                      1: MD_INLINE_ITEM_LIST@10..14
+                        0: MD_TEXTUAL@10..14
+                          0: MD_TEXTUAL_LITERAL@10..14 "bold" [] []
+                      2: DOUBLE_STAR@14..16 "**" [] []
+                    2: MD_TEXTUAL@16..17
+                      0: MD_TEXTUAL_LITERAL@16..17 " " [] []
+                    3: MD_INLINE_EMPHASIS@17..25
+                      0: DOUBLE_STAR@17..19 "**" [] []
+                      1: MD_INLINE_ITEM_LIST@19..23
+                        0: MD_TEXTUAL@19..23
+                          0: MD_TEXTUAL_LITERAL@19..23 "bold" [] []
+                      2: DOUBLE_STAR@23..25 "**" [] []
+                    4: MD_TEXTUAL@25..29
+                      0: MD_TEXTUAL_LITERAL@25..29 " baz" [] []
+                    5: MD_TEXTUAL@29..30
+                      0: MD_TEXTUAL_LITERAL@29..30 "\n" [] []
+                  1: (empty)
+                1: MD_QUOTE_PREFIX@30..32
+                  0: MD_QUOTE_INDENT_LIST@30..30
+                  1: R_ANGLE@30..31 ">" [] []
+                  2: MD_QUOTE_POST_MARKER_SPACE@31..32 " " [] []
+        1: MD_ORDERED_LIST_ITEM@32..46
+          0: MD_BULLET_LIST@32..46
+            0: MD_BULLET@32..46
+              0: MD_LIST_MARKER_PREFIX@32..35
+                0: MD_INDENT_TOKEN_LIST@32..32
+                1: MD_ORDERED_LIST_MARKER@32..34 "1." [] []
+                2: MD_LIST_POST_MARKER_SPACE@34..35 " " [] []
+                3: MD_INDENT_TOKEN_LIST@35..35
+              1: MD_BLOCK_LIST@35..46
+                0: MD_PARAGRAPH@35..46
+                  0: MD_INLINE_ITEM_LIST@35..46
+                    0: MD_INLINE_HTML@35..38
+                      0: MD_INLINE_ITEM_LIST@35..38
+                        0: MD_TEXTUAL@35..36
+                          0: MD_TEXTUAL_LITERAL@35..36 "<" [] []
+                        1: MD_TEXTUAL@36..37
+                          0: MD_TEXTUAL_LITERAL@36..37 "b" [] []
+                        2: MD_TEXTUAL@37..38
+                          0: MD_TEXTUAL_LITERAL@37..38 ">" [] []
+                    1: MD_TEXTUAL@38..41
+                      0: MD_TEXTUAL_LITERAL@38..41 "tag" [] []
+                    2: MD_INLINE_HTML@41..45
+                      0: MD_INLINE_ITEM_LIST@41..45
+                        0: MD_TEXTUAL@41..42
+                          0: MD_TEXTUAL_LITERAL@41..42 "<" [] []
+                        1: MD_TEXTUAL@42..44
+                          0: MD_TEXTUAL_LITERAL@42..44 "/i" [] []
+                        2: MD_TEXTUAL@44..45
+                          0: MD_TEXTUAL_LITERAL@44..45 ">" [] []
+                    3: MD_TEXTUAL@45..46
+                      0: MD_TEXTUAL_LITERAL@45..46 "\n" [] []
+                  1: (empty)
+  2: EOF@46..46 "" [] []
+
+```


### PR DESCRIPTION
> [!NOTE]
> I used Codex to help investigate the fuzz mismatch and validate the fix.

## Summary

Fixes a markdown parser edge case where an ordered list marker inside a block quote could remain lazy paragraph text in the previous bullet list item.

The parser now recognizes textual ordered markers after quote-prefix handling during list continuation, allowing the quoted ordered list to start as its own list.

## Test Plan

Added a regression test covering the fuzz-discovered blockquote list-interruption case where a following ordered marker was incorrectly parsed as part of the previous bullet item.

- `just test-crate biome_markdown_parser`
- `just test-markdown-conformance`
- `just fuzz-markdown-differential`

The differential fuzzer was used to discover the original mismatch against `commonmark.js`. The checked-in regression now verifies the fixed case directly.

## Docs

N/A
