### PR TITLE
feat(css_formatter): improve SCSS map formatting

### DIFF
--- a/crates/biome_css_formatter/src/scss/auxiliary/map_expression_pair.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/map_expression_pair.rs
@@ -1,14 +1,32 @@
 use crate::prelude::*;
+use crate::utils::comment_trivia::format_leading_comments_with_soft_lines;
 use crate::utils::scss_expression::is_self_breaking_value;
 use crate::utils::scss_separator_comments::FormatScssSeparatorComments;
-use biome_css_syntax::{ScssMapExpressionPair, ScssMapExpressionPairFields};
+use biome_css_syntax::{
+    ScssMapExpressionPair, ScssMapExpressionPairFields, is_in_scss_include_arguments,
+};
+use biome_formatter::comments::CommentKind;
 use biome_formatter::{format_args, write};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssMapExpressionPair;
 impl FormatNodeRule<ScssMapExpressionPair> for FormatScssMapExpressionPair {
     fn fmt_node(&self, node: &ScssMapExpressionPair, f: &mut CssFormatter) -> FormatResult<()> {
-        self.fmt_node_with_scss_separator_comments(node, f)
+        match ScssMapPairLeadingCommentLayout::for_pair(node, f) {
+            ScssMapPairLeadingCommentLayout::Separator => {
+                self.fmt_node_with_scss_separator_comments(node, f)
+            }
+            ScssMapPairLeadingCommentLayout::GroupWithPair => {
+                write!(
+                    f,
+                    [group(&format_args![
+                        format_leading_comments_with_soft_lines(node.syntax()),
+                        format_with(|f| self.fmt_fields(node, f))
+                    ])]
+                )
+            }
+            ScssMapPairLeadingCommentLayout::Default => self.fmt_fields(node, f),
+        }
     }
 
     fn fmt_fields(&self, node: &ScssMapExpressionPair, f: &mut CssFormatter) -> FormatResult<()> {
@@ -38,7 +56,38 @@ impl FormatNodeRule<ScssMapExpressionPair> for FormatScssMapExpressionPair {
         node: &ScssMapExpressionPair,
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        self.fmt_leading_scss_separator_comments(node, f)
+        match ScssMapPairLeadingCommentLayout::for_pair(node, f) {
+            ScssMapPairLeadingCommentLayout::Separator
+            | ScssMapPairLeadingCommentLayout::GroupWithPair => Ok(()),
+            ScssMapPairLeadingCommentLayout::Default => {
+                write!(f, [format_leading_comments(node.syntax())])
+            }
+        }
+    }
+}
+
+/// How leading comments are printed for one SCSS map pair.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum ScssMapPairLeadingCommentLayout {
+    /// Include arguments use separator comments, e.g. `@include mix($a, /* c */ $b)`.
+    Separator,
+
+    /// `/* comment */ key: value` joins the pair group.
+    GroupWithPair,
+
+    /// Normal leading comments use the default comment printer.
+    Default,
+}
+
+impl ScssMapPairLeadingCommentLayout {
+    fn for_pair(node: &ScssMapExpressionPair, f: &CssFormatter) -> Self {
+        if is_in_scss_include_arguments(node.syntax()) {
+            Self::Separator
+        } else if should_group_leading_block_comments_with_pair(node, f) {
+            Self::GroupWithPair
+        } else {
+            Self::Default
+        }
     }
 }
 
@@ -65,4 +114,35 @@ impl Format<CssFormatContext> for FormatScssMapExpressionPairValue<'_> {
             )
         }
     }
+}
+
+/// Returns `true` for `/* comment */ key: value`.
+///
+/// The comment joins the pair group, so long comments break before `key`.
+fn should_group_leading_block_comments_with_pair(
+    node: &ScssMapExpressionPair,
+    f: &CssFormatter,
+) -> bool {
+    let leading_comments = f.comments().leading_comments(node.syntax());
+
+    if leading_comments.is_empty()
+        || !leading_comments.iter().all(|comment| {
+            matches!(
+                comment.kind(),
+                CommentKind::Block | CommentKind::InlineBlock
+            ) && comment.lines_after() <= 1
+        })
+    {
+        return false;
+    }
+
+    let Ok(value) = node.value() else {
+        return false;
+    };
+
+    if is_self_breaking_value(&value) {
+        return false;
+    }
+
+    true
 }

