### PR TITLE
refactor(css_parser): remove `allow_css_ratio` from SCSS expression parsing functions

### DIFF
--- a/crates/biome_css_parser/src/syntax/scss/expression/operand.rs
+++ b/crates/biome_css_parser/src/syntax/scss/expression/operand.rs
@@ -6,7 +6,7 @@ use crate::syntax::scss::{
     parse_scss_variable,
 };
 use crate::syntax::value::dimension::{is_at_any_dimension, parse_any_dimension};
-use crate::syntax::{is_at_ratio, parse_ratio, parse_regular_identifier, parse_regular_number};
+use crate::syntax::{parse_regular_identifier, parse_regular_number};
 use biome_css_syntax::CssSyntaxKind::{
     CSS_NUMBER_LITERAL, SCSS_MODULE_MEMBER_ACCESS, SCSS_NAMESPACED_VARIABLE,
 };
@@ -98,24 +98,18 @@ fn parse_scss_module_variable_operand(p: &mut CssParser) -> ParsedSyntax {
 }
 
 /// Parses an interpolatable value such as `$value#{suffix}`, `10px#{suffix}`,
-/// `10#{unit}`, or `10/10`.
+/// or `10#{unit}`.
 ///
 /// Examples:
 /// ```scss
 /// $value#{suffix}
 /// 10px#{suffix}
 /// 10#{unit}
-/// 10/10
 /// ```
 ///
 /// Docs: https://sass-lang.com/documentation/interpolation
 #[inline]
 fn parse_scss_interpolatable_value(p: &mut CssParser) -> ParsedSyntax {
-    if is_at_ratio(p) {
-        // `10/10`: parse the ratio before `/` can become an SCSS binary operator.
-        return parse_ratio(p);
-    }
-
     let first_part = match parse_scss_interpolatable_value_first_part(p) {
         Present(first_part) => first_part,
         Absent => return Absent,
@@ -142,8 +136,6 @@ fn parse_scss_interpolatable_value(p: &mut CssParser) -> ParsedSyntax {
 /// 10px#{suffix}
 /// 10#{unit}
 /// ```
-///
-/// `10/10` is not returned here because it is already a `CssRatio`.
 #[inline]
 fn parse_scss_interpolatable_value_first_part(p: &mut CssParser) -> ParsedSyntax {
     if is_at_scss_variable(p) {

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/debug.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/debug.scss
@@ -3,3 +3,6 @@
 .card {
   @debug (1, 2, 3);
 }
+
+@debug "Value: #{$value}";
+@debug clamp(#{$min}, #{$intercept} + #{$slope * 100}vw, #{$max});

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/debug.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/debug.scss.snap
@@ -12,6 +12,9 @@ expression: snapshot
   @debug (1, 2, 3);
 }
 
+@debug "Value: #{$value}";
+@debug clamp(#{$min}, #{$intercept} + #{$slope * 100}vw, #{$max});
+
 ```
 
 
@@ -114,17 +117,162 @@ CssRoot {
                 r_curly_token: R_CURLY@47..49 "}" [Newline("\n")] [],
             },
         },
+        CssAtRule {
+            at_token: AT@49..52 "@" [Newline("\n"), Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@52..58 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssInterpolatedString {
+                            opening_quote_token: SCSS_STRING_QUOTE@58..59 "\"" [] [],
+                            parts: ScssInterpolatedStringPartList [
+                                ScssStringText {
+                                    value_token: SCSS_STRING_CONTENT_LITERAL@59..66 "Value: " [] [],
+                                },
+                                ScssInterpolation {
+                                    hash_token: HASH@66..67 "#" [] [],
+                                    l_curly_token: L_CURLY@67..68 "{" [] [],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            ScssVariable {
+                                                dollar_token: DOLLAR@68..69 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@69..74 "value" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    r_curly_token: R_CURLY@74..75 "}" [] [],
+                                },
+                            ],
+                            closing_quote_token: SCSS_STRING_QUOTE@75..76 "\"" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@76..77 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@77..79 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@79..85 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        CssFunction {
+                            name: CssIdentifier {
+                                value_token: IDENT@85..90 "clamp" [] [],
+                            },
+                            l_paren_token: L_PAREN@90..91 "(" [] [],
+                            items: CssParameterList [
+                                ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@91..92 "#" [] [],
+                                            l_curly_token: L_CURLY@92..93 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@93..94 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@94..97 "min" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@97..98 "}" [] [],
+                                        },
+                                    ],
+                                },
+                                COMMA@98..100 "," [] [Whitespace(" ")],
+                                ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssBinaryExpression {
+                                            left: ScssInterpolation {
+                                                hash_token: HASH@100..101 "#" [] [],
+                                                l_curly_token: L_CURLY@101..102 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@102..103 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@103..112 "intercept" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@112..114 "}" [] [Whitespace(" ")],
+                                            },
+                                            operator: PLUS@114..116 "+" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedIdentifier {
+                                                items: ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@116..117 "#" [] [],
+                                                        l_curly_token: L_CURLY@117..118 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssBinaryExpression {
+                                                                    left: ScssVariable {
+                                                                        dollar_token: DOLLAR@118..119 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@119..125 "slope" [] [Whitespace(" ")],
+                                                                        },
+                                                                    },
+                                                                    operator: STAR@125..127 "*" [] [Whitespace(" ")],
+                                                                    right: CssNumber {
+                                                                        value_token: CSS_NUMBER_LITERAL@127..130 "100" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@130..131 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@131..133 "vw" [] [],
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                    ],
+                                },
+                                COMMA@133..135 "," [] [Whitespace(" ")],
+                                ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@135..136 "#" [] [],
+                                            l_curly_token: L_CURLY@136..137 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@137..138 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@138..141 "max" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@141..142 "}" [] [],
+                                        },
+                                    ],
+                                },
+                            ],
+                            r_paren_token: R_PAREN@142..143 ")" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@143..144 ";" [] [],
+            },
+        },
     ],
-    eof_token: EOF@49..50 "" [Newline("\n")] [],
+    eof_token: EOF@144..145 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..50
+0: CSS_ROOT@0..145
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..49
+  1: CSS_ROOT_ITEM_LIST@0..144
     0: CSS_AT_RULE@0..18
       0: AT@0..1 "@" [] []
       1: SCSS_DEBUG_AT_RULE@1..18
@@ -183,6 +331,100 @@ CssRoot {
                     2: R_PAREN@45..46 ")" [] []
               2: SEMICOLON@46..47 ";" [] []
         2: R_CURLY@47..49 "}" [Newline("\n")] []
-  2: EOF@49..50 "" [Newline("\n")] []
+    2: CSS_AT_RULE@49..77
+      0: AT@49..52 "@" [Newline("\n"), Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@52..77
+        0: DEBUG_KW@52..58 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@58..76
+          0: SCSS_EXPRESSION_ITEM_LIST@58..76
+            0: SCSS_INTERPOLATED_STRING@58..76
+              0: SCSS_STRING_QUOTE@58..59 "\"" [] []
+              1: SCSS_INTERPOLATED_STRING_PART_LIST@59..75
+                0: SCSS_STRING_TEXT@59..66
+                  0: SCSS_STRING_CONTENT_LITERAL@59..66 "Value: " [] []
+                1: SCSS_INTERPOLATION@66..75
+                  0: HASH@66..67 "#" [] []
+                  1: L_CURLY@67..68 "{" [] []
+                  2: SCSS_EXPRESSION@68..74
+                    0: SCSS_EXPRESSION_ITEM_LIST@68..74
+                      0: SCSS_VARIABLE@68..74
+                        0: DOLLAR@68..69 "$" [] []
+                        1: CSS_IDENTIFIER@69..74
+                          0: IDENT@69..74 "value" [] []
+                  3: R_CURLY@74..75 "}" [] []
+              2: SCSS_STRING_QUOTE@75..76 "\"" [] []
+        2: SEMICOLON@76..77 ";" [] []
+    3: CSS_AT_RULE@77..144
+      0: AT@77..79 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@79..144
+        0: DEBUG_KW@79..85 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@85..143
+          0: SCSS_EXPRESSION_ITEM_LIST@85..143
+            0: CSS_FUNCTION@85..143
+              0: CSS_IDENTIFIER@85..90
+                0: IDENT@85..90 "clamp" [] []
+              1: L_PAREN@90..91 "(" [] []
+              2: CSS_PARAMETER_LIST@91..142
+                0: SCSS_EXPRESSION@91..98
+                  0: SCSS_EXPRESSION_ITEM_LIST@91..98
+                    0: SCSS_INTERPOLATION@91..98
+                      0: HASH@91..92 "#" [] []
+                      1: L_CURLY@92..93 "{" [] []
+                      2: SCSS_EXPRESSION@93..97
+                        0: SCSS_EXPRESSION_ITEM_LIST@93..97
+                          0: SCSS_VARIABLE@93..97
+                            0: DOLLAR@93..94 "$" [] []
+                            1: CSS_IDENTIFIER@94..97
+                              0: IDENT@94..97 "min" [] []
+                      3: R_CURLY@97..98 "}" [] []
+                1: COMMA@98..100 "," [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@100..133
+                  0: SCSS_EXPRESSION_ITEM_LIST@100..133
+                    0: SCSS_BINARY_EXPRESSION@100..133
+                      0: SCSS_INTERPOLATION@100..114
+                        0: HASH@100..101 "#" [] []
+                        1: L_CURLY@101..102 "{" [] []
+                        2: SCSS_EXPRESSION@102..112
+                          0: SCSS_EXPRESSION_ITEM_LIST@102..112
+                            0: SCSS_VARIABLE@102..112
+                              0: DOLLAR@102..103 "$" [] []
+                              1: CSS_IDENTIFIER@103..112
+                                0: IDENT@103..112 "intercept" [] []
+                        3: R_CURLY@112..114 "}" [] [Whitespace(" ")]
+                      1: PLUS@114..116 "+" [] [Whitespace(" ")]
+                      2: SCSS_INTERPOLATED_IDENTIFIER@116..133
+                        0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@116..133
+                          0: SCSS_INTERPOLATION@116..131
+                            0: HASH@116..117 "#" [] []
+                            1: L_CURLY@117..118 "{" [] []
+                            2: SCSS_EXPRESSION@118..130
+                              0: SCSS_EXPRESSION_ITEM_LIST@118..130
+                                0: SCSS_BINARY_EXPRESSION@118..130
+                                  0: SCSS_VARIABLE@118..125
+                                    0: DOLLAR@118..119 "$" [] []
+                                    1: CSS_IDENTIFIER@119..125
+                                      0: IDENT@119..125 "slope" [] [Whitespace(" ")]
+                                  1: STAR@125..127 "*" [] [Whitespace(" ")]
+                                  2: CSS_NUMBER@127..130
+                                    0: CSS_NUMBER_LITERAL@127..130 "100" [] []
+                            3: R_CURLY@130..131 "}" [] []
+                          1: CSS_IDENTIFIER@131..133
+                            0: IDENT@131..133 "vw" [] []
+                3: COMMA@133..135 "," [] [Whitespace(" ")]
+                4: SCSS_EXPRESSION@135..142
+                  0: SCSS_EXPRESSION_ITEM_LIST@135..142
+                    0: SCSS_INTERPOLATION@135..142
+                      0: HASH@135..136 "#" [] []
+                      1: L_CURLY@136..137 "{" [] []
+                      2: SCSS_EXPRESSION@137..141
+                        0: SCSS_EXPRESSION_ITEM_LIST@137..141
+                          0: SCSS_VARIABLE@137..141
+                            0: DOLLAR@137..138 "$" [] []
+                            1: CSS_IDENTIFIER@138..141
+                              0: IDENT@138..141 "max" [] []
+                      3: R_CURLY@141..142 "}" [] []
+              3: R_PAREN@142..143 ")" [] []
+        2: SEMICOLON@143..144 ";" [] []
+  2: EOF@144..145 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/return.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/return.scss
@@ -1,2 +1,4 @@
 @return 42;
 @return $width * 2;
+@return "#{$prefix}-#{$name}";
+@return clamp(#{$min}, #{$intercept} + #{$slope * 100}vw, #{$max});

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/return.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/return.scss.snap
@@ -8,6 +8,8 @@ expression: snapshot
 ```css
 @return 42;
 @return $width * 2;
+@return "#{$prefix}-#{$name}";
+@return clamp(#{$min}, #{$intercept} + #{$slope * 100}vw, #{$max});
 
 ```
 
@@ -55,17 +57,177 @@ CssRoot {
                 semicolon_token: SEMICOLON@30..31 ";" [] [],
             },
         },
+        CssAtRule {
+            at_token: AT@31..33 "@" [Newline("\n")] [],
+            rule: ScssReturnAtRule {
+                return_token: RETURN_KW@33..40 "return" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssInterpolatedString {
+                            opening_quote_token: SCSS_STRING_QUOTE@40..41 "\"" [] [],
+                            parts: ScssInterpolatedStringPartList [
+                                ScssInterpolation {
+                                    hash_token: HASH@41..42 "#" [] [],
+                                    l_curly_token: L_CURLY@42..43 "{" [] [],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            ScssVariable {
+                                                dollar_token: DOLLAR@43..44 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@44..50 "prefix" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    r_curly_token: R_CURLY@50..51 "}" [] [],
+                                },
+                                ScssStringText {
+                                    value_token: SCSS_STRING_CONTENT_LITERAL@51..52 "-" [] [],
+                                },
+                                ScssInterpolation {
+                                    hash_token: HASH@52..53 "#" [] [],
+                                    l_curly_token: L_CURLY@53..54 "{" [] [],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            ScssVariable {
+                                                dollar_token: DOLLAR@54..55 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@55..59 "name" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    r_curly_token: R_CURLY@59..60 "}" [] [],
+                                },
+                            ],
+                            closing_quote_token: SCSS_STRING_QUOTE@60..61 "\"" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@61..62 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@62..64 "@" [Newline("\n")] [],
+            rule: ScssReturnAtRule {
+                return_token: RETURN_KW@64..71 "return" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        CssFunction {
+                            name: CssIdentifier {
+                                value_token: IDENT@71..76 "clamp" [] [],
+                            },
+                            l_paren_token: L_PAREN@76..77 "(" [] [],
+                            items: CssParameterList [
+                                ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@77..78 "#" [] [],
+                                            l_curly_token: L_CURLY@78..79 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@79..80 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@80..83 "min" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@83..84 "}" [] [],
+                                        },
+                                    ],
+                                },
+                                COMMA@84..86 "," [] [Whitespace(" ")],
+                                ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssBinaryExpression {
+                                            left: ScssInterpolation {
+                                                hash_token: HASH@86..87 "#" [] [],
+                                                l_curly_token: L_CURLY@87..88 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@88..89 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@89..98 "intercept" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@98..100 "}" [] [Whitespace(" ")],
+                                            },
+                                            operator: PLUS@100..102 "+" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedIdentifier {
+                                                items: ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@102..103 "#" [] [],
+                                                        l_curly_token: L_CURLY@103..104 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssBinaryExpression {
+                                                                    left: ScssVariable {
+                                                                        dollar_token: DOLLAR@104..105 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@105..111 "slope" [] [Whitespace(" ")],
+                                                                        },
+                                                                    },
+                                                                    operator: STAR@111..113 "*" [] [Whitespace(" ")],
+                                                                    right: CssNumber {
+                                                                        value_token: CSS_NUMBER_LITERAL@113..116 "100" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@116..117 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@117..119 "vw" [] [],
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                    ],
+                                },
+                                COMMA@119..121 "," [] [Whitespace(" ")],
+                                ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@121..122 "#" [] [],
+                                            l_curly_token: L_CURLY@122..123 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@123..124 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@124..127 "max" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@127..128 "}" [] [],
+                                        },
+                                    ],
+                                },
+                            ],
+                            r_paren_token: R_PAREN@128..129 ")" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@129..130 ";" [] [],
+            },
+        },
     ],
-    eof_token: EOF@31..32 "" [Newline("\n")] [],
+    eof_token: EOF@130..131 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..32
+0: CSS_ROOT@0..131
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..31
+  1: CSS_ROOT_ITEM_LIST@0..130
     0: CSS_AT_RULE@0..11
       0: AT@0..1 "@" [] []
       1: SCSS_RETURN_AT_RULE@1..11
@@ -90,6 +252,110 @@ CssRoot {
               2: CSS_NUMBER@29..30
                 0: CSS_NUMBER_LITERAL@29..30 "2" [] []
         2: SEMICOLON@30..31 ";" [] []
-  2: EOF@31..32 "" [Newline("\n")] []
+    2: CSS_AT_RULE@31..62
+      0: AT@31..33 "@" [Newline("\n")] []
+      1: SCSS_RETURN_AT_RULE@33..62
+        0: RETURN_KW@33..40 "return" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@40..61
+          0: SCSS_EXPRESSION_ITEM_LIST@40..61
+            0: SCSS_INTERPOLATED_STRING@40..61
+              0: SCSS_STRING_QUOTE@40..41 "\"" [] []
+              1: SCSS_INTERPOLATED_STRING_PART_LIST@41..60
+                0: SCSS_INTERPOLATION@41..51
+                  0: HASH@41..42 "#" [] []
+                  1: L_CURLY@42..43 "{" [] []
+                  2: SCSS_EXPRESSION@43..50
+                    0: SCSS_EXPRESSION_ITEM_LIST@43..50
+                      0: SCSS_VARIABLE@43..50
+                        0: DOLLAR@43..44 "$" [] []
+                        1: CSS_IDENTIFIER@44..50
+                          0: IDENT@44..50 "prefix" [] []
+                  3: R_CURLY@50..51 "}" [] []
+                1: SCSS_STRING_TEXT@51..52
+                  0: SCSS_STRING_CONTENT_LITERAL@51..52 "-" [] []
+                2: SCSS_INTERPOLATION@52..60
+                  0: HASH@52..53 "#" [] []
+                  1: L_CURLY@53..54 "{" [] []
+                  2: SCSS_EXPRESSION@54..59
+                    0: SCSS_EXPRESSION_ITEM_LIST@54..59
+                      0: SCSS_VARIABLE@54..59
+                        0: DOLLAR@54..55 "$" [] []
+                        1: CSS_IDENTIFIER@55..59
+                          0: IDENT@55..59 "name" [] []
+                  3: R_CURLY@59..60 "}" [] []
+              2: SCSS_STRING_QUOTE@60..61 "\"" [] []
+        2: SEMICOLON@61..62 ";" [] []
+    3: CSS_AT_RULE@62..130
+      0: AT@62..64 "@" [Newline("\n")] []
+      1: SCSS_RETURN_AT_RULE@64..130
+        0: RETURN_KW@64..71 "return" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@71..129
+          0: SCSS_EXPRESSION_ITEM_LIST@71..129
+            0: CSS_FUNCTION@71..129
+              0: CSS_IDENTIFIER@71..76
+                0: IDENT@71..76 "clamp" [] []
+              1: L_PAREN@76..77 "(" [] []
+              2: CSS_PARAMETER_LIST@77..128
+                0: SCSS_EXPRESSION@77..84
+                  0: SCSS_EXPRESSION_ITEM_LIST@77..84
+                    0: SCSS_INTERPOLATION@77..84
+                      0: HASH@77..78 "#" [] []
+                      1: L_CURLY@78..79 "{" [] []
+                      2: SCSS_EXPRESSION@79..83
+                        0: SCSS_EXPRESSION_ITEM_LIST@79..83
+                          0: SCSS_VARIABLE@79..83
+                            0: DOLLAR@79..80 "$" [] []
+                            1: CSS_IDENTIFIER@80..83
+                              0: IDENT@80..83 "min" [] []
+                      3: R_CURLY@83..84 "}" [] []
+                1: COMMA@84..86 "," [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@86..119
+                  0: SCSS_EXPRESSION_ITEM_LIST@86..119
+                    0: SCSS_BINARY_EXPRESSION@86..119
+                      0: SCSS_INTERPOLATION@86..100
+                        0: HASH@86..87 "#" [] []
+                        1: L_CURLY@87..88 "{" [] []
+                        2: SCSS_EXPRESSION@88..98
+                          0: SCSS_EXPRESSION_ITEM_LIST@88..98
+                            0: SCSS_VARIABLE@88..98
+                              0: DOLLAR@88..89 "$" [] []
+                              1: CSS_IDENTIFIER@89..98
+                                0: IDENT@89..98 "intercept" [] []
+                        3: R_CURLY@98..100 "}" [] [Whitespace(" ")]
+                      1: PLUS@100..102 "+" [] [Whitespace(" ")]
+                      2: SCSS_INTERPOLATED_IDENTIFIER@102..119
+                        0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@102..119
+                          0: SCSS_INTERPOLATION@102..117
+                            0: HASH@102..103 "#" [] []
+                            1: L_CURLY@103..104 "{" [] []
+                            2: SCSS_EXPRESSION@104..116
+                              0: SCSS_EXPRESSION_ITEM_LIST@104..116
+                                0: SCSS_BINARY_EXPRESSION@104..116
+                                  0: SCSS_VARIABLE@104..111
+                                    0: DOLLAR@104..105 "$" [] []
+                                    1: CSS_IDENTIFIER@105..111
+                                      0: IDENT@105..111 "slope" [] [Whitespace(" ")]
+                                  1: STAR@111..113 "*" [] [Whitespace(" ")]
+                                  2: CSS_NUMBER@113..116
+                                    0: CSS_NUMBER_LITERAL@113..116 "100" [] []
+                            3: R_CURLY@116..117 "}" [] []
+                          1: CSS_IDENTIFIER@117..119
+                            0: IDENT@117..119 "vw" [] []
+                3: COMMA@119..121 "," [] [Whitespace(" ")]
+                4: SCSS_EXPRESSION@121..128
+                  0: SCSS_EXPRESSION_ITEM_LIST@121..128
+                    0: SCSS_INTERPOLATION@121..128
+                      0: HASH@121..122 "#" [] []
+                      1: L_CURLY@122..123 "{" [] []
+                      2: SCSS_EXPRESSION@123..127
+                        0: SCSS_EXPRESSION_ITEM_LIST@123..127
+                          0: SCSS_VARIABLE@123..127
+                            0: DOLLAR@123..124 "$" [] []
+                            1: CSS_IDENTIFIER@124..127
+                              0: IDENT@124..127 "max" [] []
+                      3: R_CURLY@127..128 "}" [] []
+              3: R_PAREN@128..129 ")" [] []
+        2: SEMICOLON@129..130 ";" [] []
+  2: EOF@130..131 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/expression/complex-expressions.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/expression/complex-expressions.scss
@@ -59,6 +59,7 @@ $concat2: foo + bar;
 $concat3: "str" + ing;
 
 // Division expressions (SCSS division context)
+$division0: 10 / 2;
 $division1: (10 / 2);
 $division2: (100px / 10);
 $division3: $a / $b;

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/expression/complex-expressions.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/expression/complex-expressions.scss.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
-assertion_line: 208
 expression: snapshot
 ---
 
@@ -68,6 +67,7 @@ $concat2: foo + bar;
 $concat3: "str" + ing;
 
 // Division expressions (SCSS division context)
+$division0: 10 / 2;
 $division1: (10 / 2);
 $division2: (100px / 10);
 $division3: $a / $b;
@@ -475,12 +475,12 @@ CssRoot {
                             },
                         },
                         operator: MINUS@266..268 "-" [] [Whitespace(" ")],
-                        right: CssRatio {
-                            numerator: CssNumber {
+                        right: ScssBinaryExpression {
+                            left: CssNumber {
                                 value_token: CSS_NUMBER_LITERAL@268..270 "4" [] [Whitespace(" ")],
                             },
-                            slash_token: SLASH@270..272 "/" [] [Whitespace(" ")],
-                            denominator: CssNumber {
+                            operator: SLASH@270..272 "/" [] [Whitespace(" ")],
+                            right: CssNumber {
                                 value_token: CSS_NUMBER_LITERAL@272..273 "5" [] [],
                             },
                         },
@@ -1336,807 +1336,801 @@ CssRoot {
             name: ScssVariable {
                 dollar_token: DOLLAR@1197..1248 "$" [Newline("\n"), Newline("\n"), Comments("// Division expressio ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1248..1257 "division1" [] [],
+                    value_token: IDENT@1248..1257 "division0" [] [],
                 },
             },
             colon_token: COLON@1257..1259 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
-                    ScssParenthesizedExpression {
-                        l_paren_token: L_PAREN@1259..1260 "(" [] [],
-                        expression: ScssExpression {
-                            items: ScssExpressionItemList [
-                                CssRatio {
-                                    numerator: CssNumber {
-                                        value_token: CSS_NUMBER_LITERAL@1260..1263 "10" [] [Whitespace(" ")],
-                                    },
-                                    slash_token: SLASH@1263..1265 "/" [] [Whitespace(" ")],
-                                    denominator: CssNumber {
-                                        value_token: CSS_NUMBER_LITERAL@1265..1266 "2" [] [],
-                                    },
-                                },
-                            ],
+                    ScssBinaryExpression {
+                        left: CssNumber {
+                            value_token: CSS_NUMBER_LITERAL@1259..1262 "10" [] [Whitespace(" ")],
                         },
-                        r_paren_token: R_PAREN@1266..1267 ")" [] [],
+                        operator: SLASH@1262..1264 "/" [] [Whitespace(" ")],
+                        right: CssNumber {
+                            value_token: CSS_NUMBER_LITERAL@1264..1265 "2" [] [],
+                        },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1267..1268 ";" [] [],
+            semicolon_token: SEMICOLON@1265..1266 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1268..1270 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1266..1268 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1270..1279 "division2" [] [],
+                    value_token: IDENT@1268..1277 "division1" [] [],
                 },
             },
-            colon_token: COLON@1279..1281 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1277..1279 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssParenthesizedExpression {
-                        l_paren_token: L_PAREN@1281..1282 "(" [] [],
+                        l_paren_token: L_PAREN@1279..1280 "(" [] [],
+                        expression: ScssExpression {
+                            items: ScssExpressionItemList [
+                                ScssBinaryExpression {
+                                    left: CssNumber {
+                                        value_token: CSS_NUMBER_LITERAL@1280..1283 "10" [] [Whitespace(" ")],
+                                    },
+                                    operator: SLASH@1283..1285 "/" [] [Whitespace(" ")],
+                                    right: CssNumber {
+                                        value_token: CSS_NUMBER_LITERAL@1285..1286 "2" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                        r_paren_token: R_PAREN@1286..1287 ")" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@1287..1288 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@1288..1290 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@1290..1299 "division2" [] [],
+                },
+            },
+            colon_token: COLON@1299..1301 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    ScssParenthesizedExpression {
+                        l_paren_token: L_PAREN@1301..1302 "(" [] [],
                         expression: ScssExpression {
                             items: ScssExpressionItemList [
                                 ScssBinaryExpression {
                                     left: CssRegularDimension {
-                                        value_token: CSS_NUMBER_LITERAL@1282..1285 "100" [] [],
-                                        unit_token: IDENT@1285..1288 "px" [] [Whitespace(" ")],
+                                        value_token: CSS_NUMBER_LITERAL@1302..1305 "100" [] [],
+                                        unit_token: IDENT@1305..1308 "px" [] [Whitespace(" ")],
                                     },
-                                    operator: SLASH@1288..1290 "/" [] [Whitespace(" ")],
+                                    operator: SLASH@1308..1310 "/" [] [Whitespace(" ")],
                                     right: CssNumber {
-                                        value_token: CSS_NUMBER_LITERAL@1290..1292 "10" [] [],
+                                        value_token: CSS_NUMBER_LITERAL@1310..1312 "10" [] [],
                                     },
                                 },
                             ],
                         },
-                        r_paren_token: R_PAREN@1292..1293 ")" [] [],
+                        r_paren_token: R_PAREN@1312..1313 ")" [] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1293..1294 ";" [] [],
+            semicolon_token: SEMICOLON@1313..1314 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1294..1296 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1314..1316 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1296..1305 "division3" [] [],
+                    value_token: IDENT@1316..1325 "division3" [] [],
                 },
             },
-            colon_token: COLON@1305..1307 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1325..1327 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: ScssVariable {
-                            dollar_token: DOLLAR@1307..1308 "$" [] [],
+                            dollar_token: DOLLAR@1327..1328 "$" [] [],
                             name: CssIdentifier {
-                                value_token: IDENT@1308..1310 "a" [] [Whitespace(" ")],
+                                value_token: IDENT@1328..1330 "a" [] [Whitespace(" ")],
                             },
                         },
-                        operator: SLASH@1310..1312 "/" [] [Whitespace(" ")],
+                        operator: SLASH@1330..1332 "/" [] [Whitespace(" ")],
                         right: ScssVariable {
-                            dollar_token: DOLLAR@1312..1313 "$" [] [],
+                            dollar_token: DOLLAR@1332..1333 "$" [] [],
                             name: CssIdentifier {
-                                value_token: IDENT@1313..1314 "b" [] [],
+                                value_token: IDENT@1333..1334 "b" [] [],
                             },
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1314..1315 ";" [] [],
+            semicolon_token: SEMICOLON@1334..1335 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1315..1337 "$" [Newline("\n"), Newline("\n"), Comments("// Modulo operator"), Newline("\n")] [],
+                dollar_token: DOLLAR@1335..1357 "$" [Newline("\n"), Newline("\n"), Comments("// Modulo operator"), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1337..1341 "mod1" [] [],
+                    value_token: IDENT@1357..1361 "mod1" [] [],
                 },
             },
-            colon_token: COLON@1341..1343 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1361..1363 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@1343..1346 "10" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@1363..1366 "10" [] [Whitespace(" ")],
                         },
-                        operator: PERCENT@1346..1348 "%" [] [Whitespace(" ")],
+                        operator: PERCENT@1366..1368 "%" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@1348..1349 "3" [] [],
+                            value_token: CSS_NUMBER_LITERAL@1368..1369 "3" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1349..1350 ";" [] [],
+            semicolon_token: SEMICOLON@1369..1370 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1350..1352 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1370..1372 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1352..1356 "mod2" [] [],
+                    value_token: IDENT@1372..1376 "mod2" [] [],
                 },
             },
-            colon_token: COLON@1356..1358 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1376..1378 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@1358..1362 "100" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@1378..1382 "100" [] [Whitespace(" ")],
                         },
-                        operator: PERCENT@1362..1364 "%" [] [Whitespace(" ")],
+                        operator: PERCENT@1382..1384 "%" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@1364..1365 "7" [] [],
+                            value_token: CSS_NUMBER_LITERAL@1384..1385 "7" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1365..1366 ";" [] [],
+            semicolon_token: SEMICOLON@1385..1386 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1366..1389 "$" [Newline("\n"), Newline("\n"), Comments("// Color operations"), Newline("\n")] [],
+                dollar_token: DOLLAR@1386..1409 "$" [Newline("\n"), Newline("\n"), Comments("// Color operations"), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1389..1395 "color1" [] [],
+                    value_token: IDENT@1409..1415 "color1" [] [],
                 },
             },
-            colon_token: COLON@1395..1397 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1415..1417 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     CssColor {
-                        hash_token: HASH@1397..1398 "#" [] [],
-                        value_token: CSS_COLOR_LITERAL@1398..1401 "036" [] [],
+                        hash_token: HASH@1417..1418 "#" [] [],
+                        value_token: CSS_COLOR_LITERAL@1418..1421 "036" [] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1401..1402 ";" [] [],
+            semicolon_token: SEMICOLON@1421..1422 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1402..1404 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1422..1424 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1404..1410 "color2" [] [],
+                    value_token: IDENT@1424..1430 "color2" [] [],
                 },
             },
-            colon_token: COLON@1410..1412 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1430..1432 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     CssFunction {
                         name: CssIdentifier {
-                            value_token: IDENT@1412..1415 "rgb" [] [],
+                            value_token: IDENT@1432..1435 "rgb" [] [],
                         },
-                        l_paren_token: L_PAREN@1415..1416 "(" [] [],
+                        l_paren_token: L_PAREN@1435..1436 "(" [] [],
                         items: CssParameterList [
                             ScssExpression {
                                 items: ScssExpressionItemList [
                                     CssNumber {
-                                        value_token: CSS_NUMBER_LITERAL@1416..1419 "255" [] [],
+                                        value_token: CSS_NUMBER_LITERAL@1436..1439 "255" [] [],
                                     },
                                 ],
                             },
-                            COMMA@1419..1421 "," [] [Whitespace(" ")],
+                            COMMA@1439..1441 "," [] [Whitespace(" ")],
                             ScssExpression {
                                 items: ScssExpressionItemList [
                                     CssNumber {
-                                        value_token: CSS_NUMBER_LITERAL@1421..1422 "0" [] [],
+                                        value_token: CSS_NUMBER_LITERAL@1441..1442 "0" [] [],
                                     },
                                 ],
                             },
-                            COMMA@1422..1424 "," [] [Whitespace(" ")],
+                            COMMA@1442..1444 "," [] [Whitespace(" ")],
                             ScssExpression {
                                 items: ScssExpressionItemList [
                                     CssNumber {
-                                        value_token: CSS_NUMBER_LITERAL@1424..1425 "0" [] [],
+                                        value_token: CSS_NUMBER_LITERAL@1444..1445 "0" [] [],
                                     },
                                 ],
                             },
                         ],
-                        r_paren_token: R_PAREN@1425..1426 ")" [] [],
+                        r_paren_token: R_PAREN@1445..1446 ")" [] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1426..1427 ";" [] [],
+            semicolon_token: SEMICOLON@1446..1447 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1427..1429 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1447..1449 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1429..1438 "color-add" [] [],
+                    value_token: IDENT@1449..1458 "color-add" [] [],
                 },
             },
-            colon_token: COLON@1438..1440 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1458..1460 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: ScssVariable {
-                            dollar_token: DOLLAR@1440..1441 "$" [] [],
+                            dollar_token: DOLLAR@1460..1461 "$" [] [],
                             name: CssIdentifier {
-                                value_token: IDENT@1441..1448 "color1" [] [Whitespace(" ")],
+                                value_token: IDENT@1461..1468 "color1" [] [Whitespace(" ")],
                             },
                         },
-                        operator: PLUS@1448..1450 "+" [] [Whitespace(" ")],
+                        operator: PLUS@1468..1470 "+" [] [Whitespace(" ")],
                         right: ScssVariable {
-                            dollar_token: DOLLAR@1450..1451 "$" [] [],
+                            dollar_token: DOLLAR@1470..1471 "$" [] [],
                             name: CssIdentifier {
-                                value_token: IDENT@1451..1457 "color2" [] [],
+                                value_token: IDENT@1471..1477 "color2" [] [],
                             },
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1457..1458 ";" [] [],
+            semicolon_token: SEMICOLON@1477..1478 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1458..1480 "$" [Newline("\n"), Newline("\n"), Comments("// List operations"), Newline("\n")] [],
+                dollar_token: DOLLAR@1478..1500 "$" [Newline("\n"), Newline("\n"), Comments("// List operations"), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1480..1491 "list-concat" [] [],
+                    value_token: IDENT@1500..1511 "list-concat" [] [],
                 },
             },
-            colon_token: COLON@1491..1493 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1511..1513 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: ScssParenthesizedExpression {
-                            l_paren_token: L_PAREN@1493..1494 "(" [] [],
+                            l_paren_token: L_PAREN@1513..1514 "(" [] [],
                             expression: ScssListExpression {
                                 elements: ScssListExpressionElementList [
                                     ScssListExpressionElement {
                                         value: ScssExpression {
                                             items: ScssExpressionItemList [
                                                 CssIdentifier {
-                                                    value_token: IDENT@1494..1495 "a" [] [],
+                                                    value_token: IDENT@1514..1515 "a" [] [],
                                                 },
                                             ],
                                         },
                                     },
-                                    COMMA@1495..1497 "," [] [Whitespace(" ")],
+                                    COMMA@1515..1517 "," [] [Whitespace(" ")],
                                     ScssListExpressionElement {
                                         value: ScssExpression {
                                             items: ScssExpressionItemList [
                                                 CssIdentifier {
-                                                    value_token: IDENT@1497..1498 "b" [] [],
+                                                    value_token: IDENT@1517..1518 "b" [] [],
                                                 },
                                             ],
                                         },
                                     },
                                 ],
                             },
-                            r_paren_token: R_PAREN@1498..1500 ")" [] [Whitespace(" ")],
+                            r_paren_token: R_PAREN@1518..1520 ")" [] [Whitespace(" ")],
                         },
-                        operator: PLUS@1500..1502 "+" [] [Whitespace(" ")],
+                        operator: PLUS@1520..1522 "+" [] [Whitespace(" ")],
                         right: ScssParenthesizedExpression {
-                            l_paren_token: L_PAREN@1502..1503 "(" [] [],
+                            l_paren_token: L_PAREN@1522..1523 "(" [] [],
                             expression: ScssListExpression {
                                 elements: ScssListExpressionElementList [
                                     ScssListExpressionElement {
                                         value: ScssExpression {
                                             items: ScssExpressionItemList [
                                                 CssIdentifier {
-                                                    value_token: IDENT@1503..1504 "c" [] [],
+                                                    value_token: IDENT@1523..1524 "c" [] [],
                                                 },
                                             ],
                                         },
                                     },
-                                    COMMA@1504..1506 "," [] [Whitespace(" ")],
+                                    COMMA@1524..1526 "," [] [Whitespace(" ")],
                                     ScssListExpressionElement {
                                         value: ScssExpression {
                                             items: ScssExpressionItemList [
                                                 CssIdentifier {
-                                                    value_token: IDENT@1506..1507 "d" [] [],
+                                                    value_token: IDENT@1526..1527 "d" [] [],
                                                 },
                                             ],
                                         },
                                     },
                                 ],
                             },
-                            r_paren_token: R_PAREN@1507..1508 ")" [] [],
+                            r_paren_token: R_PAREN@1527..1528 ")" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1508..1509 ";" [] [],
+            semicolon_token: SEMICOLON@1528..1529 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1509..1511 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1529..1531 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1511..1519 "list-add" [] [],
+                    value_token: IDENT@1531..1539 "list-add" [] [],
                 },
             },
-            colon_token: COLON@1519..1521 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1539..1541 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: ScssParenthesizedExpression {
-                            l_paren_token: L_PAREN@1521..1522 "(" [] [],
+                            l_paren_token: L_PAREN@1541..1542 "(" [] [],
                             expression: ScssExpression {
                                 items: ScssExpressionItemList [
                                     CssIdentifier {
-                                        value_token: IDENT@1522..1524 "a" [] [Whitespace(" ")],
+                                        value_token: IDENT@1542..1544 "a" [] [Whitespace(" ")],
                                     },
                                     CssIdentifier {
-                                        value_token: IDENT@1524..1525 "b" [] [],
+                                        value_token: IDENT@1544..1545 "b" [] [],
                                     },
                                 ],
                             },
-                            r_paren_token: R_PAREN@1525..1527 ")" [] [Whitespace(" ")],
+                            r_paren_token: R_PAREN@1545..1547 ")" [] [Whitespace(" ")],
                         },
-                        operator: PLUS@1527..1529 "+" [] [Whitespace(" ")],
+                        operator: PLUS@1547..1549 "+" [] [Whitespace(" ")],
                         right: CssIdentifier {
-                            value_token: IDENT@1529..1530 "c" [] [],
+                            value_token: IDENT@1549..1550 "c" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1530..1531 ";" [] [],
+            semicolon_token: SEMICOLON@1550..1551 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1531..1556 "$" [Newline("\n"), Newline("\n"), Comments("// Map in expressions"), Newline("\n")] [],
+                dollar_token: DOLLAR@1551..1576 "$" [Newline("\n"), Newline("\n"), Comments("// Map in expressions"), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1556..1564 "map-expr" [] [],
+                    value_token: IDENT@1576..1584 "map-expr" [] [],
                 },
             },
-            colon_token: COLON@1564..1566 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1584..1586 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssParenthesizedExpression {
-                        l_paren_token: L_PAREN@1566..1567 "(" [] [],
+                        l_paren_token: L_PAREN@1586..1587 "(" [] [],
                         expression: ScssExpression {
                             items: ScssExpressionItemList [
                                 ScssMapExpression {
-                                    l_paren_token: L_PAREN@1567..1568 "(" [] [],
+                                    l_paren_token: L_PAREN@1587..1588 "(" [] [],
                                     pairs: ScssMapExpressionPairList [
                                         ScssMapExpressionPair {
                                             key: ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     CssIdentifier {
-                                                        value_token: IDENT@1568..1571 "key" [] [],
+                                                        value_token: IDENT@1588..1591 "key" [] [],
                                                     },
                                                 ],
                                             },
-                                            colon_token: COLON@1571..1573 ":" [] [Whitespace(" ")],
+                                            colon_token: COLON@1591..1593 ":" [] [Whitespace(" ")],
                                             value: ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     CssIdentifier {
-                                                        value_token: IDENT@1573..1578 "value" [] [],
+                                                        value_token: IDENT@1593..1598 "value" [] [],
                                                     },
                                                 ],
                                             },
                                         },
                                     ],
-                                    r_paren_token: R_PAREN@1578..1579 ")" [] [],
+                                    r_paren_token: R_PAREN@1598..1599 ")" [] [],
                                 },
                             ],
                         },
-                        r_paren_token: R_PAREN@1579..1580 ")" [] [],
+                        r_paren_token: R_PAREN@1599..1600 ")" [] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1580..1581 ";" [] [],
+            semicolon_token: SEMICOLON@1600..1601 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1581..1617 "$" [Newline("\n"), Newline("\n"), Comments("// Function calls in  ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@1601..1637 "$" [Newline("\n"), Newline("\n"), Comments("// Function calls in  ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1617..1622 "func1" [] [],
+                    value_token: IDENT@1637..1642 "func1" [] [],
                 },
             },
-            colon_token: COLON@1622..1624 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1642..1644 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssFunction {
                             name: CssIdentifier {
-                                value_token: IDENT@1624..1629 "round" [] [],
+                                value_token: IDENT@1644..1649 "round" [] [],
                             },
-                            l_paren_token: L_PAREN@1629..1630 "(" [] [],
+                            l_paren_token: L_PAREN@1649..1650 "(" [] [],
                             items: CssParameterList [
                                 ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@1630..1634 "10.5" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@1650..1654 "10.5" [] [],
                                         },
                                     ],
                                 },
                             ],
-                            r_paren_token: R_PAREN@1634..1636 ")" [] [Whitespace(" ")],
+                            r_paren_token: R_PAREN@1654..1656 ")" [] [Whitespace(" ")],
                         },
-                        operator: PLUS@1636..1638 "+" [] [Whitespace(" ")],
+                        operator: PLUS@1656..1658 "+" [] [Whitespace(" ")],
                         right: CssFunction {
                             name: CssIdentifier {
-                                value_token: IDENT@1638..1642 "ceil" [] [],
+                                value_token: IDENT@1658..1662 "ceil" [] [],
                             },
-                            l_paren_token: L_PAREN@1642..1643 "(" [] [],
+                            l_paren_token: L_PAREN@1662..1663 "(" [] [],
                             items: CssParameterList [
                                 ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@1643..1647 "20.3" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@1663..1667 "20.3" [] [],
                                         },
                                     ],
                                 },
                             ],
-                            r_paren_token: R_PAREN@1647..1648 ")" [] [],
+                            r_paren_token: R_PAREN@1667..1668 ")" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1648..1649 ";" [] [],
+            semicolon_token: SEMICOLON@1668..1669 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1649..1651 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1669..1671 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1651..1656 "func2" [] [],
+                    value_token: IDENT@1671..1676 "func2" [] [],
                 },
             },
-            colon_token: COLON@1656..1658 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1676..1678 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssFunction {
                             name: CssIdentifier {
-                                value_token: IDENT@1658..1661 "max" [] [],
+                                value_token: IDENT@1678..1681 "max" [] [],
                             },
-                            l_paren_token: L_PAREN@1661..1662 "(" [] [],
+                            l_paren_token: L_PAREN@1681..1682 "(" [] [],
                             items: CssParameterList [
                                 ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@1662..1664 "10" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@1682..1684 "10" [] [],
                                         },
                                     ],
                                 },
-                                COMMA@1664..1666 "," [] [Whitespace(" ")],
+                                COMMA@1684..1686 "," [] [Whitespace(" ")],
                                 ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@1666..1668 "20" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@1686..1688 "20" [] [],
                                         },
                                     ],
                                 },
-                                COMMA@1668..1670 "," [] [Whitespace(" ")],
+                                COMMA@1688..1690 "," [] [Whitespace(" ")],
                                 ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@1670..1672 "30" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@1690..1692 "30" [] [],
                                         },
                                     ],
                                 },
                             ],
-                            r_paren_token: R_PAREN@1672..1674 ")" [] [Whitespace(" ")],
+                            r_paren_token: R_PAREN@1692..1694 ")" [] [Whitespace(" ")],
                         },
-                        operator: MINUS@1674..1676 "-" [] [Whitespace(" ")],
+                        operator: MINUS@1694..1696 "-" [] [Whitespace(" ")],
                         right: CssFunction {
                             name: CssIdentifier {
-                                value_token: IDENT@1676..1679 "min" [] [],
+                                value_token: IDENT@1696..1699 "min" [] [],
                             },
-                            l_paren_token: L_PAREN@1679..1680 "(" [] [],
+                            l_paren_token: L_PAREN@1699..1700 "(" [] [],
                             items: CssParameterList [
                                 ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@1680..1681 "5" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@1700..1701 "5" [] [],
                                         },
                                     ],
                                 },
-                                COMMA@1681..1683 "," [] [Whitespace(" ")],
+                                COMMA@1701..1703 "," [] [Whitespace(" ")],
                                 ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@1683..1685 "10" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@1703..1705 "10" [] [],
                                         },
                                     ],
                                 },
-                                COMMA@1685..1687 "," [] [Whitespace(" ")],
+                                COMMA@1705..1707 "," [] [Whitespace(" ")],
                                 ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@1687..1689 "15" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@1707..1709 "15" [] [],
                                         },
                                     ],
                                 },
                             ],
-                            r_paren_token: R_PAREN@1689..1690 ")" [] [],
+                            r_paren_token: R_PAREN@1709..1710 ")" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1690..1691 ";" [] [],
+            semicolon_token: SEMICOLON@1710..1711 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1691..1729 "$" [Newline("\n"), Newline("\n"), Comments("// Complex calculatio ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@1711..1749 "$" [Newline("\n"), Newline("\n"), Comments("// Complex calculatio ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1729..1734 "calc1" [] [],
-                },
-            },
-            colon_token: COLON@1734..1736 ":" [] [Whitespace(" ")],
-            value: ScssExpression {
-                items: ScssExpressionItemList [
-                    ScssBinaryExpression {
-                        left: CssRegularDimension {
-                            value_token: CSS_NUMBER_LITERAL@1736..1738 "10" [] [],
-                            unit_token: IDENT@1738..1741 "px" [] [Whitespace(" ")],
-                        },
-                        operator: PLUS@1741..1743 "+" [] [Whitespace(" ")],
-                        right: CssRegularDimension {
-                            value_token: CSS_NUMBER_LITERAL@1743..1744 "5" [] [],
-                            unit_token: IDENT@1744..1746 "em" [] [],
-                        },
-                    },
-                ],
-            },
-            modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1746..1747 ";" [] [],
-        },
-        ScssVariableDeclaration {
-            name: ScssVariable {
-                dollar_token: DOLLAR@1747..1749 "$" [Newline("\n")] [],
-                name: CssIdentifier {
-                    value_token: IDENT@1749..1754 "calc2" [] [],
+                    value_token: IDENT@1749..1754 "calc1" [] [],
                 },
             },
             colon_token: COLON@1754..1756 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
-                        left: CssPercentage {
-                            value_token: CSS_NUMBER_LITERAL@1756..1759 "100" [] [],
-                            percent_token: PERCENT@1759..1761 "%" [] [Whitespace(" ")],
+                        left: CssRegularDimension {
+                            value_token: CSS_NUMBER_LITERAL@1756..1758 "10" [] [],
+                            unit_token: IDENT@1758..1761 "px" [] [Whitespace(" ")],
                         },
-                        operator: MINUS@1761..1763 "-" [] [Whitespace(" ")],
+                        operator: PLUS@1761..1763 "+" [] [Whitespace(" ")],
                         right: CssRegularDimension {
-                            value_token: CSS_NUMBER_LITERAL@1763..1765 "20" [] [],
-                            unit_token: IDENT@1765..1767 "px" [] [],
+                            value_token: CSS_NUMBER_LITERAL@1763..1764 "5" [] [],
+                            unit_token: IDENT@1764..1766 "em" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1767..1768 ";" [] [],
+            semicolon_token: SEMICOLON@1766..1767 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1768..1770 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1767..1769 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1770..1775 "calc3" [] [],
+                    value_token: IDENT@1769..1774 "calc2" [] [],
                 },
             },
-            colon_token: COLON@1775..1777 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1774..1776 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    ScssBinaryExpression {
+                        left: CssPercentage {
+                            value_token: CSS_NUMBER_LITERAL@1776..1779 "100" [] [],
+                            percent_token: PERCENT@1779..1781 "%" [] [Whitespace(" ")],
+                        },
+                        operator: MINUS@1781..1783 "-" [] [Whitespace(" ")],
+                        right: CssRegularDimension {
+                            value_token: CSS_NUMBER_LITERAL@1783..1785 "20" [] [],
+                            unit_token: IDENT@1785..1787 "px" [] [],
+                        },
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@1787..1788 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@1788..1790 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@1790..1795 "calc3" [] [],
+                },
+            },
+            colon_token: COLON@1795..1797 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssRegularDimension {
-                            value_token: CSS_NUMBER_LITERAL@1777..1779 "50" [] [],
-                            unit_token: IDENT@1779..1782 "vh" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@1797..1799 "50" [] [],
+                            unit_token: IDENT@1799..1802 "vh" [] [Whitespace(" ")],
                         },
-                        operator: STAR@1782..1784 "*" [] [Whitespace(" ")],
+                        operator: STAR@1802..1804 "*" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@1784..1785 "2" [] [],
+                            value_token: CSS_NUMBER_LITERAL@1804..1805 "2" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1785..1786 ";" [] [],
+            semicolon_token: SEMICOLON@1805..1806 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1786..1814 "$" [Newline("\n"), Newline("\n"), Comments("// Expressions with null"), Newline("\n")] [],
+                dollar_token: DOLLAR@1806..1834 "$" [Newline("\n"), Newline("\n"), Comments("// Expressions with null"), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1814..1823 "null-expr" [] [],
+                    value_token: IDENT@1834..1843 "null-expr" [] [],
                 },
             },
-            colon_token: COLON@1823..1825 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1843..1845 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssIdentifier {
-                            value_token: IDENT@1825..1830 "null" [] [Whitespace(" ")],
+                            value_token: IDENT@1845..1850 "null" [] [Whitespace(" ")],
                         },
-                        operator: OR_KW@1830..1833 "or" [] [Whitespace(" ")],
+                        operator: OR_KW@1850..1853 "or" [] [Whitespace(" ")],
                         right: CssString {
-                            value_token: CSS_STRING_LITERAL@1833..1842 "\"default\"" [] [],
+                            value_token: CSS_STRING_LITERAL@1853..1862 "\"default\"" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1842..1843 ";" [] [],
+            semicolon_token: SEMICOLON@1862..1863 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1843..1845 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1863..1865 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1845..1855 "null-check" [] [],
+                    value_token: IDENT@1865..1875 "null-check" [] [],
                 },
             },
-            colon_token: COLON@1855..1857 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1875..1877 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: ScssVariable {
-                            dollar_token: DOLLAR@1857..1858 "$" [] [],
+                            dollar_token: DOLLAR@1877..1878 "$" [] [],
                             name: CssIdentifier {
-                                value_token: IDENT@1858..1862 "var" [] [Whitespace(" ")],
+                                value_token: IDENT@1878..1882 "var" [] [Whitespace(" ")],
                             },
                         },
-                        operator: OR_KW@1862..1865 "or" [] [Whitespace(" ")],
+                        operator: OR_KW@1882..1885 "or" [] [Whitespace(" ")],
                         right: CssString {
-                            value_token: CSS_STRING_LITERAL@1865..1875 "\"fallback\"" [] [],
+                            value_token: CSS_STRING_LITERAL@1885..1895 "\"fallback\"" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1875..1876 ";" [] [],
+            semicolon_token: SEMICOLON@1895..1896 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1876..1914 "$" [Newline("\n"), Newline("\n"), Comments("// Boolean expression ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@1896..1934 "$" [Newline("\n"), Newline("\n"), Comments("// Boolean expression ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1914..1925 "bool-or-val" [] [],
+                    value_token: IDENT@1934..1945 "bool-or-val" [] [],
                 },
             },
-            colon_token: COLON@1925..1927 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1945..1947 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssIdentifier {
-                            value_token: IDENT@1927..1933 "false" [] [Whitespace(" ")],
+                            value_token: IDENT@1947..1953 "false" [] [Whitespace(" ")],
                         },
-                        operator: OR_KW@1933..1936 "or" [] [Whitespace(" ")],
+                        operator: OR_KW@1953..1956 "or" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@1936..1938 "10" [] [],
+                            value_token: CSS_NUMBER_LITERAL@1956..1958 "10" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1938..1939 ";" [] [],
+            semicolon_token: SEMICOLON@1958..1959 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1939..1941 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@1959..1961 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@1941..1953 "bool-and-val" [] [],
+                    value_token: IDENT@1961..1973 "bool-and-val" [] [],
                 },
             },
-            colon_token: COLON@1953..1955 ":" [] [Whitespace(" ")],
+            colon_token: COLON@1973..1975 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssIdentifier {
-                            value_token: IDENT@1955..1960 "true" [] [Whitespace(" ")],
+                            value_token: IDENT@1975..1980 "true" [] [Whitespace(" ")],
                         },
-                        operator: AND_KW@1960..1964 "and" [] [Whitespace(" ")],
+                        operator: AND_KW@1980..1984 "and" [] [Whitespace(" ")],
                         right: CssString {
-                            value_token: CSS_STRING_LITERAL@1964..1971 "\"value\"" [] [],
+                            value_token: CSS_STRING_LITERAL@1984..1991 "\"value\"" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@1971..1972 ";" [] [],
+            semicolon_token: SEMICOLON@1991..1992 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@1972..2000 "$" [Newline("\n"), Newline("\n"), Comments("// Nested function calls"), Newline("\n")] [],
+                dollar_token: DOLLAR@1992..2020 "$" [Newline("\n"), Newline("\n"), Comments("// Nested function calls"), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2000..2011 "nested-func" [] [],
+                    value_token: IDENT@2020..2031 "nested-func" [] [],
                 },
             },
-            colon_token: COLON@2011..2013 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2031..2033 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     CssFunction {
                         name: CssIdentifier {
-                            value_token: IDENT@2013..2018 "round" [] [],
+                            value_token: IDENT@2033..2038 "round" [] [],
                         },
-                        l_paren_token: L_PAREN@2018..2019 "(" [] [],
+                        l_paren_token: L_PAREN@2038..2039 "(" [] [],
                         items: CssParameterList [
                             ScssExpression {
                                 items: ScssExpressionItemList [
                                     CssFunction {
                                         name: CssIdentifier {
-                                            value_token: IDENT@2019..2023 "sqrt" [] [],
+                                            value_token: IDENT@2039..2043 "sqrt" [] [],
                                         },
-                                        l_paren_token: L_PAREN@2023..2024 "(" [] [],
+                                        l_paren_token: L_PAREN@2043..2044 "(" [] [],
                                         items: CssParameterList [
                                             ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     CssFunction {
                                                         name: CssIdentifier {
-                                                            value_token: IDENT@2024..2027 "abs" [] [],
+                                                            value_token: IDENT@2044..2047 "abs" [] [],
                                                         },
-                                                        l_paren_token: L_PAREN@2027..2028 "(" [] [],
+                                                        l_paren_token: L_PAREN@2047..2048 "(" [] [],
                                                         items: CssParameterList [
                                                             ScssExpression {
                                                                 items: ScssExpressionItemList [
                                                                     CssNumber {
-                                                                        value_token: CSS_NUMBER_LITERAL@2028..2031 "-16" [] [],
+                                                                        value_token: CSS_NUMBER_LITERAL@2048..2051 "-16" [] [],
                                                                     },
                                                                 ],
                                                             },
                                                         ],
-                                                        r_paren_token: R_PAREN@2031..2032 ")" [] [],
+                                                        r_paren_token: R_PAREN@2051..2052 ")" [] [],
                                                     },
                                                 ],
                                             },
                                         ],
-                                        r_paren_token: R_PAREN@2032..2033 ")" [] [],
+                                        r_paren_token: R_PAREN@2052..2053 ")" [] [],
                                     },
                                 ],
                             },
                         ],
-                        r_paren_token: R_PAREN@2033..2034 ")" [] [],
+                        r_paren_token: R_PAREN@2053..2054 ")" [] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2034..2035 ";" [] [],
+            semicolon_token: SEMICOLON@2054..2055 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2035..2065 "$" [Newline("\n"), Newline("\n"), Comments("// Expression as map  ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@2055..2085 "$" [Newline("\n"), Newline("\n"), Comments("// Expression as map  ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2065..2076 "expr-in-map" [] [],
+                    value_token: IDENT@2085..2096 "expr-in-map" [] [],
                 },
             },
-            colon_token: COLON@2076..2078 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2096..2098 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssMapExpression {
-                        l_paren_token: L_PAREN@2078..2079 "(" [] [],
+                        l_paren_token: L_PAREN@2098..2099 "(" [] [],
                         pairs: ScssMapExpressionPairList [
                             ScssMapExpressionPair {
                                 key: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssIdentifier {
-                                            value_token: IDENT@2079..2085 "sum" [Newline("\n"), Whitespace("  ")] [],
-                                        },
-                                    ],
-                                },
-                                colon_token: COLON@2085..2087 ":" [] [Whitespace(" ")],
-                                value: ScssExpression {
-                                    items: ScssExpressionItemList [
-                                        ScssBinaryExpression {
-                                            left: ScssVariable {
-                                                dollar_token: DOLLAR@2087..2088 "$" [] [],
-                                                name: CssIdentifier {
-                                                    value_token: IDENT@2088..2090 "a" [] [Whitespace(" ")],
-                                                },
-                                            },
-                                            operator: PLUS@2090..2092 "+" [] [Whitespace(" ")],
-                                            right: ScssVariable {
-                                                dollar_token: DOLLAR@2092..2093 "$" [] [],
-                                                name: CssIdentifier {
-                                                    value_token: IDENT@2093..2094 "b" [] [],
-                                                },
-                                            },
-                                        },
-                                    ],
-                                },
-                            },
-                            COMMA@2094..2095 "," [] [],
-                            ScssMapExpressionPair {
-                                key: ScssExpression {
-                                    items: ScssExpressionItemList [
-                                        CssIdentifier {
-                                            value_token: IDENT@2095..2105 "product" [Newline("\n"), Whitespace("  ")] [],
+                                            value_token: IDENT@2099..2105 "sum" [Newline("\n"), Whitespace("  ")] [],
                                         },
                                     ],
                                 },
@@ -2150,7 +2144,7 @@ CssRoot {
                                                     value_token: IDENT@2108..2110 "a" [] [Whitespace(" ")],
                                                 },
                                             },
-                                            operator: STAR@2110..2112 "*" [] [Whitespace(" ")],
+                                            operator: PLUS@2110..2112 "+" [] [Whitespace(" ")],
                                             right: ScssVariable {
                                                 dollar_token: DOLLAR@2112..2113 "$" [] [],
                                                 name: CssIdentifier {
@@ -2166,52 +2160,82 @@ CssRoot {
                                 key: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssIdentifier {
-                                            value_token: IDENT@2115..2128 "comparison" [Newline("\n"), Whitespace("  ")] [],
+                                            value_token: IDENT@2115..2125 "product" [Newline("\n"), Whitespace("  ")] [],
                                         },
                                     ],
                                 },
-                                colon_token: COLON@2128..2130 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@2125..2127 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssBinaryExpression {
                                             left: ScssVariable {
-                                                dollar_token: DOLLAR@2130..2131 "$" [] [],
+                                                dollar_token: DOLLAR@2127..2128 "$" [] [],
                                                 name: CssIdentifier {
-                                                    value_token: IDENT@2131..2133 "a" [] [Whitespace(" ")],
+                                                    value_token: IDENT@2128..2130 "a" [] [Whitespace(" ")],
                                                 },
                                             },
-                                            operator: R_ANGLE@2133..2135 ">" [] [Whitespace(" ")],
+                                            operator: STAR@2130..2132 "*" [] [Whitespace(" ")],
                                             right: ScssVariable {
-                                                dollar_token: DOLLAR@2135..2136 "$" [] [],
+                                                dollar_token: DOLLAR@2132..2133 "$" [] [],
                                                 name: CssIdentifier {
-                                                    value_token: IDENT@2136..2137 "b" [] [],
+                                                    value_token: IDENT@2133..2134 "b" [] [],
                                                 },
                                             },
                                         },
                                     ],
                                 },
                             },
-                            COMMA@2137..2138 "," [] [],
+                            COMMA@2134..2135 "," [] [],
+                            ScssMapExpressionPair {
+                                key: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssIdentifier {
+                                            value_token: IDENT@2135..2148 "comparison" [Newline("\n"), Whitespace("  ")] [],
+                                        },
+                                    ],
+                                },
+                                colon_token: COLON@2148..2150 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssBinaryExpression {
+                                            left: ScssVariable {
+                                                dollar_token: DOLLAR@2150..2151 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@2151..2153 "a" [] [Whitespace(" ")],
+                                                },
+                                            },
+                                            operator: R_ANGLE@2153..2155 ">" [] [Whitespace(" ")],
+                                            right: ScssVariable {
+                                                dollar_token: DOLLAR@2155..2156 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@2156..2157 "b" [] [],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            COMMA@2157..2158 "," [] [],
                         ],
-                        r_paren_token: R_PAREN@2138..2140 ")" [Newline("\n")] [],
+                        r_paren_token: R_PAREN@2158..2160 ")" [Newline("\n")] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2140..2141 ";" [] [],
+            semicolon_token: SEMICOLON@2160..2161 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2141..2171 "$" [Newline("\n"), Newline("\n"), Comments("// Expression as list ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@2161..2191 "$" [Newline("\n"), Newline("\n"), Comments("// Expression as list ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2171..2183 "expr-in-list" [] [],
+                    value_token: IDENT@2191..2203 "expr-in-list" [] [],
                 },
             },
-            colon_token: COLON@2183..2185 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2203..2205 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssParenthesizedExpression {
-                        l_paren_token: L_PAREN@2185..2186 "(" [] [],
+                        l_paren_token: L_PAREN@2205..2206 "(" [] [],
                         expression: ScssListExpression {
                             elements: ScssListExpressionElementList [
                                 ScssListExpressionElement {
@@ -2219,60 +2243,60 @@ CssRoot {
                                         items: ScssExpressionItemList [
                                             ScssBinaryExpression {
                                                 left: ScssVariable {
-                                                    dollar_token: DOLLAR@2186..2187 "$" [] [],
+                                                    dollar_token: DOLLAR@2206..2207 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@2187..2189 "a" [] [Whitespace(" ")],
+                                                        value_token: IDENT@2207..2209 "a" [] [Whitespace(" ")],
                                                     },
                                                 },
-                                                operator: PLUS@2189..2191 "+" [] [Whitespace(" ")],
+                                                operator: PLUS@2209..2211 "+" [] [Whitespace(" ")],
                                                 right: ScssVariable {
-                                                    dollar_token: DOLLAR@2191..2192 "$" [] [],
+                                                    dollar_token: DOLLAR@2211..2212 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@2192..2193 "b" [] [],
+                                                        value_token: IDENT@2212..2213 "b" [] [],
                                                     },
                                                 },
                                             },
                                         ],
                                     },
                                 },
-                                COMMA@2193..2195 "," [] [Whitespace(" ")],
+                                COMMA@2213..2215 "," [] [Whitespace(" ")],
                                 ScssListExpressionElement {
                                     value: ScssExpression {
                                         items: ScssExpressionItemList [
                                             ScssBinaryExpression {
                                                 left: ScssVariable {
-                                                    dollar_token: DOLLAR@2195..2196 "$" [] [],
+                                                    dollar_token: DOLLAR@2215..2216 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@2196..2198 "a" [] [Whitespace(" ")],
+                                                        value_token: IDENT@2216..2218 "a" [] [Whitespace(" ")],
                                                     },
                                                 },
-                                                operator: STAR@2198..2200 "*" [] [Whitespace(" ")],
+                                                operator: STAR@2218..2220 "*" [] [Whitespace(" ")],
                                                 right: ScssVariable {
-                                                    dollar_token: DOLLAR@2200..2201 "$" [] [],
+                                                    dollar_token: DOLLAR@2220..2221 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@2201..2202 "b" [] [],
+                                                        value_token: IDENT@2221..2222 "b" [] [],
                                                     },
                                                 },
                                             },
                                         ],
                                     },
                                 },
-                                COMMA@2202..2204 "," [] [Whitespace(" ")],
+                                COMMA@2222..2224 "," [] [Whitespace(" ")],
                                 ScssListExpressionElement {
                                     value: ScssExpression {
                                         items: ScssExpressionItemList [
                                             ScssBinaryExpression {
                                                 left: ScssVariable {
-                                                    dollar_token: DOLLAR@2204..2205 "$" [] [],
+                                                    dollar_token: DOLLAR@2224..2225 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@2205..2207 "a" [] [Whitespace(" ")],
+                                                        value_token: IDENT@2225..2227 "a" [] [Whitespace(" ")],
                                                     },
                                                 },
-                                                operator: R_ANGLE@2207..2209 ">" [] [Whitespace(" ")],
+                                                operator: R_ANGLE@2227..2229 ">" [] [Whitespace(" ")],
                                                 right: ScssVariable {
-                                                    dollar_token: DOLLAR@2209..2210 "$" [] [],
+                                                    dollar_token: DOLLAR@2229..2230 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@2210..2211 "b" [] [],
+                                                        value_token: IDENT@2230..2231 "b" [] [],
                                                     },
                                                 },
                                             },
@@ -2281,21 +2305,21 @@ CssRoot {
                                 },
                             ],
                         },
-                        r_paren_token: R_PAREN@2211..2212 ")" [] [],
+                        r_paren_token: R_PAREN@2231..2232 ")" [] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2212..2213 ";" [] [],
+            semicolon_token: SEMICOLON@2232..2233 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2213..2250 "$" [Newline("\n"), Newline("\n"), Comments("// Comma operator (li ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@2233..2270 "$" [Newline("\n"), Newline("\n"), Comments("// Comma operator (li ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2250..2260 "comma-expr" [] [],
+                    value_token: IDENT@2270..2280 "comma-expr" [] [],
                 },
             },
-            colon_token: COLON@2260..2262 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2280..2282 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssListExpression {
@@ -2304,27 +2328,27 @@ CssRoot {
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@2262..2263 "1" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@2282..2283 "1" [] [],
                                         },
                                     ],
                                 },
                             },
-                            COMMA@2263..2265 "," [] [Whitespace(" ")],
+                            COMMA@2283..2285 "," [] [Whitespace(" ")],
                             ScssListExpressionElement {
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@2265..2266 "2" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@2285..2286 "2" [] [],
                                         },
                                     ],
                                 },
                             },
-                            COMMA@2266..2268 "," [] [Whitespace(" ")],
+                            COMMA@2286..2288 "," [] [Whitespace(" ")],
                             ScssListExpressionElement {
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@2268..2269 "3" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@2288..2289 "3" [] [],
                                         },
                                     ],
                                 },
@@ -2334,268 +2358,268 @@ CssRoot {
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2269..2270 ";" [] [],
+            semicolon_token: SEMICOLON@2289..2290 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2270..2307 "$" [Newline("\n"), Newline("\n"), Comments("// Space operator (li ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@2290..2327 "$" [Newline("\n"), Newline("\n"), Comments("// Space operator (li ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2307..2317 "space-expr" [] [],
+                    value_token: IDENT@2327..2337 "space-expr" [] [],
                 },
             },
-            colon_token: COLON@2317..2319 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2337..2339 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     CssNumber {
-                        value_token: CSS_NUMBER_LITERAL@2319..2321 "1" [] [Whitespace(" ")],
+                        value_token: CSS_NUMBER_LITERAL@2339..2341 "1" [] [Whitespace(" ")],
                     },
                     CssNumber {
-                        value_token: CSS_NUMBER_LITERAL@2321..2323 "2" [] [Whitespace(" ")],
+                        value_token: CSS_NUMBER_LITERAL@2341..2343 "2" [] [Whitespace(" ")],
                     },
                     CssNumber {
-                        value_token: CSS_NUMBER_LITERAL@2323..2324 "3" [] [],
+                        value_token: CSS_NUMBER_LITERAL@2343..2344 "3" [] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2324..2325 ";" [] [],
+            semicolon_token: SEMICOLON@2344..2345 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2325..2356 "$" [Newline("\n"), Newline("\n"), Comments("// Mixed in complex c ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@2345..2376 "$" [Newline("\n"), Newline("\n"), Comments("// Mixed in complex c ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2356..2363 "complex" [] [],
+                    value_token: IDENT@2376..2383 "complex" [] [],
                 },
             },
-            colon_token: COLON@2363..2365 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2383..2385 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssMapExpression {
-                        l_paren_token: L_PAREN@2365..2366 "(" [] [],
+                        l_paren_token: L_PAREN@2385..2386 "(" [] [],
                         pairs: ScssMapExpressionPairList [
                             ScssMapExpressionPair {
                                 key: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssIdentifier {
-                                            value_token: IDENT@2366..2373 "calc" [Newline("\n"), Whitespace("  ")] [],
+                                            value_token: IDENT@2386..2393 "calc" [Newline("\n"), Whitespace("  ")] [],
                                         },
                                     ],
                                 },
-                                colon_token: COLON@2373..2375 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@2393..2395 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssBinaryExpression {
                                             left: ScssParenthesizedExpression {
-                                                l_paren_token: L_PAREN@2375..2376 "(" [] [],
+                                                l_paren_token: L_PAREN@2395..2396 "(" [] [],
                                                 expression: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         ScssBinaryExpression {
                                                             left: CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@2376..2378 "1" [] [Whitespace(" ")],
+                                                                value_token: CSS_NUMBER_LITERAL@2396..2398 "1" [] [Whitespace(" ")],
                                                             },
-                                                            operator: PLUS@2378..2380 "+" [] [Whitespace(" ")],
+                                                            operator: PLUS@2398..2400 "+" [] [Whitespace(" ")],
                                                             right: CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@2380..2381 "2" [] [],
+                                                                value_token: CSS_NUMBER_LITERAL@2400..2401 "2" [] [],
                                                             },
                                                         },
                                                     ],
                                                 },
-                                                r_paren_token: R_PAREN@2381..2383 ")" [] [Whitespace(" ")],
+                                                r_paren_token: R_PAREN@2401..2403 ")" [] [Whitespace(" ")],
                                             },
-                                            operator: STAR@2383..2385 "*" [] [Whitespace(" ")],
+                                            operator: STAR@2403..2405 "*" [] [Whitespace(" ")],
                                             right: ScssParenthesizedExpression {
-                                                l_paren_token: L_PAREN@2385..2386 "(" [] [],
+                                                l_paren_token: L_PAREN@2405..2406 "(" [] [],
                                                 expression: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         ScssBinaryExpression {
                                                             left: CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@2386..2388 "3" [] [Whitespace(" ")],
+                                                                value_token: CSS_NUMBER_LITERAL@2406..2408 "3" [] [Whitespace(" ")],
                                                             },
-                                                            operator: PLUS@2388..2390 "+" [] [Whitespace(" ")],
+                                                            operator: PLUS@2408..2410 "+" [] [Whitespace(" ")],
                                                             right: CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@2390..2391 "4" [] [],
+                                                                value_token: CSS_NUMBER_LITERAL@2410..2411 "4" [] [],
                                                             },
                                                         },
                                                     ],
                                                 },
-                                                r_paren_token: R_PAREN@2391..2392 ")" [] [],
+                                                r_paren_token: R_PAREN@2411..2412 ")" [] [],
                                             },
                                         },
                                     ],
                                 },
                             },
-                            COMMA@2392..2393 "," [] [],
+                            COMMA@2412..2413 "," [] [],
                             ScssMapExpressionPair {
                                 key: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssIdentifier {
-                                            value_token: IDENT@2393..2401 "logic" [Newline("\n"), Whitespace("  ")] [],
+                                            value_token: IDENT@2413..2421 "logic" [Newline("\n"), Whitespace("  ")] [],
                                         },
                                     ],
                                 },
-                                colon_token: COLON@2401..2403 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@2421..2423 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssBinaryExpression {
                                             left: ScssParenthesizedExpression {
-                                                l_paren_token: L_PAREN@2403..2404 "(" [] [],
+                                                l_paren_token: L_PAREN@2423..2424 "(" [] [],
                                                 expression: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         ScssBinaryExpression {
                                                             left: CssIdentifier {
-                                                                value_token: IDENT@2404..2409 "true" [] [Whitespace(" ")],
+                                                                value_token: IDENT@2424..2429 "true" [] [Whitespace(" ")],
                                                             },
-                                                            operator: AND_KW@2409..2413 "and" [] [Whitespace(" ")],
+                                                            operator: AND_KW@2429..2433 "and" [] [Whitespace(" ")],
                                                             right: CssIdentifier {
-                                                                value_token: IDENT@2413..2418 "false" [] [],
+                                                                value_token: IDENT@2433..2438 "false" [] [],
                                                             },
                                                         },
                                                     ],
                                                 },
-                                                r_paren_token: R_PAREN@2418..2420 ")" [] [Whitespace(" ")],
+                                                r_paren_token: R_PAREN@2438..2440 ")" [] [Whitespace(" ")],
                                             },
-                                            operator: OR_KW@2420..2423 "or" [] [Whitespace(" ")],
+                                            operator: OR_KW@2440..2443 "or" [] [Whitespace(" ")],
                                             right: CssIdentifier {
-                                                value_token: IDENT@2423..2427 "true" [] [],
+                                                value_token: IDENT@2443..2447 "true" [] [],
                                             },
                                         },
                                     ],
                                 },
                             },
-                            COMMA@2427..2428 "," [] [],
+                            COMMA@2447..2448 "," [] [],
                             ScssMapExpressionPair {
                                 key: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssIdentifier {
-                                            value_token: IDENT@2428..2438 "compare" [Newline("\n"), Whitespace("  ")] [],
+                                            value_token: IDENT@2448..2458 "compare" [Newline("\n"), Whitespace("  ")] [],
                                         },
                                     ],
                                 },
-                                colon_token: COLON@2438..2440 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@2458..2460 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssBinaryExpression {
                                             left: ScssParenthesizedExpression {
-                                                l_paren_token: L_PAREN@2440..2441 "(" [] [],
+                                                l_paren_token: L_PAREN@2460..2461 "(" [] [],
                                                 expression: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         ScssBinaryExpression {
                                                             left: CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@2441..2444 "10" [] [Whitespace(" ")],
+                                                                value_token: CSS_NUMBER_LITERAL@2461..2464 "10" [] [Whitespace(" ")],
                                                             },
-                                                            operator: R_ANGLE@2444..2446 ">" [] [Whitespace(" ")],
+                                                            operator: R_ANGLE@2464..2466 ">" [] [Whitespace(" ")],
                                                             right: CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@2446..2447 "5" [] [],
+                                                                value_token: CSS_NUMBER_LITERAL@2466..2467 "5" [] [],
                                                             },
                                                         },
                                                     ],
                                                 },
-                                                r_paren_token: R_PAREN@2447..2449 ")" [] [Whitespace(" ")],
+                                                r_paren_token: R_PAREN@2467..2469 ")" [] [Whitespace(" ")],
                                             },
-                                            operator: AND_KW@2449..2453 "and" [] [Whitespace(" ")],
+                                            operator: AND_KW@2469..2473 "and" [] [Whitespace(" ")],
                                             right: ScssParenthesizedExpression {
-                                                l_paren_token: L_PAREN@2453..2454 "(" [] [],
+                                                l_paren_token: L_PAREN@2473..2474 "(" [] [],
                                                 expression: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         ScssBinaryExpression {
                                                             left: CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@2454..2457 "20" [] [Whitespace(" ")],
+                                                                value_token: CSS_NUMBER_LITERAL@2474..2477 "20" [] [Whitespace(" ")],
                                                             },
-                                                            operator: L_ANGLE@2457..2459 "<" [] [Whitespace(" ")],
+                                                            operator: L_ANGLE@2477..2479 "<" [] [Whitespace(" ")],
                                                             right: CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@2459..2461 "30" [] [],
+                                                                value_token: CSS_NUMBER_LITERAL@2479..2481 "30" [] [],
                                                             },
                                                         },
                                                     ],
                                                 },
-                                                r_paren_token: R_PAREN@2461..2462 ")" [] [],
+                                                r_paren_token: R_PAREN@2481..2482 ")" [] [],
                                             },
                                         },
                                     ],
                                 },
                             },
-                            COMMA@2462..2463 "," [] [],
+                            COMMA@2482..2483 "," [] [],
                             ScssMapExpressionPair {
                                 key: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssIdentifier {
-                                            value_token: IDENT@2463..2472 "nested" [Newline("\n"), Whitespace("  ")] [],
+                                            value_token: IDENT@2483..2492 "nested" [Newline("\n"), Whitespace("  ")] [],
                                         },
                                     ],
                                 },
-                                colon_token: COLON@2472..2474 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@2492..2494 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssParenthesizedExpression {
-                                            l_paren_token: L_PAREN@2474..2475 "(" [] [],
+                                            l_paren_token: L_PAREN@2494..2495 "(" [] [],
                                             expression: ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     ScssBinaryExpression {
                                                         left: ScssParenthesizedExpression {
-                                                            l_paren_token: L_PAREN@2475..2476 "(" [] [],
+                                                            l_paren_token: L_PAREN@2495..2496 "(" [] [],
                                                             expression: ScssExpression {
                                                                 items: ScssExpressionItemList [
                                                                     ScssBinaryExpression {
                                                                         left: CssNumber {
-                                                                            value_token: CSS_NUMBER_LITERAL@2476..2478 "1" [] [Whitespace(" ")],
+                                                                            value_token: CSS_NUMBER_LITERAL@2496..2498 "1" [] [Whitespace(" ")],
                                                                         },
-                                                                        operator: PLUS@2478..2480 "+" [] [Whitespace(" ")],
+                                                                        operator: PLUS@2498..2500 "+" [] [Whitespace(" ")],
                                                                         right: ScssParenthesizedExpression {
-                                                                            l_paren_token: L_PAREN@2480..2481 "(" [] [],
+                                                                            l_paren_token: L_PAREN@2500..2501 "(" [] [],
                                                                             expression: ScssExpression {
                                                                                 items: ScssExpressionItemList [
                                                                                     ScssBinaryExpression {
                                                                                         left: CssNumber {
-                                                                                            value_token: CSS_NUMBER_LITERAL@2481..2483 "2" [] [Whitespace(" ")],
+                                                                                            value_token: CSS_NUMBER_LITERAL@2501..2503 "2" [] [Whitespace(" ")],
                                                                                         },
-                                                                                        operator: STAR@2483..2485 "*" [] [Whitespace(" ")],
+                                                                                        operator: STAR@2503..2505 "*" [] [Whitespace(" ")],
                                                                                         right: CssNumber {
-                                                                                            value_token: CSS_NUMBER_LITERAL@2485..2486 "3" [] [],
+                                                                                            value_token: CSS_NUMBER_LITERAL@2505..2506 "3" [] [],
                                                                                         },
                                                                                     },
                                                                                 ],
                                                                             },
-                                                                            r_paren_token: R_PAREN@2486..2487 ")" [] [],
+                                                                            r_paren_token: R_PAREN@2506..2507 ")" [] [],
                                                                         },
                                                                     },
                                                                 ],
                                                             },
-                                                            r_paren_token: R_PAREN@2487..2489 ")" [] [Whitespace(" ")],
+                                                            r_paren_token: R_PAREN@2507..2509 ")" [] [Whitespace(" ")],
                                                         },
-                                                        operator: MINUS@2489..2491 "-" [] [Whitespace(" ")],
+                                                        operator: MINUS@2509..2511 "-" [] [Whitespace(" ")],
                                                         right: ScssParenthesizedExpression {
-                                                            l_paren_token: L_PAREN@2491..2492 "(" [] [],
+                                                            l_paren_token: L_PAREN@2511..2512 "(" [] [],
                                                             expression: ScssExpression {
                                                                 items: ScssExpressionItemList [
-                                                                    CssRatio {
-                                                                        numerator: CssNumber {
-                                                                            value_token: CSS_NUMBER_LITERAL@2492..2494 "4" [] [Whitespace(" ")],
+                                                                    ScssBinaryExpression {
+                                                                        left: CssNumber {
+                                                                            value_token: CSS_NUMBER_LITERAL@2512..2514 "4" [] [Whitespace(" ")],
                                                                         },
-                                                                        slash_token: SLASH@2494..2496 "/" [] [Whitespace(" ")],
-                                                                        denominator: CssNumber {
-                                                                            value_token: CSS_NUMBER_LITERAL@2496..2497 "2" [] [],
+                                                                        operator: SLASH@2514..2516 "/" [] [Whitespace(" ")],
+                                                                        right: CssNumber {
+                                                                            value_token: CSS_NUMBER_LITERAL@2516..2517 "2" [] [],
                                                                         },
                                                                     },
                                                                 ],
                                                             },
-                                                            r_paren_token: R_PAREN@2497..2498 ")" [] [],
+                                                            r_paren_token: R_PAREN@2517..2518 ")" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            r_paren_token: R_PAREN@2498..2499 ")" [] [],
+                                            r_paren_token: R_PAREN@2518..2519 ")" [] [],
                                         },
                                     ],
                                 },
                             },
-                            COMMA@2499..2500 "," [] [],
+                            COMMA@2519..2520 "," [] [],
                         ],
-                        r_paren_token: R_PAREN@2500..2502 ")" [Newline("\n")] [],
+                        r_paren_token: R_PAREN@2520..2522 ")" [Newline("\n")] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2502..2503 ";" [] [],
+            semicolon_token: SEMICOLON@2522..2523 ";" [] [],
         },
         CssQualifiedRule {
             prelude: CssSelectorList [
@@ -2604,29 +2628,29 @@ CssRoot {
                     simple_selector: missing (optional),
                     sub_selectors: CssSubSelectorList [
                         CssClassSelector {
-                            dot_token: DOT@2503..2534 "." [Newline("\n"), Newline("\n"), Comments("// Expressions in sel ..."), Newline("\n")] [],
+                            dot_token: DOT@2523..2554 "." [Newline("\n"), Newline("\n"), Comments("// Expressions in sel ..."), Newline("\n")] [],
                             name: ScssInterpolatedIdentifier {
                                 items: ScssInterpolatedIdentifierPartList [
                                     CssCustomIdentifier {
-                                        value_token: IDENT@2534..2540 "class-" [] [],
+                                        value_token: IDENT@2554..2560 "class-" [] [],
                                     },
                                     ScssInterpolation {
-                                        hash_token: HASH@2540..2541 "#" [] [],
-                                        l_curly_token: L_CURLY@2541..2542 "{" [] [],
+                                        hash_token: HASH@2560..2561 "#" [] [],
+                                        l_curly_token: L_CURLY@2561..2562 "{" [] [],
                                         value: ScssExpression {
                                             items: ScssExpressionItemList [
                                                 ScssBinaryExpression {
                                                     left: CssNumber {
-                                                        value_token: CSS_NUMBER_LITERAL@2542..2544 "1" [] [Whitespace(" ")],
+                                                        value_token: CSS_NUMBER_LITERAL@2562..2564 "1" [] [Whitespace(" ")],
                                                     },
-                                                    operator: PLUS@2544..2546 "+" [] [Whitespace(" ")],
+                                                    operator: PLUS@2564..2566 "+" [] [Whitespace(" ")],
                                                     right: CssNumber {
-                                                        value_token: CSS_NUMBER_LITERAL@2546..2547 "1" [] [],
+                                                        value_token: CSS_NUMBER_LITERAL@2566..2567 "1" [] [],
                                                     },
                                                 },
                                             ],
                                         },
-                                        r_curly_token: R_CURLY@2547..2549 "}" [] [Whitespace(" ")],
+                                        r_curly_token: R_CURLY@2567..2569 "}" [] [Whitespace(" ")],
                                     },
                                 ],
                             },
@@ -2635,29 +2659,29 @@ CssRoot {
                 },
             ],
             block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@2549..2550 "{" [] [],
+                l_curly_token: L_CURLY@2569..2570 "{" [] [],
                 items: CssDeclarationOrRuleList [
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
                                 name: CssIdentifier {
-                                    value_token: IDENT@2550..2558 "color" [Newline("\n"), Whitespace("  ")] [],
+                                    value_token: IDENT@2570..2578 "color" [Newline("\n"), Whitespace("  ")] [],
                                 },
-                                colon_token: COLON@2558..2560 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@2578..2580 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssIdentifier {
-                                            value_token: IDENT@2560..2563 "red" [] [],
+                                            value_token: IDENT@2580..2583 "red" [] [],
                                         },
                                     ],
                                 },
                             },
                             important: missing (optional),
                         },
-                        semicolon_token: SEMICOLON@2563..2564 ";" [] [],
+                        semicolon_token: SEMICOLON@2583..2584 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@2564..2566 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@2584..2586 "}" [Newline("\n")] [],
             },
         },
         CssQualifiedRule {
@@ -2667,80 +2691,80 @@ CssRoot {
                     simple_selector: missing (optional),
                     sub_selectors: CssSubSelectorList [
                         CssClassSelector {
-                            dot_token: DOT@2566..2603 "." [Newline("\n"), Newline("\n"), Comments("// Expressions in pro ..."), Newline("\n")] [],
+                            dot_token: DOT@2586..2623 "." [Newline("\n"), Newline("\n"), Comments("// Expressions in pro ..."), Newline("\n")] [],
                             name: CssCustomIdentifier {
-                                value_token: IDENT@2603..2608 "test" [] [Whitespace(" ")],
+                                value_token: IDENT@2623..2628 "test" [] [Whitespace(" ")],
                             },
                         },
                     ],
                 },
             ],
             block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@2608..2609 "{" [] [],
+                l_curly_token: L_CURLY@2628..2629 "{" [] [],
                 items: CssDeclarationOrRuleList [
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
                                 name: CssIdentifier {
-                                    value_token: IDENT@2609..2617 "width" [Newline("\n"), Whitespace("  ")] [],
+                                    value_token: IDENT@2629..2637 "width" [Newline("\n"), Whitespace("  ")] [],
                                 },
-                                colon_token: COLON@2617..2619 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@2637..2639 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssParenthesizedExpression {
-                                            l_paren_token: L_PAREN@2619..2620 "(" [] [],
+                                            l_paren_token: L_PAREN@2639..2640 "(" [] [],
                                             expression: ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     ScssBinaryExpression {
                                                         left: CssPercentage {
-                                                            value_token: CSS_NUMBER_LITERAL@2620..2623 "100" [] [],
-                                                            percent_token: PERCENT@2623..2625 "%" [] [Whitespace(" ")],
+                                                            value_token: CSS_NUMBER_LITERAL@2640..2643 "100" [] [],
+                                                            percent_token: PERCENT@2643..2645 "%" [] [Whitespace(" ")],
                                                         },
-                                                        operator: SLASH@2625..2627 "/" [] [Whitespace(" ")],
+                                                        operator: SLASH@2645..2647 "/" [] [Whitespace(" ")],
                                                         right: CssNumber {
-                                                            value_token: CSS_NUMBER_LITERAL@2627..2628 "3" [] [],
+                                                            value_token: CSS_NUMBER_LITERAL@2647..2648 "3" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            r_paren_token: R_PAREN@2628..2629 ")" [] [],
+                                            r_paren_token: R_PAREN@2648..2649 ")" [] [],
                                         },
                                     ],
                                 },
                             },
                             important: missing (optional),
                         },
-                        semicolon_token: SEMICOLON@2629..2630 ";" [] [],
+                        semicolon_token: SEMICOLON@2649..2650 ";" [] [],
                     },
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
                                 name: CssIdentifier {
-                                    value_token: IDENT@2630..2639 "height" [Newline("\n"), Whitespace("  ")] [],
+                                    value_token: IDENT@2650..2659 "height" [Newline("\n"), Whitespace("  ")] [],
                                 },
-                                colon_token: COLON@2639..2641 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@2659..2661 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssBinaryExpression {
                                             left: ScssBinaryExpression {
                                                 left: ScssVariable {
-                                                    dollar_token: DOLLAR@2641..2642 "$" [] [],
+                                                    dollar_token: DOLLAR@2661..2662 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@2642..2644 "a" [] [Whitespace(" ")],
+                                                        value_token: IDENT@2662..2664 "a" [] [Whitespace(" ")],
                                                     },
                                                 },
-                                                operator: PLUS@2644..2646 "+" [] [Whitespace(" ")],
+                                                operator: PLUS@2664..2666 "+" [] [Whitespace(" ")],
                                                 right: ScssVariable {
-                                                    dollar_token: DOLLAR@2646..2647 "$" [] [],
+                                                    dollar_token: DOLLAR@2666..2667 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@2647..2649 "b" [] [Whitespace(" ")],
+                                                        value_token: IDENT@2667..2669 "b" [] [Whitespace(" ")],
                                                     },
                                                 },
                                             },
-                                            operator: PLUS@2649..2651 "+" [] [Whitespace(" ")],
+                                            operator: PLUS@2669..2671 "+" [] [Whitespace(" ")],
                                             right: CssRegularDimension {
-                                                value_token: CSS_NUMBER_LITERAL@2651..2653 "10" [] [],
-                                                unit_token: IDENT@2653..2655 "px" [] [],
+                                                value_token: CSS_NUMBER_LITERAL@2671..2673 "10" [] [],
+                                                unit_token: IDENT@2673..2675 "px" [] [],
                                             },
                                         },
                                     ],
@@ -2748,121 +2772,97 @@ CssRoot {
                             },
                             important: missing (optional),
                         },
-                        semicolon_token: SEMICOLON@2655..2656 ";" [] [],
+                        semicolon_token: SEMICOLON@2675..2676 ";" [] [],
                     },
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
                                 name: CssIdentifier {
-                                    value_token: IDENT@2656..2665 "margin" [Newline("\n"), Whitespace("  ")] [],
+                                    value_token: IDENT@2676..2685 "margin" [Newline("\n"), Whitespace("  ")] [],
                                 },
-                                colon_token: COLON@2665..2667 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@2685..2687 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssParenthesizedExpression {
-                                            l_paren_token: L_PAREN@2667..2668 "(" [] [],
+                                            l_paren_token: L_PAREN@2687..2688 "(" [] [],
                                             expression: ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     ScssBinaryExpression {
                                                         left: ScssVariable {
-                                                            dollar_token: DOLLAR@2668..2669 "$" [] [],
+                                                            dollar_token: DOLLAR@2688..2689 "$" [] [],
                                                             name: CssIdentifier {
-                                                                value_token: IDENT@2669..2671 "a" [] [Whitespace(" ")],
+                                                                value_token: IDENT@2689..2691 "a" [] [Whitespace(" ")],
                                                             },
                                                         },
-                                                        operator: STAR@2671..2673 "*" [] [Whitespace(" ")],
+                                                        operator: STAR@2691..2693 "*" [] [Whitespace(" ")],
                                                         right: CssNumber {
-                                                            value_token: CSS_NUMBER_LITERAL@2673..2674 "2" [] [],
+                                                            value_token: CSS_NUMBER_LITERAL@2693..2694 "2" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            r_paren_token: R_PAREN@2674..2676 ")" [] [Whitespace(" ")],
+                                            r_paren_token: R_PAREN@2694..2696 ")" [] [Whitespace(" ")],
                                         },
                                         ScssParenthesizedExpression {
-                                            l_paren_token: L_PAREN@2676..2677 "(" [] [],
+                                            l_paren_token: L_PAREN@2696..2697 "(" [] [],
                                             expression: ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     ScssBinaryExpression {
                                                         left: ScssVariable {
-                                                            dollar_token: DOLLAR@2677..2678 "$" [] [],
+                                                            dollar_token: DOLLAR@2697..2698 "$" [] [],
                                                             name: CssIdentifier {
-                                                                value_token: IDENT@2678..2680 "b" [] [Whitespace(" ")],
+                                                                value_token: IDENT@2698..2700 "b" [] [Whitespace(" ")],
                                                             },
                                                         },
-                                                        operator: STAR@2680..2682 "*" [] [Whitespace(" ")],
+                                                        operator: STAR@2700..2702 "*" [] [Whitespace(" ")],
                                                         right: CssNumber {
-                                                            value_token: CSS_NUMBER_LITERAL@2682..2683 "2" [] [],
+                                                            value_token: CSS_NUMBER_LITERAL@2702..2703 "2" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            r_paren_token: R_PAREN@2683..2684 ")" [] [],
+                                            r_paren_token: R_PAREN@2703..2704 ")" [] [],
                                         },
                                     ],
                                 },
                             },
                             important: missing (optional),
                         },
-                        semicolon_token: SEMICOLON@2684..2685 ";" [] [],
+                        semicolon_token: SEMICOLON@2704..2705 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@2685..2687 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@2705..2707 "}" [Newline("\n")] [],
             },
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2687..2742 "$" [Newline("\n"), Newline("\n"), Comments("// Expressions with e ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@2707..2762 "$" [Newline("\n"), Newline("\n"), Comments("// Expressions with e ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2742..2746 "plus" [] [],
+                    value_token: IDENT@2762..2766 "plus" [] [],
                 },
             },
-            colon_token: COLON@2746..2748 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2766..2768 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2748..2751 "10" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@2768..2771 "10" [] [Whitespace(" ")],
                         },
-                        operator: PLUS@2751..2753 "+" [] [Whitespace(" ")],
+                        operator: PLUS@2771..2773 "+" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2753..2755 "20" [] [],
+                            value_token: CSS_NUMBER_LITERAL@2773..2775 "20" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2755..2756 ";" [] [],
+            semicolon_token: SEMICOLON@2775..2776 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2756..2758 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2776..2778 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2758..2763 "minus" [] [],
-                },
-            },
-            colon_token: COLON@2763..2765 ":" [] [Whitespace(" ")],
-            value: ScssExpression {
-                items: ScssExpressionItemList [
-                    ScssBinaryExpression {
-                        left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2765..2768 "30" [] [Whitespace(" ")],
-                        },
-                        operator: MINUS@2768..2770 "-" [] [Whitespace(" ")],
-                        right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2770..2772 "10" [] [],
-                        },
-                    },
-                ],
-            },
-            modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2772..2773 ";" [] [],
-        },
-        ScssVariableDeclaration {
-            name: ScssVariable {
-                dollar_token: DOLLAR@2773..2775 "$" [Newline("\n")] [],
-                name: CssIdentifier {
-                    value_token: IDENT@2775..2783 "multiply" [] [],
+                    value_token: IDENT@2778..2783 "minus" [] [],
                 },
             },
             colon_token: COLON@2783..2785 ":" [] [Whitespace(" ")],
@@ -2870,247 +2870,247 @@ CssRoot {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2785..2787 "5" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@2785..2788 "30" [] [Whitespace(" ")],
                         },
-                        operator: STAR@2787..2789 "*" [] [Whitespace(" ")],
+                        operator: MINUS@2788..2790 "-" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2789..2790 "4" [] [],
+                            value_token: CSS_NUMBER_LITERAL@2790..2792 "10" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2790..2791 ";" [] [],
+            semicolon_token: SEMICOLON@2792..2793 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2791..2793 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2793..2795 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2793..2799 "divide" [] [],
+                    value_token: IDENT@2795..2803 "multiply" [] [],
                 },
             },
-            colon_token: COLON@2799..2801 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2803..2805 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    ScssBinaryExpression {
+                        left: CssNumber {
+                            value_token: CSS_NUMBER_LITERAL@2805..2807 "5" [] [Whitespace(" ")],
+                        },
+                        operator: STAR@2807..2809 "*" [] [Whitespace(" ")],
+                        right: CssNumber {
+                            value_token: CSS_NUMBER_LITERAL@2809..2810 "4" [] [],
+                        },
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@2810..2811 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@2811..2813 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@2813..2819 "divide" [] [],
+                },
+            },
+            colon_token: COLON@2819..2821 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssParenthesizedExpression {
-                        l_paren_token: L_PAREN@2801..2802 "(" [] [],
+                        l_paren_token: L_PAREN@2821..2822 "(" [] [],
                         expression: ScssExpression {
                             items: ScssExpressionItemList [
-                                CssRatio {
-                                    numerator: CssNumber {
-                                        value_token: CSS_NUMBER_LITERAL@2802..2805 "20" [] [Whitespace(" ")],
+                                ScssBinaryExpression {
+                                    left: CssNumber {
+                                        value_token: CSS_NUMBER_LITERAL@2822..2825 "20" [] [Whitespace(" ")],
                                     },
-                                    slash_token: SLASH@2805..2807 "/" [] [Whitespace(" ")],
-                                    denominator: CssNumber {
-                                        value_token: CSS_NUMBER_LITERAL@2807..2808 "4" [] [],
+                                    operator: SLASH@2825..2827 "/" [] [Whitespace(" ")],
+                                    right: CssNumber {
+                                        value_token: CSS_NUMBER_LITERAL@2827..2828 "4" [] [],
                                     },
                                 },
                             ],
                         },
-                        r_paren_token: R_PAREN@2808..2809 ")" [] [],
+                        r_paren_token: R_PAREN@2828..2829 ")" [] [],
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2809..2810 ";" [] [],
+            semicolon_token: SEMICOLON@2829..2830 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2810..2812 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2830..2832 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2812..2818 "modulo" [] [],
+                    value_token: IDENT@2832..2838 "modulo" [] [],
                 },
             },
-            colon_token: COLON@2818..2820 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2838..2840 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2820..2823 "17" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@2840..2843 "17" [] [Whitespace(" ")],
                         },
-                        operator: PERCENT@2823..2825 "%" [] [Whitespace(" ")],
+                        operator: PERCENT@2843..2845 "%" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2825..2826 "5" [] [],
+                            value_token: CSS_NUMBER_LITERAL@2845..2846 "5" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2826..2827 ";" [] [],
+            semicolon_token: SEMICOLON@2846..2847 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2827..2829 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2847..2849 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2829..2831 "gt" [] [],
+                    value_token: IDENT@2849..2851 "gt" [] [],
                 },
             },
-            colon_token: COLON@2831..2833 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2851..2853 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2833..2836 "10" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@2853..2856 "10" [] [Whitespace(" ")],
                         },
-                        operator: R_ANGLE@2836..2838 ">" [] [Whitespace(" ")],
+                        operator: R_ANGLE@2856..2858 ">" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2838..2839 "5" [] [],
+                            value_token: CSS_NUMBER_LITERAL@2858..2859 "5" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2839..2840 ";" [] [],
+            semicolon_token: SEMICOLON@2859..2860 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2840..2842 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2860..2862 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2842..2845 "gte" [] [],
+                    value_token: IDENT@2862..2865 "gte" [] [],
                 },
             },
-            colon_token: COLON@2845..2847 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2865..2867 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2847..2850 "10" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@2867..2870 "10" [] [Whitespace(" ")],
                         },
-                        operator: GTEQ@2850..2853 ">=" [] [Whitespace(" ")],
+                        operator: GTEQ@2870..2873 ">=" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2853..2855 "10" [] [],
+                            value_token: CSS_NUMBER_LITERAL@2873..2875 "10" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2855..2856 ";" [] [],
+            semicolon_token: SEMICOLON@2875..2876 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2856..2858 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2876..2878 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2858..2860 "lt" [] [],
+                    value_token: IDENT@2878..2880 "lt" [] [],
                 },
             },
-            colon_token: COLON@2860..2862 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2880..2882 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2862..2864 "5" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@2882..2884 "5" [] [Whitespace(" ")],
                         },
-                        operator: L_ANGLE@2864..2866 "<" [] [Whitespace(" ")],
+                        operator: L_ANGLE@2884..2886 "<" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2866..2868 "10" [] [],
+                            value_token: CSS_NUMBER_LITERAL@2886..2888 "10" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2868..2869 ";" [] [],
+            semicolon_token: SEMICOLON@2888..2889 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2869..2871 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2889..2891 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2871..2874 "lte" [] [],
+                    value_token: IDENT@2891..2894 "lte" [] [],
                 },
             },
-            colon_token: COLON@2874..2876 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2894..2896 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2876..2878 "5" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@2896..2898 "5" [] [Whitespace(" ")],
                         },
-                        operator: LTEQ@2878..2881 "<=" [] [Whitespace(" ")],
+                        operator: LTEQ@2898..2901 "<=" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2881..2882 "5" [] [],
+                            value_token: CSS_NUMBER_LITERAL@2901..2902 "5" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2882..2883 ";" [] [],
+            semicolon_token: SEMICOLON@2902..2903 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2883..2885 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2903..2905 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2885..2887 "eq" [] [],
+                    value_token: IDENT@2905..2907 "eq" [] [],
                 },
             },
-            colon_token: COLON@2887..2889 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2907..2909 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2889..2892 "10" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@2909..2912 "10" [] [Whitespace(" ")],
                         },
-                        operator: EQ2@2892..2895 "==" [] [Whitespace(" ")],
+                        operator: EQ2@2912..2915 "==" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2895..2897 "10" [] [],
+                            value_token: CSS_NUMBER_LITERAL@2915..2917 "10" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2897..2898 ";" [] [],
+            semicolon_token: SEMICOLON@2917..2918 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2898..2900 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2918..2920 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2900..2903 "neq" [] [],
+                    value_token: IDENT@2920..2923 "neq" [] [],
                 },
             },
-            colon_token: COLON@2903..2905 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2923..2925 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2905..2908 "10" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@2925..2928 "10" [] [Whitespace(" ")],
                         },
-                        operator: NEQ@2908..2911 "!=" [] [Whitespace(" ")],
+                        operator: NEQ@2928..2931 "!=" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@2911..2912 "5" [] [],
+                            value_token: CSS_NUMBER_LITERAL@2931..2932 "5" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2912..2913 ";" [] [],
+            semicolon_token: SEMICOLON@2932..2933 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2913..2915 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@2933..2935 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2915..2918 "and" [] [],
-                },
-            },
-            colon_token: COLON@2918..2920 ":" [] [Whitespace(" ")],
-            value: ScssExpression {
-                items: ScssExpressionItemList [
-                    ScssBinaryExpression {
-                        left: CssIdentifier {
-                            value_token: IDENT@2920..2925 "true" [] [Whitespace(" ")],
-                        },
-                        operator: AND_KW@2925..2929 "and" [] [Whitespace(" ")],
-                        right: CssIdentifier {
-                            value_token: IDENT@2929..2933 "true" [] [],
-                        },
-                    },
-                ],
-            },
-            modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2933..2934 ";" [] [],
-        },
-        ScssVariableDeclaration {
-            name: ScssVariable {
-                dollar_token: DOLLAR@2934..2936 "$" [Newline("\n")] [],
-                name: CssIdentifier {
-                    value_token: IDENT@2936..2938 "or" [] [],
+                    value_token: IDENT@2935..2938 "and" [] [],
                 },
             },
             colon_token: COLON@2938..2940 ":" [] [Whitespace(" ")],
@@ -3118,9 +3118,9 @@ CssRoot {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssIdentifier {
-                            value_token: IDENT@2940..2946 "false" [] [Whitespace(" ")],
+                            value_token: IDENT@2940..2945 "true" [] [Whitespace(" ")],
                         },
-                        operator: OR_KW@2946..2949 "or" [] [Whitespace(" ")],
+                        operator: AND_KW@2945..2949 "and" [] [Whitespace(" ")],
                         right: CssIdentifier {
                             value_token: IDENT@2949..2953 "true" [] [],
                         },
@@ -3134,196 +3134,196 @@ CssRoot {
             name: ScssVariable {
                 dollar_token: DOLLAR@2954..2956 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@2956..2959 "not" [] [],
+                    value_token: IDENT@2956..2958 "or" [] [],
                 },
             },
-            colon_token: COLON@2959..2961 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2958..2960 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
-                    ScssUnaryExpression {
-                        operator: NOT_KW@2961..2965 "not" [] [Whitespace(" ")],
-                        expression: CssIdentifier {
-                            value_token: IDENT@2965..2970 "false" [] [],
+                    ScssBinaryExpression {
+                        left: CssIdentifier {
+                            value_token: IDENT@2960..2966 "false" [] [Whitespace(" ")],
+                        },
+                        operator: OR_KW@2966..2969 "or" [] [Whitespace(" ")],
+                        right: CssIdentifier {
+                            value_token: IDENT@2969..2973 "true" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@2970..2971 ";" [] [],
+            semicolon_token: SEMICOLON@2973..2974 ";" [] [],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@2971..3002 "$" [Newline("\n"), Newline("\n"), Comments("// Operator precedenc ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@2974..2976 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@3002..3013 "precedence1" [] [],
+                    value_token: IDENT@2976..2979 "not" [] [],
                 },
             },
-            colon_token: COLON@3013..3015 ":" [] [Whitespace(" ")],
+            colon_token: COLON@2979..2981 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    ScssUnaryExpression {
+                        operator: NOT_KW@2981..2985 "not" [] [Whitespace(" ")],
+                        expression: CssIdentifier {
+                            value_token: IDENT@2985..2990 "false" [] [],
+                        },
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@2990..2991 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@2991..3022 "$" [Newline("\n"), Newline("\n"), Comments("// Operator precedenc ..."), Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@3022..3033 "precedence1" [] [],
+                },
+            },
+            colon_token: COLON@3033..3035 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@3015..3017 "1" [] [Whitespace(" ")],
+                            value_token: CSS_NUMBER_LITERAL@3035..3037 "1" [] [Whitespace(" ")],
                         },
-                        operator: PLUS@3017..3019 "+" [] [Whitespace(" ")],
+                        operator: PLUS@3037..3039 "+" [] [Whitespace(" ")],
                         right: ScssBinaryExpression {
                             left: CssNumber {
-                                value_token: CSS_NUMBER_LITERAL@3019..3021 "2" [] [Whitespace(" ")],
+                                value_token: CSS_NUMBER_LITERAL@3039..3041 "2" [] [Whitespace(" ")],
                             },
-                            operator: STAR@3021..3023 "*" [] [Whitespace(" ")],
+                            operator: STAR@3041..3043 "*" [] [Whitespace(" ")],
                             right: CssNumber {
-                                value_token: CSS_NUMBER_LITERAL@3023..3024 "3" [] [],
+                                value_token: CSS_NUMBER_LITERAL@3043..3044 "3" [] [],
                             },
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@3024..3054 ";" [] [Whitespace(" "), Comments("// Should be 1 + (2 * ...")],
+            semicolon_token: SEMICOLON@3044..3074 ";" [] [Whitespace(" "), Comments("// Should be 1 + (2 * ...")],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@3054..3056 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@3074..3076 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@3056..3067 "precedence2" [] [],
+                    value_token: IDENT@3076..3087 "precedence2" [] [],
                 },
             },
-            colon_token: COLON@3067..3069 ":" [] [Whitespace(" ")],
+            colon_token: COLON@3087..3089 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: ScssParenthesizedExpression {
-                            l_paren_token: L_PAREN@3069..3070 "(" [] [],
+                            l_paren_token: L_PAREN@3089..3090 "(" [] [],
                             expression: ScssExpression {
                                 items: ScssExpressionItemList [
                                     ScssBinaryExpression {
                                         left: CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@3070..3072 "1" [] [Whitespace(" ")],
+                                            value_token: CSS_NUMBER_LITERAL@3090..3092 "1" [] [Whitespace(" ")],
                                         },
-                                        operator: PLUS@3072..3074 "+" [] [Whitespace(" ")],
+                                        operator: PLUS@3092..3094 "+" [] [Whitespace(" ")],
                                         right: CssNumber {
-                                            value_token: CSS_NUMBER_LITERAL@3074..3075 "2" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@3094..3095 "2" [] [],
                                         },
                                     },
                                 ],
                             },
-                            r_paren_token: R_PAREN@3075..3077 ")" [] [Whitespace(" ")],
+                            r_paren_token: R_PAREN@3095..3097 ")" [] [Whitespace(" ")],
                         },
-                        operator: STAR@3077..3079 "*" [] [Whitespace(" ")],
+                        operator: STAR@3097..3099 "*" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@3079..3080 "3" [] [],
+                            value_token: CSS_NUMBER_LITERAL@3099..3100 "3" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@3080..3096 ";" [] [Whitespace(" "), Comments("// Should be 9")],
+            semicolon_token: SEMICOLON@3100..3116 ";" [] [Whitespace(" "), Comments("// Should be 9")],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@3096..3098 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@3116..3118 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@3098..3109 "precedence3" [] [],
+                    value_token: IDENT@3118..3129 "precedence3" [] [],
                 },
             },
-            colon_token: COLON@3109..3111 ":" [] [Whitespace(" ")],
+            colon_token: COLON@3129..3131 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: ScssBinaryExpression {
                             left: CssNumber {
-                                value_token: CSS_NUMBER_LITERAL@3111..3114 "10" [] [Whitespace(" ")],
+                                value_token: CSS_NUMBER_LITERAL@3131..3134 "10" [] [Whitespace(" ")],
                             },
-                            operator: MINUS@3114..3116 "-" [] [Whitespace(" ")],
+                            operator: MINUS@3134..3136 "-" [] [Whitespace(" ")],
                             right: CssNumber {
-                                value_token: CSS_NUMBER_LITERAL@3116..3118 "5" [] [Whitespace(" ")],
+                                value_token: CSS_NUMBER_LITERAL@3136..3138 "5" [] [Whitespace(" ")],
                             },
                         },
-                        operator: MINUS@3118..3120 "-" [] [Whitespace(" ")],
+                        operator: MINUS@3138..3140 "-" [] [Whitespace(" ")],
                         right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@3120..3121 "2" [] [],
+                            value_token: CSS_NUMBER_LITERAL@3140..3141 "2" [] [],
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@3121..3157 ";" [] [Whitespace(" "), Comments("// Left-to-right: (10 ...")],
+            semicolon_token: SEMICOLON@3141..3177 ";" [] [Whitespace(" "), Comments("// Left-to-right: (10 ...")],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@3157..3159 "$" [Newline("\n")] [],
+                dollar_token: DOLLAR@3177..3179 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@3159..3170 "precedence4" [] [],
+                    value_token: IDENT@3179..3190 "precedence4" [] [],
                 },
             },
-            colon_token: COLON@3170..3172 ":" [] [Whitespace(" ")],
+            colon_token: COLON@3190..3192 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: ScssBinaryExpression {
                             left: CssNumber {
-                                value_token: CSS_NUMBER_LITERAL@3172..3174 "2" [] [Whitespace(" ")],
+                                value_token: CSS_NUMBER_LITERAL@3192..3194 "2" [] [Whitespace(" ")],
                             },
-                            operator: STAR@3174..3176 "*" [] [Whitespace(" ")],
+                            operator: STAR@3194..3196 "*" [] [Whitespace(" ")],
                             right: CssNumber {
-                                value_token: CSS_NUMBER_LITERAL@3176..3178 "3" [] [Whitespace(" ")],
+                                value_token: CSS_NUMBER_LITERAL@3196..3198 "3" [] [Whitespace(" ")],
                             },
                         },
-                        operator: PLUS@3178..3180 "+" [] [Whitespace(" ")],
+                        operator: PLUS@3198..3200 "+" [] [Whitespace(" ")],
                         right: ScssBinaryExpression {
                             left: CssNumber {
-                                value_token: CSS_NUMBER_LITERAL@3180..3182 "4" [] [Whitespace(" ")],
+                                value_token: CSS_NUMBER_LITERAL@3200..3202 "4" [] [Whitespace(" ")],
                             },
-                            operator: STAR@3182..3184 "*" [] [Whitespace(" ")],
+                            operator: STAR@3202..3204 "*" [] [Whitespace(" ")],
                             right: CssNumber {
-                                value_token: CSS_NUMBER_LITERAL@3184..3185 "5" [] [],
+                                value_token: CSS_NUMBER_LITERAL@3204..3205 "5" [] [],
                             },
                         },
                     },
                 ],
             },
             modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@3185..3218 ";" [] [Whitespace(" "), Comments("// Should be (2*3) +  ...")],
+            semicolon_token: SEMICOLON@3205..3238 ";" [] [Whitespace(" "), Comments("// Should be (2*3) +  ...")],
         },
         ScssVariableDeclaration {
             name: ScssVariable {
-                dollar_token: DOLLAR@3218..3251 "$" [Newline("\n"), Newline("\n"), Comments("// Edge cases with wh ..."), Newline("\n")] [],
+                dollar_token: DOLLAR@3238..3271 "$" [Newline("\n"), Newline("\n"), Comments("// Edge cases with wh ..."), Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@3251..3259 "no-space" [] [],
+                    value_token: IDENT@3271..3279 "no-space" [] [],
                 },
             },
-            colon_token: COLON@3259..3261 ":" [] [Whitespace(" ")],
+            colon_token: COLON@3279..3281 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@3261..3262 "1" [] [],
+                            value_token: CSS_NUMBER_LITERAL@3281..3282 "1" [] [],
                         },
-                        operator: PLUS@3262..3263 "+" [] [],
-                        right: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@3263..3264 "2" [] [],
-                        },
-                    },
-                ],
-            },
-            modifiers: ScssVariableModifierList [],
-            semicolon_token: SEMICOLON@3264..3265 ";" [] [],
-        },
-        ScssVariableDeclaration {
-            name: ScssVariable {
-                dollar_token: DOLLAR@3265..3267 "$" [Newline("\n")] [],
-                name: CssIdentifier {
-                    value_token: IDENT@3267..3277 "with-space" [] [],
-                },
-            },
-            colon_token: COLON@3277..3279 ":" [] [Whitespace(" ")],
-            value: ScssExpression {
-                items: ScssExpressionItemList [
-                    ScssBinaryExpression {
-                        left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@3279..3281 "1" [] [Whitespace(" ")],
-                        },
-                        operator: PLUS@3281..3283 "+" [] [Whitespace(" ")],
+                        operator: PLUS@3282..3283 "+" [] [],
                         right: CssNumber {
                             value_token: CSS_NUMBER_LITERAL@3283..3284 "2" [] [],
                         },
@@ -3337,15 +3337,15 @@ CssRoot {
             name: ScssVariable {
                 dollar_token: DOLLAR@3285..3287 "$" [Newline("\n")] [],
                 name: CssIdentifier {
-                    value_token: IDENT@3287..3298 "mixed-space" [] [],
+                    value_token: IDENT@3287..3297 "with-space" [] [],
                 },
             },
-            colon_token: COLON@3298..3300 ":" [] [Whitespace(" ")],
+            colon_token: COLON@3297..3299 ":" [] [Whitespace(" ")],
             value: ScssExpression {
                 items: ScssExpressionItemList [
                     ScssBinaryExpression {
                         left: CssNumber {
-                            value_token: CSS_NUMBER_LITERAL@3300..3301 "1" [] [],
+                            value_token: CSS_NUMBER_LITERAL@3299..3301 "1" [] [Whitespace(" ")],
                         },
                         operator: PLUS@3301..3303 "+" [] [Whitespace(" ")],
                         right: CssNumber {
@@ -3357,17 +3357,41 @@ CssRoot {
             modifiers: ScssVariableModifierList [],
             semicolon_token: SEMICOLON@3304..3305 ";" [] [],
         },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@3305..3307 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@3307..3318 "mixed-space" [] [],
+                },
+            },
+            colon_token: COLON@3318..3320 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    ScssBinaryExpression {
+                        left: CssNumber {
+                            value_token: CSS_NUMBER_LITERAL@3320..3321 "1" [] [],
+                        },
+                        operator: PLUS@3321..3323 "+" [] [Whitespace(" ")],
+                        right: CssNumber {
+                            value_token: CSS_NUMBER_LITERAL@3323..3324 "2" [] [],
+                        },
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@3324..3325 ";" [] [],
+        },
     ],
-    eof_token: EOF@3305..3306 "" [Newline("\n")] [],
+    eof_token: EOF@3325..3326 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..3306
+0: CSS_ROOT@0..3326
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..3305
+  1: CSS_ROOT_ITEM_LIST@0..3325
     0: SCSS_VARIABLE_DECLARATION@0..75
       0: SCSS_VARIABLE@0..65
         0: DOLLAR@0..59 "$" [Comments("// Complex SCSS expre ..."), Newline("\n"), Newline("\n"), Comments("// Parenthesized expr ..."), Newline("\n")] []
@@ -3562,7 +3586,7 @@ CssRoot {
                 2: CSS_NUMBER@264..266
                   0: CSS_NUMBER_LITERAL@264..266 "3" [] [Whitespace(" ")]
             1: MINUS@266..268 "-" [] [Whitespace(" ")]
-            2: CSS_RATIO@268..273
+            2: SCSS_BINARY_EXPRESSION@268..273
               0: CSS_NUMBER@268..270
                 0: CSS_NUMBER_LITERAL@268..270 "4" [] [Whitespace(" ")]
               1: SLASH@270..272 "/" [] [Whitespace(" ")]
@@ -4129,534 +4153,531 @@ CssRoot {
               0: IDENT@1193..1196 "ing" [] []
       3: SCSS_VARIABLE_MODIFIER_LIST@1196..1196
       4: SEMICOLON@1196..1197 ";" [] []
-    36: SCSS_VARIABLE_DECLARATION@1197..1268
+    36: SCSS_VARIABLE_DECLARATION@1197..1266
       0: SCSS_VARIABLE@1197..1257
         0: DOLLAR@1197..1248 "$" [Newline("\n"), Newline("\n"), Comments("// Division expressio ..."), Newline("\n")] []
         1: CSS_IDENTIFIER@1248..1257
-          0: IDENT@1248..1257 "division1" [] []
+          0: IDENT@1248..1257 "division0" [] []
       1: COLON@1257..1259 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1259..1267
-        0: SCSS_EXPRESSION_ITEM_LIST@1259..1267
-          0: SCSS_PARENTHESIZED_EXPRESSION@1259..1267
-            0: L_PAREN@1259..1260 "(" [] []
-            1: SCSS_EXPRESSION@1260..1266
-              0: SCSS_EXPRESSION_ITEM_LIST@1260..1266
-                0: CSS_RATIO@1260..1266
-                  0: CSS_NUMBER@1260..1263
-                    0: CSS_NUMBER_LITERAL@1260..1263 "10" [] [Whitespace(" ")]
-                  1: SLASH@1263..1265 "/" [] [Whitespace(" ")]
-                  2: CSS_NUMBER@1265..1266
-                    0: CSS_NUMBER_LITERAL@1265..1266 "2" [] []
-            2: R_PAREN@1266..1267 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1267..1267
-      4: SEMICOLON@1267..1268 ";" [] []
-    37: SCSS_VARIABLE_DECLARATION@1268..1294
-      0: SCSS_VARIABLE@1268..1279
-        0: DOLLAR@1268..1270 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1270..1279
-          0: IDENT@1270..1279 "division2" [] []
-      1: COLON@1279..1281 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1281..1293
-        0: SCSS_EXPRESSION_ITEM_LIST@1281..1293
-          0: SCSS_PARENTHESIZED_EXPRESSION@1281..1293
-            0: L_PAREN@1281..1282 "(" [] []
-            1: SCSS_EXPRESSION@1282..1292
-              0: SCSS_EXPRESSION_ITEM_LIST@1282..1292
-                0: SCSS_BINARY_EXPRESSION@1282..1292
-                  0: CSS_REGULAR_DIMENSION@1282..1288
-                    0: CSS_NUMBER_LITERAL@1282..1285 "100" [] []
-                    1: IDENT@1285..1288 "px" [] [Whitespace(" ")]
-                  1: SLASH@1288..1290 "/" [] [Whitespace(" ")]
-                  2: CSS_NUMBER@1290..1292
-                    0: CSS_NUMBER_LITERAL@1290..1292 "10" [] []
-            2: R_PAREN@1292..1293 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1293..1293
-      4: SEMICOLON@1293..1294 ";" [] []
-    38: SCSS_VARIABLE_DECLARATION@1294..1315
-      0: SCSS_VARIABLE@1294..1305
-        0: DOLLAR@1294..1296 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1296..1305
-          0: IDENT@1296..1305 "division3" [] []
-      1: COLON@1305..1307 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1307..1314
-        0: SCSS_EXPRESSION_ITEM_LIST@1307..1314
-          0: SCSS_BINARY_EXPRESSION@1307..1314
-            0: SCSS_VARIABLE@1307..1310
-              0: DOLLAR@1307..1308 "$" [] []
-              1: CSS_IDENTIFIER@1308..1310
-                0: IDENT@1308..1310 "a" [] [Whitespace(" ")]
-            1: SLASH@1310..1312 "/" [] [Whitespace(" ")]
-            2: SCSS_VARIABLE@1312..1314
-              0: DOLLAR@1312..1313 "$" [] []
-              1: CSS_IDENTIFIER@1313..1314
-                0: IDENT@1313..1314 "b" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1314..1314
-      4: SEMICOLON@1314..1315 ";" [] []
-    39: SCSS_VARIABLE_DECLARATION@1315..1350
-      0: SCSS_VARIABLE@1315..1341
-        0: DOLLAR@1315..1337 "$" [Newline("\n"), Newline("\n"), Comments("// Modulo operator"), Newline("\n")] []
-        1: CSS_IDENTIFIER@1337..1341
-          0: IDENT@1337..1341 "mod1" [] []
-      1: COLON@1341..1343 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1343..1349
-        0: SCSS_EXPRESSION_ITEM_LIST@1343..1349
-          0: SCSS_BINARY_EXPRESSION@1343..1349
-            0: CSS_NUMBER@1343..1346
-              0: CSS_NUMBER_LITERAL@1343..1346 "10" [] [Whitespace(" ")]
-            1: PERCENT@1346..1348 "%" [] [Whitespace(" ")]
-            2: CSS_NUMBER@1348..1349
-              0: CSS_NUMBER_LITERAL@1348..1349 "3" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1349..1349
-      4: SEMICOLON@1349..1350 ";" [] []
-    40: SCSS_VARIABLE_DECLARATION@1350..1366
-      0: SCSS_VARIABLE@1350..1356
-        0: DOLLAR@1350..1352 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1352..1356
-          0: IDENT@1352..1356 "mod2" [] []
-      1: COLON@1356..1358 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1358..1365
-        0: SCSS_EXPRESSION_ITEM_LIST@1358..1365
-          0: SCSS_BINARY_EXPRESSION@1358..1365
-            0: CSS_NUMBER@1358..1362
-              0: CSS_NUMBER_LITERAL@1358..1362 "100" [] [Whitespace(" ")]
-            1: PERCENT@1362..1364 "%" [] [Whitespace(" ")]
-            2: CSS_NUMBER@1364..1365
-              0: CSS_NUMBER_LITERAL@1364..1365 "7" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1365..1365
-      4: SEMICOLON@1365..1366 ";" [] []
-    41: SCSS_VARIABLE_DECLARATION@1366..1402
-      0: SCSS_VARIABLE@1366..1395
-        0: DOLLAR@1366..1389 "$" [Newline("\n"), Newline("\n"), Comments("// Color operations"), Newline("\n")] []
-        1: CSS_IDENTIFIER@1389..1395
-          0: IDENT@1389..1395 "color1" [] []
-      1: COLON@1395..1397 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1397..1401
-        0: SCSS_EXPRESSION_ITEM_LIST@1397..1401
-          0: CSS_COLOR@1397..1401
-            0: HASH@1397..1398 "#" [] []
-            1: CSS_COLOR_LITERAL@1398..1401 "036" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1401..1401
-      4: SEMICOLON@1401..1402 ";" [] []
-    42: SCSS_VARIABLE_DECLARATION@1402..1427
-      0: SCSS_VARIABLE@1402..1410
-        0: DOLLAR@1402..1404 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1404..1410
-          0: IDENT@1404..1410 "color2" [] []
-      1: COLON@1410..1412 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1412..1426
-        0: SCSS_EXPRESSION_ITEM_LIST@1412..1426
-          0: CSS_FUNCTION@1412..1426
-            0: CSS_IDENTIFIER@1412..1415
-              0: IDENT@1412..1415 "rgb" [] []
-            1: L_PAREN@1415..1416 "(" [] []
-            2: CSS_PARAMETER_LIST@1416..1425
-              0: SCSS_EXPRESSION@1416..1419
-                0: SCSS_EXPRESSION_ITEM_LIST@1416..1419
-                  0: CSS_NUMBER@1416..1419
-                    0: CSS_NUMBER_LITERAL@1416..1419 "255" [] []
-              1: COMMA@1419..1421 "," [] [Whitespace(" ")]
-              2: SCSS_EXPRESSION@1421..1422
-                0: SCSS_EXPRESSION_ITEM_LIST@1421..1422
-                  0: CSS_NUMBER@1421..1422
-                    0: CSS_NUMBER_LITERAL@1421..1422 "0" [] []
-              3: COMMA@1422..1424 "," [] [Whitespace(" ")]
-              4: SCSS_EXPRESSION@1424..1425
-                0: SCSS_EXPRESSION_ITEM_LIST@1424..1425
-                  0: CSS_NUMBER@1424..1425
-                    0: CSS_NUMBER_LITERAL@1424..1425 "0" [] []
-            3: R_PAREN@1425..1426 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1426..1426
-      4: SEMICOLON@1426..1427 ";" [] []
-    43: SCSS_VARIABLE_DECLARATION@1427..1458
-      0: SCSS_VARIABLE@1427..1438
-        0: DOLLAR@1427..1429 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1429..1438
-          0: IDENT@1429..1438 "color-add" [] []
-      1: COLON@1438..1440 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1440..1457
-        0: SCSS_EXPRESSION_ITEM_LIST@1440..1457
-          0: SCSS_BINARY_EXPRESSION@1440..1457
-            0: SCSS_VARIABLE@1440..1448
-              0: DOLLAR@1440..1441 "$" [] []
-              1: CSS_IDENTIFIER@1441..1448
-                0: IDENT@1441..1448 "color1" [] [Whitespace(" ")]
-            1: PLUS@1448..1450 "+" [] [Whitespace(" ")]
-            2: SCSS_VARIABLE@1450..1457
-              0: DOLLAR@1450..1451 "$" [] []
-              1: CSS_IDENTIFIER@1451..1457
-                0: IDENT@1451..1457 "color2" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1457..1457
-      4: SEMICOLON@1457..1458 ";" [] []
-    44: SCSS_VARIABLE_DECLARATION@1458..1509
-      0: SCSS_VARIABLE@1458..1491
-        0: DOLLAR@1458..1480 "$" [Newline("\n"), Newline("\n"), Comments("// List operations"), Newline("\n")] []
-        1: CSS_IDENTIFIER@1480..1491
-          0: IDENT@1480..1491 "list-concat" [] []
-      1: COLON@1491..1493 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1493..1508
-        0: SCSS_EXPRESSION_ITEM_LIST@1493..1508
-          0: SCSS_BINARY_EXPRESSION@1493..1508
-            0: SCSS_PARENTHESIZED_EXPRESSION@1493..1500
-              0: L_PAREN@1493..1494 "(" [] []
-              1: SCSS_LIST_EXPRESSION@1494..1498
-                0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@1494..1498
-                  0: SCSS_LIST_EXPRESSION_ELEMENT@1494..1495
-                    0: SCSS_EXPRESSION@1494..1495
-                      0: SCSS_EXPRESSION_ITEM_LIST@1494..1495
-                        0: CSS_IDENTIFIER@1494..1495
-                          0: IDENT@1494..1495 "a" [] []
-                  1: COMMA@1495..1497 "," [] [Whitespace(" ")]
-                  2: SCSS_LIST_EXPRESSION_ELEMENT@1497..1498
-                    0: SCSS_EXPRESSION@1497..1498
-                      0: SCSS_EXPRESSION_ITEM_LIST@1497..1498
-                        0: CSS_IDENTIFIER@1497..1498
-                          0: IDENT@1497..1498 "b" [] []
-              2: R_PAREN@1498..1500 ")" [] [Whitespace(" ")]
-            1: PLUS@1500..1502 "+" [] [Whitespace(" ")]
-            2: SCSS_PARENTHESIZED_EXPRESSION@1502..1508
-              0: L_PAREN@1502..1503 "(" [] []
-              1: SCSS_LIST_EXPRESSION@1503..1507
-                0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@1503..1507
-                  0: SCSS_LIST_EXPRESSION_ELEMENT@1503..1504
-                    0: SCSS_EXPRESSION@1503..1504
-                      0: SCSS_EXPRESSION_ITEM_LIST@1503..1504
-                        0: CSS_IDENTIFIER@1503..1504
-                          0: IDENT@1503..1504 "c" [] []
-                  1: COMMA@1504..1506 "," [] [Whitespace(" ")]
-                  2: SCSS_LIST_EXPRESSION_ELEMENT@1506..1507
-                    0: SCSS_EXPRESSION@1506..1507
-                      0: SCSS_EXPRESSION_ITEM_LIST@1506..1507
-                        0: CSS_IDENTIFIER@1506..1507
-                          0: IDENT@1506..1507 "d" [] []
-              2: R_PAREN@1507..1508 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1508..1508
-      4: SEMICOLON@1508..1509 ";" [] []
-    45: SCSS_VARIABLE_DECLARATION@1509..1531
-      0: SCSS_VARIABLE@1509..1519
-        0: DOLLAR@1509..1511 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1511..1519
-          0: IDENT@1511..1519 "list-add" [] []
-      1: COLON@1519..1521 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1521..1530
-        0: SCSS_EXPRESSION_ITEM_LIST@1521..1530
-          0: SCSS_BINARY_EXPRESSION@1521..1530
-            0: SCSS_PARENTHESIZED_EXPRESSION@1521..1527
-              0: L_PAREN@1521..1522 "(" [] []
-              1: SCSS_EXPRESSION@1522..1525
-                0: SCSS_EXPRESSION_ITEM_LIST@1522..1525
-                  0: CSS_IDENTIFIER@1522..1524
-                    0: IDENT@1522..1524 "a" [] [Whitespace(" ")]
-                  1: CSS_IDENTIFIER@1524..1525
-                    0: IDENT@1524..1525 "b" [] []
-              2: R_PAREN@1525..1527 ")" [] [Whitespace(" ")]
-            1: PLUS@1527..1529 "+" [] [Whitespace(" ")]
-            2: CSS_IDENTIFIER@1529..1530
-              0: IDENT@1529..1530 "c" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1530..1530
-      4: SEMICOLON@1530..1531 ";" [] []
-    46: SCSS_VARIABLE_DECLARATION@1531..1581
-      0: SCSS_VARIABLE@1531..1564
-        0: DOLLAR@1531..1556 "$" [Newline("\n"), Newline("\n"), Comments("// Map in expressions"), Newline("\n")] []
-        1: CSS_IDENTIFIER@1556..1564
-          0: IDENT@1556..1564 "map-expr" [] []
-      1: COLON@1564..1566 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1566..1580
-        0: SCSS_EXPRESSION_ITEM_LIST@1566..1580
-          0: SCSS_PARENTHESIZED_EXPRESSION@1566..1580
-            0: L_PAREN@1566..1567 "(" [] []
-            1: SCSS_EXPRESSION@1567..1579
-              0: SCSS_EXPRESSION_ITEM_LIST@1567..1579
-                0: SCSS_MAP_EXPRESSION@1567..1579
-                  0: L_PAREN@1567..1568 "(" [] []
-                  1: SCSS_MAP_EXPRESSION_PAIR_LIST@1568..1578
-                    0: SCSS_MAP_EXPRESSION_PAIR@1568..1578
-                      0: SCSS_EXPRESSION@1568..1571
-                        0: SCSS_EXPRESSION_ITEM_LIST@1568..1571
-                          0: CSS_IDENTIFIER@1568..1571
-                            0: IDENT@1568..1571 "key" [] []
-                      1: COLON@1571..1573 ":" [] [Whitespace(" ")]
-                      2: SCSS_EXPRESSION@1573..1578
-                        0: SCSS_EXPRESSION_ITEM_LIST@1573..1578
-                          0: CSS_IDENTIFIER@1573..1578
-                            0: IDENT@1573..1578 "value" [] []
-                  2: R_PAREN@1578..1579 ")" [] []
-            2: R_PAREN@1579..1580 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1580..1580
-      4: SEMICOLON@1580..1581 ";" [] []
-    47: SCSS_VARIABLE_DECLARATION@1581..1649
-      0: SCSS_VARIABLE@1581..1622
-        0: DOLLAR@1581..1617 "$" [Newline("\n"), Newline("\n"), Comments("// Function calls in  ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@1617..1622
-          0: IDENT@1617..1622 "func1" [] []
-      1: COLON@1622..1624 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1624..1648
-        0: SCSS_EXPRESSION_ITEM_LIST@1624..1648
-          0: SCSS_BINARY_EXPRESSION@1624..1648
-            0: CSS_FUNCTION@1624..1636
-              0: CSS_IDENTIFIER@1624..1629
-                0: IDENT@1624..1629 "round" [] []
-              1: L_PAREN@1629..1630 "(" [] []
-              2: CSS_PARAMETER_LIST@1630..1634
-                0: SCSS_EXPRESSION@1630..1634
-                  0: SCSS_EXPRESSION_ITEM_LIST@1630..1634
-                    0: CSS_NUMBER@1630..1634
-                      0: CSS_NUMBER_LITERAL@1630..1634 "10.5" [] []
-              3: R_PAREN@1634..1636 ")" [] [Whitespace(" ")]
-            1: PLUS@1636..1638 "+" [] [Whitespace(" ")]
-            2: CSS_FUNCTION@1638..1648
-              0: CSS_IDENTIFIER@1638..1642
-                0: IDENT@1638..1642 "ceil" [] []
-              1: L_PAREN@1642..1643 "(" [] []
-              2: CSS_PARAMETER_LIST@1643..1647
-                0: SCSS_EXPRESSION@1643..1647
-                  0: SCSS_EXPRESSION_ITEM_LIST@1643..1647
-                    0: CSS_NUMBER@1643..1647
-                      0: CSS_NUMBER_LITERAL@1643..1647 "20.3" [] []
-              3: R_PAREN@1647..1648 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1648..1648
-      4: SEMICOLON@1648..1649 ";" [] []
-    48: SCSS_VARIABLE_DECLARATION@1649..1691
-      0: SCSS_VARIABLE@1649..1656
-        0: DOLLAR@1649..1651 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1651..1656
-          0: IDENT@1651..1656 "func2" [] []
-      1: COLON@1656..1658 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1658..1690
-        0: SCSS_EXPRESSION_ITEM_LIST@1658..1690
-          0: SCSS_BINARY_EXPRESSION@1658..1690
-            0: CSS_FUNCTION@1658..1674
-              0: CSS_IDENTIFIER@1658..1661
-                0: IDENT@1658..1661 "max" [] []
-              1: L_PAREN@1661..1662 "(" [] []
-              2: CSS_PARAMETER_LIST@1662..1672
-                0: SCSS_EXPRESSION@1662..1664
-                  0: SCSS_EXPRESSION_ITEM_LIST@1662..1664
-                    0: CSS_NUMBER@1662..1664
-                      0: CSS_NUMBER_LITERAL@1662..1664 "10" [] []
-                1: COMMA@1664..1666 "," [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@1666..1668
-                  0: SCSS_EXPRESSION_ITEM_LIST@1666..1668
-                    0: CSS_NUMBER@1666..1668
-                      0: CSS_NUMBER_LITERAL@1666..1668 "20" [] []
-                3: COMMA@1668..1670 "," [] [Whitespace(" ")]
-                4: SCSS_EXPRESSION@1670..1672
-                  0: SCSS_EXPRESSION_ITEM_LIST@1670..1672
-                    0: CSS_NUMBER@1670..1672
-                      0: CSS_NUMBER_LITERAL@1670..1672 "30" [] []
-              3: R_PAREN@1672..1674 ")" [] [Whitespace(" ")]
-            1: MINUS@1674..1676 "-" [] [Whitespace(" ")]
-            2: CSS_FUNCTION@1676..1690
-              0: CSS_IDENTIFIER@1676..1679
-                0: IDENT@1676..1679 "min" [] []
-              1: L_PAREN@1679..1680 "(" [] []
-              2: CSS_PARAMETER_LIST@1680..1689
-                0: SCSS_EXPRESSION@1680..1681
-                  0: SCSS_EXPRESSION_ITEM_LIST@1680..1681
-                    0: CSS_NUMBER@1680..1681
-                      0: CSS_NUMBER_LITERAL@1680..1681 "5" [] []
-                1: COMMA@1681..1683 "," [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@1683..1685
-                  0: SCSS_EXPRESSION_ITEM_LIST@1683..1685
-                    0: CSS_NUMBER@1683..1685
-                      0: CSS_NUMBER_LITERAL@1683..1685 "10" [] []
-                3: COMMA@1685..1687 "," [] [Whitespace(" ")]
-                4: SCSS_EXPRESSION@1687..1689
-                  0: SCSS_EXPRESSION_ITEM_LIST@1687..1689
-                    0: CSS_NUMBER@1687..1689
-                      0: CSS_NUMBER_LITERAL@1687..1689 "15" [] []
-              3: R_PAREN@1689..1690 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1690..1690
-      4: SEMICOLON@1690..1691 ";" [] []
-    49: SCSS_VARIABLE_DECLARATION@1691..1747
-      0: SCSS_VARIABLE@1691..1734
-        0: DOLLAR@1691..1729 "$" [Newline("\n"), Newline("\n"), Comments("// Complex calculatio ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@1729..1734
-          0: IDENT@1729..1734 "calc1" [] []
-      1: COLON@1734..1736 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1736..1746
-        0: SCSS_EXPRESSION_ITEM_LIST@1736..1746
-          0: SCSS_BINARY_EXPRESSION@1736..1746
-            0: CSS_REGULAR_DIMENSION@1736..1741
-              0: CSS_NUMBER_LITERAL@1736..1738 "10" [] []
-              1: IDENT@1738..1741 "px" [] [Whitespace(" ")]
-            1: PLUS@1741..1743 "+" [] [Whitespace(" ")]
-            2: CSS_REGULAR_DIMENSION@1743..1746
-              0: CSS_NUMBER_LITERAL@1743..1744 "5" [] []
-              1: IDENT@1744..1746 "em" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1746..1746
-      4: SEMICOLON@1746..1747 ";" [] []
-    50: SCSS_VARIABLE_DECLARATION@1747..1768
-      0: SCSS_VARIABLE@1747..1754
-        0: DOLLAR@1747..1749 "$" [Newline("\n")] []
+      2: SCSS_EXPRESSION@1259..1265
+        0: SCSS_EXPRESSION_ITEM_LIST@1259..1265
+          0: SCSS_BINARY_EXPRESSION@1259..1265
+            0: CSS_NUMBER@1259..1262
+              0: CSS_NUMBER_LITERAL@1259..1262 "10" [] [Whitespace(" ")]
+            1: SLASH@1262..1264 "/" [] [Whitespace(" ")]
+            2: CSS_NUMBER@1264..1265
+              0: CSS_NUMBER_LITERAL@1264..1265 "2" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1265..1265
+      4: SEMICOLON@1265..1266 ";" [] []
+    37: SCSS_VARIABLE_DECLARATION@1266..1288
+      0: SCSS_VARIABLE@1266..1277
+        0: DOLLAR@1266..1268 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1268..1277
+          0: IDENT@1268..1277 "division1" [] []
+      1: COLON@1277..1279 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1279..1287
+        0: SCSS_EXPRESSION_ITEM_LIST@1279..1287
+          0: SCSS_PARENTHESIZED_EXPRESSION@1279..1287
+            0: L_PAREN@1279..1280 "(" [] []
+            1: SCSS_EXPRESSION@1280..1286
+              0: SCSS_EXPRESSION_ITEM_LIST@1280..1286
+                0: SCSS_BINARY_EXPRESSION@1280..1286
+                  0: CSS_NUMBER@1280..1283
+                    0: CSS_NUMBER_LITERAL@1280..1283 "10" [] [Whitespace(" ")]
+                  1: SLASH@1283..1285 "/" [] [Whitespace(" ")]
+                  2: CSS_NUMBER@1285..1286
+                    0: CSS_NUMBER_LITERAL@1285..1286 "2" [] []
+            2: R_PAREN@1286..1287 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1287..1287
+      4: SEMICOLON@1287..1288 ";" [] []
+    38: SCSS_VARIABLE_DECLARATION@1288..1314
+      0: SCSS_VARIABLE@1288..1299
+        0: DOLLAR@1288..1290 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1290..1299
+          0: IDENT@1290..1299 "division2" [] []
+      1: COLON@1299..1301 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1301..1313
+        0: SCSS_EXPRESSION_ITEM_LIST@1301..1313
+          0: SCSS_PARENTHESIZED_EXPRESSION@1301..1313
+            0: L_PAREN@1301..1302 "(" [] []
+            1: SCSS_EXPRESSION@1302..1312
+              0: SCSS_EXPRESSION_ITEM_LIST@1302..1312
+                0: SCSS_BINARY_EXPRESSION@1302..1312
+                  0: CSS_REGULAR_DIMENSION@1302..1308
+                    0: CSS_NUMBER_LITERAL@1302..1305 "100" [] []
+                    1: IDENT@1305..1308 "px" [] [Whitespace(" ")]
+                  1: SLASH@1308..1310 "/" [] [Whitespace(" ")]
+                  2: CSS_NUMBER@1310..1312
+                    0: CSS_NUMBER_LITERAL@1310..1312 "10" [] []
+            2: R_PAREN@1312..1313 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1313..1313
+      4: SEMICOLON@1313..1314 ";" [] []
+    39: SCSS_VARIABLE_DECLARATION@1314..1335
+      0: SCSS_VARIABLE@1314..1325
+        0: DOLLAR@1314..1316 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1316..1325
+          0: IDENT@1316..1325 "division3" [] []
+      1: COLON@1325..1327 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1327..1334
+        0: SCSS_EXPRESSION_ITEM_LIST@1327..1334
+          0: SCSS_BINARY_EXPRESSION@1327..1334
+            0: SCSS_VARIABLE@1327..1330
+              0: DOLLAR@1327..1328 "$" [] []
+              1: CSS_IDENTIFIER@1328..1330
+                0: IDENT@1328..1330 "a" [] [Whitespace(" ")]
+            1: SLASH@1330..1332 "/" [] [Whitespace(" ")]
+            2: SCSS_VARIABLE@1332..1334
+              0: DOLLAR@1332..1333 "$" [] []
+              1: CSS_IDENTIFIER@1333..1334
+                0: IDENT@1333..1334 "b" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1334..1334
+      4: SEMICOLON@1334..1335 ";" [] []
+    40: SCSS_VARIABLE_DECLARATION@1335..1370
+      0: SCSS_VARIABLE@1335..1361
+        0: DOLLAR@1335..1357 "$" [Newline("\n"), Newline("\n"), Comments("// Modulo operator"), Newline("\n")] []
+        1: CSS_IDENTIFIER@1357..1361
+          0: IDENT@1357..1361 "mod1" [] []
+      1: COLON@1361..1363 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1363..1369
+        0: SCSS_EXPRESSION_ITEM_LIST@1363..1369
+          0: SCSS_BINARY_EXPRESSION@1363..1369
+            0: CSS_NUMBER@1363..1366
+              0: CSS_NUMBER_LITERAL@1363..1366 "10" [] [Whitespace(" ")]
+            1: PERCENT@1366..1368 "%" [] [Whitespace(" ")]
+            2: CSS_NUMBER@1368..1369
+              0: CSS_NUMBER_LITERAL@1368..1369 "3" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1369..1369
+      4: SEMICOLON@1369..1370 ";" [] []
+    41: SCSS_VARIABLE_DECLARATION@1370..1386
+      0: SCSS_VARIABLE@1370..1376
+        0: DOLLAR@1370..1372 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1372..1376
+          0: IDENT@1372..1376 "mod2" [] []
+      1: COLON@1376..1378 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1378..1385
+        0: SCSS_EXPRESSION_ITEM_LIST@1378..1385
+          0: SCSS_BINARY_EXPRESSION@1378..1385
+            0: CSS_NUMBER@1378..1382
+              0: CSS_NUMBER_LITERAL@1378..1382 "100" [] [Whitespace(" ")]
+            1: PERCENT@1382..1384 "%" [] [Whitespace(" ")]
+            2: CSS_NUMBER@1384..1385
+              0: CSS_NUMBER_LITERAL@1384..1385 "7" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1385..1385
+      4: SEMICOLON@1385..1386 ";" [] []
+    42: SCSS_VARIABLE_DECLARATION@1386..1422
+      0: SCSS_VARIABLE@1386..1415
+        0: DOLLAR@1386..1409 "$" [Newline("\n"), Newline("\n"), Comments("// Color operations"), Newline("\n")] []
+        1: CSS_IDENTIFIER@1409..1415
+          0: IDENT@1409..1415 "color1" [] []
+      1: COLON@1415..1417 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1417..1421
+        0: SCSS_EXPRESSION_ITEM_LIST@1417..1421
+          0: CSS_COLOR@1417..1421
+            0: HASH@1417..1418 "#" [] []
+            1: CSS_COLOR_LITERAL@1418..1421 "036" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1421..1421
+      4: SEMICOLON@1421..1422 ";" [] []
+    43: SCSS_VARIABLE_DECLARATION@1422..1447
+      0: SCSS_VARIABLE@1422..1430
+        0: DOLLAR@1422..1424 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1424..1430
+          0: IDENT@1424..1430 "color2" [] []
+      1: COLON@1430..1432 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1432..1446
+        0: SCSS_EXPRESSION_ITEM_LIST@1432..1446
+          0: CSS_FUNCTION@1432..1446
+            0: CSS_IDENTIFIER@1432..1435
+              0: IDENT@1432..1435 "rgb" [] []
+            1: L_PAREN@1435..1436 "(" [] []
+            2: CSS_PARAMETER_LIST@1436..1445
+              0: SCSS_EXPRESSION@1436..1439
+                0: SCSS_EXPRESSION_ITEM_LIST@1436..1439
+                  0: CSS_NUMBER@1436..1439
+                    0: CSS_NUMBER_LITERAL@1436..1439 "255" [] []
+              1: COMMA@1439..1441 "," [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@1441..1442
+                0: SCSS_EXPRESSION_ITEM_LIST@1441..1442
+                  0: CSS_NUMBER@1441..1442
+                    0: CSS_NUMBER_LITERAL@1441..1442 "0" [] []
+              3: COMMA@1442..1444 "," [] [Whitespace(" ")]
+              4: SCSS_EXPRESSION@1444..1445
+                0: SCSS_EXPRESSION_ITEM_LIST@1444..1445
+                  0: CSS_NUMBER@1444..1445
+                    0: CSS_NUMBER_LITERAL@1444..1445 "0" [] []
+            3: R_PAREN@1445..1446 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1446..1446
+      4: SEMICOLON@1446..1447 ";" [] []
+    44: SCSS_VARIABLE_DECLARATION@1447..1478
+      0: SCSS_VARIABLE@1447..1458
+        0: DOLLAR@1447..1449 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1449..1458
+          0: IDENT@1449..1458 "color-add" [] []
+      1: COLON@1458..1460 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1460..1477
+        0: SCSS_EXPRESSION_ITEM_LIST@1460..1477
+          0: SCSS_BINARY_EXPRESSION@1460..1477
+            0: SCSS_VARIABLE@1460..1468
+              0: DOLLAR@1460..1461 "$" [] []
+              1: CSS_IDENTIFIER@1461..1468
+                0: IDENT@1461..1468 "color1" [] [Whitespace(" ")]
+            1: PLUS@1468..1470 "+" [] [Whitespace(" ")]
+            2: SCSS_VARIABLE@1470..1477
+              0: DOLLAR@1470..1471 "$" [] []
+              1: CSS_IDENTIFIER@1471..1477
+                0: IDENT@1471..1477 "color2" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1477..1477
+      4: SEMICOLON@1477..1478 ";" [] []
+    45: SCSS_VARIABLE_DECLARATION@1478..1529
+      0: SCSS_VARIABLE@1478..1511
+        0: DOLLAR@1478..1500 "$" [Newline("\n"), Newline("\n"), Comments("// List operations"), Newline("\n")] []
+        1: CSS_IDENTIFIER@1500..1511
+          0: IDENT@1500..1511 "list-concat" [] []
+      1: COLON@1511..1513 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1513..1528
+        0: SCSS_EXPRESSION_ITEM_LIST@1513..1528
+          0: SCSS_BINARY_EXPRESSION@1513..1528
+            0: SCSS_PARENTHESIZED_EXPRESSION@1513..1520
+              0: L_PAREN@1513..1514 "(" [] []
+              1: SCSS_LIST_EXPRESSION@1514..1518
+                0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@1514..1518
+                  0: SCSS_LIST_EXPRESSION_ELEMENT@1514..1515
+                    0: SCSS_EXPRESSION@1514..1515
+                      0: SCSS_EXPRESSION_ITEM_LIST@1514..1515
+                        0: CSS_IDENTIFIER@1514..1515
+                          0: IDENT@1514..1515 "a" [] []
+                  1: COMMA@1515..1517 "," [] [Whitespace(" ")]
+                  2: SCSS_LIST_EXPRESSION_ELEMENT@1517..1518
+                    0: SCSS_EXPRESSION@1517..1518
+                      0: SCSS_EXPRESSION_ITEM_LIST@1517..1518
+                        0: CSS_IDENTIFIER@1517..1518
+                          0: IDENT@1517..1518 "b" [] []
+              2: R_PAREN@1518..1520 ")" [] [Whitespace(" ")]
+            1: PLUS@1520..1522 "+" [] [Whitespace(" ")]
+            2: SCSS_PARENTHESIZED_EXPRESSION@1522..1528
+              0: L_PAREN@1522..1523 "(" [] []
+              1: SCSS_LIST_EXPRESSION@1523..1527
+                0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@1523..1527
+                  0: SCSS_LIST_EXPRESSION_ELEMENT@1523..1524
+                    0: SCSS_EXPRESSION@1523..1524
+                      0: SCSS_EXPRESSION_ITEM_LIST@1523..1524
+                        0: CSS_IDENTIFIER@1523..1524
+                          0: IDENT@1523..1524 "c" [] []
+                  1: COMMA@1524..1526 "," [] [Whitespace(" ")]
+                  2: SCSS_LIST_EXPRESSION_ELEMENT@1526..1527
+                    0: SCSS_EXPRESSION@1526..1527
+                      0: SCSS_EXPRESSION_ITEM_LIST@1526..1527
+                        0: CSS_IDENTIFIER@1526..1527
+                          0: IDENT@1526..1527 "d" [] []
+              2: R_PAREN@1527..1528 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1528..1528
+      4: SEMICOLON@1528..1529 ";" [] []
+    46: SCSS_VARIABLE_DECLARATION@1529..1551
+      0: SCSS_VARIABLE@1529..1539
+        0: DOLLAR@1529..1531 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1531..1539
+          0: IDENT@1531..1539 "list-add" [] []
+      1: COLON@1539..1541 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1541..1550
+        0: SCSS_EXPRESSION_ITEM_LIST@1541..1550
+          0: SCSS_BINARY_EXPRESSION@1541..1550
+            0: SCSS_PARENTHESIZED_EXPRESSION@1541..1547
+              0: L_PAREN@1541..1542 "(" [] []
+              1: SCSS_EXPRESSION@1542..1545
+                0: SCSS_EXPRESSION_ITEM_LIST@1542..1545
+                  0: CSS_IDENTIFIER@1542..1544
+                    0: IDENT@1542..1544 "a" [] [Whitespace(" ")]
+                  1: CSS_IDENTIFIER@1544..1545
+                    0: IDENT@1544..1545 "b" [] []
+              2: R_PAREN@1545..1547 ")" [] [Whitespace(" ")]
+            1: PLUS@1547..1549 "+" [] [Whitespace(" ")]
+            2: CSS_IDENTIFIER@1549..1550
+              0: IDENT@1549..1550 "c" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1550..1550
+      4: SEMICOLON@1550..1551 ";" [] []
+    47: SCSS_VARIABLE_DECLARATION@1551..1601
+      0: SCSS_VARIABLE@1551..1584
+        0: DOLLAR@1551..1576 "$" [Newline("\n"), Newline("\n"), Comments("// Map in expressions"), Newline("\n")] []
+        1: CSS_IDENTIFIER@1576..1584
+          0: IDENT@1576..1584 "map-expr" [] []
+      1: COLON@1584..1586 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1586..1600
+        0: SCSS_EXPRESSION_ITEM_LIST@1586..1600
+          0: SCSS_PARENTHESIZED_EXPRESSION@1586..1600
+            0: L_PAREN@1586..1587 "(" [] []
+            1: SCSS_EXPRESSION@1587..1599
+              0: SCSS_EXPRESSION_ITEM_LIST@1587..1599
+                0: SCSS_MAP_EXPRESSION@1587..1599
+                  0: L_PAREN@1587..1588 "(" [] []
+                  1: SCSS_MAP_EXPRESSION_PAIR_LIST@1588..1598
+                    0: SCSS_MAP_EXPRESSION_PAIR@1588..1598
+                      0: SCSS_EXPRESSION@1588..1591
+                        0: SCSS_EXPRESSION_ITEM_LIST@1588..1591
+                          0: CSS_IDENTIFIER@1588..1591
+                            0: IDENT@1588..1591 "key" [] []
+                      1: COLON@1591..1593 ":" [] [Whitespace(" ")]
+                      2: SCSS_EXPRESSION@1593..1598
+                        0: SCSS_EXPRESSION_ITEM_LIST@1593..1598
+                          0: CSS_IDENTIFIER@1593..1598
+                            0: IDENT@1593..1598 "value" [] []
+                  2: R_PAREN@1598..1599 ")" [] []
+            2: R_PAREN@1599..1600 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1600..1600
+      4: SEMICOLON@1600..1601 ";" [] []
+    48: SCSS_VARIABLE_DECLARATION@1601..1669
+      0: SCSS_VARIABLE@1601..1642
+        0: DOLLAR@1601..1637 "$" [Newline("\n"), Newline("\n"), Comments("// Function calls in  ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@1637..1642
+          0: IDENT@1637..1642 "func1" [] []
+      1: COLON@1642..1644 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1644..1668
+        0: SCSS_EXPRESSION_ITEM_LIST@1644..1668
+          0: SCSS_BINARY_EXPRESSION@1644..1668
+            0: CSS_FUNCTION@1644..1656
+              0: CSS_IDENTIFIER@1644..1649
+                0: IDENT@1644..1649 "round" [] []
+              1: L_PAREN@1649..1650 "(" [] []
+              2: CSS_PARAMETER_LIST@1650..1654
+                0: SCSS_EXPRESSION@1650..1654
+                  0: SCSS_EXPRESSION_ITEM_LIST@1650..1654
+                    0: CSS_NUMBER@1650..1654
+                      0: CSS_NUMBER_LITERAL@1650..1654 "10.5" [] []
+              3: R_PAREN@1654..1656 ")" [] [Whitespace(" ")]
+            1: PLUS@1656..1658 "+" [] [Whitespace(" ")]
+            2: CSS_FUNCTION@1658..1668
+              0: CSS_IDENTIFIER@1658..1662
+                0: IDENT@1658..1662 "ceil" [] []
+              1: L_PAREN@1662..1663 "(" [] []
+              2: CSS_PARAMETER_LIST@1663..1667
+                0: SCSS_EXPRESSION@1663..1667
+                  0: SCSS_EXPRESSION_ITEM_LIST@1663..1667
+                    0: CSS_NUMBER@1663..1667
+                      0: CSS_NUMBER_LITERAL@1663..1667 "20.3" [] []
+              3: R_PAREN@1667..1668 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1668..1668
+      4: SEMICOLON@1668..1669 ";" [] []
+    49: SCSS_VARIABLE_DECLARATION@1669..1711
+      0: SCSS_VARIABLE@1669..1676
+        0: DOLLAR@1669..1671 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1671..1676
+          0: IDENT@1671..1676 "func2" [] []
+      1: COLON@1676..1678 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1678..1710
+        0: SCSS_EXPRESSION_ITEM_LIST@1678..1710
+          0: SCSS_BINARY_EXPRESSION@1678..1710
+            0: CSS_FUNCTION@1678..1694
+              0: CSS_IDENTIFIER@1678..1681
+                0: IDENT@1678..1681 "max" [] []
+              1: L_PAREN@1681..1682 "(" [] []
+              2: CSS_PARAMETER_LIST@1682..1692
+                0: SCSS_EXPRESSION@1682..1684
+                  0: SCSS_EXPRESSION_ITEM_LIST@1682..1684
+                    0: CSS_NUMBER@1682..1684
+                      0: CSS_NUMBER_LITERAL@1682..1684 "10" [] []
+                1: COMMA@1684..1686 "," [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1686..1688
+                  0: SCSS_EXPRESSION_ITEM_LIST@1686..1688
+                    0: CSS_NUMBER@1686..1688
+                      0: CSS_NUMBER_LITERAL@1686..1688 "20" [] []
+                3: COMMA@1688..1690 "," [] [Whitespace(" ")]
+                4: SCSS_EXPRESSION@1690..1692
+                  0: SCSS_EXPRESSION_ITEM_LIST@1690..1692
+                    0: CSS_NUMBER@1690..1692
+                      0: CSS_NUMBER_LITERAL@1690..1692 "30" [] []
+              3: R_PAREN@1692..1694 ")" [] [Whitespace(" ")]
+            1: MINUS@1694..1696 "-" [] [Whitespace(" ")]
+            2: CSS_FUNCTION@1696..1710
+              0: CSS_IDENTIFIER@1696..1699
+                0: IDENT@1696..1699 "min" [] []
+              1: L_PAREN@1699..1700 "(" [] []
+              2: CSS_PARAMETER_LIST@1700..1709
+                0: SCSS_EXPRESSION@1700..1701
+                  0: SCSS_EXPRESSION_ITEM_LIST@1700..1701
+                    0: CSS_NUMBER@1700..1701
+                      0: CSS_NUMBER_LITERAL@1700..1701 "5" [] []
+                1: COMMA@1701..1703 "," [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1703..1705
+                  0: SCSS_EXPRESSION_ITEM_LIST@1703..1705
+                    0: CSS_NUMBER@1703..1705
+                      0: CSS_NUMBER_LITERAL@1703..1705 "10" [] []
+                3: COMMA@1705..1707 "," [] [Whitespace(" ")]
+                4: SCSS_EXPRESSION@1707..1709
+                  0: SCSS_EXPRESSION_ITEM_LIST@1707..1709
+                    0: CSS_NUMBER@1707..1709
+                      0: CSS_NUMBER_LITERAL@1707..1709 "15" [] []
+              3: R_PAREN@1709..1710 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1710..1710
+      4: SEMICOLON@1710..1711 ";" [] []
+    50: SCSS_VARIABLE_DECLARATION@1711..1767
+      0: SCSS_VARIABLE@1711..1754
+        0: DOLLAR@1711..1749 "$" [Newline("\n"), Newline("\n"), Comments("// Complex calculatio ..."), Newline("\n")] []
         1: CSS_IDENTIFIER@1749..1754
-          0: IDENT@1749..1754 "calc2" [] []
+          0: IDENT@1749..1754 "calc1" [] []
       1: COLON@1754..1756 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1756..1767
-        0: SCSS_EXPRESSION_ITEM_LIST@1756..1767
-          0: SCSS_BINARY_EXPRESSION@1756..1767
-            0: CSS_PERCENTAGE@1756..1761
-              0: CSS_NUMBER_LITERAL@1756..1759 "100" [] []
-              1: PERCENT@1759..1761 "%" [] [Whitespace(" ")]
-            1: MINUS@1761..1763 "-" [] [Whitespace(" ")]
-            2: CSS_REGULAR_DIMENSION@1763..1767
-              0: CSS_NUMBER_LITERAL@1763..1765 "20" [] []
-              1: IDENT@1765..1767 "px" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1767..1767
-      4: SEMICOLON@1767..1768 ";" [] []
-    51: SCSS_VARIABLE_DECLARATION@1768..1786
-      0: SCSS_VARIABLE@1768..1775
-        0: DOLLAR@1768..1770 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1770..1775
-          0: IDENT@1770..1775 "calc3" [] []
-      1: COLON@1775..1777 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1777..1785
-        0: SCSS_EXPRESSION_ITEM_LIST@1777..1785
-          0: SCSS_BINARY_EXPRESSION@1777..1785
-            0: CSS_REGULAR_DIMENSION@1777..1782
-              0: CSS_NUMBER_LITERAL@1777..1779 "50" [] []
-              1: IDENT@1779..1782 "vh" [] [Whitespace(" ")]
-            1: STAR@1782..1784 "*" [] [Whitespace(" ")]
-            2: CSS_NUMBER@1784..1785
-              0: CSS_NUMBER_LITERAL@1784..1785 "2" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1785..1785
-      4: SEMICOLON@1785..1786 ";" [] []
-    52: SCSS_VARIABLE_DECLARATION@1786..1843
-      0: SCSS_VARIABLE@1786..1823
-        0: DOLLAR@1786..1814 "$" [Newline("\n"), Newline("\n"), Comments("// Expressions with null"), Newline("\n")] []
-        1: CSS_IDENTIFIER@1814..1823
-          0: IDENT@1814..1823 "null-expr" [] []
-      1: COLON@1823..1825 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1825..1842
-        0: SCSS_EXPRESSION_ITEM_LIST@1825..1842
-          0: SCSS_BINARY_EXPRESSION@1825..1842
-            0: CSS_IDENTIFIER@1825..1830
-              0: IDENT@1825..1830 "null" [] [Whitespace(" ")]
-            1: OR_KW@1830..1833 "or" [] [Whitespace(" ")]
-            2: CSS_STRING@1833..1842
-              0: CSS_STRING_LITERAL@1833..1842 "\"default\"" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1842..1842
-      4: SEMICOLON@1842..1843 ";" [] []
-    53: SCSS_VARIABLE_DECLARATION@1843..1876
-      0: SCSS_VARIABLE@1843..1855
-        0: DOLLAR@1843..1845 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1845..1855
-          0: IDENT@1845..1855 "null-check" [] []
-      1: COLON@1855..1857 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1857..1875
-        0: SCSS_EXPRESSION_ITEM_LIST@1857..1875
-          0: SCSS_BINARY_EXPRESSION@1857..1875
-            0: SCSS_VARIABLE@1857..1862
-              0: DOLLAR@1857..1858 "$" [] []
-              1: CSS_IDENTIFIER@1858..1862
-                0: IDENT@1858..1862 "var" [] [Whitespace(" ")]
-            1: OR_KW@1862..1865 "or" [] [Whitespace(" ")]
-            2: CSS_STRING@1865..1875
-              0: CSS_STRING_LITERAL@1865..1875 "\"fallback\"" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1875..1875
-      4: SEMICOLON@1875..1876 ";" [] []
-    54: SCSS_VARIABLE_DECLARATION@1876..1939
-      0: SCSS_VARIABLE@1876..1925
-        0: DOLLAR@1876..1914 "$" [Newline("\n"), Newline("\n"), Comments("// Boolean expression ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@1914..1925
-          0: IDENT@1914..1925 "bool-or-val" [] []
-      1: COLON@1925..1927 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1927..1938
-        0: SCSS_EXPRESSION_ITEM_LIST@1927..1938
-          0: SCSS_BINARY_EXPRESSION@1927..1938
-            0: CSS_IDENTIFIER@1927..1933
-              0: IDENT@1927..1933 "false" [] [Whitespace(" ")]
-            1: OR_KW@1933..1936 "or" [] [Whitespace(" ")]
-            2: CSS_NUMBER@1936..1938
-              0: CSS_NUMBER_LITERAL@1936..1938 "10" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1938..1938
-      4: SEMICOLON@1938..1939 ";" [] []
-    55: SCSS_VARIABLE_DECLARATION@1939..1972
-      0: SCSS_VARIABLE@1939..1953
-        0: DOLLAR@1939..1941 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@1941..1953
-          0: IDENT@1941..1953 "bool-and-val" [] []
-      1: COLON@1953..1955 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@1955..1971
-        0: SCSS_EXPRESSION_ITEM_LIST@1955..1971
-          0: SCSS_BINARY_EXPRESSION@1955..1971
-            0: CSS_IDENTIFIER@1955..1960
-              0: IDENT@1955..1960 "true" [] [Whitespace(" ")]
-            1: AND_KW@1960..1964 "and" [] [Whitespace(" ")]
-            2: CSS_STRING@1964..1971
-              0: CSS_STRING_LITERAL@1964..1971 "\"value\"" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@1971..1971
-      4: SEMICOLON@1971..1972 ";" [] []
-    56: SCSS_VARIABLE_DECLARATION@1972..2035
-      0: SCSS_VARIABLE@1972..2011
-        0: DOLLAR@1972..2000 "$" [Newline("\n"), Newline("\n"), Comments("// Nested function calls"), Newline("\n")] []
-        1: CSS_IDENTIFIER@2000..2011
-          0: IDENT@2000..2011 "nested-func" [] []
-      1: COLON@2011..2013 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2013..2034
-        0: SCSS_EXPRESSION_ITEM_LIST@2013..2034
-          0: CSS_FUNCTION@2013..2034
-            0: CSS_IDENTIFIER@2013..2018
-              0: IDENT@2013..2018 "round" [] []
-            1: L_PAREN@2018..2019 "(" [] []
-            2: CSS_PARAMETER_LIST@2019..2033
-              0: SCSS_EXPRESSION@2019..2033
-                0: SCSS_EXPRESSION_ITEM_LIST@2019..2033
-                  0: CSS_FUNCTION@2019..2033
-                    0: CSS_IDENTIFIER@2019..2023
-                      0: IDENT@2019..2023 "sqrt" [] []
-                    1: L_PAREN@2023..2024 "(" [] []
-                    2: CSS_PARAMETER_LIST@2024..2032
-                      0: SCSS_EXPRESSION@2024..2032
-                        0: SCSS_EXPRESSION_ITEM_LIST@2024..2032
-                          0: CSS_FUNCTION@2024..2032
-                            0: CSS_IDENTIFIER@2024..2027
-                              0: IDENT@2024..2027 "abs" [] []
-                            1: L_PAREN@2027..2028 "(" [] []
-                            2: CSS_PARAMETER_LIST@2028..2031
-                              0: SCSS_EXPRESSION@2028..2031
-                                0: SCSS_EXPRESSION_ITEM_LIST@2028..2031
-                                  0: CSS_NUMBER@2028..2031
-                                    0: CSS_NUMBER_LITERAL@2028..2031 "-16" [] []
-                            3: R_PAREN@2031..2032 ")" [] []
-                    3: R_PAREN@2032..2033 ")" [] []
-            3: R_PAREN@2033..2034 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2034..2034
-      4: SEMICOLON@2034..2035 ";" [] []
-    57: SCSS_VARIABLE_DECLARATION@2035..2141
-      0: SCSS_VARIABLE@2035..2076
-        0: DOLLAR@2035..2065 "$" [Newline("\n"), Newline("\n"), Comments("// Expression as map  ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@2065..2076
-          0: IDENT@2065..2076 "expr-in-map" [] []
-      1: COLON@2076..2078 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2078..2140
-        0: SCSS_EXPRESSION_ITEM_LIST@2078..2140
-          0: SCSS_MAP_EXPRESSION@2078..2140
-            0: L_PAREN@2078..2079 "(" [] []
-            1: SCSS_MAP_EXPRESSION_PAIR_LIST@2079..2138
-              0: SCSS_MAP_EXPRESSION_PAIR@2079..2094
-                0: SCSS_EXPRESSION@2079..2085
-                  0: SCSS_EXPRESSION_ITEM_LIST@2079..2085
-                    0: CSS_IDENTIFIER@2079..2085
-                      0: IDENT@2079..2085 "sum" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2085..2087 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2087..2094
-                  0: SCSS_EXPRESSION_ITEM_LIST@2087..2094
-                    0: SCSS_BINARY_EXPRESSION@2087..2094
-                      0: SCSS_VARIABLE@2087..2090
-                        0: DOLLAR@2087..2088 "$" [] []
-                        1: CSS_IDENTIFIER@2088..2090
-                          0: IDENT@2088..2090 "a" [] [Whitespace(" ")]
-                      1: PLUS@2090..2092 "+" [] [Whitespace(" ")]
-                      2: SCSS_VARIABLE@2092..2094
-                        0: DOLLAR@2092..2093 "$" [] []
-                        1: CSS_IDENTIFIER@2093..2094
-                          0: IDENT@2093..2094 "b" [] []
-              1: COMMA@2094..2095 "," [] []
-              2: SCSS_MAP_EXPRESSION_PAIR@2095..2114
-                0: SCSS_EXPRESSION@2095..2105
-                  0: SCSS_EXPRESSION_ITEM_LIST@2095..2105
-                    0: CSS_IDENTIFIER@2095..2105
-                      0: IDENT@2095..2105 "product" [Newline("\n"), Whitespace("  ")] []
+      2: SCSS_EXPRESSION@1756..1766
+        0: SCSS_EXPRESSION_ITEM_LIST@1756..1766
+          0: SCSS_BINARY_EXPRESSION@1756..1766
+            0: CSS_REGULAR_DIMENSION@1756..1761
+              0: CSS_NUMBER_LITERAL@1756..1758 "10" [] []
+              1: IDENT@1758..1761 "px" [] [Whitespace(" ")]
+            1: PLUS@1761..1763 "+" [] [Whitespace(" ")]
+            2: CSS_REGULAR_DIMENSION@1763..1766
+              0: CSS_NUMBER_LITERAL@1763..1764 "5" [] []
+              1: IDENT@1764..1766 "em" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1766..1766
+      4: SEMICOLON@1766..1767 ";" [] []
+    51: SCSS_VARIABLE_DECLARATION@1767..1788
+      0: SCSS_VARIABLE@1767..1774
+        0: DOLLAR@1767..1769 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1769..1774
+          0: IDENT@1769..1774 "calc2" [] []
+      1: COLON@1774..1776 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1776..1787
+        0: SCSS_EXPRESSION_ITEM_LIST@1776..1787
+          0: SCSS_BINARY_EXPRESSION@1776..1787
+            0: CSS_PERCENTAGE@1776..1781
+              0: CSS_NUMBER_LITERAL@1776..1779 "100" [] []
+              1: PERCENT@1779..1781 "%" [] [Whitespace(" ")]
+            1: MINUS@1781..1783 "-" [] [Whitespace(" ")]
+            2: CSS_REGULAR_DIMENSION@1783..1787
+              0: CSS_NUMBER_LITERAL@1783..1785 "20" [] []
+              1: IDENT@1785..1787 "px" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1787..1787
+      4: SEMICOLON@1787..1788 ";" [] []
+    52: SCSS_VARIABLE_DECLARATION@1788..1806
+      0: SCSS_VARIABLE@1788..1795
+        0: DOLLAR@1788..1790 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1790..1795
+          0: IDENT@1790..1795 "calc3" [] []
+      1: COLON@1795..1797 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1797..1805
+        0: SCSS_EXPRESSION_ITEM_LIST@1797..1805
+          0: SCSS_BINARY_EXPRESSION@1797..1805
+            0: CSS_REGULAR_DIMENSION@1797..1802
+              0: CSS_NUMBER_LITERAL@1797..1799 "50" [] []
+              1: IDENT@1799..1802 "vh" [] [Whitespace(" ")]
+            1: STAR@1802..1804 "*" [] [Whitespace(" ")]
+            2: CSS_NUMBER@1804..1805
+              0: CSS_NUMBER_LITERAL@1804..1805 "2" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1805..1805
+      4: SEMICOLON@1805..1806 ";" [] []
+    53: SCSS_VARIABLE_DECLARATION@1806..1863
+      0: SCSS_VARIABLE@1806..1843
+        0: DOLLAR@1806..1834 "$" [Newline("\n"), Newline("\n"), Comments("// Expressions with null"), Newline("\n")] []
+        1: CSS_IDENTIFIER@1834..1843
+          0: IDENT@1834..1843 "null-expr" [] []
+      1: COLON@1843..1845 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1845..1862
+        0: SCSS_EXPRESSION_ITEM_LIST@1845..1862
+          0: SCSS_BINARY_EXPRESSION@1845..1862
+            0: CSS_IDENTIFIER@1845..1850
+              0: IDENT@1845..1850 "null" [] [Whitespace(" ")]
+            1: OR_KW@1850..1853 "or" [] [Whitespace(" ")]
+            2: CSS_STRING@1853..1862
+              0: CSS_STRING_LITERAL@1853..1862 "\"default\"" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1862..1862
+      4: SEMICOLON@1862..1863 ";" [] []
+    54: SCSS_VARIABLE_DECLARATION@1863..1896
+      0: SCSS_VARIABLE@1863..1875
+        0: DOLLAR@1863..1865 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1865..1875
+          0: IDENT@1865..1875 "null-check" [] []
+      1: COLON@1875..1877 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1877..1895
+        0: SCSS_EXPRESSION_ITEM_LIST@1877..1895
+          0: SCSS_BINARY_EXPRESSION@1877..1895
+            0: SCSS_VARIABLE@1877..1882
+              0: DOLLAR@1877..1878 "$" [] []
+              1: CSS_IDENTIFIER@1878..1882
+                0: IDENT@1878..1882 "var" [] [Whitespace(" ")]
+            1: OR_KW@1882..1885 "or" [] [Whitespace(" ")]
+            2: CSS_STRING@1885..1895
+              0: CSS_STRING_LITERAL@1885..1895 "\"fallback\"" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1895..1895
+      4: SEMICOLON@1895..1896 ";" [] []
+    55: SCSS_VARIABLE_DECLARATION@1896..1959
+      0: SCSS_VARIABLE@1896..1945
+        0: DOLLAR@1896..1934 "$" [Newline("\n"), Newline("\n"), Comments("// Boolean expression ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@1934..1945
+          0: IDENT@1934..1945 "bool-or-val" [] []
+      1: COLON@1945..1947 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1947..1958
+        0: SCSS_EXPRESSION_ITEM_LIST@1947..1958
+          0: SCSS_BINARY_EXPRESSION@1947..1958
+            0: CSS_IDENTIFIER@1947..1953
+              0: IDENT@1947..1953 "false" [] [Whitespace(" ")]
+            1: OR_KW@1953..1956 "or" [] [Whitespace(" ")]
+            2: CSS_NUMBER@1956..1958
+              0: CSS_NUMBER_LITERAL@1956..1958 "10" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1958..1958
+      4: SEMICOLON@1958..1959 ";" [] []
+    56: SCSS_VARIABLE_DECLARATION@1959..1992
+      0: SCSS_VARIABLE@1959..1973
+        0: DOLLAR@1959..1961 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@1961..1973
+          0: IDENT@1961..1973 "bool-and-val" [] []
+      1: COLON@1973..1975 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@1975..1991
+        0: SCSS_EXPRESSION_ITEM_LIST@1975..1991
+          0: SCSS_BINARY_EXPRESSION@1975..1991
+            0: CSS_IDENTIFIER@1975..1980
+              0: IDENT@1975..1980 "true" [] [Whitespace(" ")]
+            1: AND_KW@1980..1984 "and" [] [Whitespace(" ")]
+            2: CSS_STRING@1984..1991
+              0: CSS_STRING_LITERAL@1984..1991 "\"value\"" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@1991..1991
+      4: SEMICOLON@1991..1992 ";" [] []
+    57: SCSS_VARIABLE_DECLARATION@1992..2055
+      0: SCSS_VARIABLE@1992..2031
+        0: DOLLAR@1992..2020 "$" [Newline("\n"), Newline("\n"), Comments("// Nested function calls"), Newline("\n")] []
+        1: CSS_IDENTIFIER@2020..2031
+          0: IDENT@2020..2031 "nested-func" [] []
+      1: COLON@2031..2033 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2033..2054
+        0: SCSS_EXPRESSION_ITEM_LIST@2033..2054
+          0: CSS_FUNCTION@2033..2054
+            0: CSS_IDENTIFIER@2033..2038
+              0: IDENT@2033..2038 "round" [] []
+            1: L_PAREN@2038..2039 "(" [] []
+            2: CSS_PARAMETER_LIST@2039..2053
+              0: SCSS_EXPRESSION@2039..2053
+                0: SCSS_EXPRESSION_ITEM_LIST@2039..2053
+                  0: CSS_FUNCTION@2039..2053
+                    0: CSS_IDENTIFIER@2039..2043
+                      0: IDENT@2039..2043 "sqrt" [] []
+                    1: L_PAREN@2043..2044 "(" [] []
+                    2: CSS_PARAMETER_LIST@2044..2052
+                      0: SCSS_EXPRESSION@2044..2052
+                        0: SCSS_EXPRESSION_ITEM_LIST@2044..2052
+                          0: CSS_FUNCTION@2044..2052
+                            0: CSS_IDENTIFIER@2044..2047
+                              0: IDENT@2044..2047 "abs" [] []
+                            1: L_PAREN@2047..2048 "(" [] []
+                            2: CSS_PARAMETER_LIST@2048..2051
+                              0: SCSS_EXPRESSION@2048..2051
+                                0: SCSS_EXPRESSION_ITEM_LIST@2048..2051
+                                  0: CSS_NUMBER@2048..2051
+                                    0: CSS_NUMBER_LITERAL@2048..2051 "-16" [] []
+                            3: R_PAREN@2051..2052 ")" [] []
+                    3: R_PAREN@2052..2053 ")" [] []
+            3: R_PAREN@2053..2054 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2054..2054
+      4: SEMICOLON@2054..2055 ";" [] []
+    58: SCSS_VARIABLE_DECLARATION@2055..2161
+      0: SCSS_VARIABLE@2055..2096
+        0: DOLLAR@2055..2085 "$" [Newline("\n"), Newline("\n"), Comments("// Expression as map  ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@2085..2096
+          0: IDENT@2085..2096 "expr-in-map" [] []
+      1: COLON@2096..2098 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2098..2160
+        0: SCSS_EXPRESSION_ITEM_LIST@2098..2160
+          0: SCSS_MAP_EXPRESSION@2098..2160
+            0: L_PAREN@2098..2099 "(" [] []
+            1: SCSS_MAP_EXPRESSION_PAIR_LIST@2099..2158
+              0: SCSS_MAP_EXPRESSION_PAIR@2099..2114
+                0: SCSS_EXPRESSION@2099..2105
+                  0: SCSS_EXPRESSION_ITEM_LIST@2099..2105
+                    0: CSS_IDENTIFIER@2099..2105
+                      0: IDENT@2099..2105 "sum" [Newline("\n"), Whitespace("  ")] []
                 1: COLON@2105..2107 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@2107..2114
                   0: SCSS_EXPRESSION_ITEM_LIST@2107..2114
@@ -4665,787 +4686,806 @@ CssRoot {
                         0: DOLLAR@2107..2108 "$" [] []
                         1: CSS_IDENTIFIER@2108..2110
                           0: IDENT@2108..2110 "a" [] [Whitespace(" ")]
-                      1: STAR@2110..2112 "*" [] [Whitespace(" ")]
+                      1: PLUS@2110..2112 "+" [] [Whitespace(" ")]
                       2: SCSS_VARIABLE@2112..2114
                         0: DOLLAR@2112..2113 "$" [] []
                         1: CSS_IDENTIFIER@2113..2114
                           0: IDENT@2113..2114 "b" [] []
-              3: COMMA@2114..2115 "," [] []
-              4: SCSS_MAP_EXPRESSION_PAIR@2115..2137
-                0: SCSS_EXPRESSION@2115..2128
-                  0: SCSS_EXPRESSION_ITEM_LIST@2115..2128
-                    0: CSS_IDENTIFIER@2115..2128
-                      0: IDENT@2115..2128 "comparison" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2128..2130 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2130..2137
-                  0: SCSS_EXPRESSION_ITEM_LIST@2130..2137
-                    0: SCSS_BINARY_EXPRESSION@2130..2137
-                      0: SCSS_VARIABLE@2130..2133
-                        0: DOLLAR@2130..2131 "$" [] []
-                        1: CSS_IDENTIFIER@2131..2133
-                          0: IDENT@2131..2133 "a" [] [Whitespace(" ")]
-                      1: R_ANGLE@2133..2135 ">" [] [Whitespace(" ")]
-                      2: SCSS_VARIABLE@2135..2137
-                        0: DOLLAR@2135..2136 "$" [] []
-                        1: CSS_IDENTIFIER@2136..2137
-                          0: IDENT@2136..2137 "b" [] []
-              5: COMMA@2137..2138 "," [] []
-            2: R_PAREN@2138..2140 ")" [Newline("\n")] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2140..2140
-      4: SEMICOLON@2140..2141 ";" [] []
-    58: SCSS_VARIABLE_DECLARATION@2141..2213
-      0: SCSS_VARIABLE@2141..2183
-        0: DOLLAR@2141..2171 "$" [Newline("\n"), Newline("\n"), Comments("// Expression as list ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@2171..2183
-          0: IDENT@2171..2183 "expr-in-list" [] []
-      1: COLON@2183..2185 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2185..2212
-        0: SCSS_EXPRESSION_ITEM_LIST@2185..2212
-          0: SCSS_PARENTHESIZED_EXPRESSION@2185..2212
-            0: L_PAREN@2185..2186 "(" [] []
-            1: SCSS_LIST_EXPRESSION@2186..2211
-              0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@2186..2211
-                0: SCSS_LIST_EXPRESSION_ELEMENT@2186..2193
-                  0: SCSS_EXPRESSION@2186..2193
-                    0: SCSS_EXPRESSION_ITEM_LIST@2186..2193
-                      0: SCSS_BINARY_EXPRESSION@2186..2193
-                        0: SCSS_VARIABLE@2186..2189
-                          0: DOLLAR@2186..2187 "$" [] []
-                          1: CSS_IDENTIFIER@2187..2189
-                            0: IDENT@2187..2189 "a" [] [Whitespace(" ")]
-                        1: PLUS@2189..2191 "+" [] [Whitespace(" ")]
-                        2: SCSS_VARIABLE@2191..2193
-                          0: DOLLAR@2191..2192 "$" [] []
-                          1: CSS_IDENTIFIER@2192..2193
-                            0: IDENT@2192..2193 "b" [] []
-                1: COMMA@2193..2195 "," [] [Whitespace(" ")]
-                2: SCSS_LIST_EXPRESSION_ELEMENT@2195..2202
-                  0: SCSS_EXPRESSION@2195..2202
-                    0: SCSS_EXPRESSION_ITEM_LIST@2195..2202
-                      0: SCSS_BINARY_EXPRESSION@2195..2202
-                        0: SCSS_VARIABLE@2195..2198
-                          0: DOLLAR@2195..2196 "$" [] []
-                          1: CSS_IDENTIFIER@2196..2198
-                            0: IDENT@2196..2198 "a" [] [Whitespace(" ")]
-                        1: STAR@2198..2200 "*" [] [Whitespace(" ")]
-                        2: SCSS_VARIABLE@2200..2202
-                          0: DOLLAR@2200..2201 "$" [] []
-                          1: CSS_IDENTIFIER@2201..2202
-                            0: IDENT@2201..2202 "b" [] []
-                3: COMMA@2202..2204 "," [] [Whitespace(" ")]
-                4: SCSS_LIST_EXPRESSION_ELEMENT@2204..2211
-                  0: SCSS_EXPRESSION@2204..2211
-                    0: SCSS_EXPRESSION_ITEM_LIST@2204..2211
-                      0: SCSS_BINARY_EXPRESSION@2204..2211
-                        0: SCSS_VARIABLE@2204..2207
-                          0: DOLLAR@2204..2205 "$" [] []
-                          1: CSS_IDENTIFIER@2205..2207
-                            0: IDENT@2205..2207 "a" [] [Whitespace(" ")]
-                        1: R_ANGLE@2207..2209 ">" [] [Whitespace(" ")]
-                        2: SCSS_VARIABLE@2209..2211
-                          0: DOLLAR@2209..2210 "$" [] []
-                          1: CSS_IDENTIFIER@2210..2211
-                            0: IDENT@2210..2211 "b" [] []
-            2: R_PAREN@2211..2212 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2212..2212
-      4: SEMICOLON@2212..2213 ";" [] []
-    59: SCSS_VARIABLE_DECLARATION@2213..2270
-      0: SCSS_VARIABLE@2213..2260
-        0: DOLLAR@2213..2250 "$" [Newline("\n"), Newline("\n"), Comments("// Comma operator (li ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@2250..2260
-          0: IDENT@2250..2260 "comma-expr" [] []
-      1: COLON@2260..2262 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2262..2269
-        0: SCSS_EXPRESSION_ITEM_LIST@2262..2269
-          0: SCSS_LIST_EXPRESSION@2262..2269
-            0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@2262..2269
-              0: SCSS_LIST_EXPRESSION_ELEMENT@2262..2263
-                0: SCSS_EXPRESSION@2262..2263
-                  0: SCSS_EXPRESSION_ITEM_LIST@2262..2263
-                    0: CSS_NUMBER@2262..2263
-                      0: CSS_NUMBER_LITERAL@2262..2263 "1" [] []
-              1: COMMA@2263..2265 "," [] [Whitespace(" ")]
-              2: SCSS_LIST_EXPRESSION_ELEMENT@2265..2266
-                0: SCSS_EXPRESSION@2265..2266
-                  0: SCSS_EXPRESSION_ITEM_LIST@2265..2266
-                    0: CSS_NUMBER@2265..2266
-                      0: CSS_NUMBER_LITERAL@2265..2266 "2" [] []
-              3: COMMA@2266..2268 "," [] [Whitespace(" ")]
-              4: SCSS_LIST_EXPRESSION_ELEMENT@2268..2269
-                0: SCSS_EXPRESSION@2268..2269
-                  0: SCSS_EXPRESSION_ITEM_LIST@2268..2269
-                    0: CSS_NUMBER@2268..2269
-                      0: CSS_NUMBER_LITERAL@2268..2269 "3" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2269..2269
-      4: SEMICOLON@2269..2270 ";" [] []
-    60: SCSS_VARIABLE_DECLARATION@2270..2325
-      0: SCSS_VARIABLE@2270..2317
-        0: DOLLAR@2270..2307 "$" [Newline("\n"), Newline("\n"), Comments("// Space operator (li ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@2307..2317
-          0: IDENT@2307..2317 "space-expr" [] []
-      1: COLON@2317..2319 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2319..2324
-        0: SCSS_EXPRESSION_ITEM_LIST@2319..2324
-          0: CSS_NUMBER@2319..2321
-            0: CSS_NUMBER_LITERAL@2319..2321 "1" [] [Whitespace(" ")]
-          1: CSS_NUMBER@2321..2323
-            0: CSS_NUMBER_LITERAL@2321..2323 "2" [] [Whitespace(" ")]
-          2: CSS_NUMBER@2323..2324
-            0: CSS_NUMBER_LITERAL@2323..2324 "3" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2324..2324
-      4: SEMICOLON@2324..2325 ";" [] []
-    61: SCSS_VARIABLE_DECLARATION@2325..2503
-      0: SCSS_VARIABLE@2325..2363
-        0: DOLLAR@2325..2356 "$" [Newline("\n"), Newline("\n"), Comments("// Mixed in complex c ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@2356..2363
-          0: IDENT@2356..2363 "complex" [] []
-      1: COLON@2363..2365 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2365..2502
-        0: SCSS_EXPRESSION_ITEM_LIST@2365..2502
-          0: SCSS_MAP_EXPRESSION@2365..2502
-            0: L_PAREN@2365..2366 "(" [] []
-            1: SCSS_MAP_EXPRESSION_PAIR_LIST@2366..2500
-              0: SCSS_MAP_EXPRESSION_PAIR@2366..2392
-                0: SCSS_EXPRESSION@2366..2373
-                  0: SCSS_EXPRESSION_ITEM_LIST@2366..2373
-                    0: CSS_IDENTIFIER@2366..2373
-                      0: IDENT@2366..2373 "calc" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2373..2375 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2375..2392
-                  0: SCSS_EXPRESSION_ITEM_LIST@2375..2392
-                    0: SCSS_BINARY_EXPRESSION@2375..2392
-                      0: SCSS_PARENTHESIZED_EXPRESSION@2375..2383
-                        0: L_PAREN@2375..2376 "(" [] []
-                        1: SCSS_EXPRESSION@2376..2381
-                          0: SCSS_EXPRESSION_ITEM_LIST@2376..2381
-                            0: SCSS_BINARY_EXPRESSION@2376..2381
-                              0: CSS_NUMBER@2376..2378
-                                0: CSS_NUMBER_LITERAL@2376..2378 "1" [] [Whitespace(" ")]
-                              1: PLUS@2378..2380 "+" [] [Whitespace(" ")]
-                              2: CSS_NUMBER@2380..2381
-                                0: CSS_NUMBER_LITERAL@2380..2381 "2" [] []
-                        2: R_PAREN@2381..2383 ")" [] [Whitespace(" ")]
-                      1: STAR@2383..2385 "*" [] [Whitespace(" ")]
-                      2: SCSS_PARENTHESIZED_EXPRESSION@2385..2392
-                        0: L_PAREN@2385..2386 "(" [] []
-                        1: SCSS_EXPRESSION@2386..2391
-                          0: SCSS_EXPRESSION_ITEM_LIST@2386..2391
-                            0: SCSS_BINARY_EXPRESSION@2386..2391
-                              0: CSS_NUMBER@2386..2388
-                                0: CSS_NUMBER_LITERAL@2386..2388 "3" [] [Whitespace(" ")]
-                              1: PLUS@2388..2390 "+" [] [Whitespace(" ")]
-                              2: CSS_NUMBER@2390..2391
-                                0: CSS_NUMBER_LITERAL@2390..2391 "4" [] []
-                        2: R_PAREN@2391..2392 ")" [] []
-              1: COMMA@2392..2393 "," [] []
-              2: SCSS_MAP_EXPRESSION_PAIR@2393..2427
-                0: SCSS_EXPRESSION@2393..2401
-                  0: SCSS_EXPRESSION_ITEM_LIST@2393..2401
-                    0: CSS_IDENTIFIER@2393..2401
-                      0: IDENT@2393..2401 "logic" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2401..2403 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2403..2427
-                  0: SCSS_EXPRESSION_ITEM_LIST@2403..2427
-                    0: SCSS_BINARY_EXPRESSION@2403..2427
-                      0: SCSS_PARENTHESIZED_EXPRESSION@2403..2420
-                        0: L_PAREN@2403..2404 "(" [] []
-                        1: SCSS_EXPRESSION@2404..2418
-                          0: SCSS_EXPRESSION_ITEM_LIST@2404..2418
-                            0: SCSS_BINARY_EXPRESSION@2404..2418
-                              0: CSS_IDENTIFIER@2404..2409
-                                0: IDENT@2404..2409 "true" [] [Whitespace(" ")]
-                              1: AND_KW@2409..2413 "and" [] [Whitespace(" ")]
-                              2: CSS_IDENTIFIER@2413..2418
-                                0: IDENT@2413..2418 "false" [] []
-                        2: R_PAREN@2418..2420 ")" [] [Whitespace(" ")]
-                      1: OR_KW@2420..2423 "or" [] [Whitespace(" ")]
-                      2: CSS_IDENTIFIER@2423..2427
-                        0: IDENT@2423..2427 "true" [] []
-              3: COMMA@2427..2428 "," [] []
-              4: SCSS_MAP_EXPRESSION_PAIR@2428..2462
-                0: SCSS_EXPRESSION@2428..2438
-                  0: SCSS_EXPRESSION_ITEM_LIST@2428..2438
-                    0: CSS_IDENTIFIER@2428..2438
-                      0: IDENT@2428..2438 "compare" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2438..2440 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2440..2462
-                  0: SCSS_EXPRESSION_ITEM_LIST@2440..2462
-                    0: SCSS_BINARY_EXPRESSION@2440..2462
-                      0: SCSS_PARENTHESIZED_EXPRESSION@2440..2449
-                        0: L_PAREN@2440..2441 "(" [] []
-                        1: SCSS_EXPRESSION@2441..2447
-                          0: SCSS_EXPRESSION_ITEM_LIST@2441..2447
-                            0: SCSS_BINARY_EXPRESSION@2441..2447
-                              0: CSS_NUMBER@2441..2444
-                                0: CSS_NUMBER_LITERAL@2441..2444 "10" [] [Whitespace(" ")]
-                              1: R_ANGLE@2444..2446 ">" [] [Whitespace(" ")]
-                              2: CSS_NUMBER@2446..2447
-                                0: CSS_NUMBER_LITERAL@2446..2447 "5" [] []
-                        2: R_PAREN@2447..2449 ")" [] [Whitespace(" ")]
-                      1: AND_KW@2449..2453 "and" [] [Whitespace(" ")]
-                      2: SCSS_PARENTHESIZED_EXPRESSION@2453..2462
-                        0: L_PAREN@2453..2454 "(" [] []
-                        1: SCSS_EXPRESSION@2454..2461
-                          0: SCSS_EXPRESSION_ITEM_LIST@2454..2461
-                            0: SCSS_BINARY_EXPRESSION@2454..2461
-                              0: CSS_NUMBER@2454..2457
-                                0: CSS_NUMBER_LITERAL@2454..2457 "20" [] [Whitespace(" ")]
-                              1: L_ANGLE@2457..2459 "<" [] [Whitespace(" ")]
-                              2: CSS_NUMBER@2459..2461
-                                0: CSS_NUMBER_LITERAL@2459..2461 "30" [] []
-                        2: R_PAREN@2461..2462 ")" [] []
-              5: COMMA@2462..2463 "," [] []
-              6: SCSS_MAP_EXPRESSION_PAIR@2463..2499
-                0: SCSS_EXPRESSION@2463..2472
-                  0: SCSS_EXPRESSION_ITEM_LIST@2463..2472
-                    0: CSS_IDENTIFIER@2463..2472
-                      0: IDENT@2463..2472 "nested" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2472..2474 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2474..2499
-                  0: SCSS_EXPRESSION_ITEM_LIST@2474..2499
-                    0: SCSS_PARENTHESIZED_EXPRESSION@2474..2499
-                      0: L_PAREN@2474..2475 "(" [] []
-                      1: SCSS_EXPRESSION@2475..2498
-                        0: SCSS_EXPRESSION_ITEM_LIST@2475..2498
-                          0: SCSS_BINARY_EXPRESSION@2475..2498
-                            0: SCSS_PARENTHESIZED_EXPRESSION@2475..2489
-                              0: L_PAREN@2475..2476 "(" [] []
-                              1: SCSS_EXPRESSION@2476..2487
-                                0: SCSS_EXPRESSION_ITEM_LIST@2476..2487
-                                  0: SCSS_BINARY_EXPRESSION@2476..2487
-                                    0: CSS_NUMBER@2476..2478
-                                      0: CSS_NUMBER_LITERAL@2476..2478 "1" [] [Whitespace(" ")]
-                                    1: PLUS@2478..2480 "+" [] [Whitespace(" ")]
-                                    2: SCSS_PARENTHESIZED_EXPRESSION@2480..2487
-                                      0: L_PAREN@2480..2481 "(" [] []
-                                      1: SCSS_EXPRESSION@2481..2486
-                                        0: SCSS_EXPRESSION_ITEM_LIST@2481..2486
-                                          0: SCSS_BINARY_EXPRESSION@2481..2486
-                                            0: CSS_NUMBER@2481..2483
-                                              0: CSS_NUMBER_LITERAL@2481..2483 "2" [] [Whitespace(" ")]
-                                            1: STAR@2483..2485 "*" [] [Whitespace(" ")]
-                                            2: CSS_NUMBER@2485..2486
-                                              0: CSS_NUMBER_LITERAL@2485..2486 "3" [] []
-                                      2: R_PAREN@2486..2487 ")" [] []
-                              2: R_PAREN@2487..2489 ")" [] [Whitespace(" ")]
-                            1: MINUS@2489..2491 "-" [] [Whitespace(" ")]
-                            2: SCSS_PARENTHESIZED_EXPRESSION@2491..2498
-                              0: L_PAREN@2491..2492 "(" [] []
-                              1: SCSS_EXPRESSION@2492..2497
-                                0: SCSS_EXPRESSION_ITEM_LIST@2492..2497
-                                  0: CSS_RATIO@2492..2497
-                                    0: CSS_NUMBER@2492..2494
-                                      0: CSS_NUMBER_LITERAL@2492..2494 "4" [] [Whitespace(" ")]
-                                    1: SLASH@2494..2496 "/" [] [Whitespace(" ")]
-                                    2: CSS_NUMBER@2496..2497
-                                      0: CSS_NUMBER_LITERAL@2496..2497 "2" [] []
-                              2: R_PAREN@2497..2498 ")" [] []
-                      2: R_PAREN@2498..2499 ")" [] []
-              7: COMMA@2499..2500 "," [] []
-            2: R_PAREN@2500..2502 ")" [Newline("\n")] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2502..2502
-      4: SEMICOLON@2502..2503 ";" [] []
-    62: CSS_QUALIFIED_RULE@2503..2566
-      0: CSS_SELECTOR_LIST@2503..2549
-        0: CSS_COMPOUND_SELECTOR@2503..2549
-          0: CSS_NESTED_SELECTOR_LIST@2503..2503
+              1: COMMA@2114..2115 "," [] []
+              2: SCSS_MAP_EXPRESSION_PAIR@2115..2134
+                0: SCSS_EXPRESSION@2115..2125
+                  0: SCSS_EXPRESSION_ITEM_LIST@2115..2125
+                    0: CSS_IDENTIFIER@2115..2125
+                      0: IDENT@2115..2125 "product" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2125..2127 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2127..2134
+                  0: SCSS_EXPRESSION_ITEM_LIST@2127..2134
+                    0: SCSS_BINARY_EXPRESSION@2127..2134
+                      0: SCSS_VARIABLE@2127..2130
+                        0: DOLLAR@2127..2128 "$" [] []
+                        1: CSS_IDENTIFIER@2128..2130
+                          0: IDENT@2128..2130 "a" [] [Whitespace(" ")]
+                      1: STAR@2130..2132 "*" [] [Whitespace(" ")]
+                      2: SCSS_VARIABLE@2132..2134
+                        0: DOLLAR@2132..2133 "$" [] []
+                        1: CSS_IDENTIFIER@2133..2134
+                          0: IDENT@2133..2134 "b" [] []
+              3: COMMA@2134..2135 "," [] []
+              4: SCSS_MAP_EXPRESSION_PAIR@2135..2157
+                0: SCSS_EXPRESSION@2135..2148
+                  0: SCSS_EXPRESSION_ITEM_LIST@2135..2148
+                    0: CSS_IDENTIFIER@2135..2148
+                      0: IDENT@2135..2148 "comparison" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2148..2150 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2150..2157
+                  0: SCSS_EXPRESSION_ITEM_LIST@2150..2157
+                    0: SCSS_BINARY_EXPRESSION@2150..2157
+                      0: SCSS_VARIABLE@2150..2153
+                        0: DOLLAR@2150..2151 "$" [] []
+                        1: CSS_IDENTIFIER@2151..2153
+                          0: IDENT@2151..2153 "a" [] [Whitespace(" ")]
+                      1: R_ANGLE@2153..2155 ">" [] [Whitespace(" ")]
+                      2: SCSS_VARIABLE@2155..2157
+                        0: DOLLAR@2155..2156 "$" [] []
+                        1: CSS_IDENTIFIER@2156..2157
+                          0: IDENT@2156..2157 "b" [] []
+              5: COMMA@2157..2158 "," [] []
+            2: R_PAREN@2158..2160 ")" [Newline("\n")] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2160..2160
+      4: SEMICOLON@2160..2161 ";" [] []
+    59: SCSS_VARIABLE_DECLARATION@2161..2233
+      0: SCSS_VARIABLE@2161..2203
+        0: DOLLAR@2161..2191 "$" [Newline("\n"), Newline("\n"), Comments("// Expression as list ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@2191..2203
+          0: IDENT@2191..2203 "expr-in-list" [] []
+      1: COLON@2203..2205 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2205..2232
+        0: SCSS_EXPRESSION_ITEM_LIST@2205..2232
+          0: SCSS_PARENTHESIZED_EXPRESSION@2205..2232
+            0: L_PAREN@2205..2206 "(" [] []
+            1: SCSS_LIST_EXPRESSION@2206..2231
+              0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@2206..2231
+                0: SCSS_LIST_EXPRESSION_ELEMENT@2206..2213
+                  0: SCSS_EXPRESSION@2206..2213
+                    0: SCSS_EXPRESSION_ITEM_LIST@2206..2213
+                      0: SCSS_BINARY_EXPRESSION@2206..2213
+                        0: SCSS_VARIABLE@2206..2209
+                          0: DOLLAR@2206..2207 "$" [] []
+                          1: CSS_IDENTIFIER@2207..2209
+                            0: IDENT@2207..2209 "a" [] [Whitespace(" ")]
+                        1: PLUS@2209..2211 "+" [] [Whitespace(" ")]
+                        2: SCSS_VARIABLE@2211..2213
+                          0: DOLLAR@2211..2212 "$" [] []
+                          1: CSS_IDENTIFIER@2212..2213
+                            0: IDENT@2212..2213 "b" [] []
+                1: COMMA@2213..2215 "," [] [Whitespace(" ")]
+                2: SCSS_LIST_EXPRESSION_ELEMENT@2215..2222
+                  0: SCSS_EXPRESSION@2215..2222
+                    0: SCSS_EXPRESSION_ITEM_LIST@2215..2222
+                      0: SCSS_BINARY_EXPRESSION@2215..2222
+                        0: SCSS_VARIABLE@2215..2218
+                          0: DOLLAR@2215..2216 "$" [] []
+                          1: CSS_IDENTIFIER@2216..2218
+                            0: IDENT@2216..2218 "a" [] [Whitespace(" ")]
+                        1: STAR@2218..2220 "*" [] [Whitespace(" ")]
+                        2: SCSS_VARIABLE@2220..2222
+                          0: DOLLAR@2220..2221 "$" [] []
+                          1: CSS_IDENTIFIER@2221..2222
+                            0: IDENT@2221..2222 "b" [] []
+                3: COMMA@2222..2224 "," [] [Whitespace(" ")]
+                4: SCSS_LIST_EXPRESSION_ELEMENT@2224..2231
+                  0: SCSS_EXPRESSION@2224..2231
+                    0: SCSS_EXPRESSION_ITEM_LIST@2224..2231
+                      0: SCSS_BINARY_EXPRESSION@2224..2231
+                        0: SCSS_VARIABLE@2224..2227
+                          0: DOLLAR@2224..2225 "$" [] []
+                          1: CSS_IDENTIFIER@2225..2227
+                            0: IDENT@2225..2227 "a" [] [Whitespace(" ")]
+                        1: R_ANGLE@2227..2229 ">" [] [Whitespace(" ")]
+                        2: SCSS_VARIABLE@2229..2231
+                          0: DOLLAR@2229..2230 "$" [] []
+                          1: CSS_IDENTIFIER@2230..2231
+                            0: IDENT@2230..2231 "b" [] []
+            2: R_PAREN@2231..2232 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2232..2232
+      4: SEMICOLON@2232..2233 ";" [] []
+    60: SCSS_VARIABLE_DECLARATION@2233..2290
+      0: SCSS_VARIABLE@2233..2280
+        0: DOLLAR@2233..2270 "$" [Newline("\n"), Newline("\n"), Comments("// Comma operator (li ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@2270..2280
+          0: IDENT@2270..2280 "comma-expr" [] []
+      1: COLON@2280..2282 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2282..2289
+        0: SCSS_EXPRESSION_ITEM_LIST@2282..2289
+          0: SCSS_LIST_EXPRESSION@2282..2289
+            0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@2282..2289
+              0: SCSS_LIST_EXPRESSION_ELEMENT@2282..2283
+                0: SCSS_EXPRESSION@2282..2283
+                  0: SCSS_EXPRESSION_ITEM_LIST@2282..2283
+                    0: CSS_NUMBER@2282..2283
+                      0: CSS_NUMBER_LITERAL@2282..2283 "1" [] []
+              1: COMMA@2283..2285 "," [] [Whitespace(" ")]
+              2: SCSS_LIST_EXPRESSION_ELEMENT@2285..2286
+                0: SCSS_EXPRESSION@2285..2286
+                  0: SCSS_EXPRESSION_ITEM_LIST@2285..2286
+                    0: CSS_NUMBER@2285..2286
+                      0: CSS_NUMBER_LITERAL@2285..2286 "2" [] []
+              3: COMMA@2286..2288 "," [] [Whitespace(" ")]
+              4: SCSS_LIST_EXPRESSION_ELEMENT@2288..2289
+                0: SCSS_EXPRESSION@2288..2289
+                  0: SCSS_EXPRESSION_ITEM_LIST@2288..2289
+                    0: CSS_NUMBER@2288..2289
+                      0: CSS_NUMBER_LITERAL@2288..2289 "3" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2289..2289
+      4: SEMICOLON@2289..2290 ";" [] []
+    61: SCSS_VARIABLE_DECLARATION@2290..2345
+      0: SCSS_VARIABLE@2290..2337
+        0: DOLLAR@2290..2327 "$" [Newline("\n"), Newline("\n"), Comments("// Space operator (li ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@2327..2337
+          0: IDENT@2327..2337 "space-expr" [] []
+      1: COLON@2337..2339 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2339..2344
+        0: SCSS_EXPRESSION_ITEM_LIST@2339..2344
+          0: CSS_NUMBER@2339..2341
+            0: CSS_NUMBER_LITERAL@2339..2341 "1" [] [Whitespace(" ")]
+          1: CSS_NUMBER@2341..2343
+            0: CSS_NUMBER_LITERAL@2341..2343 "2" [] [Whitespace(" ")]
+          2: CSS_NUMBER@2343..2344
+            0: CSS_NUMBER_LITERAL@2343..2344 "3" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2344..2344
+      4: SEMICOLON@2344..2345 ";" [] []
+    62: SCSS_VARIABLE_DECLARATION@2345..2523
+      0: SCSS_VARIABLE@2345..2383
+        0: DOLLAR@2345..2376 "$" [Newline("\n"), Newline("\n"), Comments("// Mixed in complex c ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@2376..2383
+          0: IDENT@2376..2383 "complex" [] []
+      1: COLON@2383..2385 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2385..2522
+        0: SCSS_EXPRESSION_ITEM_LIST@2385..2522
+          0: SCSS_MAP_EXPRESSION@2385..2522
+            0: L_PAREN@2385..2386 "(" [] []
+            1: SCSS_MAP_EXPRESSION_PAIR_LIST@2386..2520
+              0: SCSS_MAP_EXPRESSION_PAIR@2386..2412
+                0: SCSS_EXPRESSION@2386..2393
+                  0: SCSS_EXPRESSION_ITEM_LIST@2386..2393
+                    0: CSS_IDENTIFIER@2386..2393
+                      0: IDENT@2386..2393 "calc" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2393..2395 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2395..2412
+                  0: SCSS_EXPRESSION_ITEM_LIST@2395..2412
+                    0: SCSS_BINARY_EXPRESSION@2395..2412
+                      0: SCSS_PARENTHESIZED_EXPRESSION@2395..2403
+                        0: L_PAREN@2395..2396 "(" [] []
+                        1: SCSS_EXPRESSION@2396..2401
+                          0: SCSS_EXPRESSION_ITEM_LIST@2396..2401
+                            0: SCSS_BINARY_EXPRESSION@2396..2401
+                              0: CSS_NUMBER@2396..2398
+                                0: CSS_NUMBER_LITERAL@2396..2398 "1" [] [Whitespace(" ")]
+                              1: PLUS@2398..2400 "+" [] [Whitespace(" ")]
+                              2: CSS_NUMBER@2400..2401
+                                0: CSS_NUMBER_LITERAL@2400..2401 "2" [] []
+                        2: R_PAREN@2401..2403 ")" [] [Whitespace(" ")]
+                      1: STAR@2403..2405 "*" [] [Whitespace(" ")]
+                      2: SCSS_PARENTHESIZED_EXPRESSION@2405..2412
+                        0: L_PAREN@2405..2406 "(" [] []
+                        1: SCSS_EXPRESSION@2406..2411
+                          0: SCSS_EXPRESSION_ITEM_LIST@2406..2411
+                            0: SCSS_BINARY_EXPRESSION@2406..2411
+                              0: CSS_NUMBER@2406..2408
+                                0: CSS_NUMBER_LITERAL@2406..2408 "3" [] [Whitespace(" ")]
+                              1: PLUS@2408..2410 "+" [] [Whitespace(" ")]
+                              2: CSS_NUMBER@2410..2411
+                                0: CSS_NUMBER_LITERAL@2410..2411 "4" [] []
+                        2: R_PAREN@2411..2412 ")" [] []
+              1: COMMA@2412..2413 "," [] []
+              2: SCSS_MAP_EXPRESSION_PAIR@2413..2447
+                0: SCSS_EXPRESSION@2413..2421
+                  0: SCSS_EXPRESSION_ITEM_LIST@2413..2421
+                    0: CSS_IDENTIFIER@2413..2421
+                      0: IDENT@2413..2421 "logic" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2421..2423 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2423..2447
+                  0: SCSS_EXPRESSION_ITEM_LIST@2423..2447
+                    0: SCSS_BINARY_EXPRESSION@2423..2447
+                      0: SCSS_PARENTHESIZED_EXPRESSION@2423..2440
+                        0: L_PAREN@2423..2424 "(" [] []
+                        1: SCSS_EXPRESSION@2424..2438
+                          0: SCSS_EXPRESSION_ITEM_LIST@2424..2438
+                            0: SCSS_BINARY_EXPRESSION@2424..2438
+                              0: CSS_IDENTIFIER@2424..2429
+                                0: IDENT@2424..2429 "true" [] [Whitespace(" ")]
+                              1: AND_KW@2429..2433 "and" [] [Whitespace(" ")]
+                              2: CSS_IDENTIFIER@2433..2438
+                                0: IDENT@2433..2438 "false" [] []
+                        2: R_PAREN@2438..2440 ")" [] [Whitespace(" ")]
+                      1: OR_KW@2440..2443 "or" [] [Whitespace(" ")]
+                      2: CSS_IDENTIFIER@2443..2447
+                        0: IDENT@2443..2447 "true" [] []
+              3: COMMA@2447..2448 "," [] []
+              4: SCSS_MAP_EXPRESSION_PAIR@2448..2482
+                0: SCSS_EXPRESSION@2448..2458
+                  0: SCSS_EXPRESSION_ITEM_LIST@2448..2458
+                    0: CSS_IDENTIFIER@2448..2458
+                      0: IDENT@2448..2458 "compare" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2458..2460 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2460..2482
+                  0: SCSS_EXPRESSION_ITEM_LIST@2460..2482
+                    0: SCSS_BINARY_EXPRESSION@2460..2482
+                      0: SCSS_PARENTHESIZED_EXPRESSION@2460..2469
+                        0: L_PAREN@2460..2461 "(" [] []
+                        1: SCSS_EXPRESSION@2461..2467
+                          0: SCSS_EXPRESSION_ITEM_LIST@2461..2467
+                            0: SCSS_BINARY_EXPRESSION@2461..2467
+                              0: CSS_NUMBER@2461..2464
+                                0: CSS_NUMBER_LITERAL@2461..2464 "10" [] [Whitespace(" ")]
+                              1: R_ANGLE@2464..2466 ">" [] [Whitespace(" ")]
+                              2: CSS_NUMBER@2466..2467
+                                0: CSS_NUMBER_LITERAL@2466..2467 "5" [] []
+                        2: R_PAREN@2467..2469 ")" [] [Whitespace(" ")]
+                      1: AND_KW@2469..2473 "and" [] [Whitespace(" ")]
+                      2: SCSS_PARENTHESIZED_EXPRESSION@2473..2482
+                        0: L_PAREN@2473..2474 "(" [] []
+                        1: SCSS_EXPRESSION@2474..2481
+                          0: SCSS_EXPRESSION_ITEM_LIST@2474..2481
+                            0: SCSS_BINARY_EXPRESSION@2474..2481
+                              0: CSS_NUMBER@2474..2477
+                                0: CSS_NUMBER_LITERAL@2474..2477 "20" [] [Whitespace(" ")]
+                              1: L_ANGLE@2477..2479 "<" [] [Whitespace(" ")]
+                              2: CSS_NUMBER@2479..2481
+                                0: CSS_NUMBER_LITERAL@2479..2481 "30" [] []
+                        2: R_PAREN@2481..2482 ")" [] []
+              5: COMMA@2482..2483 "," [] []
+              6: SCSS_MAP_EXPRESSION_PAIR@2483..2519
+                0: SCSS_EXPRESSION@2483..2492
+                  0: SCSS_EXPRESSION_ITEM_LIST@2483..2492
+                    0: CSS_IDENTIFIER@2483..2492
+                      0: IDENT@2483..2492 "nested" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2492..2494 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2494..2519
+                  0: SCSS_EXPRESSION_ITEM_LIST@2494..2519
+                    0: SCSS_PARENTHESIZED_EXPRESSION@2494..2519
+                      0: L_PAREN@2494..2495 "(" [] []
+                      1: SCSS_EXPRESSION@2495..2518
+                        0: SCSS_EXPRESSION_ITEM_LIST@2495..2518
+                          0: SCSS_BINARY_EXPRESSION@2495..2518
+                            0: SCSS_PARENTHESIZED_EXPRESSION@2495..2509
+                              0: L_PAREN@2495..2496 "(" [] []
+                              1: SCSS_EXPRESSION@2496..2507
+                                0: SCSS_EXPRESSION_ITEM_LIST@2496..2507
+                                  0: SCSS_BINARY_EXPRESSION@2496..2507
+                                    0: CSS_NUMBER@2496..2498
+                                      0: CSS_NUMBER_LITERAL@2496..2498 "1" [] [Whitespace(" ")]
+                                    1: PLUS@2498..2500 "+" [] [Whitespace(" ")]
+                                    2: SCSS_PARENTHESIZED_EXPRESSION@2500..2507
+                                      0: L_PAREN@2500..2501 "(" [] []
+                                      1: SCSS_EXPRESSION@2501..2506
+                                        0: SCSS_EXPRESSION_ITEM_LIST@2501..2506
+                                          0: SCSS_BINARY_EXPRESSION@2501..2506
+                                            0: CSS_NUMBER@2501..2503
+                                              0: CSS_NUMBER_LITERAL@2501..2503 "2" [] [Whitespace(" ")]
+                                            1: STAR@2503..2505 "*" [] [Whitespace(" ")]
+                                            2: CSS_NUMBER@2505..2506
+                                              0: CSS_NUMBER_LITERAL@2505..2506 "3" [] []
+                                      2: R_PAREN@2506..2507 ")" [] []
+                              2: R_PAREN@2507..2509 ")" [] [Whitespace(" ")]
+                            1: MINUS@2509..2511 "-" [] [Whitespace(" ")]
+                            2: SCSS_PARENTHESIZED_EXPRESSION@2511..2518
+                              0: L_PAREN@2511..2512 "(" [] []
+                              1: SCSS_EXPRESSION@2512..2517
+                                0: SCSS_EXPRESSION_ITEM_LIST@2512..2517
+                                  0: SCSS_BINARY_EXPRESSION@2512..2517
+                                    0: CSS_NUMBER@2512..2514
+                                      0: CSS_NUMBER_LITERAL@2512..2514 "4" [] [Whitespace(" ")]
+                                    1: SLASH@2514..2516 "/" [] [Whitespace(" ")]
+                                    2: CSS_NUMBER@2516..2517
+                                      0: CSS_NUMBER_LITERAL@2516..2517 "2" [] []
+                              2: R_PAREN@2517..2518 ")" [] []
+                      2: R_PAREN@2518..2519 ")" [] []
+              7: COMMA@2519..2520 "," [] []
+            2: R_PAREN@2520..2522 ")" [Newline("\n")] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2522..2522
+      4: SEMICOLON@2522..2523 ";" [] []
+    63: CSS_QUALIFIED_RULE@2523..2586
+      0: CSS_SELECTOR_LIST@2523..2569
+        0: CSS_COMPOUND_SELECTOR@2523..2569
+          0: CSS_NESTED_SELECTOR_LIST@2523..2523
           1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@2503..2549
-            0: CSS_CLASS_SELECTOR@2503..2549
-              0: DOT@2503..2534 "." [Newline("\n"), Newline("\n"), Comments("// Expressions in sel ..."), Newline("\n")] []
-              1: SCSS_INTERPOLATED_IDENTIFIER@2534..2549
-                0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@2534..2549
-                  0: CSS_CUSTOM_IDENTIFIER@2534..2540
-                    0: IDENT@2534..2540 "class-" [] []
-                  1: SCSS_INTERPOLATION@2540..2549
-                    0: HASH@2540..2541 "#" [] []
-                    1: L_CURLY@2541..2542 "{" [] []
-                    2: SCSS_EXPRESSION@2542..2547
-                      0: SCSS_EXPRESSION_ITEM_LIST@2542..2547
-                        0: SCSS_BINARY_EXPRESSION@2542..2547
-                          0: CSS_NUMBER@2542..2544
-                            0: CSS_NUMBER_LITERAL@2542..2544 "1" [] [Whitespace(" ")]
-                          1: PLUS@2544..2546 "+" [] [Whitespace(" ")]
-                          2: CSS_NUMBER@2546..2547
-                            0: CSS_NUMBER_LITERAL@2546..2547 "1" [] []
-                    3: R_CURLY@2547..2549 "}" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@2549..2566
-        0: L_CURLY@2549..2550 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@2550..2564
-          0: CSS_DECLARATION_WITH_SEMICOLON@2550..2564
-            0: CSS_DECLARATION@2550..2563
-              0: CSS_GENERIC_PROPERTY@2550..2563
-                0: CSS_IDENTIFIER@2550..2558
-                  0: IDENT@2550..2558 "color" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2558..2560 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2560..2563
-                  0: SCSS_EXPRESSION_ITEM_LIST@2560..2563
-                    0: CSS_IDENTIFIER@2560..2563
-                      0: IDENT@2560..2563 "red" [] []
+          2: CSS_SUB_SELECTOR_LIST@2523..2569
+            0: CSS_CLASS_SELECTOR@2523..2569
+              0: DOT@2523..2554 "." [Newline("\n"), Newline("\n"), Comments("// Expressions in sel ..."), Newline("\n")] []
+              1: SCSS_INTERPOLATED_IDENTIFIER@2554..2569
+                0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@2554..2569
+                  0: CSS_CUSTOM_IDENTIFIER@2554..2560
+                    0: IDENT@2554..2560 "class-" [] []
+                  1: SCSS_INTERPOLATION@2560..2569
+                    0: HASH@2560..2561 "#" [] []
+                    1: L_CURLY@2561..2562 "{" [] []
+                    2: SCSS_EXPRESSION@2562..2567
+                      0: SCSS_EXPRESSION_ITEM_LIST@2562..2567
+                        0: SCSS_BINARY_EXPRESSION@2562..2567
+                          0: CSS_NUMBER@2562..2564
+                            0: CSS_NUMBER_LITERAL@2562..2564 "1" [] [Whitespace(" ")]
+                          1: PLUS@2564..2566 "+" [] [Whitespace(" ")]
+                          2: CSS_NUMBER@2566..2567
+                            0: CSS_NUMBER_LITERAL@2566..2567 "1" [] []
+                    3: R_CURLY@2567..2569 "}" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@2569..2586
+        0: L_CURLY@2569..2570 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@2570..2584
+          0: CSS_DECLARATION_WITH_SEMICOLON@2570..2584
+            0: CSS_DECLARATION@2570..2583
+              0: CSS_GENERIC_PROPERTY@2570..2583
+                0: CSS_IDENTIFIER@2570..2578
+                  0: IDENT@2570..2578 "color" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2578..2580 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2580..2583
+                  0: SCSS_EXPRESSION_ITEM_LIST@2580..2583
+                    0: CSS_IDENTIFIER@2580..2583
+                      0: IDENT@2580..2583 "red" [] []
               1: (empty)
-            1: SEMICOLON@2563..2564 ";" [] []
-        2: R_CURLY@2564..2566 "}" [Newline("\n")] []
-    63: CSS_QUALIFIED_RULE@2566..2687
-      0: CSS_SELECTOR_LIST@2566..2608
-        0: CSS_COMPOUND_SELECTOR@2566..2608
-          0: CSS_NESTED_SELECTOR_LIST@2566..2566
+            1: SEMICOLON@2583..2584 ";" [] []
+        2: R_CURLY@2584..2586 "}" [Newline("\n")] []
+    64: CSS_QUALIFIED_RULE@2586..2707
+      0: CSS_SELECTOR_LIST@2586..2628
+        0: CSS_COMPOUND_SELECTOR@2586..2628
+          0: CSS_NESTED_SELECTOR_LIST@2586..2586
           1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@2566..2608
-            0: CSS_CLASS_SELECTOR@2566..2608
-              0: DOT@2566..2603 "." [Newline("\n"), Newline("\n"), Comments("// Expressions in pro ..."), Newline("\n")] []
-              1: CSS_CUSTOM_IDENTIFIER@2603..2608
-                0: IDENT@2603..2608 "test" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@2608..2687
-        0: L_CURLY@2608..2609 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@2609..2685
-          0: CSS_DECLARATION_WITH_SEMICOLON@2609..2630
-            0: CSS_DECLARATION@2609..2629
-              0: CSS_GENERIC_PROPERTY@2609..2629
-                0: CSS_IDENTIFIER@2609..2617
-                  0: IDENT@2609..2617 "width" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2617..2619 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2619..2629
-                  0: SCSS_EXPRESSION_ITEM_LIST@2619..2629
-                    0: SCSS_PARENTHESIZED_EXPRESSION@2619..2629
-                      0: L_PAREN@2619..2620 "(" [] []
-                      1: SCSS_EXPRESSION@2620..2628
-                        0: SCSS_EXPRESSION_ITEM_LIST@2620..2628
-                          0: SCSS_BINARY_EXPRESSION@2620..2628
-                            0: CSS_PERCENTAGE@2620..2625
-                              0: CSS_NUMBER_LITERAL@2620..2623 "100" [] []
-                              1: PERCENT@2623..2625 "%" [] [Whitespace(" ")]
-                            1: SLASH@2625..2627 "/" [] [Whitespace(" ")]
-                            2: CSS_NUMBER@2627..2628
-                              0: CSS_NUMBER_LITERAL@2627..2628 "3" [] []
-                      2: R_PAREN@2628..2629 ")" [] []
+          2: CSS_SUB_SELECTOR_LIST@2586..2628
+            0: CSS_CLASS_SELECTOR@2586..2628
+              0: DOT@2586..2623 "." [Newline("\n"), Newline("\n"), Comments("// Expressions in pro ..."), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@2623..2628
+                0: IDENT@2623..2628 "test" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@2628..2707
+        0: L_CURLY@2628..2629 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@2629..2705
+          0: CSS_DECLARATION_WITH_SEMICOLON@2629..2650
+            0: CSS_DECLARATION@2629..2649
+              0: CSS_GENERIC_PROPERTY@2629..2649
+                0: CSS_IDENTIFIER@2629..2637
+                  0: IDENT@2629..2637 "width" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2637..2639 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2639..2649
+                  0: SCSS_EXPRESSION_ITEM_LIST@2639..2649
+                    0: SCSS_PARENTHESIZED_EXPRESSION@2639..2649
+                      0: L_PAREN@2639..2640 "(" [] []
+                      1: SCSS_EXPRESSION@2640..2648
+                        0: SCSS_EXPRESSION_ITEM_LIST@2640..2648
+                          0: SCSS_BINARY_EXPRESSION@2640..2648
+                            0: CSS_PERCENTAGE@2640..2645
+                              0: CSS_NUMBER_LITERAL@2640..2643 "100" [] []
+                              1: PERCENT@2643..2645 "%" [] [Whitespace(" ")]
+                            1: SLASH@2645..2647 "/" [] [Whitespace(" ")]
+                            2: CSS_NUMBER@2647..2648
+                              0: CSS_NUMBER_LITERAL@2647..2648 "3" [] []
+                      2: R_PAREN@2648..2649 ")" [] []
               1: (empty)
-            1: SEMICOLON@2629..2630 ";" [] []
-          1: CSS_DECLARATION_WITH_SEMICOLON@2630..2656
-            0: CSS_DECLARATION@2630..2655
-              0: CSS_GENERIC_PROPERTY@2630..2655
-                0: CSS_IDENTIFIER@2630..2639
-                  0: IDENT@2630..2639 "height" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2639..2641 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2641..2655
-                  0: SCSS_EXPRESSION_ITEM_LIST@2641..2655
-                    0: SCSS_BINARY_EXPRESSION@2641..2655
-                      0: SCSS_BINARY_EXPRESSION@2641..2649
-                        0: SCSS_VARIABLE@2641..2644
-                          0: DOLLAR@2641..2642 "$" [] []
-                          1: CSS_IDENTIFIER@2642..2644
-                            0: IDENT@2642..2644 "a" [] [Whitespace(" ")]
-                        1: PLUS@2644..2646 "+" [] [Whitespace(" ")]
-                        2: SCSS_VARIABLE@2646..2649
-                          0: DOLLAR@2646..2647 "$" [] []
-                          1: CSS_IDENTIFIER@2647..2649
-                            0: IDENT@2647..2649 "b" [] [Whitespace(" ")]
-                      1: PLUS@2649..2651 "+" [] [Whitespace(" ")]
-                      2: CSS_REGULAR_DIMENSION@2651..2655
-                        0: CSS_NUMBER_LITERAL@2651..2653 "10" [] []
-                        1: IDENT@2653..2655 "px" [] []
+            1: SEMICOLON@2649..2650 ";" [] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@2650..2676
+            0: CSS_DECLARATION@2650..2675
+              0: CSS_GENERIC_PROPERTY@2650..2675
+                0: CSS_IDENTIFIER@2650..2659
+                  0: IDENT@2650..2659 "height" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2659..2661 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2661..2675
+                  0: SCSS_EXPRESSION_ITEM_LIST@2661..2675
+                    0: SCSS_BINARY_EXPRESSION@2661..2675
+                      0: SCSS_BINARY_EXPRESSION@2661..2669
+                        0: SCSS_VARIABLE@2661..2664
+                          0: DOLLAR@2661..2662 "$" [] []
+                          1: CSS_IDENTIFIER@2662..2664
+                            0: IDENT@2662..2664 "a" [] [Whitespace(" ")]
+                        1: PLUS@2664..2666 "+" [] [Whitespace(" ")]
+                        2: SCSS_VARIABLE@2666..2669
+                          0: DOLLAR@2666..2667 "$" [] []
+                          1: CSS_IDENTIFIER@2667..2669
+                            0: IDENT@2667..2669 "b" [] [Whitespace(" ")]
+                      1: PLUS@2669..2671 "+" [] [Whitespace(" ")]
+                      2: CSS_REGULAR_DIMENSION@2671..2675
+                        0: CSS_NUMBER_LITERAL@2671..2673 "10" [] []
+                        1: IDENT@2673..2675 "px" [] []
               1: (empty)
-            1: SEMICOLON@2655..2656 ";" [] []
-          2: CSS_DECLARATION_WITH_SEMICOLON@2656..2685
-            0: CSS_DECLARATION@2656..2684
-              0: CSS_GENERIC_PROPERTY@2656..2684
-                0: CSS_IDENTIFIER@2656..2665
-                  0: IDENT@2656..2665 "margin" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@2665..2667 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@2667..2684
-                  0: SCSS_EXPRESSION_ITEM_LIST@2667..2684
-                    0: SCSS_PARENTHESIZED_EXPRESSION@2667..2676
-                      0: L_PAREN@2667..2668 "(" [] []
-                      1: SCSS_EXPRESSION@2668..2674
-                        0: SCSS_EXPRESSION_ITEM_LIST@2668..2674
-                          0: SCSS_BINARY_EXPRESSION@2668..2674
-                            0: SCSS_VARIABLE@2668..2671
-                              0: DOLLAR@2668..2669 "$" [] []
-                              1: CSS_IDENTIFIER@2669..2671
-                                0: IDENT@2669..2671 "a" [] [Whitespace(" ")]
-                            1: STAR@2671..2673 "*" [] [Whitespace(" ")]
-                            2: CSS_NUMBER@2673..2674
-                              0: CSS_NUMBER_LITERAL@2673..2674 "2" [] []
-                      2: R_PAREN@2674..2676 ")" [] [Whitespace(" ")]
-                    1: SCSS_PARENTHESIZED_EXPRESSION@2676..2684
-                      0: L_PAREN@2676..2677 "(" [] []
-                      1: SCSS_EXPRESSION@2677..2683
-                        0: SCSS_EXPRESSION_ITEM_LIST@2677..2683
-                          0: SCSS_BINARY_EXPRESSION@2677..2683
-                            0: SCSS_VARIABLE@2677..2680
-                              0: DOLLAR@2677..2678 "$" [] []
-                              1: CSS_IDENTIFIER@2678..2680
-                                0: IDENT@2678..2680 "b" [] [Whitespace(" ")]
-                            1: STAR@2680..2682 "*" [] [Whitespace(" ")]
-                            2: CSS_NUMBER@2682..2683
-                              0: CSS_NUMBER_LITERAL@2682..2683 "2" [] []
-                      2: R_PAREN@2683..2684 ")" [] []
+            1: SEMICOLON@2675..2676 ";" [] []
+          2: CSS_DECLARATION_WITH_SEMICOLON@2676..2705
+            0: CSS_DECLARATION@2676..2704
+              0: CSS_GENERIC_PROPERTY@2676..2704
+                0: CSS_IDENTIFIER@2676..2685
+                  0: IDENT@2676..2685 "margin" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@2685..2687 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@2687..2704
+                  0: SCSS_EXPRESSION_ITEM_LIST@2687..2704
+                    0: SCSS_PARENTHESIZED_EXPRESSION@2687..2696
+                      0: L_PAREN@2687..2688 "(" [] []
+                      1: SCSS_EXPRESSION@2688..2694
+                        0: SCSS_EXPRESSION_ITEM_LIST@2688..2694
+                          0: SCSS_BINARY_EXPRESSION@2688..2694
+                            0: SCSS_VARIABLE@2688..2691
+                              0: DOLLAR@2688..2689 "$" [] []
+                              1: CSS_IDENTIFIER@2689..2691
+                                0: IDENT@2689..2691 "a" [] [Whitespace(" ")]
+                            1: STAR@2691..2693 "*" [] [Whitespace(" ")]
+                            2: CSS_NUMBER@2693..2694
+                              0: CSS_NUMBER_LITERAL@2693..2694 "2" [] []
+                      2: R_PAREN@2694..2696 ")" [] [Whitespace(" ")]
+                    1: SCSS_PARENTHESIZED_EXPRESSION@2696..2704
+                      0: L_PAREN@2696..2697 "(" [] []
+                      1: SCSS_EXPRESSION@2697..2703
+                        0: SCSS_EXPRESSION_ITEM_LIST@2697..2703
+                          0: SCSS_BINARY_EXPRESSION@2697..2703
+                            0: SCSS_VARIABLE@2697..2700
+                              0: DOLLAR@2697..2698 "$" [] []
+                              1: CSS_IDENTIFIER@2698..2700
+                                0: IDENT@2698..2700 "b" [] [Whitespace(" ")]
+                            1: STAR@2700..2702 "*" [] [Whitespace(" ")]
+                            2: CSS_NUMBER@2702..2703
+                              0: CSS_NUMBER_LITERAL@2702..2703 "2" [] []
+                      2: R_PAREN@2703..2704 ")" [] []
               1: (empty)
-            1: SEMICOLON@2684..2685 ";" [] []
-        2: R_CURLY@2685..2687 "}" [Newline("\n")] []
-    64: SCSS_VARIABLE_DECLARATION@2687..2756
-      0: SCSS_VARIABLE@2687..2746
-        0: DOLLAR@2687..2742 "$" [Newline("\n"), Newline("\n"), Comments("// Expressions with e ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@2742..2746
-          0: IDENT@2742..2746 "plus" [] []
-      1: COLON@2746..2748 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2748..2755
-        0: SCSS_EXPRESSION_ITEM_LIST@2748..2755
-          0: SCSS_BINARY_EXPRESSION@2748..2755
-            0: CSS_NUMBER@2748..2751
-              0: CSS_NUMBER_LITERAL@2748..2751 "10" [] [Whitespace(" ")]
-            1: PLUS@2751..2753 "+" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2753..2755
-              0: CSS_NUMBER_LITERAL@2753..2755 "20" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2755..2755
-      4: SEMICOLON@2755..2756 ";" [] []
-    65: SCSS_VARIABLE_DECLARATION@2756..2773
-      0: SCSS_VARIABLE@2756..2763
-        0: DOLLAR@2756..2758 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2758..2763
-          0: IDENT@2758..2763 "minus" [] []
-      1: COLON@2763..2765 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2765..2772
-        0: SCSS_EXPRESSION_ITEM_LIST@2765..2772
-          0: SCSS_BINARY_EXPRESSION@2765..2772
-            0: CSS_NUMBER@2765..2768
-              0: CSS_NUMBER_LITERAL@2765..2768 "30" [] [Whitespace(" ")]
-            1: MINUS@2768..2770 "-" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2770..2772
-              0: CSS_NUMBER_LITERAL@2770..2772 "10" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2772..2772
-      4: SEMICOLON@2772..2773 ";" [] []
-    66: SCSS_VARIABLE_DECLARATION@2773..2791
-      0: SCSS_VARIABLE@2773..2783
-        0: DOLLAR@2773..2775 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2775..2783
-          0: IDENT@2775..2783 "multiply" [] []
+            1: SEMICOLON@2704..2705 ";" [] []
+        2: R_CURLY@2705..2707 "}" [Newline("\n")] []
+    65: SCSS_VARIABLE_DECLARATION@2707..2776
+      0: SCSS_VARIABLE@2707..2766
+        0: DOLLAR@2707..2762 "$" [Newline("\n"), Newline("\n"), Comments("// Expressions with e ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@2762..2766
+          0: IDENT@2762..2766 "plus" [] []
+      1: COLON@2766..2768 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2768..2775
+        0: SCSS_EXPRESSION_ITEM_LIST@2768..2775
+          0: SCSS_BINARY_EXPRESSION@2768..2775
+            0: CSS_NUMBER@2768..2771
+              0: CSS_NUMBER_LITERAL@2768..2771 "10" [] [Whitespace(" ")]
+            1: PLUS@2771..2773 "+" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2773..2775
+              0: CSS_NUMBER_LITERAL@2773..2775 "20" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2775..2775
+      4: SEMICOLON@2775..2776 ";" [] []
+    66: SCSS_VARIABLE_DECLARATION@2776..2793
+      0: SCSS_VARIABLE@2776..2783
+        0: DOLLAR@2776..2778 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2778..2783
+          0: IDENT@2778..2783 "minus" [] []
       1: COLON@2783..2785 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2785..2790
-        0: SCSS_EXPRESSION_ITEM_LIST@2785..2790
-          0: SCSS_BINARY_EXPRESSION@2785..2790
-            0: CSS_NUMBER@2785..2787
-              0: CSS_NUMBER_LITERAL@2785..2787 "5" [] [Whitespace(" ")]
-            1: STAR@2787..2789 "*" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2789..2790
-              0: CSS_NUMBER_LITERAL@2789..2790 "4" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2790..2790
-      4: SEMICOLON@2790..2791 ";" [] []
-    67: SCSS_VARIABLE_DECLARATION@2791..2810
-      0: SCSS_VARIABLE@2791..2799
-        0: DOLLAR@2791..2793 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2793..2799
-          0: IDENT@2793..2799 "divide" [] []
-      1: COLON@2799..2801 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2801..2809
-        0: SCSS_EXPRESSION_ITEM_LIST@2801..2809
-          0: SCSS_PARENTHESIZED_EXPRESSION@2801..2809
-            0: L_PAREN@2801..2802 "(" [] []
-            1: SCSS_EXPRESSION@2802..2808
-              0: SCSS_EXPRESSION_ITEM_LIST@2802..2808
-                0: CSS_RATIO@2802..2808
-                  0: CSS_NUMBER@2802..2805
-                    0: CSS_NUMBER_LITERAL@2802..2805 "20" [] [Whitespace(" ")]
-                  1: SLASH@2805..2807 "/" [] [Whitespace(" ")]
-                  2: CSS_NUMBER@2807..2808
-                    0: CSS_NUMBER_LITERAL@2807..2808 "4" [] []
-            2: R_PAREN@2808..2809 ")" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2809..2809
-      4: SEMICOLON@2809..2810 ";" [] []
-    68: SCSS_VARIABLE_DECLARATION@2810..2827
-      0: SCSS_VARIABLE@2810..2818
-        0: DOLLAR@2810..2812 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2812..2818
-          0: IDENT@2812..2818 "modulo" [] []
-      1: COLON@2818..2820 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2820..2826
-        0: SCSS_EXPRESSION_ITEM_LIST@2820..2826
-          0: SCSS_BINARY_EXPRESSION@2820..2826
-            0: CSS_NUMBER@2820..2823
-              0: CSS_NUMBER_LITERAL@2820..2823 "17" [] [Whitespace(" ")]
-            1: PERCENT@2823..2825 "%" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2825..2826
-              0: CSS_NUMBER_LITERAL@2825..2826 "5" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2826..2826
-      4: SEMICOLON@2826..2827 ";" [] []
-    69: SCSS_VARIABLE_DECLARATION@2827..2840
-      0: SCSS_VARIABLE@2827..2831
-        0: DOLLAR@2827..2829 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2829..2831
-          0: IDENT@2829..2831 "gt" [] []
-      1: COLON@2831..2833 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2833..2839
-        0: SCSS_EXPRESSION_ITEM_LIST@2833..2839
-          0: SCSS_BINARY_EXPRESSION@2833..2839
-            0: CSS_NUMBER@2833..2836
-              0: CSS_NUMBER_LITERAL@2833..2836 "10" [] [Whitespace(" ")]
-            1: R_ANGLE@2836..2838 ">" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2838..2839
-              0: CSS_NUMBER_LITERAL@2838..2839 "5" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2839..2839
-      4: SEMICOLON@2839..2840 ";" [] []
-    70: SCSS_VARIABLE_DECLARATION@2840..2856
-      0: SCSS_VARIABLE@2840..2845
-        0: DOLLAR@2840..2842 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2842..2845
-          0: IDENT@2842..2845 "gte" [] []
-      1: COLON@2845..2847 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2847..2855
-        0: SCSS_EXPRESSION_ITEM_LIST@2847..2855
-          0: SCSS_BINARY_EXPRESSION@2847..2855
-            0: CSS_NUMBER@2847..2850
-              0: CSS_NUMBER_LITERAL@2847..2850 "10" [] [Whitespace(" ")]
-            1: GTEQ@2850..2853 ">=" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2853..2855
-              0: CSS_NUMBER_LITERAL@2853..2855 "10" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2855..2855
-      4: SEMICOLON@2855..2856 ";" [] []
-    71: SCSS_VARIABLE_DECLARATION@2856..2869
-      0: SCSS_VARIABLE@2856..2860
-        0: DOLLAR@2856..2858 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2858..2860
-          0: IDENT@2858..2860 "lt" [] []
-      1: COLON@2860..2862 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2862..2868
-        0: SCSS_EXPRESSION_ITEM_LIST@2862..2868
-          0: SCSS_BINARY_EXPRESSION@2862..2868
-            0: CSS_NUMBER@2862..2864
-              0: CSS_NUMBER_LITERAL@2862..2864 "5" [] [Whitespace(" ")]
-            1: L_ANGLE@2864..2866 "<" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2866..2868
-              0: CSS_NUMBER_LITERAL@2866..2868 "10" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2868..2868
-      4: SEMICOLON@2868..2869 ";" [] []
-    72: SCSS_VARIABLE_DECLARATION@2869..2883
-      0: SCSS_VARIABLE@2869..2874
-        0: DOLLAR@2869..2871 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2871..2874
-          0: IDENT@2871..2874 "lte" [] []
-      1: COLON@2874..2876 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2876..2882
-        0: SCSS_EXPRESSION_ITEM_LIST@2876..2882
-          0: SCSS_BINARY_EXPRESSION@2876..2882
-            0: CSS_NUMBER@2876..2878
-              0: CSS_NUMBER_LITERAL@2876..2878 "5" [] [Whitespace(" ")]
-            1: LTEQ@2878..2881 "<=" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2881..2882
-              0: CSS_NUMBER_LITERAL@2881..2882 "5" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2882..2882
-      4: SEMICOLON@2882..2883 ";" [] []
-    73: SCSS_VARIABLE_DECLARATION@2883..2898
-      0: SCSS_VARIABLE@2883..2887
-        0: DOLLAR@2883..2885 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2885..2887
-          0: IDENT@2885..2887 "eq" [] []
-      1: COLON@2887..2889 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2889..2897
-        0: SCSS_EXPRESSION_ITEM_LIST@2889..2897
-          0: SCSS_BINARY_EXPRESSION@2889..2897
-            0: CSS_NUMBER@2889..2892
-              0: CSS_NUMBER_LITERAL@2889..2892 "10" [] [Whitespace(" ")]
-            1: EQ2@2892..2895 "==" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2895..2897
-              0: CSS_NUMBER_LITERAL@2895..2897 "10" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2897..2897
-      4: SEMICOLON@2897..2898 ";" [] []
-    74: SCSS_VARIABLE_DECLARATION@2898..2913
-      0: SCSS_VARIABLE@2898..2903
-        0: DOLLAR@2898..2900 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2900..2903
-          0: IDENT@2900..2903 "neq" [] []
-      1: COLON@2903..2905 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2905..2912
-        0: SCSS_EXPRESSION_ITEM_LIST@2905..2912
-          0: SCSS_BINARY_EXPRESSION@2905..2912
-            0: CSS_NUMBER@2905..2908
-              0: CSS_NUMBER_LITERAL@2905..2908 "10" [] [Whitespace(" ")]
-            1: NEQ@2908..2911 "!=" [] [Whitespace(" ")]
-            2: CSS_NUMBER@2911..2912
-              0: CSS_NUMBER_LITERAL@2911..2912 "5" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2912..2912
-      4: SEMICOLON@2912..2913 ";" [] []
-    75: SCSS_VARIABLE_DECLARATION@2913..2934
-      0: SCSS_VARIABLE@2913..2918
-        0: DOLLAR@2913..2915 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2915..2918
-          0: IDENT@2915..2918 "and" [] []
-      1: COLON@2918..2920 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2920..2933
-        0: SCSS_EXPRESSION_ITEM_LIST@2920..2933
-          0: SCSS_BINARY_EXPRESSION@2920..2933
-            0: CSS_IDENTIFIER@2920..2925
-              0: IDENT@2920..2925 "true" [] [Whitespace(" ")]
-            1: AND_KW@2925..2929 "and" [] [Whitespace(" ")]
-            2: CSS_IDENTIFIER@2929..2933
-              0: IDENT@2929..2933 "true" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2933..2933
-      4: SEMICOLON@2933..2934 ";" [] []
-    76: SCSS_VARIABLE_DECLARATION@2934..2954
-      0: SCSS_VARIABLE@2934..2938
-        0: DOLLAR@2934..2936 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2936..2938
-          0: IDENT@2936..2938 "or" [] []
+      2: SCSS_EXPRESSION@2785..2792
+        0: SCSS_EXPRESSION_ITEM_LIST@2785..2792
+          0: SCSS_BINARY_EXPRESSION@2785..2792
+            0: CSS_NUMBER@2785..2788
+              0: CSS_NUMBER_LITERAL@2785..2788 "30" [] [Whitespace(" ")]
+            1: MINUS@2788..2790 "-" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2790..2792
+              0: CSS_NUMBER_LITERAL@2790..2792 "10" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2792..2792
+      4: SEMICOLON@2792..2793 ";" [] []
+    67: SCSS_VARIABLE_DECLARATION@2793..2811
+      0: SCSS_VARIABLE@2793..2803
+        0: DOLLAR@2793..2795 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2795..2803
+          0: IDENT@2795..2803 "multiply" [] []
+      1: COLON@2803..2805 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2805..2810
+        0: SCSS_EXPRESSION_ITEM_LIST@2805..2810
+          0: SCSS_BINARY_EXPRESSION@2805..2810
+            0: CSS_NUMBER@2805..2807
+              0: CSS_NUMBER_LITERAL@2805..2807 "5" [] [Whitespace(" ")]
+            1: STAR@2807..2809 "*" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2809..2810
+              0: CSS_NUMBER_LITERAL@2809..2810 "4" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2810..2810
+      4: SEMICOLON@2810..2811 ";" [] []
+    68: SCSS_VARIABLE_DECLARATION@2811..2830
+      0: SCSS_VARIABLE@2811..2819
+        0: DOLLAR@2811..2813 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2813..2819
+          0: IDENT@2813..2819 "divide" [] []
+      1: COLON@2819..2821 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2821..2829
+        0: SCSS_EXPRESSION_ITEM_LIST@2821..2829
+          0: SCSS_PARENTHESIZED_EXPRESSION@2821..2829
+            0: L_PAREN@2821..2822 "(" [] []
+            1: SCSS_EXPRESSION@2822..2828
+              0: SCSS_EXPRESSION_ITEM_LIST@2822..2828
+                0: SCSS_BINARY_EXPRESSION@2822..2828
+                  0: CSS_NUMBER@2822..2825
+                    0: CSS_NUMBER_LITERAL@2822..2825 "20" [] [Whitespace(" ")]
+                  1: SLASH@2825..2827 "/" [] [Whitespace(" ")]
+                  2: CSS_NUMBER@2827..2828
+                    0: CSS_NUMBER_LITERAL@2827..2828 "4" [] []
+            2: R_PAREN@2828..2829 ")" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2829..2829
+      4: SEMICOLON@2829..2830 ";" [] []
+    69: SCSS_VARIABLE_DECLARATION@2830..2847
+      0: SCSS_VARIABLE@2830..2838
+        0: DOLLAR@2830..2832 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2832..2838
+          0: IDENT@2832..2838 "modulo" [] []
+      1: COLON@2838..2840 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2840..2846
+        0: SCSS_EXPRESSION_ITEM_LIST@2840..2846
+          0: SCSS_BINARY_EXPRESSION@2840..2846
+            0: CSS_NUMBER@2840..2843
+              0: CSS_NUMBER_LITERAL@2840..2843 "17" [] [Whitespace(" ")]
+            1: PERCENT@2843..2845 "%" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2845..2846
+              0: CSS_NUMBER_LITERAL@2845..2846 "5" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2846..2846
+      4: SEMICOLON@2846..2847 ";" [] []
+    70: SCSS_VARIABLE_DECLARATION@2847..2860
+      0: SCSS_VARIABLE@2847..2851
+        0: DOLLAR@2847..2849 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2849..2851
+          0: IDENT@2849..2851 "gt" [] []
+      1: COLON@2851..2853 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2853..2859
+        0: SCSS_EXPRESSION_ITEM_LIST@2853..2859
+          0: SCSS_BINARY_EXPRESSION@2853..2859
+            0: CSS_NUMBER@2853..2856
+              0: CSS_NUMBER_LITERAL@2853..2856 "10" [] [Whitespace(" ")]
+            1: R_ANGLE@2856..2858 ">" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2858..2859
+              0: CSS_NUMBER_LITERAL@2858..2859 "5" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2859..2859
+      4: SEMICOLON@2859..2860 ";" [] []
+    71: SCSS_VARIABLE_DECLARATION@2860..2876
+      0: SCSS_VARIABLE@2860..2865
+        0: DOLLAR@2860..2862 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2862..2865
+          0: IDENT@2862..2865 "gte" [] []
+      1: COLON@2865..2867 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2867..2875
+        0: SCSS_EXPRESSION_ITEM_LIST@2867..2875
+          0: SCSS_BINARY_EXPRESSION@2867..2875
+            0: CSS_NUMBER@2867..2870
+              0: CSS_NUMBER_LITERAL@2867..2870 "10" [] [Whitespace(" ")]
+            1: GTEQ@2870..2873 ">=" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2873..2875
+              0: CSS_NUMBER_LITERAL@2873..2875 "10" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2875..2875
+      4: SEMICOLON@2875..2876 ";" [] []
+    72: SCSS_VARIABLE_DECLARATION@2876..2889
+      0: SCSS_VARIABLE@2876..2880
+        0: DOLLAR@2876..2878 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2878..2880
+          0: IDENT@2878..2880 "lt" [] []
+      1: COLON@2880..2882 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2882..2888
+        0: SCSS_EXPRESSION_ITEM_LIST@2882..2888
+          0: SCSS_BINARY_EXPRESSION@2882..2888
+            0: CSS_NUMBER@2882..2884
+              0: CSS_NUMBER_LITERAL@2882..2884 "5" [] [Whitespace(" ")]
+            1: L_ANGLE@2884..2886 "<" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2886..2888
+              0: CSS_NUMBER_LITERAL@2886..2888 "10" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2888..2888
+      4: SEMICOLON@2888..2889 ";" [] []
+    73: SCSS_VARIABLE_DECLARATION@2889..2903
+      0: SCSS_VARIABLE@2889..2894
+        0: DOLLAR@2889..2891 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2891..2894
+          0: IDENT@2891..2894 "lte" [] []
+      1: COLON@2894..2896 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2896..2902
+        0: SCSS_EXPRESSION_ITEM_LIST@2896..2902
+          0: SCSS_BINARY_EXPRESSION@2896..2902
+            0: CSS_NUMBER@2896..2898
+              0: CSS_NUMBER_LITERAL@2896..2898 "5" [] [Whitespace(" ")]
+            1: LTEQ@2898..2901 "<=" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2901..2902
+              0: CSS_NUMBER_LITERAL@2901..2902 "5" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2902..2902
+      4: SEMICOLON@2902..2903 ";" [] []
+    74: SCSS_VARIABLE_DECLARATION@2903..2918
+      0: SCSS_VARIABLE@2903..2907
+        0: DOLLAR@2903..2905 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2905..2907
+          0: IDENT@2905..2907 "eq" [] []
+      1: COLON@2907..2909 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2909..2917
+        0: SCSS_EXPRESSION_ITEM_LIST@2909..2917
+          0: SCSS_BINARY_EXPRESSION@2909..2917
+            0: CSS_NUMBER@2909..2912
+              0: CSS_NUMBER_LITERAL@2909..2912 "10" [] [Whitespace(" ")]
+            1: EQ2@2912..2915 "==" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2915..2917
+              0: CSS_NUMBER_LITERAL@2915..2917 "10" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2917..2917
+      4: SEMICOLON@2917..2918 ";" [] []
+    75: SCSS_VARIABLE_DECLARATION@2918..2933
+      0: SCSS_VARIABLE@2918..2923
+        0: DOLLAR@2918..2920 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2920..2923
+          0: IDENT@2920..2923 "neq" [] []
+      1: COLON@2923..2925 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2925..2932
+        0: SCSS_EXPRESSION_ITEM_LIST@2925..2932
+          0: SCSS_BINARY_EXPRESSION@2925..2932
+            0: CSS_NUMBER@2925..2928
+              0: CSS_NUMBER_LITERAL@2925..2928 "10" [] [Whitespace(" ")]
+            1: NEQ@2928..2931 "!=" [] [Whitespace(" ")]
+            2: CSS_NUMBER@2931..2932
+              0: CSS_NUMBER_LITERAL@2931..2932 "5" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2932..2932
+      4: SEMICOLON@2932..2933 ";" [] []
+    76: SCSS_VARIABLE_DECLARATION@2933..2954
+      0: SCSS_VARIABLE@2933..2938
+        0: DOLLAR@2933..2935 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2935..2938
+          0: IDENT@2935..2938 "and" [] []
       1: COLON@2938..2940 ":" [] [Whitespace(" ")]
       2: SCSS_EXPRESSION@2940..2953
         0: SCSS_EXPRESSION_ITEM_LIST@2940..2953
           0: SCSS_BINARY_EXPRESSION@2940..2953
-            0: CSS_IDENTIFIER@2940..2946
-              0: IDENT@2940..2946 "false" [] [Whitespace(" ")]
-            1: OR_KW@2946..2949 "or" [] [Whitespace(" ")]
+            0: CSS_IDENTIFIER@2940..2945
+              0: IDENT@2940..2945 "true" [] [Whitespace(" ")]
+            1: AND_KW@2945..2949 "and" [] [Whitespace(" ")]
             2: CSS_IDENTIFIER@2949..2953
               0: IDENT@2949..2953 "true" [] []
       3: SCSS_VARIABLE_MODIFIER_LIST@2953..2953
       4: SEMICOLON@2953..2954 ";" [] []
-    77: SCSS_VARIABLE_DECLARATION@2954..2971
-      0: SCSS_VARIABLE@2954..2959
+    77: SCSS_VARIABLE_DECLARATION@2954..2974
+      0: SCSS_VARIABLE@2954..2958
         0: DOLLAR@2954..2956 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@2956..2959
-          0: IDENT@2956..2959 "not" [] []
-      1: COLON@2959..2961 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@2961..2970
-        0: SCSS_EXPRESSION_ITEM_LIST@2961..2970
-          0: SCSS_UNARY_EXPRESSION@2961..2970
-            0: NOT_KW@2961..2965 "not" [] [Whitespace(" ")]
-            1: CSS_IDENTIFIER@2965..2970
-              0: IDENT@2965..2970 "false" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@2970..2970
-      4: SEMICOLON@2970..2971 ";" [] []
-    78: SCSS_VARIABLE_DECLARATION@2971..3054
-      0: SCSS_VARIABLE@2971..3013
-        0: DOLLAR@2971..3002 "$" [Newline("\n"), Newline("\n"), Comments("// Operator precedenc ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@3002..3013
-          0: IDENT@3002..3013 "precedence1" [] []
-      1: COLON@3013..3015 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@3015..3024
-        0: SCSS_EXPRESSION_ITEM_LIST@3015..3024
-          0: SCSS_BINARY_EXPRESSION@3015..3024
-            0: CSS_NUMBER@3015..3017
-              0: CSS_NUMBER_LITERAL@3015..3017 "1" [] [Whitespace(" ")]
-            1: PLUS@3017..3019 "+" [] [Whitespace(" ")]
-            2: SCSS_BINARY_EXPRESSION@3019..3024
-              0: CSS_NUMBER@3019..3021
-                0: CSS_NUMBER_LITERAL@3019..3021 "2" [] [Whitespace(" ")]
-              1: STAR@3021..3023 "*" [] [Whitespace(" ")]
-              2: CSS_NUMBER@3023..3024
-                0: CSS_NUMBER_LITERAL@3023..3024 "3" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@3024..3024
-      4: SEMICOLON@3024..3054 ";" [] [Whitespace(" "), Comments("// Should be 1 + (2 * ...")]
-    79: SCSS_VARIABLE_DECLARATION@3054..3096
-      0: SCSS_VARIABLE@3054..3067
-        0: DOLLAR@3054..3056 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@3056..3067
-          0: IDENT@3056..3067 "precedence2" [] []
-      1: COLON@3067..3069 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@3069..3080
-        0: SCSS_EXPRESSION_ITEM_LIST@3069..3080
-          0: SCSS_BINARY_EXPRESSION@3069..3080
-            0: SCSS_PARENTHESIZED_EXPRESSION@3069..3077
-              0: L_PAREN@3069..3070 "(" [] []
-              1: SCSS_EXPRESSION@3070..3075
-                0: SCSS_EXPRESSION_ITEM_LIST@3070..3075
-                  0: SCSS_BINARY_EXPRESSION@3070..3075
-                    0: CSS_NUMBER@3070..3072
-                      0: CSS_NUMBER_LITERAL@3070..3072 "1" [] [Whitespace(" ")]
-                    1: PLUS@3072..3074 "+" [] [Whitespace(" ")]
-                    2: CSS_NUMBER@3074..3075
-                      0: CSS_NUMBER_LITERAL@3074..3075 "2" [] []
-              2: R_PAREN@3075..3077 ")" [] [Whitespace(" ")]
-            1: STAR@3077..3079 "*" [] [Whitespace(" ")]
-            2: CSS_NUMBER@3079..3080
-              0: CSS_NUMBER_LITERAL@3079..3080 "3" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@3080..3080
-      4: SEMICOLON@3080..3096 ";" [] [Whitespace(" "), Comments("// Should be 9")]
-    80: SCSS_VARIABLE_DECLARATION@3096..3157
-      0: SCSS_VARIABLE@3096..3109
-        0: DOLLAR@3096..3098 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@3098..3109
-          0: IDENT@3098..3109 "precedence3" [] []
-      1: COLON@3109..3111 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@3111..3121
-        0: SCSS_EXPRESSION_ITEM_LIST@3111..3121
-          0: SCSS_BINARY_EXPRESSION@3111..3121
-            0: SCSS_BINARY_EXPRESSION@3111..3118
-              0: CSS_NUMBER@3111..3114
-                0: CSS_NUMBER_LITERAL@3111..3114 "10" [] [Whitespace(" ")]
-              1: MINUS@3114..3116 "-" [] [Whitespace(" ")]
-              2: CSS_NUMBER@3116..3118
-                0: CSS_NUMBER_LITERAL@3116..3118 "5" [] [Whitespace(" ")]
-            1: MINUS@3118..3120 "-" [] [Whitespace(" ")]
-            2: CSS_NUMBER@3120..3121
-              0: CSS_NUMBER_LITERAL@3120..3121 "2" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@3121..3121
-      4: SEMICOLON@3121..3157 ";" [] [Whitespace(" "), Comments("// Left-to-right: (10 ...")]
-    81: SCSS_VARIABLE_DECLARATION@3157..3218
-      0: SCSS_VARIABLE@3157..3170
-        0: DOLLAR@3157..3159 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@3159..3170
-          0: IDENT@3159..3170 "precedence4" [] []
-      1: COLON@3170..3172 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@3172..3185
-        0: SCSS_EXPRESSION_ITEM_LIST@3172..3185
-          0: SCSS_BINARY_EXPRESSION@3172..3185
-            0: SCSS_BINARY_EXPRESSION@3172..3178
-              0: CSS_NUMBER@3172..3174
-                0: CSS_NUMBER_LITERAL@3172..3174 "2" [] [Whitespace(" ")]
-              1: STAR@3174..3176 "*" [] [Whitespace(" ")]
-              2: CSS_NUMBER@3176..3178
-                0: CSS_NUMBER_LITERAL@3176..3178 "3" [] [Whitespace(" ")]
-            1: PLUS@3178..3180 "+" [] [Whitespace(" ")]
-            2: SCSS_BINARY_EXPRESSION@3180..3185
-              0: CSS_NUMBER@3180..3182
-                0: CSS_NUMBER_LITERAL@3180..3182 "4" [] [Whitespace(" ")]
-              1: STAR@3182..3184 "*" [] [Whitespace(" ")]
-              2: CSS_NUMBER@3184..3185
-                0: CSS_NUMBER_LITERAL@3184..3185 "5" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@3185..3185
-      4: SEMICOLON@3185..3218 ";" [] [Whitespace(" "), Comments("// Should be (2*3) +  ...")]
-    82: SCSS_VARIABLE_DECLARATION@3218..3265
-      0: SCSS_VARIABLE@3218..3259
-        0: DOLLAR@3218..3251 "$" [Newline("\n"), Newline("\n"), Comments("// Edge cases with wh ..."), Newline("\n")] []
-        1: CSS_IDENTIFIER@3251..3259
-          0: IDENT@3251..3259 "no-space" [] []
-      1: COLON@3259..3261 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@3261..3264
-        0: SCSS_EXPRESSION_ITEM_LIST@3261..3264
-          0: SCSS_BINARY_EXPRESSION@3261..3264
-            0: CSS_NUMBER@3261..3262
-              0: CSS_NUMBER_LITERAL@3261..3262 "1" [] []
-            1: PLUS@3262..3263 "+" [] []
-            2: CSS_NUMBER@3263..3264
-              0: CSS_NUMBER_LITERAL@3263..3264 "2" [] []
-      3: SCSS_VARIABLE_MODIFIER_LIST@3264..3264
-      4: SEMICOLON@3264..3265 ";" [] []
-    83: SCSS_VARIABLE_DECLARATION@3265..3285
-      0: SCSS_VARIABLE@3265..3277
-        0: DOLLAR@3265..3267 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@3267..3277
-          0: IDENT@3267..3277 "with-space" [] []
-      1: COLON@3277..3279 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@3279..3284
-        0: SCSS_EXPRESSION_ITEM_LIST@3279..3284
-          0: SCSS_BINARY_EXPRESSION@3279..3284
-            0: CSS_NUMBER@3279..3281
-              0: CSS_NUMBER_LITERAL@3279..3281 "1" [] [Whitespace(" ")]
-            1: PLUS@3281..3283 "+" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@2956..2958
+          0: IDENT@2956..2958 "or" [] []
+      1: COLON@2958..2960 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2960..2973
+        0: SCSS_EXPRESSION_ITEM_LIST@2960..2973
+          0: SCSS_BINARY_EXPRESSION@2960..2973
+            0: CSS_IDENTIFIER@2960..2966
+              0: IDENT@2960..2966 "false" [] [Whitespace(" ")]
+            1: OR_KW@2966..2969 "or" [] [Whitespace(" ")]
+            2: CSS_IDENTIFIER@2969..2973
+              0: IDENT@2969..2973 "true" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2973..2973
+      4: SEMICOLON@2973..2974 ";" [] []
+    78: SCSS_VARIABLE_DECLARATION@2974..2991
+      0: SCSS_VARIABLE@2974..2979
+        0: DOLLAR@2974..2976 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@2976..2979
+          0: IDENT@2976..2979 "not" [] []
+      1: COLON@2979..2981 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@2981..2990
+        0: SCSS_EXPRESSION_ITEM_LIST@2981..2990
+          0: SCSS_UNARY_EXPRESSION@2981..2990
+            0: NOT_KW@2981..2985 "not" [] [Whitespace(" ")]
+            1: CSS_IDENTIFIER@2985..2990
+              0: IDENT@2985..2990 "false" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@2990..2990
+      4: SEMICOLON@2990..2991 ";" [] []
+    79: SCSS_VARIABLE_DECLARATION@2991..3074
+      0: SCSS_VARIABLE@2991..3033
+        0: DOLLAR@2991..3022 "$" [Newline("\n"), Newline("\n"), Comments("// Operator precedenc ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@3022..3033
+          0: IDENT@3022..3033 "precedence1" [] []
+      1: COLON@3033..3035 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@3035..3044
+        0: SCSS_EXPRESSION_ITEM_LIST@3035..3044
+          0: SCSS_BINARY_EXPRESSION@3035..3044
+            0: CSS_NUMBER@3035..3037
+              0: CSS_NUMBER_LITERAL@3035..3037 "1" [] [Whitespace(" ")]
+            1: PLUS@3037..3039 "+" [] [Whitespace(" ")]
+            2: SCSS_BINARY_EXPRESSION@3039..3044
+              0: CSS_NUMBER@3039..3041
+                0: CSS_NUMBER_LITERAL@3039..3041 "2" [] [Whitespace(" ")]
+              1: STAR@3041..3043 "*" [] [Whitespace(" ")]
+              2: CSS_NUMBER@3043..3044
+                0: CSS_NUMBER_LITERAL@3043..3044 "3" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@3044..3044
+      4: SEMICOLON@3044..3074 ";" [] [Whitespace(" "), Comments("// Should be 1 + (2 * ...")]
+    80: SCSS_VARIABLE_DECLARATION@3074..3116
+      0: SCSS_VARIABLE@3074..3087
+        0: DOLLAR@3074..3076 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@3076..3087
+          0: IDENT@3076..3087 "precedence2" [] []
+      1: COLON@3087..3089 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@3089..3100
+        0: SCSS_EXPRESSION_ITEM_LIST@3089..3100
+          0: SCSS_BINARY_EXPRESSION@3089..3100
+            0: SCSS_PARENTHESIZED_EXPRESSION@3089..3097
+              0: L_PAREN@3089..3090 "(" [] []
+              1: SCSS_EXPRESSION@3090..3095
+                0: SCSS_EXPRESSION_ITEM_LIST@3090..3095
+                  0: SCSS_BINARY_EXPRESSION@3090..3095
+                    0: CSS_NUMBER@3090..3092
+                      0: CSS_NUMBER_LITERAL@3090..3092 "1" [] [Whitespace(" ")]
+                    1: PLUS@3092..3094 "+" [] [Whitespace(" ")]
+                    2: CSS_NUMBER@3094..3095
+                      0: CSS_NUMBER_LITERAL@3094..3095 "2" [] []
+              2: R_PAREN@3095..3097 ")" [] [Whitespace(" ")]
+            1: STAR@3097..3099 "*" [] [Whitespace(" ")]
+            2: CSS_NUMBER@3099..3100
+              0: CSS_NUMBER_LITERAL@3099..3100 "3" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@3100..3100
+      4: SEMICOLON@3100..3116 ";" [] [Whitespace(" "), Comments("// Should be 9")]
+    81: SCSS_VARIABLE_DECLARATION@3116..3177
+      0: SCSS_VARIABLE@3116..3129
+        0: DOLLAR@3116..3118 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@3118..3129
+          0: IDENT@3118..3129 "precedence3" [] []
+      1: COLON@3129..3131 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@3131..3141
+        0: SCSS_EXPRESSION_ITEM_LIST@3131..3141
+          0: SCSS_BINARY_EXPRESSION@3131..3141
+            0: SCSS_BINARY_EXPRESSION@3131..3138
+              0: CSS_NUMBER@3131..3134
+                0: CSS_NUMBER_LITERAL@3131..3134 "10" [] [Whitespace(" ")]
+              1: MINUS@3134..3136 "-" [] [Whitespace(" ")]
+              2: CSS_NUMBER@3136..3138
+                0: CSS_NUMBER_LITERAL@3136..3138 "5" [] [Whitespace(" ")]
+            1: MINUS@3138..3140 "-" [] [Whitespace(" ")]
+            2: CSS_NUMBER@3140..3141
+              0: CSS_NUMBER_LITERAL@3140..3141 "2" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@3141..3141
+      4: SEMICOLON@3141..3177 ";" [] [Whitespace(" "), Comments("// Left-to-right: (10 ...")]
+    82: SCSS_VARIABLE_DECLARATION@3177..3238
+      0: SCSS_VARIABLE@3177..3190
+        0: DOLLAR@3177..3179 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@3179..3190
+          0: IDENT@3179..3190 "precedence4" [] []
+      1: COLON@3190..3192 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@3192..3205
+        0: SCSS_EXPRESSION_ITEM_LIST@3192..3205
+          0: SCSS_BINARY_EXPRESSION@3192..3205
+            0: SCSS_BINARY_EXPRESSION@3192..3198
+              0: CSS_NUMBER@3192..3194
+                0: CSS_NUMBER_LITERAL@3192..3194 "2" [] [Whitespace(" ")]
+              1: STAR@3194..3196 "*" [] [Whitespace(" ")]
+              2: CSS_NUMBER@3196..3198
+                0: CSS_NUMBER_LITERAL@3196..3198 "3" [] [Whitespace(" ")]
+            1: PLUS@3198..3200 "+" [] [Whitespace(" ")]
+            2: SCSS_BINARY_EXPRESSION@3200..3205
+              0: CSS_NUMBER@3200..3202
+                0: CSS_NUMBER_LITERAL@3200..3202 "4" [] [Whitespace(" ")]
+              1: STAR@3202..3204 "*" [] [Whitespace(" ")]
+              2: CSS_NUMBER@3204..3205
+                0: CSS_NUMBER_LITERAL@3204..3205 "5" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@3205..3205
+      4: SEMICOLON@3205..3238 ";" [] [Whitespace(" "), Comments("// Should be (2*3) +  ...")]
+    83: SCSS_VARIABLE_DECLARATION@3238..3285
+      0: SCSS_VARIABLE@3238..3279
+        0: DOLLAR@3238..3271 "$" [Newline("\n"), Newline("\n"), Comments("// Edge cases with wh ..."), Newline("\n")] []
+        1: CSS_IDENTIFIER@3271..3279
+          0: IDENT@3271..3279 "no-space" [] []
+      1: COLON@3279..3281 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@3281..3284
+        0: SCSS_EXPRESSION_ITEM_LIST@3281..3284
+          0: SCSS_BINARY_EXPRESSION@3281..3284
+            0: CSS_NUMBER@3281..3282
+              0: CSS_NUMBER_LITERAL@3281..3282 "1" [] []
+            1: PLUS@3282..3283 "+" [] []
             2: CSS_NUMBER@3283..3284
               0: CSS_NUMBER_LITERAL@3283..3284 "2" [] []
       3: SCSS_VARIABLE_MODIFIER_LIST@3284..3284
       4: SEMICOLON@3284..3285 ";" [] []
     84: SCSS_VARIABLE_DECLARATION@3285..3305
-      0: SCSS_VARIABLE@3285..3298
+      0: SCSS_VARIABLE@3285..3297
         0: DOLLAR@3285..3287 "$" [Newline("\n")] []
-        1: CSS_IDENTIFIER@3287..3298
-          0: IDENT@3287..3298 "mixed-space" [] []
-      1: COLON@3298..3300 ":" [] [Whitespace(" ")]
-      2: SCSS_EXPRESSION@3300..3304
-        0: SCSS_EXPRESSION_ITEM_LIST@3300..3304
-          0: SCSS_BINARY_EXPRESSION@3300..3304
-            0: CSS_NUMBER@3300..3301
-              0: CSS_NUMBER_LITERAL@3300..3301 "1" [] []
+        1: CSS_IDENTIFIER@3287..3297
+          0: IDENT@3287..3297 "with-space" [] []
+      1: COLON@3297..3299 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@3299..3304
+        0: SCSS_EXPRESSION_ITEM_LIST@3299..3304
+          0: SCSS_BINARY_EXPRESSION@3299..3304
+            0: CSS_NUMBER@3299..3301
+              0: CSS_NUMBER_LITERAL@3299..3301 "1" [] [Whitespace(" ")]
             1: PLUS@3301..3303 "+" [] [Whitespace(" ")]
             2: CSS_NUMBER@3303..3304
               0: CSS_NUMBER_LITERAL@3303..3304 "2" [] []
       3: SCSS_VARIABLE_MODIFIER_LIST@3304..3304
       4: SEMICOLON@3304..3305 ";" [] []
-  2: EOF@3305..3306 "" [Newline("\n")] []
+    85: SCSS_VARIABLE_DECLARATION@3305..3325
+      0: SCSS_VARIABLE@3305..3318
+        0: DOLLAR@3305..3307 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@3307..3318
+          0: IDENT@3307..3318 "mixed-space" [] []
+      1: COLON@3318..3320 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@3320..3324
+        0: SCSS_EXPRESSION_ITEM_LIST@3320..3324
+          0: SCSS_BINARY_EXPRESSION@3320..3324
+            0: CSS_NUMBER@3320..3321
+              0: CSS_NUMBER_LITERAL@3320..3321 "1" [] []
+            1: PLUS@3321..3323 "+" [] [Whitespace(" ")]
+            2: CSS_NUMBER@3323..3324
+              0: CSS_NUMBER_LITERAL@3323..3324 "2" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@3324..3324
+      4: SEMICOLON@3324..3325 ";" [] []
+  2: EOF@3325..3326 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/binary-operators.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/binary-operators.scss
@@ -11,26 +11,33 @@ div {
 }
 
 .division {
-  $var: a / b; // division
-  decl: a / b; // not division
-  with-parens: (a / b); // division
+  $var: a / b;
+  decl: a / b;
+  with-parens: (a / b);
 }
 
-/* TODO(scss at-rules):
 @function f() {
-  @return a / b; // division
+  @return a / b;
+  @return 10 / 2;
 }
-@debug 15px / 30px; // not division
-@debug 1 * 2 / 3; // division
-@debug (1 + 2) / 3; // division
-@debug fn() / 3; // division
-@debug $var / 3; // division
-@debug mod.$var / 3; // division
-*/
+
+@debug 15px / 30px;
+@debug 10 / 2;
+@debug 10/2;
+@debug (10 / 2);
+@debug (bold 10 / 2 sans-serif);
+@debug (10 / 2 bold);
+@debug (10 / 2, bold);
+@debug (a: b, c: 10 / 2);
+@debug (10 / 2 bold: b, c: 10 / 2);
+@debug 10 / 2 + 1;
+@debug 10/2+1;
+@debug 1 * 2 / 3;
+@debug (1 + 2) / 3;
+@debug fn() / 3;
+@debug $var / 3;
+@debug mod.$var / 3;
 
 a {
   prop: a,-1*b;
 }
-
-
-

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/binary-operators.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/binary-operators.scss.snap
@@ -19,29 +19,36 @@ div {
 }
 
 .division {
-  $var: a / b; // division
-  decl: a / b; // not division
-  with-parens: (a / b); // division
+  $var: a / b;
+  decl: a / b;
+  with-parens: (a / b);
 }
 
-/* TODO(scss at-rules):
 @function f() {
-  @return a / b; // division
+  @return a / b;
+  @return 10 / 2;
 }
-@debug 15px / 30px; // not division
-@debug 1 * 2 / 3; // division
-@debug (1 + 2) / 3; // division
-@debug fn() / 3; // division
-@debug $var / 3; // division
-@debug mod.$var / 3; // division
-*/
+
+@debug 15px / 30px;
+@debug 10 / 2;
+@debug 10/2;
+@debug (10 / 2);
+@debug (bold 10 / 2 sans-serif);
+@debug (10 / 2 bold);
+@debug (10 / 2, bold);
+@debug (a: b, c: 10 / 2);
+@debug (10 / 2 bold: b, c: 10 / 2);
+@debug 10 / 2 + 1;
+@debug 10/2+1;
+@debug 1 * 2 / 3;
+@debug (1 + 2) / 3;
+@debug fn() / 3;
+@debug $var / 3;
+@debug mod.$var / 3;
 
 a {
   prop: a,-1*b;
 }
-
-
-
 
 ```
 
@@ -306,24 +313,24 @@ CssRoot {
                             ],
                         },
                         modifiers: ScssVariableModifierList [],
-                        semicolon_token: SEMICOLON@169..182 ";" [] [Whitespace(" "), Comments("// division")],
+                        semicolon_token: SEMICOLON@169..170 ";" [] [],
                     },
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
                                 name: CssIdentifier {
-                                    value_token: IDENT@182..189 "decl" [Newline("\n"), Whitespace("  ")] [],
+                                    value_token: IDENT@170..177 "decl" [Newline("\n"), Whitespace("  ")] [],
                                 },
-                                colon_token: COLON@189..191 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@177..179 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssBinaryExpression {
                                             left: CssIdentifier {
-                                                value_token: IDENT@191..193 "a" [] [Whitespace(" ")],
+                                                value_token: IDENT@179..181 "a" [] [Whitespace(" ")],
                                             },
-                                            operator: SLASH@193..195 "/" [] [Whitespace(" ")],
+                                            operator: SLASH@181..183 "/" [] [Whitespace(" ")],
                                             right: CssIdentifier {
-                                                value_token: IDENT@195..196 "b" [] [],
+                                                value_token: IDENT@183..184 "b" [] [],
                                             },
                                         },
                                     ],
@@ -331,43 +338,616 @@ CssRoot {
                             },
                             important: missing (optional),
                         },
-                        semicolon_token: SEMICOLON@196..213 ";" [] [Whitespace(" "), Comments("// not division")],
+                        semicolon_token: SEMICOLON@184..185 ";" [] [],
                     },
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
                                 name: CssIdentifier {
-                                    value_token: IDENT@213..227 "with-parens" [Newline("\n"), Whitespace("  ")] [],
+                                    value_token: IDENT@185..199 "with-parens" [Newline("\n"), Whitespace("  ")] [],
                                 },
-                                colon_token: COLON@227..229 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@199..201 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssParenthesizedExpression {
-                                            l_paren_token: L_PAREN@229..230 "(" [] [],
+                                            l_paren_token: L_PAREN@201..202 "(" [] [],
                                             expression: ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     ScssBinaryExpression {
                                                         left: CssIdentifier {
-                                                            value_token: IDENT@230..232 "a" [] [Whitespace(" ")],
+                                                            value_token: IDENT@202..204 "a" [] [Whitespace(" ")],
                                                         },
-                                                        operator: SLASH@232..234 "/" [] [Whitespace(" ")],
+                                                        operator: SLASH@204..206 "/" [] [Whitespace(" ")],
                                                         right: CssIdentifier {
-                                                            value_token: IDENT@234..235 "b" [] [],
+                                                            value_token: IDENT@206..207 "b" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            r_paren_token: R_PAREN@235..236 ")" [] [],
+                                            r_paren_token: R_PAREN@207..208 ")" [] [],
                                         },
                                     ],
                                 },
                             },
                             important: missing (optional),
                         },
-                        semicolon_token: SEMICOLON@236..249 ";" [] [Whitespace(" "), Comments("// division")],
+                        semicolon_token: SEMICOLON@208..209 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@249..251 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@209..211 "}" [Newline("\n")] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@211..214 "@" [Newline("\n"), Newline("\n")] [],
+            rule: ScssFunctionAtRule {
+                function_token: FUNCTION_KW@214..223 "function" [] [Whitespace(" ")],
+                name: CssIdentifier {
+                    value_token: IDENT@223..224 "f" [] [],
+                },
+                parameters: ScssParameterList {
+                    l_paren_token: L_PAREN@224..225 "(" [] [],
+                    items: ScssParameterItemList [],
+                    r_paren_token: R_PAREN@225..227 ")" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@227..228 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssAtRule {
+                            at_token: AT@228..232 "@" [Newline("\n"), Whitespace("  ")] [],
+                            rule: ScssReturnAtRule {
+                                return_token: RETURN_KW@232..239 "return" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssBinaryExpression {
+                                            left: CssIdentifier {
+                                                value_token: IDENT@239..241 "a" [] [Whitespace(" ")],
+                                            },
+                                            operator: SLASH@241..243 "/" [] [Whitespace(" ")],
+                                            right: CssIdentifier {
+                                                value_token: IDENT@243..244 "b" [] [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                semicolon_token: SEMICOLON@244..245 ";" [] [],
+                            },
+                        },
+                        CssAtRule {
+                            at_token: AT@245..249 "@" [Newline("\n"), Whitespace("  ")] [],
+                            rule: ScssReturnAtRule {
+                                return_token: RETURN_KW@249..256 "return" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
+                                                value_token: CSS_NUMBER_LITERAL@256..259 "10" [] [Whitespace(" ")],
+                                            },
+                                            operator: SLASH@259..261 "/" [] [Whitespace(" ")],
+                                            right: CssNumber {
+                                                value_token: CSS_NUMBER_LITERAL@261..262 "2" [] [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                semicolon_token: SEMICOLON@262..263 ";" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@263..265 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@265..268 "@" [Newline("\n"), Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@268..274 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: CssRegularDimension {
+                                value_token: CSS_NUMBER_LITERAL@274..276 "15" [] [],
+                                unit_token: IDENT@276..279 "px" [] [Whitespace(" ")],
+                            },
+                            operator: SLASH@279..281 "/" [] [Whitespace(" ")],
+                            right: CssRegularDimension {
+                                value_token: CSS_NUMBER_LITERAL@281..283 "30" [] [],
+                                unit_token: IDENT@283..285 "px" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@285..286 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@286..288 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@288..294 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@294..297 "10" [] [Whitespace(" ")],
+                            },
+                            operator: SLASH@297..299 "/" [] [Whitespace(" ")],
+                            right: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@299..300 "2" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@300..301 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@301..303 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@303..309 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@309..311 "10" [] [],
+                            },
+                            operator: SLASH@311..312 "/" [] [],
+                            right: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@312..313 "2" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@313..314 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@314..316 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@316..322 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssParenthesizedExpression {
+                            l_paren_token: L_PAREN@322..323 "(" [] [],
+                            expression: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    ScssBinaryExpression {
+                                        left: CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@323..326 "10" [] [Whitespace(" ")],
+                                        },
+                                        operator: SLASH@326..328 "/" [] [Whitespace(" ")],
+                                        right: CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@328..329 "2" [] [],
+                                        },
+                                    },
+                                ],
+                            },
+                            r_paren_token: R_PAREN@329..330 ")" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@330..331 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@331..333 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@333..339 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssParenthesizedExpression {
+                            l_paren_token: L_PAREN@339..340 "(" [] [],
+                            expression: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    CssIdentifier {
+                                        value_token: IDENT@340..345 "bold" [] [Whitespace(" ")],
+                                    },
+                                    ScssBinaryExpression {
+                                        left: CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@345..348 "10" [] [Whitespace(" ")],
+                                        },
+                                        operator: SLASH@348..350 "/" [] [Whitespace(" ")],
+                                        right: CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@350..352 "2" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                    CssIdentifier {
+                                        value_token: IDENT@352..362 "sans-serif" [] [],
+                                    },
+                                ],
+                            },
+                            r_paren_token: R_PAREN@362..363 ")" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@363..364 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@364..366 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@366..372 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssParenthesizedExpression {
+                            l_paren_token: L_PAREN@372..373 "(" [] [],
+                            expression: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    ScssBinaryExpression {
+                                        left: CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@373..376 "10" [] [Whitespace(" ")],
+                                        },
+                                        operator: SLASH@376..378 "/" [] [Whitespace(" ")],
+                                        right: CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@378..380 "2" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                    CssIdentifier {
+                                        value_token: IDENT@380..384 "bold" [] [],
+                                    },
+                                ],
+                            },
+                            r_paren_token: R_PAREN@384..385 ")" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@385..386 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@386..388 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@388..394 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssParenthesizedExpression {
+                            l_paren_token: L_PAREN@394..395 "(" [] [],
+                            expression: ScssListExpression {
+                                elements: ScssListExpressionElementList [
+                                    ScssListExpressionElement {
+                                        value: ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                ScssBinaryExpression {
+                                                    left: CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@395..398 "10" [] [Whitespace(" ")],
+                                                    },
+                                                    operator: SLASH@398..400 "/" [] [Whitespace(" ")],
+                                                    right: CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@400..401 "2" [] [],
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                    COMMA@401..403 "," [] [Whitespace(" ")],
+                                    ScssListExpressionElement {
+                                        value: ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@403..407 "bold" [] [],
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                            r_paren_token: R_PAREN@407..408 ")" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@408..409 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@409..411 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@411..417 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssMapExpression {
+                            l_paren_token: L_PAREN@417..418 "(" [] [],
+                            pairs: ScssMapExpressionPairList [
+                                ScssMapExpressionPair {
+                                    key: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@418..419 "a" [] [],
+                                            },
+                                        ],
+                                    },
+                                    colon_token: COLON@419..421 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@421..422 "b" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                COMMA@422..424 "," [] [Whitespace(" ")],
+                                ScssMapExpressionPair {
+                                    key: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@424..425 "c" [] [],
+                                            },
+                                        ],
+                                    },
+                                    colon_token: COLON@425..427 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            ScssBinaryExpression {
+                                                left: CssNumber {
+                                                    value_token: CSS_NUMBER_LITERAL@427..430 "10" [] [Whitespace(" ")],
+                                                },
+                                                operator: SLASH@430..432 "/" [] [Whitespace(" ")],
+                                                right: CssNumber {
+                                                    value_token: CSS_NUMBER_LITERAL@432..433 "2" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@433..434 ")" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@434..435 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@435..437 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@437..443 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssMapExpression {
+                            l_paren_token: L_PAREN@443..444 "(" [] [],
+                            pairs: ScssMapExpressionPairList [
+                                ScssMapExpressionPair {
+                                    key: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            ScssBinaryExpression {
+                                                left: CssNumber {
+                                                    value_token: CSS_NUMBER_LITERAL@444..447 "10" [] [Whitespace(" ")],
+                                                },
+                                                operator: SLASH@447..449 "/" [] [Whitespace(" ")],
+                                                right: CssNumber {
+                                                    value_token: CSS_NUMBER_LITERAL@449..451 "2" [] [Whitespace(" ")],
+                                                },
+                                            },
+                                            CssIdentifier {
+                                                value_token: IDENT@451..455 "bold" [] [],
+                                            },
+                                        ],
+                                    },
+                                    colon_token: COLON@455..457 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@457..458 "b" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                COMMA@458..460 "," [] [Whitespace(" ")],
+                                ScssMapExpressionPair {
+                                    key: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@460..461 "c" [] [],
+                                            },
+                                        ],
+                                    },
+                                    colon_token: COLON@461..463 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            ScssBinaryExpression {
+                                                left: CssNumber {
+                                                    value_token: CSS_NUMBER_LITERAL@463..466 "10" [] [Whitespace(" ")],
+                                                },
+                                                operator: SLASH@466..468 "/" [] [Whitespace(" ")],
+                                                right: CssNumber {
+                                                    value_token: CSS_NUMBER_LITERAL@468..469 "2" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@469..470 ")" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@470..471 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@471..473 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@473..479 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: ScssBinaryExpression {
+                                left: CssNumber {
+                                    value_token: CSS_NUMBER_LITERAL@479..482 "10" [] [Whitespace(" ")],
+                                },
+                                operator: SLASH@482..484 "/" [] [Whitespace(" ")],
+                                right: CssNumber {
+                                    value_token: CSS_NUMBER_LITERAL@484..486 "2" [] [Whitespace(" ")],
+                                },
+                            },
+                            operator: PLUS@486..488 "+" [] [Whitespace(" ")],
+                            right: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@488..489 "1" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@489..490 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@490..492 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@492..498 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: ScssBinaryExpression {
+                                left: CssNumber {
+                                    value_token: CSS_NUMBER_LITERAL@498..500 "10" [] [],
+                                },
+                                operator: SLASH@500..501 "/" [] [],
+                                right: CssNumber {
+                                    value_token: CSS_NUMBER_LITERAL@501..502 "2" [] [],
+                                },
+                            },
+                            operator: PLUS@502..503 "+" [] [],
+                            right: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@503..504 "1" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@504..505 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@505..507 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@507..513 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: ScssBinaryExpression {
+                                left: CssNumber {
+                                    value_token: CSS_NUMBER_LITERAL@513..515 "1" [] [Whitespace(" ")],
+                                },
+                                operator: STAR@515..517 "*" [] [Whitespace(" ")],
+                                right: CssNumber {
+                                    value_token: CSS_NUMBER_LITERAL@517..519 "2" [] [Whitespace(" ")],
+                                },
+                            },
+                            operator: SLASH@519..521 "/" [] [Whitespace(" ")],
+                            right: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@521..522 "3" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@522..523 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@523..525 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@525..531 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: ScssParenthesizedExpression {
+                                l_paren_token: L_PAREN@531..532 "(" [] [],
+                                expression: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
+                                                value_token: CSS_NUMBER_LITERAL@532..534 "1" [] [Whitespace(" ")],
+                                            },
+                                            operator: PLUS@534..536 "+" [] [Whitespace(" ")],
+                                            right: CssNumber {
+                                                value_token: CSS_NUMBER_LITERAL@536..537 "2" [] [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                r_paren_token: R_PAREN@537..539 ")" [] [Whitespace(" ")],
+                            },
+                            operator: SLASH@539..541 "/" [] [Whitespace(" ")],
+                            right: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@541..542 "3" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@542..543 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@543..545 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@545..551 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: CssFunction {
+                                name: CssIdentifier {
+                                    value_token: IDENT@551..553 "fn" [] [],
+                                },
+                                l_paren_token: L_PAREN@553..554 "(" [] [],
+                                items: CssParameterList [],
+                                r_paren_token: R_PAREN@554..556 ")" [] [Whitespace(" ")],
+                            },
+                            operator: SLASH@556..558 "/" [] [Whitespace(" ")],
+                            right: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@558..559 "3" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@559..560 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@560..562 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@562..568 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: ScssVariable {
+                                dollar_token: DOLLAR@568..569 "$" [] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@569..573 "var" [] [Whitespace(" ")],
+                                },
+                            },
+                            operator: SLASH@573..575 "/" [] [Whitespace(" ")],
+                            right: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@575..576 "3" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@576..577 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@577..579 "@" [Newline("\n")] [],
+            rule: ScssDebugAtRule {
+                debug_token: DEBUG_KW@579..585 "debug" [] [Whitespace(" ")],
+                value: ScssExpression {
+                    items: ScssExpressionItemList [
+                        ScssBinaryExpression {
+                            left: ScssModuleMemberAccess {
+                                module: CssIdentifier {
+                                    value_token: IDENT@585..588 "mod" [] [],
+                                },
+                                dot_token: DOT@588..589 "." [] [],
+                                member: ScssVariable {
+                                    dollar_token: DOLLAR@589..590 "$" [] [],
+                                    name: CssIdentifier {
+                                        value_token: IDENT@590..594 "var" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            operator: SLASH@594..596 "/" [] [Whitespace(" ")],
+                            right: CssNumber {
+                                value_token: CSS_NUMBER_LITERAL@596..597 "3" [] [],
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@597..598 ";" [] [],
             },
         },
         CssQualifiedRule {
@@ -377,22 +957,22 @@ CssRoot {
                     simple_selector: CssTypeSelector {
                         namespace: missing (optional),
                         ident: CssIdentifier {
-                            value_token: IDENT@251..519 "a" [Newline("\n"), Newline("\n"), Comments("/* TODO(scss at-rules ..."), Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                            value_token: IDENT@598..602 "a" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
                         },
                     },
                     sub_selectors: CssSubSelectorList [],
                 },
             ],
             block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@519..520 "{" [] [],
+                l_curly_token: L_CURLY@602..603 "{" [] [],
                 items: CssDeclarationOrRuleList [
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
                                 name: CssIdentifier {
-                                    value_token: IDENT@520..527 "prop" [Newline("\n"), Whitespace("  ")] [],
+                                    value_token: IDENT@603..610 "prop" [Newline("\n"), Whitespace("  ")] [],
                                 },
-                                colon_token: COLON@527..529 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@610..612 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssListExpression {
@@ -401,22 +981,22 @@ CssRoot {
                                                     value: ScssExpression {
                                                         items: ScssExpressionItemList [
                                                             CssIdentifier {
-                                                                value_token: IDENT@529..530 "a" [] [],
+                                                                value_token: IDENT@612..613 "a" [] [],
                                                             },
                                                         ],
                                                     },
                                                 },
-                                                COMMA@530..531 "," [] [],
+                                                COMMA@613..614 "," [] [],
                                                 ScssListExpressionElement {
                                                     value: ScssExpression {
                                                         items: ScssExpressionItemList [
                                                             ScssBinaryExpression {
                                                                 left: CssNumber {
-                                                                    value_token: CSS_NUMBER_LITERAL@531..533 "-1" [] [],
+                                                                    value_token: CSS_NUMBER_LITERAL@614..616 "-1" [] [],
                                                                 },
-                                                                operator: STAR@533..534 "*" [] [],
+                                                                operator: STAR@616..617 "*" [] [],
                                                                 right: CssIdentifier {
-                                                                    value_token: IDENT@534..535 "b" [] [],
+                                                                    value_token: IDENT@617..618 "b" [] [],
                                                                 },
                                                             },
                                                         ],
@@ -429,23 +1009,23 @@ CssRoot {
                             },
                             important: missing (optional),
                         },
-                        semicolon_token: SEMICOLON@535..536 ";" [] [],
+                        semicolon_token: SEMICOLON@618..619 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@536..538 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@619..621 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@538..542 "" [Newline("\n"), Newline("\n"), Newline("\n"), Newline("\n")] [],
+    eof_token: EOF@621..622 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..542
+0: CSS_ROOT@0..622
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..538
+  1: CSS_ROOT_ITEM_LIST@0..621
     0: CSS_QUALIFIED_RULE@0..21
       0: CSS_SELECTOR_LIST@0..2
         0: CSS_COMPOUND_SELECTOR@0..2
@@ -583,7 +1163,7 @@ CssRoot {
               1: (empty)
             1: SEMICOLON@139..140 ";" [] []
         2: R_CURLY@140..142 "}" [Newline("\n")] []
-    2: CSS_QUALIFIED_RULE@142..251
+    2: CSS_QUALIFIED_RULE@142..211
       0: CSS_SELECTOR_LIST@142..154
         0: CSS_COMPOUND_SELECTOR@142..154
           0: CSS_NESTED_SELECTOR_LIST@142..142
@@ -593,10 +1173,10 @@ CssRoot {
               0: DOT@142..145 "." [Newline("\n"), Newline("\n")] []
               1: CSS_CUSTOM_IDENTIFIER@145..154
                 0: IDENT@145..154 "division" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@154..251
+      1: CSS_DECLARATION_OR_RULE_BLOCK@154..211
         0: L_CURLY@154..155 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@155..249
-          0: SCSS_VARIABLE_DECLARATION@155..182
+        1: CSS_DECLARATION_OR_RULE_LIST@155..209
+          0: SCSS_VARIABLE_DECLARATION@155..170
             0: SCSS_VARIABLE@155..162
               0: DOLLAR@155..159 "$" [Newline("\n"), Whitespace("  ")] []
               1: CSS_IDENTIFIER@159..162
@@ -611,85 +1191,455 @@ CssRoot {
                   2: CSS_IDENTIFIER@168..169
                     0: IDENT@168..169 "b" [] []
             3: SCSS_VARIABLE_MODIFIER_LIST@169..169
-            4: SEMICOLON@169..182 ";" [] [Whitespace(" "), Comments("// division")]
-          1: CSS_DECLARATION_WITH_SEMICOLON@182..213
-            0: CSS_DECLARATION@182..196
-              0: CSS_GENERIC_PROPERTY@182..196
-                0: CSS_IDENTIFIER@182..189
-                  0: IDENT@182..189 "decl" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@189..191 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@191..196
-                  0: SCSS_EXPRESSION_ITEM_LIST@191..196
-                    0: SCSS_BINARY_EXPRESSION@191..196
-                      0: CSS_IDENTIFIER@191..193
-                        0: IDENT@191..193 "a" [] [Whitespace(" ")]
-                      1: SLASH@193..195 "/" [] [Whitespace(" ")]
-                      2: CSS_IDENTIFIER@195..196
-                        0: IDENT@195..196 "b" [] []
+            4: SEMICOLON@169..170 ";" [] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@170..185
+            0: CSS_DECLARATION@170..184
+              0: CSS_GENERIC_PROPERTY@170..184
+                0: CSS_IDENTIFIER@170..177
+                  0: IDENT@170..177 "decl" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@177..179 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@179..184
+                  0: SCSS_EXPRESSION_ITEM_LIST@179..184
+                    0: SCSS_BINARY_EXPRESSION@179..184
+                      0: CSS_IDENTIFIER@179..181
+                        0: IDENT@179..181 "a" [] [Whitespace(" ")]
+                      1: SLASH@181..183 "/" [] [Whitespace(" ")]
+                      2: CSS_IDENTIFIER@183..184
+                        0: IDENT@183..184 "b" [] []
               1: (empty)
-            1: SEMICOLON@196..213 ";" [] [Whitespace(" "), Comments("// not division")]
-          2: CSS_DECLARATION_WITH_SEMICOLON@213..249
-            0: CSS_DECLARATION@213..236
-              0: CSS_GENERIC_PROPERTY@213..236
-                0: CSS_IDENTIFIER@213..227
-                  0: IDENT@213..227 "with-parens" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@227..229 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@229..236
-                  0: SCSS_EXPRESSION_ITEM_LIST@229..236
-                    0: SCSS_PARENTHESIZED_EXPRESSION@229..236
-                      0: L_PAREN@229..230 "(" [] []
-                      1: SCSS_EXPRESSION@230..235
-                        0: SCSS_EXPRESSION_ITEM_LIST@230..235
-                          0: SCSS_BINARY_EXPRESSION@230..235
-                            0: CSS_IDENTIFIER@230..232
-                              0: IDENT@230..232 "a" [] [Whitespace(" ")]
-                            1: SLASH@232..234 "/" [] [Whitespace(" ")]
-                            2: CSS_IDENTIFIER@234..235
-                              0: IDENT@234..235 "b" [] []
-                      2: R_PAREN@235..236 ")" [] []
+            1: SEMICOLON@184..185 ";" [] []
+          2: CSS_DECLARATION_WITH_SEMICOLON@185..209
+            0: CSS_DECLARATION@185..208
+              0: CSS_GENERIC_PROPERTY@185..208
+                0: CSS_IDENTIFIER@185..199
+                  0: IDENT@185..199 "with-parens" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@199..201 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@201..208
+                  0: SCSS_EXPRESSION_ITEM_LIST@201..208
+                    0: SCSS_PARENTHESIZED_EXPRESSION@201..208
+                      0: L_PAREN@201..202 "(" [] []
+                      1: SCSS_EXPRESSION@202..207
+                        0: SCSS_EXPRESSION_ITEM_LIST@202..207
+                          0: SCSS_BINARY_EXPRESSION@202..207
+                            0: CSS_IDENTIFIER@202..204
+                              0: IDENT@202..204 "a" [] [Whitespace(" ")]
+                            1: SLASH@204..206 "/" [] [Whitespace(" ")]
+                            2: CSS_IDENTIFIER@206..207
+                              0: IDENT@206..207 "b" [] []
+                      2: R_PAREN@207..208 ")" [] []
               1: (empty)
-            1: SEMICOLON@236..249 ";" [] [Whitespace(" "), Comments("// division")]
-        2: R_CURLY@249..251 "}" [Newline("\n")] []
-    3: CSS_QUALIFIED_RULE@251..538
-      0: CSS_SELECTOR_LIST@251..519
-        0: CSS_COMPOUND_SELECTOR@251..519
-          0: CSS_NESTED_SELECTOR_LIST@251..251
-          1: CSS_TYPE_SELECTOR@251..519
+            1: SEMICOLON@208..209 ";" [] []
+        2: R_CURLY@209..211 "}" [Newline("\n")] []
+    3: CSS_AT_RULE@211..265
+      0: AT@211..214 "@" [Newline("\n"), Newline("\n")] []
+      1: SCSS_FUNCTION_AT_RULE@214..265
+        0: FUNCTION_KW@214..223 "function" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@223..224
+          0: IDENT@223..224 "f" [] []
+        2: SCSS_PARAMETER_LIST@224..227
+          0: L_PAREN@224..225 "(" [] []
+          1: SCSS_PARAMETER_ITEM_LIST@225..225
+          2: R_PAREN@225..227 ")" [] [Whitespace(" ")]
+        3: CSS_DECLARATION_OR_RULE_BLOCK@227..265
+          0: L_CURLY@227..228 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@228..263
+            0: CSS_AT_RULE@228..245
+              0: AT@228..232 "@" [Newline("\n"), Whitespace("  ")] []
+              1: SCSS_RETURN_AT_RULE@232..245
+                0: RETURN_KW@232..239 "return" [] [Whitespace(" ")]
+                1: SCSS_EXPRESSION@239..244
+                  0: SCSS_EXPRESSION_ITEM_LIST@239..244
+                    0: SCSS_BINARY_EXPRESSION@239..244
+                      0: CSS_IDENTIFIER@239..241
+                        0: IDENT@239..241 "a" [] [Whitespace(" ")]
+                      1: SLASH@241..243 "/" [] [Whitespace(" ")]
+                      2: CSS_IDENTIFIER@243..244
+                        0: IDENT@243..244 "b" [] []
+                2: SEMICOLON@244..245 ";" [] []
+            1: CSS_AT_RULE@245..263
+              0: AT@245..249 "@" [Newline("\n"), Whitespace("  ")] []
+              1: SCSS_RETURN_AT_RULE@249..263
+                0: RETURN_KW@249..256 "return" [] [Whitespace(" ")]
+                1: SCSS_EXPRESSION@256..262
+                  0: SCSS_EXPRESSION_ITEM_LIST@256..262
+                    0: SCSS_BINARY_EXPRESSION@256..262
+                      0: CSS_NUMBER@256..259
+                        0: CSS_NUMBER_LITERAL@256..259 "10" [] [Whitespace(" ")]
+                      1: SLASH@259..261 "/" [] [Whitespace(" ")]
+                      2: CSS_NUMBER@261..262
+                        0: CSS_NUMBER_LITERAL@261..262 "2" [] []
+                2: SEMICOLON@262..263 ";" [] []
+          2: R_CURLY@263..265 "}" [Newline("\n")] []
+    4: CSS_AT_RULE@265..286
+      0: AT@265..268 "@" [Newline("\n"), Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@268..286
+        0: DEBUG_KW@268..274 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@274..285
+          0: SCSS_EXPRESSION_ITEM_LIST@274..285
+            0: SCSS_BINARY_EXPRESSION@274..285
+              0: CSS_REGULAR_DIMENSION@274..279
+                0: CSS_NUMBER_LITERAL@274..276 "15" [] []
+                1: IDENT@276..279 "px" [] [Whitespace(" ")]
+              1: SLASH@279..281 "/" [] [Whitespace(" ")]
+              2: CSS_REGULAR_DIMENSION@281..285
+                0: CSS_NUMBER_LITERAL@281..283 "30" [] []
+                1: IDENT@283..285 "px" [] []
+        2: SEMICOLON@285..286 ";" [] []
+    5: CSS_AT_RULE@286..301
+      0: AT@286..288 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@288..301
+        0: DEBUG_KW@288..294 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@294..300
+          0: SCSS_EXPRESSION_ITEM_LIST@294..300
+            0: SCSS_BINARY_EXPRESSION@294..300
+              0: CSS_NUMBER@294..297
+                0: CSS_NUMBER_LITERAL@294..297 "10" [] [Whitespace(" ")]
+              1: SLASH@297..299 "/" [] [Whitespace(" ")]
+              2: CSS_NUMBER@299..300
+                0: CSS_NUMBER_LITERAL@299..300 "2" [] []
+        2: SEMICOLON@300..301 ";" [] []
+    6: CSS_AT_RULE@301..314
+      0: AT@301..303 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@303..314
+        0: DEBUG_KW@303..309 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@309..313
+          0: SCSS_EXPRESSION_ITEM_LIST@309..313
+            0: SCSS_BINARY_EXPRESSION@309..313
+              0: CSS_NUMBER@309..311
+                0: CSS_NUMBER_LITERAL@309..311 "10" [] []
+              1: SLASH@311..312 "/" [] []
+              2: CSS_NUMBER@312..313
+                0: CSS_NUMBER_LITERAL@312..313 "2" [] []
+        2: SEMICOLON@313..314 ";" [] []
+    7: CSS_AT_RULE@314..331
+      0: AT@314..316 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@316..331
+        0: DEBUG_KW@316..322 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@322..330
+          0: SCSS_EXPRESSION_ITEM_LIST@322..330
+            0: SCSS_PARENTHESIZED_EXPRESSION@322..330
+              0: L_PAREN@322..323 "(" [] []
+              1: SCSS_EXPRESSION@323..329
+                0: SCSS_EXPRESSION_ITEM_LIST@323..329
+                  0: SCSS_BINARY_EXPRESSION@323..329
+                    0: CSS_NUMBER@323..326
+                      0: CSS_NUMBER_LITERAL@323..326 "10" [] [Whitespace(" ")]
+                    1: SLASH@326..328 "/" [] [Whitespace(" ")]
+                    2: CSS_NUMBER@328..329
+                      0: CSS_NUMBER_LITERAL@328..329 "2" [] []
+              2: R_PAREN@329..330 ")" [] []
+        2: SEMICOLON@330..331 ";" [] []
+    8: CSS_AT_RULE@331..364
+      0: AT@331..333 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@333..364
+        0: DEBUG_KW@333..339 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@339..363
+          0: SCSS_EXPRESSION_ITEM_LIST@339..363
+            0: SCSS_PARENTHESIZED_EXPRESSION@339..363
+              0: L_PAREN@339..340 "(" [] []
+              1: SCSS_EXPRESSION@340..362
+                0: SCSS_EXPRESSION_ITEM_LIST@340..362
+                  0: CSS_IDENTIFIER@340..345
+                    0: IDENT@340..345 "bold" [] [Whitespace(" ")]
+                  1: SCSS_BINARY_EXPRESSION@345..352
+                    0: CSS_NUMBER@345..348
+                      0: CSS_NUMBER_LITERAL@345..348 "10" [] [Whitespace(" ")]
+                    1: SLASH@348..350 "/" [] [Whitespace(" ")]
+                    2: CSS_NUMBER@350..352
+                      0: CSS_NUMBER_LITERAL@350..352 "2" [] [Whitespace(" ")]
+                  2: CSS_IDENTIFIER@352..362
+                    0: IDENT@352..362 "sans-serif" [] []
+              2: R_PAREN@362..363 ")" [] []
+        2: SEMICOLON@363..364 ";" [] []
+    9: CSS_AT_RULE@364..386
+      0: AT@364..366 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@366..386
+        0: DEBUG_KW@366..372 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@372..385
+          0: SCSS_EXPRESSION_ITEM_LIST@372..385
+            0: SCSS_PARENTHESIZED_EXPRESSION@372..385
+              0: L_PAREN@372..373 "(" [] []
+              1: SCSS_EXPRESSION@373..384
+                0: SCSS_EXPRESSION_ITEM_LIST@373..384
+                  0: SCSS_BINARY_EXPRESSION@373..380
+                    0: CSS_NUMBER@373..376
+                      0: CSS_NUMBER_LITERAL@373..376 "10" [] [Whitespace(" ")]
+                    1: SLASH@376..378 "/" [] [Whitespace(" ")]
+                    2: CSS_NUMBER@378..380
+                      0: CSS_NUMBER_LITERAL@378..380 "2" [] [Whitespace(" ")]
+                  1: CSS_IDENTIFIER@380..384
+                    0: IDENT@380..384 "bold" [] []
+              2: R_PAREN@384..385 ")" [] []
+        2: SEMICOLON@385..386 ";" [] []
+    10: CSS_AT_RULE@386..409
+      0: AT@386..388 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@388..409
+        0: DEBUG_KW@388..394 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@394..408
+          0: SCSS_EXPRESSION_ITEM_LIST@394..408
+            0: SCSS_PARENTHESIZED_EXPRESSION@394..408
+              0: L_PAREN@394..395 "(" [] []
+              1: SCSS_LIST_EXPRESSION@395..407
+                0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@395..407
+                  0: SCSS_LIST_EXPRESSION_ELEMENT@395..401
+                    0: SCSS_EXPRESSION@395..401
+                      0: SCSS_EXPRESSION_ITEM_LIST@395..401
+                        0: SCSS_BINARY_EXPRESSION@395..401
+                          0: CSS_NUMBER@395..398
+                            0: CSS_NUMBER_LITERAL@395..398 "10" [] [Whitespace(" ")]
+                          1: SLASH@398..400 "/" [] [Whitespace(" ")]
+                          2: CSS_NUMBER@400..401
+                            0: CSS_NUMBER_LITERAL@400..401 "2" [] []
+                  1: COMMA@401..403 "," [] [Whitespace(" ")]
+                  2: SCSS_LIST_EXPRESSION_ELEMENT@403..407
+                    0: SCSS_EXPRESSION@403..407
+                      0: SCSS_EXPRESSION_ITEM_LIST@403..407
+                        0: CSS_IDENTIFIER@403..407
+                          0: IDENT@403..407 "bold" [] []
+              2: R_PAREN@407..408 ")" [] []
+        2: SEMICOLON@408..409 ";" [] []
+    11: CSS_AT_RULE@409..435
+      0: AT@409..411 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@411..435
+        0: DEBUG_KW@411..417 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@417..434
+          0: SCSS_EXPRESSION_ITEM_LIST@417..434
+            0: SCSS_MAP_EXPRESSION@417..434
+              0: L_PAREN@417..418 "(" [] []
+              1: SCSS_MAP_EXPRESSION_PAIR_LIST@418..433
+                0: SCSS_MAP_EXPRESSION_PAIR@418..422
+                  0: SCSS_EXPRESSION@418..419
+                    0: SCSS_EXPRESSION_ITEM_LIST@418..419
+                      0: CSS_IDENTIFIER@418..419
+                        0: IDENT@418..419 "a" [] []
+                  1: COLON@419..421 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@421..422
+                    0: SCSS_EXPRESSION_ITEM_LIST@421..422
+                      0: CSS_IDENTIFIER@421..422
+                        0: IDENT@421..422 "b" [] []
+                1: COMMA@422..424 "," [] [Whitespace(" ")]
+                2: SCSS_MAP_EXPRESSION_PAIR@424..433
+                  0: SCSS_EXPRESSION@424..425
+                    0: SCSS_EXPRESSION_ITEM_LIST@424..425
+                      0: CSS_IDENTIFIER@424..425
+                        0: IDENT@424..425 "c" [] []
+                  1: COLON@425..427 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@427..433
+                    0: SCSS_EXPRESSION_ITEM_LIST@427..433
+                      0: SCSS_BINARY_EXPRESSION@427..433
+                        0: CSS_NUMBER@427..430
+                          0: CSS_NUMBER_LITERAL@427..430 "10" [] [Whitespace(" ")]
+                        1: SLASH@430..432 "/" [] [Whitespace(" ")]
+                        2: CSS_NUMBER@432..433
+                          0: CSS_NUMBER_LITERAL@432..433 "2" [] []
+              2: R_PAREN@433..434 ")" [] []
+        2: SEMICOLON@434..435 ";" [] []
+    12: CSS_AT_RULE@435..471
+      0: AT@435..437 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@437..471
+        0: DEBUG_KW@437..443 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@443..470
+          0: SCSS_EXPRESSION_ITEM_LIST@443..470
+            0: SCSS_MAP_EXPRESSION@443..470
+              0: L_PAREN@443..444 "(" [] []
+              1: SCSS_MAP_EXPRESSION_PAIR_LIST@444..469
+                0: SCSS_MAP_EXPRESSION_PAIR@444..458
+                  0: SCSS_EXPRESSION@444..455
+                    0: SCSS_EXPRESSION_ITEM_LIST@444..455
+                      0: SCSS_BINARY_EXPRESSION@444..451
+                        0: CSS_NUMBER@444..447
+                          0: CSS_NUMBER_LITERAL@444..447 "10" [] [Whitespace(" ")]
+                        1: SLASH@447..449 "/" [] [Whitespace(" ")]
+                        2: CSS_NUMBER@449..451
+                          0: CSS_NUMBER_LITERAL@449..451 "2" [] [Whitespace(" ")]
+                      1: CSS_IDENTIFIER@451..455
+                        0: IDENT@451..455 "bold" [] []
+                  1: COLON@455..457 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@457..458
+                    0: SCSS_EXPRESSION_ITEM_LIST@457..458
+                      0: CSS_IDENTIFIER@457..458
+                        0: IDENT@457..458 "b" [] []
+                1: COMMA@458..460 "," [] [Whitespace(" ")]
+                2: SCSS_MAP_EXPRESSION_PAIR@460..469
+                  0: SCSS_EXPRESSION@460..461
+                    0: SCSS_EXPRESSION_ITEM_LIST@460..461
+                      0: CSS_IDENTIFIER@460..461
+                        0: IDENT@460..461 "c" [] []
+                  1: COLON@461..463 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@463..469
+                    0: SCSS_EXPRESSION_ITEM_LIST@463..469
+                      0: SCSS_BINARY_EXPRESSION@463..469
+                        0: CSS_NUMBER@463..466
+                          0: CSS_NUMBER_LITERAL@463..466 "10" [] [Whitespace(" ")]
+                        1: SLASH@466..468 "/" [] [Whitespace(" ")]
+                        2: CSS_NUMBER@468..469
+                          0: CSS_NUMBER_LITERAL@468..469 "2" [] []
+              2: R_PAREN@469..470 ")" [] []
+        2: SEMICOLON@470..471 ";" [] []
+    13: CSS_AT_RULE@471..490
+      0: AT@471..473 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@473..490
+        0: DEBUG_KW@473..479 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@479..489
+          0: SCSS_EXPRESSION_ITEM_LIST@479..489
+            0: SCSS_BINARY_EXPRESSION@479..489
+              0: SCSS_BINARY_EXPRESSION@479..486
+                0: CSS_NUMBER@479..482
+                  0: CSS_NUMBER_LITERAL@479..482 "10" [] [Whitespace(" ")]
+                1: SLASH@482..484 "/" [] [Whitespace(" ")]
+                2: CSS_NUMBER@484..486
+                  0: CSS_NUMBER_LITERAL@484..486 "2" [] [Whitespace(" ")]
+              1: PLUS@486..488 "+" [] [Whitespace(" ")]
+              2: CSS_NUMBER@488..489
+                0: CSS_NUMBER_LITERAL@488..489 "1" [] []
+        2: SEMICOLON@489..490 ";" [] []
+    14: CSS_AT_RULE@490..505
+      0: AT@490..492 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@492..505
+        0: DEBUG_KW@492..498 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@498..504
+          0: SCSS_EXPRESSION_ITEM_LIST@498..504
+            0: SCSS_BINARY_EXPRESSION@498..504
+              0: SCSS_BINARY_EXPRESSION@498..502
+                0: CSS_NUMBER@498..500
+                  0: CSS_NUMBER_LITERAL@498..500 "10" [] []
+                1: SLASH@500..501 "/" [] []
+                2: CSS_NUMBER@501..502
+                  0: CSS_NUMBER_LITERAL@501..502 "2" [] []
+              1: PLUS@502..503 "+" [] []
+              2: CSS_NUMBER@503..504
+                0: CSS_NUMBER_LITERAL@503..504 "1" [] []
+        2: SEMICOLON@504..505 ";" [] []
+    15: CSS_AT_RULE@505..523
+      0: AT@505..507 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@507..523
+        0: DEBUG_KW@507..513 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@513..522
+          0: SCSS_EXPRESSION_ITEM_LIST@513..522
+            0: SCSS_BINARY_EXPRESSION@513..522
+              0: SCSS_BINARY_EXPRESSION@513..519
+                0: CSS_NUMBER@513..515
+                  0: CSS_NUMBER_LITERAL@513..515 "1" [] [Whitespace(" ")]
+                1: STAR@515..517 "*" [] [Whitespace(" ")]
+                2: CSS_NUMBER@517..519
+                  0: CSS_NUMBER_LITERAL@517..519 "2" [] [Whitespace(" ")]
+              1: SLASH@519..521 "/" [] [Whitespace(" ")]
+              2: CSS_NUMBER@521..522
+                0: CSS_NUMBER_LITERAL@521..522 "3" [] []
+        2: SEMICOLON@522..523 ";" [] []
+    16: CSS_AT_RULE@523..543
+      0: AT@523..525 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@525..543
+        0: DEBUG_KW@525..531 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@531..542
+          0: SCSS_EXPRESSION_ITEM_LIST@531..542
+            0: SCSS_BINARY_EXPRESSION@531..542
+              0: SCSS_PARENTHESIZED_EXPRESSION@531..539
+                0: L_PAREN@531..532 "(" [] []
+                1: SCSS_EXPRESSION@532..537
+                  0: SCSS_EXPRESSION_ITEM_LIST@532..537
+                    0: SCSS_BINARY_EXPRESSION@532..537
+                      0: CSS_NUMBER@532..534
+                        0: CSS_NUMBER_LITERAL@532..534 "1" [] [Whitespace(" ")]
+                      1: PLUS@534..536 "+" [] [Whitespace(" ")]
+                      2: CSS_NUMBER@536..537
+                        0: CSS_NUMBER_LITERAL@536..537 "2" [] []
+                2: R_PAREN@537..539 ")" [] [Whitespace(" ")]
+              1: SLASH@539..541 "/" [] [Whitespace(" ")]
+              2: CSS_NUMBER@541..542
+                0: CSS_NUMBER_LITERAL@541..542 "3" [] []
+        2: SEMICOLON@542..543 ";" [] []
+    17: CSS_AT_RULE@543..560
+      0: AT@543..545 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@545..560
+        0: DEBUG_KW@545..551 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@551..559
+          0: SCSS_EXPRESSION_ITEM_LIST@551..559
+            0: SCSS_BINARY_EXPRESSION@551..559
+              0: CSS_FUNCTION@551..556
+                0: CSS_IDENTIFIER@551..553
+                  0: IDENT@551..553 "fn" [] []
+                1: L_PAREN@553..554 "(" [] []
+                2: CSS_PARAMETER_LIST@554..554
+                3: R_PAREN@554..556 ")" [] [Whitespace(" ")]
+              1: SLASH@556..558 "/" [] [Whitespace(" ")]
+              2: CSS_NUMBER@558..559
+                0: CSS_NUMBER_LITERAL@558..559 "3" [] []
+        2: SEMICOLON@559..560 ";" [] []
+    18: CSS_AT_RULE@560..577
+      0: AT@560..562 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@562..577
+        0: DEBUG_KW@562..568 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@568..576
+          0: SCSS_EXPRESSION_ITEM_LIST@568..576
+            0: SCSS_BINARY_EXPRESSION@568..576
+              0: SCSS_VARIABLE@568..573
+                0: DOLLAR@568..569 "$" [] []
+                1: CSS_IDENTIFIER@569..573
+                  0: IDENT@569..573 "var" [] [Whitespace(" ")]
+              1: SLASH@573..575 "/" [] [Whitespace(" ")]
+              2: CSS_NUMBER@575..576
+                0: CSS_NUMBER_LITERAL@575..576 "3" [] []
+        2: SEMICOLON@576..577 ";" [] []
+    19: CSS_AT_RULE@577..598
+      0: AT@577..579 "@" [Newline("\n")] []
+      1: SCSS_DEBUG_AT_RULE@579..598
+        0: DEBUG_KW@579..585 "debug" [] [Whitespace(" ")]
+        1: SCSS_EXPRESSION@585..597
+          0: SCSS_EXPRESSION_ITEM_LIST@585..597
+            0: SCSS_BINARY_EXPRESSION@585..597
+              0: SCSS_MODULE_MEMBER_ACCESS@585..594
+                0: CSS_IDENTIFIER@585..588
+                  0: IDENT@585..588 "mod" [] []
+                1: DOT@588..589 "." [] []
+                2: SCSS_VARIABLE@589..594
+                  0: DOLLAR@589..590 "$" [] []
+                  1: CSS_IDENTIFIER@590..594
+                    0: IDENT@590..594 "var" [] [Whitespace(" ")]
+              1: SLASH@594..596 "/" [] [Whitespace(" ")]
+              2: CSS_NUMBER@596..597
+                0: CSS_NUMBER_LITERAL@596..597 "3" [] []
+        2: SEMICOLON@597..598 ";" [] []
+    20: CSS_QUALIFIED_RULE@598..621
+      0: CSS_SELECTOR_LIST@598..602
+        0: CSS_COMPOUND_SELECTOR@598..602
+          0: CSS_NESTED_SELECTOR_LIST@598..598
+          1: CSS_TYPE_SELECTOR@598..602
             0: (empty)
-            1: CSS_IDENTIFIER@251..519
-              0: IDENT@251..519 "a" [Newline("\n"), Newline("\n"), Comments("/* TODO(scss at-rules ..."), Newline("\n"), Newline("\n")] [Whitespace(" ")]
-          2: CSS_SUB_SELECTOR_LIST@519..519
-      1: CSS_DECLARATION_OR_RULE_BLOCK@519..538
-        0: L_CURLY@519..520 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@520..536
-          0: CSS_DECLARATION_WITH_SEMICOLON@520..536
-            0: CSS_DECLARATION@520..535
-              0: CSS_GENERIC_PROPERTY@520..535
-                0: CSS_IDENTIFIER@520..527
-                  0: IDENT@520..527 "prop" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@527..529 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@529..535
-                  0: SCSS_EXPRESSION_ITEM_LIST@529..535
-                    0: SCSS_LIST_EXPRESSION@529..535
-                      0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@529..535
-                        0: SCSS_LIST_EXPRESSION_ELEMENT@529..530
-                          0: SCSS_EXPRESSION@529..530
-                            0: SCSS_EXPRESSION_ITEM_LIST@529..530
-                              0: CSS_IDENTIFIER@529..530
-                                0: IDENT@529..530 "a" [] []
-                        1: COMMA@530..531 "," [] []
-                        2: SCSS_LIST_EXPRESSION_ELEMENT@531..535
-                          0: SCSS_EXPRESSION@531..535
-                            0: SCSS_EXPRESSION_ITEM_LIST@531..535
-                              0: SCSS_BINARY_EXPRESSION@531..535
-                                0: CSS_NUMBER@531..533
-                                  0: CSS_NUMBER_LITERAL@531..533 "-1" [] []
-                                1: STAR@533..534 "*" [] []
-                                2: CSS_IDENTIFIER@534..535
-                                  0: IDENT@534..535 "b" [] []
+            1: CSS_IDENTIFIER@598..602
+              0: IDENT@598..602 "a" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+          2: CSS_SUB_SELECTOR_LIST@602..602
+      1: CSS_DECLARATION_OR_RULE_BLOCK@602..621
+        0: L_CURLY@602..603 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@603..619
+          0: CSS_DECLARATION_WITH_SEMICOLON@603..619
+            0: CSS_DECLARATION@603..618
+              0: CSS_GENERIC_PROPERTY@603..618
+                0: CSS_IDENTIFIER@603..610
+                  0: IDENT@603..610 "prop" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@610..612 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@612..618
+                  0: SCSS_EXPRESSION_ITEM_LIST@612..618
+                    0: SCSS_LIST_EXPRESSION@612..618
+                      0: SCSS_LIST_EXPRESSION_ELEMENT_LIST@612..618
+                        0: SCSS_LIST_EXPRESSION_ELEMENT@612..613
+                          0: SCSS_EXPRESSION@612..613
+                            0: SCSS_EXPRESSION_ITEM_LIST@612..613
+                              0: CSS_IDENTIFIER@612..613
+                                0: IDENT@612..613 "a" [] []
+                        1: COMMA@613..614 "," [] []
+                        2: SCSS_LIST_EXPRESSION_ELEMENT@614..618
+                          0: SCSS_EXPRESSION@614..618
+                            0: SCSS_EXPRESSION_ITEM_LIST@614..618
+                              0: SCSS_BINARY_EXPRESSION@614..618
+                                0: CSS_NUMBER@614..616
+                                  0: CSS_NUMBER_LITERAL@614..616 "-1" [] []
+                                1: STAR@616..617 "*" [] []
+                                2: CSS_IDENTIFIER@617..618
+                                  0: IDENT@617..618 "b" [] []
               1: (empty)
-            1: SEMICOLON@535..536 ";" [] []
-        2: R_CURLY@536..538 "}" [Newline("\n")] []
-  2: EOF@538..542 "" [Newline("\n"), Newline("\n"), Newline("\n"), Newline("\n")] []
+            1: SEMICOLON@618..619 ";" [] []
+        2: R_CURLY@619..621 "}" [Newline("\n")] []
+  2: EOF@621..622 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/division-operator.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/division-operator.scss.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
-assertion_line: 208
 expression: snapshot
 ---
 
@@ -275,12 +274,12 @@ CssRoot {
                                 colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@16..18 "10" [] [],
                                             },
-                                            slash_token: SLASH@18..19 "/" [] [],
-                                            denominator: CssNumber {
+                                            operator: SLASH@18..19 "/" [] [],
+                                            right: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@19..21 "10" [] [],
                                             },
                                         },
@@ -300,12 +299,12 @@ CssRoot {
                                 colon_token: COLON@31..33 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@33..36 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@36..37 "/" [] [],
-                                            denominator: CssNumber {
+                                            operator: SLASH@36..37 "/" [] [],
+                                            right: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@37..39 "10" [] [],
                                             },
                                         },
@@ -325,12 +324,12 @@ CssRoot {
                                 colon_token: COLON@49..51 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@51..53 "10" [] [],
                                             },
-                                            slash_token: SLASH@53..55 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
+                                            operator: SLASH@53..55 "/" [] [Whitespace(" ")],
+                                            right: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@55..57 "10" [] [],
                                             },
                                         },
@@ -350,12 +349,12 @@ CssRoot {
                                 colon_token: COLON@67..69 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@69..72 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@72..74 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
+                                            operator: SLASH@72..74 "/" [] [Whitespace(" ")],
+                                            right: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@74..76 "10" [] [],
                                             },
                                         },
@@ -511,26 +510,30 @@ CssRoot {
                                 colon_token: COLON@170..172 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@172..174 "10" [] [],
                                             },
-                                            slash_token: SLASH@174..175 "/" [] [],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@175..176 "1" [] [],
-                                            },
-                                        },
-                                        ScssInterpolation {
-                                            hash_token: HASH@176..177 "#" [] [],
-                                            l_curly_token: L_CURLY@177..178 "{" [] [],
-                                            value: ScssExpression {
-                                                items: ScssExpressionItemList [
+                                            operator: SLASH@174..175 "/" [] [],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
                                                     CssNumber {
-                                                        value_token: CSS_NUMBER_LITERAL@178..179 "0" [] [],
+                                                        value_token: CSS_NUMBER_LITERAL@175..176 "1" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@176..177 "#" [] [],
+                                                        l_curly_token: L_CURLY@177..178 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@178..179 "0" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@179..180 "}" [] [],
                                                     },
                                                 ],
                                             },
-                                            r_curly_token: R_CURLY@179..180 "}" [] [],
                                         },
                                     ],
                                 },
@@ -548,26 +551,30 @@ CssRoot {
                                 colon_token: COLON@191..193 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@193..196 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@196..197 "/" [] [],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@197..198 "1" [] [],
-                                            },
-                                        },
-                                        ScssInterpolation {
-                                            hash_token: HASH@198..199 "#" [] [],
-                                            l_curly_token: L_CURLY@199..200 "{" [] [],
-                                            value: ScssExpression {
-                                                items: ScssExpressionItemList [
+                                            operator: SLASH@196..197 "/" [] [],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
                                                     CssNumber {
-                                                        value_token: CSS_NUMBER_LITERAL@200..201 "0" [] [],
+                                                        value_token: CSS_NUMBER_LITERAL@197..198 "1" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@198..199 "#" [] [],
+                                                        l_curly_token: L_CURLY@199..200 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@200..201 "0" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@201..202 "}" [] [],
                                                     },
                                                 ],
                                             },
-                                            r_curly_token: R_CURLY@201..202 "}" [] [],
                                         },
                                     ],
                                 },
@@ -585,26 +592,30 @@ CssRoot {
                                 colon_token: COLON@213..215 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@215..217 "10" [] [],
                                             },
-                                            slash_token: SLASH@217..219 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@219..220 "1" [] [],
-                                            },
-                                        },
-                                        ScssInterpolation {
-                                            hash_token: HASH@220..221 "#" [] [],
-                                            l_curly_token: L_CURLY@221..222 "{" [] [],
-                                            value: ScssExpression {
-                                                items: ScssExpressionItemList [
+                                            operator: SLASH@217..219 "/" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
                                                     CssNumber {
-                                                        value_token: CSS_NUMBER_LITERAL@222..223 "0" [] [],
+                                                        value_token: CSS_NUMBER_LITERAL@219..220 "1" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@220..221 "#" [] [],
+                                                        l_curly_token: L_CURLY@221..222 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@222..223 "0" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@223..224 "}" [] [],
                                                     },
                                                 ],
                                             },
-                                            r_curly_token: R_CURLY@223..224 "}" [] [],
                                         },
                                     ],
                                 },
@@ -622,26 +633,30 @@ CssRoot {
                                 colon_token: COLON@235..237 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@237..240 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@240..242 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@242..243 "1" [] [],
-                                            },
-                                        },
-                                        ScssInterpolation {
-                                            hash_token: HASH@243..244 "#" [] [],
-                                            l_curly_token: L_CURLY@244..245 "{" [] [],
-                                            value: ScssExpression {
-                                                items: ScssExpressionItemList [
+                                            operator: SLASH@240..242 "/" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
                                                     CssNumber {
-                                                        value_token: CSS_NUMBER_LITERAL@245..246 "0" [] [],
+                                                        value_token: CSS_NUMBER_LITERAL@242..243 "1" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@243..244 "#" [] [],
+                                                        l_curly_token: L_CURLY@244..245 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@245..246 "0" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@246..247 "}" [] [],
                                                     },
                                                 ],
                                             },
-                                            r_curly_token: R_CURLY@246..247 "}" [] [],
                                         },
                                     ],
                                 },
@@ -2367,33 +2382,33 @@ CssRoot {
                                 colon_token: COLON@1130..1132 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1132..1134 "10" [] [],
                                             },
-                                            slash_token: SLASH@1134..1135 "/" [] [],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1135..1136 "1" [] [],
-                                            },
-                                        },
-                                        ScssInterpolatedIdentifier {
-                                            items: ScssInterpolatedIdentifierPartList [
-                                                ScssInterpolation {
-                                                    hash_token: HASH@1136..1137 "#" [] [],
-                                                    l_curly_token: L_CURLY@1137..1138 "{" [] [],
-                                                    value: ScssExpression {
-                                                        items: ScssExpressionItemList [
-                                                            CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@1138..1139 "0" [] [],
-                                                            },
-                                                        ],
+                                            operator: SLASH@1134..1135 "/" [] [],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1135..1136 "1" [] [],
                                                     },
-                                                    r_curly_token: R_CURLY@1139..1140 "}" [] [],
-                                                },
-                                                CssIdentifier {
-                                                    value_token: IDENT@1140..1142 "px" [] [],
-                                                },
-                                            ],
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1136..1137 "#" [] [],
+                                                        l_curly_token: L_CURLY@1137..1138 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@1138..1139 "0" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1139..1140 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1140..1142 "px" [] [],
+                                                    },
+                                                ],
+                                            },
                                         },
                                     ],
                                 },
@@ -2411,33 +2426,33 @@ CssRoot {
                                 colon_token: COLON@1153..1155 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1155..1158 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@1158..1159 "/" [] [],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1159..1160 "1" [] [],
-                                            },
-                                        },
-                                        ScssInterpolatedIdentifier {
-                                            items: ScssInterpolatedIdentifierPartList [
-                                                ScssInterpolation {
-                                                    hash_token: HASH@1160..1161 "#" [] [],
-                                                    l_curly_token: L_CURLY@1161..1162 "{" [] [],
-                                                    value: ScssExpression {
-                                                        items: ScssExpressionItemList [
-                                                            CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@1162..1163 "0" [] [],
-                                                            },
-                                                        ],
+                                            operator: SLASH@1158..1159 "/" [] [],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1159..1160 "1" [] [],
                                                     },
-                                                    r_curly_token: R_CURLY@1163..1164 "}" [] [],
-                                                },
-                                                CssIdentifier {
-                                                    value_token: IDENT@1164..1166 "px" [] [],
-                                                },
-                                            ],
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1160..1161 "#" [] [],
+                                                        l_curly_token: L_CURLY@1161..1162 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@1162..1163 "0" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1163..1164 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1164..1166 "px" [] [],
+                                                    },
+                                                ],
+                                            },
                                         },
                                     ],
                                 },
@@ -2455,33 +2470,33 @@ CssRoot {
                                 colon_token: COLON@1177..1179 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1179..1181 "10" [] [],
                                             },
-                                            slash_token: SLASH@1181..1183 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1183..1184 "1" [] [],
-                                            },
-                                        },
-                                        ScssInterpolatedIdentifier {
-                                            items: ScssInterpolatedIdentifierPartList [
-                                                ScssInterpolation {
-                                                    hash_token: HASH@1184..1185 "#" [] [],
-                                                    l_curly_token: L_CURLY@1185..1186 "{" [] [],
-                                                    value: ScssExpression {
-                                                        items: ScssExpressionItemList [
-                                                            CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@1186..1187 "0" [] [],
-                                                            },
-                                                        ],
+                                            operator: SLASH@1181..1183 "/" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1183..1184 "1" [] [],
                                                     },
-                                                    r_curly_token: R_CURLY@1187..1188 "}" [] [],
-                                                },
-                                                CssIdentifier {
-                                                    value_token: IDENT@1188..1190 "px" [] [],
-                                                },
-                                            ],
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1184..1185 "#" [] [],
+                                                        l_curly_token: L_CURLY@1185..1186 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@1186..1187 "0" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1187..1188 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1188..1190 "px" [] [],
+                                                    },
+                                                ],
+                                            },
                                         },
                                     ],
                                 },
@@ -2499,33 +2514,33 @@ CssRoot {
                                 colon_token: COLON@1201..1203 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1203..1206 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@1206..1208 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1208..1209 "1" [] [],
-                                            },
-                                        },
-                                        ScssInterpolatedIdentifier {
-                                            items: ScssInterpolatedIdentifierPartList [
-                                                ScssInterpolation {
-                                                    hash_token: HASH@1209..1210 "#" [] [],
-                                                    l_curly_token: L_CURLY@1210..1211 "{" [] [],
-                                                    value: ScssExpression {
-                                                        items: ScssExpressionItemList [
-                                                            CssNumber {
-                                                                value_token: CSS_NUMBER_LITERAL@1211..1212 "0" [] [],
-                                                            },
-                                                        ],
+                                            operator: SLASH@1206..1208 "/" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1208..1209 "1" [] [],
                                                     },
-                                                    r_curly_token: R_CURLY@1212..1213 "}" [] [],
-                                                },
-                                                CssIdentifier {
-                                                    value_token: IDENT@1213..1215 "px" [] [],
-                                                },
-                                            ],
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1209..1210 "#" [] [],
+                                                        l_curly_token: L_CURLY@1210..1211 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@1211..1212 "0" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1212..1213 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1213..1215 "px" [] [],
+                                                    },
+                                                ],
+                                            },
                                         },
                                     ],
                                 },
@@ -2543,26 +2558,30 @@ CssRoot {
                                 colon_token: COLON@1226..1228 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1228..1230 "10" [] [],
                                             },
-                                            slash_token: SLASH@1230..1231 "/" [] [],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1231..1233 "10" [] [],
-                                            },
-                                        },
-                                        ScssInterpolation {
-                                            hash_token: HASH@1233..1234 "#" [] [],
-                                            l_curly_token: L_CURLY@1234..1235 "{" [] [],
-                                            value: ScssExpression {
-                                                items: ScssExpressionItemList [
-                                                    CssIdentifier {
-                                                        value_token: IDENT@1235..1237 "px" [] [],
+                                            operator: SLASH@1230..1231 "/" [] [],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1231..1233 "10" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1233..1234 "#" [] [],
+                                                        l_curly_token: L_CURLY@1234..1235 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@1235..1237 "px" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1237..1238 "}" [] [],
                                                     },
                                                 ],
                                             },
-                                            r_curly_token: R_CURLY@1237..1238 "}" [] [],
                                         },
                                     ],
                                 },
@@ -2580,26 +2599,30 @@ CssRoot {
                                 colon_token: COLON@1249..1251 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1251..1254 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@1254..1255 "/" [] [],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1255..1257 "10" [] [],
-                                            },
-                                        },
-                                        ScssInterpolation {
-                                            hash_token: HASH@1257..1258 "#" [] [],
-                                            l_curly_token: L_CURLY@1258..1259 "{" [] [],
-                                            value: ScssExpression {
-                                                items: ScssExpressionItemList [
-                                                    CssIdentifier {
-                                                        value_token: IDENT@1259..1261 "px" [] [],
+                                            operator: SLASH@1254..1255 "/" [] [],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1255..1257 "10" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1257..1258 "#" [] [],
+                                                        l_curly_token: L_CURLY@1258..1259 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@1259..1261 "px" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1261..1262 "}" [] [],
                                                     },
                                                 ],
                                             },
-                                            r_curly_token: R_CURLY@1261..1262 "}" [] [],
                                         },
                                     ],
                                 },
@@ -2617,26 +2640,30 @@ CssRoot {
                                 colon_token: COLON@1273..1275 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1275..1277 "10" [] [],
                                             },
-                                            slash_token: SLASH@1277..1279 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1279..1281 "10" [] [],
-                                            },
-                                        },
-                                        ScssInterpolation {
-                                            hash_token: HASH@1281..1282 "#" [] [],
-                                            l_curly_token: L_CURLY@1282..1283 "{" [] [],
-                                            value: ScssExpression {
-                                                items: ScssExpressionItemList [
-                                                    CssIdentifier {
-                                                        value_token: IDENT@1283..1285 "px" [] [],
+                                            operator: SLASH@1277..1279 "/" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1279..1281 "10" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1281..1282 "#" [] [],
+                                                        l_curly_token: L_CURLY@1282..1283 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@1283..1285 "px" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1285..1286 "}" [] [],
                                                     },
                                                 ],
                                             },
-                                            r_curly_token: R_CURLY@1285..1286 "}" [] [],
                                         },
                                     ],
                                 },
@@ -2654,26 +2681,30 @@ CssRoot {
                                 colon_token: COLON@1297..1299 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1299..1302 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@1302..1304 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1304..1306 "10" [] [],
-                                            },
-                                        },
-                                        ScssInterpolation {
-                                            hash_token: HASH@1306..1307 "#" [] [],
-                                            l_curly_token: L_CURLY@1307..1308 "{" [] [],
-                                            value: ScssExpression {
-                                                items: ScssExpressionItemList [
-                                                    CssIdentifier {
-                                                        value_token: IDENT@1308..1310 "px" [] [],
+                                            operator: SLASH@1302..1304 "/" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1304..1306 "10" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1306..1307 "#" [] [],
+                                                        l_curly_token: L_CURLY@1307..1308 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@1308..1310 "px" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1310..1311 "}" [] [],
                                                     },
                                                 ],
                                             },
-                                            r_curly_token: R_CURLY@1310..1311 "}" [] [],
                                         },
                                     ],
                                 },
@@ -2691,33 +2722,33 @@ CssRoot {
                                 colon_token: COLON@1322..1324 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1324..1326 "10" [] [],
                                             },
-                                            slash_token: SLASH@1326..1327 "/" [] [],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1327..1329 "10" [] [],
-                                            },
-                                        },
-                                        ScssInterpolatedIdentifier {
-                                            items: ScssInterpolatedIdentifierPartList [
-                                                ScssInterpolation {
-                                                    hash_token: HASH@1329..1330 "#" [] [],
-                                                    l_curly_token: L_CURLY@1330..1331 "{" [] [],
-                                                    value: ScssExpression {
-                                                        items: ScssExpressionItemList [
-                                                            CssIdentifier {
-                                                                value_token: IDENT@1331..1332 "p" [] [],
-                                                            },
-                                                        ],
+                                            operator: SLASH@1326..1327 "/" [] [],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1327..1329 "10" [] [],
                                                     },
-                                                    r_curly_token: R_CURLY@1332..1333 "}" [] [],
-                                                },
-                                                CssIdentifier {
-                                                    value_token: IDENT@1333..1334 "x" [] [],
-                                                },
-                                            ],
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1329..1330 "#" [] [],
+                                                        l_curly_token: L_CURLY@1330..1331 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@1331..1332 "p" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1332..1333 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1333..1334 "x" [] [],
+                                                    },
+                                                ],
+                                            },
                                         },
                                     ],
                                 },
@@ -2735,33 +2766,33 @@ CssRoot {
                                 colon_token: COLON@1345..1347 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1347..1350 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@1350..1351 "/" [] [],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1351..1353 "10" [] [],
-                                            },
-                                        },
-                                        ScssInterpolatedIdentifier {
-                                            items: ScssInterpolatedIdentifierPartList [
-                                                ScssInterpolation {
-                                                    hash_token: HASH@1353..1354 "#" [] [],
-                                                    l_curly_token: L_CURLY@1354..1355 "{" [] [],
-                                                    value: ScssExpression {
-                                                        items: ScssExpressionItemList [
-                                                            CssIdentifier {
-                                                                value_token: IDENT@1355..1356 "p" [] [],
-                                                            },
-                                                        ],
+                                            operator: SLASH@1350..1351 "/" [] [],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1351..1353 "10" [] [],
                                                     },
-                                                    r_curly_token: R_CURLY@1356..1357 "}" [] [],
-                                                },
-                                                CssIdentifier {
-                                                    value_token: IDENT@1357..1358 "x" [] [],
-                                                },
-                                            ],
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1353..1354 "#" [] [],
+                                                        l_curly_token: L_CURLY@1354..1355 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@1355..1356 "p" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1356..1357 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1357..1358 "x" [] [],
+                                                    },
+                                                ],
+                                            },
                                         },
                                     ],
                                 },
@@ -2779,33 +2810,33 @@ CssRoot {
                                 colon_token: COLON@1369..1371 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1371..1373 "10" [] [],
                                             },
-                                            slash_token: SLASH@1373..1375 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1375..1377 "10" [] [],
-                                            },
-                                        },
-                                        ScssInterpolatedIdentifier {
-                                            items: ScssInterpolatedIdentifierPartList [
-                                                ScssInterpolation {
-                                                    hash_token: HASH@1377..1378 "#" [] [],
-                                                    l_curly_token: L_CURLY@1378..1379 "{" [] [],
-                                                    value: ScssExpression {
-                                                        items: ScssExpressionItemList [
-                                                            CssIdentifier {
-                                                                value_token: IDENT@1379..1380 "p" [] [],
-                                                            },
-                                                        ],
+                                            operator: SLASH@1373..1375 "/" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1375..1377 "10" [] [],
                                                     },
-                                                    r_curly_token: R_CURLY@1380..1381 "}" [] [],
-                                                },
-                                                CssIdentifier {
-                                                    value_token: IDENT@1381..1382 "x" [] [],
-                                                },
-                                            ],
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1377..1378 "#" [] [],
+                                                        l_curly_token: L_CURLY@1378..1379 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@1379..1380 "p" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1380..1381 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1381..1382 "x" [] [],
+                                                    },
+                                                ],
+                                            },
                                         },
                                     ],
                                 },
@@ -2823,33 +2854,33 @@ CssRoot {
                                 colon_token: COLON@1393..1395 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
-                                        CssRatio {
-                                            numerator: CssNumber {
+                                        ScssBinaryExpression {
+                                            left: CssNumber {
                                                 value_token: CSS_NUMBER_LITERAL@1395..1398 "10" [] [Whitespace(" ")],
                                             },
-                                            slash_token: SLASH@1398..1400 "/" [] [Whitespace(" ")],
-                                            denominator: CssNumber {
-                                                value_token: CSS_NUMBER_LITERAL@1400..1402 "10" [] [],
-                                            },
-                                        },
-                                        ScssInterpolatedIdentifier {
-                                            items: ScssInterpolatedIdentifierPartList [
-                                                ScssInterpolation {
-                                                    hash_token: HASH@1402..1403 "#" [] [],
-                                                    l_curly_token: L_CURLY@1403..1404 "{" [] [],
-                                                    value: ScssExpression {
-                                                        items: ScssExpressionItemList [
-                                                            CssIdentifier {
-                                                                value_token: IDENT@1404..1405 "p" [] [],
-                                                            },
-                                                        ],
+                                            operator: SLASH@1398..1400 "/" [] [Whitespace(" ")],
+                                            right: ScssInterpolatedValue {
+                                                items: ScssInterpolatedValuePartList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1400..1402 "10" [] [],
                                                     },
-                                                    r_curly_token: R_CURLY@1405..1406 "}" [] [],
-                                                },
-                                                CssIdentifier {
-                                                    value_token: IDENT@1406..1407 "x" [] [],
-                                                },
-                                            ],
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@1402..1403 "#" [] [],
+                                                        l_curly_token: L_CURLY@1403..1404 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@1404..1405 "p" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@1405..1406 "}" [] [],
+                                                    },
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1406..1407 "x" [] [],
+                                                    },
+                                                ],
+                                            },
                                         },
                                     ],
                                 },
@@ -9817,7 +9848,7 @@ CssRoot {
                 1: COLON@14..16 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@16..21
                   0: SCSS_EXPRESSION_ITEM_LIST@16..21
-                    0: CSS_RATIO@16..21
+                    0: SCSS_BINARY_EXPRESSION@16..21
                       0: CSS_NUMBER@16..18
                         0: CSS_NUMBER_LITERAL@16..18 "10" [] []
                       1: SLASH@18..19 "/" [] []
@@ -9833,7 +9864,7 @@ CssRoot {
                 1: COLON@31..33 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@33..39
                   0: SCSS_EXPRESSION_ITEM_LIST@33..39
-                    0: CSS_RATIO@33..39
+                    0: SCSS_BINARY_EXPRESSION@33..39
                       0: CSS_NUMBER@33..36
                         0: CSS_NUMBER_LITERAL@33..36 "10" [] [Whitespace(" ")]
                       1: SLASH@36..37 "/" [] []
@@ -9849,7 +9880,7 @@ CssRoot {
                 1: COLON@49..51 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@51..57
                   0: SCSS_EXPRESSION_ITEM_LIST@51..57
-                    0: CSS_RATIO@51..57
+                    0: SCSS_BINARY_EXPRESSION@51..57
                       0: CSS_NUMBER@51..53
                         0: CSS_NUMBER_LITERAL@51..53 "10" [] []
                       1: SLASH@53..55 "/" [] [Whitespace(" ")]
@@ -9865,7 +9896,7 @@ CssRoot {
                 1: COLON@67..69 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@69..76
                   0: SCSS_EXPRESSION_ITEM_LIST@69..76
-                    0: CSS_RATIO@69..76
+                    0: SCSS_BINARY_EXPRESSION@69..76
                       0: CSS_NUMBER@69..72
                         0: CSS_NUMBER_LITERAL@69..72 "10" [] [Whitespace(" ")]
                       1: SLASH@72..74 "/" [] [Whitespace(" ")]
@@ -9969,20 +10000,22 @@ CssRoot {
                 1: COLON@170..172 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@172..180
                   0: SCSS_EXPRESSION_ITEM_LIST@172..180
-                    0: CSS_RATIO@172..176
+                    0: SCSS_BINARY_EXPRESSION@172..180
                       0: CSS_NUMBER@172..174
                         0: CSS_NUMBER_LITERAL@172..174 "10" [] []
                       1: SLASH@174..175 "/" [] []
-                      2: CSS_NUMBER@175..176
-                        0: CSS_NUMBER_LITERAL@175..176 "1" [] []
-                    1: SCSS_INTERPOLATION@176..180
-                      0: HASH@176..177 "#" [] []
-                      1: L_CURLY@177..178 "{" [] []
-                      2: SCSS_EXPRESSION@178..179
-                        0: SCSS_EXPRESSION_ITEM_LIST@178..179
-                          0: CSS_NUMBER@178..179
-                            0: CSS_NUMBER_LITERAL@178..179 "0" [] []
-                      3: R_CURLY@179..180 "}" [] []
+                      2: SCSS_INTERPOLATED_VALUE@175..180
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@175..180
+                          0: CSS_NUMBER@175..176
+                            0: CSS_NUMBER_LITERAL@175..176 "1" [] []
+                          1: SCSS_INTERPOLATION@176..180
+                            0: HASH@176..177 "#" [] []
+                            1: L_CURLY@177..178 "{" [] []
+                            2: SCSS_EXPRESSION@178..179
+                              0: SCSS_EXPRESSION_ITEM_LIST@178..179
+                                0: CSS_NUMBER@178..179
+                                  0: CSS_NUMBER_LITERAL@178..179 "0" [] []
+                            3: R_CURLY@179..180 "}" [] []
               1: (empty)
             1: SEMICOLON@180..181 ";" [] []
           9: CSS_DECLARATION_WITH_SEMICOLON@181..203
@@ -9993,20 +10026,22 @@ CssRoot {
                 1: COLON@191..193 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@193..202
                   0: SCSS_EXPRESSION_ITEM_LIST@193..202
-                    0: CSS_RATIO@193..198
+                    0: SCSS_BINARY_EXPRESSION@193..202
                       0: CSS_NUMBER@193..196
                         0: CSS_NUMBER_LITERAL@193..196 "10" [] [Whitespace(" ")]
                       1: SLASH@196..197 "/" [] []
-                      2: CSS_NUMBER@197..198
-                        0: CSS_NUMBER_LITERAL@197..198 "1" [] []
-                    1: SCSS_INTERPOLATION@198..202
-                      0: HASH@198..199 "#" [] []
-                      1: L_CURLY@199..200 "{" [] []
-                      2: SCSS_EXPRESSION@200..201
-                        0: SCSS_EXPRESSION_ITEM_LIST@200..201
-                          0: CSS_NUMBER@200..201
-                            0: CSS_NUMBER_LITERAL@200..201 "0" [] []
-                      3: R_CURLY@201..202 "}" [] []
+                      2: SCSS_INTERPOLATED_VALUE@197..202
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@197..202
+                          0: CSS_NUMBER@197..198
+                            0: CSS_NUMBER_LITERAL@197..198 "1" [] []
+                          1: SCSS_INTERPOLATION@198..202
+                            0: HASH@198..199 "#" [] []
+                            1: L_CURLY@199..200 "{" [] []
+                            2: SCSS_EXPRESSION@200..201
+                              0: SCSS_EXPRESSION_ITEM_LIST@200..201
+                                0: CSS_NUMBER@200..201
+                                  0: CSS_NUMBER_LITERAL@200..201 "0" [] []
+                            3: R_CURLY@201..202 "}" [] []
               1: (empty)
             1: SEMICOLON@202..203 ";" [] []
           10: CSS_DECLARATION_WITH_SEMICOLON@203..225
@@ -10017,20 +10052,22 @@ CssRoot {
                 1: COLON@213..215 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@215..224
                   0: SCSS_EXPRESSION_ITEM_LIST@215..224
-                    0: CSS_RATIO@215..220
+                    0: SCSS_BINARY_EXPRESSION@215..224
                       0: CSS_NUMBER@215..217
                         0: CSS_NUMBER_LITERAL@215..217 "10" [] []
                       1: SLASH@217..219 "/" [] [Whitespace(" ")]
-                      2: CSS_NUMBER@219..220
-                        0: CSS_NUMBER_LITERAL@219..220 "1" [] []
-                    1: SCSS_INTERPOLATION@220..224
-                      0: HASH@220..221 "#" [] []
-                      1: L_CURLY@221..222 "{" [] []
-                      2: SCSS_EXPRESSION@222..223
-                        0: SCSS_EXPRESSION_ITEM_LIST@222..223
-                          0: CSS_NUMBER@222..223
-                            0: CSS_NUMBER_LITERAL@222..223 "0" [] []
-                      3: R_CURLY@223..224 "}" [] []
+                      2: SCSS_INTERPOLATED_VALUE@219..224
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@219..224
+                          0: CSS_NUMBER@219..220
+                            0: CSS_NUMBER_LITERAL@219..220 "1" [] []
+                          1: SCSS_INTERPOLATION@220..224
+                            0: HASH@220..221 "#" [] []
+                            1: L_CURLY@221..222 "{" [] []
+                            2: SCSS_EXPRESSION@222..223
+                              0: SCSS_EXPRESSION_ITEM_LIST@222..223
+                                0: CSS_NUMBER@222..223
+                                  0: CSS_NUMBER_LITERAL@222..223 "0" [] []
+                            3: R_CURLY@223..224 "}" [] []
               1: (empty)
             1: SEMICOLON@224..225 ";" [] []
           11: CSS_DECLARATION_WITH_SEMICOLON@225..248
@@ -10041,20 +10078,22 @@ CssRoot {
                 1: COLON@235..237 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@237..247
                   0: SCSS_EXPRESSION_ITEM_LIST@237..247
-                    0: CSS_RATIO@237..243
+                    0: SCSS_BINARY_EXPRESSION@237..247
                       0: CSS_NUMBER@237..240
                         0: CSS_NUMBER_LITERAL@237..240 "10" [] [Whitespace(" ")]
                       1: SLASH@240..242 "/" [] [Whitespace(" ")]
-                      2: CSS_NUMBER@242..243
-                        0: CSS_NUMBER_LITERAL@242..243 "1" [] []
-                    1: SCSS_INTERPOLATION@243..247
-                      0: HASH@243..244 "#" [] []
-                      1: L_CURLY@244..245 "{" [] []
-                      2: SCSS_EXPRESSION@245..246
-                        0: SCSS_EXPRESSION_ITEM_LIST@245..246
-                          0: CSS_NUMBER@245..246
-                            0: CSS_NUMBER_LITERAL@245..246 "0" [] []
-                      3: R_CURLY@246..247 "}" [] []
+                      2: SCSS_INTERPOLATED_VALUE@242..247
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@242..247
+                          0: CSS_NUMBER@242..243
+                            0: CSS_NUMBER_LITERAL@242..243 "1" [] []
+                          1: SCSS_INTERPOLATION@243..247
+                            0: HASH@243..244 "#" [] []
+                            1: L_CURLY@244..245 "{" [] []
+                            2: SCSS_EXPRESSION@245..246
+                              0: SCSS_EXPRESSION_ITEM_LIST@245..246
+                                0: CSS_NUMBER@245..246
+                                  0: CSS_NUMBER_LITERAL@245..246 "0" [] []
+                            3: R_CURLY@246..247 "}" [] []
               1: (empty)
             1: SEMICOLON@247..248 ";" [] []
           12: CSS_DECLARATION_WITH_SEMICOLON@248..269
@@ -11154,24 +11193,24 @@ CssRoot {
                 1: COLON@1130..1132 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1132..1142
                   0: SCSS_EXPRESSION_ITEM_LIST@1132..1142
-                    0: CSS_RATIO@1132..1136
+                    0: SCSS_BINARY_EXPRESSION@1132..1142
                       0: CSS_NUMBER@1132..1134
                         0: CSS_NUMBER_LITERAL@1132..1134 "10" [] []
                       1: SLASH@1134..1135 "/" [] []
-                      2: CSS_NUMBER@1135..1136
-                        0: CSS_NUMBER_LITERAL@1135..1136 "1" [] []
-                    1: SCSS_INTERPOLATED_IDENTIFIER@1136..1142
-                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1136..1142
-                        0: SCSS_INTERPOLATION@1136..1140
-                          0: HASH@1136..1137 "#" [] []
-                          1: L_CURLY@1137..1138 "{" [] []
-                          2: SCSS_EXPRESSION@1138..1139
-                            0: SCSS_EXPRESSION_ITEM_LIST@1138..1139
-                              0: CSS_NUMBER@1138..1139
-                                0: CSS_NUMBER_LITERAL@1138..1139 "0" [] []
-                          3: R_CURLY@1139..1140 "}" [] []
-                        1: CSS_IDENTIFIER@1140..1142
-                          0: IDENT@1140..1142 "px" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1135..1142
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1135..1142
+                          0: CSS_NUMBER@1135..1136
+                            0: CSS_NUMBER_LITERAL@1135..1136 "1" [] []
+                          1: SCSS_INTERPOLATION@1136..1140
+                            0: HASH@1136..1137 "#" [] []
+                            1: L_CURLY@1137..1138 "{" [] []
+                            2: SCSS_EXPRESSION@1138..1139
+                              0: SCSS_EXPRESSION_ITEM_LIST@1138..1139
+                                0: CSS_NUMBER@1138..1139
+                                  0: CSS_NUMBER_LITERAL@1138..1139 "0" [] []
+                            3: R_CURLY@1139..1140 "}" [] []
+                          2: CSS_IDENTIFIER@1140..1142
+                            0: IDENT@1140..1142 "px" [] []
               1: (empty)
             1: SEMICOLON@1142..1143 ";" [] []
           9: CSS_DECLARATION_WITH_SEMICOLON@1143..1167
@@ -11182,24 +11221,24 @@ CssRoot {
                 1: COLON@1153..1155 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1155..1166
                   0: SCSS_EXPRESSION_ITEM_LIST@1155..1166
-                    0: CSS_RATIO@1155..1160
+                    0: SCSS_BINARY_EXPRESSION@1155..1166
                       0: CSS_NUMBER@1155..1158
                         0: CSS_NUMBER_LITERAL@1155..1158 "10" [] [Whitespace(" ")]
                       1: SLASH@1158..1159 "/" [] []
-                      2: CSS_NUMBER@1159..1160
-                        0: CSS_NUMBER_LITERAL@1159..1160 "1" [] []
-                    1: SCSS_INTERPOLATED_IDENTIFIER@1160..1166
-                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1160..1166
-                        0: SCSS_INTERPOLATION@1160..1164
-                          0: HASH@1160..1161 "#" [] []
-                          1: L_CURLY@1161..1162 "{" [] []
-                          2: SCSS_EXPRESSION@1162..1163
-                            0: SCSS_EXPRESSION_ITEM_LIST@1162..1163
-                              0: CSS_NUMBER@1162..1163
-                                0: CSS_NUMBER_LITERAL@1162..1163 "0" [] []
-                          3: R_CURLY@1163..1164 "}" [] []
-                        1: CSS_IDENTIFIER@1164..1166
-                          0: IDENT@1164..1166 "px" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1159..1166
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1159..1166
+                          0: CSS_NUMBER@1159..1160
+                            0: CSS_NUMBER_LITERAL@1159..1160 "1" [] []
+                          1: SCSS_INTERPOLATION@1160..1164
+                            0: HASH@1160..1161 "#" [] []
+                            1: L_CURLY@1161..1162 "{" [] []
+                            2: SCSS_EXPRESSION@1162..1163
+                              0: SCSS_EXPRESSION_ITEM_LIST@1162..1163
+                                0: CSS_NUMBER@1162..1163
+                                  0: CSS_NUMBER_LITERAL@1162..1163 "0" [] []
+                            3: R_CURLY@1163..1164 "}" [] []
+                          2: CSS_IDENTIFIER@1164..1166
+                            0: IDENT@1164..1166 "px" [] []
               1: (empty)
             1: SEMICOLON@1166..1167 ";" [] []
           10: CSS_DECLARATION_WITH_SEMICOLON@1167..1191
@@ -11210,24 +11249,24 @@ CssRoot {
                 1: COLON@1177..1179 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1179..1190
                   0: SCSS_EXPRESSION_ITEM_LIST@1179..1190
-                    0: CSS_RATIO@1179..1184
+                    0: SCSS_BINARY_EXPRESSION@1179..1190
                       0: CSS_NUMBER@1179..1181
                         0: CSS_NUMBER_LITERAL@1179..1181 "10" [] []
                       1: SLASH@1181..1183 "/" [] [Whitespace(" ")]
-                      2: CSS_NUMBER@1183..1184
-                        0: CSS_NUMBER_LITERAL@1183..1184 "1" [] []
-                    1: SCSS_INTERPOLATED_IDENTIFIER@1184..1190
-                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1184..1190
-                        0: SCSS_INTERPOLATION@1184..1188
-                          0: HASH@1184..1185 "#" [] []
-                          1: L_CURLY@1185..1186 "{" [] []
-                          2: SCSS_EXPRESSION@1186..1187
-                            0: SCSS_EXPRESSION_ITEM_LIST@1186..1187
-                              0: CSS_NUMBER@1186..1187
-                                0: CSS_NUMBER_LITERAL@1186..1187 "0" [] []
-                          3: R_CURLY@1187..1188 "}" [] []
-                        1: CSS_IDENTIFIER@1188..1190
-                          0: IDENT@1188..1190 "px" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1183..1190
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1183..1190
+                          0: CSS_NUMBER@1183..1184
+                            0: CSS_NUMBER_LITERAL@1183..1184 "1" [] []
+                          1: SCSS_INTERPOLATION@1184..1188
+                            0: HASH@1184..1185 "#" [] []
+                            1: L_CURLY@1185..1186 "{" [] []
+                            2: SCSS_EXPRESSION@1186..1187
+                              0: SCSS_EXPRESSION_ITEM_LIST@1186..1187
+                                0: CSS_NUMBER@1186..1187
+                                  0: CSS_NUMBER_LITERAL@1186..1187 "0" [] []
+                            3: R_CURLY@1187..1188 "}" [] []
+                          2: CSS_IDENTIFIER@1188..1190
+                            0: IDENT@1188..1190 "px" [] []
               1: (empty)
             1: SEMICOLON@1190..1191 ";" [] []
           11: CSS_DECLARATION_WITH_SEMICOLON@1191..1216
@@ -11238,24 +11277,24 @@ CssRoot {
                 1: COLON@1201..1203 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1203..1215
                   0: SCSS_EXPRESSION_ITEM_LIST@1203..1215
-                    0: CSS_RATIO@1203..1209
+                    0: SCSS_BINARY_EXPRESSION@1203..1215
                       0: CSS_NUMBER@1203..1206
                         0: CSS_NUMBER_LITERAL@1203..1206 "10" [] [Whitespace(" ")]
                       1: SLASH@1206..1208 "/" [] [Whitespace(" ")]
-                      2: CSS_NUMBER@1208..1209
-                        0: CSS_NUMBER_LITERAL@1208..1209 "1" [] []
-                    1: SCSS_INTERPOLATED_IDENTIFIER@1209..1215
-                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1209..1215
-                        0: SCSS_INTERPOLATION@1209..1213
-                          0: HASH@1209..1210 "#" [] []
-                          1: L_CURLY@1210..1211 "{" [] []
-                          2: SCSS_EXPRESSION@1211..1212
-                            0: SCSS_EXPRESSION_ITEM_LIST@1211..1212
-                              0: CSS_NUMBER@1211..1212
-                                0: CSS_NUMBER_LITERAL@1211..1212 "0" [] []
-                          3: R_CURLY@1212..1213 "}" [] []
-                        1: CSS_IDENTIFIER@1213..1215
-                          0: IDENT@1213..1215 "px" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1208..1215
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1208..1215
+                          0: CSS_NUMBER@1208..1209
+                            0: CSS_NUMBER_LITERAL@1208..1209 "1" [] []
+                          1: SCSS_INTERPOLATION@1209..1213
+                            0: HASH@1209..1210 "#" [] []
+                            1: L_CURLY@1210..1211 "{" [] []
+                            2: SCSS_EXPRESSION@1211..1212
+                              0: SCSS_EXPRESSION_ITEM_LIST@1211..1212
+                                0: CSS_NUMBER@1211..1212
+                                  0: CSS_NUMBER_LITERAL@1211..1212 "0" [] []
+                            3: R_CURLY@1212..1213 "}" [] []
+                          2: CSS_IDENTIFIER@1213..1215
+                            0: IDENT@1213..1215 "px" [] []
               1: (empty)
             1: SEMICOLON@1215..1216 ";" [] []
           12: CSS_DECLARATION_WITH_SEMICOLON@1216..1239
@@ -11266,20 +11305,22 @@ CssRoot {
                 1: COLON@1226..1228 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1228..1238
                   0: SCSS_EXPRESSION_ITEM_LIST@1228..1238
-                    0: CSS_RATIO@1228..1233
+                    0: SCSS_BINARY_EXPRESSION@1228..1238
                       0: CSS_NUMBER@1228..1230
                         0: CSS_NUMBER_LITERAL@1228..1230 "10" [] []
                       1: SLASH@1230..1231 "/" [] []
-                      2: CSS_NUMBER@1231..1233
-                        0: CSS_NUMBER_LITERAL@1231..1233 "10" [] []
-                    1: SCSS_INTERPOLATION@1233..1238
-                      0: HASH@1233..1234 "#" [] []
-                      1: L_CURLY@1234..1235 "{" [] []
-                      2: SCSS_EXPRESSION@1235..1237
-                        0: SCSS_EXPRESSION_ITEM_LIST@1235..1237
-                          0: CSS_IDENTIFIER@1235..1237
-                            0: IDENT@1235..1237 "px" [] []
-                      3: R_CURLY@1237..1238 "}" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1231..1238
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1231..1238
+                          0: CSS_NUMBER@1231..1233
+                            0: CSS_NUMBER_LITERAL@1231..1233 "10" [] []
+                          1: SCSS_INTERPOLATION@1233..1238
+                            0: HASH@1233..1234 "#" [] []
+                            1: L_CURLY@1234..1235 "{" [] []
+                            2: SCSS_EXPRESSION@1235..1237
+                              0: SCSS_EXPRESSION_ITEM_LIST@1235..1237
+                                0: CSS_IDENTIFIER@1235..1237
+                                  0: IDENT@1235..1237 "px" [] []
+                            3: R_CURLY@1237..1238 "}" [] []
               1: (empty)
             1: SEMICOLON@1238..1239 ";" [] []
           13: CSS_DECLARATION_WITH_SEMICOLON@1239..1263
@@ -11290,20 +11331,22 @@ CssRoot {
                 1: COLON@1249..1251 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1251..1262
                   0: SCSS_EXPRESSION_ITEM_LIST@1251..1262
-                    0: CSS_RATIO@1251..1257
+                    0: SCSS_BINARY_EXPRESSION@1251..1262
                       0: CSS_NUMBER@1251..1254
                         0: CSS_NUMBER_LITERAL@1251..1254 "10" [] [Whitespace(" ")]
                       1: SLASH@1254..1255 "/" [] []
-                      2: CSS_NUMBER@1255..1257
-                        0: CSS_NUMBER_LITERAL@1255..1257 "10" [] []
-                    1: SCSS_INTERPOLATION@1257..1262
-                      0: HASH@1257..1258 "#" [] []
-                      1: L_CURLY@1258..1259 "{" [] []
-                      2: SCSS_EXPRESSION@1259..1261
-                        0: SCSS_EXPRESSION_ITEM_LIST@1259..1261
-                          0: CSS_IDENTIFIER@1259..1261
-                            0: IDENT@1259..1261 "px" [] []
-                      3: R_CURLY@1261..1262 "}" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1255..1262
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1255..1262
+                          0: CSS_NUMBER@1255..1257
+                            0: CSS_NUMBER_LITERAL@1255..1257 "10" [] []
+                          1: SCSS_INTERPOLATION@1257..1262
+                            0: HASH@1257..1258 "#" [] []
+                            1: L_CURLY@1258..1259 "{" [] []
+                            2: SCSS_EXPRESSION@1259..1261
+                              0: SCSS_EXPRESSION_ITEM_LIST@1259..1261
+                                0: CSS_IDENTIFIER@1259..1261
+                                  0: IDENT@1259..1261 "px" [] []
+                            3: R_CURLY@1261..1262 "}" [] []
               1: (empty)
             1: SEMICOLON@1262..1263 ";" [] []
           14: CSS_DECLARATION_WITH_SEMICOLON@1263..1287
@@ -11314,20 +11357,22 @@ CssRoot {
                 1: COLON@1273..1275 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1275..1286
                   0: SCSS_EXPRESSION_ITEM_LIST@1275..1286
-                    0: CSS_RATIO@1275..1281
+                    0: SCSS_BINARY_EXPRESSION@1275..1286
                       0: CSS_NUMBER@1275..1277
                         0: CSS_NUMBER_LITERAL@1275..1277 "10" [] []
                       1: SLASH@1277..1279 "/" [] [Whitespace(" ")]
-                      2: CSS_NUMBER@1279..1281
-                        0: CSS_NUMBER_LITERAL@1279..1281 "10" [] []
-                    1: SCSS_INTERPOLATION@1281..1286
-                      0: HASH@1281..1282 "#" [] []
-                      1: L_CURLY@1282..1283 "{" [] []
-                      2: SCSS_EXPRESSION@1283..1285
-                        0: SCSS_EXPRESSION_ITEM_LIST@1283..1285
-                          0: CSS_IDENTIFIER@1283..1285
-                            0: IDENT@1283..1285 "px" [] []
-                      3: R_CURLY@1285..1286 "}" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1279..1286
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1279..1286
+                          0: CSS_NUMBER@1279..1281
+                            0: CSS_NUMBER_LITERAL@1279..1281 "10" [] []
+                          1: SCSS_INTERPOLATION@1281..1286
+                            0: HASH@1281..1282 "#" [] []
+                            1: L_CURLY@1282..1283 "{" [] []
+                            2: SCSS_EXPRESSION@1283..1285
+                              0: SCSS_EXPRESSION_ITEM_LIST@1283..1285
+                                0: CSS_IDENTIFIER@1283..1285
+                                  0: IDENT@1283..1285 "px" [] []
+                            3: R_CURLY@1285..1286 "}" [] []
               1: (empty)
             1: SEMICOLON@1286..1287 ";" [] []
           15: CSS_DECLARATION_WITH_SEMICOLON@1287..1312
@@ -11338,20 +11383,22 @@ CssRoot {
                 1: COLON@1297..1299 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1299..1311
                   0: SCSS_EXPRESSION_ITEM_LIST@1299..1311
-                    0: CSS_RATIO@1299..1306
+                    0: SCSS_BINARY_EXPRESSION@1299..1311
                       0: CSS_NUMBER@1299..1302
                         0: CSS_NUMBER_LITERAL@1299..1302 "10" [] [Whitespace(" ")]
                       1: SLASH@1302..1304 "/" [] [Whitespace(" ")]
-                      2: CSS_NUMBER@1304..1306
-                        0: CSS_NUMBER_LITERAL@1304..1306 "10" [] []
-                    1: SCSS_INTERPOLATION@1306..1311
-                      0: HASH@1306..1307 "#" [] []
-                      1: L_CURLY@1307..1308 "{" [] []
-                      2: SCSS_EXPRESSION@1308..1310
-                        0: SCSS_EXPRESSION_ITEM_LIST@1308..1310
-                          0: CSS_IDENTIFIER@1308..1310
-                            0: IDENT@1308..1310 "px" [] []
-                      3: R_CURLY@1310..1311 "}" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1304..1311
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1304..1311
+                          0: CSS_NUMBER@1304..1306
+                            0: CSS_NUMBER_LITERAL@1304..1306 "10" [] []
+                          1: SCSS_INTERPOLATION@1306..1311
+                            0: HASH@1306..1307 "#" [] []
+                            1: L_CURLY@1307..1308 "{" [] []
+                            2: SCSS_EXPRESSION@1308..1310
+                              0: SCSS_EXPRESSION_ITEM_LIST@1308..1310
+                                0: CSS_IDENTIFIER@1308..1310
+                                  0: IDENT@1308..1310 "px" [] []
+                            3: R_CURLY@1310..1311 "}" [] []
               1: (empty)
             1: SEMICOLON@1311..1312 ";" [] []
           16: CSS_DECLARATION_WITH_SEMICOLON@1312..1335
@@ -11362,24 +11409,24 @@ CssRoot {
                 1: COLON@1322..1324 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1324..1334
                   0: SCSS_EXPRESSION_ITEM_LIST@1324..1334
-                    0: CSS_RATIO@1324..1329
+                    0: SCSS_BINARY_EXPRESSION@1324..1334
                       0: CSS_NUMBER@1324..1326
                         0: CSS_NUMBER_LITERAL@1324..1326 "10" [] []
                       1: SLASH@1326..1327 "/" [] []
-                      2: CSS_NUMBER@1327..1329
-                        0: CSS_NUMBER_LITERAL@1327..1329 "10" [] []
-                    1: SCSS_INTERPOLATED_IDENTIFIER@1329..1334
-                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1329..1334
-                        0: SCSS_INTERPOLATION@1329..1333
-                          0: HASH@1329..1330 "#" [] []
-                          1: L_CURLY@1330..1331 "{" [] []
-                          2: SCSS_EXPRESSION@1331..1332
-                            0: SCSS_EXPRESSION_ITEM_LIST@1331..1332
-                              0: CSS_IDENTIFIER@1331..1332
-                                0: IDENT@1331..1332 "p" [] []
-                          3: R_CURLY@1332..1333 "}" [] []
-                        1: CSS_IDENTIFIER@1333..1334
-                          0: IDENT@1333..1334 "x" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1327..1334
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1327..1334
+                          0: CSS_NUMBER@1327..1329
+                            0: CSS_NUMBER_LITERAL@1327..1329 "10" [] []
+                          1: SCSS_INTERPOLATION@1329..1333
+                            0: HASH@1329..1330 "#" [] []
+                            1: L_CURLY@1330..1331 "{" [] []
+                            2: SCSS_EXPRESSION@1331..1332
+                              0: SCSS_EXPRESSION_ITEM_LIST@1331..1332
+                                0: CSS_IDENTIFIER@1331..1332
+                                  0: IDENT@1331..1332 "p" [] []
+                            3: R_CURLY@1332..1333 "}" [] []
+                          2: CSS_IDENTIFIER@1333..1334
+                            0: IDENT@1333..1334 "x" [] []
               1: (empty)
             1: SEMICOLON@1334..1335 ";" [] []
           17: CSS_DECLARATION_WITH_SEMICOLON@1335..1359
@@ -11390,24 +11437,24 @@ CssRoot {
                 1: COLON@1345..1347 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1347..1358
                   0: SCSS_EXPRESSION_ITEM_LIST@1347..1358
-                    0: CSS_RATIO@1347..1353
+                    0: SCSS_BINARY_EXPRESSION@1347..1358
                       0: CSS_NUMBER@1347..1350
                         0: CSS_NUMBER_LITERAL@1347..1350 "10" [] [Whitespace(" ")]
                       1: SLASH@1350..1351 "/" [] []
-                      2: CSS_NUMBER@1351..1353
-                        0: CSS_NUMBER_LITERAL@1351..1353 "10" [] []
-                    1: SCSS_INTERPOLATED_IDENTIFIER@1353..1358
-                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1353..1358
-                        0: SCSS_INTERPOLATION@1353..1357
-                          0: HASH@1353..1354 "#" [] []
-                          1: L_CURLY@1354..1355 "{" [] []
-                          2: SCSS_EXPRESSION@1355..1356
-                            0: SCSS_EXPRESSION_ITEM_LIST@1355..1356
-                              0: CSS_IDENTIFIER@1355..1356
-                                0: IDENT@1355..1356 "p" [] []
-                          3: R_CURLY@1356..1357 "}" [] []
-                        1: CSS_IDENTIFIER@1357..1358
-                          0: IDENT@1357..1358 "x" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1351..1358
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1351..1358
+                          0: CSS_NUMBER@1351..1353
+                            0: CSS_NUMBER_LITERAL@1351..1353 "10" [] []
+                          1: SCSS_INTERPOLATION@1353..1357
+                            0: HASH@1353..1354 "#" [] []
+                            1: L_CURLY@1354..1355 "{" [] []
+                            2: SCSS_EXPRESSION@1355..1356
+                              0: SCSS_EXPRESSION_ITEM_LIST@1355..1356
+                                0: CSS_IDENTIFIER@1355..1356
+                                  0: IDENT@1355..1356 "p" [] []
+                            3: R_CURLY@1356..1357 "}" [] []
+                          2: CSS_IDENTIFIER@1357..1358
+                            0: IDENT@1357..1358 "x" [] []
               1: (empty)
             1: SEMICOLON@1358..1359 ";" [] []
           18: CSS_DECLARATION_WITH_SEMICOLON@1359..1383
@@ -11418,24 +11465,24 @@ CssRoot {
                 1: COLON@1369..1371 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1371..1382
                   0: SCSS_EXPRESSION_ITEM_LIST@1371..1382
-                    0: CSS_RATIO@1371..1377
+                    0: SCSS_BINARY_EXPRESSION@1371..1382
                       0: CSS_NUMBER@1371..1373
                         0: CSS_NUMBER_LITERAL@1371..1373 "10" [] []
                       1: SLASH@1373..1375 "/" [] [Whitespace(" ")]
-                      2: CSS_NUMBER@1375..1377
-                        0: CSS_NUMBER_LITERAL@1375..1377 "10" [] []
-                    1: SCSS_INTERPOLATED_IDENTIFIER@1377..1382
-                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1377..1382
-                        0: SCSS_INTERPOLATION@1377..1381
-                          0: HASH@1377..1378 "#" [] []
-                          1: L_CURLY@1378..1379 "{" [] []
-                          2: SCSS_EXPRESSION@1379..1380
-                            0: SCSS_EXPRESSION_ITEM_LIST@1379..1380
-                              0: CSS_IDENTIFIER@1379..1380
-                                0: IDENT@1379..1380 "p" [] []
-                          3: R_CURLY@1380..1381 "}" [] []
-                        1: CSS_IDENTIFIER@1381..1382
-                          0: IDENT@1381..1382 "x" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1375..1382
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1375..1382
+                          0: CSS_NUMBER@1375..1377
+                            0: CSS_NUMBER_LITERAL@1375..1377 "10" [] []
+                          1: SCSS_INTERPOLATION@1377..1381
+                            0: HASH@1377..1378 "#" [] []
+                            1: L_CURLY@1378..1379 "{" [] []
+                            2: SCSS_EXPRESSION@1379..1380
+                              0: SCSS_EXPRESSION_ITEM_LIST@1379..1380
+                                0: CSS_IDENTIFIER@1379..1380
+                                  0: IDENT@1379..1380 "p" [] []
+                            3: R_CURLY@1380..1381 "}" [] []
+                          2: CSS_IDENTIFIER@1381..1382
+                            0: IDENT@1381..1382 "x" [] []
               1: (empty)
             1: SEMICOLON@1382..1383 ";" [] []
           19: CSS_DECLARATION_WITH_SEMICOLON@1383..1408
@@ -11446,24 +11493,24 @@ CssRoot {
                 1: COLON@1393..1395 ":" [] [Whitespace(" ")]
                 2: SCSS_EXPRESSION@1395..1407
                   0: SCSS_EXPRESSION_ITEM_LIST@1395..1407
-                    0: CSS_RATIO@1395..1402
+                    0: SCSS_BINARY_EXPRESSION@1395..1407
                       0: CSS_NUMBER@1395..1398
                         0: CSS_NUMBER_LITERAL@1395..1398 "10" [] [Whitespace(" ")]
                       1: SLASH@1398..1400 "/" [] [Whitespace(" ")]
-                      2: CSS_NUMBER@1400..1402
-                        0: CSS_NUMBER_LITERAL@1400..1402 "10" [] []
-                    1: SCSS_INTERPOLATED_IDENTIFIER@1402..1407
-                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1402..1407
-                        0: SCSS_INTERPOLATION@1402..1406
-                          0: HASH@1402..1403 "#" [] []
-                          1: L_CURLY@1403..1404 "{" [] []
-                          2: SCSS_EXPRESSION@1404..1405
-                            0: SCSS_EXPRESSION_ITEM_LIST@1404..1405
-                              0: CSS_IDENTIFIER@1404..1405
-                                0: IDENT@1404..1405 "p" [] []
-                          3: R_CURLY@1405..1406 "}" [] []
-                        1: CSS_IDENTIFIER@1406..1407
-                          0: IDENT@1406..1407 "x" [] []
+                      2: SCSS_INTERPOLATED_VALUE@1400..1407
+                        0: SCSS_INTERPOLATED_VALUE_PART_LIST@1400..1407
+                          0: CSS_NUMBER@1400..1402
+                            0: CSS_NUMBER_LITERAL@1400..1402 "10" [] []
+                          1: SCSS_INTERPOLATION@1402..1406
+                            0: HASH@1402..1403 "#" [] []
+                            1: L_CURLY@1403..1404 "{" [] []
+                            2: SCSS_EXPRESSION@1404..1405
+                              0: SCSS_EXPRESSION_ITEM_LIST@1404..1405
+                                0: CSS_IDENTIFIER@1404..1405
+                                  0: IDENT@1404..1405 "p" [] []
+                            3: R_CURLY@1405..1406 "}" [] []
+                          2: CSS_IDENTIFIER@1406..1407
+                            0: IDENT@1406..1407 "x" [] []
               1: (empty)
             1: SEMICOLON@1407..1408 ";" [] []
           20: CSS_DECLARATION_WITH_SEMICOLON@1408..1430


### PR DESCRIPTION
  > This PR was implemented with assistance from OpenAI Codex.

 ## Summary

  Updates SCSS expression parsing so / is always parsed as a binary operator instead of being completed as a CSS ratio inside SCSS expressions.

```scss
  $value: 10 / 2;
  @debug 10/2;
  @debug (10 / 2);
  @debug (a: b, c: 10 / 2);
```


  ## Test Plan

  - cargo test -p biome_css_parser
