### PR TITLE
fix(noReactNativeDeepImports): change source from .same() to .inspired()

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_react_native_deep_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_react_native_deep_imports.rs
@@ -48,7 +48,7 @@ declare_lint_rule! {
         version: "2.4.13",
         name: "noReactNativeDeepImports",
         language: "js",
-        sources: &[RuleSource::EslintReactNative("no-deep-imports").same()],
+        sources: &[RuleSource::EslintReactNative("no-deep-imports").inspired()],
         domains: &[RuleDomain::ReactNative],
         recommended: true,
         severity: Severity::Error,


### PR DESCRIPTION
### Description

**Fixes [#10123](https://github.com/biomejs/biome/issues/10123)**

The `noReactNativeDeepImports` rule lists `RuleSource::EslintReactNative("no-deep-imports").same()` as its source, but the referenced rule does not exist in [eslint-plugin-react-native](https://github.com/Intellicode/eslint-plugin-react-native/tree/master/docs/rules).

The available rules in the plugin are: `no-color-literals`, `no-inline-styles`, `no-raw-text`, `no-single-element-style-arrays`, `no-unused-styles`, `sort-styles`, `split-platform-components`. There is no `no-deep-imports` rule.

### Fix

Changed `.same()` to `.inspired()` to correctly indicate this Biome rule is inspired by the React Native ecosystem rather than implementing an existing ESLint rule.