--- a/crates/biome_css_formatter/src/scss/auxiliary/parenthesized_expression.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/parenthesized_expression.rs
@@ -4,7 +4,7 @@ use crate::utils::scss_include_keyword_value::is_top_level_include_keyword_paren
 use crate::utils::scss_separator_comments::FormatScssSeparatorComments;
 use biome_css_syntax::{
     AnyScssExpression, AnyScssExpressionItem, ScssParenthesizedExpression,
-    ScssParenthesizedExpressionFields, is_scss_map_outer_parenthesized_value_map,
+    ScssParenthesizedExpressionFields, is_scss_map_outer_parenthesized_value,
     scss_include_keyword_argument_owner, unwrap_single_expression_item,
 };
 use biome_formatter::{format_args, write};
@@ -49,13 +49,13 @@ impl<'a> ScssParenthesizedExpressionLayout<'a> {
         Self { node }
     }
 
-    /// Formats the comma owned by include value parentheses.
+    /// Formats the trailing comma inside parentheses that Prettier breaks.
     ///
-    /// Example: `@include mix($arg: (a))` prints `(a,)`.
+    /// Examples: `@include mix($arg: (a))`, `key: (value)`.
     fn trailing_comma(&self) -> impl Format<CssFormatContext> + '_ {
         format_with(|f| {
             if self.should_print_trailing_comma() {
-                write!(f, [token(",")])
+                write!(f, [if_group_breaks(&token(","))])
             } else {
                 Ok(())
             }
@@ -64,31 +64,43 @@ impl<'a> ScssParenthesizedExpressionLayout<'a> {
 
     /// Expands parenthesized map values and include keyword values.
     ///
-    /// Examples: `key: ((nested: map))`, `@include mix($arg: (a))`.
+    /// Examples: `key: (value)`, `@include mix($arg: (a))`.
     fn should_expand(&self) -> bool {
-        is_scss_map_outer_parenthesized_value_map(self.node)
+        is_scss_map_outer_parenthesized_value(self.node)
             || is_top_level_include_keyword_parenthesized_value(self.node)
             || self.has_nested_include_parentheses()
             || self.has_include_trailing_comment()
     }
 
-    /// Prints a comma for include values that Prettier treats as lists.
+    /// Allows a trailing comma for parentheses Prettier treats as one-item lists.
     ///
-    /// Examples: `@include mix($arg: (a))`, `@include mix($arg: ((a)))`.
+    /// Examples: `@include mix($arg: (a))`, `key: (value)`.
     fn should_print_trailing_comma(&self) -> bool {
-        self.has_nested_include_parentheses() || self.should_print_include_value_comma()
+        self.should_print_map_trailing_comma()
+            || self.has_nested_include_parentheses()
+            || self.should_print_include_trailing_comma()
     }
 
-    /// Prints the top-level include value comma unless the child owns it.
+    /// Allows the trailing comma in maps such as `key: (value)`.
+    fn should_print_map_trailing_comma(&self) -> bool {
+        is_scss_map_outer_parenthesized_value(self.node)
+            && self
+                .node
+                .expression()
+                .ok()
+                .is_some_and(|expression| !expression_owns_list_comma(&expression))
+    }
+
+    /// Allows the top-level include comma unless the child list owns commas.
     ///
     /// Example: `$arg: (a)` prints a comma, but `$arg: (a, b)` does not.
-    fn should_print_include_value_comma(&self) -> bool {
+    fn should_print_include_trailing_comma(&self) -> bool {
         is_top_level_include_keyword_parenthesized_value(self.node)
             && self
                 .node
                 .expression()
                 .ok()
-                .is_some_and(|expression| !expression_owns_trailing_comma(&expression))
+                .is_some_and(|expression| !expression_owns_list_comma(&expression))
     }
 
     /// Detects the outer include value in `@include mix($arg: ((a)))`.
@@ -136,16 +148,12 @@ impl Format<CssFormatContext> for ScssParenthesizedExpressionLayout<'_> {
     }
 }
 
-/// Lists and maps already print their own comma in `$arg: (a, b)`.
-fn expression_owns_trailing_comma(expression: &AnyScssExpression) -> bool {
-    matches!(
-        expression,
-        AnyScssExpression::ScssListExpression(_) | AnyScssExpression::ScssMapExpression(_)
-    ) || unwrap_single_expression_item(expression).is_some_and(|item| {
-        matches!(
-            item,
-            AnyScssExpressionItem::ScssListExpression(_)
-                | AnyScssExpressionItem::ScssMapExpression(_)
-        )
-    })
+/// Lists already print their own item comma in `$arg: (a, b)`.
+///
+/// Maps only print pair separators, so `key: ((a: b))` still needs the outer
+/// scalar comma after the nested map.
+fn expression_owns_list_comma(expression: &AnyScssExpression) -> bool {
+    matches!(expression, AnyScssExpression::ScssListExpression(_))
+        || unwrap_single_expression_item(expression)
+            .is_some_and(|item| matches!(item, AnyScssExpressionItem::ScssListExpression(_)))
 }

--- a/crates/biome_css_formatter/src/utils/comment_trivia.rs
+++ b/crates/biome_css_formatter/src/utils/comment_trivia.rs
@@ -1,6 +1,8 @@
+use crate::comments::FormatCssLeadingComment;
 use crate::prelude::*;
 use biome_css_syntax::{CssLanguage, CssSyntaxNode};
 use biome_formatter::comments::{CommentKind, DecoratedComment};
+use biome_formatter::{FormatRefWithRule, write};
 
 /// Returns `true` when the last leading block comment stays with this node.
 pub(crate) fn has_same_group_leading_block_comment(node: &CssSyntaxNode, f: &CssFormatter) -> bool {
@@ -13,6 +15,40 @@ pub(crate) fn has_same_group_leading_block_comment(node: &CssSyntaxNode, f: &Css
                 CommentKind::Block | CommentKind::InlineBlock
             ) && comment.lines_after() <= 1
         })
+}
+
+/// Formats leading comments with soft lines after each comment.
+///
+/// Group this with the node for `/* comment */ key: value`, so the pair breaks
+/// only when the group does not fit.
+pub(crate) const fn format_leading_comments_with_soft_lines(
+    node: &CssSyntaxNode,
+) -> FormatLeadingCommentsWithSoftLines<'_> {
+    FormatLeadingCommentsWithSoftLines { node }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct FormatLeadingCommentsWithSoftLines<'a> {
+    node: &'a CssSyntaxNode,
+}
+
+impl Format<CssFormatContext> for FormatLeadingCommentsWithSoftLines<'_> {
+    fn fmt(&self, f: &mut CssFormatter) -> FormatResult<()> {
+        let comments = f.comments().clone();
+
+        for comment in comments.leading_comments(self.node) {
+            write!(
+                f,
+                [
+                    FormatRefWithRule::new(comment, FormatCssLeadingComment),
+                    soft_line_break_or_space()
+                ]
+            )?;
+            comment.mark_formatted();
+        }
+
+        Ok(())
+    }
 }
 
 /// Returns `true` for comments that stay on the node's closing line.

