### PR TITLE
fix(markdown_parser): keep loose lazy continuation

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -1059,16 +1059,6 @@ fn handle_line_continuation(
         return InlineNewlineAction::Break;
     }
 
-    if required_indent > 0 && p.state().list_nesting_depth >= 2 {
-        let marker_indent = p.state().list_item_marker_indent;
-        if marker_indent > 0 {
-            let indent = p.line_start_leading_indent();
-            if indent < required_indent && indent <= marker_indent {
-                return InlineNewlineAction::Break;
-            }
-        }
-    }
-
     if p.at(MD_TEXTUAL_LITERAL) {
         let text = p.cur_text();
         if text.starts_with("```") || text.starts_with("~~~") {

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/lazy_continuation_at_marker_indent.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/lazy_continuation_at_marker_indent.md.snap
@@ -70,21 +70,12 @@ MdDocument {
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@9..10 "\n" [] [],
                                                 },
-                                            ],
-                                            hard_line: missing (optional),
-                                        },
-                                        MdContinuationIndent {
-                                            indent: MdIndentTokenList [
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@10..11 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@10..11 " " [] [],
                                                 },
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@11..12 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@11..12 " " [] [],
                                                 },
-                                            ],
-                                        },
-                                        MdParagraph {
-                                            list: MdInlineItemList [
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@12..16 "lazy" [] [],
                                                 },
@@ -165,21 +156,12 @@ MdDocument {
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@55..56 "\n" [] [],
                                                 },
-                                            ],
-                                            hard_line: missing (optional),
-                                        },
-                                        MdContinuationIndent {
-                                            indent: MdIndentTokenList [
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@56..57 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@56..57 " " [] [],
                                                 },
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@57..58 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@57..58 " " [] [],
                                                 },
