### PR TITLE
fix(astro): include newline in the astro fence

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_and_fix_astro_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_and_fix_astro_files.snap
@@ -6,6 +6,7 @@ expression: redactor(content)
 
 ```astro
 ---
+
 ---
 <div></div>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_astro_files.snap
@@ -37,11 +37,8 @@ file.astro:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━�
   
   i Unsafe fix: Remove debugger statement
   
-    1   │ - 
-    2   │ - debugger;
-      1 │ + 
-    3 2 │   
-  
+    1 │ debugger;
+      │ ---------
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_stdin_write_unsafe_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/lint_stdin_write_unsafe_successfully.snap
@@ -15,6 +15,7 @@ debugger;
 
 ```block
 ---
+
 ---
 <div></div>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -63,15 +63,14 @@ file.astro:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━�
   
   i Safe fix: Organize imports and exports (Biome)
   
-    1 1 │   
-    2   │ - import·{·getLocale·}·from·"astro:i18n";
-    3   │ - import·{·Code·}·from·"astro:components";
-      2 │ + import·{·Code·}·from·"astro:components";
-      3 │ + import·{·getLocale·}·from·"astro:i18n";
-    4 4 │   import "style.css";
-    5   │ - import·{·B,·A·}·from·"./util.js";
-      5 │ + import·{·A,·B·}·from·"./util.js";
-    6 6 │   
+    1   │ - import·{·getLocale·}·from·"astro:i18n";
+    2   │ - import·{·Code·}·from·"astro:components";
+      1 │ + import·{·Code·}·from·"astro:components";
+      2 │ + import·{·getLocale·}·from·"astro:i18n";
+    3 3 │   import "style.css";
+    4   │ - import·{·B,·A·}·from·"./util.js";
+      4 │ + import·{·A,·B·}·from·"./util.js";
+    5 5 │   
   
 
 ```

--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -12,7 +12,8 @@ use biome_js_parser::{JsParserOptions, parse_js_with_cache};
 use biome_js_syntax::{JsFileSource, TextRange, TextSize};
 use biome_parser::AnyParse;
 use biome_rowan::NodeCache;
-use regex::{Matches, Regex, RegexBuilder};
+use core::ops::Range;
+use regex::{Regex, RegexBuilder};
 use std::sync::LazyLock;
 
 use super::SearchCapabilities;
@@ -20,7 +21,7 @@ use super::SearchCapabilities;
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct AstroFileHandler;
 
-pub static ASTRO_FENCE: LazyLock<Regex> = LazyLock::new(|| {
+static ASTRO_FENCE: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new(r#"^---\s*$"#)
         .multi_line(true)
         .build()
@@ -34,30 +35,36 @@ impl AstroFileHandler {
     pub fn input(text: &str) -> &str {
         let mut matches = Self::matches(text);
         match (matches.next(), matches.next()) {
-            (Some(start), Some(end)) => &text[start.end()..end.start()],
+            (Some(start), Some(end)) => &text[start.end..end.start],
             _ => "",
         }
     }
 
-    /// Returns the start byte offset of the Astro fence
+    /// Returns the start byte offset after the Astro fence
     pub fn start(input: &str) -> Option<u32> {
-        ASTRO_FENCE.find_iter(input).next().map(|m| m.end() as u32)
+        Self::matches(input).next().map(|m| m.end as u32)
     }
 
-    fn matches(input: &str) -> Matches<'_, '_> {
-        ASTRO_FENCE.find_iter(input)
+    fn matches(input: &str) -> impl Iterator<Item = Range<usize>> {
+        ASTRO_FENCE.find_iter(input).map(|m| {
+            if input[m.end()..].starts_with('\n') {
+                m.start()..(m.end() + 1)
+            } else {
+                m.start()..m.end()
+            }
+        })
     }
 
     /// It takes the original content of an Astro file, and new output of an Astro file. The output is only the content contained inside the
     /// Astro fences. The function replaces `output` inside those fences.
     pub fn output(input: &str, output: &str) -> String {
         let mut matches = Self::matches(input);
-        if let (Some(start), Some(end)) = (matches.next(), matches.next()) {
+        if let (Some(prefix), Some(suffix)) = (matches.next(), matches.next()) {
             format!(
                 "{}{}{}",
-                &input[..start.end() + 1],
-                output.trim_start(),
-                &input[end.start()..]
+                &input[..prefix.end],
+                output,
+                &input[suffix.start..],
             )
         } else {
             input.to_string()


### PR DESCRIPTION
## Summary

This improves over https://github.com/biomejs/biome/pull/9592

This PR makes sure that the newline (if any) is part of the Astro fence.
Also, this fixes a bug where too many spaces can be trimmed by a `trim_start()`. 

I also discovered a bug related to code fixes: The reported lines of code fixes are relative to the extracted JavaScript, instead of the entire file.
Until now this was not noticed because our tests put the Astro fence on the first line and as the newline wasn't part of the fence, this conveniently matched the correct line number.
By including the newline with the fence, the bug is visible.
I didn't find the place where to adjust the code fix ranges yet.
I am afraid it is not so easy, because code fixes are applied on the extracted JavaScript, not the entire file.

## Test Plan

TBD

## Docs

- [ ] Changeset
