### PR TITLE
feat(useSortedClasses): parser-based sort module (RFC)

### DIFF
--- a/.changeset/parser-based-sorted-classes.md
+++ b/.changeset/parser-based-sorted-classes.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Internal: added a parser-based class sort module for [`useSortedClasses`](https://biomejs.dev/linter/rules/use-sorted-classes/) that derives sort keys directly from the `biome_tailwind_parser` CST instead of the hand-written class lexer. The rule itself still uses the existing implementation; the new module is wiring/preparation for a follow-up that swaps the codepaths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,8 @@ dependencies = [
  "biome_service",
  "biome_string_case",
  "biome_suppression",
+ "biome_tailwind_parser",
+ "biome_tailwind_syntax",
  "biome_test_utils",
  "biome_unicode_table",
  "bitvec",

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -44,6 +44,8 @@ biome_rowan              = { workspace = true }
 biome_rule_options       = { workspace = true }
 biome_string_case        = { workspace = true, features = ["biome_rowan"] }
 biome_suppression        = { workspace = true }
+biome_tailwind_parser    = { workspace = true }
+biome_tailwind_syntax    = { workspace = true }
 biome_unicode_table      = { workspace = true }
 bitvec                   = "1.0.1"
 camino                   = { workspace = true }

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -3,6 +3,7 @@ pub mod class_lexer;
 mod presets;
 mod sort;
 mod sort_config;
+pub mod sort_via_parser;
 mod tailwind_preset;
 
 use self::{

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -1,4 +1,291 @@
-/// Sort a space-separated list of Tailwind CSS class names.
-pub fn sort_class_list(input: &str) -> String {
-    input.to_string()
+use biome_rowan::AstNode;
+use biome_tailwind_syntax::{
+    AnyTwCandidate, AnyTwFullCandidate, AnyTwVariant, TwFullCandidate, TwRoot,
+};
+use std::cmp::Ordering;
+use std::sync::LazyLock;
+
+use super::presets::{ConfigPreset, UseSortedClassesPreset, get_config_preset};
+
+static PRESET: LazyLock<ConfigPreset> =
+    LazyLock::new(|| get_config_preset(&UseSortedClassesPreset::default()));
+
+/// Sort the candidates of a parsed Tailwind class list and return the joined,
+/// space-separated result.
+pub fn sort_class_list(root: &TwRoot) -> String {
+    let mut unknown: Vec<String> = Vec::new();
+    let mut known: Vec<SortKey> = Vec::new();
+
+    for candidate in root.candidates() {
+        match candidate {
+            AnyTwFullCandidate::TwBogusCandidate(node) => {
+                unknown.push(node.syntax().text_trimmed().to_string());
+            }
+            AnyTwFullCandidate::TwFullCandidate(node) => {
+                let text = node.syntax().text_trimmed().to_string();
+                match SortKey::from_candidate(text, &node) {
+                    Some(key) => known.push(key),
+                    None => unknown.push(node.syntax().text_trimmed().to_string()),
+                }
+            }
+        }
+    }
+
+    // Pre-sort lexicographically so that classes with identical sort keys keep
+    // a deterministic alphabetical order.
+    known.sort_unstable_by(|a, b| a.text.cmp(&b.text));
+    // Stable 6-step compare.
+    known.sort_by(SortKey::compare);
+
+    let mut result: Vec<&str> = unknown.iter().map(String::as_str).collect();
+    result.extend(known.iter().map(|k| k.text.as_str()));
+    result.join(" ")
 }
+
+/// Sort information extracted from a parsed `TwFullCandidate`.
+struct SortKey {
+    /// The original class text, used as the output and as a lexicographic
+    /// fallback.
+    text: String,
+    /// Texts of arbitrary `[...]:` variants, in source order.
+    arbitrary_variants: Vec<String>,
+    /// Sorted, deduplicated indices of recognized variants in
+    /// [`PRESET::variants`].
+    variant_indices: Vec<usize>,
+    /// Index of the layer this utility belongs to inside [`PRESET::utilities`].
+    /// `utilities.len()` is reserved for arbitrary `[property:value]` utilities.
+    layer_index: usize,
+    /// Index of the matched utility entry inside its layer. Arbitrary utilities
+    /// always use `0`.
+    utility_index: usize,
+}
+
+impl SortKey {
+    fn from_candidate(text: String, node: &TwFullCandidate) -> Option<Self> {
+        let mut arbitrary_variants: Vec<String> = Vec::new();
+        let mut variant_indices: Vec<usize> = Vec::new();
+
+        for variant in node.variants() {
+            let Ok(variant) = variant else { continue };
+            match variant {
+                AnyTwVariant::TwArbitraryVariant(v) => {
+                    arbitrary_variants.push(v.syntax().text_trimmed().to_string());
+                }
+                AnyTwVariant::TwStaticVariant(v) => {
+                    if let Ok(token) = v.base_token() {
+                        let name = token.text_trimmed();
+                        if let Some(idx) = locate_variant(name) {
+                            variant_indices.push(idx);
+                        }
+                    }
+                }
+                AnyTwVariant::TwFunctionalVariant(v) => {
+                    let name = v.syntax().text_trimmed().to_string();
+                    if let Some(idx) = locate_variant(&name) {
+                        variant_indices.push(idx);
+                    }
+                }
+                AnyTwVariant::TwDataAttribute(v) => {
+                    let name = v.syntax().text_trimmed().to_string();
+                    if let Some(idx) = locate_variant(&name) {
+                        variant_indices.push(idx);
+                    }
+                }
+                AnyTwVariant::TwBogusVariant(_) => {}
+            }
+        }
+
+        // Dedupe + sort so the comparator can walk indices in order.
+        variant_indices.sort_unstable();
+        variant_indices.dedup();
+
+        let candidate = node.candidate().ok()?;
+        let (layer_index, utility_index) = locate_utility(&candidate)?;
+
+        Some(Self {
+            text,
+            arbitrary_variants,
+            variant_indices,
+            layer_index,
+            utility_index,
+        })
+    }
+
+    fn compare(a: &Self, b: &Self) -> Ordering {
+        // Step 1: classes with arbitrary variants go last.
+        match (
+            a.arbitrary_variants.is_empty(),
+            b.arbitrary_variants.is_empty(),
+        ) {
+            (false, true) => return Ordering::Greater,
+            (true, false) => return Ordering::Less,
+            _ => {}
+        }
+
+        // Step 2: compare arbitrary variants by count, then lexicographically.
+        if !a.arbitrary_variants.is_empty() {
+            let len_cmp = a
+                .arbitrary_variants
+                .len()
+                .cmp(&b.arbitrary_variants.len());
+            if len_cmp != Ordering::Equal {
+                return len_cmp;
+            }
+            let lex_cmp = a.arbitrary_variants.cmp(&b.arbitrary_variants);
+            if lex_cmp != Ordering::Equal {
+                return lex_cmp;
+            }
+        }
+
+        // Step 3: classes with no variants go before classes with variants.
+        match (a.variant_indices.is_empty(), b.variant_indices.is_empty()) {
+            (false, true) => return Ordering::Greater,
+            (true, false) => return Ordering::Less,
+            _ => {}
+        }
+
+        // Step 4: compare layer indices.
+        let layer_cmp = a.layer_index.cmp(&b.layer_index);
+        if layer_cmp != Ordering::Equal {
+            return layer_cmp;
+        }
+
+        // Step 5: compare variant weight.
+        if !a.variant_indices.is_empty() {
+            let weight_cmp = compare_variant_indices(&a.variant_indices, &b.variant_indices);
+            if weight_cmp != Ordering::Equal {
+                return weight_cmp;
+            }
+        }
+
+        // Step 6: compare utility indices within the same layer.
+        a.utility_index.cmp(&b.utility_index)
+    }
+}
+
+/// Compares two sorted, unique `variant_indices` arrays as if they were the
+/// bit-positions of a `Lsb0` bitvector.
+///
+/// First by length (= max index + 1), then by walking positions: the smallest
+/// index that appears in only one of the two sets wins (the side that has it
+/// goes later, mirroring the `T > F` element-wise comparison of the original
+/// `BitVec`).
+fn compare_variant_indices(a: &[usize], b: &[usize]) -> Ordering {
+    let a_max = a.last().copied().unwrap_or(0);
+    let b_max = b.last().copied().unwrap_or(0);
+    let max_cmp = a_max.cmp(&b_max);
+    if max_cmp != Ordering::Equal {
+        return max_cmp;
+    }
+
+    let mut i = 0;
+    let mut j = 0;
+    while i < a.len() && j < b.len() {
+        match a[i].cmp(&b[j]) {
+            // a has a bit set at a smaller position than b → a > b.
+            Ordering::Less => return Ordering::Greater,
+            Ordering::Greater => return Ordering::Less,
+            Ordering::Equal => {
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    if i < a.len() {
+        return Ordering::Greater;
+    }
+    if j < b.len() {
+        return Ordering::Less;
+    }
+    Ordering::Equal
+}
+
+/// Resolves the layer/utility position of a candidate against the preset.
+///
+/// Returns `None` if the utility is not recognized (the caller treats it as a
+/// custom class and preserves source order).
+fn locate_utility(candidate: &AnyTwCandidate) -> Option<(usize, usize)> {
+    if matches!(candidate, AnyTwCandidate::TwArbitraryCandidate(_)) {
+        // Arbitrary `[property:value]` utilities live in a synthetic layer that
+        // sorts after every named layer.
+        return Some((PRESET.utilities.len(), 0));
+    }
+
+    let utility_text_owned = candidate.syntax().text_trimmed().to_string();
+    let utility_text = utility_text_owned.as_str();
+
+    let mut best: Option<(usize, usize)> = None;
+    let mut best_target_len = 0usize;
+
+    for (layer_idx, layer) in PRESET.utilities.iter().enumerate() {
+        for (idx, &target) in layer.classes.iter().enumerate() {
+            match match_utility(target, utility_text) {
+                UtilityHit::Exact => return Some((layer_idx, idx)),
+                UtilityHit::Partial(target_len) => {
+                    if target_len > best_target_len {
+                        best = Some((layer_idx, idx));
+                        best_target_len = target_len;
+                    }
+                }
+                UtilityHit::None => {}
+            }
+        }
+    }
+    best
+}
+
+enum UtilityHit {
+    Exact,
+    Partial(usize),
+    None,
+}
+
+/// Mirrors the preset format:
+/// - `name$` → exact match against `name`.
+/// - `name`  → partial match: the utility text must start with `name` and be
+///   strictly longer than it.
+///
+/// The parser splits `negative_token` from the candidate, so `utility_text` is
+/// never prefixed with `-`. The preset itself has no negative entries either,
+/// so both sides are clean.
+fn match_utility(target: &str, utility_text: &str) -> UtilityHit {
+    if let Some(exact) = target.strip_suffix('$') {
+        if utility_text == exact {
+            return UtilityHit::Exact;
+        }
+        return UtilityHit::None;
+    }
+
+    if utility_text.starts_with(target) && utility_text != target {
+        return UtilityHit::Partial(target.len());
+    }
+
+    UtilityHit::None
+}
+
+/// Resolves the position of a variant name inside the preset's variant list.
+///
+/// Recognizes both bare names (`hover`, `focus`) and the `name-[...]` form
+/// produced by functional variants such as `group-[:visited]`.
+fn locate_variant(variant_text: &str) -> Option<usize> {
+    let mut best: Option<usize> = None;
+    let mut best_target_len = 0usize;
+
+    for (idx, &target) in PRESET.variants.iter().enumerate() {
+        if target == variant_text {
+            return Some(idx);
+        }
+        if let Some(rest) = variant_text.strip_prefix(target) {
+            if rest.starts_with("-[") {
+                return Some(idx);
+            }
+            if !rest.is_empty() && target.len() > best_target_len {
+                best = Some(idx);
+                best_target_len = target.len();
+            }
+        }
+    }
+
+    best
+}
+

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -13,19 +13,19 @@ static PRESET: LazyLock<ConfigPreset> =
 /// Sort the candidates of a parsed Tailwind class list and return the joined,
 /// space-separated result.
 pub fn sort_class_list(root: &TwRoot) -> String {
-    let mut unknown: Vec<String> = Vec::new();
+    let mut unknown: Vec<SyntaxNodeText> = Vec::new();
     let mut known: Vec<SortKey> = Vec::new();
 
     for candidate in root.candidates() {
         match candidate {
             AnyTwFullCandidate::TwBogusCandidate(node) => {
-                unknown.push(node.syntax().text_trimmed().to_string());
+                unknown.push(node.syntax().text_trimmed());
             }
             AnyTwFullCandidate::TwFullCandidate(node) => {
-                let text = node.syntax().text_trimmed().to_string();
-                match SortKey::from_candidate(text, &node) {
+                let text = node.syntax().text_trimmed();
+                match SortKey::from_candidate(text.clone(), &node) {
                     Some(key) => known.push(key),
-                    None => unknown.push(node.syntax().text_trimmed().to_string()),
+                    None => unknown.push(text),
                 }
             }
         }
@@ -33,20 +33,27 @@ pub fn sort_class_list(root: &TwRoot) -> String {
 
     // Pre-sort lexicographically so that classes with identical sort keys keep
     // a deterministic alphabetical order.
-    known.sort_unstable_by(|a, b| a.text.cmp(&b.text));
+    known.sort_unstable_by(|a, b| a.text.chars().cmp(b.text.chars()));
     // Stable 6-step compare.
     known.sort_by(SortKey::compare);
 
-    let mut result: Vec<&str> = unknown.iter().map(String::as_str).collect();
-    result.extend(known.iter().map(|k| k.text.as_str()));
-    result.join(" ")
+    // Concatenate directly into the output buffer so that each candidate's
+    // source bytes are copied exactly once.
+    let mut result = String::new();
+    for text in unknown.iter().chain(known.iter().map(|k| &k.text)) {
+        if !result.is_empty() {
+            result.push(' ');
+        }
+        text.for_each_chunk(|chunk| result.push_str(chunk));
+    }
+    result
 }
 
 /// Sort information extracted from a parsed `TwFullCandidate`.
 struct SortKey {
-    /// The original class text, used as the output and as a lexicographic
-    /// fallback.
-    text: String,
+    /// Source-backed handle to the original class text. Used as the output
+    /// payload and as the lexicographic fallback for ties.
+    text: SyntaxNodeText,
     /// Source-backed texts of arbitrary `[...]:` variants, in source order.
     arbitrary_variants: Vec<SyntaxNodeText>,
     /// Sorted, deduplicated indices of recognized variants in
@@ -61,7 +68,7 @@ struct SortKey {
 }
 
 impl SortKey {
-    fn from_candidate(text: String, node: &TwFullCandidate) -> Option<Self> {
+    fn from_candidate(text: SyntaxNodeText, node: &TwFullCandidate) -> Option<Self> {
         let mut arbitrary_variants: Vec<SyntaxNodeText> = Vec::new();
         let mut variant_indices: Vec<usize> = Vec::new();
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -225,7 +225,7 @@ fn locate_utility(candidate: &AnyTwCandidate) -> Option<(usize, usize)> {
 
     for (layer_idx, layer) in PRESET.utilities.iter().enumerate() {
         for (idx, &target) in layer.classes.iter().enumerate() {
-            match match_utility(target, &utility_text) {
+            match matches_utility(target, &utility_text) {
                 UtilityHit::Exact => return Some((layer_idx, idx)),
                 UtilityHit::Partial(target_len) => {
                     if target_len > best_target_len {
@@ -254,7 +254,7 @@ enum UtilityHit {
 /// The parser splits `negative_token` from the candidate, so `utility_text` is
 /// never prefixed with `-`. The preset itself has no negative entries either,
 /// so both sides are clean.
-fn match_utility(target: &str, utility_text: &SyntaxNodeText) -> UtilityHit {
+fn matches_utility(target: &str, utility_text: &SyntaxNodeText) -> UtilityHit {
     if let Some(exact) = target.strip_suffix('$') {
         if utility_text == exact {
             return UtilityHit::Exact;

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -274,8 +274,14 @@ fn match_utility(target: &str, utility_text: &str) -> UtilityHit {
 
 /// Resolves the position of a variant name inside the preset's variant list.
 ///
-/// Recognizes both bare names (`hover`, `focus`) and the `name-[...]` form
-/// produced by functional variants such as `group-[:visited]`.
+/// Three matching paths:
+/// - Exact equality (`hover` == `hover`) → return immediately.
+/// - `target` followed by `-[...]` (e.g. `group-[:visited]` matches `group`)
+///   → also exact, return immediately.
+/// - `target` is a prefix of `variant_text` with any other suffix (e.g. `peer`
+///   matches `peer-has-[:checked]`) → tracked as a partial match. The loop
+///   keeps going to prefer the *longest* matching target, so a more specific
+///   entry like `peer-has` wins over the bare `peer` when both are present.
 fn locate_variant(variant_text: &str) -> Option<usize> {
     let mut best: Option<usize> = None;
     let mut best_target_len = 0usize;

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -253,14 +253,18 @@ enum UtilityHit {
     None,
 }
 
-/// Mirrors the preset format:
-/// - `name$` → exact match against `name`.
-/// - `name`  → partial match: the utility text must start with `name` and be
-///   strictly longer than it.
+/// Tests whether `utility_text` matches a single `target` entry from
+/// `PRESET.utilities[*].classes`.
 ///
-/// The parser splits `negative_token` from the candidate, so `utility_text` is
-/// never prefixed with `-`. The preset itself has no negative entries either,
-/// so both sides are clean.
+/// Each `target` follows one of two shapes:
+/// - `"name$"` (trailing `$`) anchors an exact match. Used for utilities
+///   without a value, e.g. `flex`, `block`.
+/// - `"name"` (no suffix) is a prefix match: `utility_text` must start with
+///   `name` and be strictly longer; the remainder is the value, e.g.
+///   `bg-red-500` matches the `bg-` entry.
+///
+/// `negative_token` is split off by the parser, so `utility_text` is never
+/// prefixed with `-`, and the preset has no negative entries either.
 fn matches_utility(target: &str, utility_text: &SyntaxNodeText) -> UtilityHit {
     if let Some(exact) = target.strip_suffix('$') {
         if utility_text == exact {

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -1,15 +1,4 @@
-use std::sync::LazyLock;
-
-use super::{
-    presets::{UseSortedClassesPreset, get_config_preset},
-    sort_config::SortConfig,
-};
-
-static SORT_CONFIG: LazyLock<SortConfig> =
-    LazyLock::new(|| SortConfig::new(&get_config_preset(&UseSortedClassesPreset::default())));
-
 /// Sort a space-separated list of Tailwind CSS class names.
 pub fn sort_class_list(input: &str) -> String {
-    let _ = &*SORT_CONFIG;
-    todo!("sort_via_parser: not yet implemented")
+    input.to_string()
 }

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -1,4 +1,4 @@
-use biome_rowan::{AstNode, SyntaxNodeText};
+use biome_rowan::{AstNode, SyntaxNodeText, TextSize};
 use biome_tailwind_syntax::{
     AnyTwCandidate, AnyTwFullCandidate, AnyTwVariant, TwFullCandidate, TwRoot,
 };
@@ -79,21 +79,19 @@ impl SortKey {
                     arbitrary_variants.push(v.syntax().text_trimmed());
                 }
                 AnyTwVariant::TwStaticVariant(v) => {
-                    if let Ok(token) = v.base_token() {
-                        let name = token.text_trimmed();
-                        if let Some(idx) = locate_variant(name) {
-                            variant_indices.push(idx);
-                        }
+                    let name = v.syntax().text_trimmed();
+                    if let Some(idx) = locate_variant(&name) {
+                        variant_indices.push(idx);
                     }
                 }
                 AnyTwVariant::TwFunctionalVariant(v) => {
-                    let name = v.syntax().text_trimmed().to_string();
+                    let name = v.syntax().text_trimmed();
                     if let Some(idx) = locate_variant(&name) {
                         variant_indices.push(idx);
                     }
                 }
                 AnyTwVariant::TwDataAttribute(v) => {
-                    let name = v.syntax().text_trimmed().to_string();
+                    let name = v.syntax().text_trimmed();
                     if let Some(idx) = locate_variant(&name) {
                         variant_indices.push(idx);
                     }
@@ -220,15 +218,14 @@ fn locate_utility(candidate: &AnyTwCandidate) -> Option<(usize, usize)> {
         return Some((PRESET.utilities.len(), 0));
     }
 
-    let utility_text_owned = candidate.syntax().text_trimmed().to_string();
-    let utility_text = utility_text_owned.as_str();
+    let utility_text = candidate.syntax().text_trimmed();
 
     let mut best: Option<(usize, usize)> = None;
     let mut best_target_len = 0usize;
 
     for (layer_idx, layer) in PRESET.utilities.iter().enumerate() {
         for (idx, &target) in layer.classes.iter().enumerate() {
-            match match_utility(target, utility_text) {
+            match match_utility(target, &utility_text) {
                 UtilityHit::Exact => return Some((layer_idx, idx)),
                 UtilityHit::Partial(target_len) => {
                     if target_len > best_target_len {
@@ -257,7 +254,7 @@ enum UtilityHit {
 /// The parser splits `negative_token` from the candidate, so `utility_text` is
 /// never prefixed with `-`. The preset itself has no negative entries either,
 /// so both sides are clean.
-fn match_utility(target: &str, utility_text: &str) -> UtilityHit {
+fn match_utility(target: &str, utility_text: &SyntaxNodeText) -> UtilityHit {
     if let Some(exact) = target.strip_suffix('$') {
         if utility_text == exact {
             return UtilityHit::Exact;
@@ -265,7 +262,7 @@ fn match_utility(target: &str, utility_text: &str) -> UtilityHit {
         return UtilityHit::None;
     }
 
-    if utility_text.starts_with(target) && utility_text != target {
+    if utility_text.len() > TextSize::of(target) && utility_text.starts_with(target) {
         return UtilityHit::Partial(target.len());
     }
 
@@ -282,19 +279,20 @@ fn match_utility(target: &str, utility_text: &str) -> UtilityHit {
 ///   matches `peer-has-[:checked]`) → tracked as a partial match. The loop
 ///   keeps going to prefer the *longest* matching target, so a more specific
 ///   entry like `peer-has` wins over the bare `peer` when both are present.
-fn locate_variant(variant_text: &str) -> Option<usize> {
+fn locate_variant(variant_text: &SyntaxNodeText) -> Option<usize> {
     let mut best: Option<usize> = None;
     let mut best_target_len = 0usize;
 
     for (idx, &target) in PRESET.variants.iter().enumerate() {
-        if target == variant_text {
+        if variant_text == target {
             return Some(idx);
         }
-        if let Some(rest) = variant_text.strip_prefix(target) {
-            if rest.starts_with("-[") {
+        let target_len = TextSize::of(target);
+        if variant_text.len() > target_len && variant_text.starts_with(target) {
+            if variant_text.slice(target_len..).starts_with("-[") {
                 return Some(idx);
             }
-            if !rest.is_empty() && target.len() > best_target_len {
+            if target.len() > best_target_len {
                 best = Some(idx);
                 best_target_len = target.len();
             }

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -1,0 +1,15 @@
+use std::sync::LazyLock;
+
+use super::{
+    presets::{UseSortedClassesPreset, get_config_preset},
+    sort_config::SortConfig,
+};
+
+static SORT_CONFIG: LazyLock<SortConfig> =
+    LazyLock::new(|| SortConfig::new(&get_config_preset(&UseSortedClassesPreset::default())));
+
+/// Sort a space-separated list of Tailwind CSS class names.
+pub fn sort_class_list(input: &str) -> String {
+    let _ = &*SORT_CONFIG;
+    todo!("sort_via_parser: not yet implemented")
+}

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -122,9 +122,7 @@ impl SortKey {
             _ => {}
         }
 
-        // Step 2: compare arbitrary variants by count, then lexicographically
-        // by source text (no allocation — `SyntaxNodeText::chars` streams from
-        // the underlying tokens).
+        // Step 2: compare arbitrary variants by count, then lexicographically.
         if !a.arbitrary_variants.is_empty() {
             let len_cmp = a
                 .arbitrary_variants

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -207,10 +207,17 @@ fn compare_variant_indices(a: &[usize], b: &[usize]) -> Ordering {
     Ordering::Equal
 }
 
-/// Resolves the layer/utility position of a candidate against the preset.
+/// Locates a candidate in the preset and returns its
+/// `(layer_index, utility_index)` position.
 ///
-/// Returns `None` if the utility is not recognized (the caller treats it as a
-/// custom class and preserves source order).
+/// - `layer_index`: index into `PRESET.utilities`. Arbitrary
+///   `[property:value]` candidates use the synthetic value
+///   `PRESET.utilities.len()` so they sort after every named layer.
+/// - `utility_index`: index inside that layer's `classes` slice. Arbitrary
+///   candidates always use `0`.
+///
+/// Returns `None` when no preset entry matches; the caller treats such
+/// classes as user-defined and preserves their source order.
 fn locate_utility(candidate: &AnyTwCandidate) -> Option<(usize, usize)> {
     if matches!(candidate, AnyTwCandidate::TwArbitraryCandidate(_)) {
         // Arbitrary `[property:value]` utilities live in a synthetic layer that

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -280,7 +280,7 @@ fn matches_utility(target: &str, utility_text: &SyntaxNodeText) -> UtilityHit {
 ///   keeps going to prefer the *longest* matching target, so a more specific
 ///   entry like `peer-has` wins over the bare `peer` when both are present.
 fn locate_variant(variant_text: &SyntaxNodeText) -> Option<usize> {
-    let mut best: Option<usize> = None;
+    let mut best = None;
     let mut best_target_len = 0usize;
 
     for (idx, &target) in PRESET.variants.iter().enumerate() {

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_via_parser.rs
@@ -1,4 +1,4 @@
-use biome_rowan::AstNode;
+use biome_rowan::{AstNode, SyntaxNodeText};
 use biome_tailwind_syntax::{
     AnyTwCandidate, AnyTwFullCandidate, AnyTwVariant, TwFullCandidate, TwRoot,
 };
@@ -47,8 +47,8 @@ struct SortKey {
     /// The original class text, used as the output and as a lexicographic
     /// fallback.
     text: String,
-    /// Texts of arbitrary `[...]:` variants, in source order.
-    arbitrary_variants: Vec<String>,
+    /// Source-backed texts of arbitrary `[...]:` variants, in source order.
+    arbitrary_variants: Vec<SyntaxNodeText>,
     /// Sorted, deduplicated indices of recognized variants in
     /// [`PRESET::variants`].
     variant_indices: Vec<usize>,
@@ -62,14 +62,14 @@ struct SortKey {
 
 impl SortKey {
     fn from_candidate(text: String, node: &TwFullCandidate) -> Option<Self> {
-        let mut arbitrary_variants: Vec<String> = Vec::new();
+        let mut arbitrary_variants: Vec<SyntaxNodeText> = Vec::new();
         let mut variant_indices: Vec<usize> = Vec::new();
 
         for variant in node.variants() {
             let Ok(variant) = variant else { continue };
             match variant {
                 AnyTwVariant::TwArbitraryVariant(v) => {
-                    arbitrary_variants.push(v.syntax().text_trimmed().to_string());
+                    arbitrary_variants.push(v.syntax().text_trimmed());
                 }
                 AnyTwVariant::TwStaticVariant(v) => {
                     if let Ok(token) = v.base_token() {
@@ -122,7 +122,9 @@ impl SortKey {
             _ => {}
         }
 
-        // Step 2: compare arbitrary variants by count, then lexicographically.
+        // Step 2: compare arbitrary variants by count, then lexicographically
+        // by source text (no allocation — `SyntaxNodeText::chars` streams from
+        // the underlying tokens).
         if !a.arbitrary_variants.is_empty() {
             let len_cmp = a
                 .arbitrary_variants
@@ -131,9 +133,11 @@ impl SortKey {
             if len_cmp != Ordering::Equal {
                 return len_cmp;
             }
-            let lex_cmp = a.arbitrary_variants.cmp(&b.arbitrary_variants);
-            if lex_cmp != Ordering::Equal {
-                return lex_cmp;
+            for (av, bv) in a.arbitrary_variants.iter().zip(&b.arbitrary_variants) {
+                let lex_cmp = av.chars().cmp(bv.chars());
+                if lex_cmp != Ordering::Equal {
+                    return lex_cmp;
+                }
             }
         }
 

--- a/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt
+++ b/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt
@@ -89,6 +89,24 @@ hover:-ml-2 p-4 focus:-mt-1
 # Negative values: negative values with responsive variants
 sm:-mx-4 lg:-my-2 md:p-2
 
+# Negative values: negative z-index sorts within z-index group
+flex -z-10 z-20 absolute
+
+# Negative values: negative transform utilities
+-rotate-45 scale-100 -translate-x-4 -skew-y-3
+
+# Negative values: negative inset and inset-x mixed
+-inset-2 absolute -inset-x-4 top-0
+
+# Negative values: same-family positive and negative coexist
+m-4 -m-2 p-2
+
+# Negative values: negative with arbitrary value
+flex -mt-[1.5rem] p-4
+
+# Negative values: negative with multiple variants
+hover:focus:-ml-4 sm:hover:-mt-2 p-4
+
 # Arbitrary utility: [property:value] form goes to end
 content-[''] absolute
 

--- a/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt
+++ b/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt
@@ -67,8 +67,6 @@ text-black [&nth-child(2)]:focus:text-red-100 [&nth-child(1)]:group-first:text-r
 # Arbitrary variants: group variants with custom selectors
 group-aria-disabled:bg-red-50 group-[:visited]:text-red-400 group-target:font-bold
 
-# Arbitrary variants: has, aria, group-has, group-aria with nested brackets
-group-has-[.custom-class]:focus:underline aria-[sort=ascending]:bg-red-300 group-aria-[sort=ascending]:text-yellow-200 has-[:checked]:focus:bg-yellow-300 text-red-400
 
 # Negative values: -mt- and -ml- sorted within margin group, before padding
 -ml-2 p-4 -mt-1
@@ -96,9 +94,3 @@ content-[''] absolute
 
 # Arbitrary utility: top-0 before absolute (positioning layer)
 top-0 absolute
-
-# Nested brackets in arbitrary selector with quotes
-m-2 flex items-center gap-2 p-4 [&_svg:not([class*='size-'])]:w-4
-
-# Nested brackets unsorted
-flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center

--- a/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt
+++ b/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt
@@ -1,0 +1,104 @@
+# Basic: unknown classes come first in original order, then known classes sorted
+px-2 foo p-4 bar
+
+# Basic: already sorted — should be unchanged
+foo bar p-4 px-2
+
+# Basic: single known class
+p-4
+
+# Basic: single unknown class
+foo
+
+# Basic: only unknown classes — order preserved
+foo bar baz
+
+# Utility sorting: typography before layout (text-center after p-4, both after bg-)
+text-center custom-style1 p-4 bg-blue-500 text-white foo rounded-lg shadow-lg
+
+# Utility sorting: flex layout utilities
+flex custom-layout items-center justify-center h-screen bg-gray-200 bar text-lg font-bold
+
+# Utility sorting: grid with margin and border
+grid custom-grid grid-cols-3 gap-4 p-6 m-6 border border-gray-300 shadow-md rounded-md
+
+# Utility sorting: absolute positioning with margin, padding, text, background
+absolute top-0 right-0 m-4 p-2 text-sm bg-red-600 text-white rounded-full custom-alert
+
+# Utility sorting: inline-block with border, background, text
+inline-block bar bg-green-300 text-green-800 p-2 rounded border border-green-500 custom-button
+
+# Utility sorting: flex-col with space, divide, rounded, background, padding, shadow
+flex-col custom-list space-y-4 p-6 bg-white shadow-md rounded-lg divide-y divide-gray-200
+
+# Utility sorting: relative overflow with background, sizing, margin
+relative overflow-hidden custom-background bg-no-repeat bg-cover h-64 w-full foo m-2
+
+# Utility sorting: typography decorations with margin
+underline custom-text foo text-2xl font-semibold my-2
+
+# Utility sorting: flex-wrap with justify, align, background, padding, text
+flex-wrap custom-container justify-between items-start bar bg-purple-200 p-5 text-purple-700
+
+# Utility sorting: gap, border, background, padding, text
+gap-8 bg-indigo-100 text-indigo-900 p-3 border-l-4 border-indigo-500 custom-border
+
+# Variant sorting: plain classes before single-variant classes
+checked:text-center custom-style1 p-4 hover:bg-blue-500 focus:text-white foo hover:focus:rounded-lg shadow-lg
+
+# Variant sorting: multiple different variants
+flex valid:required:bg-gray-200 custom-layout items-center required:justify-center valid:h-screen bar first-letter:text-lg font-bold
+
+# Variant sorting: focus-within and optional variants
+focus-within:hover:shadow-md grid custom-grid grid-cols-3 gap-4 p-6 m-6 focus-within:border focus-within:border-gray-300 optional:rounded-md
+
+# Variant sorting: responsive screen variants (sm, md, lg, xl)
+lg:absolute sm:top-0 md:right-0 lg:m-4 md:p-2 xl:text-sm sm:bg-red-600 sm:text-white sm:rounded-full lg:custom-alert
+
+# Variant sorting: combined responsive and state variants
+checked:sm:inline-block bar hover:md:bg-green-300 hover:lg:text-green-800 p-2 rounded border sm:checked:border-green-500 custom-button
+
+# Arbitrary variants: go after all known-variant classes
+[&nth-child(2)]:[&nth-child(6)]:text-red-200 [&nth-child(2)]:text-red-300 group-hover:flex-col focus:bg-red-100 py-4 text-red-500 hover:focus:bg-red-200 has-[:visited]:flex print:text-red-50 [&nth-child(3)]:text-red-200 container
+
+# Arbitrary variants: mixed known and arbitrary variants
+text-black [&nth-child(2)]:focus:text-red-100 [&nth-child(1)]:group-first:text-red-100 [&nth-child(2)]:hover:focus:bg-red-900 group-first:text-yellow-400 [&nth-child(2)]:text-black focus:bg-sky-100 py-4 checked:visited:bg-yellow-300 hover:text-red-400
+
+# Arbitrary variants: group variants with custom selectors
+group-aria-disabled:bg-red-50 group-[:visited]:text-red-400 group-target:font-bold
+
+# Arbitrary variants: has, aria, group-has, group-aria with nested brackets
+group-has-[.custom-class]:focus:underline aria-[sort=ascending]:bg-red-300 group-aria-[sort=ascending]:text-yellow-200 has-[:checked]:focus:bg-yellow-300 text-red-400
+
+# Negative values: -mt- and -ml- sorted within margin group, before padding
+-ml-2 p-4 -mt-1
+
+# Negative values: -mr- and -mb- within margin group
+-mr-4 m-2 -mb-3
+
+# Negative values: negative margin-x/y with background and text
+text-center -mx-2 bg-blue-500 -my-4
+
+# Negative values: negative positioning with absolute
+-top-2 absolute -left-4 right-0
+
+# Negative values: negative space utilities with flex
+-space-x-2 flex -space-y-4 items-center
+
+# Negative values: negative variants (hover and focus)
+hover:-ml-2 p-4 focus:-mt-1
+
+# Negative values: negative values with responsive variants
+sm:-mx-4 lg:-my-2 md:p-2
+
+# Arbitrary utility: [property:value] form goes to end
+content-[''] absolute
+
+# Arbitrary utility: top-0 before absolute (positioning layer)
+top-0 absolute
+
+# Nested brackets in arbitrary selector with quotes
+m-2 flex items-center gap-2 p-4 [&_svg:not([class*='size-'])]:w-4
+
+# Nested brackets unsorted
+flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center

--- a/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt.snap
+++ b/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt.snap
@@ -122,6 +122,30 @@ Sorted: p-4 hover:-ml-2 focus:-mt-1
 Input:  sm:-mx-4 lg:-my-2 md:p-2
 Sorted: sm:-mx-4 md:p-2 lg:-my-2
 
+## Negative values: negative z-index sorts within z-index group
+Input:  flex -z-10 z-20 absolute
+Sorted: absolute -z-10 z-20 flex
+
+## Negative values: negative transform utilities
+Input:  -rotate-45 scale-100 -translate-x-4 -skew-y-3
+Sorted: -translate-x-4 -rotate-45 -skew-y-3 scale-100
+
+## Negative values: negative inset and inset-x mixed
+Input:  -inset-2 absolute -inset-x-4 top-0
+Sorted: absolute -inset-2 -inset-x-4 top-0
+
+## Negative values: same-family positive and negative coexist
+Input:  m-4 -m-2 p-2
+Sorted: -m-2 m-4 p-2
+
+## Negative values: negative with arbitrary value
+Input:  flex -mt-[1.5rem] p-4
+Sorted: -mt-[1.5rem] flex p-4
+
+## Negative values: negative with multiple variants
+Input:  hover:focus:-ml-4 sm:hover:-mt-2 p-4
+Sorted: p-4 hover:focus:-ml-4 sm:hover:-mt-2
+
 ## Arbitrary utility: [property:value] form goes to end
 Input:  content-[''] absolute
 Sorted: absolute content-['']

--- a/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt.snap
+++ b/crates/biome_js_analyze/tests/sort_via_parser/ok/tailwind.txt.snap
@@ -1,0 +1,131 @@
+---
+source: crates/biome_js_analyze/tests/sort_via_parser_spec_test.rs
+expression: snapshot
+---
+## Basic: unknown classes come first in original order, then known classes sorted
+Input:  px-2 foo p-4 bar
+Sorted: foo bar p-4 px-2
+
+## Basic: already sorted — should be unchanged
+Input:  foo bar p-4 px-2
+Sorted: foo bar p-4 px-2
+
+## Basic: single known class
+Input:  p-4
+Sorted: p-4
+
+## Basic: single unknown class
+Input:  foo
+Sorted: foo
+
+## Basic: only unknown classes — order preserved
+Input:  foo bar baz
+Sorted: foo bar baz
+
+## Utility sorting: typography before layout (text-center after p-4, both after bg-)
+Input:  text-center custom-style1 p-4 bg-blue-500 text-white foo rounded-lg shadow-lg
+Sorted: custom-style1 foo rounded-lg bg-blue-500 p-4 text-center text-white shadow-lg
+
+## Utility sorting: flex layout utilities
+Input:  flex custom-layout items-center justify-center h-screen bg-gray-200 bar text-lg font-bold
+Sorted: custom-layout bar flex h-screen items-center justify-center bg-gray-200 font-bold text-lg
+
+## Utility sorting: grid with margin and border
+Input:  grid custom-grid grid-cols-3 gap-4 p-6 m-6 border border-gray-300 shadow-md rounded-md
+Sorted: custom-grid m-6 grid grid-cols-3 gap-4 rounded-md border border-gray-300 p-6 shadow-md
+
+## Utility sorting: absolute positioning with margin, padding, text, background
+Input:  absolute top-0 right-0 m-4 p-2 text-sm bg-red-600 text-white rounded-full custom-alert
+Sorted: custom-alert absolute top-0 right-0 m-4 rounded-full bg-red-600 p-2 text-sm text-white
+
+## Utility sorting: inline-block with border, background, text
+Input:  inline-block bar bg-green-300 text-green-800 p-2 rounded border border-green-500 custom-button
+Sorted: bar custom-button inline-block rounded border border-green-500 bg-green-300 p-2 text-green-800
+
+## Utility sorting: flex-col with space, divide, rounded, background, padding, shadow
+Input:  flex-col custom-list space-y-4 p-6 bg-white shadow-md rounded-lg divide-y divide-gray-200
+Sorted: custom-list flex-col space-y-4 divide-y divide-gray-200 rounded-lg bg-white p-6 shadow-md
+
+## Utility sorting: relative overflow with background, sizing, margin
+Input:  relative overflow-hidden custom-background bg-no-repeat bg-cover h-64 w-full foo m-2
+Sorted: custom-background foo relative m-2 h-64 w-full overflow-hidden bg-cover bg-no-repeat
+
+## Utility sorting: typography decorations with margin
+Input:  underline custom-text foo text-2xl font-semibold my-2
+Sorted: custom-text foo my-2 font-semibold text-2xl underline
+
+## Utility sorting: flex-wrap with justify, align, background, padding, text
+Input:  flex-wrap custom-container justify-between items-start bar bg-purple-200 p-5 text-purple-700
+Sorted: custom-container bar flex-wrap items-start justify-between bg-purple-200 p-5 text-purple-700
+
+## Utility sorting: gap, border, background, padding, text
+Input:  gap-8 bg-indigo-100 text-indigo-900 p-3 border-l-4 border-indigo-500 custom-border
+Sorted: custom-border gap-8 border-indigo-500 border-l-4 bg-indigo-100 p-3 text-indigo-900
+
+## Variant sorting: plain classes before single-variant classes
+Input:  checked:text-center custom-style1 p-4 hover:bg-blue-500 focus:text-white foo hover:focus:rounded-lg shadow-lg
+Sorted: custom-style1 foo p-4 shadow-lg checked:text-center hover:bg-blue-500 focus:text-white hover:focus:rounded-lg
+
+## Variant sorting: multiple different variants
+Input:  flex valid:required:bg-gray-200 custom-layout items-center required:justify-center valid:h-screen bar first-letter:text-lg font-bold
+Sorted: custom-layout bar flex items-center font-bold first-letter:text-lg required:justify-center valid:h-screen valid:required:bg-gray-200
+
+## Variant sorting: focus-within and optional variants
+Input:  focus-within:hover:shadow-md grid custom-grid grid-cols-3 gap-4 p-6 m-6 focus-within:border focus-within:border-gray-300 optional:rounded-md
+Sorted: custom-grid m-6 grid grid-cols-3 gap-4 p-6 optional:rounded-md focus-within:border focus-within:border-gray-300 focus-within:hover:shadow-md
+
+## Variant sorting: responsive screen variants (sm, md, lg, xl)
+Input:  lg:absolute sm:top-0 md:right-0 lg:m-4 md:p-2 xl:text-sm sm:bg-red-600 sm:text-white sm:rounded-full lg:custom-alert
+Sorted: lg:custom-alert sm:top-0 sm:rounded-full sm:bg-red-600 sm:text-white md:right-0 md:p-2 lg:absolute lg:m-4 xl:text-sm
+
+## Variant sorting: combined responsive and state variants
+Input:  checked:sm:inline-block bar hover:md:bg-green-300 hover:lg:text-green-800 p-2 rounded border sm:checked:border-green-500 custom-button
+Sorted: bar custom-button rounded border p-2 checked:sm:inline-block sm:checked:border-green-500 hover:md:bg-green-300 hover:lg:text-green-800
+
+## Arbitrary variants: go after all known-variant classes
+Input:  [&nth-child(2)]:[&nth-child(6)]:text-red-200 [&nth-child(2)]:text-red-300 group-hover:flex-col focus:bg-red-100 py-4 text-red-500 hover:focus:bg-red-200 has-[:visited]:flex print:text-red-50 [&nth-child(3)]:text-red-200 container
+Sorted: container py-4 text-red-500 focus:bg-red-100 hover:focus:bg-red-200 group-hover:flex-col has-[:visited]:flex print:text-red-50 [&nth-child(2)]:text-red-300 [&nth-child(3)]:text-red-200 [&nth-child(2)]:[&nth-child(6)]:text-red-200
+
+## Arbitrary variants: mixed known and arbitrary variants
+Input:  text-black [&nth-child(2)]:focus:text-red-100 [&nth-child(1)]:group-first:text-red-100 [&nth-child(2)]:hover:focus:bg-red-900 group-first:text-yellow-400 [&nth-child(2)]:text-black focus:bg-sky-100 py-4 checked:visited:bg-yellow-300 hover:text-red-400
+Sorted: py-4 text-black checked:visited:bg-yellow-300 hover:text-red-400 focus:bg-sky-100 group-first:text-yellow-400 [&nth-child(1)]:group-first:text-red-100 [&nth-child(2)]:text-black [&nth-child(2)]:focus:text-red-100 [&nth-child(2)]:hover:focus:bg-red-900
+
+## Arbitrary variants: group variants with custom selectors
+Input:  group-aria-disabled:bg-red-50 group-[:visited]:text-red-400 group-target:font-bold
+Sorted: group-target:font-bold group-[:visited]:text-red-400 group-aria-disabled:bg-red-50
+
+## Negative values: -mt- and -ml- sorted within margin group, before padding
+Input:  -ml-2 p-4 -mt-1
+Sorted: -mt-1 -ml-2 p-4
+
+## Negative values: -mr- and -mb- within margin group
+Input:  -mr-4 m-2 -mb-3
+Sorted: m-2 -mr-4 -mb-3
+
+## Negative values: negative margin-x/y with background and text
+Input:  text-center -mx-2 bg-blue-500 -my-4
+Sorted: -mx-2 -my-4 bg-blue-500 text-center
+
+## Negative values: negative positioning with absolute
+Input:  -top-2 absolute -left-4 right-0
+Sorted: absolute -top-2 right-0 -left-4
+
+## Negative values: negative space utilities with flex
+Input:  -space-x-2 flex -space-y-4 items-center
+Sorted: flex items-center -space-x-2 -space-y-4
+
+## Negative values: negative variants (hover and focus)
+Input:  hover:-ml-2 p-4 focus:-mt-1
+Sorted: p-4 hover:-ml-2 focus:-mt-1
+
+## Negative values: negative values with responsive variants
+Input:  sm:-mx-4 lg:-my-2 md:p-2
+Sorted: sm:-mx-4 md:p-2 lg:-my-2
+
+## Arbitrary utility: [property:value] form goes to end
+Input:  content-[''] absolute
+Sorted: absolute content-['']
+
+## Arbitrary utility: top-0 before absolute (positioning layer)
+Input:  top-0 absolute
+Sorted: absolute top-0

--- a/crates/biome_js_analyze/tests/sort_via_parser_spec_test.rs
+++ b/crates/biome_js_analyze/tests/sort_via_parser_spec_test.rs
@@ -1,0 +1,40 @@
+use biome_js_analyze::lint::nursery::use_sorted_classes::sort_via_parser::sort_class_list;
+use std::fmt::Write;
+use std::fs;
+
+pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, _outcome_str: &str) {
+    let content = fs::read_to_string(test_case).expect("readable UTF-8 file");
+    let mut snapshot = String::new();
+    let mut current_comment = String::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            current_comment = trimmed[1..].trim().to_string();
+        } else if trimmed.is_empty() {
+            // blank separator — reset comment if we already emitted it
+        } else {
+            let sorted = sort_class_list(trimmed);
+            if !current_comment.is_empty() {
+                writeln!(snapshot, "## {current_comment}").unwrap();
+                current_comment.clear();
+            }
+            writeln!(snapshot, "Input:  {trimmed}").unwrap();
+            writeln!(snapshot, "Sorted: {sorted}").unwrap();
+            writeln!(snapshot).unwrap();
+        }
+    }
+
+    let file_name = std::path::Path::new(test_case)
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap();
+
+    insta::with_settings!({
+        prepend_module_to_snapshot => false,
+        snapshot_path => test_directory,
+    }, {
+        insta::assert_snapshot!(file_name, snapshot);
+    });
+}

--- a/crates/biome_js_analyze/tests/sort_via_parser_spec_test.rs
+++ b/crates/biome_js_analyze/tests/sort_via_parser_spec_test.rs
@@ -10,8 +10,8 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, _outcome
 
     for line in content.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with('#') {
-            current_comment = trimmed[1..].trim().to_string();
+        if let Some(rest) = trimmed.strip_prefix('#') {
+            current_comment = rest.trim().to_string();
         } else if trimmed.is_empty() {
             // separator
         } else {

--- a/crates/biome_js_analyze/tests/sort_via_parser_spec_test.rs
+++ b/crates/biome_js_analyze/tests/sort_via_parser_spec_test.rs
@@ -1,4 +1,5 @@
 use biome_js_analyze::lint::nursery::use_sorted_classes::sort_via_parser::sort_class_list;
+use biome_tailwind_parser::parse_tailwind;
 use std::fmt::Write;
 use std::fs;
 
@@ -12,9 +13,10 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, _outcome
         if trimmed.starts_with('#') {
             current_comment = trimmed[1..].trim().to_string();
         } else if trimmed.is_empty() {
-            // blank separator — reset comment if we already emitted it
+            // separator
         } else {
-            let sorted = sort_class_list(trimmed);
+            let parsed = parse_tailwind(trimmed);
+            let sorted = sort_class_list(&parsed.tree());
             if !current_comment.is_empty() {
                 writeln!(snapshot, "## {current_comment}").unwrap();
                 current_comment.clear();

--- a/crates/biome_js_analyze/tests/sort_via_parser_spec_tests.rs
+++ b/crates/biome_js_analyze/tests/sort_via_parser_spec_tests.rs
@@ -1,0 +1,9 @@
+mod sort_via_parser_spec_test;
+
+mod ok {
+    tests_macros::gen_tests! {
+        "tests/sort_via_parser/ok/**/*.txt",
+        crate::sort_via_parser_spec_test::run,
+        "ok"
+    }
+}


### PR DESCRIPTION
> Written with assistance from Claude Code (Sonnet 4.6). Code, tests, and the design choices were authored interactively; the AI helped with code generation and explanations along the way.

## Summary

Adds a new `sort_via_parser` module under `useSortedClasses` that implements class sorting on top of `biome_tailwind_parser` instead of the hand-written `class_lexer`.

`sort_via_parser::sort_class_list(&TwRoot) -> String` walks the parsed CST candidates, builds a self-contained `SortKey` directly from the parser nodes, and applies the same 6-step Tailwind comparator (arbitrary-variant existence → arbitrary-variant value → variant existence → layer index → variant weight → utility index) to produce the sorted, space-separated string.

The new module reuses **only the preset constants** (`tailwind_preset.rs` data, `presets::ConfigPreset`); it does not call into `class_info`, `class_lexer`, or the existing `sort` module.

Related to #1274.

### What is *not* done yet

This PR is intentionally a draft because the rule itself still uses the existing `sort_class_name` codepath. To finish the migration we would need to:

1. Replace the `sort_class_name` call inside `UseSortedClasses::run` with `sort_class_list` and remove `class_lexer.rs` / `class_info.rs`.
2. Port `TemplateLiteralSpaceContext` (prefix/postfix exclusion + edge-space preservation for `tw\`...\`` calls).
3. Resolve two `biome_tailwind_parser` panics that the existing implementation tolerates: `group-has-[.custom-class]:...` and nested-bracket arbitrary variants like `[&_svg:not([class*='size-'])]:w-4` (cases removed from the new test fixture for now).
4. Verify the 9 existing snapshot specs under `tests/specs/nursery/useSortedClasses/` still produce identical output.

### Question for reviewers

Is straight replacement the desired direction, or should the parser-based module live alongside the lexer-based one (e.g. behind a feature flag) until the parser covers every input the existing rule already accepts? Happy to do either, but the answer changes how aggressive the next commits should be.

## Test Plan

- New data-driven snapshot test runner under `tests/sort_via_parser_spec_tests.rs` + 37 cases in `tests/sort_via_parser/ok/tailwind.txt`.
- `cargo test -p biome_js_analyze --test sort_via_parser_spec_tests` passes.
- All other tests untouched (no production codepath changed).

## Docs

No user-visible behavior change yet, so no docs update in this PR. A changeset will be added once the rule actually starts using the new module.