### PR TITLE
fix(noUselessFragments): allow Fragment with slot attribute (#10248)

### DIFF
--- a/.changeset/no-useless-fragments-astro-slot.md
+++ b/.changeset/no-useless-fragments-astro-slot.md
@@ -1,0 +1,14 @@
+---
+"@biomejs/biome": patch
+---
+
+[`noUselessFragments`](https://biomejs.dev/linter/rules/no-useless-fragments/) no longer flags a `Fragment` carrying a `slot` attribute.
+
+Astro uses the `slot` prop on `<Fragment>` to forward children to a [named slot](https://docs.astro.build/en/basics/astro-components/#named-slots). The Fragment is the carrier for the slot prop and cannot be removed, so the rule must preserve it just as it already preserves `key`-keyed fragments.
+
+```jsx
+<Foo>
+  <Fragment slot="a">text</Fragment>
+  <Fragment slot="b">{value}</Fragment>
+</Foo>
+```

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -211,7 +211,9 @@ impl Rule for NoUselessFragments {
 
                 // The `Fragment` component supports only the "key" prop and react emits a warning for not supported props.
                 // We assume that the user knows - and fixed - that and only care about the prop that is actually supported.
-                let attribute_key =
+                // Astro additionally uses the "slot" prop on `<Fragment>` to forward children to a named slot,
+                // so a Fragment carrying a `slot` attribute is meaningful and must be preserved as well.
+                let has_meaningful_attribute =
                     opening_element
                         .attributes()
                         .into_iter()
@@ -220,14 +222,15 @@ impl Rule for NoUselessFragments {
                             let attribute_name = attribute.name().ok()?;
                             let attribute_name = attribute_name.as_jsx_name()?;
 
-                            if attribute_name.value_token().ok()?.text_trimmed() == "key" {
+                            let name = attribute_name.value_token().ok()?;
+                            if matches!(name.text_trimmed(), "key" | "slot") {
                                 Some(())
                             } else {
                                 None
                             }
                         });
 
-                if attribute_key.is_some() {
+                if has_meaningful_attribute.is_some() {
                     return None;
                 }
 

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10248.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10248.jsx
@@ -1,0 +1,31 @@
+/* should not generate diagnostics */
+import { Fragment } from "react";
+
+// Astro forwards children to a named slot via the `slot` prop on <Fragment>.
+// The Fragment is meaningful and must not be flagged as useless.
+
+function NamedSlots({ item, text }) {
+    return (
+        <Foo>
+            <Fragment slot="a">text</Fragment>
+            <Fragment slot="b">{text}</Fragment>
+        </Foo>
+    );
+}
+
+function NamedSlotsInLogical({ item, text }) {
+    return item && (
+        <Foo>
+            <Fragment slot="a">text</Fragment>
+            <Fragment slot="b">{item.text}</Fragment>
+        </Foo>
+    );
+}
+
+function EmptySlotName() {
+    return (
+        <Foo>
+            <Fragment slot="">text</Fragment>
+        </Foo>
+    );
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10248.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10248.jsx.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_10248.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+import { Fragment } from "react";
+
+// Astro forwards children to a named slot via the `slot` prop on <Fragment>.
+// The Fragment is meaningful and must not be flagged as useless.
+
+function NamedSlots({ item, text }) {
+    return (
+        <Foo>
+            <Fragment slot="a">text</Fragment>
+            <Fragment slot="b">{text}</Fragment>
+        </Foo>
+    );
+}
+
+function NamedSlotsInLogical({ item, text }) {
+    return item && (
+        <Foo>
+            <Fragment slot="a">text</Fragment>
+            <Fragment slot="b">{item.text}</Fragment>
+        </Foo>
+    );
+}
+
+function EmptySlotName() {
+    return (
+        <Foo>
+            <Fragment slot="">text</Fragment>
+        </Foo>
+    );
+}
+
+```


### PR DESCRIPTION
## Summary

`lint/complexity/noUselessFragments` false-positives on `<Fragment slot="…">` when nested inside another component. The `slot` prop is how Astro [forwards children to a named slot](https://docs.astro.build/en/basics/astro-components/#named-slots), so a `Fragment` carrying a `slot` attribute is the carrier for the prop and cannot be removed without changing semantics.

The rule already preserves `key`-keyed fragments for the analogous reason in React (the Fragment is the hint to the reconciler). This PR mirrors that exemption for `slot`.

## Before / after

```jsx
<Foo>
  <Fragment slot="a">text</Fragment>
  <Fragment slot="b">{value}</Fragment>
</Foo>
```

- **Before:** both `<Fragment slot="…">` flagged with `lint/complexity/noUselessFragments` and an unsafe fix that drops the slot binding.
- **After:** no diagnostic; the existing `<Fragment><Component /></Fragment>` (no `slot`) is still reported, regression-pinned by `withJsxElementInvalid.jsx`.

## Implementation

Single-line widening of the attribute filter inside the `JsxElement` branch:

```diff
-if attribute_name.value_token().ok()?.text_trimmed() == "key" {
+if matches!(name.text_trimmed(), "key" | "slot") {
```

Renamed the local from `attribute_key` to `has_meaningful_attribute` and updated the comment to spell out the Astro use case alongside the React `key` rationale.

## Test fixtures

`crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10248.jsx` — three valid cases:

- `<Fragment slot="a">text</Fragment>` and `<Fragment slot="b">{text}</Fragment>` nested in a parent component
- the same inside a logical expression (`item && (...)`)
- empty slot name (`slot=""`)

The existing `withJsxElementInvalid.jsx` already covers the regression-pin for `<Fragment><Component /></Fragment>` (no slot — must still be flagged).

`cargo test -p biome_js_analyze no_useless_fragments` → 35 passed, 0 failed.

Closes #10248