### PR TITLE
fix(grit): support positional arguments in pattern, function, and node calls

### DIFF
--- a/.changeset/fix-gritql-positional-args.md
+++ b/.changeset/fix-gritql-positional-args.md
@@ -1,0 +1,9 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where GritQL patterns rejected positional (unkeyed) arguments.
+
+The GritQL spec explicitly allows omitting parameter names when arguments are passed in order, but Biome was rejecting anything other than named arguments (e.g., `console_method_to_info(`log`)` would fail while `console_method_to_info(method = `log`)` worked).
+
+The fix operates at two layers: the parser now correctly distinguishes a positional pattern from a named argument using lookahead, and the pattern compiler now resolves non-variable positional arguments by position instead of rejecting them outright. This applies to user-defined patterns, functions, predicates, and AST node patterns.

--- a/.changeset/fix-gritql-positional-args.md
+++ b/.changeset/fix-gritql-positional-args.md
@@ -3,7 +3,3 @@
 ---
 
 Fixed a bug where GritQL patterns rejected positional (unkeyed) arguments.
-
-The GritQL spec explicitly allows omitting parameter names when arguments are passed in order, but Biome was rejecting anything other than named arguments (e.g., `console_method_to_info(`log`)` would fail while `console_method_to_info(method = `log`)` worked).
-
-The fix operates at two layers: the parser now correctly distinguishes a positional pattern from a named argument using lookahead, and the pattern compiler now resolves non-variable positional arguments by position instead of rejecting them outright. This applies to user-defined patterns, functions, predicates, and AST node patterns.

