### PR TITLE
fix(format/html/vue): preserve newlines around standalone interpolations

### DIFF
--- a/.changeset/poor-bikes-cut.md
+++ b/.changeset/poor-bikes-cut.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed Vue and Svelte formatting for standalone interpolations in inline elements. Biome now preserves existing newlines in cases like:
+
+```diff
+- <span> {{ value }} </span>
++ <span>
++   {{ value }}
++ </span>
+```

--- a/.claude/skills/prettier-compare/SKILL.md
+++ b/.claude/skills/prettier-compare/SKILL.md
@@ -47,3 +47,4 @@ echo 'const x = 1' | bun packages/prettier-compare/bin/prettier-compare.js --reb
 - Reference `packages/prettier-compare/README.md` for deeper CLI details; mirror any updates here, keeping the hard requirement that commands include `--rebuild`.
 - Use single quotes for code snippets passed as CLI arguments to avoid shell interpretation issues.
 - "\n" does not get escaped into a newline when passed as a CLI argument. You should write a literal newline or use a file instead.
+- The tool is OK to run in read-only/planning modes even when running it with `--rebuild` since it only rebuilds the Biome WASM bundle and does not modify any source files.

--- a/crates/biome_html_formatter/src/html/lists/element_list.rs
+++ b/crates/biome_html_formatter/src/html/lists/element_list.rs
@@ -193,8 +193,8 @@ use crate::{
 use biome_formatter::{FormatRuleWithOptions, GroupId, prelude::*};
 use biome_formatter::{format_args, write};
 use biome_html_syntax::{
-    AnyHtmlContent, AnyHtmlElement, HtmlClosingElement, HtmlClosingElementFields, HtmlElement,
-    HtmlElementList, HtmlRoot, HtmlSyntaxToken,
+    AnyHtmlContent, AnyHtmlElement, AnyHtmlTextExpression, HtmlClosingElement,
+    HtmlClosingElementFields, HtmlElement, HtmlElementList, HtmlRoot, HtmlSyntaxToken,
 };
 use biome_rowan::AstNode;
 
@@ -379,6 +379,12 @@ impl FormatHtmlElementList {
 
         // Trim trailing new lines from children
         let mut children = children;
+        let has_leading_newline = children
+            .first()
+            .is_some_and(|child| matches!(child, HtmlChild::Newline | HtmlChild::EmptyLine));
+        let had_trailing_newline = children
+            .last()
+            .is_some_and(|child| matches!(child, HtmlChild::Newline | HtmlChild::EmptyLine));
         if !self.is_container_whitespace_sensitive {
             while matches!(
                 children.last(),
@@ -436,6 +442,14 @@ impl FormatHtmlElementList {
                 force_multiline = true;
             }
 
+            if self.is_container_whitespace_sensitive
+                && has_leading_newline
+                && had_trailing_newline
+                && has_single_interpolation_child(&children)
+            {
+                force_multiline = true;
+            }
+
             if force_multiline {
                 write!(f, [expand_parent()])?;
             }
@@ -469,13 +483,21 @@ impl FormatHtmlElementList {
                 if self.is_container_whitespace_sensitive && child.is_any_whitespace() {
                     if is_first_child {
                         // Leading whitespace: becomes a space in flat mode
-                        write!(f, [soft_line_break_or_space()])?;
+                        if force_multiline {
+                            write!(f, [hard_line_break()])?;
+                        } else {
+                            write!(f, [soft_line_break_or_space()])?;
+                        }
                         is_first_child = false;
                         last = Some(child);
                         continue;
                     } else if is_last_child {
                         // Trailing whitespace: becomes a space in flat mode
-                        write!(f, [soft_line_break_or_space()])?;
+                        if force_multiline {
+                            write!(f, [hard_line_break()])?;
+                        } else {
+                            write!(f, [soft_line_break_or_space()])?;
+                        }
                         last = Some(child);
                         continue;
                     }
@@ -947,6 +969,22 @@ fn is_br_element(element: &AnyHtmlElement) -> bool {
     element
         .name()
         .is_some_and(|name| name.text().eq_ignore_ascii_case("br"))
+}
+
+fn has_single_interpolation_child(children: &[HtmlChild]) -> bool {
+    let mut meaningful_children = children.iter().filter(|child| !child.is_any_whitespace());
+
+    let Some(HtmlChild::NonText(AnyHtmlElement::AnyHtmlContent(
+        AnyHtmlContent::AnyHtmlTextExpression(
+            AnyHtmlTextExpression::HtmlDoubleTextExpression(_)
+            | AnyHtmlTextExpression::HtmlSingleTextExpression(_),
+        ),
+    ))) = meaningful_children.next()
+    else {
+        return false;
+    };
+
+    meaningful_children.next().is_none()
 }
 
 fn format_partial_closing_tag(

--- a/crates/biome_html_formatter/tests/specs/html/svelte/preserve_newline_nontext_children.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/preserve_newline_nontext_children.svelte
@@ -19,3 +19,24 @@
 	{foo}
 	{bar}
 </div>
+
+<!-- Newlines around expression in inline element should be preserved -->
+<span class="video-length">
+	{lengthDisplay}
+</span>
+<span class="video-length">{lengthDisplay}</span>
+
+<!-- Text in inline element should still collapse -->
+<span>
+	hello
+	world
+</span>
+
+<!-- Mixed inline content should stay inline -->
+<span>before {value} after</span>
+
+<!-- Mixed multiline inline content should stay multiline -->
+<span>
+	hello
+	<em>x</em>
+</span>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/preserve_newline_nontext_children.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/preserve_newline_nontext_children.svelte.snap
@@ -28,6 +28,27 @@ info: svelte/preserve_newline_nontext_children.svelte
 	{bar}
 </div>
 
+<!-- Newlines around expression in inline element should be preserved -->
+<span class="video-length">
+	{lengthDisplay}
+</span>
+<span class="video-length">{lengthDisplay}</span>
+
+<!-- Text in inline element should still collapse -->
+<span>
+	hello
+	world
+</span>
+
+<!-- Mixed inline content should stay inline -->
+<span>before {value} after</span>
+
+<!-- Mixed multiline inline content should stay multiline -->
+<span>
+	hello
+	<em>x</em>
+</span>
+
 ```
 
 
@@ -55,5 +76,23 @@ info: svelte/preserve_newline_nontext_children.svelte
 	{foo}
 	{bar}
 </div>
+
+<!-- Newlines around expression in inline element should be preserved -->
+<span class="video-length">
+	{lengthDisplay}
+</span>
+<span class="video-length">{lengthDisplay}</span>
+
+<!-- Text in inline element should still collapse -->
+<span> hello world </span>
+
+<!-- Mixed inline content should stay inline -->
+<span>before {value} after</span>
+
+<!-- Mixed multiline inline content should stay multiline -->
+<span>
+	hello
+	<em>x</em>
+</span>
 
 ```

--- a/crates/biome_html_formatter/tests/specs/html/vue/preserve-newline-nontext-children.vue
+++ b/crates/biome_html_formatter/tests/specs/html/vue/preserve-newline-nontext-children.vue
@@ -76,3 +76,28 @@
 		<UserPanel />
 	</template>
 </template>
+
+<template>
+	<span class="video-length">
+		{{ lengthDisplay }}
+	</span>
+	<span class="video-length">{{ lengthDisplay }}</span>
+</template>
+
+<template>
+	<span>
+		hello
+		world
+	</span>
+</template>
+
+<template>
+	<span>before {{ value }} after</span>
+</template>
+
+<template>
+	<span>
+		hello
+		<em>x</em>
+	</span>
+</template>

--- a/crates/biome_html_formatter/tests/specs/html/vue/preserve-newline-nontext-children.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/vue/preserve-newline-nontext-children.vue.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 249
 info: vue/preserve-newline-nontext-children.vue
 ---
 
@@ -86,6 +85,31 @@ info: vue/preserve-newline-nontext-children.vue
 	</template>
 </template>
 
+<template>
+	<span class="video-length">
+		{{ lengthDisplay }}
+	</span>
+	<span class="video-length">{{ lengthDisplay }}</span>
+</template>
+
+<template>
+	<span>
+		hello
+		world
+	</span>
+</template>
+
+<template>
+	<span>before {{ value }} after</span>
+</template>
+
+<template>
+	<span>
+		hello
+		<em>x</em>
+	</span>
+</template>
+
 ```
 
 
@@ -167,6 +191,28 @@ info: vue/preserve-newline-nontext-children.vue
 	<template #default>
 		<UserPanel />
 	</template>
+</template>
+
+<template>
+	<span class="video-length">
+		{{ lengthDisplay }}
+	</span>
+	<span class="video-length">{{ lengthDisplay }}</span>
+</template>
+
+<template>
+	<span> hello world </span>
+</template>
+
+<template>
+	<span>before {{ value }} after</span>
+</template>
+
+<template>
+	<span>
+		hello
+		<em>x</em>
+	</span>
 </template>
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR fixes another bug that is probably related to #9450

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
