### PR TITLE
fix(lint/js): keep functional class values intact in useSortedClasses

### DIFF
--- a/.changeset/grumpy-ears-relax.md
+++ b/.changeset/grumpy-ears-relax.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10261](https://github.com/biomejs/biome/issues/10261): [`useSortedClasses`](https://biomejs.dev/linter/rules/use-sorted-classes/) now keeps functional class values containing spaces, such as `border-oklch(0.922 0 0)`, as a single token when sorting utility classes.

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
@@ -127,6 +127,63 @@ fn compare_classes(a: &ClassInfo, b: &ClassInfo) -> Ordering {
     Ordering::Equal
 }
 
+fn split_class_list(class_list: &str) -> Vec<&str> {
+    let mut result = Vec::new();
+    let mut token_start: Option<usize> = None;
+    let mut bracket_depth = 0usize;
+    let mut paren_depth = 0usize;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    for (index, ch) in class_list.char_indices() {
+        if let Some(active_quote) = quote {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+
+        if let Some(start) = token_start {
+            if ch.is_whitespace() && bracket_depth == 0 && paren_depth == 0 {
+                result.push(&class_list[start..index]);
+                token_start = None;
+                continue;
+            }
+
+            match ch {
+                '[' => bracket_depth += 1,
+                ']' => bracket_depth = bracket_depth.saturating_sub(1),
+                '(' => paren_depth += 1,
+                ')' => paren_depth = paren_depth.saturating_sub(1),
+                '\'' | '"' | '`' => quote = Some(ch),
+                _ => {}
+            }
+        } else if !ch.is_whitespace() {
+            token_start = Some(index);
+            match ch {
+                '[' => bracket_depth += 1,
+                '(' => paren_depth += 1,
+                '\'' | '"' | '`' => quote = Some(ch),
+                _ => {}
+            }
+        }
+    }
+
+    if let Some(start) = token_start {
+        result.push(&class_list[start..]);
+    }
+
+    result
+}
+
 /// Sort the given class string according to the given sort config.
 pub fn sort_class_name(
     class_name: &TokenText,
@@ -138,20 +195,21 @@ pub fn sort_class_name(
         .map_or((false, false), |ctx| ctx.get_ignore_flags());
 
     // Obtain classes by splitting the class string by whitespace.
-    let mut classes_iter = class_name.split_whitespace();
+    let mut classes = split_class_list(class_name.text());
     let class_str_prefix = if ignore_prefix {
-        classes_iter.next()
+        if classes.is_empty() {
+            None
+        } else {
+            Some(classes.remove(0))
+        }
     } else {
         None
     };
     let class_str_postfix = if ignore_postfix {
-        classes_iter.next_back()
+        classes.pop()
     } else {
         None
     };
-
-    // Collect the remaining classes into a vector if needed.
-    let classes: Vec<&str> = classes_iter.collect();
 
     // Separate custom classes from recognized classes, and compute the recognized classes' info.
     // Custom classes always go first, in the order that they appear in.
@@ -215,9 +273,9 @@ pub fn get_sort_class_name_range(
     range: &TextRange,
     template_literal_space_context: &Option<TemplateLiteralSpaceContext>,
 ) -> Option<TextRange> {
-    let mut class_iter = class_name.split_whitespace();
-    let first_class_len = class_iter.next().map_or(0, |s| s.len()) as u32;
-    let last_class_len = class_iter.next_back().map_or(0, |s| s.len()) as u32;
+    let classes = split_class_list(class_name.text());
+    let first_class_len = classes.first().map_or(0, |s| s.len()) as u32;
+    let last_class_len = classes.last().map_or(0, |s| s.len()) as u32;
 
     let (ignore_prefix, ignore_postfix) = template_literal_space_context
         .as_ref()

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_oklch_spaces.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_oklch_spaces.jsx
@@ -1,0 +1,8 @@
+/* should generate diagnostics */
+<div class="border-oklch(0.922 0 0) p-4 m-2" />;
+
+/* should not generate diagnostics */
+<div class="m-2 border-oklch(0.922 0 0) p-4" />;
+
+/* should generate diagnostics */
+<div className={`border-oklch(0.922 0 0) p-4 m-2`} />;

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_oklch_spaces.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_oklch_spaces.jsx.snap
@@ -1,0 +1,69 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: issue_oklch_spaces.jsx
+---
+# Input
+```jsx
+/* should generate diagnostics */
+<div class="border-oklch(0.922 0 0) p-4 m-2" />;
+
+/* should not generate diagnostics */
+<div class="m-2 border-oklch(0.922 0 0) p-4" />;
+
+/* should generate diagnostics */
+<div className={`border-oklch(0.922 0 0) p-4 m-2`} />;
+
+```
+
+# Diagnostics
+```
+issue_oklch_spaces.jsx:2:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ <div class="border-oklch(0.922 0 0) p-4 m-2" />;
+      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ /* should not generate diagnostics */
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+    1 1 │   /* should generate diagnostics */
+    2   │ - <div·class="border-oklch(0.922·0·0)·p-4·m-2"·/>;
+      2 │ + <div·class="m-2·border-oklch(0.922·0·0)·p-4"·/>;
+    3 3 │   
+    4 4 │   /* should not generate diagnostics */
+  
+
+```
+
+```
+issue_oklch_spaces.jsx:8:18 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    7 │ /* should generate diagnostics */
+  > 8 │ <div className={`border-oklch(0.922 0 0) p-4 m-2`} />;
+      │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    9 │ 
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+    6 6 │   
+    7 7 │   /* should generate diagnostics */
+    8   │ - <div·className={`border-oklch(0.922·0·0)·p-4·m-2`}·/>;
+      8 │ + <div·className={`m-2·border-oklch(0.922·0·0)·p-4`}·/>;
+    9 9 │   
+  
+
+```


### PR DESCRIPTION
## Summary
Fixes #10261

Fixed [`useSortedClasses`](https://biomejs.dev/linter/rules/use-sorted-classes/) class splitting so whitespace inside functional values (for example, `border-oklch(0.922 0 0)`) is not treated as class separators.
Added regression coverage for string and template literal cases to ensure sorting and diagnostic ranges remain correct for functional values containing spaces.

## Test Plan
Ran `cargo test -p biome_js_analyze nursery::use_sorted_classes -- --nocapture`.

## Docs
N/A

> This PR was created with AI assistance (OpenCode).