-                                            ],
-                                        },
-                                        MdParagraph {
-                                            list: MdInlineItemList [
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@58..73 "outer continued" [] [],
                                                 },
@@ -237,24 +219,19 @@ MdDocument {
                     2: MD_LIST_POST_MARKER_SPACE@7..8 " " [] []
                     3: MD_INDENT_TOKEN_LIST@8..8
                   1: MD_BLOCK_LIST@8..17
-                    0: MD_PARAGRAPH@8..10
-                      0: MD_INLINE_ITEM_LIST@8..10
+                    0: MD_PARAGRAPH@8..17
+                      0: MD_INLINE_ITEM_LIST@8..17
                         0: MD_TEXTUAL@8..9
                           0: MD_TEXTUAL_LITERAL@8..9 "b" [] []
                         1: MD_TEXTUAL@9..10
                           0: MD_TEXTUAL_LITERAL@9..10 "\n" [] []
-                      1: (empty)
-                    1: MD_CONTINUATION_INDENT@10..12
-                      0: MD_INDENT_TOKEN_LIST@10..12
-                        0: MD_INDENT_TOKEN@10..11
-                          0: MD_INDENT_CHAR@10..11 " " [] []
-                        1: MD_INDENT_TOKEN@11..12
-                          0: MD_INDENT_CHAR@11..12 " " [] []
-                    2: MD_PARAGRAPH@12..17
-                      0: MD_INLINE_ITEM_LIST@12..17
-                        0: MD_TEXTUAL@12..16
+                        2: MD_TEXTUAL@10..11
+                          0: MD_TEXTUAL_LITERAL@10..11 " " [] []
+                        3: MD_TEXTUAL@11..12
+                          0: MD_TEXTUAL_LITERAL@11..12 " " [] []
+                        4: MD_TEXTUAL@12..16
                           0: MD_TEXTUAL_LITERAL@12..16 "lazy" [] []
-                        1: MD_TEXTUAL@16..17
+                        5: MD_TEXTUAL@16..17
                           0: MD_TEXTUAL_LITERAL@16..17 "\n" [] []
                       1: (empty)
             2: MD_NEWLINE@17..18
@@ -286,8 +263,8 @@ MdDocument {
                     2: MD_LIST_POST_MARKER_SPACE@29..30 " " [] []
                     3: MD_INDENT_TOKEN_LIST@30..30
                   1: MD_BLOCK_LIST@30..74
-                    0: MD_PARAGRAPH@30..56
-                      0: MD_INLINE_ITEM_LIST@30..56
+                    0: MD_PARAGRAPH@30..74
+                      0: MD_INLINE_ITEM_LIST@30..74
                         0: MD_TEXTUAL@30..35
                           0: MD_TEXTUAL_LITERAL@30..35 "inner" [] []
                         1: MD_TEXTUAL@35..36
@@ -304,18 +281,13 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@40..55 "inner continued" [] []
                         7: MD_TEXTUAL@55..56
                           0: MD_TEXTUAL_LITERAL@55..56 "\n" [] []
-                      1: (empty)
-                    1: MD_CONTINUATION_INDENT@56..58
-                      0: MD_INDENT_TOKEN_LIST@56..58
-                        0: MD_INDENT_TOKEN@56..57
-                          0: MD_INDENT_CHAR@56..57 " " [] []
-                        1: MD_INDENT_TOKEN@57..58
-                          0: MD_INDENT_CHAR@57..58 " " [] []
-                    2: MD_PARAGRAPH@58..74
-                      0: MD_INLINE_ITEM_LIST@58..74
-                        0: MD_TEXTUAL@58..73
+                        8: MD_TEXTUAL@56..57
+                          0: MD_TEXTUAL_LITERAL@56..57 " " [] []
+                        9: MD_TEXTUAL@57..58
+                          0: MD_TEXTUAL_LITERAL@57..58 " " [] []
+                        10: MD_TEXTUAL@58..73
                           0: MD_TEXTUAL_LITERAL@58..73 "outer continued" [] []
-                        1: MD_TEXTUAL@73..74
+                        11: MD_TEXTUAL@73..74
                           0: MD_TEXTUAL_LITERAL@73..74 "\n" [] []
                       1: (empty)
   2: EOF@74..74 "" [] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_indented_continuation.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_indented_continuation.md.snap
@@ -121,21 +121,12 @@ MdDocument {
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@46..47 "\n" [] [],
                                                 },
-                                            ],
-                                            hard_line: missing (optional),
-                                        },
-                                        MdContinuationIndent {
-                                            indent: MdIndentTokenList [
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@47..48 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@47..48 " " [] [],
                                                 },
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@48..49 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@48..49 " " [] [],
                                                 },
-                                            ],
-                                        },
-                                        MdParagraph {
-                                            list: MdInlineItemList [
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@49..58 "lazy line" [] [],
                                                 },
@@ -228,24 +219,19 @@ MdDocument {
                     2: MD_LIST_POST_MARKER_SPACE@39..40 " " [] []
                     3: MD_INDENT_TOKEN_LIST@40..40
                   1: MD_BLOCK_LIST@40..59
-                    0: MD_PARAGRAPH@40..47
-                      0: MD_INLINE_ITEM_LIST@40..47
+                    0: MD_PARAGRAPH@40..59
+                      0: MD_INLINE_ITEM_LIST@40..59
                         0: MD_TEXTUAL@40..46
                           0: MD_TEXTUAL_LITERAL@40..46 "nested" [] []
                         1: MD_TEXTUAL@46..47
                           0: MD_TEXTUAL_LITERAL@46..47 "\n" [] []
-                      1: (empty)
-                    1: MD_CONTINUATION_INDENT@47..49
-                      0: MD_INDENT_TOKEN_LIST@47..49
-                        0: MD_INDENT_TOKEN@47..48
-                          0: MD_INDENT_CHAR@47..48 " " [] []
-                        1: MD_INDENT_TOKEN@48..49
-                          0: MD_INDENT_CHAR@48..49 " " [] []
-                    2: MD_PARAGRAPH@49..59
-                      0: MD_INLINE_ITEM_LIST@49..59
-                        0: MD_TEXTUAL@49..58
+                        2: MD_TEXTUAL@47..48
+                          0: MD_TEXTUAL_LITERAL@47..48 " " [] []
+                        3: MD_TEXTUAL@48..49
+                          0: MD_TEXTUAL_LITERAL@48..49 " " [] []
+                        4: MD_TEXTUAL@49..58
                           0: MD_TEXTUAL_LITERAL@49..58 "lazy line" [] []
-                        1: MD_TEXTUAL@58..59
+                        5: MD_TEXTUAL@58..59
                           0: MD_TEXTUAL_LITERAL@58..59 "\n" [] []
                       1: (empty)
   2: EOF@59..59 "" [] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_continuation_edge_cases.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_continuation_edge_cases.md.snap
@@ -346,21 +346,12 @@ MdDocument {
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@322..323 "\n" [] [],
                                                 },
-                                            ],
-                                            hard_line: missing (optional),
-                                        },
-                                        MdContinuationIndent {
-                                            indent: MdIndentTokenList [
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@323..324 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@323..324 " " [] [],
                                                 },
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@324..325 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@324..325 " " [] [],
                                                 },
