### PR TITLE
fix(organizeImports): error on unknown predefined groups

### DIFF
--- a/.changeset/hungry-parts-enter.md
+++ b/.changeset/hungry-parts-enter.md
@@ -1,0 +1,19 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10185](https://github.com/biomejs/biome/issues/10185). [`organizeImports](https://biomejs.dev/assist/actions/organize-imports/) now errors when it encounters an inexistent predefine group.
+
+The following configuration is now reported as invalid because `:INEXISTENT:` is an unknown predefined group.
+
+```json
+{
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": { "options": { "groups": [":INEXISTENT:"] } }
+      }
+    }
+  }
+}
+```

--- a/.changeset/hungry-parts-enter.md
+++ b/.changeset/hungry-parts-enter.md
@@ -2,7 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10185](https://github.com/biomejs/biome/issues/10185). [`organizeImports](https://biomejs.dev/assist/actions/organize-imports/) now errors when it encounters an inexistent predefine group.
+Fixed [#10185](https://github.com/biomejs/biome/issues/10185). [`organizeImports](https://biomejs.dev/assist/actions/organize-imports/) now errors when it encounters an unknown predefined group.
 
 The following configuration is now reported as invalid because `:INEXISTENT:` is an unknown predefined group.
 

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -201,6 +201,8 @@ declare_source_rule! {
     /// import type { T } from "@my/lib";
     /// ```
     ///
+    /// The `source` field accepts predefined groups and glob patterns.
+    ///
     /// ### `identifierOrder`
     ///
     /// By default, attributes, imported and exported names are sorted with a `natural` sort order.

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/invalid-config-inexistent-predef-group.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/invalid-config-inexistent-predef-group.js.snap
@@ -11,76 +11,74 @@ expression: invalid-config-inexistent-predef-group.js
 ```
 invalid-config-inexistent-predef-group.options:10:15 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The predefined group :ANYthing: doesn't exist.
-
+  × The predefined group :ANYthing: doesn't exist. Use a known predefined group.
+  
      8 │           "options": {
      9 │             "groups": [
   > 10 │               ":ANYthing:",
        │               ^^^^^^^^^^^^
     11 │               "!:ANYthing:",
     12 │               {
-
+  
 
 ```
 
 ```
 invalid-config-inexistent-predef-group.options:11:15 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The predefined group :ANYthing: doesn't exist.
-
+  × The predefined group :ANYthing: doesn't exist. Use a known predefined group.
+  
      9 │             "groups": [
     10 │               ":ANYthing:",
   > 11 │               "!:ANYthing:",
        │               ^^^^^^^^^^^^^
     12 │               {
     13 │                 "source": ":ANYthing:"
-
+  
 
 ```
 
 ```
 invalid-config-inexistent-predef-group.options:13:27 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The predefined group :ANYthing: doesn't exist.
-
+  × The predefined group :ANYthing: doesn't exist. Use a known predefined group.
+  
     11 │               "!:ANYthing:",
     12 │               {
   > 13 │                 "source": ":ANYthing:"
        │                           ^^^^^^^^^^^^
     14 │               },
     15 │               {
-
+  
 
 ```
 
 ```
 invalid-config-inexistent-predef-group.options:16:27 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The predefined group :ANYthing: doesn't exist.
-
+  × The predefined group :ANYthing: doesn't exist. Use a known predefined group.
+  
     14 │               },
     15 │               {
   > 16 │                 "source": "!:ANYthing:"
        │                           ^^^^^^^^^^^^^
     17 │               },
     18 │               {
-
+  
 
 ```
 
 ```
 invalid-config-inexistent-predef-group.options:21:19 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × :BLANK_LINE: is not a source matcher and thus it cannot be placed in source.
-
+  × :BLANK_LINE: isn't valid in this position. Remove it.
+  
     19 │                 "source": [
     20 │                   ":NODE:",
   > 21 │                   ":BLANK_LINE:"
        │                   ^^^^^^^^^^^^^^
     22 │                 ]
     23 │               }
-
-  i :BLANK_LINE: can only be placed as an eleemtn of the groups array.
-
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/invalid-config-inexistent-predef-group.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/invalid-config-inexistent-predef-group.js.snap
@@ -12,14 +12,14 @@ expression: invalid-config-inexistent-predef-group.js
 invalid-config-inexistent-predef-group.options:10:15 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The predefined group :ANYthing: doesn't exist.
-  
+
      8 │           "options": {
      9 │             "groups": [
   > 10 │               ":ANYthing:",
        │               ^^^^^^^^^^^^
     11 │               "!:ANYthing:",
     12 │               {
-  
+
 
 ```
 
@@ -27,14 +27,14 @@ invalid-config-inexistent-predef-group.options:10:15 deserialize ━━━━━
 invalid-config-inexistent-predef-group.options:11:15 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The predefined group :ANYthing: doesn't exist.
-  
+
      9 │             "groups": [
     10 │               ":ANYthing:",
   > 11 │               "!:ANYthing:",
        │               ^^^^^^^^^^^^^
     12 │               {
     13 │                 "source": ":ANYthing:"
-  
+
 
 ```
 
@@ -42,14 +42,14 @@ invalid-config-inexistent-predef-group.options:11:15 deserialize ━━━━━
 invalid-config-inexistent-predef-group.options:13:27 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The predefined group :ANYthing: doesn't exist.
-  
+
     11 │               "!:ANYthing:",
     12 │               {
   > 13 │                 "source": ":ANYthing:"
        │                           ^^^^^^^^^^^^
     14 │               },
     15 │               {
-  
+
 
 ```
 
@@ -57,14 +57,14 @@ invalid-config-inexistent-predef-group.options:13:27 deserialize ━━━━━
 invalid-config-inexistent-predef-group.options:16:27 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The predefined group :ANYthing: doesn't exist.
-  
+
     14 │               },
     15 │               {
   > 16 │                 "source": "!:ANYthing:"
        │                           ^^^^^^^^^^^^^
     17 │               },
     18 │               {
-  
+
 
 ```
 
@@ -72,15 +72,15 @@ invalid-config-inexistent-predef-group.options:16:27 deserialize ━━━━━
 invalid-config-inexistent-predef-group.options:21:19 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × :BLANK_LINE: is not a source matcher and thus it cannot be placed in source.
-  
+
     19 │                 "source": [
     20 │                   ":NODE:",
   > 21 │                   ":BLANK_LINE:"
        │                   ^^^^^^^^^^^^^^
     22 │                 ]
     23 │               }
-  
-  i :BLANK_LINE: can only be placed as an eleemtn of of the groups array.
-  
+
+  i :BLANK_LINE: can only be placed as an eleemtn of the groups array.
+
 
 ```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/invalid-config-inexistent-predef-group.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/invalid-config-inexistent-predef-group.js.snap
@@ -1,0 +1,86 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-config-inexistent-predef-group.js
+---
+# Input
+```js
+
+```
+
+# Diagnostics
+```
+invalid-config-inexistent-predef-group.options:10:15 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The predefined group :ANYthing: doesn't exist.
+  
+     8 │           "options": {
+     9 │             "groups": [
+  > 10 │               ":ANYthing:",
+       │               ^^^^^^^^^^^^
+    11 │               "!:ANYthing:",
+    12 │               {
+  
+
+```
+
+```
+invalid-config-inexistent-predef-group.options:11:15 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The predefined group :ANYthing: doesn't exist.
+  
+     9 │             "groups": [
+    10 │               ":ANYthing:",
+  > 11 │               "!:ANYthing:",
+       │               ^^^^^^^^^^^^^
+    12 │               {
+    13 │                 "source": ":ANYthing:"
+  
+
+```
+
+```
+invalid-config-inexistent-predef-group.options:13:27 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The predefined group :ANYthing: doesn't exist.
+  
+    11 │               "!:ANYthing:",
+    12 │               {
+  > 13 │                 "source": ":ANYthing:"
+       │                           ^^^^^^^^^^^^
+    14 │               },
+    15 │               {
+  
+
+```
+
+```
+invalid-config-inexistent-predef-group.options:16:27 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The predefined group :ANYthing: doesn't exist.
+  
+    14 │               },
+    15 │               {
+  > 16 │                 "source": "!:ANYthing:"
+       │                           ^^^^^^^^^^^^^
+    17 │               },
+    18 │               {
+  
+
+```
+
+```
+invalid-config-inexistent-predef-group.options:21:19 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × :BLANK_LINE: is not a source matcher and thus it cannot be placed in source.
+  
+    19 │                 "source": [
+    20 │                   ":NODE:",
+  > 21 │                   ":BLANK_LINE:"
+       │                   ^^^^^^^^^^^^^^
+    22 │                 ]
+    23 │               }
+  
+  i :BLANK_LINE: can only be placed as an eleemtn of of the groups array.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/invalid-config-inexistent-predef-group.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/invalid-config-inexistent-predef-group.options.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              ":ANYthing:",
+              "!:ANYthing:",
+              {
+                "source": ":ANYthing:"
+              },
+              {
+                "source": "!:ANYthing:"
+              },
+              {
+                "source": [
+                  ":NODE:",
+                  ":BLANK_LINE:"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_rule_options/src/organize_imports/import_groups.rs
+++ b/crates/biome_rule_options/src/organize_imports/import_groups.rs
@@ -1,4 +1,5 @@
-use biome_deserialize::{Deserializable, DeserializationContext, Text};
+use biome_console::markup;
+use biome_deserialize::{Deserializable, DeserializationContext, DeserializationDiagnostic, Text};
 use biome_deserialize_macros::Deserializable;
 use biome_glob::{CandidatePath, Glob};
 use biome_resolver::is_builtin_node_module;
@@ -254,7 +255,31 @@ impl biome_deserialize::Deserializable for SourceMatcher {
     ) -> Option<Self> {
         let text = biome_deserialize::Text::deserialize(ctx, value, name)?;
         if text.ends_with(':') && (text.starts_with(':') || text.starts_with("!:")) {
-            text.parse().ok().map(SourceMatcher::Predefined)
+            match text.parse() {
+                Ok(predefined_group) => Some(SourceMatcher::Predefined(predefined_group)),
+                Err(_error) => {
+                    let diagnostic = if text == ":BLANK_LINE:" {
+                        DeserializationDiagnostic::new(markup! {
+                            <Emphasis>{":BLANK_LINE:"}</Emphasis>
+                            " is not a source matcher and thus it cannot be placed in "
+                            <Emphasis>{"source"}</Emphasis>"."
+                        })
+                        .with_note(markup! {
+                            <Emphasis>{":BLANK_LINE:"}</Emphasis>
+                            " can only be placed as an eleemtn of of the "
+                            <Emphasis>{"groups"}</Emphasis>" array."
+                        })
+                    } else {
+                        DeserializationDiagnostic::new(markup! {
+                            "The predefined group "<Emphasis>{
+                                format_args!("{}", text.strip_prefix("!").unwrap_or(&text))
+                            }</Emphasis>" doesn't exist."
+                        })
+                    };
+                    ctx.report(diagnostic.with_range(value.range()));
+                    None
+                }
+            }
         } else {
             Deserializable::deserialize(ctx, value, name).map(SourceMatcher::Glob)
         }

--- a/crates/biome_rule_options/src/organize_imports/import_groups.rs
+++ b/crates/biome_rule_options/src/organize_imports/import_groups.rs
@@ -261,19 +261,15 @@ impl biome_deserialize::Deserializable for SourceMatcher {
                     let diagnostic = if text == ":BLANK_LINE:" {
                         DeserializationDiagnostic::new(markup! {
                             <Emphasis>{":BLANK_LINE:"}</Emphasis>
-                            " is not a source matcher and thus it cannot be placed in "
-                            <Emphasis>{"source"}</Emphasis>"."
-                        })
-                        .with_note(markup! {
-                            <Emphasis>{":BLANK_LINE:"}</Emphasis>
-                            " can only be placed as an eleemtn of the "
-                            <Emphasis>{"groups"}</Emphasis>" array."
+                            " isn't valid in this position. Remove it."
                         })
                     } else {
                         DeserializationDiagnostic::new(markup! {
-                            "The predefined group "<Emphasis>{
+                            "The predefined group "
+                            <Emphasis>{
                                 format_args!("{}", text.strip_prefix("!").unwrap_or(&text))
-                            }</Emphasis>" doesn't exist."
+                            }</Emphasis>
+                            " doesn't exist. Use a known predefined group."
                         })
                     };
                     ctx.report(diagnostic.with_range(value.range()));

--- a/crates/biome_rule_options/src/organize_imports/import_groups.rs
+++ b/crates/biome_rule_options/src/organize_imports/import_groups.rs
@@ -266,7 +266,7 @@ impl biome_deserialize::Deserializable for SourceMatcher {
                         })
                         .with_note(markup! {
                             <Emphasis>{":BLANK_LINE:"}</Emphasis>
-                            " can only be placed as an eleemtn of of the "
+                            " can only be placed as an eleemtn of the "
                             <Emphasis>{"groups"}</Emphasis>" array."
                         })
                     } else {


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/10185

Fix https://github.com/biomejs/biome/issues/10168

`organizeImports`'s option deserialization now errors on unknown predefined groups.

This PR also improves the docs of `organizeImports` documenting what the `source` field accepts.


## Test Plan

I added a test.

## Docs

I added a changeset.