### PR TITLE
refactor(line_index): use SIMD intrinsics for better performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,10 @@ name = "biome_line_index"
 version = "0.1.0"
 dependencies = [
  "biome_text_size",
+ "codspeed-criterion-compat",
+ "mimalloc",
  "rustc-hash 2.1.2",
+ "tikv-jemallocator",
 ]
 
 [[package]]

--- a/crates/biome_line_index/Cargo.toml
+++ b/crates/biome_line_index/Cargo.toml
@@ -13,9 +13,22 @@ publish              = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bench]]
+harness = false
+name    = "line_index"
+
 [dependencies]
 biome_text_size = { workspace = true }
 rustc-hash      = { workspace = true }
+
+[dev-dependencies]
+criterion = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+
+[target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dev-dependencies]
+tikv-jemallocator = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+mimalloc = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/biome_line_index/benches/line_index.rs
+++ b/crates/biome_line_index/benches/line_index.rs
@@ -1,0 +1,74 @@
+use biome_line_index::LineIndex;
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+
+#[cfg(target_os = "windows")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(all(
+    any(target_os = "macos", target_os = "linux"),
+    not(target_env = "musl"),
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+// Jemallocator does not work on aarch64 with musl, so use the system allocator instead.
+#[cfg(all(target_env = "musl", target_os = "linux", target_arch = "aarch64"))]
+#[global_allocator]
+static GLOBAL: std::alloc::System = std::alloc::System;
+
+fn ascii_single_line() -> String {
+    "let value = object.property + another_value; ".repeat(16_384)
+}
+
+fn ascii_many_lines() -> String {
+    "const value = object.property + another_value;\n".repeat(16_384)
+}
+
+fn sparse_unicode() -> String {
+    "const label = 'Jan 1, 2018 - Jan 1, 2019'; // ok\n".repeat(512)
+        + &"const label = 'Jan 1, 2018 - Jan 1, 2019'; // unicode\n".repeat(512)
+}
+
+fn dense_unicode() -> String {
+    "const message = '😀👍✨ àéîøü 你好 мир';\n".repeat(16_384)
+}
+
+fn bench_line_index(criterion: &mut Criterion) {
+    let cases = [
+        ("ascii_single_line", ascii_single_line()),
+        ("ascii_many_lines", ascii_many_lines()),
+        ("sparse_unicode", sparse_unicode()),
+        ("dense_unicode", dense_unicode()),
+    ];
+
+    let mut group = criterion.benchmark_group("line_index");
+    for (name, source) in &cases {
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_with_input(BenchmarkId::new(*name, "scalar"), source, |b, source| {
+            b.iter(|| black_box(LineIndex::new_scalar(black_box(source))));
+        });
+
+        if LineIndex::new_sse42(source).is_some() {
+            group.bench_with_input(BenchmarkId::new(*name, "sse4.2"), source, |b, source| {
+                b.iter(|| black_box(LineIndex::new_sse42(black_box(source)).unwrap()));
+            });
+        }
+
+        if LineIndex::new_avx2(source).is_some() {
+            group.bench_with_input(BenchmarkId::new(*name, "avx2"), source, |b, source| {
+                b.iter(|| black_box(LineIndex::new_avx2(black_box(source)).unwrap()));
+            });
+        }
+
+        if LineIndex::new_neon(source).is_some() {
+            group.bench_with_input(BenchmarkId::new(*name, "neon"), source, |b, source| {
+                b.iter(|| black_box(LineIndex::new_neon(black_box(source)).unwrap()));
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(line_index, bench_line_index);
+criterion_main!(line_index);

--- a/crates/biome_line_index/src/lib.rs
+++ b/crates/biome_line_index/src/lib.rs
@@ -123,6 +123,53 @@ mod tests {
         check_conversion!(line_index: WideLineCol { line: 0, col: 27 } => TextSize::from(33));
     }
 
+    #[test]
+    fn avx2_matches_scalar_line_index() {
+        let source = line_index_test_source();
+        let Some(line_index) = LineIndex::new_avx2(&source) else {
+            return;
+        };
+
+        assert_eq!(line_index, LineIndex::new(&source));
+    }
+
+    #[test]
+    fn sse42_matches_scalar_line_index() {
+        let source = line_index_test_source();
+        let Some(line_index) = LineIndex::new_sse42(&source) else {
+            return;
+        };
+
+        assert_eq!(line_index, LineIndex::new(&source));
+    }
+
+    #[test]
+    fn neon_matches_scalar_line_index() {
+        let source = line_index_test_source();
+        let Some(line_index) = LineIndex::new_neon(&source) else {
+            return;
+        };
+
+        assert_eq!(line_index, LineIndex::new(&source));
+    }
+
+    fn line_index_test_source() -> String {
+        [
+            "short",
+            &"a".repeat(15),
+            &"a".repeat(16),
+            &"a".repeat(17),
+            &"a".repeat(31),
+            &"a".repeat(32),
+            &"a".repeat(33),
+            "emoji 😀 before chunk boundary",
+            "emoji near chunk boundary aaaaaaaaaaaaaaaaaaaaa😀",
+            "multi-byte accents àéîøü",
+            "multiple\nlines\nwith unicode 👍\nend",
+        ]
+        .join("\n")
+    }
+
     #[ignore]
     #[test]
     fn test_every_chars() {

--- a/crates/biome_line_index/src/line_index.rs
+++ b/crates/biome_line_index/src/line_index.rs
@@ -3,6 +3,15 @@
 
 use std::mem;
 
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::*;
+#[cfg(target_arch = "arm")]
+use std::arch::arm::*;
+#[cfg(target_arch = "x86")]
+use std::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
 use biome_text_size::TextSize;
 use rustc_hash::FxHashMap;
 
@@ -18,6 +27,13 @@ pub struct LineIndex {
 
 impl LineIndex {
     pub fn new(text: &str) -> Self {
+        Self::new_avx2(text)
+            .or_else(|| Self::new_sse42(text))
+            .or_else(|| Self::new_neon(text))
+            .unwrap_or_else(|| Self::new_scalar(text))
+    }
+
+    pub fn new_scalar(text: &str) -> Self {
         let mut line_wide_chars = FxHashMap::default();
         let mut wide_chars = Vec::new();
 
@@ -57,6 +73,321 @@ impl LineIndex {
         }
 
         // Save any utf-16 characters seen in the last line
+        if !wide_chars.is_empty() {
+            line_wide_chars.insert(line, wide_chars);
+        }
+
+        Self {
+            newlines,
+            line_wide_chars,
+        }
+    }
+
+    /// Builds a line index using an AVX2 fast path for ASCII text spans.
+    ///
+    /// Returns `None` when the current CPU does not support AVX2, or on non-x86 targets.
+    pub fn new_avx2(text: &str) -> Option<Self> {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if std::is_x86_feature_detected!("avx2") {
+                // SAFETY: the runtime check above guarantees AVX2 support.
+                return Some(unsafe { Self::new_avx2_unchecked(text) });
+            }
+        }
+
+        None
+    }
+
+    /// Builds a line index using an SSE4.2 fast path for ASCII text spans.
+    ///
+    /// Returns `None` when the current CPU does not support SSE4.2, or on non-x86 targets.
+    pub fn new_sse42(text: &str) -> Option<Self> {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if std::is_x86_feature_detected!("sse4.2") {
+                // SAFETY: the runtime check above guarantees SSE4.2 support.
+                return Some(unsafe { Self::new_sse42_unchecked(text) });
+            }
+        }
+
+        None
+    }
+
+    /// Builds a line index using a NEON fast path for ASCII text spans.
+    ///
+    /// Returns `None` when the current CPU does not support NEON, or on non-ARM targets.
+    pub fn new_neon(_text: &str) -> Option<Self> {
+        #[cfg(target_arch = "aarch64")]
+        {
+            // SAFETY: NEON is part of the baseline AArch64 target features.
+            return Some(unsafe { Self::new_neon_unchecked(_text) });
+        }
+
+        #[cfg(target_arch = "arm")]
+        {
+            if std::arch::is_arm_feature_detected!("neon") {
+                // SAFETY: the runtime check above guarantees NEON support.
+                return Some(unsafe { Self::new_neon_unchecked(_text) });
+            }
+        }
+
+        None
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    unsafe fn new_neon_unchecked(text: &str) -> Self {
+        unsafe { Self::new_neon_impl(text) }
+    }
+
+    #[cfg(target_arch = "arm")]
+    #[target_feature(enable = "neon")]
+    unsafe fn new_neon_unchecked(text: &str) -> Self {
+        unsafe { Self::new_neon_impl(text) }
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+    unsafe fn new_neon_impl(text: &str) -> Self {
+        let mut line_wide_chars = FxHashMap::default();
+        let mut wide_chars = Vec::new();
+
+        let mut newlines = vec![TextSize::from(0)];
+        let mut current_col = TextSize::from(0);
+        let mut line = 0;
+        let mut offset = 0;
+        let bytes = text.as_bytes();
+
+        let newline = unsafe { vdupq_n_u8(b'\n') };
+        let high_bit = unsafe { vdupq_n_u8(0x80) };
+
+        while offset + 16 <= bytes.len() {
+            let chunk = unsafe { vld1q_u8(bytes.as_ptr().add(offset)) };
+
+            // Mark bytes that need scalar handling: line breaks update `newlines`,
+            // and non-ASCII bytes start UTF-8 code points that need wide-char bookkeeping.
+            let newline_matches = unsafe { vceqq_u8(chunk, newline) };
+            let non_ascii = unsafe { vandq_u8(chunk, high_bit) };
+            let interesting = unsafe { vorrq_u8(newline_matches, non_ascii) };
+
+            let Some(ascii_len) = first_nonzero_lane(interesting) else {
+                // Entire chunk is ASCII with no newlines, so only the UTF-8 column advances.
+                current_col += TextSize::from(16);
+                offset += 16;
+                continue;
+            };
+
+            if ascii_len > 0 {
+                // Skip the safe ASCII prefix before the first interesting byte,
+                // then handle that one byte/code point scalar and resume SIMD.
+                current_col += TextSize::try_from(ascii_len).expect("TextSize overflow");
+                offset += ascii_len;
+            }
+
+            let char = text[offset..]
+                .chars()
+                .next()
+                .expect("offset must be within input");
+
+            process_char(
+                char,
+                offset,
+                &mut newlines,
+                &mut line_wide_chars,
+                &mut wide_chars,
+                &mut current_col,
+                &mut line,
+            );
+
+            offset += char.len_utf8();
+        }
+
+        while offset < bytes.len() {
+            let char = text[offset..]
+                .chars()
+                .next()
+                .expect("offset must be within input");
+
+            process_char(
+                char,
+                offset,
+                &mut newlines,
+                &mut line_wide_chars,
+                &mut wide_chars,
+                &mut current_col,
+                &mut line,
+            );
+
+            offset += char.len_utf8();
+        }
+
+        if !wide_chars.is_empty() {
+            line_wide_chars.insert(line, wide_chars);
+        }
+
+        Self {
+            newlines,
+            line_wide_chars,
+        }
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "sse4.2")]
+    unsafe fn new_sse42_unchecked(text: &str) -> Self {
+        let mut line_wide_chars = FxHashMap::default();
+        let mut wide_chars = Vec::new();
+
+        let mut newlines = vec![TextSize::from(0)];
+        let mut current_col = TextSize::from(0);
+        let mut line = 0;
+        let mut offset = 0;
+        let bytes = text.as_bytes();
+
+        let newline = _mm_set1_epi8(b'\n' as i8);
+
+        while offset + 16 <= bytes.len() {
+            let chunk = unsafe { _mm_loadu_si128(bytes.as_ptr().add(offset).cast()) };
+
+            // `movemask` gives one bit per byte. Newlines and bytes with the high
+            // bit set require scalar handling; all other bytes can be skipped in bulk.
+            let interesting_mask = (_mm_movemask_epi8(_mm_cmpeq_epi8(chunk, newline))
+                | _mm_movemask_epi8(chunk)) as u32;
+
+            if interesting_mask == 0 {
+                // Entire chunk is ASCII with no newlines, so only the UTF-8 column advances.
+                current_col += TextSize::from(16);
+                offset += 16;
+                continue;
+            }
+
+            let ascii_len = interesting_mask.trailing_zeros() as usize;
+            if ascii_len > 0 {
+                // Skip the safe ASCII prefix before the first interesting byte,
+                // then handle that one byte/code point scalar and resume SIMD.
+                current_col += TextSize::try_from(ascii_len).expect("TextSize overflow");
+                offset += ascii_len;
+            }
+
+            let char = text[offset..]
+                .chars()
+                .next()
+                .expect("offset must be within input");
+
+            process_char(
+                char,
+                offset,
+                &mut newlines,
+                &mut line_wide_chars,
+                &mut wide_chars,
+                &mut current_col,
+                &mut line,
+            );
+
+            offset += char.len_utf8();
+        }
+
+        while offset < bytes.len() {
+            let char = text[offset..]
+                .chars()
+                .next()
+                .expect("offset must be within input");
+
+            process_char(
+                char,
+                offset,
+                &mut newlines,
+                &mut line_wide_chars,
+                &mut wide_chars,
+                &mut current_col,
+                &mut line,
+            );
+
+            offset += char.len_utf8();
+        }
+
+        if !wide_chars.is_empty() {
+            line_wide_chars.insert(line, wide_chars);
+        }
+
+        Self {
+            newlines,
+            line_wide_chars,
+        }
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2")]
+    unsafe fn new_avx2_unchecked(text: &str) -> Self {
+        let mut line_wide_chars = FxHashMap::default();
+        let mut wide_chars = Vec::new();
+
+        let mut newlines = vec![TextSize::from(0)];
+        let mut current_col = TextSize::from(0);
+        let mut line = 0;
+        let mut offset = 0;
+        let bytes = text.as_bytes();
+
+        let newline = _mm256_set1_epi8(b'\n' as i8);
+
+        while offset + 32 <= bytes.len() {
+            let chunk = unsafe { _mm256_loadu_si256(bytes.as_ptr().add(offset).cast()) };
+
+            // `movemask` gives one bit per byte. Newlines and bytes with the high
+            // bit set require scalar handling; all other bytes can be skipped in bulk.
+            let interesting_mask = (_mm256_movemask_epi8(_mm256_cmpeq_epi8(chunk, newline))
+                | _mm256_movemask_epi8(chunk)) as u32;
+
+            if interesting_mask == 0 {
+                // Entire chunk is ASCII with no newlines, so only the UTF-8 column advances.
+                current_col += TextSize::from(32);
+                offset += 32;
+                continue;
+            }
+
+            let ascii_len = interesting_mask.trailing_zeros() as usize;
+            if ascii_len > 0 {
+                // Skip the safe ASCII prefix before the first interesting byte,
+                // then handle that one byte/code point scalar and resume SIMD.
+                current_col += TextSize::try_from(ascii_len).expect("TextSize overflow");
+                offset += ascii_len;
+            }
+
+            let char = text[offset..]
+                .chars()
+                .next()
+                .expect("offset must be within input");
+
+            process_char(
+                char,
+                offset,
+                &mut newlines,
+                &mut line_wide_chars,
+                &mut wide_chars,
+                &mut current_col,
+                &mut line,
+            );
+
+            offset += char.len_utf8();
+        }
+
+        while offset < bytes.len() {
+            let char = text[offset..]
+                .chars()
+                .next()
+                .expect("offset must be within input");
+
+            process_char(
+                char,
+                offset,
+                &mut newlines,
+                &mut line_wide_chars,
+                &mut wide_chars,
+                &mut current_col,
+                &mut line,
+            );
+
+            offset += char.len_utf8();
+        }
+
         if !wide_chars.is_empty() {
             line_wide_chars.insert(line, wide_chars);
         }
@@ -141,4 +472,54 @@ impl LineIndex {
 
         col.into()
     }
+}
+
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "arm"
+))]
+fn process_char(
+    char: char,
+    offset: usize,
+    newlines: &mut Vec<TextSize>,
+    line_wide_chars: &mut FxHashMap<u32, Vec<WideChar>>,
+    wide_chars: &mut Vec<WideChar>,
+    current_col: &mut TextSize,
+    line: &mut u32,
+) {
+    let char_size = TextSize::of(char);
+
+    if char == '\n' {
+        // SAFETY: the conversion from `usize` to `TextSize` can fail if `offset`
+        // is larger than 2^32. We don't support such large files.
+        let char_offset = TextSize::try_from(offset).expect("TextSize overflow");
+        newlines.push(char_offset + char_size);
+
+        if !wide_chars.is_empty() {
+            line_wide_chars.insert(*line, mem::take(wide_chars));
+        }
+
+        *current_col = TextSize::from(0);
+        *line += 1;
+    } else {
+        if !char.is_ascii() {
+            wide_chars.push(WideChar {
+                start: *current_col,
+                end: *current_col + char_size,
+            });
+        }
+
+        *current_col += char_size;
+    }
+}
+
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+fn first_nonzero_lane(vector: uint8x16_t) -> Option<usize> {
+    // NEON does not expose an x86-style movemask. Store the 16 lane flags and
+    // find the first non-zero lane to locate the first byte needing scalar work.
+    let mut lanes = [0u8; 16];
+    unsafe { vst1q_u8(lanes.as_mut_ptr(), vector) };
+    lanes.iter().position(|lane| *lane != 0)
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This essentially uses SIMD intrinsics to add a ASCII fast path to the scanning that `LineIndex` does. On my machine, the benchmarks indicate speedups from ~1.5 GB/s to anywhere between ~2.8-10+ GB/s throughput. Notably, there is a regression in speed when (approximately 0.33x) for text that is made of majority unicode text. For most code (particularly JS, CSS, GraphQL), this is likely not going to be a problem, but HTML and JSON documents are more likely to have problems because those usually contain data that is meant for humans to read. 

I used gpt 5.5 to do the initial research and the implementations.
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Tested locally on my x64 machine

Using CI to test the ARM path since our runners are ARM based.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
