### PR TITLE
fix: collect readonly class property arrow writes

### DIFF
--- a/.changeset/fix-readonly-class-property-arrow-callback.md
+++ b/.changeset/fix-readonly-class-property-arrow-callback.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10193](https://github.com/biomejs/biome/issues/10193): `style/useReadonlyClassProperties` no longer reports class properties as readonly-able when they are assigned inside arrow callbacks nested in class property initializers.

--- a/crates/biome_js_analyze/src/services/semantic_class.rs
+++ b/crates/biome_js_analyze/src/services/semantic_class.rs
@@ -215,6 +215,8 @@ fn class_member_references(list: &JsClassMemberList) -> ClassMemberReferences {
                         return collect_class_property_reads_from_static_member(
                             static_member_expression,
                         );
+                    } else {
+                        return collect_references_from_property_initializer(&expression);
                     }
                 };
                 None
@@ -587,6 +589,142 @@ fn collect_references_from_body(
     visit_references_in_body(member, &scoped_this_references, &mut writes, &mut reads);
 
     Some(ClassMemberReferences { reads, writes })
+}
+
+/// Collects references to class members from arrow functions nested in a class property initializer.
+///
+/// Arrow functions capture the class initializer's lexical `this`, while normal functions establish
+/// their own `this`, so this intentionally skips non-arrow function bodies.
+fn collect_references_from_property_initializer(
+    expression: &AnyJsExpression,
+) -> Option<ClassMemberReferences> {
+    let mut reads = FxHashSet::default();
+    let mut writes = FxHashSet::default();
+    let mut skipped_ranges = vec![];
+
+    for event in expression.syntax().preorder() {
+        match event {
+            WalkEvent::Enter(node) => {
+                if skipped_ranges
+                    .iter()
+                    .any(|range: &TextRange| range.contains_range(node.text_range()))
+                {
+                    continue;
+                }
+
+                if let Some(arrow_function) = JsArrowFunctionExpression::cast_ref(&node) {
+                    collect_references_from_arrow_function(
+                        &arrow_function,
+                        &[],
+                        &mut writes,
+                        &mut reads,
+                    );
+                    skipped_ranges.push(node.text_range());
+                    continue;
+                }
+
+                if matches!(
+                    node.kind(),
+                    JsSyntaxKind::JS_CLASS_EXPRESSION
+                        | JsSyntaxKind::JS_CLASS_DECLARATION
+                        | JsSyntaxKind::JS_CLASS_EXPORT_DEFAULT_DECLARATION
+                        | JsSyntaxKind::JS_FUNCTION_EXPRESSION
+                        | JsSyntaxKind::JS_FUNCTION_DECLARATION
+                        | JsSyntaxKind::JS_FUNCTION_EXPORT_DEFAULT_DECLARATION
+                        | JsSyntaxKind::JS_FUNCTION_BODY
+                ) {
+                    skipped_ranges.push(node.text_range());
+                }
+            }
+            WalkEvent::Leave(node) => {
+                if let Some(last) = skipped_ranges.last()
+                    && *last == node.text_range()
+                {
+                    skipped_ranges.pop();
+                }
+            }
+        }
+    }
+
+    Some(ClassMemberReferences { reads, writes })
+}
+
+fn collect_references_from_arrow_function(
+    arrow_function: &JsArrowFunctionExpression,
+    inherited_this_references: &[ClassMemberReference],
+    writes: &mut FxHashSet<ClassMemberReference>,
+    reads: &mut FxHashSet<ClassMemberReference>,
+) {
+    let Some(body) = arrow_function
+        .body()
+        .ok()
+        .and_then(|body| body.as_js_function_body().cloned())
+    else {
+        return;
+    };
+
+    let mut this_references = FxHashSet::default();
+    this_references.extend(inherited_this_references.iter().cloned());
+    this_references.extend(ThisScopeReferences::new(&body).local_this_references);
+
+    let current_scope = FunctionThisReferences {
+        scope: body.clone(),
+        this_references,
+    };
+    visit_references_in_body(
+        arrow_function.syntax(),
+        std::slice::from_ref(&current_scope),
+        writes,
+        reads,
+    );
+
+    let inherited_this_references: Vec<_> = current_scope.this_references.iter().cloned().collect();
+    let mut skipped_ranges = vec![];
+
+    for event in body.syntax().preorder() {
+        match event {
+            WalkEvent::Enter(node) => {
+                if skipped_ranges
+                    .iter()
+                    .any(|range: &TextRange| range.contains_range(node.text_range()))
+                {
+                    continue;
+                }
+
+                if let Some(nested_arrow_function) = JsArrowFunctionExpression::cast_ref(&node) {
+                    collect_references_from_arrow_function(
+                        &nested_arrow_function,
+                        &inherited_this_references,
+                        writes,
+                        reads,
+                    );
+                    skipped_ranges.push(node.text_range());
+                    continue;
+                }
+
+                if matches!(
+                    node.kind(),
+                    JsSyntaxKind::JS_CLASS_EXPRESSION
+                        | JsSyntaxKind::JS_CLASS_DECLARATION
+                        | JsSyntaxKind::JS_CLASS_EXPORT_DEFAULT_DECLARATION
+                        | JsSyntaxKind::JS_FUNCTION_EXPRESSION
+                        | JsSyntaxKind::JS_FUNCTION_DECLARATION
+                        | JsSyntaxKind::JS_FUNCTION_EXPORT_DEFAULT_DECLARATION
+                ) || (node.kind() == JsSyntaxKind::JS_FUNCTION_BODY
+                    && node.key() != body.syntax().key())
+                {
+                    skipped_ranges.push(node.text_range());
+                }
+            }
+            WalkEvent::Leave(node) => {
+                if let Some(last) = skipped_ranges.last()
+                    && *last == node.text_range()
+                {
+                    skipped_ranges.pop();
+                }
+            }
+        }
+    }
 }
 
 /// Traverses a JavaScript method or initializer body to collect references
