### PR TITLE
test(markdown_parser): cover quoted ordered sublist

### DIFF
--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_sublist_after_list_item.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_sublist_after_list_item.md
@@ -1,0 +1,2 @@
+> - parent
+>   1. child

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_sublist_after_list_item.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_sublist_after_list_item.md.snap
@@ -1,0 +1,147 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+assertion_line: 192
+expression: snapshot
+---
+
+## Input
+
+```
+> - parent
+>   1. child
+
+```
+
+
+## AST
+
+```
+MdDocument {
+    bom_token: missing (optional),
+    value: MdBlockList [
+        MdQuote {
+            prefix: MdQuotePrefix {
+                pre_marker_indent: MdQuoteIndentList [],
+                marker_token: R_ANGLE@0..1 ">" [] [],
+                post_marker_space_token: MD_QUOTE_POST_MARKER_SPACE@1..2 " " [] [],
+            },
+            content: MdBlockList [
+                MdBulletListItem {
+                    md_bullet_list: MdBulletList [
+                        MdBullet {
+                            prefix: MdListMarkerPrefix {
+                                pre_marker_indent: MdIndentTokenList [],
+                                marker: MINUS@2..3 "-" [] [],
+                                post_marker_space_token: MD_LIST_POST_MARKER_SPACE@3..4 " " [] [],
+                                content_indent: MdIndentTokenList [],
+                            },
+                            content: MdBlockList [
+                                MdParagraph {
+                                    list: MdInlineItemList [
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@4..10 "parent" [] [],
+                                        },
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@10..11 "\n" [] [],
+                                        },
+                                    ],
+                                    hard_line: missing (optional),
+                                },
+                                MdQuotePrefix {
+                                    pre_marker_indent: MdQuoteIndentList [],
+                                    marker_token: R_ANGLE@11..12 ">" [] [],
+                                    post_marker_space_token: MD_QUOTE_POST_MARKER_SPACE@12..13 " " [] [],
+                                },
+                                MdOrderedListItem {
+                                    md_bullet_list: MdBulletList [
+                                        MdBullet {
+                                            prefix: MdListMarkerPrefix {
+                                                pre_marker_indent: MdIndentTokenList [
+                                                    MdIndentToken {
+                                                        md_indent_char_token: MD_INDENT_CHAR@13..15 "  " [] [],
+                                                    },
+                                                ],
+                                                marker: MD_ORDERED_LIST_MARKER@15..17 "1." [] [],
+                                                post_marker_space_token: MD_LIST_POST_MARKER_SPACE@17..18 " " [] [],
+                                                content_indent: MdIndentTokenList [],
+                                            },
+                                            content: MdBlockList [
+                                                MdParagraph {
+                                                    list: MdInlineItemList [
+                                                        MdTextual {
+                                                            value_token: MD_TEXTUAL_LITERAL@18..23 "child" [] [],
+                                                        },
+                                                        MdTextual {
+                                                            value_token: MD_TEXTUAL_LITERAL@23..24 "\n" [] [],
+                                                        },
+                                                    ],
+                                                    hard_line: missing (optional),
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@24..24 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_DOCUMENT@0..24
+  0: (empty)
+  1: MD_BLOCK_LIST@0..24
+    0: MD_QUOTE@0..24
+      0: MD_QUOTE_PREFIX@0..2
+        0: MD_QUOTE_INDENT_LIST@0..0
+        1: R_ANGLE@0..1 ">" [] []
+        2: MD_QUOTE_POST_MARKER_SPACE@1..2 " " [] []
+      1: MD_BLOCK_LIST@2..24
+        0: MD_BULLET_LIST_ITEM@2..24
+          0: MD_BULLET_LIST@2..24
+            0: MD_BULLET@2..24
+              0: MD_LIST_MARKER_PREFIX@2..4
+                0: MD_INDENT_TOKEN_LIST@2..2
+                1: MINUS@2..3 "-" [] []
+                2: MD_LIST_POST_MARKER_SPACE@3..4 " " [] []
+                3: MD_INDENT_TOKEN_LIST@4..4
+              1: MD_BLOCK_LIST@4..24
+                0: MD_PARAGRAPH@4..11
+                  0: MD_INLINE_ITEM_LIST@4..11
+                    0: MD_TEXTUAL@4..10
+                      0: MD_TEXTUAL_LITERAL@4..10 "parent" [] []
+                    1: MD_TEXTUAL@10..11
+                      0: MD_TEXTUAL_LITERAL@10..11 "\n" [] []
+                  1: (empty)
+                1: MD_QUOTE_PREFIX@11..13
+                  0: MD_QUOTE_INDENT_LIST@11..11
+                  1: R_ANGLE@11..12 ">" [] []
+                  2: MD_QUOTE_POST_MARKER_SPACE@12..13 " " [] []
+                2: MD_ORDERED_LIST_ITEM@13..24
+                  0: MD_BULLET_LIST@13..24
+                    0: MD_BULLET@13..24
+                      0: MD_LIST_MARKER_PREFIX@13..18
+                        0: MD_INDENT_TOKEN_LIST@13..15
+                          0: MD_INDENT_TOKEN@13..15
+                            0: MD_INDENT_CHAR@13..15 "  " [] []
+                        1: MD_ORDERED_LIST_MARKER@15..17 "1." [] []
+                        2: MD_LIST_POST_MARKER_SPACE@17..18 " " [] []
+                        3: MD_INDENT_TOKEN_LIST@18..18
+                      1: MD_BLOCK_LIST@18..24
+                        0: MD_PARAGRAPH@18..24
+                          0: MD_INLINE_ITEM_LIST@18..24
+                            0: MD_TEXTUAL@18..23
+                              0: MD_TEXTUAL_LITERAL@18..23 "child" [] []
+                            1: MD_TEXTUAL@23..24
+                              0: MD_TEXTUAL_LITERAL@23..24 "\n" [] []
+                          1: (empty)
+  2: EOF@24..24 "" [] []
+
+```


### PR DESCRIPTION
> [!NOTE]
> I used Codex to help verify the parser shape and add the regression fixture.

## Summary

Adds markdown parser snapshot coverage for a quoted bullet list item that contains an indented ordered sublist.

The parser already builds the expected nested CST shape for this case; this PR checks in a focused fixture and snapshot to prevent regressions.

## Test Plan

Added a parser fixture covering the quoted ordered sublist case.

- `just test-crate biome_markdown_parser`
- `just f`
- `just l`

## Docs

N/A