### PR TITLE
fix(format/html): preserve multiline element-only children

### DIFF
--- a/.changeset/ninety-kids-tie.md
+++ b/.changeset/ninety-kids-tie.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9450](https://github.com/biomejs/biome/issues/9450): HTML and Vue element formatting now preserves child line breaks when an element contains another element child on its own line, instead of collapsing the child element onto the same line.

--- a/crates/biome_html_formatter/src/html/auxiliary/element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/element.rs
@@ -4,8 +4,8 @@ use crate::verbatim::{format_html_leading_comments, format_html_leading_comments
 use crate::{html::lists::element_list::FormatHtmlElementList, prelude::*};
 use biome_formatter::{CstFormatContext, FormatRefWithRule, FormatRuleWithOptions, write};
 use biome_html_syntax::{
-    AnyHtmlTagName, HtmlElement, HtmlElementFields, HtmlElementList, HtmlRoot,
-    HtmlSelfClosingElement, HtmlSyntaxToken,
+    AnyHtmlContent, AnyHtmlElement, AnyHtmlTagName, HtmlElement, HtmlElementFields,
+    HtmlElementList, HtmlRoot, HtmlSelfClosingElement, HtmlSyntaxToken,
 };
 use biome_rowan::TokenText;
 use biome_string_case::StrLikeExtension;
@@ -140,7 +140,6 @@ impl FormatHtmlElement {
             .is_some_and(|ancestor| HtmlRoot::can_cast(ancestor.kind()));
         let is_template_element = get_tag_name_text(&tag_name)
             .is_some_and(|tt| tt.to_ascii_lowercase_cow() == "template");
-
         let should_be_verbatim = match tag_name {
             AnyHtmlTagName::HtmlComponentName(_) | AnyHtmlTagName::HtmlMemberName(_) => false,
             AnyHtmlTagName::HtmlTagName(tag_name) => HTML_VERBATIM_TAGS.iter().any(|tag| {
@@ -188,14 +187,12 @@ impl FormatHtmlElement {
         let forces_break_children = should_force_break_content
             // If `<template>` is at the root level, always force multiline formatting of its children.
             || (is_root_element_list && is_template_element)
-            // Nested `<template>` elements with a leading newline
-            // and direct element children should also force multiline, since `<template>` acts
-            // as a structural container in frameworks like Vue/Svelte.
-            // Without a leading newline (e.g. `<template #body><p>foo</p></template>`),
-            // the children stay inline.
-            || (is_template_element
-                && content_has_leading_newline
-                && has_non_text_child(&children));
+            // Elements with a leading newline and direct element children should force
+            // multiline unless they mix text with element children. Without a leading
+            // newline (e.g. `<span><em>foo</em></span>`), the children stay inline.
+            || (content_has_leading_newline
+                && has_non_text_child(&children)
+                && !has_text_child(&children));
 
         // "Borrowing" in this context refers to tokens in nodes that would normally be
         // formatted by that node's formatter, but are instead formatted by a sibling
@@ -348,5 +345,17 @@ fn has_non_text_child(node: &HtmlElementList) -> bool {
     node.iter().any(|child| {
         HtmlElement::can_cast(child.syntax().kind())
             || HtmlSelfClosingElement::can_cast(child.syntax().kind())
+    })
+}
+
+fn has_text_child(node: &HtmlElementList) -> bool {
+    node.iter().any(|child| {
+        let AnyHtmlElement::AnyHtmlContent(AnyHtmlContent::HtmlContent(content)) = child else {
+            return false;
+        };
+
+        content
+            .value_token()
+            .is_ok_and(|token| !token.text_trimmed().is_empty())
     })
 }

--- a/crates/biome_html_formatter/tests/specs/html/vue/preserve-newline-nontext-children.vue
+++ b/crates/biome_html_formatter/tests/specs/html/vue/preserve-newline-nontext-children.vue
@@ -1,0 +1,78 @@
+<template>
+	<Transition name="fade">
+		<BaseLoader v-if="isLoading" />
+	</Transition>
+</template>
+
+<template>
+	<KeepAlive>
+		<UserPanel />
+	</KeepAlive>
+</template>
+
+<template>
+	<Teleport to="body">
+		<UserPanel />
+	</Teleport>
+</template>
+
+<template>
+	<UForm>
+		<BaseLoader v-if="isLoading" />
+	</UForm>
+</template>
+
+<template>
+	<Layout.Header>
+		<UserAvatar />
+	</Layout.Header>
+</template>
+
+<template>
+	<my-widget>
+		<inner-widget />
+	</my-widget>
+</template>
+
+<template>
+	<span>
+		<em>label</em>
+	</span>
+</template>
+
+<template>
+	<Transition name="fade"><BaseLoader v-if="isLoading" /></Transition>
+</template>
+
+<template>
+	<UForm>
+		Submit
+	</UForm>
+</template>
+
+<template>
+	<div>
+		<span>label</span>
+	</div>
+</template>
+
+<template>
+	<UForm>
+		<BaseLoader />
+		<UserPanel />
+	</UForm>
+</template>
+
+<template>
+	<UForm>
+		Before
+		<BaseLoader />
+		After
+	</UForm>
+</template>
+
+<template>
+	<template #default>
+		<UserPanel />
+	</template>
+</template>

--- a/crates/biome_html_formatter/tests/specs/html/vue/preserve-newline-nontext-children.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/vue/preserve-newline-nontext-children.vue.snap
@@ -1,0 +1,172 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
+info: vue/preserve-newline-nontext-children.vue
+---
+
+# Input
+
+```vue
+<template>
+	<Transition name="fade">
+		<BaseLoader v-if="isLoading" />
+	</Transition>
+</template>
+
+<template>
+	<KeepAlive>
+		<UserPanel />
+	</KeepAlive>
+</template>
+
+<template>
+	<Teleport to="body">
+		<UserPanel />
+	</Teleport>
+</template>
+
+<template>
+	<UForm>
+		<BaseLoader v-if="isLoading" />
+	</UForm>
+</template>
+
+<template>
+	<Layout.Header>
+		<UserAvatar />
+	</Layout.Header>
+</template>
+
+<template>
+	<my-widget>
+		<inner-widget />
+	</my-widget>
+</template>
+
+<template>
+	<span>
+		<em>label</em>
+	</span>
+</template>
+
+<template>
+	<Transition name="fade"><BaseLoader v-if="isLoading" /></Transition>
+</template>
+
+<template>
+	<UForm>
+		Submit
+	</UForm>
+</template>
+
+<template>
+	<div>
+		<span>label</span>
+	</div>
+</template>
+
+<template>
+	<UForm>
+		<BaseLoader />
+		<UserPanel />
+	</UForm>
+</template>
+
+<template>
+	<UForm>
+		Before
+		<BaseLoader />
+		After
+	</UForm>
+</template>
+
+<template>
+	<template #default>
+		<UserPanel />
+	</template>
+</template>
+
+```
+
+
+# Formatted
+
+```vue
+<template>
+	<Transition name="fade">
+		<BaseLoader v-if="isLoading" />
+	</Transition>
+</template>
+
+<template>
+	<KeepAlive>
+		<UserPanel />
+	</KeepAlive>
+</template>
+
+<template>
+	<Teleport to="body">
+		<UserPanel />
+	</Teleport>
+</template>
+
+<template>
+	<UForm>
+		<BaseLoader v-if="isLoading" />
+	</UForm>
+</template>
+
+<template>
+	<Layout.Header>
+		<UserAvatar />
+	</Layout.Header>
+</template>
+
+<template>
+	<my-widget>
+		<inner-widget />
+	</my-widget>
+</template>
+
+<template>
+	<span>
+		<em>label</em>
+	</span>
+</template>
+
+<template>
+	<Transition name="fade"><BaseLoader v-if="isLoading" /></Transition>
+</template>
+
+<template>
+	<UForm> Submit </UForm>
+</template>
+
+<template>
+	<div>
+		<span>label</span>
+	</div>
+</template>
+
+<template>
+	<UForm>
+		<BaseLoader />
+		<UserPanel />
+	</UForm>
+</template>
+
+<template>
+	<UForm>
+		Before
+		<BaseLoader />
+		After
+	</UForm>
+</template>
+
+<template>
+	<template #default>
+		<UserPanel />
+	</template>
+</template>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/preserve-newline-nontext-children.html
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/preserve-newline-nontext-children.html
@@ -3,6 +3,21 @@
 	<span>text</span>
 </div>
 
+<!-- Newlines around nested inline elements should be preserved -->
+<span>
+	<em>label</em>
+</span>
+
+<!-- Newlines around custom elements should be preserved -->
+<my-widget>
+	<inner-widget></inner-widget>
+</my-widget>
+
+<!-- Newlines around anchor children should be preserved -->
+<a>
+	<span>label</span>
+</a>
+
 <!-- No newlines = stays inline -->
 <div><span>text</span></div>
 
@@ -12,10 +27,21 @@
 	<span>Bar</span>
 </div>
 
+<!-- Text-only child stays inline -->
+<span>
+	label
+</span>
+
 <!-- Mixed content (element + text) should NOT force multiline -->
 <div>
 	<span>Foo</span> Bar
 </div>
+
+<!-- Mixed text and element children on separate lines should be preserved -->
+<p>
+	<span>Foo</span>
+	Bar
+</p>
 
 <!-- Comment-only child with newlines should be preserved -->
 <div>

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/preserve-newline-nontext-children.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/preserve-newline-nontext-children.html.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
 info: whitespace/preserve-newline-nontext-children.html
 ---
 
@@ -11,6 +12,21 @@ info: whitespace/preserve-newline-nontext-children.html
 	<span>text</span>
 </div>
 
+<!-- Newlines around nested inline elements should be preserved -->
+<span>
+	<em>label</em>
+</span>
+
+<!-- Newlines around custom elements should be preserved -->
+<my-widget>
+	<inner-widget></inner-widget>
+</my-widget>
+
+<!-- Newlines around anchor children should be preserved -->
+<a>
+	<span>label</span>
+</a>
+
 <!-- No newlines = stays inline -->
 <div><span>text</span></div>
 
@@ -20,10 +36,21 @@ info: whitespace/preserve-newline-nontext-children.html
 	<span>Bar</span>
 </div>
 
+<!-- Text-only child stays inline -->
+<span>
+	label
+</span>
+
 <!-- Mixed content (element + text) should NOT force multiline -->
 <div>
 	<span>Foo</span> Bar
 </div>
+
+<!-- Mixed text and element children on separate lines should be preserved -->
+<p>
+	<span>Foo</span>
+	Bar
+</p>
 
 <!-- Comment-only child with newlines should be preserved -->
 <div>
@@ -44,6 +71,21 @@ info: whitespace/preserve-newline-nontext-children.html
 	<span>text</span>
 </div>
 
+<!-- Newlines around nested inline elements should be preserved -->
+<span>
+	<em>label</em>
+</span>
+
+<!-- Newlines around custom elements should be preserved -->
+<my-widget>
+	<inner-widget></inner-widget>
+</my-widget>
+
+<!-- Newlines around anchor children should be preserved -->
+<a>
+	<span>label</span>
+</a>
+
 <!-- No newlines = stays inline -->
 <div><span>text</span></div>
 
@@ -53,8 +95,17 @@ info: whitespace/preserve-newline-nontext-children.html
 	<span>Bar</span>
 </div>
 
+<!-- Text-only child stays inline -->
+<span> label </span>
+
 <!-- Mixed content (element + text) should NOT force multiline -->
 <div><span>Foo</span> Bar</div>
+
+<!-- Mixed text and element children on separate lines should be preserved -->
+<p>
+	<span>Foo</span>
+	Bar
+</p>
 
 <!-- Comment-only child with newlines should be preserved -->
 <div>

--- a/crates/biome_html_formatter/tests/specs/prettier/html/css/mj-style.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/html/css/mj-style.html.snap
@@ -22,15 +22,17 @@ info: html/css/mj-style.html
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,3 +1 @@
--<mjml>
+@@ -1,3 +1,3 @@
+ <mjml>
 -  <mj-style> .should-not-format{ as: 'css' }</mj-style>
--</mjml>
-+<mjml> <mj-style> .should-not-format { as: 'css' }</mj-style> </mjml>
++  <mj-style> .should-not-format { as: 'css' }</mj-style>
+ </mjml>
 ```
 
 # Output
 
 ```html
-<mjml> <mj-style> .should-not-format { as: 'css' }</mj-style> </mjml>
+<mjml>
+  <mj-style> .should-not-format { as: 'css' }</mj-style>
+</mjml>
 ```

--- a/packages/prettier-compare/README.md
+++ b/packages/prettier-compare/README.md
@@ -34,7 +34,7 @@ packages/prettier-compare/
 4. **IR Comparison**: Show intermediate representation from both formatters
 5. **Diagnostics Section**: Display syntax errors from both tools
 6. **Watch Mode**: Rebuild WASM on Rust file changes with debounce and spinner
-7. **All Languages**: Support JS/TS, JSON, CSS, HTML, GraphQL, etc.
+7. **All Languages**: Support JS/TS, JSON, CSS, HTML, Vue, GraphQL, etc.
 
 ## Usage
 

--- a/packages/prettier-compare/src/languages.ts
+++ b/packages/prettier-compare/src/languages.ts
@@ -70,6 +70,11 @@ export const LANGUAGES: Record<string, LanguageConfig> = {
 		prettierParser: "html",
 		displayName: "HTML",
 	},
+	vue: {
+		biomeFilePath: "file.vue",
+		prettierParser: "vue",
+		displayName: "Vue",
+	},
 	graphql: {
 		biomeFilePath: "file.graphql",
 		prettierParser: "graphql",


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->


tests generated by gpt 5.5 first, then fixed manually.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #9450, for real this time i think

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
new tests, and a lot of them

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
