### PR TITLE
fix(config): support trailingCommas in overrides

### DIFF
--- a/.changeset/legal-glasses-lead.md
+++ b/.changeset/legal-glasses-lead.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added support for `formatter.trailingCommas` in overrides. This option was previously available in the top-level formatter configuration but missing from formatter overrides.

--- a/crates/biome_cli/tests/cases/overrides_formatter.rs
+++ b/crates/biome_cli/tests/cases/overrides_formatter.rs
@@ -113,6 +113,47 @@ fn does_include_file_with_different_formatting() {
 }
 
 #[test]
+fn does_override_formatter_trailing_commas() {
+    let mut console = BufferConsole::default();
+    let fs = MemoryFileSystem::default();
+    let file_path = Utf8Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        r#"{
+  "overrides": [{ "includes": ["special/**"], "formatter": { "lineWidth": 20, "trailingCommas": "none" } }]
+}
+
+"#
+        .as_bytes(),
+    );
+
+    let test = Utf8Path::new("test.js");
+    fs.insert(test.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
+
+    let test2 = Utf8Path::new("special/test2.js");
+    fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--write", test.as_str(), test2.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, test2, "const a = [\n\t\"loreum\",\n\t\"ipsum\"\n];\n");
+    assert_file_contents(&fs, test, FORMATTED_LINE_WIDTH);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_override_formatter_trailing_commas",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn does_include_file_with_different_formatting_and_all_of_them() {
     let mut console = BufferConsole::default();
     let fs = MemoryFileSystem::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_override_formatter_trailing_commas.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/does_override_formatter_trailing_commas.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "overrides": [
+    {
+      "includes": ["special/**"],
+      "formatter": { "lineWidth": 20, "trailingCommas": "none" }
+    }
+  ]
+}
+```
+
+## `special/test2.js`
+
+```js
+const a = [
+	"loreum",
+	"ipsum"
+];
+
+```
+
+## `test.js`
+
+```js
+const a = ["loreum", "ipsum"];
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 2 files in <TIME>. Fixed 2 files.
+```

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -12,6 +12,7 @@ use biome_formatter::{
     AttributePosition, BracketSameLine, BracketSpacing, Expand, IndentStyle, IndentWidth,
     LineEnding, LineWidth, TrailingNewline,
 };
+use biome_js_formatter::context::trailing_commas::TrailingCommas;
 use biome_plugin_loader::Plugins;
 #[cfg(feature = "cli")]
 use bpaf::Bpaf;
@@ -188,6 +189,14 @@ pub struct OverrideFormatterConfiguration {
         bpaf(long("object-wrap"), argument("auto|always|never"))
     )]
     pub expand: Option<Expand>,
+
+    /// Print trailing commas wherever possible in multi-line comma-separated syntactic structures.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "cli",
+        bpaf(long("trailing-commas"), argument("all|es5|none"))
+    )]
+    pub trailing_commas: Option<TrailingCommas>,
 
     /// Whether to add a trailing newline at the end of the file.
     ///

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -35,9 +35,11 @@ use biome_html_formatter::HtmlFormatOptions;
 use biome_html_parser::HtmlParserOptions;
 use biome_html_syntax::HtmlLanguage;
 use biome_js_formatter::context::JsFormatOptions;
+use biome_js_formatter::context::trailing_commas::TrailingCommas;
 use biome_js_parser::JsParserOptions;
 use biome_js_syntax::JsLanguage;
 use biome_json_formatter::context::JsonFormatOptions;
+use biome_json_formatter::context::TrailingCommas as JsonTrailingCommas;
 use biome_json_parser::JsonParserOptions;
 use biome_json_syntax::JsonLanguage;
 use biome_markdown_syntax::MarkdownLanguage;
@@ -577,6 +579,7 @@ pub struct OverrideFormatSettings {
     pub bracket_same_line: Option<BracketSameLine>,
     pub attribute_position: Option<AttributePosition>,
     pub expand: Option<Expand>,
+    pub trailing_commas: Option<TrailingCommas>,
     pub trailing_newline: Option<TrailingNewline>,
 }
 
@@ -593,6 +596,7 @@ impl From<OverrideFormatterConfiguration> for OverrideFormatSettings {
             bracket_same_line: conf.bracket_same_line,
             attribute_position: conf.attribute_position,
             expand: conf.expand,
+            trailing_commas: conf.trailing_commas,
             trailing_newline: conf.trailing_newline,
         }
     }
@@ -1638,7 +1642,7 @@ impl OverrideSettingPattern {
         if let Some(quote_properties) = js_formatter.quote_properties {
             options.set_quote_properties(quote_properties);
         }
-        if let Some(trailing_commas) = js_formatter.trailing_commas {
+        if let Some(trailing_commas) = js_formatter.trailing_commas.or(formatter.trailing_commas) {
             options.set_trailing_commas(trailing_commas);
         }
         if let Some(semicolons) = js_formatter.semicolons {
@@ -1689,6 +1693,11 @@ impl OverrideSettingPattern {
         }
         if let Some(trailing_commas) = json_formatter.trailing_commas {
             options.set_trailing_commas(trailing_commas);
+        } else if let Some(trailing_commas) = formatter.trailing_commas {
+            options.set_trailing_commas(match trailing_commas {
+                TrailingCommas::All | TrailingCommas::Es5 => JsonTrailingCommas::All,
+                TrailingCommas::None => JsonTrailingCommas::None,
+            });
         }
         if let Some(expand_lists) = json_formatter.expand.or(formatter.expand) {
             options.set_expand(expand_lists);
@@ -1922,6 +1931,7 @@ pub fn to_override_settings(
                 bracket_same_line: formatter.bracket_same_line,
                 attribute_position: formatter.attribute_position,
                 expand: formatter.expand,
+                trailing_commas: formatter.trailing_commas,
                 trailing_newline: formatter.trailing_newline,
             })
             .unwrap_or_default();

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1159,6 +1159,10 @@ has syntax errors
 	 */
 	lineWidth?: LineWidth;
 	/**
+	 * Print trailing commas wherever possible in multi-line comma-separated syntactic structures.
+	 */
+	trailingCommas?: JsTrailingCommas;
+	/**
 	* Whether to add a trailing newline at the end of the file.
 
 Setting this option to `false` is **highly discouraged** because it could cause many problems with other tools:

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -7291,6 +7291,10 @@
 					"description": "What's the max width of a line. Defaults to 80.",
 					"anyOf": [{ "$ref": "#/$defs/LineWidth" }, { "type": "null" }]
 				},
+				"trailingCommas": {
+					"description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.",
+					"anyOf": [{ "$ref": "#/$defs/JsTrailingCommas" }, { "type": "null" }]
+				},
 				"trailingNewline": {
 					"description": "Whether to add a trailing newline at the end of the file.\n\nSetting this option to `false` is **highly discouraged** because it could cause many problems with other tools:\n- https://thoughtbot.com/blog/no-newline-at-end-of-file\n- https://callmeryan.medium.com/no-newline-at-end-of-file-navigating-gits-warning-for-android-developers-af14e73dd804\n- https://unix.stackexchange.com/questions/345548/how-to-cat-files-together-adding-missing-newlines-at-end-of-some-files\n\nDisable the option at your own risk.\n\nDefaults to true.",
 					"anyOf": [{ "$ref": "#/$defs/TrailingNewline" }, { "type": "null" }]


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This top-level option was missing from the override configuration.

I suppose its technically a new feature, but it's my understanding that overrides should match the top level configuration.

Implemented by gpt 5.5

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
