### PR TITLE
fix(markdown_parser): parse tab-indented siblings

### DIFF
--- a/.changeset/bright-dragons-clean.md
+++ b/.changeset/bright-dragons-clean.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed an issue where diagnostics showed an incorrect location in Astro files. 
+Fixed an issue where diagnostics showed an incorrect location in Astro files.

--- a/crates/biome_markdown_formatter/tests/specs/prettier/markdown/list/nested-tab.md.snap
+++ b/crates/biome_markdown_formatter/tests/specs/prettier/markdown/list/nested-tab.md.snap
@@ -52,7 +52,7 @@ info: markdown/list/nested-tab.md
 -    _ Sub-Nested List item 1
 -    _ Sub-Nested List item 2
 +	- Nested List item 1
-+	* Nested List item 2
++	- Nested List item 2
 +    	- Sub-Nested List item 1
 +    	* Sub-Nested List item 2
 ```
@@ -74,7 +74,7 @@ info: markdown/list/nested-tab.md
 - Top level list item 1
 - Top level list item 2
 	- Nested List item 1
-	* Nested List item 2
+	- Nested List item 2
     	- Sub-Nested List item 1
     	* Sub-Nested List item 2
 ```

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -1058,9 +1058,9 @@ fn break_for_setext_after_inline_newline(
     false
 }
 
