### PR TITLE
fix: trim astro frontmatter content before processing it

### DIFF
--- a/.changeset/tricky-news-peel.md
+++ b/.changeset/tricky-news-peel.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10309](https://github.com/biomejs/biome/issues/10309): Biome no longer adds newlines to Astro frontmatter when linter or assist `--write` mode is enabled.

--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -1,5 +1,7 @@
 use crate::run_cli;
-use crate::snap_test::{SnapshotPayload, assert_cli_snapshot, markup_to_string};
+use crate::snap_test::{
+    SnapshotPayload, assert_cli_snapshot, assert_file_contents, markup_to_string,
+};
 use biome_console::{BufferConsole, markup};
 use biome_fs::MemoryFileSystem;
 use bpaf::Args;
@@ -839,6 +841,114 @@ fn issue_7912() {
         console,
         result,
     ));
+}
+
+#[test]
+fn issue_10309_noop_lint_write_preserves_astro_frontmatter() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{ "html": { "experimentalFullSupportEnabled": true, "formatter": { "enabled": true } } }"#.as_bytes(),
+    );
+
+    // this test asserts that newlines don't get inserted in the beginning frontmatter erroneously.
+    let astro_file_path = Utf8Path::new("file.astro");
+    let source = r#"---
+            const title = "Hello World";
+---
+
+<html>
+  <head>
+            <title>{title}</title>
+  </head>
+  <body>
+            <h1>{title}</h1>
+  </body>
+</html>"#;
+    fs.insert(astro_file_path.into(), source.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "lint",
+                "--write",
+                "--only=suspicious/noDebugger",
+                astro_file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+    assert_file_contents(&fs, astro_file_path, source);
+}
+
+#[test]
+fn issue_10309_lint_write_fix_preserves_astro_frontmatter_trivia() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{ "html": { "experimentalFullSupportEnabled": true, "formatter": { "enabled": true } } }"#.as_bytes(),
+    );
+
+    let astro_file_path = Utf8Path::new("file.astro");
+    fs.insert(
+        astro_file_path.into(),
+        r#"---
+            const title = "Hello World";
+            debugger;
+---
+
+<html>
+  <head>
+            <title>{title}</title>
+  </head>
+  <body>
+            <h1>{title}</h1>
+  </body>
+</html>"#
+            .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "lint",
+                "--write",
+                "--unsafe",
+                "--only=noDebugger",
+                astro_file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    // no newlines should be inserted at the start of the frontmatter.
+    assert_file_contents(
+        &fs,
+        astro_file_path,
+        r#"---
+            const title = "Hello World";
+---
+
+<html>
+  <head>
+            <title>{title}</title>
+  </head>
+  <body>
+            <h1>{title}</h1>
+  </body>
+</html>"#,
+    );
+    assert!(result.is_ok(), "run_cli returned {result:?}");
 }
 
 #[test]

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/issue_7912.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/issue_7912.snap
@@ -17,7 +17,6 @@ expression: redactor(content)
 
 ```astro
 ---
-            
             const title = "Hello World";
 ---
 
@@ -34,5 +33,5 @@ expression: redactor(content)
 # Emitted Messages
 
 ```block
-Checked 1 file in <TIME>. Fixed 1 file.
+Checked 1 file in <TIME>. No fixes applied.
 ```

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
@@ -568,15 +568,14 @@ fn build_attribute_expression_candidate(
 /// Build an `EmbedCandidate::Frontmatter` from Astro's `---` block.
 fn build_astro_frontmatter_candidate(element: &AstroEmbeddedContent) -> Option<EmbedCandidate> {
     let content_token = element.content_token()?;
+    let content_range = content_token.text_trimmed_range();
 
     Some(EmbedCandidate::Frontmatter {
         content: EmbedContent {
             element_range: element.range(),
-            content_range: content_token.text_trimmed_range(),
-            content_offset: content_token.text_range().start(),
-            // Use full token text (including trivia) to match the untrimmed content_offset.
-            // The parser needs text and offset to be consistent.
-            text: content_token.token_text(),
+            content_range,
+            content_offset: content_range.start(),
+            text: content_token.token_text_trimmed(),
         },
     })
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
GPT 5.5 implemented the fix after heavy steering. I'm not entirely sure if this is the right fix, but the tests pass and there's no regressions.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #10309

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots, new tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