@@ -1001,6 +1139,49 @@ mod tests {
             .expect("No object binding pattern found")
             .syntax()
             .clone()
+    }
+
+    #[test]
+    fn test_class_property_initializer_arrow_callback_writes() {
+        let parse = parse_ts(
+            r#"
+            import _ from "lodash";
+
+            class Example {
+                private notReadonlyMember = "";
+
+                private readonly someDebouncedFunc = _.debounce(() => {
+                    this.notReadonlyMember = "new value";
+                }, 50);
+
+                private functionCallbackMember = "";
+
+                private readonly functionCallback = debounce(function () {
+                    this.functionCallbackMember = "new value";
+                });
+            }
+        "#,
+        );
+        let members = parse
+            .syntax()
+            .descendants()
+            .find_map(JsClassMemberList::cast)
+            .expect("No class member list found");
+
+        let references = class_member_references(&members);
+
+        assert_writes(
+            &references.writes,
+            &[("notReadonlyMember", AccessKind::Write)],
+            "class property initializer arrow callback",
+        );
+        assert!(
+            references
+                .writes
+                .iter()
+                .all(|reference| reference.name.text() != "functionCallbackMember"),
+            "normal function callbacks should not use the class initializer's lexical this"
+        );
     }
 
     #[test]

--- a/crates/biome_js_analyze/src/services/semantic_class.rs
+++ b/crates/biome_js_analyze/src/services/semantic_class.rs
@@ -238,7 +238,7 @@ fn class_member_references(list: &JsClassMemberList) -> ClassMemberReferences {
 /// Represents a function body and all `this` references (including aliases) valid within its lexical scope.
 #[derive(Clone, Debug)]
 struct FunctionThisReferences {
-    scope: JsSyntaxNode,
+    scope: AnyJsFunctionBody,
     this_references: FxHashSet<ClassMemberReference>,
 }
 
@@ -287,7 +287,7 @@ impl ThisScopeVisitor<'_> {
                         scoped_this_references.extend(current_scope);
 
                         self.current_this_scopes.push(FunctionThisReferences {
-                            scope: body.syntax().clone(),
+                            scope: AnyJsFunctionBody::JsFunctionBody(body.clone()),
                             this_references: scoped_this_references,
                         });
                     }
@@ -306,7 +306,7 @@ impl ThisScopeVisitor<'_> {
                     scoped_this_references.extend(current_scope_aliases.clone());
 
                     self.current_this_scopes.push(FunctionThisReferences {
-                        scope: body.syntax().clone(),
+                        scope: AnyJsFunctionBody::JsFunctionBody(body.clone()),
                         this_references: scoped_this_references,
                     });
                 }