-                                            ],
-                                        },
-                                        MdParagraph {
-                                            list: MdInlineItemList [
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@325..365 "outer continuation at parent indentation" [] [],
                                                 },
@@ -682,8 +673,8 @@ MdDocument {
                     2: MD_LIST_POST_MARKER_SPACE@288..289 " " [] []
                     3: MD_INDENT_TOKEN_LIST@289..289
                   1: MD_BLOCK_LIST@289..366
-                    0: MD_PARAGRAPH@289..323
-                      0: MD_INLINE_ITEM_LIST@289..323
+                    0: MD_PARAGRAPH@289..366
+                      0: MD_INLINE_ITEM_LIST@289..366
                         0: MD_TEXTUAL@289..299
                           0: MD_TEXTUAL_LITERAL@289..299 "inner item" [] []
                         1: MD_TEXTUAL@299..300
@@ -700,18 +691,13 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@304..322 "inner continuation" [] []
                         7: MD_TEXTUAL@322..323
                           0: MD_TEXTUAL_LITERAL@322..323 "\n" [] []
-                      1: (empty)
-                    1: MD_CONTINUATION_INDENT@323..325
-                      0: MD_INDENT_TOKEN_LIST@323..325
-                        0: MD_INDENT_TOKEN@323..324
-                          0: MD_INDENT_CHAR@323..324 " " [] []
-                        1: MD_INDENT_TOKEN@324..325
-                          0: MD_INDENT_CHAR@324..325 " " [] []
-                    2: MD_PARAGRAPH@325..366
-                      0: MD_INLINE_ITEM_LIST@325..366
-                        0: MD_TEXTUAL@325..365
+                        8: MD_TEXTUAL@323..324
+                          0: MD_TEXTUAL_LITERAL@323..324 " " [] []
+                        9: MD_TEXTUAL@324..325
+                          0: MD_TEXTUAL_LITERAL@324..325 " " [] []
+                        10: MD_TEXTUAL@325..365
                           0: MD_TEXTUAL_LITERAL@325..365 "outer continuation at parent indentation" [] []
-                        1: MD_TEXTUAL@365..366
+                        11: MD_TEXTUAL@365..366
                           0: MD_TEXTUAL_LITERAL@365..366 "\n" [] []
                       1: (empty)
             2: MD_NEWLINE@366..367

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_indentation.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_indentation.md.snap
@@ -772,21 +772,12 @@ MdDocument {
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@741..742 "\n" [] [],
                                                 },
-                                            ],
-                                            hard_line: missing (optional),
-                                        },
-                                        MdContinuationIndent {
-                                            indent: MdIndentTokenList [
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@742..743 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@742..743 " " [] [],
                                                 },
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@743..744 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@743..744 " " [] [],
                                                 },
-                                            ],
-                                        },
-                                        MdParagraph {
-                                            list: MdInlineItemList [
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@744..759 "outer continued" [] [],
                                                 },
@@ -1338,8 +1329,8 @@ MdDocument {
                     2: MD_LIST_POST_MARKER_SPACE@715..716 " " [] []
                     3: MD_INDENT_TOKEN_LIST@716..716
                   1: MD_BLOCK_LIST@716..760
-                    0: MD_PARAGRAPH@716..742
-                      0: MD_INLINE_ITEM_LIST@716..742
+                    0: MD_PARAGRAPH@716..760
+                      0: MD_INLINE_ITEM_LIST@716..760
                         0: MD_TEXTUAL@716..721
                           0: MD_TEXTUAL_LITERAL@716..721 "inner" [] []
                         1: MD_TEXTUAL@721..722
@@ -1356,18 +1347,13 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@726..741 "inner continued" [] []
                         7: MD_TEXTUAL@741..742
                           0: MD_TEXTUAL_LITERAL@741..742 "\n" [] []
-                      1: (empty)
-                    1: MD_CONTINUATION_INDENT@742..744
-                      0: MD_INDENT_TOKEN_LIST@742..744
-                        0: MD_INDENT_TOKEN@742..743
-                          0: MD_INDENT_CHAR@742..743 " " [] []
-                        1: MD_INDENT_TOKEN@743..744
-                          0: MD_INDENT_CHAR@743..744 " " [] []
-                    2: MD_PARAGRAPH@744..760
-                      0: MD_INLINE_ITEM_LIST@744..760
-                        0: MD_TEXTUAL@744..759
+                        8: MD_TEXTUAL@742..743
+                          0: MD_TEXTUAL_LITERAL@742..743 " " [] []
+                        9: MD_TEXTUAL@743..744
+                          0: MD_TEXTUAL_LITERAL@743..744 " " [] []
+                        10: MD_TEXTUAL@744..759
                           0: MD_TEXTUAL_LITERAL@744..759 "outer continued" [] []
-                        1: MD_TEXTUAL@759..760
+                        11: MD_TEXTUAL@759..760
                           0: MD_TEXTUAL_LITERAL@759..760 "\n" [] []
                       1: (empty)
     39: MD_NEWLINE@760..761

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_fence.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_fence.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 192
 expression: snapshot
 ---
 
@@ -69,21 +68,12 @@ MdDocument {
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@18..19 "\n" [] [],
                                                 },
-                                            ],
-                                            hard_line: missing (optional),
-                                        },
-                                        MdContinuationIndent {
-                                            indent: MdIndentTokenList [
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@19..20 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@19..20 " " [] [],
                                                 },
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@20..21 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@20..21 " " [] [],
                                                 },
