### PR TITLE
fix(biome_configuration): grammar typo in extends docstring (#10260)

### DIFF
--- a/crates/biome_configuration/src/extends.rs
+++ b/crates/biome_configuration/src/extends.rs
@@ -7,7 +7,7 @@ use biome_deserialize_macros::Merge;
 use biome_diagnostics::Severity;
 use serde::{Deserialize, Serialize};
 
-/// A list of paths to other JSON files, used to extends the current configuration.
+/// A list of paths to other JSON files, used to extend the current configuration.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Merge)]
 #[serde(deny_unknown_fields, rename_all = "camelCase", untagged)]
 pub enum Extends {

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -137,7 +137,7 @@ pub struct Configuration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub root: Option<RootEnabled>,
 
-    /// A list of paths to other JSON files, used to extends the current configuration.
+    /// A list of paths to other JSON files, used to extend the current configuration.
     #[cfg_attr(feature = "cli", bpaf(hide, pure(Default::default())))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extends: Option<Extends>,


### PR DESCRIPTION
Closes #10260.

Fixes a grammatical typo in the \`extends\` field's docstring — it currently reads:

> A list of paths to other JSON files, used to **extends** the current configuration.

Should be:

> A list of paths to other JSON files, used to **extend** the current configuration.

The docstring is rendered into the JSON schema's \`description\` field (\`https://biomejs.dev/schemas/2.4.14/schema.json\`) which IDEs surface on hover.

Two files updated, +2 / -2:

- \`crates/biome_configuration/src/lib.rs\`
- \`crates/biome_configuration/src/extends.rs\`