@@ -397,7 +397,7 @@ fn is_this_reference(
         return scoped_this_references
             .iter()
             .any(|FunctionThisReferences { scope, .. }| {
-                is_within_scope_without_shadowing(syntax, scope)
+                is_within_scope_without_shadowing(syntax, function_body_syntax(scope))
             });
     }
 
@@ -419,13 +419,21 @@ fn is_this_reference(
                         .eq(value_token.token_text_trimmed().text())
                 });
 
-                let is_within_scope = is_within_scope_without_shadowing(name_syntax, scope);
+                let is_within_scope =
+                    is_within_scope_without_shadowing(name_syntax, function_body_syntax(scope));
 
                 is_alias && is_within_scope
             },
         )
     } else {
         false
+    }
+}
+
+fn function_body_syntax(body: &AnyJsFunctionBody) -> &JsSyntaxNode {
+    match body {
+        AnyJsFunctionBody::AnyJsExpression(expression) => expression.syntax(),
+        AnyJsFunctionBody::JsFunctionBody(body) => body.syntax(),
     }
 }
 
@@ -656,12 +664,8 @@ fn collect_references_from_arrow_function(
         this_references.extend(ThisScopeReferences::new(function_body).local_this_references);
     }
 
-    let scope = match &body {
-        AnyJsFunctionBody::AnyJsExpression(_) => arrow_function.syntax().clone(),
-        AnyJsFunctionBody::JsFunctionBody(body) => body.syntax().clone(),
-    };
     let current_scope = FunctionThisReferences {
-        scope,
+        scope: body.clone(),
         this_references,
     };
     visit_references_in_body(
@@ -673,10 +677,7 @@ fn collect_references_from_arrow_function(
 
     let inherited_this_references: Vec<_> = current_scope.this_references.iter().cloned().collect();
     let mut skipped_ranges = vec![];
-    let body_syntax = match &body {
-        AnyJsFunctionBody::AnyJsExpression(expression) => expression.syntax(),
-        AnyJsFunctionBody::JsFunctionBody(body) => body.syntax(),
-    };
+    let body_syntax = function_body_syntax(&body);
 
     for event in body_syntax.preorder() {
         match event {
@@ -961,7 +962,7 @@ fn collect_references_from_constructor(constructor_body: &JsFunctionBody) -> Cla
 
     for this_scope in all_descendants_fn_bodies_and_this_scopes.iter() {
         visit_references_in_body(
-            &this_scope.scope,
+            function_body_syntax(&this_scope.scope),
             std::slice::from_ref(this_scope),
             &mut writes,
             &mut reads,

--- a/crates/biome_js_analyze/src/services/semantic_class.rs
+++ b/crates/biome_js_analyze/src/services/semantic_class.rs
@@ -3,7 +3,7 @@ use biome_analyze::{
     RuleMetadata, ServiceBag, ServicesDiagnostic, Visitor, VisitorContext, VisitorFinishContext,
 };
 use biome_js_syntax::{
-    AnyJsBindingPattern, AnyJsClass, AnyJsClassMember, AnyJsExpression,
+    AnyJsBindingPattern, AnyJsClass, AnyJsClassMember, AnyJsExpression, AnyJsFunctionBody,
     AnyJsObjectBindingPatternMember, AnyJsRoot, JsArrayAssignmentPattern,
     JsArrowFunctionExpression, JsAssignmentExpression, JsClassMemberList, JsConstructorClassMember,
     JsFunctionBody, JsLanguage, JsObjectAssignmentPattern, JsObjectBindingPattern,
@@ -201,15 +201,7 @@ fn class_member_references(list: &JsClassMemberList) -> ClassMemberReferences {
                 .and_then(|body| collect_references_from_body(getter.syntax(), &body)),
             AnyJsClassMember::JsPropertyClassMember(property) => {
                 if let Ok(expression) = property.value()?.expression() {
-                    if let Some(arrow_function) =
-                        JsArrowFunctionExpression::cast(expression.clone().into_syntax())
-                    {
-                        if let Ok(any_js_body) = arrow_function.body()
-                            && let Some(body) = any_js_body.as_js_function_body()
-                        {
-                            return collect_references_from_body(arrow_function.syntax(), body);
-                        }
-                    } else if let Some(static_member_expression) =
+                    if let Some(static_member_expression) =
                         expression.as_js_static_member_expression()
                     {
                         return collect_class_property_reads_from_static_member(
@@ -246,7 +238,7 @@ fn class_member_references(list: &JsClassMemberList) -> ClassMemberReferences {
 /// Represents a function body and all `this` references (including aliases) valid within its lexical scope.
 #[derive(Clone, Debug)]
 struct FunctionThisReferences {
-    scope: JsFunctionBody,
+    scope: JsSyntaxNode,
     this_references: FxHashSet<ClassMemberReference>,
 }
 
@@ -295,7 +287,7 @@ impl ThisScopeVisitor<'_> {
                         scoped_this_references.extend(current_scope);
 
                         self.current_this_scopes.push(FunctionThisReferences {
-                            scope: body.clone(),
+                            scope: body.syntax().clone(),
                             this_references: scoped_this_references,
                         });
                     }
@@ -314,7 +306,7 @@ impl ThisScopeVisitor<'_> {
                     scoped_this_references.extend(current_scope_aliases.clone());
 
                     self.current_this_scopes.push(FunctionThisReferences {
-                        scope: body.clone(),
+                        scope: body.syntax().clone(),
                         this_references: scoped_this_references,
                     });
                 }
@@ -405,7 +397,7 @@ fn is_this_reference(
         return scoped_this_references
             .iter()
             .any(|FunctionThisReferences { scope, .. }| {
-                is_within_scope_without_shadowing(syntax, scope.syntax())
+                is_within_scope_without_shadowing(syntax, scope)
             });
     }
 
@@ -427,8 +419,7 @@ fn is_this_reference(
                         .eq(value_token.token_text_trimmed().text())
                 });
 
-                let is_within_scope =
-                    is_within_scope_without_shadowing(name_syntax, scope.syntax());
+                let is_within_scope = is_within_scope_without_shadowing(name_syntax, scope);
 
                 is_alias && is_within_scope
             },
@@ -655,20 +646,22 @@ fn collect_references_from_arrow_function(
     writes: &mut FxHashSet<ClassMemberReference>,
     reads: &mut FxHashSet<ClassMemberReference>,
 ) {
-    let Some(body) = arrow_function
-        .body()
-        .ok()
-        .and_then(|body| body.as_js_function_body().cloned())
-    else {
+    let Ok(body) = arrow_function.body() else {
         return;
     };
 
     let mut this_references = FxHashSet::default();
     this_references.extend(inherited_this_references.iter().cloned());
-    this_references.extend(ThisScopeReferences::new(&body).local_this_references);
+    if let Some(function_body) = body.as_js_function_body() {
+        this_references.extend(ThisScopeReferences::new(function_body).local_this_references);
+    }
 
+    let scope = match &body {
+        AnyJsFunctionBody::AnyJsExpression(_) => arrow_function.syntax().clone(),
+        AnyJsFunctionBody::JsFunctionBody(body) => body.syntax().clone(),
+    };
     let current_scope = FunctionThisReferences {
-        scope: body.clone(),
+        scope,
         this_references,
     };
     visit_references_in_body(
@@ -680,8 +673,12 @@ fn collect_references_from_arrow_function(
 
     let inherited_this_references: Vec<_> = current_scope.this_references.iter().cloned().collect();
     let mut skipped_ranges = vec![];
+    let body_syntax = match &body {
+        AnyJsFunctionBody::AnyJsExpression(expression) => expression.syntax(),
+        AnyJsFunctionBody::JsFunctionBody(body) => body.syntax(),
+    };
 
-    for event in body.syntax().preorder() {
+    for event in body_syntax.preorder() {
         match event {
             WalkEvent::Enter(node) => {
                 if skipped_ranges
@@ -711,7 +708,7 @@ fn collect_references_from_arrow_function(
                         | JsSyntaxKind::JS_FUNCTION_DECLARATION
                         | JsSyntaxKind::JS_FUNCTION_EXPORT_DEFAULT_DECLARATION
                 ) || (node.kind() == JsSyntaxKind::JS_FUNCTION_BODY
-                    && node.key() != body.syntax().key())
+                    && node.key() != body_syntax.key())
                 {
                     skipped_ranges.push(node.text_range());
                 }
@@ -964,7 +961,7 @@ fn collect_references_from_constructor(constructor_body: &JsFunctionBody) -> Cla
 
     for this_scope in all_descendants_fn_bodies_and_this_scopes.iter() {
         visit_references_in_body(
-            this_scope.scope.syntax(),
+            &this_scope.scope,
             std::slice::from_ref(this_scope),
             &mut writes,
             &mut reads,
@@ -1154,10 +1151,32 @@ mod tests {
                     this.notReadonlyMember = "new value";
                 }, 50);
 
+                private expressionAssignedMember = "";
+
+                private readonly expressionAssignedCallback = _.debounce(
+                    () => this.expressionAssignedMember = "new value",
+                    50,
+                );
+
+                private expressionUpdatedMember = 0;
+
+                private readonly expressionUpdatedCallback = _.debounce(
+                    () => this.expressionUpdatedMember++,
+                    50,
+                );
+
                 private functionCallbackMember = "";
 
                 private readonly functionCallback = debounce(function () {
                     this.functionCallbackMember = "new value";
+                });
+
+                private nestedClassMember = "";
+
+                private readonly nestedClassCallback = debounce(() => class Nested {
+                    method() {
+                        this.nestedClassMember = "new value";
+                    }
                 });
             }
         "#,
@@ -1172,8 +1191,17 @@ mod tests {
 
         assert_writes(
             &references.writes,
-            &[("notReadonlyMember", AccessKind::Write)],
+            &[
+                ("notReadonlyMember", AccessKind::Write),
+                ("expressionAssignedMember", AccessKind::Write),
+                ("expressionUpdatedMember", AccessKind::Write),
+            ],
             "class property initializer arrow callback",
+        );
+        assert_reads(
+            &references.reads,
+            &[("expressionUpdatedMember", AccessKind::MeaningfulRead)],
+            "expression-bodied arrow update callback",
         );
         assert!(
             references
@@ -1181,6 +1209,13 @@ mod tests {
                 .iter()
                 .all(|reference| reference.name.text() != "functionCallbackMember"),
             "normal function callbacks should not use the class initializer's lexical this"
+        );
+        assert!(
+            references
+                .writes
+                .iter()
+                .all(|reference| reference.name.text() != "nestedClassMember"),
+            "nested class expressions should not use the outer class initializer's lexical this"
         );
     }
 

--- a/crates/biome_js_analyze/src/services/semantic_class.rs
+++ b/crates/biome_js_analyze/src/services/semantic_class.rs
@@ -397,7 +397,7 @@ fn is_this_reference(
         return scoped_this_references
             .iter()
             .any(|FunctionThisReferences { scope, .. }| {
-                is_within_scope_without_shadowing(syntax, function_body_syntax(scope))
+                is_within_scope_without_shadowing(syntax, scope.syntax())
             });
     }
 
@@ -420,20 +420,13 @@ fn is_this_reference(
                 });
 
                 let is_within_scope =
-                    is_within_scope_without_shadowing(name_syntax, function_body_syntax(scope));
+                    is_within_scope_without_shadowing(name_syntax, scope.syntax());
 
                 is_alias && is_within_scope
             },
         )
     } else {
         false
-    }
-}
-
-fn function_body_syntax(body: &AnyJsFunctionBody) -> &JsSyntaxNode {
-    match body {
-        AnyJsFunctionBody::AnyJsExpression(expression) => expression.syntax(),
-        AnyJsFunctionBody::JsFunctionBody(body) => body.syntax(),
     }
 }
 
@@ -677,7 +670,7 @@ fn collect_references_from_arrow_function(
 
     let inherited_this_references: Vec<_> = current_scope.this_references.iter().cloned().collect();
     let mut skipped_ranges = vec![];
-    let body_syntax = function_body_syntax(&body);
+    let body_syntax = body.syntax();
 
     for event in body_syntax.preorder() {
         match event {
@@ -962,7 +955,7 @@ fn collect_references_from_constructor(constructor_body: &JsFunctionBody) -> Cla
 
     for this_scope in all_descendants_fn_bodies_and_this_scopes.iter() {
         visit_references_in_body(
-            function_body_syntax(&this_scope.scope),
+            this_scope.scope.syntax(),
             std::slice::from_ref(this_scope),
             &mut writes,
             &mut reads,

--- a/crates/biome_js_analyze/tests/specs/style/useReadonlyClassProperties/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useReadonlyClassProperties/valid.ts
@@ -695,3 +695,15 @@ export default class Example {
 		this.notReadonlyMember = "new value";
 	}, 50);
 }
+
+class ExampleExpressionBodyAssignment {
+	private notReadonlyMember = "";
+
+	private readonly someDebouncedFunc = _.debounce(() => this.notReadonlyMember = "new value", 50);
+}
+
+class ExampleExpressionBodyUpdate {
+	private notReadonlyMember = 0;
+
+	private readonly someDebouncedFunc = _.debounce(() => this.notReadonlyMember++, 50);
+}

--- a/crates/biome_js_analyze/tests/specs/style/useReadonlyClassProperties/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useReadonlyClassProperties/valid.ts
@@ -1,5 +1,7 @@
 /* should not generate diagnostics */
 
+import _ from "lodash";
+
 function ignore() {
 }
 
@@ -684,4 +686,12 @@ class TesAssignmentInNestedCallback {
 			},
 		});
 	}
+}
+
+export default class Example {
+	private notReadonlyMember = "";
+
+	private readonly someDebouncedFunc = _.debounce(() => {
+		this.notReadonlyMember = "new value";
+	}, 50);
 }

--- a/crates/biome_js_analyze/tests/specs/style/useReadonlyClassProperties/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useReadonlyClassProperties/valid.ts.snap
@@ -702,4 +702,16 @@ export default class Example {
 	}, 50);
 }
 
+class ExampleExpressionBodyAssignment {
+	private notReadonlyMember = "";
+
+	private readonly someDebouncedFunc = _.debounce(() => this.notReadonlyMember = "new value", 50);
+}
+
+class ExampleExpressionBodyUpdate {
+	private notReadonlyMember = 0;
+
+	private readonly someDebouncedFunc = _.debounce(() => this.notReadonlyMember++, 50);
+}
+
 ```

--- a/crates/biome_js_analyze/tests/specs/style/useReadonlyClassProperties/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useReadonlyClassProperties/valid.ts.snap
@@ -6,6 +6,8 @@ expression: valid.ts
 ```ts
 /* should not generate diagnostics */
 
+import _ from "lodash";
+
 function ignore() {
 }
 
@@ -690,6 +692,14 @@ class TesAssignmentInNestedCallback {
 			},
 		});
 	}
+}
+
+export default class Example {
+	private notReadonlyMember = "";
+
+	private readonly someDebouncedFunc = _.debounce(() => {
+		this.notReadonlyMember = "new value";
+	}, 50);
 }
 
 ```


### PR DESCRIPTION
## Summary

Fixes #10193.

This PR fixes a false positive in `useReadonlyClassProperties`.

The rule could incorrectly report a class property as eligible for `readonly` when that property was reassigned inside an arrow callback nested in another class property initializer.

For example:

```ts
import _ from "lodash";

export default class Example {
	private notReadonlyMember = "";

	private readonly someDebouncedFunc = _.debounce(() => {
		this.notReadonlyMember = "new value";
	}, 50);
}
```

In this case, notReadonlyMember should not be reported as readonly-able because it is written inside the _.debounce arrow callback.
The root cause was that class property initializer references were only collected when the initializer itself was an arrow function. This missed cases where the arrow function was nested inside another expression, such as a call expression.
This PR updates the class member reference collection so that writes inside nested arrow callbacks in property initializers are collected, while preserving JavaScript lexical this semantics. Normal function () {} callbacks and nested class scopes are still ignored so they are not treated as using the class instance this.
A changeset was added for this bug fix.

# Test Plan

Added regression coverage for the exact issue reported in #10193.
The new tests verify that:
writes to this.x inside an arrow callback nested in a class property initializer are collected;
normal function () {} callbacks are not treated as using the class initializer's lexical this;
the original _.debounce(() => { this.notReadonlyMember = ... }) repro is accepted as valid and no longer reports useReadonlyClassProperties.

# Commands run:

cargo fmt
cargo fmt --check
cargo test -p biome_js_analyze semantic_class
cargo test -p biome_js_analyze use_readonly_class_properties -- --show-output
cargo insta accept

# Docs

No documentation changes are required.
This is a bug fix for an existing lint rule and does not add a new rule, action, or user-facing option.