-                                            ],
-                                        },
-                                        MdParagraph {
-                                            list: MdInlineItemList [
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] [],
                                                 },
@@ -162,24 +152,19 @@ MdDocument {
                     2: MD_LIST_POST_MARKER_SPACE@11..12 " " [] []
                     3: MD_INDENT_TOKEN_LIST@12..12
                   1: MD_BLOCK_LIST@12..31
-                    0: MD_PARAGRAPH@12..19
-                      0: MD_INLINE_ITEM_LIST@12..19
+                    0: MD_PARAGRAPH@12..31
+                      0: MD_INLINE_ITEM_LIST@12..31
                         0: MD_TEXTUAL@12..18
                           0: MD_TEXTUAL_LITERAL@12..18 "nested" [] []
                         1: MD_TEXTUAL@18..19
                           0: MD_TEXTUAL_LITERAL@18..19 "\n" [] []
-                      1: (empty)
-                    1: MD_CONTINUATION_INDENT@19..21
-                      0: MD_INDENT_TOKEN_LIST@19..21
-                        0: MD_INDENT_TOKEN@19..20
-                          0: MD_INDENT_CHAR@19..20 " " [] []
-                        1: MD_INDENT_TOKEN@20..21
-                          0: MD_INDENT_CHAR@20..21 " " [] []
-                    2: MD_PARAGRAPH@21..31
-                      0: MD_INLINE_ITEM_LIST@21..31
-                        0: MD_TEXTUAL@21..30
+                        2: MD_TEXTUAL@19..20
+                          0: MD_TEXTUAL_LITERAL@19..20 " " [] []
+                        3: MD_TEXTUAL@20..21
+                          0: MD_TEXTUAL_LITERAL@20..21 " " [] []
+                        4: MD_TEXTUAL@21..30
                           0: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] []
-                        1: MD_TEXTUAL@30..31
+                        5: MD_TEXTUAL@30..31
                           0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
                       1: (empty)
     1: MD_FENCED_CODE_BLOCK@31..48

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_link_reference.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_link_reference.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 192
 expression: snapshot
 ---
 
@@ -67,35 +66,18 @@ MdDocument {
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@18..19 "\n" [] [],
                                                 },
-                                            ],
-                                            hard_line: missing (optional),
-                                        },
-                                        MdContinuationIndent {
-                                            indent: MdIndentTokenList [
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@19..20 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@19..20 " " [] [],
                                                 },
-                                                MdIndentToken {
-                                                    md_indent_char_token: MD_INDENT_CHAR@20..21 " " [] [],
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@20..21 " " [] [],
                                                 },
-                                            ],
-                                        },
-                                        MdParagraph {
-                                            list: MdInlineItemList [
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] [],
                                                 },
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
                                                 },
