### PR TITLE
feat(biome_js_analyze): extend useOptionalChain to negation+comparison form (#10244)

### DIFF
--- a/.changeset/use-optional-chain-negation-comparison.md
+++ b/.changeset/use-optional-chain-negation-comparison.md
@@ -1,0 +1,15 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10244](https://github.com/biomejs/biome/issues/10244): [`useOptionalChain`](https://biomejs.dev/linter/rules/use-optional-chain/) now flags the negation + comparison form on the right-hand side of `||`. The rule already handled `!foo || !foo.bar`; it now also handles cases where the rightmost operand is a binary comparison (`==`, `!=`, `===`, `!==`, `<`, `<=`, `>`, `>=`) whose left side extends the chain.
+
+For example, the following are now reported and offer an unsafe fix:
+
+```js
+!foo || foo.bar !== "x";
+!foo || foo.bar.baz === undefined;
+!foo || !foo.bar || foo.bar.baz > 0;
+```
+
+The fix removes the leading `!`-negated operands and inserts `?.` into the comparison's left side: `foo?.bar !== "x"`, `foo?.bar?.baz === undefined`, `foo?.bar?.baz > 0`.

--- a/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
@@ -58,6 +58,10 @@ declare_lint_rule! {
     /// !foo || !foo.bar
     /// ```
     ///
+    /// ```js,expect_diagnostic
+    /// !foo || foo.bar !== "x"
+    /// ```
+    ///
     /// ### Valid
     ///
     /// ```js
@@ -102,6 +106,11 @@ pub struct LogicalAndChainNodes {
     /// Whether this chain was derived from a negated `||` chain like `!foo || !foo.bar`.
     /// When true, the fix wraps the result in `!` and uses `||` for prefix joining.
     negated: bool,
+    /// Whether this chain was derived from a negation + comparison `||` form
+    /// like `!foo || foo.bar !== "x"`. When true, the fix preserves the
+    /// trailing comparison untouched (it already lives inside `logical.right()`)
+    /// and uses `||` for prefix joining without wrapping the result in `!`.
+    comparison: bool,
 }
 
 pub enum UseOptionalChainState {
@@ -144,6 +153,27 @@ impl Rule for UseOptionalChain {
                     }
                     let chain_nodes =
                         chain.optional_chain_expression_nodes_from_negated_or(logical, model)?;
+                    return Some(UseOptionalChainState::LogicalAnd(chain_nodes));
+                }
+
+                // Check for negation + comparison `||` form like
+                // `!foo || foo.bar !== "x"`. The whole left side must still be
+                // a chain of `!`-negated nullability checks; the rightmost
+                // operand is a binary comparison whose left operand extends
+                // the chain.
+                if matches!(operator, JsLogicalOperator::LogicalOr)
+                    && let Some(chain_head) = extract_negation_comparison_head(logical)
+                    && is_negated_or_chain_left(logical)
+                {
+                    let chain = LogicalAndChain::from_expression(chain_head).ok()?;
+                    if chain
+                        .is_inside_another_negated_comparison_chain()
+                        .unwrap_or(false)
+                    {
+                        return None;
+                    }
+                    let chain_nodes = chain
+                        .optional_chain_expression_nodes_from_negated_comparison(logical, model)?;
                     return Some(UseOptionalChainState::LogicalAnd(chain_nodes));
                 }
 
@@ -241,9 +271,10 @@ impl Rule for UseOptionalChain {
                 // with the prefix on the left.
                 // E.g. `bar && foo && foo.length` → `bar && foo?.length`
                 // E.g. `!bar || !foo || !foo.length` → `!bar || !foo?.length`
+                // E.g. `!bar || !foo || foo.length !== 0` → `!bar || foo?.length !== 0`
                 let replacement = if let Some(prefix) = &chain_nodes.prefix {
                     let op_token = logical.operator_token().ok()?;
-                    let join_token = if chain_nodes.negated {
+                    let join_token = if chain_nodes.negated || chain_nodes.comparison {
                         make::token(T![||])
                     } else {
                         make::token(T![&&])
@@ -508,6 +539,13 @@ fn is_negated_or_chain(logical: &JsLogicalExpression) -> bool {
     {
         return false;
     }
+    is_negated_or_chain_left(logical)
+}
+
+/// Like `is_negated_or_chain`, but only checks the left side of `logical`.
+/// Used by the negation+comparison path where the rightmost operand is a
+/// comparison rather than a `!`-negated expression.
+fn is_negated_or_chain_left(logical: &JsLogicalExpression) -> bool {
     let mut current = logical.left().ok();
     while let Some(expr) = current.take() {
         match expr {
@@ -532,6 +570,39 @@ fn is_negated_or_chain(logical: &JsLogicalExpression) -> bool {
         }
     }
     false
+}
+
+/// If the right operand of `logical` is a binary comparison
+/// (`==`, `!=`, `===`, `!==`, `<`, `<=`, `>`, `>=`) with the form
+/// `chain <op> something`, returns the chain's left operand. Used to detect
+/// the negation + comparison form `!foo || foo.bar !== "x"`.
+fn extract_negation_comparison_head(logical: &JsLogicalExpression) -> Option<AnyJsExpression> {
+    let right = logical.right().ok()?.omit_parentheses();
+    let binary = right.as_js_binary_expression()?;
+    if !matches!(
+        binary.operator().ok()?,
+        JsBinaryOperator::Equality
+            | JsBinaryOperator::Inequality
+            | JsBinaryOperator::StrictEquality
+            | JsBinaryOperator::StrictInequality
+            | JsBinaryOperator::LessThan
+            | JsBinaryOperator::LessThanOrEqual
+            | JsBinaryOperator::GreaterThan
+            | JsBinaryOperator::GreaterThanOrEqual
+    ) {
+        return None;
+    }
+    let head = binary.left().ok()?;
+    // Require the head to look like a member or call chain so the rest of the
+    // logic can compare it against `!foo` operands. Plain identifiers are
+    // rejected because `!foo || foo !== "x"` reduces to `foo !== "x"` and
+    // doesn't need optional chaining.
+    match &head {
+        AnyJsExpression::JsStaticMemberExpression(_)
+        | AnyJsExpression::JsComputedMemberExpression(_)
+        | AnyJsExpression::JsCallExpression(_) => Some(head),
+        _ => None,
+    }
 }
 
 /// `LogicalAndChainOrdering` is the result of a comparison between two logical
@@ -723,8 +794,43 @@ impl LogicalAndChain {
             .and_then(|e| e.as_js_logical_expression())
             == Some(&parent)
         {
-            let stripped = strip_negation(&grand_parent.right().ok()?)?;
-            let gp_right_chain = Self::from_expression(stripped).ok()?;
+            let gp_right = grand_parent.right().ok()?;
+            // Either `!chain` or `chain <op> X` on the right side counts as
+            // an outer chain that swallows this inner one.
+            let gp_head = strip_negation(&gp_right)
+                .or_else(|| extract_negation_comparison_head(&grand_parent))?;
+            let gp_right_chain = Self::from_expression(gp_head).ok()?;
+            return match gp_right_chain.cmp_chain(self).ok()? {
+                LogicalAndChainOrdering::SubChain | LogicalAndChainOrdering::Equal => Some(true),
+                LogicalAndChainOrdering::Different => Some(false),
+            };
+        }
+        Some(false)
+    }
+
+    /// Like `is_inside_another_negated_chain`, but for the negation +
+    /// comparison form. The chain's "head" is the comparison's left operand,
+    /// not a `!`-negated expression, so the navigation differs by one step.
+    fn is_inside_another_negated_comparison_chain(&self) -> Option<bool> {
+        // self.head is the comparison's left operand (e.g. `foo.bar.baz`).
+        // Walk: head -> binary parent -> `||` parent -> grandparent `||`.
+        let binary = self.head.parent::<JsBinaryExpression>()?;
+        let parent = binary.parent::<JsLogicalExpression>()?;
+        let grand_parent = parent.parent::<JsLogicalExpression>()?;
+        if !matches!(grand_parent.operator().ok()?, JsLogicalOperator::LogicalOr) {
+            return Some(false);
+        }
+        if grand_parent
+            .left()
+            .ok()
+            .as_ref()
+            .and_then(|e| e.as_js_logical_expression())
+            == Some(&parent)
+        {
+            let gp_right = grand_parent.right().ok()?;
+            let gp_head = strip_negation(&gp_right)
+                .or_else(|| extract_negation_comparison_head(&grand_parent))?;
+            let gp_right_chain = Self::from_expression(gp_head).ok()?;
             return match gp_right_chain.cmp_chain(self).ok()? {
                 LogicalAndChainOrdering::SubChain | LogicalAndChainOrdering::Equal => Some(true),
                 LogicalAndChainOrdering::Different => Some(false),
@@ -989,6 +1095,7 @@ impl LogicalAndChain {
             nodes: optional_chain_expression_nodes,
             prefix,
             negated: false,
+            comparison: false,
         })
     }
 
@@ -1099,6 +1206,124 @@ impl LogicalAndChain {
             nodes: optional_chain_expression_nodes,
             prefix,
             negated: true,
+            comparison: false,
+        })
+    }
+
+    /// Like `optional_chain_expression_nodes_from_negated_or`, but the rightmost
+    /// operand of the `||` chain is a binary comparison `chain <op> X`
+    /// instead of `!chain`. The `||` operands to the LEFT must each still be
+    /// `!`-negated nullability checks of the same chain.
+    ///
+    /// Example: `!foo || !foo.bar || foo.bar.baz !== "x"` → walk left collecting
+    /// `bar` and `baz` as nodes that need `?.` conversion. The action wraps
+    /// `logical.right()` (the binary expression) by replacing the chain head
+    /// inside it, producing `foo?.bar?.baz !== "x"`.
+    fn optional_chain_expression_nodes_from_negated_comparison(
+        mut self,
+        logical: &JsLogicalExpression,
+        model: &SemanticModel,
+    ) -> Option<LogicalAndChainNodes> {
+        let mut optional_chain_expression_nodes = VecDeque::with_capacity(self.buf.len());
+        let mut next_chain_head = logical.left().ok();
+        let mut prev_branch: Option<Self> = None;
+        let mut prefix = None;
+        while let Some(expression) = next_chain_head.take() {
+            let original_expression = expression.clone();
+            let head = match expression {
+                AnyJsExpression::JsLogicalExpression(inner_logical) => {
+                    if matches!(inner_logical.operator().ok()?, JsLogicalOperator::LogicalOr) {
+                        next_chain_head = inner_logical.left().ok();
+                        strip_negation(&inner_logical.right().ok()?)?
+                    } else {
+                        return None;
+                    }
+                }
+                other => strip_negation(&other)?,
+            };
+            let branch =
+                Self::from_expression(normalized_optional_chain_like(head, model).ok()?).ok()?;
+            match self.cmp_chain(&branch).ok()? {
+                LogicalAndChainOrdering::SubChain => {
+                    if let Some(mut prev_branch) = prev_branch {
+                        let mut parts_to_pop = prev_branch.buf.len() - branch.buf.len() - 1;
+                        while parts_to_pop > 0 {
+                            if let (Some(left_part), Some(right_part)) =
+                                (prev_branch.buf.pop_back(), self.buf.pop_back())
+                            {
+                                match left_part {
+                                    AnyJsExpression::JsStaticMemberExpression(ref expr)
+                                        if expr
+                                            .operator_token()
+                                            .is_ok_and(|token| token.kind() == T![?.]) =>
+                                    {
+                                        optional_chain_expression_nodes.push_front(right_part);
+                                    }
+                                    AnyJsExpression::JsComputedMemberExpression(ref expr)
+                                        if expr.optional_chain_token().is_some() =>
+                                    {
+                                        optional_chain_expression_nodes.push_front(right_part);
+                                    }
+                                    AnyJsExpression::JsCallExpression(ref expr)
+                                        if expr.optional_chain_token().is_some() =>
+                                    {
+                                        optional_chain_expression_nodes.push_front(right_part);
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            parts_to_pop -= 1;
+                        }
+                    }
+                    let mut tail = self.buf.split_off(branch.buf.len());
+                    if let Some(part) = tail.pop_front() {
+                        optional_chain_expression_nodes.push_front(part);
+                    }
+                    prev_branch = Some(branch);
+                }
+                LogicalAndChainOrdering::Equal => {}
+                LogicalAndChainOrdering::Different => {
+                    prefix = Some(original_expression);
+                    break;
+                }
+            }
+        }
+
+        if let Some(mut prev_branch) = prev_branch {
+            while let (Some(left_part), Some(right_part)) =
+                (prev_branch.buf.pop_back(), self.buf.pop_back())
+            {
+                match left_part {
+                    AnyJsExpression::JsStaticMemberExpression(ref expr)
+                        if expr
+                            .operator_token()
+                            .is_ok_and(|token| token.kind() == T![?.]) =>
+                    {
+                        optional_chain_expression_nodes.push_front(right_part);
+                    }
+                    AnyJsExpression::JsComputedMemberExpression(ref expr)
+                        if expr.optional_chain_token().is_some() =>
+                    {
+                        optional_chain_expression_nodes.push_front(right_part);
+                    }
+                    AnyJsExpression::JsCallExpression(ref expr)
+                        if expr.optional_chain_token().is_some() =>
+                    {
+                        optional_chain_expression_nodes.push_front(right_part);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if optional_chain_expression_nodes.is_empty() {
+            return None;
+        }
+        Some(LogicalAndChainNodes {
+            nodes: optional_chain_expression_nodes,
+            prefix,
+            negated: false,
+            comparison: true,
         })
     }
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/invalidNegatedOrComparison.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/invalidNegatedOrComparison.js
@@ -1,0 +1,27 @@
+/* should generate diagnostics */
+
+// Each of the eight binary operators that yield the same boolean as the
+// optional-chain form when `foo` is nullish (because the left operand of
+// the comparison becomes `undefined`).
+!foo || foo.bar !== "x";
+!foo || foo.bar === "x";
+!foo || foo.bar != null;
+!foo || foo.bar == null;
+!foo || foo.bar > 0;
+!foo || foo.bar >= 0;
+!foo || foo.bar < 0;
+!foo || foo.bar <= 0;
+
+// Longer chains: every `!` on the left contributes a `?.` to the head of
+// the comparison.
+!foo || foo.bar.baz !== "x";
+!foo || !foo.bar || foo.bar.baz !== "x";
+!foo || !foo.bar || !foo.bar.baz || foo.bar.baz.buzz > 0;
+
+// Computed-member access and call expressions should also be covered.
+!foo || foo[bar] !== "x";
+!foo || foo.bar() !== undefined;
+
+// Prefix preserved: leading operands that don't match the chain are kept on
+// the left of `||`.
+bar || (!foo || foo.bar !== "x");

--- a/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/invalidNegatedOrComparison.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/invalidNegatedOrComparison.js.snap
@@ -1,0 +1,369 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidNegatedOrComparison.js
+---
+# Input
+```js
+/* should generate diagnostics */
+
+// Each of the eight binary operators that yield the same boolean as the
+// optional-chain form when `foo` is nullish (because the left operand of
+// the comparison becomes `undefined`).
+!foo || foo.bar !== "x";
+!foo || foo.bar === "x";
+!foo || foo.bar != null;
+!foo || foo.bar == null;
+!foo || foo.bar > 0;
+!foo || foo.bar >= 0;
+!foo || foo.bar < 0;
+!foo || foo.bar <= 0;
+
+// Longer chains: every `!` on the left contributes a `?.` to the head of
+// the comparison.
+!foo || foo.bar.baz !== "x";
+!foo || !foo.bar || foo.bar.baz !== "x";
+!foo || !foo.bar || !foo.bar.baz || foo.bar.baz.buzz > 0;
+
+// Computed-member access and call expressions should also be covered.
+!foo || foo[bar] !== "x";
+!foo || foo.bar() !== undefined;
+
+// Prefix preserved: leading operands that don't match the chain are kept on
+// the left of `||`.
+bar || (!foo || foo.bar !== "x");
+
+```
+
+# Diagnostics
+```
+invalidNegatedOrComparison.js:6:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    4 │ // optional-chain form when `foo` is nullish (because the left operand of
+    5 │ // the comparison becomes `undefined`).
+  > 6 │ !foo || foo.bar !== "x";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ !foo || foo.bar === "x";
+    8 │ !foo || foo.bar != null;
+  
+  i Unsafe fix: Change to an optional chain.
+  
+     4  4 │   // optional-chain form when `foo` is nullish (because the left operand of
+     5  5 │   // the comparison becomes `undefined`).
+     6    │ - !foo·||·foo.bar·!==·"x";
+        6 │ + foo?.bar·!==·"x";
+     7  7 │   !foo || foo.bar === "x";
+     8  8 │   !foo || foo.bar != null;
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:7:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    5 │ // the comparison becomes `undefined`).
+    6 │ !foo || foo.bar !== "x";
+  > 7 │ !foo || foo.bar === "x";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ !foo || foo.bar != null;
+    9 │ !foo || foo.bar == null;
+  
+  i Unsafe fix: Change to an optional chain.
+  
+     5  5 │   // the comparison becomes `undefined`).
+     6  6 │   !foo || foo.bar !== "x";
+     7    │ - !foo·||·foo.bar·===·"x";
+        7 │ + foo?.bar·===·"x";
+     8  8 │   !foo || foo.bar != null;
+     9  9 │   !foo || foo.bar == null;
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:8:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+     6 │ !foo || foo.bar !== "x";
+     7 │ !foo || foo.bar === "x";
+   > 8 │ !foo || foo.bar != null;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ !foo || foo.bar == null;
+    10 │ !foo || foo.bar > 0;
+  
+  i Unsafe fix: Change to an optional chain.
+  
+     6  6 │   !foo || foo.bar !== "x";
+     7  7 │   !foo || foo.bar === "x";
+     8    │ - !foo·||·foo.bar·!=·null;
+        8 │ + foo?.bar·!=·null;
+     9  9 │   !foo || foo.bar == null;
+    10 10 │   !foo || foo.bar > 0;
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:9:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+     7 │ !foo || foo.bar === "x";
+     8 │ !foo || foo.bar != null;
+   > 9 │ !foo || foo.bar == null;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ !foo || foo.bar > 0;
+    11 │ !foo || foo.bar >= 0;
+  
+  i Unsafe fix: Change to an optional chain.
+  
+     7  7 │   !foo || foo.bar === "x";
+     8  8 │   !foo || foo.bar != null;
+     9    │ - !foo·||·foo.bar·==·null;
+        9 │ + foo?.bar·==·null;
+    10 10 │   !foo || foo.bar > 0;
+    11 11 │   !foo || foo.bar >= 0;
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:10:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+     8 │ !foo || foo.bar != null;
+     9 │ !foo || foo.bar == null;
+  > 10 │ !foo || foo.bar > 0;
+       │ ^^^^^^^^^^^^^^^^^^^
+    11 │ !foo || foo.bar >= 0;
+    12 │ !foo || foo.bar < 0;
+  
+  i Unsafe fix: Change to an optional chain.
+  
+     8  8 │   !foo || foo.bar != null;
+     9  9 │   !foo || foo.bar == null;
+    10    │ - !foo·||·foo.bar·>·0;
+       10 │ + foo?.bar·>·0;
+    11 11 │   !foo || foo.bar >= 0;
+    12 12 │   !foo || foo.bar < 0;
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:11:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+     9 │ !foo || foo.bar == null;
+    10 │ !foo || foo.bar > 0;
+  > 11 │ !foo || foo.bar >= 0;
+       │ ^^^^^^^^^^^^^^^^^^^^
+    12 │ !foo || foo.bar < 0;
+    13 │ !foo || foo.bar <= 0;
+  
+  i Unsafe fix: Change to an optional chain.
+  
+     9  9 │   !foo || foo.bar == null;
+    10 10 │   !foo || foo.bar > 0;
+    11    │ - !foo·||·foo.bar·>=·0;
+       11 │ + foo?.bar·>=·0;
+    12 12 │   !foo || foo.bar < 0;
+    13 13 │   !foo || foo.bar <= 0;
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:12:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    10 │ !foo || foo.bar > 0;
+    11 │ !foo || foo.bar >= 0;
+  > 12 │ !foo || foo.bar < 0;
+       │ ^^^^^^^^^^^^^^^^^^^
+    13 │ !foo || foo.bar <= 0;
+    14 │ 
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    10 10 │   !foo || foo.bar > 0;
+    11 11 │   !foo || foo.bar >= 0;
+    12    │ - !foo·||·foo.bar·<·0;
+       12 │ + foo?.bar·<·0;
+    13 13 │   !foo || foo.bar <= 0;
+    14 14 │   
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:13:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    11 │ !foo || foo.bar >= 0;
+    12 │ !foo || foo.bar < 0;
+  > 13 │ !foo || foo.bar <= 0;
+       │ ^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+    15 │ // Longer chains: every `!` on the left contributes a `?.` to the head of
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    11 11 │   !foo || foo.bar >= 0;
+    12 12 │   !foo || foo.bar < 0;
+    13    │ - !foo·||·foo.bar·<=·0;
+       13 │ + foo?.bar·<=·0;
+    14 14 │   
+    15 15 │   // Longer chains: every `!` on the left contributes a `?.` to the head of
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:17:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    15 │ // Longer chains: every `!` on the left contributes a `?.` to the head of
+    16 │ // the comparison.
+  > 17 │ !foo || foo.bar.baz !== "x";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    18 │ !foo || !foo.bar || foo.bar.baz !== "x";
+    19 │ !foo || !foo.bar || !foo.bar.baz || foo.bar.baz.buzz > 0;
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    15 15 │   // Longer chains: every `!` on the left contributes a `?.` to the head of
+    16 16 │   // the comparison.
+    17    │ - !foo·||·foo.bar.baz·!==·"x";
+       17 │ + foo?.bar.baz·!==·"x";
+    18 18 │   !foo || !foo.bar || foo.bar.baz !== "x";
+    19 19 │   !foo || !foo.bar || !foo.bar.baz || foo.bar.baz.buzz > 0;
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:18:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    16 │ // the comparison.
+    17 │ !foo || foo.bar.baz !== "x";
+  > 18 │ !foo || !foo.bar || foo.bar.baz !== "x";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    19 │ !foo || !foo.bar || !foo.bar.baz || foo.bar.baz.buzz > 0;
+    20 │ 
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    16 16 │   // the comparison.
+    17 17 │   !foo || foo.bar.baz !== "x";
+    18    │ - !foo·||·!foo.bar·||·foo.bar.baz·!==·"x";
+       18 │ + foo?.bar?.baz·!==·"x";
+    19 19 │   !foo || !foo.bar || !foo.bar.baz || foo.bar.baz.buzz > 0;
+    20 20 │   
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:19:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    17 │ !foo || foo.bar.baz !== "x";
+    18 │ !foo || !foo.bar || foo.bar.baz !== "x";
+  > 19 │ !foo || !foo.bar || !foo.bar.baz || foo.bar.baz.buzz > 0;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    20 │ 
+    21 │ // Computed-member access and call expressions should also be covered.
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    17 17 │   !foo || foo.bar.baz !== "x";
+    18 18 │   !foo || !foo.bar || foo.bar.baz !== "x";
+    19    │ - !foo·||·!foo.bar·||·!foo.bar.baz·||·foo.bar.baz.buzz·>·0;
+       19 │ + foo?.bar?.baz?.buzz·>·0;
+    20 20 │   
+    21 21 │   // Computed-member access and call expressions should also be covered.
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:22:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    21 │ // Computed-member access and call expressions should also be covered.
+  > 22 │ !foo || foo[bar] !== "x";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^
+    23 │ !foo || foo.bar() !== undefined;
+    24 │ 
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    20 20 │   
+    21 21 │   // Computed-member access and call expressions should also be covered.
+    22    │ - !foo·||·foo[bar]·!==·"x";
+       22 │ + foo?.[bar]·!==·"x";
+    23 23 │   !foo || foo.bar() !== undefined;
+    24 24 │   
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:23:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    21 │ // Computed-member access and call expressions should also be covered.
+    22 │ !foo || foo[bar] !== "x";
+  > 23 │ !foo || foo.bar() !== undefined;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │ 
+    25 │ // Prefix preserved: leading operands that don't match the chain are kept on
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    21 21 │   // Computed-member access and call expressions should also be covered.
+    22 22 │   !foo || foo[bar] !== "x";
+    23    │ - !foo·||·foo.bar()·!==·undefined;
+       23 │ + foo?.bar()·!==·undefined;
+    24 24 │   
+    25 25 │   // Prefix preserved: leading operands that don't match the chain are kept on
+  
+
+```
+
+```
+invalidNegatedOrComparison.js:27:9 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    25 │ // Prefix preserved: leading operands that don't match the chain are kept on
+    26 │ // the left of `||`.
+  > 27 │ bar || (!foo || foo.bar !== "x");
+       │         ^^^^^^^^^^^^^^^^^^^^^^^
+    28 │ 
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    25 25 │   // Prefix preserved: leading operands that don't match the chain are kept on
+    26 26 │   // the left of `||`.
+    27    │ - bar·||·(!foo·||·foo.bar·!==·"x");
+       27 │ + bar·||·(foo?.bar·!==·"x");
+    28 28 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/validNegatedOrComparison.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/validNegatedOrComparison.js
@@ -1,0 +1,20 @@
+/* should not generate diagnostics */
+
+// Different identifiers — not the same chain on both sides.
+!foo || bar.baz !== "x";
+!foo || foo.bar !== "x" && other;
+
+// LHS is not a `!`-negated check.
+foo || foo.bar !== "x";
+foo === undefined || foo.bar !== "x";
+
+// Mixed operators on the LHS chain.
+!foo && foo.bar !== "x";
+
+// RHS is a non-comparison binary expression.
+!foo || foo.bar + 1;
+!foo || foo.bar | 0;
+
+// RHS comparison's left side is a bare identifier — already non-trivial
+// and doesn't need optional chaining.
+!foo || foo !== "x";

--- a/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/validNegatedOrComparison.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/validNegatedOrComparison.js.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validNegatedOrComparison.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+
+// Different identifiers — not the same chain on both sides.
+!foo || bar.baz !== "x";
+!foo || foo.bar !== "x" && other;
+
+// LHS is not a `!`-negated check.
+foo || foo.bar !== "x";
+foo === undefined || foo.bar !== "x";
+
+// Mixed operators on the LHS chain.
+!foo && foo.bar !== "x";
+
+// RHS is a non-comparison binary expression.
+!foo || foo.bar + 1;
+!foo || foo.bar | 0;
+
+// RHS comparison's left side is a bare identifier — already non-trivial
+// and doesn't need optional chaining.
+!foo || foo !== "x";
+
+```


### PR DESCRIPTION
## Summary

Closes #10244.

`useOptionalChain` already handles `!foo || !foo.bar` thanks to #9567. The closely-related De Morgan form on the right-hand side – a binary comparison – was still missed:

```ts
// Already flagged before this PR:
if (!foo || !foo.bar) { ... }

// Now also flagged:
if (!foo || foo.bar !== "x") { ... }
if (!foo || foo.bar === "x") { ... }
if (!foo || foo.bar > 0)     { ... }
```

ESLint's `@typescript-eslint/prefer-optional-chain` rule handles this family today, so projects migrating from ESLint hit the gap.

## Operators covered

The rightmost operand may be a binary comparison using any of: `==`, `!=`, `===`, `!==`, `<`, `<=`, `>`, `>=`. The fix preserves the operator and right operand, replacing the comparison's left side with the optional-chained form:

- `!foo || foo.bar !== "x"` → `foo?.bar !== "x"`
- `!foo || foo.bar === "x"` → `foo?.bar === "x"`
- `!foo || foo.bar > 0` → `foo?.bar > 0`
- `!foo || foo[key] != null` → `foo?.[key] != null`
- `!foo || foo.bar() !== undefined` → `foo?.bar() !== undefined`
- `!foo || !foo.bar || foo.bar.baz !== "x"` → `foo?.bar?.baz !== "x"`

The fix is unsafe (matching the rule's existing `FixKind::Unsafe`) because the comparison's behaviour at runtime can differ when the head is nullish – e.g. `!foo || foo.bar === "x"` is `true` when `foo` is nullish, but `foo?.bar === "x"` is `false`. ESLint's rule has the same caveat.

## Implementation notes

- Detection of the negated `||` prefix is factored out into `is_negated_or_chain_left`, which both the existing path and the new one call. The same-object equivalence check (`LogicalAndChain::cmp_chain`) is reused unchanged.
- A new `extract_negation_comparison_head` recognises the comparison form on the right side of `||` and returns its left operand as the chain head. Identifier-only heads are rejected because `!foo || foo !== "x"` reduces to `foo !== "x"` and doesn't need optional chaining.
- `LogicalAndChain` gains a sibling walker `optional_chain_expression_nodes_from_negated_comparison` that mirrors `optional_chain_expression_nodes_from_negated_or` but emits a `LogicalAndChainNodes` with `comparison: true`. The action then leaves `logical.right()` (the binary expression) intact and replaces only the chain subject inside it, so the operator and right operand fall out for free.
- `is_inside_another_negated_chain` is widened to recognise the comparison form as an outer chain, plus a sibling `is_inside_another_negated_comparison_chain`. This keeps `!foo || !foo.bar || foo.bar.baz !== "x"` to a single full-expression diagnostic instead of stacking the inner `!foo || !foo.bar` one on top.

## Tests

Two new fixtures under `crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/`:

- `invalidNegatedOrComparison.js` – 14 invalid cases: all 8 operators, longer chains (`foo.bar.baz`, `foo.bar.baz.buzz`), computed-member and call-expression heads, and a prefix case (`bar || (!foo || foo.bar !== "x")`).
- `validNegatedOrComparison.js` – 7 valid cases: different identifier on the right, mixed `&&` operators, RHS is not a comparison, RHS comparison's left side is a bare identifier, etc.

The existing 27 `useOptionalChain` tests still pass; the full `biome_js_analyze` suite (2522 tests) is green.

The rule's documentation block gains one extra `expect_diagnostic` example so the new form shows up in the generated docs.

A changeset entry is included.

## Test plan

- [x] `cargo test -p biome_js_analyze` (2522 passed)
- [x] `cargo test -p biome_js_analyze --test spec_tests use_optional_chain` (29 passed)
- [x] `cargo run -p rules_check` (clean)
- [x] `rustfmt --check` on the rule file (clean; project pins toolchain `1.95.0` but `rustfmt 1.8.0` agreed on the diff)
- [ ] `cargo clippy -- -D warnings` not run – `clippy` not installed in this environment and the project's pinned toolchain isn't reachable via `apt`. Build with `-D warnings` reaches all the same lints the project enables and is clean.