### PR TITLE
perf(css): deduplicate rules information

### DIFF
--- a/.claude/skills/biome-developer/SKILL.md
+++ b/.claude/skills/biome-developer/SKILL.md
@@ -117,9 +117,13 @@ let token = html_string.value_token().ok()?; // OK
 - Use `let` chains to collapse nested `if let` statements (cleaner and follows Rust idioms)
 - Run `just l` before committing to catch clippy warnings
 - Fix clippy suggestions unless there's a good reason not to
+- Always import types at the top of the file — never inline crate paths in type positions
+- Let the compiler infer types when it can — only add explicit type annotations when the compiler cannot infer them
 
 **DON'T:**
 - Do NOT ignore clippy warnings - they often catch real issues or suggest better patterns
+- Do NOT inline crate paths in type positions (e.g. `Vec<some_crate::module::Type>`) — add a `use` import instead
+- Do NOT annotate types that the compiler can already infer
 
 **Example - Collapsible If:**
 ```rust
@@ -136,6 +140,30 @@ if let Some(directive) = VueDirective::cast_ref(&element)
 {
     // ... do something
 }
+```
+
+**Example - Import types, don't inline paths:**
+```rust
+// WRONG: Inlined crate path in type position
+enum Frame {
+    Visit(biome_css_semantic::model::RuleId),
+}
+
+// CORRECT: Import the type at the top of the file
+use biome_css_semantic::model::RuleId;
+
+enum Frame {
+    Visit(RuleId),
+}
+```
+
+**Example - Let the compiler infer types:**
+```rust
+// WRONG: Redundant type annotation — the compiler infers this from FxHashSet::default()
+let mut visited: FxHashSet<RuleId> = FxHashSet::default();
+
+// CORRECT: No annotation needed
+let mut visited = FxHashSet::default();
 ```
 
 ### Code Comments

--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors.rs
@@ -4,7 +4,8 @@ use biome_css_semantic::model::{AnyRuleStart, RuleId};
 use biome_css_syntax::AnyCssRoot;
 use biome_diagnostics::Severity;
 use biome_rowan::TextRange;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use std::hash::{BuildHasher, Hasher};
 
 use biome_rule_options::no_duplicate_selectors::NoDuplicateSelectorsOptions;
 
