### PR TITLE
fix(formatter): flush indentation after align end

### DIFF
--- a/crates/biome_formatter/src/printer/mod.rs
+++ b/crates/biome_formatter/src/printer/mod.rs
@@ -289,9 +289,21 @@ impl<'a> Printer<'a> {
                 }
                 stack.pop(tag.kind())?;
             }
-            FormatElement::Tag(tag @ (EndIndent | EndAlign | EndLineSuffix)) => {
+            FormatElement::Tag(tag @ (EndIndent | EndLineSuffix)) => {
                 stack.pop(tag.kind())?;
                 indent_stack.pop();
+            }
+            FormatElement::Tag(EndAlign) => {
+                stack.pop(TagKind::Align)?;
+                indent_stack.pop();
+                // A line break inside the align block captures `pending_indent`
+                // from the indent stack while the align is active. After popping,
+                // the indent stack no longer includes that align, but
+                // `pending_indent` still does — sync it so the stale alignment
+                // doesn't leak to the next text element outside the block.
+                if !self.state.pending_indent.is_empty() {
+                    self.state.pending_indent = indent_stack.indention();
+                }
             }
             FormatElement::Tag(tag @ EndDedent(mode)) => {
                 match mode {
@@ -2134,5 +2146,61 @@ Group 1 breaks"#
         }));
 
         assert_eq!(result.as_code(), "textanother");
+    }
+
+    #[test]
+    fn align_does_not_leak_pending_indent() {
+        // A hard_line_break as the last element inside align() used to
+        // capture the align's indentation into pending_indent. Because
+        // EndAlign did not sync pending_indent back to the (now smaller)
+        // indent stack, the next text element outside the align block
+        // would be printed with the stale, wider indentation.
+        let result = format(&format_args![
+            token("- "),
+            align(2, &format_args![token("content"), hard_line_break()]),
+            token("next")
+        ]);
+
+        // "next" must start at column 0 — the align(2) block has ended.
+        assert_eq!("- content\nnext", result.as_code());
+    }
+
+    #[test]
+    fn nested_align_does_not_leak_pending_indent() {
+        let result = format(&format_args![
+            token("- "),
+            align(
+                2,
+                &format_args![
+                    token("a"),
+                    hard_line_break(),
+                    token("- "),
+                    align(2, &format_args![token("b"), hard_line_break()]),
+                    token("after_inner")
+                ]
+            ),
+            hard_line_break(),
+            token("after_outer")
+        ]);
+
+        // After inner align(2) ends, "after_inner" should get 2 spaces
+        // (from the outer align), not 4.
+        // After outer align(2) ends, "after_outer" should get 0 spaces.
+        assert_eq!("- a\n  - b\n  after_inner\nafter_outer", result.as_code());
+    }
+
+    #[test]
+    fn align_without_trailing_break_no_leak() {
+        // When the last element inside align is text (not a line break),
+        // pending_indent is empty and no leak can occur.
+        let result = format(&format_args![
+            token("- "),
+            align(2, &token("content")),
+            hard_line_break(),
+            token("next")
+        ]);
+
+        // "next" at column 0 — the hard_line_break is outside align.
+        assert_eq!("- content\nnext", result.as_code());
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Found this sneaky bug while implementing the markdown formatter, but I will ship it as is. Thank you AI agent for spotting that!

The `align` IR didn't correctly flush its indentation after a line break, and this would end up in losing it when printing child elements.

The fix is very small. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added tests and verified manually that, without the fix, the emitted output is incorrect.

<!-- What demonstrates that your implementation is correct? -->

## Docs

I didn't add a changeset because we don't have an existing case across the board, but it affects markdown, which isn't shipped yet.

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
