### PR TITLE
fix(useConsistentObjectDefinitions): skip named function expressions in shorthand mode

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_consistent_object_definitions.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_object_definitions.rs
@@ -148,8 +148,14 @@ impl Rule for UseConsistentObjectDefinitions {
                         let variable_token = identifier_token.name().ok()?.value_token().ok()?;
                         inner_string_text(&variable_token)
                     }
-                    AnyJsExpression::JsFunctionExpression(_function_token) => {
-                        // Functions are always shorthandable
+                    AnyJsExpression::JsFunctionExpression(func) => {
+                        // Named function expressions (function c() {}) cannot be safely
+                        // converted to shorthand ({c() {}}) because it changes the function's
+                        // name property: obj.c.name would be "c" before and "c" after, but
+                        // for {a: function c() {}} the name is "c" while {a() {}} is "a".
+                        if func.id().is_some() {
+                            return None;
+                        }
                         match syntax {
                             ObjectPropertySyntax::Shorthand => return Some(()),
                             ObjectPropertySyntax::Explicit => return None,

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentObjectDefinitions/validShorthand.js
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentObjectDefinitions/validShorthand.js
@@ -49,3 +49,10 @@ const validShorthand = {
 
     ...spread,
 };
+
+// Named function expressions — must NOT be converted to shorthand
+// because obj.a.name === "c" would change to obj.a.name === "a"
+const namedFuncValid = {
+    a: function c() {},
+    b: function () {},
+};


### PR DESCRIPTION
### Description

**Fixes [#10212](https://github.com/biomejs/biome/issues/10212)**

The `useConsistentObjectDefinitions` rule currently converts *all* function expressions to shorthand methods when `syntax: "shorthand"` is set, including **named** function expressions. This changes runtime behavior:

```js
const obj = {
  a: function () {},    // obj.a.name === "a"   (anonymous — safe to convert)
  b: function c() {},   // obj.b.name === "c"   (named — converting to {b() {}} changes name to "b")
};
```

After the current rule fix:
```js
const obj = {
  a() {},   // obj.a.name === "a"  ✅ unchanged
  b() {},   // obj.b.name === "b"  ❌ was "c" before
};
```

### Fix

In the `run` function, when encountering a `JsFunctionExpression` value, check `func.id()`. If the function has a name (e.g. `function c()`), skip the shorthand suggestion — it is **not** safe to convert.

### Test case added

Named function expressions `a: function c() {}` and anonymous `b: function () {}` added to `validShorthand.js` — no diagnostic should fire for either when `syntax: "shorthand"`.