### PR TITLE
perf(core): cache analyzer visitor

### DIFF
--- a/.changeset/free-news-exist.md
+++ b/.changeset/free-news-exist.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of the Biome linter. The improvements are more visible in bigger projects that have more than ~1k files. Early tests showed that in a code base with ~2k files, Biome took less than 26% of time to finish the command.

--- a/crates/biome_analyze/src/options.rs
+++ b/crates/biome_analyze/src/options.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashMap;
 use crate::{FixKind, Rule, RuleKey};
 use std::any::{Any, TypeId};
 use std::borrow::Cow;
+use std::rc::Rc;
 use std::sync::Arc;
 
 /// A convenient new type data structure to store the options that belong to a rule
@@ -53,10 +54,10 @@ impl AnalyzerRules {
 }
 
 /// A data structured derived from the `biome.json` file
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct AnalyzerConfiguration {
     /// A list of rules and their options
-    pub(crate) rules: AnalyzerRules,
+    pub(crate) rules: Rc<AnalyzerRules>,
 
     /// A collection of bindings that the analyzers should consider as "external".
     ///
@@ -86,7 +87,7 @@ pub struct AnalyzerConfiguration {
 
 impl AnalyzerConfiguration {
     pub fn with_rules(mut self, rules: AnalyzerRules) -> Self {
-        self.rules = rules;
+        self.rules = Rc::new(rules);
         self
     }
 
@@ -132,7 +133,7 @@ impl AnalyzerConfiguration {
 }
 
 /// A set of information useful to the analyzer infrastructure
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct AnalyzerOptions {
     /// A data structured derived from the [`biome.json`] file
     pub(crate) configuration: AnalyzerConfiguration,

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -574,6 +574,7 @@ fn lint(params: LintParams) -> LintResults {
         .with_path(params.path.as_path())
         .with_enabled_selectors(params.enabled_selectors)
         .with_project_layout(params.project_layout.clone())
+        .with_cache(params.analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {
@@ -631,6 +632,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         working_directory,
         compute_actions,
         snippet_services: _,
+        analyzer_cache,
     } = params;
     let tree = parse.tree();
     let Some(file_source) = language.to_css_file_source() else {
@@ -658,6 +660,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout.clone())
+        .with_cache(&analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -660,7 +660,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout.clone())
-        .with_cache(&analyzer_cache)
+        .with_cache(analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -536,7 +536,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout)
-        .with_cache(&analyzer_cache)
+        .with_cache(analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -461,6 +461,7 @@ fn lint(params: LintParams) -> LintResults {
         .with_path(params.path.as_path())
         .with_enabled_selectors(params.enabled_selectors)
         .with_project_layout(params.project_layout.clone())
+        .with_cache(params.analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {
@@ -505,6 +506,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         working_directory,
         compute_actions,
         snippet_services: _,
+        analyzer_cache,
     } = params;
     let _ = debug_span!("Code actions GraphQL", range =? range, path =? path).entered();
     let tree = parse.tree();
@@ -534,6 +536,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout)
+        .with_cache(&analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -557,6 +557,7 @@ fn lint(params: LintParams) -> LintResults {
         .with_path(params.path.as_path())
         .with_enabled_selectors(params.enabled_selectors)
         .with_project_layout(params.project_layout.clone())
+        .with_cache(params.analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -640,7 +640,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout.clone())
-        .with_cache(&analyzer_cache)
+        .with_cache(analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -611,6 +611,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         working_directory,
         compute_actions,
         snippet_services: _,
+        analyzer_cache,
     } = params;
     let _ = debug_span!("Code actions HTML", range =? range, path =? path).entered();
     let tree = parse.tree();
@@ -639,6 +640,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout.clone())
+        .with_cache(&analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -966,6 +966,7 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
         .with_path(params.path.as_path())
         .with_enabled_selectors(params.enabled_selectors)
         .with_project_layout(params.project_layout.clone())
+        .with_cache(params.analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {
@@ -1033,6 +1034,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         working_directory,
         compute_actions,
         snippet_services,
+        analyzer_cache,
     } = params;
     let _ = debug_span!("Code actions JavaScript", range =? range, path =? path).entered();
     let tree = parse.tree();
@@ -1055,6 +1057,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout.clone())
+        .with_cache(&analyzer_cache)
         .finish();
     let filter = AnalysisFilter {
         categories,

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -1057,7 +1057,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout.clone())
-        .with_cache(&analyzer_cache)
+        .with_cache(analyzer_cache)
         .finish();
     let filter = AnalysisFilter {
         categories,

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -636,7 +636,7 @@ fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout)
-        .with_cache(&analyzer_cache)
+        .with_cache(analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -543,6 +543,7 @@ fn lint(params: LintParams) -> LintResults {
         .with_path(params.path.as_path())
         .with_enabled_selectors(params.enabled_selectors)
         .with_project_layout(params.project_layout.clone())
+        .with_cache(params.analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {
@@ -611,6 +612,7 @@ fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         working_directory,
         compute_actions,
         snippet_services: _,
+        analyzer_cache,
     } = params;
 
     let _ = debug_span!("Code actions JSON",  range =? range, path =? path).entered();
@@ -634,6 +636,7 @@ fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         .with_path(path.as_path())
         .with_enabled_selectors(rules)
         .with_project_layout(project_layout)
+        .with_cache(&analyzer_cache)
         .finish();
 
     let filter = AnalysisFilter {

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -1174,7 +1174,7 @@ pub(crate) struct CodeActionsParams<'a> {
     pub(crate) compute_actions: bool,
     // Services attached to the current embedded snippet, when actions are run on snippets.
     pub(crate) snippet_services: Option<&'a DocumentServices>,
-    pub(crate) analyzer_cache: AnalyzerVisitorCache,
+    pub(crate) analyzer_cache: &'a AnalyzerVisitorCache,
 }
 
 pub(crate) struct UpdateSnippetsNodes {

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -64,7 +64,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-use tracing::instrument;
+use tracing::{instrument, trace};
 
 pub mod astro;
 pub(crate) mod css;
@@ -2444,6 +2444,7 @@ impl AnalyzerVisitorCache {
     }
     pub(crate) fn insert_entry(&self, key: AnalyzerCacheKey, entry: CachedRuleSet) {
         if self.0.len() > Self::MAX_ENTRIES {
+            trace!("Evicted cache entry: {:?}", key);
             self.evict_cache();
         }
 

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -16,6 +16,7 @@ use crate::workspace::{
     AnyEmbeddedSnippet, CodeAction, DocumentServices, FixAction, FixFileMode, FixFileResult,
     GetSyntaxTreeResult, PullActionsResult, PullDiagnosticsAndActionsResult, RenameResult,
 };
+use biome_analyze::options::JsxRuntime;
 use biome_analyze::{
     ActionFilter, AnalyzerAction, AnalyzerDiagnostic, AnalyzerOptions, AnalyzerPluginVec,
     AnalyzerSignal, ControlFlow, FixKind, GroupCategory, Never, Queryable, RegistryVisitor, Rule,
@@ -57,9 +58,11 @@ use grit::GritFileHandler;
 use html::HtmlFileHandler;
 pub use javascript::JsFormatterSettings;
 use md::MarkdownFileHandler;
-use rustc_hash::FxHashSet;
+use papaya::HashMap;
+use rustc_hash::{FxHashSet, FxHasher};
 use std::borrow::Cow;
 use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use tracing::instrument;
 
@@ -609,6 +612,8 @@ pub(crate) struct LintParams<'a> {
     pub(crate) diagnostic_level: Severity,
     /// When true, promote assist diagnostics (`assist/*`) to error severity.
     pub(crate) enforce_assist: bool,
+    /// Cached rules for the current analyzer pass.
+    pub(crate) analyzer_cache: &'a AnalyzerVisitorCache,
 }
 
 pub(crate) struct DiagnosticsAndActionsParams<'a> {
@@ -2137,12 +2142,12 @@ impl RegistryVisitor<HtmlLanguage> for AssistsVisitor<'_, '_> {
 }
 
 /// Result of building the analyzer visitor: the resolved rule filters and options.
-pub(crate) struct AnalyzerVisitorResult<'a> {
-    pub(crate) enabled_rules: Vec<RuleFilter<'a>>,
-    pub(crate) disabled_rules: Vec<RuleFilter<'a>>,
+pub(crate) struct AnalyzerVisitorResult {
+    pub(crate) enabled_rules: Vec<RuleFilter<'static>>,
+    pub(crate) disabled_rules: Vec<RuleFilter<'static>>,
     pub(crate) analyzer_options: AnalyzerOptions,
     /// Subset of `enabled_rules` that have a code fix (`FixKind::Safe` or `FixKind::Unsafe`).
-    pub(crate) fixable_rules: Vec<RuleFilter<'a>>,
+    pub(crate) fixable_rules: Vec<RuleFilter<'static>>,
 }
 
 pub(crate) struct AnalyzerVisitorBuilder<'a> {
@@ -2153,6 +2158,7 @@ pub(crate) struct AnalyzerVisitorBuilder<'a> {
     enabled_selectors: Option<&'a [AnalyzerSelector]>,
     project_layout: Arc<ProjectLayout>,
     analyzer_options: AnalyzerOptions,
+    cache: Option<&'a AnalyzerVisitorCache>,
 }
 
 impl<'b> AnalyzerVisitorBuilder<'b> {
@@ -2165,6 +2171,7 @@ impl<'b> AnalyzerVisitorBuilder<'b> {
             enabled_selectors: None,
             project_layout: Default::default(),
             analyzer_options,
+            cache: None,
         }
     }
 
@@ -2199,7 +2206,115 @@ impl<'b> AnalyzerVisitorBuilder<'b> {
     }
 
     #[must_use]
-    pub(crate) fn finish(self) -> AnalyzerVisitorResult<'b> {
+    pub(crate) fn with_cache(mut self, cache: &'b AnalyzerVisitorCache) -> Self {
+        self.cache = Some(cache);
+        self
+    }
+
+    fn compute_cache_key(&self) -> Option<AnalyzerCacheKey> {
+        let path = self.path?;
+
+        // 1. override_indices: which override patterns match this file.
+        let override_indices: Vec<_> = self
+            .settings
+            .override_settings
+            .patterns
+            .iter()
+            .enumerate()
+            .filter_map(|(i, pattern)| pattern.is_file_included(path).then_some(i))
+            .collect();
+
+        // 2. manifest_id: identity of the nearest package.json.
+        let manifest_id =
+            self.project_layout
+                .find_node_manifest_for_path(path)
+                .map(|(manifest_path, _)| {
+                    let mut h = FxHasher::default();
+                    manifest_path.hash(&mut h);
+                    h.finish()
+                });
+
+        // 3. jsx_factory_hash: JSX factory/fragment from tsconfig.
+        let jsx_factory_hash =
+            if self.analyzer_options.jsx_runtime() == Some(JsxRuntime::ReactClassic) {
+                let mut h = FxHasher::default();
+                // Query tsconfig for the jsx factory — same lookup as finish() does later.
+                let factory = self
+                    .project_layout
+                    .query_tsconfig_for_path(path, |tsconfig| {
+                        tsconfig.jsx_factory_identifier().map(|s| s.to_string())
+                    })
+                    .flatten();
+                let fragment_factory = self
+                    .project_layout
+                    .query_tsconfig_for_path(path, |tsconfig| {
+                        tsconfig
+                            .jsx_fragment_factory_identifier()
+                            .map(|s| s.to_string())
+                    })
+                    .flatten();
+                factory.hash(&mut h);
+                fragment_factory.hash(&mut h);
+                h.finish()
+            } else {
+                0
+            };
+
+        // 4. filter_hash: only/skip/enabled_selectors from the command invocation.
+        let filter_hash = {
+            let mut h = FxHasher::default();
+            if let Some(only) = self.only {
+                for selector in only {
+                    selector.hash(&mut h);
+                }
+            }
+            if let Some(skip) = self.skip {
+                for selector in skip {
+                    selector.hash(&mut h);
+                }
+            }
+            if let Some(enabled) = self.enabled_selectors {
+                for selector in enabled {
+                    selector.hash(&mut h);
+                }
+            }
+            h.finish()
+        };
+
+        Some(AnalyzerCacheKey {
+            override_indices,
+            manifest_id,
+            jsx_factory_hash,
+            filter_hash,
+        })
+    }
+
+    #[must_use]
+    pub(crate) fn finish(self) -> AnalyzerVisitorResult {
+        let key = self.compute_cache_key();
+        // 1. Try cache hit
+        if let Some(cache) = &self.cache
+            && let Some(key) = key.clone()
+            && let Some(cached) = cache.get_entry(&key)
+        {
+            // Cache HIT: apply stored mutations to the builder's owned AnalyzerOptions
+            let mut opts = self.analyzer_options;
+            opts.push_globals(cached.globals.iter().cloned());
+            if let Some(f) = &cached.jsx_factory {
+                opts.set_jsx_factory(Some(f.clone()));
+            }
+            if let Some(f) = &cached.jsx_fragment_factory {
+                opts.set_jsx_fragment_factory(Some(f.clone()));
+            }
+            return AnalyzerVisitorResult {
+                enabled_rules: cached.enabled_rules.clone(),
+                disabled_rules: cached.disabled_rules.clone(),
+                fixable_rules: cached.fixable_rules.clone(),
+                analyzer_options: opts,
+            };
+        }
+
+        let original_options = self.analyzer_options.clone();
         let mut analyzer_options = self.analyzer_options;
         let mut disabled_rules = vec![];
         let mut enabled_rules = vec![];
@@ -2291,18 +2406,419 @@ impl<'b> AnalyzerVisitorBuilder<'b> {
         let mut fixable_rules = linter_fixable_rules;
         fixable_rules.extend(assists_fixable_rules);
 
-        AnalyzerVisitorResult {
+        let result = AnalyzerVisitorResult {
             enabled_rules,
             disabled_rules,
             analyzer_options,
             fixable_rules,
+        };
+
+        if let Some(key) = key.as_ref()
+            && let Some(cache) = self.cache.as_ref()
+        {
+            let cached = CachedRuleSet::extract_from(&result, &original_options);
+            cache.insert_entry(key.clone(), cached);
+        }
+
+        result
+    }
+}
+
+/// Reusable cache when building the [AnalysisFilter]
+#[derive(Debug, Default)]
+pub(crate) struct AnalyzerVisitorCache(HashMap<AnalyzerCacheKey, Arc<CachedRuleSet>>);
+
+impl AnalyzerVisitorCache {
+    // NOTE: for now, we want to have a more conservative approach.
+    // We don't know what's the effect of the cache on the daemon, considering that it can hold multiple projects.
+    /// Max entries for the current cache
+    const MAX_ENTRIES: usize = 256;
+
+    /// Evicts all entries from the current cache
+    pub(crate) fn evict_cache(&self) {
+        self.0.pin().clear();
+    }
+
+    pub(crate) fn get_entry(&self, key: &AnalyzerCacheKey) -> Option<Arc<CachedRuleSet>> {
+        self.0.pin().get(key).cloned()
+    }
+    pub(crate) fn insert_entry(&self, key: AnalyzerCacheKey, entry: CachedRuleSet) {
+        if self.0.len() > Self::MAX_ENTRIES {
+            self.evict_cache();
+        }
+
+        self.0.pin().insert(key, Arc::new(entry));
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+pub(crate) struct AnalyzerCacheKey {
+    /// Which override patterns matched (indices into settings overrides).
+    override_indices: Vec<usize>,
+    /// Identity of the nearest package.json (path hash, or None).
+    manifest_id: Option<u64>,
+    /// JSX factory + fragment factory from tsconfig (if ReactClassic).
+    jsx_factory_hash: u64,
+    /// Hash of only/skip/enabled_selectors (constant within a batch).
+    filter_hash: u64,
+}
+
+/// The cacheable output
+#[derive(Debug, Clone)]
+pub(crate) struct CachedRuleSet {
+    pub(crate) enabled_rules: Vec<RuleFilter<'static>>,
+    pub(crate) disabled_rules: Vec<RuleFilter<'static>>,
+    pub(crate) fixable_rules: Vec<RuleFilter<'static>>,
+    /// Globals added during domain/manifest resolution.
+    pub(crate) globals: Vec<Box<str>>,
+    /// JSX factory from tsconfig (None if not ReactClassic or not resolved).
+    pub(crate) jsx_factory: Option<Box<str>>,
+    pub(crate) jsx_fragment_factory: Option<Box<str>>,
+}
+
+impl CachedRuleSet {
+    fn extract_from(result: &AnalyzerVisitorResult, options: &AnalyzerOptions) -> Self {
+        Self {
+            enabled_rules: result.enabled_rules.clone(),
+            disabled_rules: result.disabled_rules.clone(),
+            fixable_rules: result.fixable_rules.clone(),
+            globals: options
+                .globals()
+                .iter()
+                .map(|s| s.to_string().into_boxed_str())
+                .collect::<Vec<_>>(),
+            jsx_factory: options
+                .jsx_factory()
+                .map(|s| s.to_string().into_boxed_str()),
+            jsx_fragment_factory: options
+                .jsx_fragment_factory()
+                .map(|s| s.to_string().into_boxed_str()),
         }
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::{DocumentFileSource, Features};
     use camino::Utf8Path;
+
+    mod analyzer_cache {
+        use super::super::{
+            AnalyzerCacheKey, AnalyzerVisitorBuilder, AnalyzerVisitorCache, CachedRuleSet,
+        };
+        use biome_analyze::{AnalyzerOptions, RuleFilter};
+        use biome_project_layout::ProjectLayout;
+        use camino::Utf8Path;
+        use std::sync::Arc;
+
+        use crate::settings::Settings;
+
+        #[test]
+        fn insert_and_retrieve_entry() {
+            let cache = AnalyzerVisitorCache::default();
+            let key = AnalyzerCacheKey {
+                override_indices: vec![],
+                manifest_id: None,
+                jsx_factory_hash: 0,
+                filter_hash: 0,
+            };
+            let entry = CachedRuleSet {
+                enabled_rules: vec![RuleFilter::Rule("style", "noVar")],
+                disabled_rules: vec![],
+                fixable_rules: vec![],
+                globals: vec![],
+                jsx_factory: None,
+                jsx_fragment_factory: None,
+            };
+
+            cache.insert_entry(key.clone(), entry);
+
+            let retrieved = cache.get_entry(&key);
+            assert!(retrieved.is_some());
+            let retrieved = retrieved.unwrap();
+            assert_eq!(retrieved.enabled_rules.len(), 1);
+            assert_eq!(
+                retrieved.enabled_rules[0],
+                RuleFilter::Rule("style", "noVar")
+            );
+        }
+
+        #[test]
+        fn different_keys_produce_separate_entries() {
+            let cache = AnalyzerVisitorCache::default();
+            let key_a = AnalyzerCacheKey {
+                override_indices: vec![0],
+                manifest_id: None,
+                jsx_factory_hash: 0,
+                filter_hash: 0,
+            };
+            let key_b = AnalyzerCacheKey {
+                override_indices: vec![1],
+                manifest_id: None,
+                jsx_factory_hash: 0,
+                filter_hash: 0,
+            };
+
+            cache.insert_entry(
+                key_a.clone(),
+                CachedRuleSet {
+                    enabled_rules: vec![RuleFilter::Rule("style", "noVar")],
+                    disabled_rules: vec![],
+                    fixable_rules: vec![],
+                    globals: vec![],
+                    jsx_factory: None,
+                    jsx_fragment_factory: None,
+                },
+            );
+            cache.insert_entry(
+                key_b.clone(),
+                CachedRuleSet {
+                    enabled_rules: vec![RuleFilter::Rule("correctness", "noUnusedVariables")],
+                    disabled_rules: vec![],
+                    fixable_rules: vec![],
+                    globals: vec![],
+                    jsx_factory: None,
+                    jsx_fragment_factory: None,
+                },
+            );
+
+            let a = cache.get_entry(&key_a).unwrap();
+            let b = cache.get_entry(&key_b).unwrap();
+            assert_eq!(a.enabled_rules[0], RuleFilter::Rule("style", "noVar"));
+            assert_eq!(
+                b.enabled_rules[0],
+                RuleFilter::Rule("correctness", "noUnusedVariables")
+            );
+        }
+
+        #[test]
+        fn evict_cache_clears_all_entries() {
+            let cache = AnalyzerVisitorCache::default();
+            let key = AnalyzerCacheKey {
+                override_indices: vec![],
+                manifest_id: None,
+                jsx_factory_hash: 0,
+                filter_hash: 0,
+            };
+            cache.insert_entry(
+                key.clone(),
+                CachedRuleSet {
+                    enabled_rules: vec![],
+                    disabled_rules: vec![],
+                    fixable_rules: vec![],
+                    globals: vec![],
+                    jsx_factory: None,
+                    jsx_fragment_factory: None,
+                },
+            );
+
+            assert!(cache.get_entry(&key).is_some());
+            cache.evict_cache();
+            assert!(cache.get_entry(&key).is_none());
+        }
+
+        #[test]
+        fn max_entries_triggers_eviction() {
+            let cache = AnalyzerVisitorCache::default();
+
+            // Insert MAX_ENTRIES + 2 entries. Eviction triggers on the (MAX_ENTRIES+2)th
+            // insert because `len() > MAX_ENTRIES` is checked before each insert.
+            for i in 0..=(AnalyzerVisitorCache::MAX_ENTRIES + 1) {
+                let key = AnalyzerCacheKey {
+                    override_indices: vec![i],
+                    manifest_id: None,
+                    jsx_factory_hash: 0,
+                    filter_hash: 0,
+                };
+                cache.insert_entry(
+                    key,
+                    CachedRuleSet {
+                        enabled_rules: vec![],
+                        disabled_rules: vec![],
+                        fixable_rules: vec![],
+                        globals: vec![],
+                        jsx_factory: None,
+                        jsx_fragment_factory: None,
+                    },
+                );
+            }
+
+            // After eviction, only the last inserted entry should remain.
+            let first_key = AnalyzerCacheKey {
+                override_indices: vec![0],
+                manifest_id: None,
+                jsx_factory_hash: 0,
+                filter_hash: 0,
+            };
+            assert!(
+                cache.get_entry(&first_key).is_none(),
+                "early entries should be evicted after exceeding MAX_ENTRIES"
+            );
+
+            // The last entry (inserted after the clear) should exist.
+            let last_key = AnalyzerCacheKey {
+                override_indices: vec![AnalyzerVisitorCache::MAX_ENTRIES + 1],
+                manifest_id: None,
+                jsx_factory_hash: 0,
+                filter_hash: 0,
+            };
+            assert!(
+                cache.get_entry(&last_key).is_some(),
+                "entry inserted after eviction should be present"
+            );
+        }
+
+        #[test]
+        fn same_path_produces_same_cache_key() {
+            let settings = Settings::default();
+            let project_layout = Arc::new(ProjectLayout::default());
+            let options = AnalyzerOptions::default();
+            let path = Utf8Path::new("src/index.ts");
+
+            let builder_a = AnalyzerVisitorBuilder::new(&settings, options.clone())
+                .with_path(path)
+                .with_project_layout(project_layout.clone());
+            let key_a = builder_a.compute_cache_key();
+
+            let builder_b = AnalyzerVisitorBuilder::new(&settings, options)
+                .with_path(path)
+                .with_project_layout(project_layout);
+            let key_b = builder_b.compute_cache_key();
+
+            assert_eq!(key_a, key_b);
+        }
+
+        #[test]
+        fn different_only_filters_produce_different_keys() {
+            use biome_configuration::analyzer::AnalyzerSelector;
+            use std::str::FromStr;
+
+            let settings = Settings::default();
+            let project_layout = Arc::new(ProjectLayout::default());
+            let path = Utf8Path::new("src/index.ts");
+
+            let only_a: Vec<AnalyzerSelector> = vec![];
+            let builder_a = AnalyzerVisitorBuilder::new(&settings, AnalyzerOptions::default())
+                .with_path(path)
+                .with_only(&only_a)
+                .with_project_layout(project_layout.clone());
+            let key_a = builder_a.compute_cache_key();
+
+            let only_b = vec![AnalyzerSelector::from_str("lint/suspicious/noVar").unwrap()];
+            let builder_b = AnalyzerVisitorBuilder::new(&settings, AnalyzerOptions::default())
+                .with_path(path)
+                .with_only(&only_b)
+                .with_project_layout(project_layout);
+            let key_b = builder_b.compute_cache_key();
+
+            assert_ne!(key_a, key_b);
+        }
+
+        #[test]
+        fn no_path_returns_none_key() {
+            let settings = Settings::default();
+            let builder = AnalyzerVisitorBuilder::new(&settings, AnalyzerOptions::default());
+            assert!(builder.compute_cache_key().is_none());
+        }
+
+        #[test]
+        fn cache_hit_applies_globals_from_cached_entry() {
+            let cache = AnalyzerVisitorCache::default();
+            let settings = Settings::default();
+            let project_layout = Arc::new(ProjectLayout::default());
+            let path = Utf8Path::new("src/index.ts");
+
+            let key = AnalyzerCacheKey {
+                override_indices: vec![],
+                manifest_id: None,
+                jsx_factory_hash: 0,
+                filter_hash: 0,
+            };
+            cache.insert_entry(
+                key,
+                CachedRuleSet {
+                    enabled_rules: vec![RuleFilter::Rule("style", "noVar")],
+                    disabled_rules: vec![],
+                    fixable_rules: vec![],
+                    globals: vec!["React".into(), "JSX".into()],
+                    jsx_factory: Some("h".into()),
+                    jsx_fragment_factory: Some("Fragment".into()),
+                },
+            );
+
+            let result = AnalyzerVisitorBuilder::new(&settings, AnalyzerOptions::default())
+                .with_path(path)
+                .with_project_layout(project_layout)
+                .with_cache(&cache)
+                .finish();
+
+            assert_eq!(
+                result.enabled_rules,
+                vec![RuleFilter::Rule("style", "noVar")]
+            );
+            assert!(result.analyzer_options.globals().contains(&"React".into()));
+            assert!(result.analyzer_options.globals().contains(&"JSX".into()));
+            assert_eq!(result.analyzer_options.jsx_factory(), Some("h"));
+            assert_eq!(
+                result.analyzer_options.jsx_fragment_factory(),
+                Some("Fragment")
+            );
+        }
+
+        #[test]
+        fn cache_miss_populates_cache_for_next_call() {
+            let cache = AnalyzerVisitorCache::default();
+            let settings = Settings::default();
+            let project_layout = Arc::new(ProjectLayout::default());
+            let path = Utf8Path::new("src/index.ts");
+
+            // First call — cache miss, populates the cache
+            let result_a = AnalyzerVisitorBuilder::new(&settings, AnalyzerOptions::default())
+                .with_path(path)
+                .with_project_layout(project_layout.clone())
+                .with_cache(&cache)
+                .finish();
+
+            // Second call — should be a cache hit with identical result
+            let result_b = AnalyzerVisitorBuilder::new(&settings, AnalyzerOptions::default())
+                .with_path(path)
+                .with_project_layout(project_layout)
+                .with_cache(&cache)
+                .finish();
+
+            assert_eq!(result_a.enabled_rules, result_b.enabled_rules);
+            assert_eq!(result_a.disabled_rules, result_b.disabled_rules);
+            assert_eq!(result_a.fixable_rules, result_b.fixable_rules);
+        }
+
+        #[test]
+        fn filter_hash_distinguishes_skip_from_empty() {
+            use biome_configuration::analyzer::AnalyzerSelector;
+            use std::str::FromStr;
+
+            let settings = Settings::default();
+            let project_layout = Arc::new(ProjectLayout::default());
+            let path = Utf8Path::new("src/index.ts");
+
+            let empty: Vec<AnalyzerSelector> = vec![];
+            let builder_no_skip =
+                AnalyzerVisitorBuilder::new(&settings, AnalyzerOptions::default())
+                    .with_path(path)
+                    .with_skip(&empty)
+                    .with_project_layout(project_layout.clone());
+            let key_no_skip = builder_no_skip.compute_cache_key();
+
+            let skip = vec![AnalyzerSelector::from_str("lint/suspicious/noVar").unwrap()];
+            let builder_with_skip =
+                AnalyzerVisitorBuilder::new(&settings, AnalyzerOptions::default())
+                    .with_path(path)
+                    .with_skip(&skip)
+                    .with_project_layout(project_layout);
+            let key_with_skip = builder_with_skip.compute_cache_key();
+
+            assert_ne!(key_no_skip, key_with_skip);
+        }
+    }
 
     #[test]
     fn markdown_file_source_detection_and_capabilities() {

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -1174,6 +1174,7 @@ pub(crate) struct CodeActionsParams<'a> {
     pub(crate) compute_actions: bool,
     // Services attached to the current embedded snippet, when actions are run on snippets.
     pub(crate) snippet_services: Option<&'a DocumentServices>,
+    pub(crate) analyzer_cache: AnalyzerVisitorCache,
 }
 
 pub(crate) struct UpdateSnippetsNodes {
@@ -2314,7 +2315,6 @@ impl<'b> AnalyzerVisitorBuilder<'b> {
             };
         }
 
-        let original_options = self.analyzer_options.clone();
         let mut analyzer_options = self.analyzer_options;
         let mut disabled_rules = vec![];
         let mut enabled_rules = vec![];
@@ -2416,7 +2416,7 @@ impl<'b> AnalyzerVisitorBuilder<'b> {
         if let Some(key) = key.as_ref()
             && let Some(cache) = self.cache.as_ref()
         {
-            let cached = CachedRuleSet::extract_from(&result, &original_options);
+            let cached = CachedRuleSet::extract_from(&result);
             cache.insert_entry(key.clone(), cached);
         }
 
@@ -2477,20 +2477,23 @@ pub(crate) struct CachedRuleSet {
 }
 
 impl CachedRuleSet {
-    fn extract_from(result: &AnalyzerVisitorResult, options: &AnalyzerOptions) -> Self {
+    fn extract_from(result: &AnalyzerVisitorResult) -> Self {
         Self {
             enabled_rules: result.enabled_rules.clone(),
             disabled_rules: result.disabled_rules.clone(),
             fixable_rules: result.fixable_rules.clone(),
-            globals: options
+            globals: result
+                .analyzer_options
                 .globals()
                 .iter()
                 .map(|s| s.to_string().into_boxed_str())
                 .collect::<Vec<_>>(),
-            jsx_factory: options
+            jsx_factory: result
+                .analyzer_options
                 .jsx_factory()
                 .map(|s| s.to_string().into_boxed_str()),
-            jsx_fragment_factory: options
+            jsx_fragment_factory: result
+                .analyzer_options
                 .jsx_fragment_factory()
                 .map(|s| s.to_string().into_boxed_str()),
         }

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1540,6 +1540,7 @@ impl Workspace for WorkspaceServer {
         self.module_graph.unload_path(&project_path);
         self.project_layout.unload_folder(&project_path);
         self.plugin_caches.pin().remove(&project_path);
+        self.analyzer_cache.pin().remove(&params.project_key);
 
         Ok(())
     }

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -4,8 +4,9 @@ use crate::configuration::{LoadedConfiguration, ProjectScanComputer, read_config
 use crate::diagnostics::{FileTooLarge, NoIgnoreFileFound, VcsDiagnostic};
 use crate::file_handlers::svelte::SvelteFileHandler;
 use crate::file_handlers::{
-    Capabilities, CodeActionsParams, DiagnosticsAndActionsParams, DocumentFileSource, Features,
-    FixAllParams, FormatEmbedNode, LintParams, LintResults, ParseResult, UpdateSnippetsNodes,
+    AnalyzerVisitorCache, Capabilities, CodeActionsParams, DiagnosticsAndActionsParams,
+    DocumentFileSource, Features, FixAllParams, FormatEmbedNode, LintParams, LintResults,
+    ParseResult, UpdateSnippetsNodes,
 };
 use crate::projects::{GetFileFeaturesParams, ProjectKey, Projects};
 use crate::scanner::{
@@ -128,6 +129,9 @@ pub struct WorkspaceServer {
 
     /// Channel sender for sending notifications of service data updates.
     notification_tx: watch::Sender<ServiceNotification>,
+
+    /// Re-usable cache for analyzer visitors.
+    analyzer_cache: AnalyzerVisitorCache,
 }
 
 /// The `Workspace` object is long-lived, so we want it to be able to cross
@@ -161,6 +165,7 @@ impl WorkspaceServer {
             scanner: Scanner::new(watcher_tx),
             fs,
             notification_tx,
+            analyzer_cache: AnalyzerVisitorCache::default(),
         }
     }
 
@@ -1123,6 +1128,7 @@ impl WorkspaceServer {
                     self.project_layout.remove_package(&package_path);
                 }
             }
+            self.analyzer_cache.evict_cache();
         } else if filename.is_some_and(|filename| filename == "tsconfig.json") {
             let package_path = path
                 .parent()
@@ -1139,6 +1145,7 @@ impl WorkspaceServer {
                         .remove_tsconfig_from_package(&package_path);
                 }
             }
+            self.analyzer_cache.evict_cache();
         } else if let Some(turbo_filename) =
             filename.filter(|f| *f == "turbo.json" || *f == "turbo.jsonc")
         {
@@ -1492,6 +1499,8 @@ impl Workspace for WorkspaceServer {
                 self.refresh_pnpm_workspace_catalogs_for_scope(project_key, project_path.as_path());
             }
         }
+
+        self.analyzer_cache.evict_cache();
 
         Ok(UpdateSettingsResult { diagnostics })
     }
@@ -2011,6 +2020,7 @@ impl Workspace for WorkspaceServer {
                 max_diagnostics,
                 diagnostic_level,
                 enforce_assist,
+                analyzer_cache: &self.analyzer_cache,
             });
 
             let LintResults {
@@ -2051,6 +2061,7 @@ impl Workspace for WorkspaceServer {
                     max_diagnostics,
                     diagnostic_level,
                     enforce_assist,
+                    analyzer_cache: &self.analyzer_cache,
                 });
 
                 diagnostics.extend(results.diagnostics);

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -131,7 +131,7 @@ pub struct WorkspaceServer {
     notification_tx: watch::Sender<ServiceNotification>,
 
     /// Re-usable cache for analyzer visitors.
-    analyzer_cache: AnalyzerVisitorCache,
+    analyzer_cache: HashMap<ProjectKey, AnalyzerVisitorCache>,
 }
 
 /// The `Workspace` object is long-lived, so we want it to be able to cross
@@ -165,7 +165,7 @@ impl WorkspaceServer {
             scanner: Scanner::new(watcher_tx),
             fs,
             notification_tx,
-            analyzer_cache: AnalyzerVisitorCache::default(),
+            analyzer_cache: HashMap::default(),
         }
     }
 
@@ -1128,7 +1128,9 @@ impl WorkspaceServer {
                     self.project_layout.remove_package(&package_path);
                 }
             }
-            self.analyzer_cache.evict_cache();
+            if let Some(cache) = self.analyzer_cache.pin().get(&project_key) {
+                cache.evict_cache();
+            }
         } else if filename.is_some_and(|filename| filename == "tsconfig.json") {
             let package_path = path
                 .parent()
@@ -1145,7 +1147,9 @@ impl WorkspaceServer {
                         .remove_tsconfig_from_package(&package_path);
                 }
             }
-            self.analyzer_cache.evict_cache();
+            if let Some(cache) = self.analyzer_cache.pin().get(&project_key) {
+                cache.evict_cache();
+            }
         } else if let Some(turbo_filename) =
             filename.filter(|f| *f == "turbo.json" || *f == "turbo.jsonc")
         {
@@ -1322,6 +1326,9 @@ impl Workspace for WorkspaceServer {
         };
 
         let project_key = self.projects.insert_project(path);
+        self.analyzer_cache
+            .pin()
+            .insert(project_key, Default::default());
 
         Ok(OpenProjectResult { project_key })
     }
@@ -1500,7 +1507,9 @@ impl Workspace for WorkspaceServer {
             }
         }
 
-        self.analyzer_cache.evict_cache();
+        if let Some(cache) = self.analyzer_cache.pin().get(&project_key) {
+            cache.evict_cache();
+        }
 
         Ok(UpdateSettingsResult { diagnostics })
     }
@@ -1985,6 +1994,10 @@ impl Workspace for WorkspaceServer {
             .filter(|d| d.severity() >= Severity::Error)
             .count();
 
+        let analyzer_cache_guard = self.analyzer_cache.pin();
+        let analyzer_cache =
+            analyzer_cache_guard.get_or_insert(project_key, AnalyzerVisitorCache::default());
+
         let (diagnostics, errors, warnings, infos, skipped_diagnostics) = if (categories.is_lint()
             || categories.is_assist())
             && let Some(lint) = capabilities.analyzer.lint
@@ -2020,7 +2033,7 @@ impl Workspace for WorkspaceServer {
                 max_diagnostics,
                 diagnostic_level,
                 enforce_assist,
-                analyzer_cache: &self.analyzer_cache,
+                analyzer_cache,
             });
 
             let LintResults {
@@ -2061,7 +2074,7 @@ impl Workspace for WorkspaceServer {
                     max_diagnostics,
                     diagnostic_level,
                     enforce_assist,
-                    analyzer_cache: &self.analyzer_cache,
+                    analyzer_cache,
                 });
 
                 diagnostics.extend(results.diagnostics);
@@ -2281,6 +2294,7 @@ impl Workspace for WorkspaceServer {
             working_directory: Some(working_directory.as_path()),
             compute_actions,
             snippet_services: None,
+            analyzer_cache: AnalyzerVisitorCache::default(),
         });
 
         for embedded_snippet in &embedded_snippets {
@@ -2311,6 +2325,7 @@ impl Workspace for WorkspaceServer {
                 working_directory: Some(working_directory.as_path()),
                 compute_actions,
                 snippet_services: Some(embedded_snippet.as_snippet_services()),
+                analyzer_cache: AnalyzerVisitorCache::default(),
             });
 
             result.actions.extend(embedded_actions_result.actions);

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -2274,6 +2274,9 @@ impl Workspace for WorkspaceServer {
         let language =
             self.get_file_source(&path, settings.experimental_full_html_support_enabled());
         let settings = self.settings_handle(&settings, inline_config);
+        let analyzer_cache_guard = self.analyzer_cache.pin();
+        let analyzer_cache =
+            analyzer_cache_guard.get_or_insert(project_key, AnalyzerVisitorCache::default());
 
         let mut result = code_actions(CodeActionsParams {
             parse,
@@ -2294,7 +2297,7 @@ impl Workspace for WorkspaceServer {
             working_directory: Some(working_directory.as_path()),
             compute_actions,
             snippet_services: None,
-            analyzer_cache: AnalyzerVisitorCache::default(),
+            analyzer_cache,
         });
 
         for embedded_snippet in &embedded_snippets {
@@ -2325,7 +2328,7 @@ impl Workspace for WorkspaceServer {
                 working_directory: Some(working_directory.as_path()),
                 compute_actions,
                 snippet_services: Some(embedded_snippet.as_snippet_services()),
-                analyzer_cache: AnalyzerVisitorCache::default(),
+                analyzer_cache,
             });
 
             result.actions.extend(embedded_actions_result.actions);


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a caching strategy for the computed `AnalysisFilter`. This little guy is computed **every time** for each file that gets linted/fixed, however it's always the same on project level, so there's no reason to compute it every single time.

The cache is saved in the workspace, and it's lock-free. The cache key is computed using the following information:
- the rules applied via `--only`, `--skip` and `enabled_selectors` (the configuration)
- the overrides, specifically the list of overrides that matches the given path. We save their index.
- the manifests (`package.json` and `tsconfig.json`), because they influence the globals and enabled rules
- the values of JSX factory, it changes how rules behave


I discovered the information with the help of an AI agent, but wrote the code myself. Tests were generated via AI.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new unit tests for the cache.
Manually tested (dev mode) within the Astro monorepo and I haven't see any regressions in terms of linting result (no regressions).

<!-- What demonstrates that your implementation is correct? -->

## Docs

I didn't add a changeset because there's not proof (yet) of increased performance, because the saving is theoretical. Unless I can prove it, I don't think it's worth having one. 

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