--- a/crates/biome_grit_parser/src/parser/mod.rs
+++ b/crates/biome_grit_parser/src/parser/mod.rs
@@ -259,7 +259,7 @@ fn parse_language_flavor_kind(p: &mut GritParser) -> ParsedSyntax {
 fn parse_maybe_named_arg(p: &mut GritParser) -> ParsedSyntax {
     match p.cur() {
         T![')'] => Absent,
-        GRIT_NAME => parse_named_arg(p),
+        GRIT_NAME if p.lookahead() == T![=] => parse_named_arg(p),
         _ => parse_pattern(p),
     }
 }

--- a/crates/biome_grit_parser/tests/grit_test_suite/ok/positional_args.grit
+++ b/crates/biome_grit_parser/tests/grit_test_suite/ok/positional_args.grit
@@ -1,0 +1,4 @@
+pattern console_method_to_info($method) {
+  `console.$method($message)` => `console.info($message)`
+}
+console_method_to_info(`log`)

--- a/crates/biome_grit_parser/tests/grit_test_suite/ok/positional_args.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/ok/positional_args.grit.snap
@@ -1,0 +1,121 @@
+---
+source: crates/biome_grit_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```grit
+pattern console_method_to_info($method) {
+  `console.$method($message)` => `console.info($message)`
+}
+console_method_to_info(`log`)
+
+```
+
+## AST
+
+```
+GritRoot {
+    bom_token: missing (optional),
+    version: missing (optional),
+    language: missing (optional),
+    definitions: GritDefinitionList [
+        GritPatternDefinition {
+            visibility_token: missing (optional),
+            pattern_token: PATTERN_KW@0..8 "pattern" [] [Whitespace(" ")],
+            name: GritName {
+                value_token: GRIT_NAME@8..30 "console_method_to_info" [] [],
+            },
+            l_paren_token: L_PAREN@30..31 "(" [] [],
+            args: GritVariableList [
+                GritVariable {
+                    value_token: GRIT_VARIABLE@31..38 "$method" [] [],
+                },
+            ],
+            r_paren_token: R_PAREN@38..40 ")" [] [Whitespace(" ")],
+            language: missing (optional),
+            body: GritPatternDefinitionBody {
+                l_curly_token: L_CURLY@40..41 "{" [] [],
+                patterns: GritPatternList [
+                    GritRewrite {
+                        left: GritCodeSnippet {
+                            source: GritBacktickSnippetLiteral {
+                                value_token: GRIT_BACKTICK_SNIPPET@41..72 "`console.$method($message)`" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                            },
+                        },
+                        annotation: missing (optional),
+                        fat_arrow_token: FAT_ARROW@72..75 "=>" [] [Whitespace(" ")],
+                        right: GritCodeSnippet {
+                            source: GritBacktickSnippetLiteral {
+                                value_token: GRIT_BACKTICK_SNIPPET@75..99 "`console.info($message)`" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@99..101 "}" [Newline("\n")] [],
+            },
+        },
+        missing separator,
+        GritNodeLike {
+            name: GritName {
+                value_token: GRIT_NAME@101..124 "console_method_to_info" [Newline("\n")] [],
+            },
+            l_paren_token: L_PAREN@124..125 "(" [] [],
+            named_args: GritNamedArgList [
+                GritCodeSnippet {
+                    source: GritBacktickSnippetLiteral {
+                        value_token: GRIT_BACKTICK_SNIPPET@125..130 "`log`" [] [],
+                    },
+                },
+            ],
+            r_paren_token: R_PAREN@130..131 ")" [] [],
+        },
+    ],
+    eof_token: EOF@131..132 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRIT_ROOT@0..132
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: GRIT_DEFINITION_LIST@0..131
+    0: GRIT_PATTERN_DEFINITION@0..101
+      0: (empty)
+      1: PATTERN_KW@0..8 "pattern" [] [Whitespace(" ")]
+      2: GRIT_NAME@8..30
+        0: GRIT_NAME@8..30 "console_method_to_info" [] []
+      3: L_PAREN@30..31 "(" [] []
+      4: GRIT_VARIABLE_LIST@31..38
+        0: GRIT_VARIABLE@31..38
+          0: GRIT_VARIABLE@31..38 "$method" [] []
+      5: R_PAREN@38..40 ")" [] [Whitespace(" ")]
+      6: (empty)
+      7: GRIT_PATTERN_DEFINITION_BODY@40..101
+        0: L_CURLY@40..41 "{" [] []
+        1: GRIT_PATTERN_LIST@41..99
+          0: GRIT_REWRITE@41..99
+            0: GRIT_CODE_SNIPPET@41..72
+              0: GRIT_BACKTICK_SNIPPET_LITERAL@41..72
+                0: GRIT_BACKTICK_SNIPPET@41..72 "`console.$method($message)`" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: (empty)
+            2: FAT_ARROW@72..75 "=>" [] [Whitespace(" ")]
+            3: GRIT_CODE_SNIPPET@75..99
+              0: GRIT_BACKTICK_SNIPPET_LITERAL@75..99
+                0: GRIT_BACKTICK_SNIPPET@75..99 "`console.info($message)`" [] []
+        2: R_CURLY@99..101 "}" [Newline("\n")] []
+    1: (empty)
+    2: GRIT_NODE_LIKE@101..131
+      0: GRIT_NAME@101..124
+        0: GRIT_NAME@101..124 "console_method_to_info" [Newline("\n")] []
+      1: L_PAREN@124..125 "(" [] []
+      2: GRIT_NAMED_ARG_LIST@125..130
+        0: GRIT_CODE_SNIPPET@125..130
+          0: GRIT_BACKTICK_SNIPPET_LITERAL@125..130
+            0: GRIT_BACKTICK_SNIPPET@125..130 "`log`" [] []
+      3: R_PAREN@130..131 ")" [] []
+  4: EOF@131..132 "" [Newline("\n")] []
+
+```

--- a/crates/biome_grit_parser/tests/grit_test_suite/ok/positional_args_pattern_call.grit
+++ b/crates/biome_grit_parser/tests/grit_test_suite/ok/positional_args_pattern_call.grit
@@ -1,0 +1,9 @@
+pattern is_log() {
+  `log`
+}
+
+pattern console_method_to_info($method) {
+  `console.$method($message)` => `console.info($message)`
+}
+
+console_method_to_info(is_log())

--- a/crates/biome_grit_parser/tests/grit_test_suite/ok/positional_args_pattern_call.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/ok/positional_args_pattern_call.grit.snap
@@ -1,0 +1,172 @@
+---
+source: crates/biome_grit_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```grit
+pattern is_log() {
+  `log`
+}
+
+pattern console_method_to_info($method) {
+  `console.$method($message)` => `console.info($message)`
+}
+
+console_method_to_info(is_log())
+
+```
+
+## AST
+
+```
+GritRoot {
+    bom_token: missing (optional),
+    version: missing (optional),
+    language: missing (optional),
+    definitions: GritDefinitionList [
+        GritPatternDefinition {
+            visibility_token: missing (optional),
+            pattern_token: PATTERN_KW@0..8 "pattern" [] [Whitespace(" ")],
+            name: GritName {
+                value_token: GRIT_NAME@8..14 "is_log" [] [],
+            },
+            l_paren_token: L_PAREN@14..15 "(" [] [],
+            args: GritVariableList [],
+            r_paren_token: R_PAREN@15..17 ")" [] [Whitespace(" ")],
+            language: missing (optional),
+            body: GritPatternDefinitionBody {
+                l_curly_token: L_CURLY@17..18 "{" [] [],
+                patterns: GritPatternList [
+                    GritCodeSnippet {
+                        source: GritBacktickSnippetLiteral {
+                            value_token: GRIT_BACKTICK_SNIPPET@18..26 "`log`" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@26..28 "}" [Newline("\n")] [],
+            },
+        },
+        missing separator,
+        GritPatternDefinition {
+            visibility_token: missing (optional),
+            pattern_token: PATTERN_KW@28..38 "pattern" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            name: GritName {
+                value_token: GRIT_NAME@38..60 "console_method_to_info" [] [],
+            },
+            l_paren_token: L_PAREN@60..61 "(" [] [],
+            args: GritVariableList [
+                GritVariable {
+                    value_token: GRIT_VARIABLE@61..68 "$method" [] [],
+                },
+            ],
+            r_paren_token: R_PAREN@68..70 ")" [] [Whitespace(" ")],
+            language: missing (optional),
+            body: GritPatternDefinitionBody {
+                l_curly_token: L_CURLY@70..71 "{" [] [],
+                patterns: GritPatternList [
+                    GritRewrite {
+                        left: GritCodeSnippet {
+                            source: GritBacktickSnippetLiteral {
+                                value_token: GRIT_BACKTICK_SNIPPET@71..102 "`console.$method($message)`" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                            },
+                        },
+                        annotation: missing (optional),
+                        fat_arrow_token: FAT_ARROW@102..105 "=>" [] [Whitespace(" ")],
+                        right: GritCodeSnippet {
+                            source: GritBacktickSnippetLiteral {
+                                value_token: GRIT_BACKTICK_SNIPPET@105..129 "`console.info($message)`" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@129..131 "}" [Newline("\n")] [],
+            },
+        },
+        missing separator,
+        GritNodeLike {
+            name: GritName {
+                value_token: GRIT_NAME@131..155 "console_method_to_info" [Newline("\n"), Newline("\n")] [],
+            },
+            l_paren_token: L_PAREN@155..156 "(" [] [],
+            named_args: GritNamedArgList [
+                GritNodeLike {
+                    name: GritName {
+                        value_token: GRIT_NAME@156..162 "is_log" [] [],
+                    },
+                    l_paren_token: L_PAREN@162..163 "(" [] [],
+                    named_args: GritNamedArgList [],
+                    r_paren_token: R_PAREN@163..164 ")" [] [],
+                },
+            ],
+            r_paren_token: R_PAREN@164..165 ")" [] [],
+        },
+    ],
+    eof_token: EOF@165..166 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRIT_ROOT@0..166
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: GRIT_DEFINITION_LIST@0..165
+    0: GRIT_PATTERN_DEFINITION@0..28
+      0: (empty)
+      1: PATTERN_KW@0..8 "pattern" [] [Whitespace(" ")]
+      2: GRIT_NAME@8..14
+        0: GRIT_NAME@8..14 "is_log" [] []
+      3: L_PAREN@14..15 "(" [] []
+      4: GRIT_VARIABLE_LIST@15..15
+      5: R_PAREN@15..17 ")" [] [Whitespace(" ")]
+      6: (empty)
+      7: GRIT_PATTERN_DEFINITION_BODY@17..28
+        0: L_CURLY@17..18 "{" [] []
+        1: GRIT_PATTERN_LIST@18..26
+          0: GRIT_CODE_SNIPPET@18..26
+            0: GRIT_BACKTICK_SNIPPET_LITERAL@18..26
+              0: GRIT_BACKTICK_SNIPPET@18..26 "`log`" [Newline("\n"), Whitespace("  ")] []
+        2: R_CURLY@26..28 "}" [Newline("\n")] []
+    1: (empty)
+    2: GRIT_PATTERN_DEFINITION@28..131
+      0: (empty)
+      1: PATTERN_KW@28..38 "pattern" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      2: GRIT_NAME@38..60
+        0: GRIT_NAME@38..60 "console_method_to_info" [] []
+      3: L_PAREN@60..61 "(" [] []
+      4: GRIT_VARIABLE_LIST@61..68
+        0: GRIT_VARIABLE@61..68
+          0: GRIT_VARIABLE@61..68 "$method" [] []
+      5: R_PAREN@68..70 ")" [] [Whitespace(" ")]
+      6: (empty)
+      7: GRIT_PATTERN_DEFINITION_BODY@70..131
+        0: L_CURLY@70..71 "{" [] []
+        1: GRIT_PATTERN_LIST@71..129
+          0: GRIT_REWRITE@71..129
+            0: GRIT_CODE_SNIPPET@71..102
+              0: GRIT_BACKTICK_SNIPPET_LITERAL@71..102
+                0: GRIT_BACKTICK_SNIPPET@71..102 "`console.$method($message)`" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+            1: (empty)
+            2: FAT_ARROW@102..105 "=>" [] [Whitespace(" ")]
+            3: GRIT_CODE_SNIPPET@105..129
+              0: GRIT_BACKTICK_SNIPPET_LITERAL@105..129
+                0: GRIT_BACKTICK_SNIPPET@105..129 "`console.info($message)`" [] []
+        2: R_CURLY@129..131 "}" [Newline("\n")] []
+    3: (empty)
+    4: GRIT_NODE_LIKE@131..165
+      0: GRIT_NAME@131..155
+        0: GRIT_NAME@131..155 "console_method_to_info" [Newline("\n"), Newline("\n")] []
+      1: L_PAREN@155..156 "(" [] []
+      2: GRIT_NAMED_ARG_LIST@156..164
+        0: GRIT_NODE_LIKE@156..164
+          0: GRIT_NAME@156..162
+            0: GRIT_NAME@156..162 "is_log" [] []
+          1: L_PAREN@162..163 "(" [] []
+          2: GRIT_NAMED_ARG_LIST@163..163
+          3: R_PAREN@163..164 ")" [] []
+      3: R_PAREN@164..165 ")" [] []
+  4: EOF@165..166 "" [Newline("\n")] []
+
+```

--- a/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
@@ -210,9 +210,18 @@ pub(super) fn node_to_args_pairs(
                             .as_ref()
                             .and_then(|params| params.get(i))
                             .map(|p| p.strip_prefix(lang.metavariable_prefix()).unwrap_or(p))
-                            .ok_or_else(|| NodeLikeArgumentError::TooManyArguments {
-                                name: fn_name.to_string(),
-                                max_args: expected_params.as_ref().map_or(0, |p| p.len()),
+                            .ok_or_else(|| {
+                                if let Some(params) = expected_params.as_ref() {
+                                    NodeLikeArgumentError::TooManyArguments {
+                                        name: fn_name.to_string(),
+                                        max_args: params.len(),
+                                    }
+                                } else {
+                                    NodeLikeArgumentError::MissingArgumentName {
+                                        name: fn_name.to_string(),
+                                        variable: String::new(),
+                                    }
+                                }
                             })?
                             .to_owned()
                     }

--- a/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
@@ -172,42 +172,52 @@ pub(super) fn node_to_args_pairs(
         .enumerate()
         .map(|(i, node)| match node {
             Ok(AnyGritMaybeNamedArg::AnyGritPattern(pattern)) => {
-                let var = match pattern {
-                    AnyGritPattern::GritVariable(var) => var,
-                    _ => Err(NodeLikeArgumentError::ExpectedVariable {
-                        name: fn_name.to_string(),
-                    })?,
+                let name = match &pattern {
+                    AnyGritPattern::GritVariable(var) => {
+                        let var_name = var.to_trimmed_string();
+                        let name = var_name
+                            .strip_prefix(lang.metavariable_prefix())
+                            .filter(|stripped| {
+                                expected_params.as_ref().is_none_or(|expected| {
+                                    expected.iter().any(|exp| exp == &var_name || exp == stripped)
+                                })
+                            })
+                            .or_else(|| {
+                                expected_params.as_ref().and_then(|params| {
+                                    params.get(i).map(|p| {
+                                        p.strip_prefix(lang.metavariable_prefix()).unwrap_or(p)
+                                    })
+                                })
+                            })
+                            .ok_or_else(|| {
+                                if let Some(exp) = expected_params {
+                                    NodeLikeArgumentError::TooManyArguments {
+                                        name: fn_name.to_string(),
+                                        max_args: exp.len(),
+                                    }
+                                } else {
+                                    NodeLikeArgumentError::MissingArgumentName {
+                                        name: fn_name.to_string(),
+                                        variable: var_name.clone(),
+                                    }
+                                }
+                            })?;
+                        name.to_owned()
+                    }
+                    _ => {
+                        // Non-variable positional args: resolve parameter name by position
+                        expected_params
+                            .as_ref()
+                            .and_then(|params| params.get(i))
+                            .map(|p| p.strip_prefix(lang.metavariable_prefix()).unwrap_or(p))
+                            .ok_or_else(|| NodeLikeArgumentError::TooManyArguments {
+                                name: fn_name.to_string(),
+                                max_args: expected_params.as_ref().map_or(0, |p| p.len()),
+                            })?
+                            .to_owned()
+                    }
                 };
-
-                let name = var.to_trimmed_string();
-                let name = name
-                    .strip_prefix(lang.metavariable_prefix())
-                    .filter(|stripped| {
-                        expected_params.as_ref().is_none_or(|expected| {
-                            expected.iter().any(|exp| exp == &name || exp == stripped)
-                        })
-                    })
-                    .or_else(|| {
-                        expected_params.as_ref().and_then(|params| {
-                            params
-                                .get(i)
-                                .map(|p| p.strip_prefix(lang.metavariable_prefix()).unwrap_or(p))
-                        })
-                    })
-                    .ok_or_else(|| {
-                        if let Some(exp) = expected_params {
-                            NodeLikeArgumentError::TooManyArguments {
-                                name: fn_name.to_string(),
-                                max_args: exp.len(),
-                            }
-                        } else {
-                            NodeLikeArgumentError::MissingArgumentName {
-                                name: fn_name.to_string(),
-                                variable: name.clone(),
-                            }
-                        }
-                    })?;
-                Ok((name.to_owned(), AnyGritPattern::GritVariable(var)))
+                Ok((name, pattern))
             }
             Ok(AnyGritMaybeNamedArg::GritNamedArg(named_arg)) => {
                 let name = named_arg.name()?;

--- a/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
@@ -179,7 +179,9 @@ pub(super) fn node_to_args_pairs(
                             .strip_prefix(lang.metavariable_prefix())
                             .filter(|stripped| {
                                 expected_params.as_ref().is_none_or(|expected| {
-                                    expected.iter().any(|exp| exp == &var_name || exp == stripped)
+                                    expected
+                                        .iter()
+                                        .any(|exp| exp == &var_name || exp == stripped)
                                 })
                             })
                             .or_else(|| {

--- a/crates/biome_grit_patterns/src/pattern_compiler/node_like_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/node_like_compiler.rs
@@ -5,7 +5,7 @@ use crate::grit_node_patterns::{GritNodePattern, GritNodePatternArg};
 use crate::grit_target_language::GritNodePatternSource;
 use crate::grit_target_node::GritTargetSyntaxKind;
 use crate::{CompileError, grit_context::GritQueryContext};
-use biome_grit_syntax::{AnyGritMaybeNamedArg, AnyGritPattern, GritNodeLike, GritSyntaxKind};
+use biome_grit_syntax::{AnyGritMaybeNamedArg, GritNodeLike, GritSyntaxKind};
 use biome_rowan::TokenText;
 use grit_pattern_matcher::pattern::Pattern;
 use std::cmp::Ordering;
@@ -77,13 +77,6 @@ fn node_pattern_from_node_with_name_and_kind(
     for (index, arg) in node.named_args().into_iter().enumerate() {
         let (arg_name, slot_index, pattern) = match arg {
             Ok(AnyGritMaybeNamedArg::AnyGritPattern(pattern)) => {
-                let AnyGritPattern::GritVariable(variable) = pattern else {
-                    return Err(NodeLikeArgumentError::ExpectedVariable {
-                        name: name.to_string(),
-                    }
-                    .into());
-                };
-
                 let Some((slot_name, slot_index)) = node_slots.get(index) else {
                     return Err(NodeLikeArgumentError::TooManyArguments {
                         name: name.to_string(),
@@ -92,11 +85,7 @@ fn node_pattern_from_node_with_name_and_kind(
                     .into());
                 };
 
-                (
-                    (*slot_name).to_string(),
-                    *slot_index,
-                    AnyGritPattern::GritVariable(variable),
-                )
+                ((*slot_name).to_string(), *slot_index, pattern)
             }
             Ok(AnyGritMaybeNamedArg::GritNamedArg(named_arg)) => {
                 let arg_name = named_arg.name()?.value_token()?.token_text_trimmed();

--- a/crates/biome_grit_patterns/tests/specs/ts/positional_args.grit
+++ b/crates/biome_grit_patterns/tests/specs/ts/positional_args.grit
@@ -1,0 +1,4 @@
+pattern console_method_to_info($method) {
+  `console.$method($message)` => `console.info($message)`
+}
+console_method_to_info(`log`)

--- a/crates/biome_grit_patterns/tests/specs/ts/positional_args.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/positional_args.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_grit_patterns/tests/spec_tests.rs
+expression: positional_args
+---
+SnapshotResult {
+    messages: [],
+    matched_ranges: [
+        "1:1-1:29",
+    ],
+    rewritten_files: [],
+    created_files: [],
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/positional_args.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/positional_args.snap
@@ -7,6 +7,14 @@ SnapshotResult {
     matched_ranges: [
         "1:1-1:29",
     ],
-    rewritten_files: [],
+    rewritten_files: [
+        OutputFile {
+            messages: [],
+            variables: [],
+            source_file: "tests/specs/ts/positional_args.ts",
+            content: "console.info(\"hello, world!\");\nconsole.warn(\"should not match\");\n",
+            byte_ranges: None,
+        },
+    ],
     created_files: [],
 }

--- a/crates/biome_grit_patterns/tests/specs/ts/positional_args.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/positional_args.ts
@@ -1,0 +1,2 @@
+console.log("hello, world!");
+console.warn("should not match");


### PR DESCRIPTION
Fixes #10114.

The GritQL spec says positional arguments are valid, so `console_method_to_info(\`log\`)` should work the same as `console_method_to_info(method = \`log\`)`. Biome was rejecting them.

The fix needed two places. In the parser, `parse_maybe_named_arg` sent every `GRIT_NAME` token to `parse_named_arg`, which requires `=`. A positional call like `is_log()` would get misparsed as a broken named arg. One token of lookahead fixes it.

In the pattern compiler, `node_to_args_pairs` rejected any positional arg that wasn't a `GritVariable` — backtick snippets and other patterns were all refused with `ExpectedVariable`. The same restriction in `node_pattern_from_node_with_name_and_kind` blocked AST node patterns too. Both now resolve the parameter name by position.

> AI assistance was used in writing this PR.

## Test Plan

- `ok/positional_args.grit` — the exact GritQL from the issue parses without errors
- `ok/positional_args_pattern_call.grit` — positional pattern call (`is_log()`) parses correctly
- `specs/ts/positional_args.{grit,ts,snap}` — end-to-end: the pattern compiles and matches `console.log(...)` but not `console.warn(...)`