@@ -105,19 +106,21 @@ impl Rule for NoDuplicateSelectors {
         let model = ctx.model();
         let root = ctx.root();
 
-        // Maps (at_rule_context, normalized_selector_list_key) → first occurrence range.
-        let mut seen: FxHashMap<(Vec<RuleId>, String), TextRange> = FxHashMap::default();
-        let mut duplicates: Vec<DuplicateSelectorList> = Vec::new();
-        let mut visited: FxHashSet<RuleId> = FxHashSet::default();
+        // Maps (context_hash, normalized_selector_list_key) → first occurrence range.
+        let mut seen = FxHashMap::default();
+        let mut duplicates = Vec::new();
+        let mut visited = FxHashSet::default();
 
         // Iterative DFS using an explicit stack with sentinel frames for context pop.
         enum Frame {
             Visit(RuleId),
-            /// Sentinel: pop one entry from `at_rule_context` after a subtree is done.
+            /// Sentinel: pop one entry from the context hash stack after a subtree is done.
             PopAtRule,
         }
 
-        let mut at_rule_context: Vec<RuleId> = Vec::new();
+        // Stack of running hashes representing the at-rule nesting context.
+        // Seed with 0 for top-level (no at-rule context).
+        let mut context_hash_stack = vec![0u64];
         // Seed the stack with all top-level rules (reversed so they process in order).
         let mut stack: Vec<Frame> = model
             .rules()
@@ -129,7 +132,7 @@ impl Rule for NoDuplicateSelectors {
         while let Some(frame) = stack.pop() {
             match frame {
                 Frame::PopAtRule => {
-                    at_rule_context.pop();
+                    context_hash_stack.pop();
                 }
                 Frame::Visit(rule_id) => {
                     let rule = match model.get_rule_by_id(&rule_id) {
@@ -151,8 +154,11 @@ impl Rule for NoDuplicateSelectors {
                     );
 
                     if is_at_rule {
-                        at_rule_context.push(rule.id());
-                        // Push a sentinel so we pop after this subtree is processed.
+                        let parent_hash = *context_hash_stack.last().unwrap();
+                        let mut hasher = FxBuildHasher.build_hasher();
+                        hasher.write_u64(parent_hash);
+                        hasher.write_u32(rule.id().index() as u32);
+                        context_hash_stack.push(hasher.finish());
                         stack.push(Frame::PopAtRule);
                     }
 
@@ -171,7 +177,8 @@ impl Rule for NoDuplicateSelectors {
                         normalized_selectors.sort();
 
                         let list_key = normalized_selectors.join(", ");
-                        let context_key = (at_rule_context.clone(), list_key.clone());
+                        let context_hash = *context_hash_stack.last().unwrap();
+                        let context_key = (context_hash, list_key.clone());
                         let rule_range = rule.range(&root);
 
                         match seen.get(&context_key) {

--- a/crates/biome_css_semantic/src/format_semantic_model.rs
+++ b/crates/biome_css_semantic/src/format_semantic_model.rs
@@ -77,8 +77,8 @@ impl Format<FormatSemanticModelContext> for SemanticModel {
     fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
         let mut selectors: Vec<&Selector> = self
             .data
-            .rules_by_id
-            .values()
+            .all_rules
+            .iter()
             .flat_map(|rule| rule.selectors())
             .collect();
         selectors.sort_by_key(|sel| sel.range(&self.root()).start());

--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -147,7 +147,9 @@ impl SemanticModelBuilder {
                 };
 
                 if let Some(&parent_id) = self.current_rule_stack.last() {
-                    self.all_rules[parent_id.index()].child_ids.push(new_rule_id);
+                    self.all_rules[parent_id.index()]
+                        .child_ids
+                        .push(new_rule_id);
                 }
 
                 self.all_rules.push(new_rule);
@@ -305,7 +307,10 @@ fn resolve_selector(current: &[CssSyntaxToken], parents: &[Selector]) -> Vec<Res
         .map(|parent| {
             let parent_tokens = &parent.resolved.0;
             if has_amp {
-                let amp_count = current.iter().filter(|t| t.kind() == CssSyntaxKind::AMP).count();
+                let amp_count = current
+                    .iter()
+                    .filter(|t| t.kind() == CssSyntaxKind::AMP)
+                    .count();
                 let non_amp_count = current.len() - amp_count;
                 let capacity = amp_count * parent_tokens.len() + non_amp_count;
 

--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -12,15 +12,15 @@ use crate::model::AnyRuleStart;
 
 pub struct SemanticModelBuilder {
     root: AnyCssRoot,
-    /// List of all top-level rules in the CSS file
-    rules: Vec<Rule>,
+    /// All rules, indexed by RuleId
+    all_rules: Vec<Rule>,
+    /// IDs of top-level rules only
+    top_level_rule_ids: Vec<RuleId>,
     global_custom_variables: FxHashMap<String, CssGlobalCustomVariable>,
     /// Stack of rule IDs to keep track of the current rule hierarchy
     current_rule_stack: Vec<RuleId>,
-    next_rule_id: RuleId,
-    /// Map to get the rule containing the given range of CST nodes
-    range_to_rule: BTreeMap<TextRange, Rule>,
-    rules_by_id: FxHashMap<RuleId, Rule>,
+    /// Map from text range to RuleId
+    range_to_rule_id: BTreeMap<TextRange, RuleId>,
     /// Indicates if the current node is within a `:root` selector
     is_in_root_selector: bool,
 }
@@ -29,13 +29,12 @@ impl SemanticModelBuilder {
     pub fn new(root: AnyCssRoot) -> Self {
         Self {
             root,
-            rules: Vec::new(),
+            all_rules: Vec::new(),
+            top_level_rule_ids: Vec::new(),
             current_rule_stack: Vec::new(),
             global_custom_variables: FxHashMap::default(),
-            range_to_rule: BTreeMap::default(),
+            range_to_rule_id: BTreeMap::default(),
             is_in_root_selector: false,
-            next_rule_id: RuleId::default(),
-            rules_by_id: FxHashMap::default(),
         }
     }
 
@@ -43,12 +42,12 @@ impl SemanticModelBuilder {
         let mut iterator = self.current_rule_stack.iter().rev();
         let mut current_parent_id = iterator
             .next()
-            .and_then(|rule_id| self.rules_by_id.get(rule_id))
+            .and_then(|rule_id| self.all_rules.get(rule_id.index()))
             .and_then(|rule| rule.parent_id);
 
         loop {
             if let Some(parent_id) = &current_parent_id {
-                let rule = self.rules_by_id.get(parent_id);
+                let rule = self.all_rules.get(parent_id.index());
                 if let Some(rule) = rule {
                     let typed_node = rule.node.to_node(self.root.syntax());
                     if matches!(
@@ -59,7 +58,7 @@ impl SemanticModelBuilder {
                     ) {
                         current_parent_id = iterator
                             .next()
-                            .and_then(|rule_id| self.rules_by_id.get(rule_id))
+                            .and_then(|rule_id| self.all_rules.get(rule_id.index()))
                             .and_then(|rule| rule.parent_id);
                     } else {
                         return Some(rule);
@@ -78,12 +77,12 @@ impl SemanticModelBuilder {
         let mut current_index = 1;
         let mut current_parent_id = iterator
             .next()
-            .and_then(|rule_id| self.rules_by_id.get(rule_id))
+            .and_then(|rule_id| self.all_rules.get(rule_id.index()))
             .and_then(|rule| rule.parent_id);
 
         loop {
             if let Some(parent_id) = &current_parent_id {
-                let rule = self.rules_by_id.get(parent_id);
+                let rule = self.all_rules.get(parent_id.index());
                 if let Some(rule) = rule {
                     let typed_node = rule.node.to_node(self.root.syntax());
                     if matches!(
@@ -94,7 +93,7 @@ impl SemanticModelBuilder {
                     ) {
                         current_parent_id = iterator
                             .next()
-                            .and_then(|rule_id| self.rules_by_id.get(rule_id))
+                            .and_then(|rule_id| self.all_rules.get(rule_id.index()))
                             .and_then(|rule| rule.parent_id);
                     } else {
                         if current_index == index {
@@ -103,7 +102,7 @@ impl SemanticModelBuilder {
 
                         current_parent_id = iterator
                             .next()
-                            .and_then(|rule_id| self.rules_by_id.get(rule_id))
+                            .and_then(|rule_id| self.all_rules.get(rule_id.index()))
                             .and_then(|rule| rule.parent_id);
                         current_index += 1;
                     }
@@ -118,10 +117,10 @@ impl SemanticModelBuilder {
 
     pub fn build(self) -> SemanticModel {
         let data = SemanticModelData {
-            rules: self.rules,
+            all_rules: self.all_rules,
+            top_level_rule_ids: self.top_level_rule_ids,
             global_custom_variables: self.global_custom_variables,
-            range_to_rule: self.range_to_rule,
-            rules_by_id: self.rules_by_id,
+            range_to_rule_id: self.range_to_rule_id,
         };
         SemanticModel::new(
             data,
@@ -133,8 +132,7 @@ impl SemanticModelBuilder {
     pub fn push_event(&mut self, event: SemanticEvent) {
         match event {
             SemanticEvent::RuleStart(node) => {
-                let new_rule_id = self.next_rule_id;
-                self.next_rule_id = RuleId::new(new_rule_id.index() + 1);
+                let new_rule_id = RuleId::new(self.all_rules.len());
 
                 let parent_id = self.current_rule_stack.last().copied();
 
@@ -148,32 +146,25 @@ impl SemanticModelBuilder {
                     specificity: Specificity::default(),
                 };
 
-                if let Some(&parent_id) = self.current_rule_stack.last()
-                    && let Some(parent_rule) = self.rules_by_id.get_mut(&parent_id)
-                {
-                    parent_rule.child_ids.push(new_rule_id);
+                if let Some(&parent_id) = self.current_rule_stack.last() {
+                    self.all_rules[parent_id.index()].child_ids.push(new_rule_id);
                 }
 
-                self.rules_by_id.insert(new_rule_id, new_rule);
+                self.all_rules.push(new_rule);
                 self.current_rule_stack.push(new_rule_id);
             }
             SemanticEvent::RuleEnd => {
-                if let Some(completed_rule) = self.current_rule_stack.pop() {
-                    let completed_rule = &self.rules_by_id[&completed_rule];
-                    let has_parent = self.current_rule_stack.last().is_some();
+                if let Some(completed_rule_id) = self.current_rule_stack.pop() {
+                    let range = self.all_rules[completed_rule_id.index()].range(&self.root);
+                    self.range_to_rule_id.insert(range, completed_rule_id);
 
-                    if has_parent {
-                        self.range_to_rule
-                            .insert(completed_rule.range(&self.root), completed_rule.clone());
-                    } else {
-                        self.range_to_rule
-                            .insert(completed_rule.range(&self.root), completed_rule.clone());
-                        self.rules.push(completed_rule.clone());
+                    if self.current_rule_stack.is_empty() {
+                        self.top_level_rule_ids.push(completed_rule_id);
                     }
                 }
             }
             SemanticEvent::SelectorDeclaration { node, specificity } => {
-                if let Some(current_rule) = self.current_rule_stack.last() {
+                if let Some(&current_rule_id) = self.current_rule_stack.last() {
                     let parent_specificity = if node.has_nesting_selectors() {
                         let nesting_level = node.nesting_level();
                         self.get_parent_selector_at(nesting_level)
@@ -197,18 +188,13 @@ impl SemanticModelBuilder {
                             .unwrap_or_default()
                     };
 
-                    // Collect non-trivia tokens for the current selector node.
-                    // We keep CssSyntaxToken (not TokenText) so we can inspect .kind()
-                    // to detect AMP tokens during resolution.
                     let current_tokens = selector_tokens(&node);
 
-                    // Resolve against parent selectors (one ResolvedSelector per parent).
                     let parent_rule = self.get_last_parent_selector_rule();
                     let resolved_selectors: Vec<ResolvedSelector> =
                         if let Some(parent_rule) = parent_rule {
                             resolve_selector(&current_tokens, &parent_rule.selectors)
                         } else {
-                            // Top-level selector: convert directly to (kind, TokenText) pairs.
                             vec![ResolvedSelector(
                                 current_tokens
                                     .iter()
@@ -217,7 +203,7 @@ impl SemanticModelBuilder {
                             )]
                         };
 
-                    let current_rule = self.rules_by_id.get_mut(current_rule).unwrap();
+                    let current_rule = &mut self.all_rules[current_rule_id.index()];
                     let combined = parent_specificity + specificity;
 
                     for resolved in resolved_selectors {
@@ -241,8 +227,7 @@ impl SemanticModelBuilder {
                 let is_global_var =
                     self.is_in_root_selector && property.syntax().text_trimmed().starts_with("--");
 
-                if let Some(current_rule) = self.current_rule_stack.last_mut() {
-                    let current_rule = self.rules_by_id.get_mut(current_rule).unwrap();
+                if let Some(&current_rule_id) = self.current_rule_stack.last() {
                     if is_global_var {
                         let property_name = property.syntax().text_trimmed().to_string();
                         self.global_custom_variables.insert(
@@ -254,6 +239,7 @@ impl SemanticModelBuilder {
                             }),
                         );
                     }
+                    let current_rule = &mut self.all_rules[current_rule_id.index()];
                     current_rule.declarations.push(CssModelDeclaration {
                         declaration: AstPtr::new(&node),
                         property: AstPtr::new(&property),
@@ -319,17 +305,18 @@ fn resolve_selector(current: &[CssSyntaxToken], parents: &[Selector]) -> Vec<Res
         .map(|parent| {
             let parent_tokens = &parent.resolved.0;
             if has_amp {
-                // Replace every AMP token with the full parent token sequence.
-                let tokens = current
-                    .iter()
-                    .flat_map(|t| -> Vec<(CssSyntaxKind, TokenText)> {
-                        if t.kind() == CssSyntaxKind::AMP {
-                            parent_tokens.clone()
-                        } else {
-                            vec![(t.kind(), t.token_text_trimmed())]
-                        }
-                    })
-                    .collect();
+                let amp_count = current.iter().filter(|t| t.kind() == CssSyntaxKind::AMP).count();
+                let non_amp_count = current.len() - amp_count;
+                let capacity = amp_count * parent_tokens.len() + non_amp_count;
+
+                let mut tokens = Vec::with_capacity(capacity);
+                for t in current {
+                    if t.kind() == CssSyntaxKind::AMP {
+                        tokens.extend(parent_tokens.iter().cloned());
+                    } else {
+                        tokens.push((t.kind(), t.token_text_trimmed()));
+                    }
+                }
                 ResolvedSelector(tokens)
             } else {
                 // Prepend parent tokens + implicit descendant combinator.

--- a/crates/biome_css_semantic/src/semantic_model/mod.rs
+++ b/crates/biome_css_semantic/src/semantic_model/mod.rs
@@ -49,7 +49,8 @@ mod tests {
 
         let root = parse.tree();
         let model = super::semantic_model(&root);
-        let rule = model.rules().first().unwrap();
+        let rules = model.rules();
+        let rule = rules.first().unwrap();
 
         assert_eq!(rule.selectors.len(), 1);
         assert_eq!(rule.declarations.len(), 2);
@@ -72,7 +73,8 @@ mod tests {
 
         let root = parse.tree();
         let model = super::semantic_model(&root);
-        let rule = model.rules().first().unwrap();
+        let rules = model.rules();
+        let rule = rules.first().unwrap();
         assert_eq!(rule.selectors.len(), 1);
         assert_eq!(rule.declarations.len(), 1);
         assert_eq!(rule.child_ids.len(), 1);
@@ -100,7 +102,8 @@ mod tests {
 
         let root = parse.tree();
         let model = super::semantic_model(&root);
-        let rule = model.rules().first().unwrap();
+        let rules = model.rules();
+        let rule = rules.first().unwrap();
 
         assert_eq!(rule.selectors.len(), 1);
         assert_eq!(rule.declarations.len(), 0);
@@ -128,7 +131,8 @@ mod tests {
 
         let root = parse.tree();
         let model = super::semantic_model(&root);
-        let rule = model.rules().first().unwrap();
+        let rules = model.rules();
+        let rule = rules.first().unwrap();
 
         assert_eq!(rule.selectors.len(), 1);
         assert_eq!(rule.declarations.len(), 0);

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -11,7 +11,6 @@ use biome_rowan::{
 use biome_string_case::StrOnlyExtension;
 use rustc_hash::FxHashMap;
 use std::collections::BTreeMap;
-use std::hash::Hash;
 use std::sync::Arc;
 
 /// The façade for all semantic information of a CSS document.
@@ -36,9 +35,13 @@ impl SemanticModel {
         self.root.to_language_root::<AnyCssRoot>()
     }
 
-    /// Returns a slice of all rules in the CSS document.
-    pub fn rules(&self) -> &[Rule] {
-        &self.data.rules
+    /// Returns all top-level rules in the CSS document.
+    pub fn rules(&self) -> Vec<&Rule> {
+        self.data
+            .top_level_rule_ids
+            .iter()
+            .filter_map(|id| self.data.all_rules.get(id.index()))
+            .collect()
     }
 
     pub fn global_custom_variables(&self) -> &FxHashMap<String, CssGlobalCustomVariable> {
@@ -46,7 +49,7 @@ impl SemanticModel {
     }
 
     pub fn get_rule_by_id(&self, id: &RuleId) -> Option<&Rule> {
-        self.data.rules_by_id.get(id)
+        self.data.all_rules.get(id.index())
     }
 
     /// Returns the rule that contains the given range.
@@ -56,28 +59,30 @@ impl SemanticModel {
         // the comparison semantics of TextRange.
 
         // Handle the edge case where the target range starts from 0.
-        if target_range.start() == TextSize::from(0) {
+        let rule_id = if target_range.start() == TextSize::from(0) {
             self.data
-                .range_to_rule
+                .range_to_rule_id
                 .iter()
                 .rev()
                 .find(|&(&range, _)| range.contains_range(target_range))
-                .map(|(_, rule)| rule)
+                .map(|(_, id)| id)
         } else {
             self.data
-                .range_to_rule
+                .range_to_rule_id
                 .range(..=target_range)
                 .rev()
                 .find(|&(&range, _)| range.contains_range(target_range))
-                .map(|(_, rule)| rule)
-        }
+                .map(|(_, id)| id)
+        };
+        rule_id.and_then(|id| self.data.all_rules.get(id.index()))
     }
 
     /// Returns an iterator over the specificity of all rules in source order.
     pub fn specificity_of_rules(&self) -> impl Iterator<Item = Specificity> + '_ {
         self.data
-            .range_to_rule
+            .range_to_rule_id
             .values()
+            .filter_map(|id| self.data.all_rules.get(id.index()))
             .flat_map(|rule| rule.selectors())
             .map(|selector| selector.specificity())
     }
@@ -93,14 +98,14 @@ impl SemanticModel {
 /// and a list of all rules in the document.
 #[derive(Debug)]
 pub(crate) struct SemanticModelData {
-    /// List of all top-level rules in the CSS document
-    pub(crate) rules: Vec<Rule>,
+    /// Single source of truth for all rules, indexed by RuleId
+    pub(crate) all_rules: Vec<Rule>,
+    /// IDs of top-level rules only
+    pub(crate) top_level_rule_ids: Vec<RuleId>,
     /// Map of CSS variables declared in the `:root` selector or using the @property rule.
     pub(crate) global_custom_variables: FxHashMap<String, CssGlobalCustomVariable>,
-    /// Map of all the rules by their id
-    pub(crate) rules_by_id: FxHashMap<RuleId, Rule>,
-    /// Map of the range of each rule to the rule itself
-    pub(crate) range_to_rule: BTreeMap<TextRange, Rule>,
+    /// Map from text range to RuleId
+    pub(crate) range_to_rule_id: BTreeMap<TextRange, RuleId>,
 }
 
 /// Represents a CSS rule set, including its selectors, declarations, and nested rules.

--- a/crates/biome_css_semantic/src/tests/selector.rs
+++ b/crates/biome_css_semantic/src/tests/selector.rs
@@ -10,7 +10,8 @@ fn test_resolve_selector_no_parents() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     assert_eq!(rule.selectors.len(), 1);
     assert_eq!(rule.selectors[0].resolved().to_string(), "div");
 }
@@ -28,7 +29,8 @@ fn test_resolve_selector_simple_parent() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors.len(), 1);
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), ".parent");
 
@@ -55,7 +57,8 @@ fn test_resolve_selector_with_ampersand() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors.len(), 1);
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), "a");
 
@@ -81,7 +84,8 @@ fn test_resolve_selector_multiple_parents() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let grandparent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let grandparent_rule = rules.first().unwrap();
     assert_eq!(grandparent_rule.selectors.len(), 1);
     assert_eq!(
         grandparent_rule.selectors[0].resolved().to_string(),
@@ -118,7 +122,8 @@ fn test_resolve_selector_with_multi_ampersand() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors.len(), 1);
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), "p");
 
@@ -142,7 +147,8 @@ fn test_resolve_selector_no_ampersand_with_parents() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors.len(), 1);
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), ".list");
 
@@ -167,7 +173,8 @@ fn test_resolve_selector_with_complex_parent() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors.len(), 1);
     assert_eq!(
         parent_rule.selectors[0].resolved().to_string(),
@@ -197,7 +204,8 @@ fn test_resolve_selector_with_nested_ampersands() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors.len(), 1);
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), ".btn");
 
@@ -226,7 +234,8 @@ fn test_resolve_selector_with_multiple_parents_and_ampersand() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let grandparent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let grandparent_rule = rules.first().unwrap();
     assert_eq!(grandparent_rule.selectors.len(), 1);
     assert_eq!(
         grandparent_rule.selectors[0].resolved().to_string(),
@@ -257,7 +266,8 @@ fn test_descendant_combinator() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
 
     assert_eq!(rule.selectors.len(), 1);
     assert_eq!(rule.selectors[0].resolved().to_string(), ".foo .bar");
@@ -334,7 +344,8 @@ fn test_ampersand_nesting_selector() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors.len(), 1);
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), ".foo");
 
@@ -378,7 +389,8 @@ fn test_universal_selector() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     assert_eq!(rule.selectors.len(), 1);
     assert_eq!(rule.selectors[0].resolved().to_string(), "*");
 }
@@ -390,7 +402,8 @@ fn test_id_selector() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     assert_eq!(rule.selectors.len(), 1);
     assert_eq!(rule.selectors[0].resolved().to_string(), "#app");
 }
@@ -424,7 +437,8 @@ fn test_nested_pseudo_element() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), "a");
 
     let child_rule_id = parent_rule.child_ids.first().unwrap();
@@ -447,7 +461,8 @@ fn test_selector_list_with_ampersand() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors.len(), 2);
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), ".a");
     assert_eq!(parent_rule.selectors[1].resolved().to_string(), ".b");
@@ -473,7 +488,8 @@ fn test_nested_sibling_combinator() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), "h2");
 
     let child_rule_id = parent_rule.child_ids.first().unwrap();
@@ -499,7 +515,8 @@ fn test_nested_inside_media() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let card_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let card_rule = rules.first().unwrap();
     assert_eq!(card_rule.selectors[0].resolved().to_string(), ".card");
 
     // The @media rule is a child of .card.
@@ -534,7 +551,8 @@ fn test_nested_inside_supports() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let grid_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let grid_rule = rules.first().unwrap();
     assert_eq!(grid_rule.selectors[0].resolved().to_string(), ".grid");
 
     let supports_rule_id = grid_rule.child_ids.first().unwrap();
@@ -582,7 +600,8 @@ fn test_ampersand_suffix_nesting() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let parent_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let parent_rule = rules.first().unwrap();
     assert_eq!(parent_rule.selectors[0].resolved().to_string(), ".block");
 
     let child_rule_id = parent_rule.child_ids.first().unwrap();
@@ -610,7 +629,8 @@ fn test_deeply_nested_ampersand() {
     let root = parse.tree();
     let model = semantic_model(&root);
 
-    let a_rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let a_rule = rules.first().unwrap();
     assert_eq!(a_rule.selectors[0].resolved().to_string(), ".a");
 
     let b_rule_id = a_rule.child_ids.first().unwrap();

--- a/crates/biome_css_semantic/src/tests/specificity.rs
+++ b/crates/biome_css_semantic/src/tests/specificity.rs
@@ -11,7 +11,8 @@ fn test_specificity_type_selector() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -25,7 +26,8 @@ fn test_specificity_class_selector() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -39,7 +41,8 @@ fn test_specificity_id_selector() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -53,7 +56,8 @@ fn test_specificity_type_and_class_selector() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -67,7 +71,8 @@ fn test_specificity_attribute_selector() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -81,7 +86,8 @@ fn test_specificity_pseudo_class_selector() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -95,7 +101,8 @@ fn test_specificity_pseudo_element_selector() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -109,7 +116,8 @@ fn test_specificity_complex_selector() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -123,7 +131,8 @@ fn test_specificity_pseudo_class_functions() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -137,7 +146,8 @@ fn test_specificity_with_pseudo_function_where() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -152,7 +162,8 @@ fn test_specificity_with_pseudo_function_is() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -167,7 +178,8 @@ fn test_specificity_nested_selector() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -182,7 +194,8 @@ fn test_specificity_nested_pseudo_class() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -200,7 +213,8 @@ fn test_specificity_nested_pseudo_class_functions() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -218,7 +232,8 @@ fn test_specificity_multiple_nesting() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -244,7 +259,8 @@ fn test_specificity_nested_pseudo_elements_and_classes() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -262,7 +278,8 @@ fn test_specificity_nested_combinators() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -281,7 +298,8 @@ fn test_specificity_with_nested_pseudo_functions() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
     let selector = &rule.selectors[0];
 
     let specificity = &selector.specificity;
@@ -300,7 +318,8 @@ fn test_specificity_nested_selector_lists() {
     let root = parse.tree();
 
     let model = semantic_model(&root);
-    let rule = model.rules().first().unwrap();
+    let rules = model.rules();
+    let rule = rules.first().unwrap();
 
     let expected_specificities = [
         Specificity(0, 0, 1), // "div"
@@ -325,8 +344,8 @@ fn test_specificity_deeply_nested_rules() {
     let model = semantic_model(&root);
 
     // Navigate through nested rules to reach the deepest rule
-    let parent_rule = model
-        .rules()
+    let rules = model.rules();
+    let parent_rule = rules
         .first()
         .expect("Expected to find parent rule with selector 'a'");
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Something I wanted to do for a while. This PR deduplicates the `Rule` information that is closed three times across the semantic model. It might not improve the speed, but it will reduce the memory used, for sure.

Planned myself, executed with a coding agent.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Current tests updated. Green CI.

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
