### PR TITLE
feat(css_formatter): improve SCSS map value and pair formatting for better readability

### DIFF
--- a/crates/biome_css_formatter/src/scss/auxiliary/map_expression_pair.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/map_expression_pair.rs
@@ -1,10 +1,7 @@
 use crate::prelude::*;
 use crate::utils::scss_expression::is_self_breaking_value;
 use crate::utils::scss_separator_comments::FormatScssSeparatorComments;
-use biome_css_syntax::{
-    ScssMapExpressionPair, ScssMapExpressionPairFields, is_in_scss_include_arguments,
-    is_in_scss_map_key, is_scss_map_value,
-};
+use biome_css_syntax::{ScssMapExpressionPair, ScssMapExpressionPairFields};
 use biome_formatter::{format_args, write};
 
 #[derive(Debug, Clone, Default)]
@@ -23,22 +20,14 @@ impl FormatNodeRule<ScssMapExpressionPair> for FormatScssMapExpressionPair {
 
         let child_value_is_self_breaking = value.as_ref().is_ok_and(is_self_breaking_value);
 
-        // Pairs inside a map key may wrap after `:` so long keys do not push a
-        // scalar value too far to the right.
-        let allow_scalar_value_wrap =
-            is_in_scss_map_key(node) || is_in_scss_include_arguments(node.syntax());
-        let value_is_direct_map_value = value.as_ref().ok().is_some_and(is_scss_map_value);
-
         let formatted_value = format_with(|f| {
             if child_value_is_self_breaking {
                 // Keep `key: (` on one line and let the value formatter decide
                 // its own internal breaks.
                 write!(f, [space(), value.format()])
-            } else if allow_scalar_value_wrap && value_is_direct_map_value {
-                // Allow long keys to wrap a scalar value after the colon:
-                //
-                // "very long key":
-                //   "value",
+            } else {
+                // Match Prettier's map item shape:
+                // `key: value` may break as `key:\n  value`.
                 write!(
                     f,
                     [indent(&format_args![
@@ -46,8 +35,6 @@ impl FormatNodeRule<ScssMapExpressionPair> for FormatScssMapExpressionPair {
                         value.format()
                     ])]
                 )
-            } else {
-                write!(f, [space(), value.format()])
             }
         });
 
@@ -55,7 +42,8 @@ impl FormatNodeRule<ScssMapExpressionPair> for FormatScssMapExpressionPair {
             f,
             [group(&format_args![
                 key.format(),
-                group(&format_args![colon_token.format(), formatted_value])
+                colon_token.format(),
+                formatted_value
             ])]
         )
     }

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/map/2554.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/map/2554.scss.snap
@@ -135,56 +135,8 @@ $value
 ```diff
 --- Prettier
 +++ Biome
-@@ -43,110 +43,53 @@
-   other-key: other-value,
- );
- $map: (
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
- );
- $map: (
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
- );
- $map: (
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
- );
- $map: (
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
- );
- $map: (
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
- );
- $map: (
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
--  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
--    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+@@ -79,74 +79,29 @@
+     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
  );
  $map: (
 -  key: (
@@ -323,28 +275,40 @@ $map: (
   other-key: other-value,
 );
 $map: (
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
 );
 $map: (
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
 );
 $map: (
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
 );
 $map: (
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
 );
 $map: (
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
 );
 $map: (
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+  very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+    very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
 );
 $map: (
   key: (#d82d2d, #666),
@@ -411,16 +375,28 @@ $map: map-merge(
 
 # Lines exceeding max width of 80 characters
 ```
-   46:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-   47:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-   50:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-   51:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-   54:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-   55:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-   58:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-   59:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-   62:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-   63:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
-   66:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-   67:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+   46:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+   47:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+   48:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+   49:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+   52:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+   53:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+   54:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+   55:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+   58:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+   59:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+   60:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+   61:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+   64:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+   65:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+   66:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+   67:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+   70:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+   71:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+   72:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+   73:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+   76:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+   77:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+   78:   very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+   79:     very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/map/function-argument/function-argument-2.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/map/function-argument/function-argument-2.scss.snap
@@ -33,28 +33,28 @@ $display-breakpoints: map-deep-merge(
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,13 +1,16 @@
+@@ -1,13 +1,20 @@
  $display-breakpoints: map-deep-merge(
    (
--    "sm-only":
+     "sm-only":
 -      "only screen and (min-width: #{$map-get + $grid-breakpoints + "hogehoge"}) and (max-width: #{$a})",
--    "sm-only":
++      "only screen and (min-width: #{$map-get + $grid-breakpoints +
++      "hogehoge"}) and (max-width: #{$a})",
+     "sm-only":
 -      "inside a long long long long long long long long long long long long long long string #{call("")}",
--    "sm-only":
++      "inside a long long long long long long long long long long long long long long string #{call(
++        ""
++      )}",
+     "sm-only":
 -      "inside a long long long long long long long long long long long long long long string #{$foo} and #{call("")}",
--    "sm-only":
++      "inside a long long long long long long long long long long long long long long string #{$foo} and #{call(
++        ""
++      )}",
+     "sm-only":
 -      "inside a long long long long long long long long long long long long long long string #{call($a)}",
