### PR TITLE
docs: replace "allows to" with "allows you to" in code comments and dev docs

### DIFF
--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -769,7 +769,7 @@ could be `["e", "f"]` instead of `["f"]`.
 When merging rules options, you usually want to resetting the options instead of combining them.
 
 Note that every option is also wrapped in an `Option<_>`.
-This allows to properly merge options by tracking the ones that are set and the ones that are unset.
+This allows you to properly merge options by tracking the ones that are set and the ones that are unset.
 
 With these types in place, you can set the associated type `Options` of the rule:
 
@@ -1580,7 +1580,7 @@ use biome_analyze::declare_lint_rule;
 declare_lint_rule! {
     /// Disallow the use of `var`.
     ///
-    /// _ES2015_ allows to create variables with block scope instead of function scope
+    /// _ES2015_ allows you to create variables with block scope instead of function scope
     /// using the `let` and `const` keywords.
     /// Block scope is common in many other programming languages and helps to avoid mistakes.
     ///

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -1407,7 +1407,7 @@ pub trait Rule: RuleMeta + Sized {
         None
     }
 
-    /// Create a code action that allows to suppress the rule. The function
+    /// Create a code action that allows you to suppress the rule. The function
     /// returns the node to which the suppression comment is applied.
     fn inline_suppression(
         ctx: &RuleContext<Self>,

--- a/crates/biome_analyze/src/utils.rs
+++ b/crates/biome_analyze/src/utils.rs
@@ -114,7 +114,7 @@ where
 /// The separator is always kept if some comments are attached.
 ///
 /// This utility is notably useful when a delimited list with an optional last separator is reordered.
-/// It allows to add missing separators and remove an extra separator.
+/// It allows you to add missing separators and remove an extra separator.
 /// Usually, you collect every pair of nodes and separators in a vector and then pass a mutable iterator to `fix_separators`.
 ///
 /// See [sorted_separated_list_by] as a usage example.

--- a/crates/biome_aria_metadata/build.rs
+++ b/crates/biome_aria_metadata/build.rs
@@ -291,7 +291,7 @@ fn main() -> io::Result<()> {
     };
 
     // We print the code even if it cannot be parsed,
-    // this allows to debug the code by directly looking at it.
+    // this allows you to debug the code by directly looking at it.
     let out_dir = env::var("OUT_DIR").unwrap();
     fs::write(PathBuf::from(out_dir).join("roles_and_attributes.rs"), ast)?;
 

--- a/crates/biome_formatter/shared_traits.rs
+++ b/crates/biome_formatter/shared_traits.rs
@@ -43,7 +43,7 @@ where
 
 /// Implement [AsFormat] for [Option] when `T` implements [AsFormat]
 ///
-/// Allows to call format on optional AST fields without having to unwrap the field first.
+/// Allows you to call format on optional AST fields without having to unwrap the field first.
 impl<T, C> AsFormat<C> for Option<T>
 where
     T: AsFormat<C>,
@@ -77,7 +77,7 @@ where
 
 /// Implement [IntoFormat] for [Option] when `T` implements [IntoFormat]
 ///
-/// Allows to call format on optional AST fields without having to unwrap the field first.
+/// Allows you to call format on optional AST fields without having to unwrap the field first.
 impl<T, Context> IntoFormat<Context> for Option<T>
 where
     T: IntoFormat<Context>,

--- a/crates/biome_formatter/src/builders.rs
+++ b/crates/biome_formatter/src/builders.rs
@@ -586,7 +586,7 @@ impl<Context> std::fmt::Debug for FormatLabelled<'_, Context> {
     }
 }
 
-/// Inserts a single space. Allows to separate different tokens.
+/// Inserts a single space. Allows you to separate different tokens.
 ///
 /// # Examples
 ///

--- a/crates/biome_formatter/src/comments.rs
+++ b/crates/biome_formatter/src/comments.rs
@@ -72,7 +72,7 @@
 //!
 //! Because all children of the `continue` statement are tokens, it is only possible to make the comments leading, dangling, or trailing comments of the `continue` statement. But this results in a loss of information as the formatting code can no longer distinguish if a comment appeared before or after the label and, thus, has to format them the same way.
 //!