-                                            ],
-                                            hard_line: missing (optional),
-                                        },
-                                        MdContinuationIndent {
-                                            indent: MdIndentTokenList [],
-                                        },
-                                        MdParagraph {
-                                            list: MdInlineItemList [
                                                 MdTextual {
                                                     value_token: MD_TEXTUAL_LITERAL@31..32 "[" [] [],
                                                 },
@@ -165,41 +147,31 @@ MdDocument {
                     2: MD_LIST_POST_MARKER_SPACE@11..12 " " [] []
                     3: MD_INDENT_TOKEN_LIST@12..12
                   1: MD_BLOCK_LIST@12..45
-                    0: MD_PARAGRAPH@12..19
-                      0: MD_INLINE_ITEM_LIST@12..19
+                    0: MD_PARAGRAPH@12..45
+                      0: MD_INLINE_ITEM_LIST@12..45
                         0: MD_TEXTUAL@12..18
                           0: MD_TEXTUAL_LITERAL@12..18 "nested" [] []
                         1: MD_TEXTUAL@18..19
                           0: MD_TEXTUAL_LITERAL@18..19 "\n" [] []
-                      1: (empty)
-                    1: MD_CONTINUATION_INDENT@19..21
-                      0: MD_INDENT_TOKEN_LIST@19..21
-                        0: MD_INDENT_TOKEN@19..20
-                          0: MD_INDENT_CHAR@19..20 " " [] []
-                        1: MD_INDENT_TOKEN@20..21
-                          0: MD_INDENT_CHAR@20..21 " " [] []
-                    2: MD_PARAGRAPH@21..31
-                      0: MD_INLINE_ITEM_LIST@21..31
-                        0: MD_TEXTUAL@21..30
+                        2: MD_TEXTUAL@19..20
+                          0: MD_TEXTUAL_LITERAL@19..20 " " [] []
+                        3: MD_TEXTUAL@20..21
+                          0: MD_TEXTUAL_LITERAL@20..21 " " [] []
+                        4: MD_TEXTUAL@21..30
                           0: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] []
-                        1: MD_TEXTUAL@30..31
+                        5: MD_TEXTUAL@30..31
                           0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
-                      1: (empty)
-                    3: MD_CONTINUATION_INDENT@31..31
-                      0: MD_INDENT_TOKEN_LIST@31..31
-                    4: MD_PARAGRAPH@31..45
-                      0: MD_INLINE_ITEM_LIST@31..45
-                        0: MD_TEXTUAL@31..32
+                        6: MD_TEXTUAL@31..32
                           0: MD_TEXTUAL_LITERAL@31..32 "[" [] []
-                        1: MD_TEXTUAL@32..37
+                        7: MD_TEXTUAL@32..37
                           0: MD_TEXTUAL_LITERAL@32..37 "valid" [] []
-                        2: MD_TEXTUAL@37..38
+                        8: MD_TEXTUAL@37..38
                           0: MD_TEXTUAL_LITERAL@37..38 "]" [] []
-                        3: MD_TEXTUAL@38..39
+                        9: MD_TEXTUAL@38..39
                           0: MD_TEXTUAL_LITERAL@38..39 ":" [] []
-                        4: MD_TEXTUAL@39..44
+                        10: MD_TEXTUAL@39..44
                           0: MD_TEXTUAL_LITERAL@39..44 " /url" [] []
-                        5: MD_TEXTUAL@44..45
+                        11: MD_TEXTUAL@44..45
                           0: MD_TEXTUAL_LITERAL@44..45 "\n" [] []
                       1: (empty)
   2: EOF@45..45 "" [] []

--- a/crates/biome_markdown_parser/tests/spec_test.rs
+++ b/crates/biome_markdown_parser/tests/spec_test.rs
@@ -465,6 +465,12 @@ pub fn quick_test() {
         "- outer\n  - nested\n  lazy line\nhello\n",
         "<ul>\n<li>outer\n<ul>\n<li>nested\nlazy line\nhello</li>\n</ul>\n</li>\n</ul>\n",
     );
+    // Fuzzer: lazy continuation in a loose nested list item
+    test_example(
+        30006,
+        "- outer\n  - nested\n  lazy line\n\n    indented\n",
+        "<ul>\n<li>outer\n<ul>\n<li>\n<p>nested\nlazy line</p>\n<p>indented</p>\n</li>\n</ul>\n</li>\n</ul>\n",
+    );
 }
 
 fn fuzz_test_example(num: u32, input: &str, expected: &str) {


### PR DESCRIPTION
> [!NOTE]
> I used Codex to help verify the parser shape and add the regression fixture.

## Summary

Fixes a markdown parser case where a lazy continuation line in a nested list item was split into a separate paragraph once the item became loose.

The parser now keeps that continuation in the same paragraph, matching CommonMark and the existing tight-list behavior.

## Test Plan

Added a parser regression covering the loose nested lazy continuation case.

- `just test-crate biome_markdown_parser`
- `just f`
- `just l`

## Docs

N/A