-+    "sm-only": "only screen and (min-width: #{$map-get + $grid-breakpoints +
-+    "hogehoge"}) and (max-width: #{$a})",
-+    "sm-only": "inside a long long long long long long long long long long long long long long string #{call(
-+      ""
-+    )}",
-+    "sm-only": "inside a long long long long long long long long long long long long long long string #{$foo} and #{call(
-+      ""
-+    )}",
-+    "sm-only": "inside a long long long long long long long long long long long long long long string #{call(
-+      $a
-+    )}",
++      "inside a long long long long long long long long long long long long long long string #{call(
++        $a
++      )}",
    ),
    $display-breakpoints
  );
@@ -65,17 +65,21 @@ $display-breakpoints: map-deep-merge(
 ```scss
 $display-breakpoints: map-deep-merge(
   (
-    "sm-only": "only screen and (min-width: #{$map-get + $grid-breakpoints +
-    "hogehoge"}) and (max-width: #{$a})",
-    "sm-only": "inside a long long long long long long long long long long long long long long string #{call(
-      ""
-    )}",
-    "sm-only": "inside a long long long long long long long long long long long long long long string #{$foo} and #{call(
-      ""
-    )}",
-    "sm-only": "inside a long long long long long long long long long long long long long long string #{call(
-      $a
-    )}",
+    "sm-only":
+      "only screen and (min-width: #{$map-get + $grid-breakpoints +
+      "hogehoge"}) and (max-width: #{$a})",
+    "sm-only":
+      "inside a long long long long long long long long long long long long long long string #{call(
+        ""
+      )}",
+    "sm-only":
+      "inside a long long long long long long long long long long long long long long string #{$foo} and #{call(
+        ""
+      )}",
+    "sm-only":
+      "inside a long long long long long long long long long long long long long long string #{call(
+        $a
+      )}",
   ),
   $display-breakpoints
 );
@@ -92,7 +96,7 @@ $display-breakpoints: map-deep-merge(
 
 # Lines exceeding max width of 80 characters
 ```
-    5:     "sm-only": "inside a long long long long long long long long long long long long long long string #{call(
-    8:     "sm-only": "inside a long long long long long long long long long long long long long long string #{$foo} and #{call(
-   11:     "sm-only": "inside a long long long long long long long long long long long long long long string #{call(
+    7:       "inside a long long long long long long long long long long long long long long string #{call(
+   11:       "inside a long long long long long long long long long long long long long long string #{$foo} and #{call(
+   15:       "inside a long long long long long long long long long long long long long long string #{call(
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/map/function-argument/functional-argument.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/map/function-argument/functional-argument.scss.snap
@@ -100,24 +100,19 @@ font-weight:
 ```diff
 --- Prettier
 +++ Biome
-@@ -3,10 +3,12 @@
-   (
-     "print-only": "only print",
-     "screen-only": "only screen",
--    "xs-only":
--      "only screen and (max-width: #{map-get($grid-breakpoints, "sm") - 1})",
--    "sm-only":
+@@ -6,7 +6,10 @@
+     "xs-only":
+       "only screen and (max-width: #{map-get($grid-breakpoints, "sm") - 1})",
+     "sm-only":
 -      "only screen and (min-width: #{map-get($grid-breakpoints, "sm")}) and (max-width: #{map-get($grid-breakpoints, "md") - 1})",
-+    "xs-only": "only screen and (max-width: #{map-get($grid-breakpoints, "sm") -
-+    1})",
-+    "sm-only": "only screen and (min-width: #{map-get(
-+      $grid-breakpoints,
-+      "sm"
-+    )}) and (max-width: #{map-get($grid-breakpoints, "md") - 1})",
++      "only screen and (min-width: #{map-get(
++        $grid-breakpoints,
++        "sm"
++      )}) and (max-width: #{map-get($grid-breakpoints, "md") - 1})",
    ),
    $display-breakpoints
  );
-@@ -31,7 +33,7 @@
+@@ -31,7 +34,7 @@
    "bold": 700,
  );
  @each $name, $boldness in $icons {
@@ -126,7 +121,7 @@ font-weight:
      color: red;
      font-weight: "#{$boldness}";
    }
-@@ -43,7 +45,7 @@
+@@ -43,7 +46,7 @@
    "bold": 700,
  );
  @each $name, $boldness in $icons {
@@ -145,12 +140,13 @@ $display-breakpoints: map-deep-merge(
   (
     "print-only": "only print",
     "screen-only": "only screen",
-    "xs-only": "only screen and (max-width: #{map-get($grid-breakpoints, "sm") -
-    1})",
-    "sm-only": "only screen and (min-width: #{map-get(
-      $grid-breakpoints,
-      "sm"
-    )}) and (max-width: #{map-get($grid-breakpoints, "md") - 1})",
+    "xs-only":
+      "only screen and (max-width: #{map-get($grid-breakpoints, "sm") - 1})",
+    "sm-only":
+      "only screen and (min-width: #{map-get(
+        $grid-breakpoints,
+        "sm"
+      )}) and (max-width: #{map-get($grid-breakpoints, "md") - 1})",
   ),
   $display-breakpoints
 );

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/map/key-values.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/map/key-values.scss.snap
@@ -59,7 +59,7 @@ $map: (
    (
      "list",
      "list",
-@@ -43,8 +39,8 @@
+@@ -43,13 +39,14 @@
      "list",
      "list",
    ): (
@@ -70,6 +70,13 @@ $map: (
    (
      "key": "value",
      "key": "value",
+     "key": "value",
+     "key": "value",
+     "key": "value",
+-  ): 1,
++  ):
++    1,
+ );
 ```
 
 # Output
@@ -124,6 +131,7 @@ $map: (
     "key": "value",
     "key": "value",
     "key": "value",
-  ): 1,
+  ):
+    1,
 );
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/map/keys.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/map/keys.scss.snap
@@ -1,0 +1,73 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/map/keys.scss
+---
+
+# Input
+
+```scss
+$map: (
+  'string': 'hello world',
+  ('list'): 'hello world',
+  ('key': 'value'): 'hello world',
+  ('list', 'long long long long long long long long long long long long long list'): 'hello world',
+  ('key': 'value','long long long long long long long long long long long long long map': 'value',): 'hello world',
+);
+
+// #10000
+$map: (
+	('my list'): 'hello world',
+);
+
+```
+
+
+# Prettier differences
+
+```diff
+--- Prettier
++++ Biome
+@@ -5,12 +5,14 @@
+   (
+     "list",
+     "long long long long long long long long long long long long long list",
+-  ): "hello world",
++  ):
++    "hello world",
+   (
+     "key": "value",
+     "long long long long long long long long long long long long long map":
+       "value",
+-  ): "hello world",
++  ):
++    "hello world",
+ );
+ 
+ // #10000
+```
+
+# Output
+
+```scss
+$map: (
+  "string": "hello world",
+  ("list"): "hello world",
+  ("key": "value"): "hello world",
+  (
+    "list",
+    "long long long long long long long long long long long long long list",
+  ):
+    "hello world",
+  (
+    "key": "value",
+    "long long long long long long long long long long long long long map":
+      "value",
+  ):
+    "hello world",
+);
+
+// #10000
+$map: (
+  ("my list"): "hello world",
+);
+```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-context.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-context.scss.snap
@@ -41,15 +41,11 @@ $doubleParenMapValue: (
 $doubleParenMapValueBroken: (
 	key: (
 		(
-			very-very-very-very-very-very-very-very-long-map-key: very-very-very-very-very-very-very-very-long-map-value,
+			very-very-very-very-very-very-very-very-long-map-key:
+				very-very-very-very-very-very-very-very-long-map-value,
 			other-key: other-other-value,
 		)
 	),
 );
 
-```
-
-# Lines exceeding max width of 80 characters
-```
-   23: 			very-very-very-very-very-very-very-very-long-map-key: very-very-very-very-very-very-very-very-long-map-value,
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-expansion.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-expansion.scss.snap
@@ -25,31 +25,38 @@ $longListKey: (
 	(
 		"list",
 		"long long long long long long long long long long long long long list",
-	): "hello world",
+	):
+		"hello world",
 );
 $longMapKey: (
 	(
 		"key": "value",
 		"long long long long long long long long long long long long long map":
 			"value",
-	): "hello world",
+	):
+		"hello world",
 );
 $nestedMapInKey: (
 	fn(
 		(
 			a: b,
 		)
-	): c,
+	):
+		c,
 );
 $longPairs: (
-	very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-	very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+	very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+		very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+	very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+		very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
 );
 
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-   25: 	very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
-   26: 	very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key: very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
+   28: 	very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-key:
+   29: 		very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-value,
+   30: 	very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-key:
+   31: 		very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-verylong-other-value,
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-wrapping.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-wrapping.scss
@@ -1,0 +1,2 @@
+$map:(very-very-very-very-very-very-very-verylong-key:very-very-very-very-very-very-very-verylong-value,other-key:other-value);
+

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-wrapping.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-wrapping.scss.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/expression/map-pair-wrapping.scss
+---
+
+# Input
+
+```scss
+$map:(very-very-very-very-very-very-very-verylong-key:very-very-very-very-very-very-very-verylong-value,other-key:other-value);
+
+
+```
+
+
+# Formatted
+
+```scss
+$map: (
+	very-very-very-very-very-very-very-verylong-key:
+		very-very-very-very-very-very-very-verylong-value,
+	other-key: other-value,
+);
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-values.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-values.scss.snap
@@ -46,15 +46,11 @@ $mapValueListBroken: (
 $mapValueMapBroken: (
 	key: (
 		(
-			very-very-very-very-very-very-very-very-long-map-key: very-very-very-very-very-very-very-very-long-map-value,
+			very-very-very-very-very-very-very-very-long-map-key:
+				very-very-very-very-very-very-very-very-long-map-value,
 			other-key: other-other-value,
 		)
 	),
 );
 
-```
-
-# Lines exceeding max width of 80 characters
-```
-   28: 			very-very-very-very-very-very-very-very-long-map-key: very-very-very-very-very-very-very-very-long-map-value,
 ```


### PR DESCRIPTION
  > This PR was created with AI assistance (Codex).

  ## Summary

  Improves SCSS map formatting so long map pairs can wrap after the colon instead of exceeding the configured line width.

```scss
$map: (
  	very-very-very-very-very-very-very-verylong-key:
  		very-very-very-very-very-very-very-verylong-value,
  	other-key: other-value,
  );
```

  ## Test Plan
  
  - cargo test -p biome_css_formatter