--- a/crates/biome_css_formatter/src/utils/scss_map_layout.rs
+++ b/crates/biome_css_formatter/src/utils/scss_map_layout.rs
@@ -62,8 +62,8 @@ impl<'a> ScssMapLayout<'a> {
             .iter()
             .any(|comment| comment.kind().is_line())
         {
-            // `(// comment)` would comment out the closing `)` and produce
-            // invalid SCSS.
+            // `(// comment)` comments out the closing `)`, so keep line
+            // comments on their own line.
             return write!(
                 f,
                 [group(&format_args![

--- a/crates/biome_css_formatter/src/utils/scss_separator_comments.rs
+++ b/crates/biome_css_formatter/src/utils/scss_separator_comments.rs
@@ -102,20 +102,18 @@ fn write_separator_leading_comments(
     f: &mut CssFormatter,
     indented_body: Option<&SeparatorCommentBody<'_>>,
 ) -> FormatResult<()> {
-    let comment_count = f.comments().leading_comments(node).len();
+    let comments = f.comments().clone();
+    let leading_comments = comments.leading_comments(node);
+    let comment_count = leading_comments.len();
 
-    for index in 0..comment_count {
-        let (comment, lines_after, kind) = {
-            let comment = f.comments().leading_comments(node)[index].clone();
-            let lines_after = comment.lines_after();
-            let kind = comment.kind();
-            (comment, lines_after, kind)
-        };
+    for (index, comment) in leading_comments.iter().enumerate() {
+        let lines_after = comment.lines_after();
+        let kind = comment.kind();
         let is_last_comment = index + 1 == comment_count;
 
         write!(
             f,
-            [FormatRefWithRule::new(&comment, FormatCssLeadingComment)]
+            [FormatRefWithRule::new(comment, FormatCssLeadingComment)]
         )?;
 
         match kind {
@@ -148,7 +146,7 @@ fn write_separator_leading_comments(
             }
         }
 
-        f.comments().leading_comments(node)[index].mark_formatted();
+        comment.mark_formatted();
     }
 
     Ok(())

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/map/3235.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/map/3235.scss.snap
@@ -117,17 +117,6 @@ other-key: (key: other-other-value)
    );
  }
  
-@@ -69,9 +69,7 @@
- );
- 
- $map: (
--  key: (
--    value,
--  ),
-+  key: (value),
-   other-key: (
-     key: other-other-value,
-   ),
 ```
 
 # Output
@@ -204,7 +193,9 @@ $o-grid-default-config: (
 );
 
 $map: (
-  key: (value),
+  key: (
+    value,
+  ),
   other-key: (
     key: other-other-value,
   ),

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/map/comment.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/map/comment.scss.snap
@@ -42,19 +42,15 @@ $map: (
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,21 +1,22 @@
+@@ -1,21 +1,20 @@
  $map: (
--  /* comment */ key1: value,
+   /* comment */ key1: value,
 -
-+  /* comment */
-+  key1: value,
    // comment
    key2: value,
 -
--  /* comment */ /* comment */ key3: value,
+   /* comment */ /* comment */ key3: value,
 -
-+  /* comment */ /* comment */
-+  key3: value,
    /* comment */
    key4: (
 -      key: value,
@@ -83,12 +79,10 @@ $map: (
 
 ```scss
 $map: (
-  /* comment */
-  key1: value,
+  /* comment */ key1: value,
   // comment
   key2: value,
-  /* comment */ /* comment */
-  key3: value,
+  /* comment */ /* comment */ key3: value,
   /* comment */
   key4: (
     key: value,

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/map/key-values.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/map/key-values.scss.snap
@@ -27,7 +27,7 @@ $map: (
 ```diff
 --- Prettier
 +++ Biome
-@@ -6,17 +6,15 @@
+@@ -6,8 +6,8 @@
      "key": "value",
      "key": "value",
    ): (
@@ -38,28 +38,29 @@ $map: (
    (
      "key": "value",
      "key": "value",
+@@ -15,8 +15,8 @@
      "key": "value",
      "key": "value",
-     "key": "value",
--  ): (
+   ): (
 -      "list",
 -    ),
-+  ): ("list"),
++    "list",
++  ),
    (
      "list",
      "list",
-@@ -28,9 +26,7 @@
+@@ -29,8 +29,8 @@
      "list",
      "list",
-     "list",
--  ): (
+   ): (
 -      "list",
 -    ),
-+  ): ("list"),
++    "list",
++  ),
    (
      "list",
      "list",
-@@ -43,13 +39,14 @@
+@@ -43,13 +43,14 @@
      "list",
      "list",
    ): (
@@ -98,7 +99,9 @@ $map: (
     "key": "value",
     "key": "value",
     "key": "value",
-  ): ("list"),
+  ): (
+    "list",
+  ),
   (
     "list",
     "list",
@@ -110,7 +113,9 @@ $map: (
     "list",
     "list",
     "list",
-  ): ("list"),
+  ): (
+    "list",
+  ),
   (
     "list",
     "list",

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-comments.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-comments.scss
@@ -10,3 +10,18 @@ $commentedNestedMapValue:(key:(other-key:other-other-value),/* end */);
 $emptyBlockCommentMap:(/* comment */);
 $emptyLineCommentMap:(// comment
 );
+$leadingBlockCommentMap:(
+/* comment */
+key1:value,
+key2:value
+);
+$leadingBlockCommentsMap:(
+/* comment */ /* comment */
+key2:value,
+key3:value
+);
+$leadingBlockCommentNestedMap:(
+/* comment */
+key3:(key:value,key:value),
+key4:value
+);

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-comments.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-comments.scss.snap
@@ -18,6 +18,21 @@ $commentedNestedMapValue:(key:(other-key:other-other-value),/* end */);
 $emptyBlockCommentMap:(/* comment */);
 $emptyLineCommentMap:(// comment
 );
+$leadingBlockCommentMap:(
+/* comment */
+key1:value,
+key2:value
+);
+$leadingBlockCommentsMap:(
+/* comment */ /* comment */
+key2:value,
+key3:value
+);
+$leadingBlockCommentNestedMap:(
+/* comment */
+key3:(key:value,key:value),
+key4:value
+);
 
 ```
 
@@ -50,6 +65,22 @@ $commentedNestedMapValue: (
 $emptyBlockCommentMap: (/* comment */);
 $emptyLineCommentMap: (
 	// comment
+);
+$leadingBlockCommentMap: (
+	/* comment */ key1: value,
+	key2: value,
+);
+$leadingBlockCommentsMap: (
+	/* comment */ /* comment */ key2: value,
+	key3: value,
+);
+$leadingBlockCommentNestedMap: (
+	/* comment */
+	key3: (
+		key: value,
+		key: value,
+	),
+	key4: value,
 );
 
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-context.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-context.scss.snap
@@ -23,19 +23,23 @@ $nestedValueCall: (
 	key: fn((a, b)),
 );
 $nestedValueParen: (
-	key: (fn((a, b))),
+	key: (
+		fn((a, b)),
+	),
 );
 $nestedValueMultiArg: (
 	key: foo((a, b), (c, d)),
 );
 $doubleParenListValue: (
-	key: ((a, b)),
+	key: (
+		(a, b),
+	),
 );
 $doubleParenMapValue: (
 	key: (
 		(
 			a: b,
-		)
+		),
 	),
 );
 $doubleParenMapValueBroken: (
@@ -44,7 +48,7 @@ $doubleParenMapValueBroken: (
 			very-very-very-very-very-very-very-very-long-map-key:
 				very-very-very-very-very-very-very-very-long-map-value,
 			other-key: other-other-value,
-		)
+		),
 	),
 );
 

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-parenthesized-value.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-parenthesized-value.scss
@@ -1,0 +1,5 @@
+$map:(key:(value),other-key:(nested:value));
+
+$map-with-list:(key:(value,),other-key:(nested:value));
+
+$nested-map:(key:(nested:value),other-key:(value));

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-parenthesized-value.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-parenthesized-value.scss.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/expression/map-parenthesized-value.scss
+---
+
+# Input
+
+```scss
+$map:(key:(value),other-key:(nested:value));
+
+$map-with-list:(key:(value,),other-key:(nested:value));
+
+$nested-map:(key:(nested:value),other-key:(value));
+
+```
+
+
+# Formatted
+
+```scss
+$map: (
+	key: (
+		value,
+	),
+	other-key: (
+		nested: value,
+	),
+);
+
+$map-with-list: (
+	key: (
+		value,
+	),
+	other-key: (
+		nested: value,
+	),
+);
+
+$nested-map: (
+	key: (
+		nested: value,
+	),
+	other-key: (
+		value,
+	),
+);
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-values.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-values.scss.snap
@@ -20,7 +20,9 @@ $mapValueMapBroken:(key:((very-very-very-very-very-very-very-very-long-map-key:v
 
 ```scss
 $mapValueScalar: (
-	key: (value),
+	key: (
+		value,
+	),
 );
 $mapValueList: (
 	key: (
@@ -39,7 +41,7 @@ $mapValueMap: (
 );
 $mapValueScalarBroken: (
 	key: (
-		very-very-very-very-very-very-very-very-very-very-very-very-very-long-scalar
+		very-very-very-very-very-very-very-very-very-very-very-very-very-long-scalar,
 	),
 );
 $mapValueListBroken: (
@@ -55,7 +57,7 @@ $mapValueMapBroken: (
 			very-very-very-very-very-very-very-very-long-map-key:
 				very-very-very-very-very-very-very-very-long-map-value,
 			other-key: other-other-value,
-		)
+		),
 	),
 );
 

--- a/crates/biome_css_syntax/src/lib.rs
+++ b/crates/biome_css_syntax/src/lib.rs
@@ -18,10 +18,11 @@ pub use file_source::{CssFileLanguage, CssFileSource, CssVariant, EmbeddingKind}
 pub use scss_ext::{
     ScssMapContext, ScssMapPositionKind, ScssMapRole, is_in_scss_control_condition_sequence,
     is_in_scss_include_arguments, is_in_scss_map_key, is_scss_map_key,
-    is_scss_map_outer_parenthesized_value_list, is_scss_map_outer_parenthesized_value_map,
-    is_scss_map_value, scss_include_keyword_argument_owner,
-    scss_keyword_argument_from_css_expression, scss_keyword_argument_from_expression,
-    scss_keyword_argument_from_syntax, single_expression_item, unwrap_single_expression_item,
+    is_scss_map_outer_parenthesized_value, is_scss_map_outer_parenthesized_value_list,
+    is_scss_map_outer_parenthesized_value_map, is_scss_map_value,
+    scss_include_keyword_argument_owner, scss_keyword_argument_from_css_expression,
+    scss_keyword_argument_from_expression, scss_keyword_argument_from_syntax,
+    single_expression_item, unwrap_single_expression_item,
 };
 pub use syntax_node::*;
 

--- a/crates/biome_css_syntax/src/scss_ext/map.rs
+++ b/crates/biome_css_syntax/src/scss_ext/map.rs
@@ -51,10 +51,10 @@ where
     )
 }
 
-/// Returns `true` for the outer value wrapper whose payload is a map.
+/// Returns `true` for the outer value wrapper in a map pair.
 ///
-/// Example: in `(key: (a: b))`, `(a: b)` returns `true`.
-pub fn is_scss_map_outer_parenthesized_value_map(node: &ScssParenthesizedExpression) -> bool {
+/// Example: in `(key: (value))`, `(value)` returns `true`.
+pub fn is_scss_map_outer_parenthesized_value(node: &ScssParenthesizedExpression) -> bool {
     let Some((pair, ScssMapRole::Value)) = enclosing_pair_and_role(node) else {
         return false;
     };
@@ -62,10 +62,19 @@ pub fn is_scss_map_outer_parenthesized_value_map(node: &ScssParenthesizedExpress
         return false;
     };
 
-    outer_parenthesized_value(&value).is_some_and(|parenthesized| {
-        parenthesized.syntax() == node.syntax()
-            && outer_parenthesized_value_map(&parenthesized).is_some()
-    })
+    outer_parenthesized_value(&value)
+        .is_some_and(|parenthesized| parenthesized.syntax() == node.syntax())
+}
+
+/// Returns `true` for the outer value wrapper whose payload is a map.
+///
+/// Example: in `(key: (a: b))`, `(a: b)` returns `true`.
+pub fn is_scss_map_outer_parenthesized_value_map(node: &ScssParenthesizedExpression) -> bool {
+    if !is_scss_map_outer_parenthesized_value(node) {
+        return false;
+    }
+
+    outer_parenthesized_value_map(node).is_some()
 }
 
 /// Returns `true` for the list payload inside an outer value wrapper.

--- a/crates/biome_css_syntax/src/scss_ext/mod.rs
+++ b/crates/biome_css_syntax/src/scss_ext/mod.rs
@@ -11,6 +11,6 @@ pub use expression::{
 pub use include::{is_in_scss_include_arguments, scss_include_keyword_argument_owner};
 pub use map::{
     ScssMapContext, ScssMapPositionKind, ScssMapRole, is_in_scss_map_key, is_scss_map_key,
-    is_scss_map_outer_parenthesized_value_list, is_scss_map_outer_parenthesized_value_map,
-    is_scss_map_value,
+    is_scss_map_outer_parenthesized_value, is_scss_map_outer_parenthesized_value_list,
+    is_scss_map_outer_parenthesized_value_map, is_scss_map_value,
 };


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

  ## Summary

  Improves SCSS map formatting parity with Prettier for parenthesized map values and map pairs with leading block comments.


  ```scss
  $map: (
  	key: (
  		value,
  	),
  	other-key: (
  		nested: value,
  	),
  );

  $leadingBlockCommentMap: (
  	/* comment */ key1: value,
  	key2: value,
  );
```

  ## Test Plan

  Passed locally:

  cargo test -p biome_css_formatter 