### PR TITLE
refactor(markdown_parser): name CommonMark magic numbers

### DIFF
--- a/crates/biome_markdown_parser/src/lexer/mod.rs
+++ b/crates/biome_markdown_parser/src/lexer/mod.rs
@@ -1370,7 +1370,7 @@ impl<'src> MarkdownLexer<'src> {
     }
 
     /// Check if current position starts a potential hard line break pattern.
-    /// Returns true if there are 2+ spaces followed by a newline.
+    /// Returns true if enough trailing spaces are followed by a newline.
     fn is_potential_hard_line_break(&self) -> bool {
         // Must have at least one space at current position (already checked by caller)
         let mut offset = 0;
@@ -1382,9 +1382,9 @@ impl<'src> MarkdownLexer<'src> {
             offset += 1;
         }
 
-        if space_count >= 2 {
-            // A hard line break requires 2+ spaces followed by a newline
-            // (https://spec.commonmark.org/0.31.2/#hard-line-breaks).
+        if space_count >= MIN_HARD_BREAK_TRAILING_SPACES {
+            // A hard line break requires enough trailing spaces followed by a
+            // newline (https://spec.commonmark.org/0.31.2/#hard-line-breaks).
             // Trailing spaces at EOF are never a valid hard line break,
             // but they must be split from the preceding text so the
             // formatter can strip them without idempotency issues.

--- a/crates/biome_markdown_parser/src/lexer/mod.rs
+++ b/crates/biome_markdown_parser/src/lexer/mod.rs
@@ -13,9 +13,10 @@ use biome_rowan::{SyntaxKind, TextSize};
 use biome_unicode_table::Dispatch::{self, AMP, *};
 use biome_unicode_table::lookup_byte;
 
-use crate::syntax::{MAX_BLOCK_PREFIX_INDENT, TAB_STOP_SPACES};
-
-const MAX_ORDERED_LIST_MARKER_DIGITS: usize = 9;
+use crate::syntax::{
+    MAX_BLOCK_PREFIX_INDENT, MAX_ORDERED_LIST_MARKER_DIGITS, MIN_FENCE_RUN_LENGTH,
+    MIN_HARD_BREAK_TRAILING_SPACES, MIN_THEMATIC_BREAK_RUN, TAB_STOP_SPACES,
+};
 
 /// Lexer context for different markdown parsing modes
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
@@ -587,7 +588,9 @@ impl<'src> MarkdownLexer<'src> {
         }
 
         // Check for hard line break: 2+ spaces followed by newline
-        if space_count >= 2 && matches!(self.current_byte(), Some(b'\n' | b'\r')) {
+        if space_count >= MIN_HARD_BREAK_TRAILING_SPACES
+            && matches!(self.current_byte(), Some(b'\n' | b'\r'))
+        {
             // Consume the newline as part of the hard line break
             match self.current_byte() {
                 Some(b'\n') => {
@@ -926,7 +929,7 @@ impl<'src> MarkdownLexer<'src> {
         // Check if this is a valid thematic break: 3+ of same char, only whitespace between,
         // followed by newline or EOF, AND must be at line start (CommonMark requirement)
         if self.after_newline
-            && count >= 3
+            && count >= MIN_THEMATIC_BREAK_RUN
             && matches!(self.current_byte(), Some(b'\n' | b'\r') | None)
         {
             return MD_THEMATIC_BREAK_LITERAL;
@@ -993,7 +996,7 @@ impl<'src> MarkdownLexer<'src> {
                 self.advance(1);
                 digit_count += 1;
                 // CommonMark limits to 9 digits max
-                if digit_count > 9 {
+                if digit_count > MAX_ORDERED_LIST_MARKER_DIGITS {
                     // Too many digits, not a valid marker
                     self.position = start_position;
                     return self.consume_textual(MarkdownLexContext::Regular);
@@ -1097,7 +1100,7 @@ impl<'src> MarkdownLexer<'src> {
         }
 
         // At line start with 3+ backticks: fenced code block
-        if self.after_newline && count >= 3 {
+        if self.after_newline && count >= MIN_FENCE_RUN_LENGTH {
             self.advance(count);
             return TRIPLE_BACKTICK;
         }
@@ -1122,7 +1125,7 @@ impl<'src> MarkdownLexer<'src> {
         }
 
         // At line start with 3+ tildes: fenced code block
-        if self.after_newline && count >= 3 {
+        if self.after_newline && count >= MIN_FENCE_RUN_LENGTH {
             self.advance(count);
             return TRIPLE_TILDE;
         }
@@ -1297,7 +1300,7 @@ impl<'src> MarkdownLexer<'src> {
 
         while pos < bytes.len() && bytes[pos].is_ascii_digit() {
             digit_count += 1;
-            if digit_count > 9 {
+            if digit_count > MAX_ORDERED_LIST_MARKER_DIGITS {
                 return false;
             }
             pos += 1;

--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -54,9 +54,9 @@ use crate::syntax::thematic_break_block::parse_thematic_break_block;
 use crate::syntax::with_virtual_line_start;
 use crate::syntax::{
     INDENT_CODE_BLOCK_SPACES, MAX_ATX_HEADING_LEVEL, MAX_BLOCK_PREFIX_INDENT,
-    MAX_ORDERED_LIST_MARKER_DIGITS, MIN_FENCE_RUN_LENGTH, MIN_THEMATIC_BREAK_RUN,
-    TAB_STOP_SPACES, at_block_interrupt, at_indent_code_block, is_paragraph_like,
-    is_whitespace_only, parse_empty_paragraph,
+    MAX_ORDERED_LIST_MARKER_DIGITS, MIN_FENCE_RUN_LENGTH, MIN_THEMATIC_BREAK_RUN, TAB_STOP_SPACES,
+    at_block_interrupt, at_indent_code_block, is_paragraph_like, is_whitespace_only,
+    parse_empty_paragraph,
 };
 use crate::syntax::{parse_any_block_with_indent_code_policy, parse_paragraph};
 use biome_rowan::{TextRange, TextSize};

--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -53,7 +53,8 @@ use crate::syntax::quote::{
 use crate::syntax::thematic_break_block::parse_thematic_break_block;
 use crate::syntax::with_virtual_line_start;
 use crate::syntax::{
-    INDENT_CODE_BLOCK_SPACES, MAX_BLOCK_PREFIX_INDENT, TAB_STOP_SPACES, at_block_interrupt,
+    INDENT_CODE_BLOCK_SPACES, MAX_BLOCK_PREFIX_INDENT, MAX_ORDERED_LIST_MARKER_DIGITS,
+    MIN_FENCE_RUN_LENGTH, MIN_THEMATIC_BREAK_RUN, TAB_STOP_SPACES, at_block_interrupt,
     at_indent_code_block, is_paragraph_like, is_whitespace_only, parse_empty_paragraph,
 };
 use crate::syntax::{parse_any_block_with_indent_code_policy, parse_paragraph};
@@ -260,7 +261,7 @@ fn is_thematic_break_pattern(p: &mut MarkdownParser) -> bool {
         }
     }
 
-    count >= 3
+    count >= MIN_THEMATIC_BREAK_RUN
 }
 
 fn at_bullet_list_item_with_base_indent(p: &mut MarkdownParser, base_indent: usize) -> bool {
@@ -1268,7 +1269,7 @@ pub(crate) fn textual_starts_with_ordered_marker(text: &str) -> bool {
     while let Some(c) = chars.peek().copied() {
         if c.is_ascii_digit() {
             digit_count += 1;
-            if digit_count > 9 {
+            if digit_count > MAX_ORDERED_LIST_MARKER_DIGITS {
                 return false;
             }
             chars.next();
@@ -1319,7 +1320,7 @@ fn quote_only_line_indent_at_current(p: &MarkdownParser, depth: usize) -> Option
     let mut i = start;
     for _ in 0..depth {
         let mut column = 0usize;
-        while i < line_end && column < 3 {
+        while i < line_end && column < MAX_BLOCK_PREFIX_INDENT {
             match bytes[i] {
                 b' ' => {
                     column += 1;
@@ -1386,7 +1387,7 @@ fn next_quote_content_indent(p: &MarkdownParser, depth: usize) -> Option<usize> 
         let mut i = line_start;
         for _ in 0..depth {
             let mut column = 0usize;
-            while i < line_end && column < 3 {
+            while i < line_end && column < MAX_BLOCK_PREFIX_INDENT {
                 match bytes[i] {
                     b' ' => {
                         column += 1;
@@ -2023,7 +2024,7 @@ fn parse_first_line_blocks(
         if p.at(TRIPLE_BACKTICK) || p.at(TRIPLE_TILDE) {
             return true;
         }
-        (p.at(BACKTICK) || p.at(TILDE)) && p.cur_text().len() >= 3
+        (p.at(BACKTICK) || p.at(TILDE)) && p.cur_text().len() >= MIN_FENCE_RUN_LENGTH
     });
 
     if fenced_code_start {
@@ -2344,7 +2345,7 @@ fn is_dash_only_thematic_break_line_text(text: &str) -> bool {
         }
     }
 
-    dash_count >= 3
+    dash_count >= MIN_THEMATIC_BREAK_RUN
 }
 
 fn emit_current_line_indent_list_bytes(p: &mut MarkdownParser, mut byte_count: usize) {

--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -53,9 +53,10 @@ use crate::syntax::quote::{
 use crate::syntax::thematic_break_block::parse_thematic_break_block;
 use crate::syntax::with_virtual_line_start;
 use crate::syntax::{
-    INDENT_CODE_BLOCK_SPACES, MAX_BLOCK_PREFIX_INDENT, MAX_ORDERED_LIST_MARKER_DIGITS,
-    MIN_FENCE_RUN_LENGTH, MIN_THEMATIC_BREAK_RUN, TAB_STOP_SPACES, at_block_interrupt,
-    at_indent_code_block, is_paragraph_like, is_whitespace_only, parse_empty_paragraph,
+    INDENT_CODE_BLOCK_SPACES, MAX_ATX_HEADING_LEVEL, MAX_BLOCK_PREFIX_INDENT,
+    MAX_ORDERED_LIST_MARKER_DIGITS, MIN_FENCE_RUN_LENGTH, MIN_THEMATIC_BREAK_RUN,
+    TAB_STOP_SPACES, at_block_interrupt, at_indent_code_block, is_paragraph_like,
+    is_whitespace_only, parse_empty_paragraph,
 };
 use crate::syntax::{parse_any_block_with_indent_code_policy, parse_paragraph};
 use biome_rowan::{TextRange, TextSize};
@@ -2378,7 +2379,7 @@ fn parse_first_line_atx_heading(p: &mut MarkdownParser, state: &mut ListItemLoop
         }
         let text = p.cur_text();
         let hash_count = text.len();
-        if !(1..=6).contains(&hash_count) {
+        if !(1..=MAX_ATX_HEADING_LEVEL).contains(&hash_count) {
             return None;
         }
         p.bump(p.cur());

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -103,6 +103,18 @@ pub(crate) const TAB_STOP_SPACES: usize = 4;
 /// CommonMark allows 0-3 spaces of optional indentation before block-level
 /// markers (blockquotes §5.1, list items §5.2/§5.3, ATX headings §4.2, etc.).
 pub(crate) const MAX_BLOCK_PREFIX_INDENT: usize = 3;
+/// CommonMark §5.2 caps ordered list markers at 9 digits.
+pub(crate) const MAX_ORDERED_LIST_MARKER_DIGITS: usize = 9;
+/// CommonMark §4.2 caps ATX headings at 6 levels (`#` through `######`).
+pub(crate) const MAX_ATX_HEADING_LEVEL: usize = 6;
+/// CommonMark §6.7 hard line breaks require at least 2 trailing spaces.
+pub(crate) const MIN_HARD_BREAK_TRAILING_SPACES: usize = 2;
+/// CommonMark §4.1 thematic breaks require a run of at least 3 matching
+/// characters (`-`, `_`, or `*`).
+pub(crate) const MIN_THEMATIC_BREAK_RUN: usize = 3;
+/// CommonMark §4.5 fenced code blocks require an opening fence of at
+/// least 3 backticks or tildes.
+pub(crate) const MIN_FENCE_RUN_LENGTH: usize = 3;
 
 pub(crate) fn parse_document(p: &mut MarkdownParser) {
     let m = p.start();
@@ -1970,7 +1982,7 @@ fn check_too_many_hashes(p: &mut MarkdownParser) -> Option<(biome_rowan::TextRan
         let range = p.cur_range();
         let count = p.cur_text().len();
 
-        if count > 6 {
+        if count > MAX_ATX_HEADING_LEVEL {
             Some((range, count))
         } else {
             None
@@ -1993,7 +2005,7 @@ fn is_valid_atx_heading_start(p: &mut MarkdownParser) -> bool {
         let hash_count = p.cur_text().len();
 
         // Too many hashes - not a valid heading (must be 1-6)
-        if hash_count > 6 {
+        if hash_count > MAX_ATX_HEADING_LEVEL {
             return false;
         }
 


### PR DESCRIPTION
> [!NOTE]
> I used Claude Code to plan and implement this refactor.

## Summary

Replaces literal `2`/`3`/`6`/`9` in the markdown parser with named constants in `syntax/mod.rs`, each citing the relevant CommonMark section. No behavior change.

## Test Plan

- `just test-crate biome_markdown_parser`
- `just test-markdown-conformance`

## Docs

N/A