-//! This hasn't shown to be a significant limitation today but the infrastructure could be extended to support a `label` on [`SourceComment`] that allows to further categorise comments.
+//! This hasn't shown to be a significant limitation today but the infrastructure could be extended to support a `label` on [`SourceComment`] that allows you to further categorise comments.
 //!
 
 mod builder;
@@ -805,7 +805,7 @@ pub struct Comments<L: Language> {
     /// }
     /// ```
     ///
-    /// Using an `Rc` here allows to cheaply clone [Comments] for these use cases.
+    /// Using an `Rc` here allows you to cheaply clone [Comments] for these use cases.
     data: Rc<CommentsData<L>>,
 }
 

--- a/crates/biome_formatter/src/format_element/tag.rs
+++ b/crates/biome_formatter/src/format_element/tag.rs
@@ -34,7 +34,7 @@ pub enum Tag {
     StartGroup(Group),
     EndGroup,
 
-    /// Allows to specify content that gets printed depending on whatever the enclosing group
+    /// Allows you to specify content that gets printed depending on whatever the enclosing group
     /// is printed on a single line or multiple lines. See [crate::builders::if_group_breaks] for examples.
     StartConditionalContent(Condition),
     EndConditionalContent,

--- a/crates/biome_formatter/src/source_map.rs
+++ b/crates/biome_formatter/src/source_map.rs
@@ -26,7 +26,7 @@ use std::iter::FusedIterator;
 ///
 /// The source map internally tracks all the ranges that have been deleted from the source code sorted by the start of the deleted range.
 /// It further stores the absolute count of deleted bytes preceding a range. The deleted range together
-/// with the absolute count allows to re-compute the source location for every transformed location
+/// with the absolute count allows you to re-compute the source location for every transformed location
 /// and has the benefit that it requires significantly fewer memory
 /// than source maps that use a source to destination position marker for every token.
 ///

--- a/crates/biome_graphql_formatter/src/lib.rs
+++ b/crates/biome_graphql_formatter/src/lib.rs
@@ -76,7 +76,7 @@ where
 
 /// Implement [AsFormat] for [Option] when `T` implements [AsFormat]
 ///
-/// Allows to call format on optional AST fields without having to unwrap the field first.
+/// Allows you to call format on optional AST fields without having to unwrap the field first.
 impl<T, C> AsFormat<C> for Option<T>
 where
     T: AsFormat<C>,
@@ -113,7 +113,7 @@ where
 
 /// Implement [IntoFormat] for [Option] when `T` implements [IntoFormat]
 ///
-/// Allows to call format on optional AST fields without having to unwrap the field first.
+/// Allows you to call format on optional AST fields without having to unwrap the field first.
 impl<T, Context> IntoFormat<Context> for Option<T>
 where
     T: IntoFormat<Context>,

--- a/crates/biome_grit_formatter/src/lib.rs
+++ b/crates/biome_grit_formatter/src/lib.rs
@@ -230,7 +230,7 @@ where
 
 /// Implement [AsFormat] for [Option] when `T` implements [AsFormat]
 ///
-/// Allows to call format on optional AST fields without having to unwrap the field first.
+/// Allows you to call format on optional AST fields without having to unwrap the field first.
 impl<T, C> AsFormat<C> for Option<T>
 where
     T: AsFormat<C>,
@@ -267,7 +267,7 @@ where
 
 /// Implement [IntoFormat] for [Option] when `T` implements [IntoFormat]
 ///
-/// Allows to call format on optional AST fields without having to unwrap the field first.
+/// Allows you to call format on optional AST fields without having to unwrap the field first.
 impl<T, Context> IntoFormat<Context> for Option<T>
 where
     T: IntoFormat<Context>,


### PR DESCRIPTION
## Summary

Grammar fix sweep across internal code comments and dev docs: `Allows to <verb>` -> `Allows you to <verb>`. 16 instances across 11 files in 5 crates (`biome_aria_metadata`, `biome_analyze`, `biome_formatter`, `biome_graphql_formatter`, `biome_grit_formatter`).

User-facing CLI help text (`biome_cli/src/cli_options.rs`) deliberately not included to keep this scoped to non-user-visible text.

## Test Plan

Comments only; no behavior change. Existing tests cover correctness.

## Docs

N/A.
