### PR TITLE
fix(parse/html): treat `of` as text in text contexts

### DIFF
--- a/.changeset/thick-poems-deny.md
+++ b/.changeset/thick-poems-deny.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10271](https://github.com/biomejs/biome/issues/10271): The HTML parser now correctly parses `of` as text content when in text contexts.

--- a/crates/biome_html_parser/src/syntax/mod.rs
+++ b/crates/biome_html_parser/src/syntax/mod.rs
@@ -13,12 +13,11 @@ use crate::syntax::astro::{
 };
 use crate::syntax::parse_error::*;
 use crate::syntax::svelte::{
-    is_at_svelte_directive_start, is_at_svelte_keyword, parse_attach_attribute,
-    parse_svelte_at_block, parse_svelte_directive, parse_svelte_hash_block,
-    parse_svelte_spread_or_expression,
+    SVELTE_KEYWORDS, is_at_svelte_directive_start, parse_attach_attribute, parse_svelte_at_block,
+    parse_svelte_directive, parse_svelte_hash_block, parse_svelte_spread_or_expression,
 };
 use crate::syntax::vue::{
-    parse_vue_directive, parse_vue_v_bind_shorthand_directive, parse_vue_v_for_value,
+    VUE_KEYWORDS, parse_vue_directive, parse_vue_v_bind_shorthand_directive, parse_vue_v_for_value,
     parse_vue_v_on_shorthand_directive, parse_vue_v_slot_shorthand_directive,
 };
 use crate::token_source::{
@@ -904,12 +903,12 @@ impl TextExpression {
     }
 }
 
-#[inline]
-fn is_at_keyword(p: &mut HtmlParser) -> bool {
-    is_at_svelte_keyword(p) || is_at_html_keyword(p)
-}
+const ALL_POSSIBLE_KEYWORDS: TokenSet<HtmlSyntaxKind> =
+    HTML_KEYWORDS.union(SVELTE_KEYWORDS).union(VUE_KEYWORDS);
+
+const HTML_KEYWORDS: TokenSet<HtmlSyntaxKind> = token_set!(T![html], T![doctype]);
 
 #[inline]
-fn is_at_html_keyword(p: &mut HtmlParser) -> bool {
-    matches!(p.cur(), T![html] | T![doctype])
+fn is_at_keyword(p: &mut HtmlParser) -> bool {
+    p.at_ts(ALL_POSSIBLE_KEYWORDS)
 }

--- a/crates/biome_html_parser/src/syntax/svelte.rs
+++ b/crates/biome_html_parser/src/syntax/svelte.rs
@@ -1266,7 +1266,7 @@ impl ParseNodeList for ModifiersList {
 
 // #region Check functions
 
-const SVELTE_KEYWORDS: TokenSet<HtmlSyntaxKind> = token_set!(
+pub const SVELTE_KEYWORDS: TokenSet<HtmlSyntaxKind> = token_set!(
     T![if],
     T![else],
     T![each],

--- a/crates/biome_html_parser/src/syntax/vue.rs
+++ b/crates/biome_html_parser/src/syntax/vue.rs
@@ -18,6 +18,8 @@ use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::*;
 
+pub const VUE_KEYWORDS: TokenSet<HtmlSyntaxKind> = token_set!(T![of], T![in]);
+
 pub(crate) fn parse_vue_directive(p: &mut HtmlParser) -> ParsedSyntax {
     if !p.at(HTML_LITERAL) {
         return Absent;

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/as.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/as.html
@@ -1,0 +1,2 @@
+as text content
+<p>as text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/as.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/as.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+as text content
+<p>as text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..15 "as text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@15..17 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@17..18 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@18..19 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@19..34 "as text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@34..35 "<" [] [],
+                slash_token: SLASH@35..36 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@36..37 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@37..38 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@38..39 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..39
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..38
+    0: HTML_CONTENT@0..15
+      0: HTML_LITERAL@0..15 "as text content" [] []
+    1: HTML_ELEMENT@15..38
+      0: HTML_OPENING_ELEMENT@15..19
+        0: L_ANGLE@15..17 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@17..18
+          0: HTML_LITERAL@17..18 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@18..18
+        3: R_ANGLE@18..19 ">" [] []
+      1: HTML_ELEMENT_LIST@19..34
+        0: HTML_CONTENT@19..34
+          0: HTML_LITERAL@19..34 "as text content" [] []
+      2: HTML_CLOSING_ELEMENT@34..38
+        0: L_ANGLE@34..35 "<" [] []
+        1: SLASH@35..36 "/" [] []
+        2: HTML_TAG_NAME@36..37
+          0: HTML_LITERAL@36..37 "p" [] []
+        3: R_ANGLE@37..38 ">" [] []
+  4: EOF@38..39 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/attach.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/attach.html
@@ -1,0 +1,2 @@
+attach text content
+<p>attach text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/attach.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/attach.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+attach text content
+<p>attach text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..19 "attach text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@19..21 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@21..22 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@22..23 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@23..42 "attach text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@42..43 "<" [] [],
+                slash_token: SLASH@43..44 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@44..45 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@45..46 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..47
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..46
+    0: HTML_CONTENT@0..19
+      0: HTML_LITERAL@0..19 "attach text content" [] []
+    1: HTML_ELEMENT@19..46
+      0: HTML_OPENING_ELEMENT@19..23
+        0: L_ANGLE@19..21 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@21..22
+          0: HTML_LITERAL@21..22 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@22..22
+        3: R_ANGLE@22..23 ">" [] []
+      1: HTML_ELEMENT_LIST@23..42
+        0: HTML_CONTENT@23..42
+          0: HTML_LITERAL@23..42 "attach text content" [] []
+      2: HTML_CLOSING_ELEMENT@42..46
+        0: L_ANGLE@42..43 "<" [] []
+        1: SLASH@43..44 "/" [] []
+        2: HTML_TAG_NAME@44..45
+          0: HTML_LITERAL@44..45 "p" [] []
+        3: R_ANGLE@45..46 ">" [] []
+  4: EOF@46..47 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/await.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/await.html
@@ -1,0 +1,2 @@
+await text content
+<p>await text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/await.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/await.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+await text content
+<p>await text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..18 "await text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@18..20 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@20..21 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@21..22 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@22..40 "await text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@40..41 "<" [] [],
+                slash_token: SLASH@41..42 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@42..43 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@43..44 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@44..45 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..45
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..44
+    0: HTML_CONTENT@0..18
+      0: HTML_LITERAL@0..18 "await text content" [] []
+    1: HTML_ELEMENT@18..44
+      0: HTML_OPENING_ELEMENT@18..22
+        0: L_ANGLE@18..20 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@20..21
+          0: HTML_LITERAL@20..21 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@21..21
+        3: R_ANGLE@21..22 ">" [] []
+      1: HTML_ELEMENT_LIST@22..40
+        0: HTML_CONTENT@22..40
+          0: HTML_LITERAL@22..40 "await text content" [] []
+      2: HTML_CLOSING_ELEMENT@40..44
+        0: L_ANGLE@40..41 "<" [] []
+        1: SLASH@41..42 "/" [] []
+        2: HTML_TAG_NAME@42..43
+          0: HTML_LITERAL@42..43 "p" [] []
+        3: R_ANGLE@43..44 ">" [] []
+  4: EOF@44..45 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/bind.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/bind.html
@@ -1,0 +1,2 @@
+bind text content
+<p>bind text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/bind.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/bind.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+bind text content
+<p>bind text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..17 "bind text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@17..19 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@19..20 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@20..21 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@21..38 "bind text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@38..39 "<" [] [],
+                slash_token: SLASH@39..40 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@40..41 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@41..42 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..43
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..42
+    0: HTML_CONTENT@0..17
+      0: HTML_LITERAL@0..17 "bind text content" [] []
+    1: HTML_ELEMENT@17..42
+      0: HTML_OPENING_ELEMENT@17..21
+        0: L_ANGLE@17..19 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@19..20
+          0: HTML_LITERAL@19..20 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@20..20
+        3: R_ANGLE@20..21 ">" [] []
+      1: HTML_ELEMENT_LIST@21..38
+        0: HTML_CONTENT@21..38
+          0: HTML_LITERAL@21..38 "bind text content" [] []
+      2: HTML_CLOSING_ELEMENT@38..42
+        0: L_ANGLE@38..39 "<" [] []
+        1: SLASH@39..40 "/" [] []
+        2: HTML_TAG_NAME@40..41
+          0: HTML_LITERAL@40..41 "p" [] []
+        3: R_ANGLE@41..42 ">" [] []
+  4: EOF@42..43 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/catch.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/catch.html
@@ -1,0 +1,2 @@
+catch text content
+<p>catch text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/catch.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/catch.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+catch text content
+<p>catch text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..18 "catch text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@18..20 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@20..21 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@21..22 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@22..40 "catch text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@40..41 "<" [] [],
+                slash_token: SLASH@41..42 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@42..43 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@43..44 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@44..45 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..45
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..44
+    0: HTML_CONTENT@0..18
+      0: HTML_LITERAL@0..18 "catch text content" [] []
+    1: HTML_ELEMENT@18..44
+      0: HTML_OPENING_ELEMENT@18..22
+        0: L_ANGLE@18..20 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@20..21
+          0: HTML_LITERAL@20..21 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@21..21
+        3: R_ANGLE@21..22 ">" [] []
+      1: HTML_ELEMENT_LIST@22..40
+        0: HTML_CONTENT@22..40
+          0: HTML_LITERAL@22..40 "catch text content" [] []
+      2: HTML_CLOSING_ELEMENT@40..44
+        0: L_ANGLE@40..41 "<" [] []
+        1: SLASH@41..42 "/" [] []
+        2: HTML_TAG_NAME@42..43
+          0: HTML_LITERAL@42..43 "p" [] []
+        3: R_ANGLE@43..44 ">" [] []
+  4: EOF@44..45 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/class.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/class.html
@@ -1,0 +1,2 @@
+class text content
+<p>class text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/class.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/class.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+class text content
+<p>class text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..18 "class text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@18..20 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@20..21 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@21..22 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@22..40 "class text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@40..41 "<" [] [],
+                slash_token: SLASH@41..42 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@42..43 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@43..44 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@44..45 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..45
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..44
+    0: HTML_CONTENT@0..18
+      0: HTML_LITERAL@0..18 "class text content" [] []
+    1: HTML_ELEMENT@18..44
+      0: HTML_OPENING_ELEMENT@18..22
+        0: L_ANGLE@18..20 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@20..21
+          0: HTML_LITERAL@20..21 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@21..21
+        3: R_ANGLE@21..22 ">" [] []
+      1: HTML_ELEMENT_LIST@22..40
+        0: HTML_CONTENT@22..40
+          0: HTML_LITERAL@22..40 "class text content" [] []
+      2: HTML_CLOSING_ELEMENT@40..44
+        0: L_ANGLE@40..41 "<" [] []
+        1: SLASH@41..42 "/" [] []
+        2: HTML_TAG_NAME@42..43
+          0: HTML_LITERAL@42..43 "p" [] []
+        3: R_ANGLE@43..44 ">" [] []
+  4: EOF@44..45 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/client.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/client.html
@@ -1,0 +1,2 @@
+client text content
+<p>client text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/client.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/client.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+client text content
+<p>client text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..19 "client text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@19..21 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@21..22 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@22..23 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@23..42 "client text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@42..43 "<" [] [],
+                slash_token: SLASH@43..44 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@44..45 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@45..46 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..47
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..46
+    0: HTML_CONTENT@0..19
+      0: HTML_LITERAL@0..19 "client text content" [] []
+    1: HTML_ELEMENT@19..46
+      0: HTML_OPENING_ELEMENT@19..23
+        0: L_ANGLE@19..21 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@21..22
+          0: HTML_LITERAL@21..22 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@22..22
+        3: R_ANGLE@22..23 ">" [] []
+      1: HTML_ELEMENT_LIST@23..42
+        0: HTML_CONTENT@23..42
+          0: HTML_LITERAL@23..42 "client text content" [] []
+      2: HTML_CLOSING_ELEMENT@42..46
+        0: L_ANGLE@42..43 "<" [] []
+        1: SLASH@43..44 "/" [] []
+        2: HTML_TAG_NAME@44..45
+          0: HTML_LITERAL@44..45 "p" [] []
+        3: R_ANGLE@45..46 ">" [] []
+  4: EOF@46..47 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/const.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/const.html
@@ -1,0 +1,2 @@
+const text content
+<p>const text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/const.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/const.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+const text content
+<p>const text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..18 "const text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@18..20 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@20..21 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@21..22 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@22..40 "const text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@40..41 "<" [] [],
+                slash_token: SLASH@41..42 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@42..43 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@43..44 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@44..45 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..45
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..44
+    0: HTML_CONTENT@0..18
+      0: HTML_LITERAL@0..18 "const text content" [] []
+    1: HTML_ELEMENT@18..44
+      0: HTML_OPENING_ELEMENT@18..22
+        0: L_ANGLE@18..20 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@20..21
+          0: HTML_LITERAL@20..21 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@21..21
+        3: R_ANGLE@21..22 ">" [] []
+      1: HTML_ELEMENT_LIST@22..40
+        0: HTML_CONTENT@22..40
+          0: HTML_LITERAL@22..40 "const text content" [] []
+      2: HTML_CLOSING_ELEMENT@40..44
+        0: L_ANGLE@40..41 "<" [] []
+        1: SLASH@41..42 "/" [] []
+        2: HTML_TAG_NAME@42..43
+          0: HTML_LITERAL@42..43 "p" [] []
+        3: R_ANGLE@43..44 ">" [] []
+  4: EOF@44..45 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/debug.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/debug.html
@@ -1,0 +1,2 @@
+debug text content
+<p>debug text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/debug.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/debug.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+debug text content
+<p>debug text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..18 "debug text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@18..20 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@20..21 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@21..22 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@22..40 "debug text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@40..41 "<" [] [],
+                slash_token: SLASH@41..42 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@42..43 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@43..44 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@44..45 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..45
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..44
+    0: HTML_CONTENT@0..18
+      0: HTML_LITERAL@0..18 "debug text content" [] []
+    1: HTML_ELEMENT@18..44
+      0: HTML_OPENING_ELEMENT@18..22
+        0: L_ANGLE@18..20 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@20..21
+          0: HTML_LITERAL@20..21 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@21..21
+        3: R_ANGLE@21..22 ">" [] []
+      1: HTML_ELEMENT_LIST@22..40
+        0: HTML_CONTENT@22..40
+          0: HTML_LITERAL@22..40 "debug text content" [] []
+      2: HTML_CLOSING_ELEMENT@40..44
+        0: L_ANGLE@40..41 "<" [] []
+        1: SLASH@41..42 "/" [] []
+        2: HTML_TAG_NAME@42..43
+          0: HTML_LITERAL@42..43 "p" [] []
+        3: R_ANGLE@43..44 ">" [] []
+  4: EOF@44..45 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/define.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/define.html
@@ -1,0 +1,2 @@
+define text content
+<p>define text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/define.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/define.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+define text content
+<p>define text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..19 "define text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@19..21 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@21..22 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@22..23 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@23..42 "define text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@42..43 "<" [] [],
+                slash_token: SLASH@43..44 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@44..45 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@45..46 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..47
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..46
+    0: HTML_CONTENT@0..19
+      0: HTML_LITERAL@0..19 "define text content" [] []
+    1: HTML_ELEMENT@19..46
+      0: HTML_OPENING_ELEMENT@19..23
+        0: L_ANGLE@19..21 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@21..22
+          0: HTML_LITERAL@21..22 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@22..22
+        3: R_ANGLE@22..23 ">" [] []
+      1: HTML_ELEMENT_LIST@23..42
+        0: HTML_CONTENT@23..42
+          0: HTML_LITERAL@23..42 "define text content" [] []
+      2: HTML_CLOSING_ELEMENT@42..46
+        0: L_ANGLE@42..43 "<" [] []
+        1: SLASH@43..44 "/" [] []
+        2: HTML_TAG_NAME@44..45
+          0: HTML_LITERAL@44..45 "p" [] []
+        3: R_ANGLE@45..46 ">" [] []
+  4: EOF@46..47 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/doctype.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/doctype.html
@@ -1,0 +1,2 @@
+doctype text content
+<p>doctype text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/doctype.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/doctype.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+doctype text content
+<p>doctype text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..20 "doctype text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@20..22 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@22..23 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@23..24 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@24..44 "doctype text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@44..45 "<" [] [],
+                slash_token: SLASH@45..46 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@46..47 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@47..48 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@48..49 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..49
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..48
+    0: HTML_CONTENT@0..20
+      0: HTML_LITERAL@0..20 "doctype text content" [] []
+    1: HTML_ELEMENT@20..48
+      0: HTML_OPENING_ELEMENT@20..24
+        0: L_ANGLE@20..22 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@22..23
+          0: HTML_LITERAL@22..23 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@23..23
+        3: R_ANGLE@23..24 ">" [] []
+      1: HTML_ELEMENT_LIST@24..44
+        0: HTML_CONTENT@24..44
+          0: HTML_LITERAL@24..44 "doctype text content" [] []
+      2: HTML_CLOSING_ELEMENT@44..48
+        0: L_ANGLE@44..45 "<" [] []
+        1: SLASH@45..46 "/" [] []
+        2: HTML_TAG_NAME@46..47
+          0: HTML_LITERAL@46..47 "p" [] []
+        3: R_ANGLE@47..48 ">" [] []
+  4: EOF@48..49 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/each.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/each.html
@@ -1,0 +1,2 @@
+each text content
+<p>each text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/each.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/each.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+each text content
+<p>each text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..17 "each text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@17..19 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@19..20 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@20..21 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@21..38 "each text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@38..39 "<" [] [],
+                slash_token: SLASH@39..40 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@40..41 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@41..42 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..43
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..42
+    0: HTML_CONTENT@0..17
+      0: HTML_LITERAL@0..17 "each text content" [] []
+    1: HTML_ELEMENT@17..42
+      0: HTML_OPENING_ELEMENT@17..21
+        0: L_ANGLE@17..19 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@19..20
+          0: HTML_LITERAL@19..20 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@20..20
+        3: R_ANGLE@20..21 ">" [] []
+      1: HTML_ELEMENT_LIST@21..38
+        0: HTML_CONTENT@21..38
+          0: HTML_LITERAL@21..38 "each text content" [] []
+      2: HTML_CLOSING_ELEMENT@38..42
+        0: L_ANGLE@38..39 "<" [] []
+        1: SLASH@39..40 "/" [] []
+        2: HTML_TAG_NAME@40..41
+          0: HTML_LITERAL@40..41 "p" [] []
+        3: R_ANGLE@41..42 ">" [] []
+  4: EOF@42..43 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/else.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/else.html
@@ -1,0 +1,2 @@
+else text content
+<p>else text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/else.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/else.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+else text content
+<p>else text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..17 "else text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@17..19 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@19..20 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@20..21 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@21..38 "else text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@38..39 "<" [] [],
+                slash_token: SLASH@39..40 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@40..41 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@41..42 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..43
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..42
+    0: HTML_CONTENT@0..17
+      0: HTML_LITERAL@0..17 "else text content" [] []
+    1: HTML_ELEMENT@17..42
+      0: HTML_OPENING_ELEMENT@17..21
+        0: L_ANGLE@17..19 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@19..20
+          0: HTML_LITERAL@19..20 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@20..20
+        3: R_ANGLE@20..21 ">" [] []
+      1: HTML_ELEMENT_LIST@21..38
+        0: HTML_CONTENT@21..38
+          0: HTML_LITERAL@21..38 "else text content" [] []
+      2: HTML_CLOSING_ELEMENT@38..42
+        0: L_ANGLE@38..39 "<" [] []
+        1: SLASH@39..40 "/" [] []
+        2: HTML_TAG_NAME@40..41
+          0: HTML_LITERAL@40..41 "p" [] []
+        3: R_ANGLE@41..42 ">" [] []
+  4: EOF@42..43 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/false.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/false.html
@@ -1,0 +1,2 @@
+false text content
+<p>false text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/false.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/false.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+false text content
+<p>false text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..18 "false text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@18..20 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@20..21 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@21..22 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@22..40 "false text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@40..41 "<" [] [],
+                slash_token: SLASH@41..42 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@42..43 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@43..44 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@44..45 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..45
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..44
+    0: HTML_CONTENT@0..18
+      0: HTML_LITERAL@0..18 "false text content" [] []
+    1: HTML_ELEMENT@18..44
+      0: HTML_OPENING_ELEMENT@18..22
+        0: L_ANGLE@18..20 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@20..21
+          0: HTML_LITERAL@20..21 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@21..21
+        3: R_ANGLE@21..22 ">" [] []
+      1: HTML_ELEMENT_LIST@22..40
+        0: HTML_CONTENT@22..40
+          0: HTML_LITERAL@22..40 "false text content" [] []
+      2: HTML_CLOSING_ELEMENT@40..44
+        0: L_ANGLE@40..41 "<" [] []
+        1: SLASH@41..42 "/" [] []
+        2: HTML_TAG_NAME@42..43
+          0: HTML_LITERAL@42..43 "p" [] []
+        3: R_ANGLE@43..44 ">" [] []
+  4: EOF@44..45 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/html.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/html.html
@@ -1,0 +1,2 @@
+html text content
+<p>html text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/html.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/html.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+html text content
+<p>html text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..17 "html text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@17..19 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@19..20 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@20..21 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@21..38 "html text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@38..39 "<" [] [],
+                slash_token: SLASH@39..40 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@40..41 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@41..42 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..43
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..42
+    0: HTML_CONTENT@0..17
+      0: HTML_LITERAL@0..17 "html text content" [] []
+    1: HTML_ELEMENT@17..42
+      0: HTML_OPENING_ELEMENT@17..21
+        0: L_ANGLE@17..19 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@19..20
+          0: HTML_LITERAL@19..20 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@20..20
+        3: R_ANGLE@20..21 ">" [] []
+      1: HTML_ELEMENT_LIST@21..38
+        0: HTML_CONTENT@21..38
+          0: HTML_LITERAL@21..38 "html text content" [] []
+      2: HTML_CLOSING_ELEMENT@38..42
+        0: L_ANGLE@38..39 "<" [] []
+        1: SLASH@39..40 "/" [] []
+        2: HTML_TAG_NAME@40..41
+          0: HTML_LITERAL@40..41 "p" [] []
+        3: R_ANGLE@41..42 ">" [] []
+  4: EOF@42..43 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/if.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/if.html
@@ -1,0 +1,2 @@
+if text content
+<p>if text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/if.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/if.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+if text content
+<p>if text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..15 "if text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@15..17 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@17..18 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@18..19 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@19..34 "if text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@34..35 "<" [] [],
+                slash_token: SLASH@35..36 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@36..37 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@37..38 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@38..39 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..39
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..38
+    0: HTML_CONTENT@0..15
+      0: HTML_LITERAL@0..15 "if text content" [] []
+    1: HTML_ELEMENT@15..38
+      0: HTML_OPENING_ELEMENT@15..19
+        0: L_ANGLE@15..17 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@17..18
+          0: HTML_LITERAL@17..18 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@18..18
+        3: R_ANGLE@18..19 ">" [] []
+      1: HTML_ELEMENT_LIST@19..34
+        0: HTML_CONTENT@19..34
+          0: HTML_LITERAL@19..34 "if text content" [] []
+      2: HTML_CLOSING_ELEMENT@34..38
+        0: L_ANGLE@34..35 "<" [] []
+        1: SLASH@35..36 "/" [] []
+        2: HTML_TAG_NAME@36..37
+          0: HTML_LITERAL@36..37 "p" [] []
+        3: R_ANGLE@37..38 ">" [] []
+  4: EOF@38..39 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/in.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/in.html
@@ -1,0 +1,2 @@
+in text content
+<p>in text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/in.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/in.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+in text content
+<p>in text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..15 "in text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@15..17 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@17..18 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@18..19 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@19..34 "in text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@34..35 "<" [] [],
+                slash_token: SLASH@35..36 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@36..37 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@37..38 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@38..39 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..39
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..38
+    0: HTML_CONTENT@0..15
+      0: HTML_LITERAL@0..15 "in text content" [] []
+    1: HTML_ELEMENT@15..38
+      0: HTML_OPENING_ELEMENT@15..19
+        0: L_ANGLE@15..17 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@17..18
+          0: HTML_LITERAL@17..18 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@18..18
+        3: R_ANGLE@18..19 ">" [] []
+      1: HTML_ELEMENT_LIST@19..34
+        0: HTML_CONTENT@19..34
+          0: HTML_LITERAL@19..34 "in text content" [] []
+      2: HTML_CLOSING_ELEMENT@34..38
+        0: L_ANGLE@34..35 "<" [] []
+        1: SLASH@35..36 "/" [] []
+        2: HTML_TAG_NAME@36..37
+          0: HTML_LITERAL@36..37 "p" [] []
+        3: R_ANGLE@37..38 ">" [] []
+  4: EOF@38..39 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/is.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/is.html
@@ -1,0 +1,2 @@
+is text content
+<p>is text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/is.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/is.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+is text content
+<p>is text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..15 "is text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@15..17 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@17..18 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@18..19 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@19..34 "is text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@34..35 "<" [] [],
+                slash_token: SLASH@35..36 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@36..37 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@37..38 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@38..39 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..39
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..38
+    0: HTML_CONTENT@0..15
+      0: HTML_LITERAL@0..15 "is text content" [] []
+    1: HTML_ELEMENT@15..38
+      0: HTML_OPENING_ELEMENT@15..19
+        0: L_ANGLE@15..17 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@17..18
+          0: HTML_LITERAL@17..18 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@18..18
+        3: R_ANGLE@18..19 ">" [] []
+      1: HTML_ELEMENT_LIST@19..34
+        0: HTML_CONTENT@19..34
+          0: HTML_LITERAL@19..34 "is text content" [] []
+      2: HTML_CLOSING_ELEMENT@34..38
+        0: L_ANGLE@34..35 "<" [] []
+        1: SLASH@35..36 "/" [] []
+        2: HTML_TAG_NAME@36..37
+          0: HTML_LITERAL@36..37 "p" [] []
+        3: R_ANGLE@37..38 ">" [] []
+  4: EOF@38..39 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/key.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/key.html
@@ -1,0 +1,2 @@
+key text content
+<p>key text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/key.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/key.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+key text content
+<p>key text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..16 "key text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@16..18 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@18..19 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@19..20 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@20..36 "key text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@36..37 "<" [] [],
+                slash_token: SLASH@37..38 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@38..39 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@39..40 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@40..41 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..41
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..40
+    0: HTML_CONTENT@0..16
+      0: HTML_LITERAL@0..16 "key text content" [] []
+    1: HTML_ELEMENT@16..40
+      0: HTML_OPENING_ELEMENT@16..20
+        0: L_ANGLE@16..18 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@18..19
+          0: HTML_LITERAL@18..19 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@19..19
+        3: R_ANGLE@19..20 ">" [] []
+      1: HTML_ELEMENT_LIST@20..36
+        0: HTML_CONTENT@20..36
+          0: HTML_LITERAL@20..36 "key text content" [] []
+      2: HTML_CLOSING_ELEMENT@36..40
+        0: L_ANGLE@36..37 "<" [] []
+        1: SLASH@37..38 "/" [] []
+        2: HTML_TAG_NAME@38..39
+          0: HTML_LITERAL@38..39 "p" [] []
+        3: R_ANGLE@39..40 ">" [] []
+  4: EOF@40..41 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/null.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/null.html
@@ -1,0 +1,2 @@
+null text content
+<p>null text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/null.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/null.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+null text content
+<p>null text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..17 "null text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@17..19 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@19..20 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@20..21 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@21..38 "null text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@38..39 "<" [] [],
+                slash_token: SLASH@39..40 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@40..41 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@41..42 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..43
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..42
+    0: HTML_CONTENT@0..17
+      0: HTML_LITERAL@0..17 "null text content" [] []
+    1: HTML_ELEMENT@17..42
+      0: HTML_OPENING_ELEMENT@17..21
+        0: L_ANGLE@17..19 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@19..20
+          0: HTML_LITERAL@19..20 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@20..20
+        3: R_ANGLE@20..21 ">" [] []
+      1: HTML_ELEMENT_LIST@21..38
+        0: HTML_CONTENT@21..38
+          0: HTML_LITERAL@21..38 "null text content" [] []
+      2: HTML_CLOSING_ELEMENT@38..42
+        0: L_ANGLE@38..39 "<" [] []
+        1: SLASH@39..40 "/" [] []
+        2: HTML_TAG_NAME@40..41
+          0: HTML_LITERAL@40..41 "p" [] []
+        3: R_ANGLE@41..42 ">" [] []
+  4: EOF@42..43 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/of.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/of.html
@@ -1,0 +1,2 @@
+of text content
+<p>of text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/of.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/of.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+of text content
+<p>of text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..15 "of text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@15..17 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@17..18 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@18..19 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@19..34 "of text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@34..35 "<" [] [],
+                slash_token: SLASH@35..36 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@36..37 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@37..38 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@38..39 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..39
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..38
+    0: HTML_CONTENT@0..15
+      0: HTML_LITERAL@0..15 "of text content" [] []
+    1: HTML_ELEMENT@15..38
+      0: HTML_OPENING_ELEMENT@15..19
+        0: L_ANGLE@15..17 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@17..18
+          0: HTML_LITERAL@17..18 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@18..18
+        3: R_ANGLE@18..19 ">" [] []
+      1: HTML_ELEMENT_LIST@19..34
+        0: HTML_CONTENT@19..34
+          0: HTML_LITERAL@19..34 "of text content" [] []
+      2: HTML_CLOSING_ELEMENT@34..38
+        0: L_ANGLE@34..35 "<" [] []
+        1: SLASH@35..36 "/" [] []
+        2: HTML_TAG_NAME@36..37
+          0: HTML_LITERAL@36..37 "p" [] []
+        3: R_ANGLE@37..38 ">" [] []
+  4: EOF@38..39 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/out.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/out.html
@@ -1,0 +1,2 @@
+out text content
+<p>out text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/out.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/out.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+out text content
+<p>out text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..16 "out text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@16..18 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@18..19 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@19..20 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@20..36 "out text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@36..37 "<" [] [],
+                slash_token: SLASH@37..38 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@38..39 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@39..40 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@40..41 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..41
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..40
+    0: HTML_CONTENT@0..16
+      0: HTML_LITERAL@0..16 "out text content" [] []
+    1: HTML_ELEMENT@16..40
+      0: HTML_OPENING_ELEMENT@16..20
+        0: L_ANGLE@16..18 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@18..19
+          0: HTML_LITERAL@18..19 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@19..19
+        3: R_ANGLE@19..20 ">" [] []
+      1: HTML_ELEMENT_LIST@20..36
+        0: HTML_CONTENT@20..36
+          0: HTML_LITERAL@20..36 "out text content" [] []
+      2: HTML_CLOSING_ELEMENT@36..40
+        0: L_ANGLE@36..37 "<" [] []
+        1: SLASH@37..38 "/" [] []
+        2: HTML_TAG_NAME@38..39
+          0: HTML_LITERAL@38..39 "p" [] []
+        3: R_ANGLE@39..40 ">" [] []
+  4: EOF@40..41 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/render.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/render.html
@@ -1,0 +1,2 @@
+render text content
+<p>render text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/render.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/render.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+render text content
+<p>render text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..19 "render text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@19..21 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@21..22 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@22..23 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@23..42 "render text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@42..43 "<" [] [],
+                slash_token: SLASH@43..44 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@44..45 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@45..46 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..47
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..46
+    0: HTML_CONTENT@0..19
+      0: HTML_LITERAL@0..19 "render text content" [] []
+    1: HTML_ELEMENT@19..46
+      0: HTML_OPENING_ELEMENT@19..23
+        0: L_ANGLE@19..21 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@21..22
+          0: HTML_LITERAL@21..22 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@22..22
+        3: R_ANGLE@22..23 ">" [] []
+      1: HTML_ELEMENT_LIST@23..42
+        0: HTML_CONTENT@23..42
+          0: HTML_LITERAL@23..42 "render text content" [] []
+      2: HTML_CLOSING_ELEMENT@42..46
+        0: L_ANGLE@42..43 "<" [] []
+        1: SLASH@43..44 "/" [] []
+        2: HTML_TAG_NAME@44..45
+          0: HTML_LITERAL@44..45 "p" [] []
+        3: R_ANGLE@45..46 ">" [] []
+  4: EOF@46..47 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/server.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/server.html
@@ -1,0 +1,2 @@
+server text content
+<p>server text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/server.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/server.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+server text content
+<p>server text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..19 "server text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@19..21 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@21..22 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@22..23 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@23..42 "server text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@42..43 "<" [] [],
+                slash_token: SLASH@43..44 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@44..45 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@45..46 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..47
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..46
+    0: HTML_CONTENT@0..19
+      0: HTML_LITERAL@0..19 "server text content" [] []
+    1: HTML_ELEMENT@19..46
+      0: HTML_OPENING_ELEMENT@19..23
+        0: L_ANGLE@19..21 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@21..22
+          0: HTML_LITERAL@21..22 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@22..22
+        3: R_ANGLE@22..23 ">" [] []
+      1: HTML_ELEMENT_LIST@23..42
+        0: HTML_CONTENT@23..42
+          0: HTML_LITERAL@23..42 "server text content" [] []
+      2: HTML_CLOSING_ELEMENT@42..46
+        0: L_ANGLE@42..43 "<" [] []
+        1: SLASH@43..44 "/" [] []
+        2: HTML_TAG_NAME@44..45
+          0: HTML_LITERAL@44..45 "p" [] []
+        3: R_ANGLE@45..46 ">" [] []
+  4: EOF@46..47 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/set.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/set.html
@@ -1,0 +1,2 @@
+set text content
+<p>set text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/set.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/set.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+set text content
+<p>set text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..16 "set text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@16..18 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@18..19 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@19..20 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@20..36 "set text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@36..37 "<" [] [],
+                slash_token: SLASH@37..38 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@38..39 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@39..40 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@40..41 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..41
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..40
+    0: HTML_CONTENT@0..16
+      0: HTML_LITERAL@0..16 "set text content" [] []
+    1: HTML_ELEMENT@16..40
+      0: HTML_OPENING_ELEMENT@16..20
+        0: L_ANGLE@16..18 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@18..19
+          0: HTML_LITERAL@18..19 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@19..19
+        3: R_ANGLE@19..20 ">" [] []
+      1: HTML_ELEMENT_LIST@20..36
+        0: HTML_CONTENT@20..36
+          0: HTML_LITERAL@20..36 "set text content" [] []
+      2: HTML_CLOSING_ELEMENT@36..40
+        0: L_ANGLE@36..37 "<" [] []
+        1: SLASH@37..38 "/" [] []
+        2: HTML_TAG_NAME@38..39
+          0: HTML_LITERAL@38..39 "p" [] []
+        3: R_ANGLE@39..40 ">" [] []
+  4: EOF@40..41 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/snippet.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/snippet.html
@@ -1,0 +1,2 @@
+snippet text content
+<p>snippet text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/snippet.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/snippet.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+snippet text content
+<p>snippet text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..20 "snippet text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@20..22 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@22..23 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@23..24 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@24..44 "snippet text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@44..45 "<" [] [],
+                slash_token: SLASH@45..46 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@46..47 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@47..48 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@48..49 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..49
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..48
+    0: HTML_CONTENT@0..20
+      0: HTML_LITERAL@0..20 "snippet text content" [] []
+    1: HTML_ELEMENT@20..48
+      0: HTML_OPENING_ELEMENT@20..24
+        0: L_ANGLE@20..22 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@22..23
+          0: HTML_LITERAL@22..23 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@23..23
+        3: R_ANGLE@23..24 ">" [] []
+      1: HTML_ELEMENT_LIST@24..44
+        0: HTML_CONTENT@24..44
+          0: HTML_LITERAL@24..44 "snippet text content" [] []
+      2: HTML_CLOSING_ELEMENT@44..48
+        0: L_ANGLE@44..45 "<" [] []
+        1: SLASH@45..46 "/" [] []
+        2: HTML_TAG_NAME@46..47
+          0: HTML_LITERAL@46..47 "p" [] []
+        3: R_ANGLE@47..48 ">" [] []
+  4: EOF@48..49 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/style.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/style.html
@@ -1,0 +1,2 @@
+style text content
+<p>style text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/style.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/style.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+style text content
+<p>style text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..18 "style text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@18..20 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@20..21 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@21..22 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@22..40 "style text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@40..41 "<" [] [],
+                slash_token: SLASH@41..42 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@42..43 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@43..44 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@44..45 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..45
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..44
+    0: HTML_CONTENT@0..18
+      0: HTML_LITERAL@0..18 "style text content" [] []
+    1: HTML_ELEMENT@18..44
+      0: HTML_OPENING_ELEMENT@18..22
+        0: L_ANGLE@18..20 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@20..21
+          0: HTML_LITERAL@20..21 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@21..21
+        3: R_ANGLE@21..22 ">" [] []
+      1: HTML_ELEMENT_LIST@22..40
+        0: HTML_CONTENT@22..40
+          0: HTML_LITERAL@22..40 "style text content" [] []
+      2: HTML_CLOSING_ELEMENT@40..44
+        0: L_ANGLE@40..41 "<" [] []
+        1: SLASH@41..42 "/" [] []
+        2: HTML_TAG_NAME@42..43
+          0: HTML_LITERAL@42..43 "p" [] []
+        3: R_ANGLE@43..44 ">" [] []
+  4: EOF@44..45 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/then.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/then.html
@@ -1,0 +1,2 @@
+then text content
+<p>then text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/then.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/then.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+then text content
+<p>then text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..17 "then text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@17..19 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@19..20 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@20..21 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@21..38 "then text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@38..39 "<" [] [],
+                slash_token: SLASH@39..40 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@40..41 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@41..42 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..43
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..42
+    0: HTML_CONTENT@0..17
+      0: HTML_LITERAL@0..17 "then text content" [] []
+    1: HTML_ELEMENT@17..42
+      0: HTML_OPENING_ELEMENT@17..21
+        0: L_ANGLE@17..19 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@19..20
+          0: HTML_LITERAL@19..20 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@20..20
+        3: R_ANGLE@20..21 ">" [] []
+      1: HTML_ELEMENT_LIST@21..38
+        0: HTML_CONTENT@21..38
+          0: HTML_LITERAL@21..38 "then text content" [] []
+      2: HTML_CLOSING_ELEMENT@38..42
+        0: L_ANGLE@38..39 "<" [] []
+        1: SLASH@39..40 "/" [] []
+        2: HTML_TAG_NAME@40..41
+          0: HTML_LITERAL@40..41 "p" [] []
+        3: R_ANGLE@41..42 ">" [] []
+  4: EOF@42..43 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/transition.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/transition.html
@@ -1,0 +1,2 @@
+transition text content
+<p>transition text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/transition.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/transition.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+transition text content
+<p>transition text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..23 "transition text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@23..25 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@25..26 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@26..27 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@27..50 "transition text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@50..51 "<" [] [],
+                slash_token: SLASH@51..52 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@52..53 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@53..54 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@54..55 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..55
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..54
+    0: HTML_CONTENT@0..23
+      0: HTML_LITERAL@0..23 "transition text content" [] []
+    1: HTML_ELEMENT@23..54
+      0: HTML_OPENING_ELEMENT@23..27
+        0: L_ANGLE@23..25 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@25..26
+          0: HTML_LITERAL@25..26 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@26..26
+        3: R_ANGLE@26..27 ">" [] []
+      1: HTML_ELEMENT_LIST@27..50
+        0: HTML_CONTENT@27..50
+          0: HTML_LITERAL@27..50 "transition text content" [] []
+      2: HTML_CLOSING_ELEMENT@50..54
+        0: L_ANGLE@50..51 "<" [] []
+        1: SLASH@51..52 "/" [] []
+        2: HTML_TAG_NAME@52..53
+          0: HTML_LITERAL@52..53 "p" [] []
+        3: R_ANGLE@53..54 ">" [] []
+  4: EOF@54..55 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/true.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/true.html
@@ -1,0 +1,2 @@
+true text content
+<p>true text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/true.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/true.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+true text content
+<p>true text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..17 "true text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@17..19 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@19..20 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@20..21 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@21..38 "true text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@38..39 "<" [] [],
+                slash_token: SLASH@39..40 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@40..41 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@41..42 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..43
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..42
+    0: HTML_CONTENT@0..17
+      0: HTML_LITERAL@0..17 "true text content" [] []
+    1: HTML_ELEMENT@17..42
+      0: HTML_OPENING_ELEMENT@17..21
+        0: L_ANGLE@17..19 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@19..20
+          0: HTML_LITERAL@19..20 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@20..20
+        3: R_ANGLE@20..21 ">" [] []
+      1: HTML_ELEMENT_LIST@21..38
+        0: HTML_CONTENT@21..38
+          0: HTML_LITERAL@21..38 "true text content" [] []
+      2: HTML_CLOSING_ELEMENT@38..42
+        0: L_ANGLE@38..39 "<" [] []
+        1: SLASH@39..40 "/" [] []
+        2: HTML_TAG_NAME@40..41
+          0: HTML_LITERAL@40..41 "p" [] []
+        3: R_ANGLE@41..42 ">" [] []
+  4: EOF@42..43 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/use.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/use.html
@@ -1,0 +1,2 @@
+use text content
+<p>use text content</p>

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/use.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/use.html.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+use text content
+<p>use text content</p>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlContent {
+            value_token: HTML_LITERAL@0..16 "use text content" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@16..18 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@18..19 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@19..20 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@20..36 "use text content" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@36..37 "<" [] [],
+                slash_token: SLASH@37..38 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@38..39 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@39..40 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@40..41 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..41
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..40
+    0: HTML_CONTENT@0..16
+      0: HTML_LITERAL@0..16 "use text content" [] []
+    1: HTML_ELEMENT@16..40
+      0: HTML_OPENING_ELEMENT@16..20
+        0: L_ANGLE@16..18 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@18..19
+          0: HTML_LITERAL@18..19 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@19..19
+        3: R_ANGLE@19..20 ">" [] []
+      1: HTML_ELEMENT_LIST@20..36
+        0: HTML_CONTENT@20..36
+          0: HTML_LITERAL@20..36 "use text content" [] []
+      2: HTML_CLOSING_ELEMENT@36..40
+        0: L_ANGLE@36..37 "<" [] []
+        1: SLASH@37..38 "/" [] []
+        2: HTML_TAG_NAME@38..39
+          0: HTML_LITERAL@38..39 "p" [] []
+        3: R_ANGLE@39..40 ">" [] []
+  4: EOF@40..41 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

I had gpt 5.5 add the tests, but i did the fix myself.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #10271

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
