### PR TITLE
docs: fix duplicate-word typos in code comments

### DIFF
--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -913,7 +913,7 @@ pub trait FormatOptions {
     /// Whether to add a trailing newline at the end of the file.
     fn trailing_newline(&self) -> TrailingNewline;
 
-    /// Derives the print options from the these format options
+    /// Derives the print options from these format options
     fn as_print_options(&self) -> PrinterOptions;
 }
 

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -284,7 +284,7 @@ fn handle_any_file<'scope>(
     }
 
     if file_type.is_symlink() {
-        // Here we don't care if it's a file or not. We care only about the the is_symlink flag being true
+        // Here we don't care if it's a file or not. We care only about the is_symlink flag being true
         let path_to_check =
             BiomePath::new_with_kind(path.clone(), PathKind::File { is_symlink: true });
         if !ctx.can_handle(&path_to_check) {

--- a/crates/biome_js_formatter/src/utils/conditional.rs
+++ b/crates/biome_js_formatter/src/utils/conditional.rs
@@ -573,7 +573,7 @@ enum ConditionalLayout {
     },
 }
 
-/// A [JsConditionalExpression] that itself or any of its parent's [JsConditionalExpression] have a a [JsxTagExpression]
+/// A [JsConditionalExpression] that itself or any of its parent's [JsConditionalExpression] have a [JsxTagExpression]
 /// as its [`test`](JsConditionalExpression::test), [`consequent`](JsConditionalExpression::consequent) or [`alternate`](JsConditionalExpression::alternate).
 ///
 /// Parenthesizes the `consequent` and `alternate` if it the group breaks except if the expressions are


### PR DESCRIPTION
Three duplicate-word typos in code comments:

- `crates/biome_fs/src/fs/os.rs:287` ("the the" -> "the")
- `crates/biome_formatter/src/lib.rs:916` ("the these" -> "these")
- `crates/biome_js_formatter/src/utils/conditional.rs:576` ("a a" -> "a")