-/// Break the paragraph when the next line is a block interrupt at
-/// `required_indent`, or when a nested item's continuation drops to
-/// the parent's indent level (§5.2 ownership, depth >= 2).
+/// Break the paragraph when the next line starts a list-interrupting
+/// block, including sibling/parent list markers whose indent is below
+/// the current item's `required_indent` (CommonMark §5.2).
 fn break_for_list_interrupt_after_inline_newline(
     p: &mut MarkdownParser,
     required_indent: usize,
@@ -1070,12 +1070,20 @@ fn break_for_list_interrupt_after_inline_newline(
     }
 
     let indent = p.line_start_leading_indent();
-    if indent < required_indent {
+    if indent < required_indent && indent > p.state().list_item_marker_indent {
         return false;
     }
 
+    if indent < required_indent {
+        if !line_start_indent_contains_tab(p) {
+            return false;
+        }
+        return line_starts_with_list_marker_after_indent(p, indent);
+    }
+
+    let skip = indent.min(required_indent);
     p.lookahead(|p| {
-        p.skip_line_indent(required_indent);
+        p.skip_line_indent(skip);
         let prev_required = p.state().list_item_required_indent;
         with_virtual_line_start(p, p.cur_range().start(), |p| {
             p.state_mut().list_item_required_indent = 0;
@@ -1083,6 +1091,59 @@ fn break_for_list_interrupt_after_inline_newline(
             p.state_mut().list_item_required_indent = prev_required;
             breaks
         })
+    })
+}
+
+/// True if current `MD_TEXTUAL_LITERAL`'s leading space/tab run contains a tab.
+/// Gates tab-only dedent recovery in [`break_for_list_interrupt_after_inline_newline`].
+fn line_start_indent_contains_tab(p: &MarkdownParser) -> bool {
+    p.at(MD_TEXTUAL_LITERAL)
+        && p.cur_text()
+            .chars()
+            .take_while(|c| *c == ' ' || *c == '\t')
+            .any(|c| c == '\t')
+}
+
+/// Lookahead: after skipping `indent` columns of leading whitespace, is the next
+/// token a list marker (`-`, `*`, `+`, ordered) followed by whitespace or EOL?
+/// Handles raw marker tokens and markers still folded into `MD_TEXTUAL_LITERAL`
+/// / `MD_SETEXT_UNDERLINE_LITERAL`.
+fn line_starts_with_list_marker_after_indent(p: &mut MarkdownParser, indent: usize) -> bool {
+    p.lookahead(|p| {
+        p.skip_line_indent(indent);
+
+        if p.at(T![-]) || p.at(T![*]) || p.at(T![+]) {
+            p.bump(p.cur());
+            return marker_followed_by_whitespace_or_eol(p);
+        }
+
+        if p.at(MD_SETEXT_UNDERLINE_LITERAL) {
+            let trimmed = p.cur_text().trim_matches(|c| c == ' ' || c == '\t');
+            if trimmed != "-" {
+                return false;
+            }
+            p.bump_remap(T![-]);
+            return marker_followed_by_whitespace_or_eol(p);
+        }
+
+        if p.at(MD_ORDERED_LIST_MARKER) {
+            p.bump(MD_ORDERED_LIST_MARKER);
+            return marker_followed_by_whitespace_or_eol(p);
+        }
+
+        if !p.at(MD_TEXTUAL_LITERAL) {
+            return false;
+        }
+
+        let text = p.cur_text();
+        let marker_kind = match text {
+            "-" => T![-],
+            "*" => T![*],
+            "+" => T![+],
+            _ => return textual_starts_with_ordered_marker(text),
+        };
+        p.bump_remap(marker_kind);
+        marker_followed_by_whitespace_or_eol(p)
     })
 }
 

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_tab_indented_siblings.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_tab_indented_siblings.md
@@ -1,0 +1,4 @@
+- Top
+	- Nested 1
+	- Nested 2
+		- Sub-Nested

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_tab_indented_siblings.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_tab_indented_siblings.md.snap
@@ -1,0 +1,237 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```
+- Top
+	- Nested 1
+	- Nested 2
+		- Sub-Nested
+
+```
+
+
+## AST
+
+```
+MdDocument {
+    bom_token: missing (optional),
+    value: MdBlockList [
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@0..1 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@1..2 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@2..5 "Top" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
+                                },
+                            ],
+                            hard_line: missing (optional),
+                        },
+                        MdContinuationIndent {
+                            indent: MdIndentTokenList [
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@6..7 "\t" [] [],
+                                },
+                            ],
+                        },
+                        MdBulletListItem {
+                            md_bullet_list: MdBulletList [
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [],
+                                        marker: MINUS@7..8 "-" [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@8..9 " " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@9..17 "Nested 1" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@17..18 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                    ],
+                                },
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@18..19 "\t" [] [],
+                                            },
+                                        ],
+                                        marker: MINUS@19..20 "-" [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@20..21 " " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@21..29 "Nested 2" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@29..30 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                        MdContinuationIndent {
+                                            indent: MdIndentTokenList [
+                                                MdIndentToken {
+                                                    md_indent_char_token: MD_INDENT_CHAR@30..31 "\t" [] [],
+                                                },
+                                                MdIndentToken {
+                                                    md_indent_char_token: MD_INDENT_CHAR@31..32 "\t" [] [],
+                                                },
+                                            ],
+                                        },
+                                        MdBulletListItem {
+                                            md_bullet_list: MdBulletList [
+                                                MdBullet {
+                                                    prefix: MdListMarkerPrefix {
+                                                        pre_marker_indent: MdIndentTokenList [],
+                                                        marker: MINUS@32..33 "-" [] [],
+                                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@33..34 " " [] [],
+                                                        content_indent: MdIndentTokenList [],
+                                                    },
+                                                    content: MdBlockList [
+                                                        MdParagraph {
+                                                            list: MdInlineItemList [
+                                                                MdTextual {
+                                                                    value_token: MD_TEXTUAL_LITERAL@34..37 "Sub" [] [],
+                                                                },
+                                                                MdTextual {
+                                                                    value_token: MD_TEXTUAL_LITERAL@37..38 "-" [] [],
+                                                                },
+                                                                MdTextual {
+                                                                    value_token: MD_TEXTUAL_LITERAL@38..44 "Nested" [] [],
+                                                                },
+                                                                MdTextual {
+                                                                    value_token: MD_TEXTUAL_LITERAL@44..45 "\n" [] [],
+                                                                },
+                                                            ],
+                                                            hard_line: missing (optional),
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@45..45 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_DOCUMENT@0..45
+  0: (empty)
+  1: MD_BLOCK_LIST@0..45
+    0: MD_BULLET_LIST_ITEM@0..45
+      0: MD_BULLET_LIST@0..45
+        0: MD_BULLET@0..45
+          0: MD_LIST_MARKER_PREFIX@0..2
+            0: MD_INDENT_TOKEN_LIST@0..0
+            1: MINUS@0..1 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@1..2 " " [] []
+            3: MD_INDENT_TOKEN_LIST@2..2
+          1: MD_BLOCK_LIST@2..45
+            0: MD_PARAGRAPH@2..6
+              0: MD_INLINE_ITEM_LIST@2..6
+                0: MD_TEXTUAL@2..5
+                  0: MD_TEXTUAL_LITERAL@2..5 "Top" [] []
+                1: MD_TEXTUAL@5..6
+                  0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
+              1: (empty)
+            1: MD_CONTINUATION_INDENT@6..7
+              0: MD_INDENT_TOKEN_LIST@6..7
+                0: MD_INDENT_TOKEN@6..7
+                  0: MD_INDENT_CHAR@6..7 "\t" [] []
+            2: MD_BULLET_LIST_ITEM@7..45
+              0: MD_BULLET_LIST@7..45
+                0: MD_BULLET@7..18
+                  0: MD_LIST_MARKER_PREFIX@7..9
+                    0: MD_INDENT_TOKEN_LIST@7..7
+                    1: MINUS@7..8 "-" [] []
+                    2: MD_LIST_POST_MARKER_SPACE@8..9 " " [] []
+                    3: MD_INDENT_TOKEN_LIST@9..9
+                  1: MD_BLOCK_LIST@9..18
+                    0: MD_PARAGRAPH@9..18
+                      0: MD_INLINE_ITEM_LIST@9..18
+                        0: MD_TEXTUAL@9..17
+                          0: MD_TEXTUAL_LITERAL@9..17 "Nested 1" [] []
+                        1: MD_TEXTUAL@17..18
+                          0: MD_TEXTUAL_LITERAL@17..18 "\n" [] []
+                      1: (empty)
+                1: MD_BULLET@18..45
+                  0: MD_LIST_MARKER_PREFIX@18..21
+                    0: MD_INDENT_TOKEN_LIST@18..19
+                      0: MD_INDENT_TOKEN@18..19
+                        0: MD_INDENT_CHAR@18..19 "\t" [] []
+                    1: MINUS@19..20 "-" [] []
+                    2: MD_LIST_POST_MARKER_SPACE@20..21 " " [] []
+                    3: MD_INDENT_TOKEN_LIST@21..21
+                  1: MD_BLOCK_LIST@21..45
+                    0: MD_PARAGRAPH@21..30
+                      0: MD_INLINE_ITEM_LIST@21..30
+                        0: MD_TEXTUAL@21..29
+                          0: MD_TEXTUAL_LITERAL@21..29 "Nested 2" [] []
+                        1: MD_TEXTUAL@29..30
+                          0: MD_TEXTUAL_LITERAL@29..30 "\n" [] []
+                      1: (empty)
+                    1: MD_CONTINUATION_INDENT@30..32
+                      0: MD_INDENT_TOKEN_LIST@30..32
+                        0: MD_INDENT_TOKEN@30..31
+                          0: MD_INDENT_CHAR@30..31 "\t" [] []
+                        1: MD_INDENT_TOKEN@31..32
+                          0: MD_INDENT_CHAR@31..32 "\t" [] []
+                    2: MD_BULLET_LIST_ITEM@32..45
+                      0: MD_BULLET_LIST@32..45
+                        0: MD_BULLET@32..45
+                          0: MD_LIST_MARKER_PREFIX@32..34
+                            0: MD_INDENT_TOKEN_LIST@32..32
+                            1: MINUS@32..33 "-" [] []
+                            2: MD_LIST_POST_MARKER_SPACE@33..34 " " [] []
+                            3: MD_INDENT_TOKEN_LIST@34..34
+                          1: MD_BLOCK_LIST@34..45
+                            0: MD_PARAGRAPH@34..45
+                              0: MD_INLINE_ITEM_LIST@34..45
+                                0: MD_TEXTUAL@34..37
+                                  0: MD_TEXTUAL_LITERAL@34..37 "Sub" [] []
+                                1: MD_TEXTUAL@37..38
+                                  0: MD_TEXTUAL_LITERAL@37..38 "-" [] []
+                                2: MD_TEXTUAL@38..44
+                                  0: MD_TEXTUAL_LITERAL@38..44 "Nested" [] []
+                                3: MD_TEXTUAL@44..45
+                                  0: MD_TEXTUAL_LITERAL@44..45 "\n" [] []
+                              1: (empty)
+  2: EOF@45..45 "" [] []
+
+```


### PR DESCRIPTION
> [!NOTE]
> I used Claude Code to plan and implement this fix.

## Summary

Fixes #10295

The markdown parser now treats tab-indented sibling list markers below the current item continuation indent as list-interrupting blocks. This preserves the nested list CST shape expected by the formatter.

Fixes a whitespace issue in `.changeset/bright-dragons-clean.md` to make the CI happy.

No changeset: this is an internal markdown parser conformance fix.

## Test Plan

- Added parser snapshot coverage for the tab-indented sibling list case.
- Updated markdown formatter snapshots for affected tab list fixtures.
- `just test-crate biome_markdown_parser`
- `just test-crate biome_markdown_formatter`
- `just test-markdown-conformance`

## Docs

N/A