### PR TITLE
fix(astro): display diagnostic advices with the correct location

### DIFF
--- a/.changeset/bright-dragons-clean.md
+++ b/.changeset/bright-dragons-clean.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed diagnostics' advices in Astro files that displayed wrong locations.
+Fixed an issue where diagnostics showed an incorrect location in Astro files. 

--- a/.changeset/bright-dragons-clean.md
+++ b/.changeset/bright-dragons-clean.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed diagnostics' advices in Astro files that displayed wrong locations.

--- a/crates/biome_cli/src/runner/impls/process_file/lint_and_assist.rs
+++ b/crates/biome_cli/src/runner/impls/process_file/lint_and_assist.rs
@@ -143,12 +143,11 @@ impl ProcessFile for LintAssistProcessFile {
             let diagnostics: Vec<Error> = pull_diagnostics_result
                 .diagnostics
                 .into_iter()
-                .map(|d| {
+                .map(|mut d| {
                     if let Some(offset) = offset {
-                        d.with_offset(TextSize::from(offset))
-                    } else {
-                        d
+                        d.offset_by(TextSize::from(offset));
                     }
+                    d
                 })
                 .map(Error::from)
                 .collect();

--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -27,6 +27,8 @@ export { a };
 const ASTRO_FILE_IMPORTS_BEFORE: &str = r#"---
 import { getLocale } from "astro:i18n";
 import { Code } from "astro:components";
+import "style.css";
+import { B, A } from "./util.js";
 ---
 <div></div>"#;
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -8,6 +8,8 @@ expression: redactor(content)
 ---
 import { getLocale } from "astro:i18n";
 import { Code } from "astro:components";
+import "style.css";
+import { B, A } from "./util.js";
 ---
 <div></div>
 ```
@@ -28,15 +30,36 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 file.astro:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Sort these imports.
+  × Some imports or exports are not organized.
+  
+    1 │ ---
+  > 2 │ import { getLocale } from "astro:i18n";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ import { Code } from "astro:components";
+  > 4 │ import "style.css";
+  > 5 │ import { B, A } from "./util.js";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ ---
+    7 │ <div></div>
+  
+  i Sort these imports.
   
     1 │ ---
   > 2 │ import { getLocale } from "astro:i18n";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   > 3 │ import { Code } from "astro:components";
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ ---
-    5 │ <div></div>
+    4 │ import "style.css";
+    5 │ import { B, A } from "./util.js";
+  
+  i Sort the imported names.
+  
+    3 │ import { Code } from "astro:components";
+    4 │ import "style.css";
+  > 5 │ import { B, A } from "./util.js";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ ---
+    7 │ <div></div>
   
   i Safe fix: Organize imports and exports (Biome)
   
@@ -45,7 +68,10 @@ file.astro:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━�
     3   │ - import·{·Code·}·from·"astro:components";
       2 │ + import·{·Code·}·from·"astro:components";
       3 │ + import·{·getLocale·}·from·"astro:i18n";
-    4 4 │   
+    4 4 │   import "style.css";
+    5   │ - import·{·B,·A·}·from·"./util.js";
+      5 │ + import·{·A,·B·}·from·"./util.js";
+    6 6 │   
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_write.snap
@@ -8,6 +8,8 @@ expression: redactor(content)
 ---
 import { Code } from "astro:components";
 import { getLocale } from "astro:i18n";
+import "style.css";
+import { A, B } from "./util.js";
 ---
 <div></div>
 ```

--- a/crates/biome_diagnostics/src/serde.rs
+++ b/crates/biome_diagnostics/src/serde.rs
@@ -75,12 +75,10 @@ impl Diagnostic {
         }
     }
 
-    pub fn with_offset(mut self, offset: TextSize) -> Self {
-        self.location.span = self
-            .location
-            .span
-            .map(|span| TextRange::new(span.start() + offset, span.end() + offset));
-        self
+    pub fn offset_by(&mut self, offset: TextSize) {
+        self.location.offset_by(offset);
+        self.advices.offset_by(offset);
+        self.verbose_advices.offset_by(offset);
     }
 }
 
@@ -148,6 +146,15 @@ struct Location {
     source_code: Option<String>,
 }
 
+impl Location {
+    /// Offset the location span by `offset`.
+    fn offset_by(&mut self, offset: TextSize) {
+        if let Some(span) = &mut self.span {
+            self.span = Some(TextRange::new(span.start() + offset, span.end() + offset));
+        }
+    }
+}
+
 impl From<super::Location<'_>> for Location {
     fn from(loc: super::Location<'_>) -> Self {
         Self {
@@ -173,6 +180,12 @@ impl Advices {
     fn new() -> Self {
         Self {
             advices: Vec::new(),
+        }
+    }
+
+    fn offset_by(&mut self, offset: TextSize) {
+        for advicde in &mut self.advices {
+            advicde.offset_by(offset);
         }
     }
 }
@@ -260,6 +273,24 @@ enum Advice {
     Backtrace(MarkupBuf, Backtrace),
     Command(String),
     Group(MarkupBuf, Advices),
+}
+
+impl Advice {
+    fn offset_by(&mut self, offset: TextSize) {
+        match self {
+            Self::Log(_, _)
+            | Self::List(_)
+            | Self::Backtrace(_, _)
+            | Self::Command(_)
+            | Self::Diff(_) => {}
+            Self::Frame(location) => {
+                location.offset_by(offset);
+            }
+            Self::Group(_, advices) => {
+                advices.offset_by(offset);
+            }
+        }
+    }
 }
 
 impl super::Advices for Advice {

--- a/crates/biome_diagnostics/src/serde.rs
+++ b/crates/biome_diagnostics/src/serde.rs
@@ -79,6 +79,9 @@ impl Diagnostic {
         self.location.offset_by(offset);
         self.advices.offset_by(offset);
         self.verbose_advices.offset_by(offset);
+        if let Some(source) = &mut self.source {
+            source.offset_by(offset);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This fixes diagnostics' advices in Astro files that was displaying wrong locations.
The main diagnostic location was offseted, while the advcies were not.

## Test Plan

I changed a test to display an advice.

## Docs

I added a changeset.
