### PR TITLE
fix(lint/js): correct the rule source of `noReactNativeDeepImports`

### DIFF
--- a/.changeset/seven-cats-stay.md
+++ b/.changeset/seven-cats-stay.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10123](https://github.com/biomejs/biome/issues/10123): Corrected the `noReactNativeDeepImports` source rule to point to the proper upstream rule, so users can migrate from the original rule correctly.
+Fixed [`#10123`](https://github.com/biomejs/biome/issues/10123): Corrected the [`noReactNativeDeepImports`](https://biomejs.dev/linter/rules/no-react-native-deep-imports/) source rule to point to the proper upstream rule, so users can migrate from the original rule correctly.

--- a/.changeset/seven-cats-stay.md
+++ b/.changeset/seven-cats-stay.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10123](https://github.com/biomejs/biome/issues/10123): Corrected the `noReactNativeDeepImports` source rule to point to the proper upstream rule, so users can migrate from the original rule correctly.

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -146,8 +146,10 @@ pub enum RuleSource<'a> {
     EslintReact(&'a str),
     /// Rules from [Eslint Plugin React Hooks](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md)
     EslintReactHooks(&'a str),
-    /// Rules from [Eslint Plugin React Native](https://github.com/Intellicode/eslint-plugin-react-native)
+    /// Rules from [Eslint Plugin React Native](https://github.com/facebook/react-native/blob/main/packages/eslint-plugin-react-native/README.md)
     EslintReactNative(&'a str),
+    /// Rules from [Eslint Plugin React Native](https://github.com/Intellicode/eslint-plugin-react-native)
+    EslintReactNativeIntellicode(&'a str),
     /// Rules from [Eslint Plugin React Prefer Function Component](https://github.com/tatethurston/eslint-plugin-react-prefer-function-component)
     EslintReactPreferFunctionComponent(&'a str),
     /// Rules from [Eslint Plugin React Refresh](https://github.com/ArnaudBarre/eslint-plugin-react-refresh)
@@ -232,7 +234,8 @@ impl<'a> std::fmt::Display for RuleSource<'a> {
             Self::EslintQwik(_) => write!(f, "eslint-plugin-qwik"),
             Self::EslintReact(_) => write!(f, "eslint-plugin-react"),
             Self::EslintReactHooks(_) => write!(f, "eslint-plugin-react-hooks"),
-            Self::EslintReactNative(_) => write!(f, "eslint-plugin-react-native"),
+            Self::EslintReactNative(_) => write!(f, "@react-native/eslint-plugin"),
+            Self::EslintReactNativeIntellicode(_) => write!(f, "eslint-plugin-react-native"),
             Self::EslintReactPreferFunctionComponent(_) => {
                 write!(f, "eslint-plugin-react-prefer-function-component")
             }
@@ -319,6 +322,7 @@ impl<'a> RuleSource<'a> {
             | Self::EslintReact(rule_name)
             | Self::EslintReactHooks(rule_name)
             | Self::EslintReactNative(rule_name)
+            | Self::EslintReactNativeIntellicode(rule_name)
             | Self::EslintReactPreferFunctionComponent(rule_name)
             | Self::EslintReactRefresh(rule_name)
             | Self::EslintReactX(rule_name)
@@ -374,7 +378,8 @@ impl<'a> RuleSource<'a> {
             Self::EslintQwik(_) => "qwik",
             Self::EslintReact(_) => "react",
             Self::EslintReactHooks(_) => "react-hooks",
-            Self::EslintReactNative(_) => "react-native",
+            Self::EslintReactNative(_) => "@react-native",
+            Self::EslintReactNativeIntellicode(_) => "react-native",
             Self::EslintReactPreferFunctionComponent(_) => "react-prefer-function-component",
             Self::EslintReactRefresh(_) => "react-refresh",
             Self::EslintReactX(_) => "react-x",
@@ -438,7 +443,8 @@ impl<'a> RuleSource<'a> {
             Self::EslintQwik(rule_name) => format!("https://qwik.dev/docs/advanced/eslint/#{rule_name}"),
             Self::EslintReact(rule_name) => format!("https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/{rule_name}.md"),
             Self::EslintReactHooks(_) =>  "https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md".to_string(),
-            Self::EslintReactNative(rule_name) => format!("https://github.com/Intellicode/eslint-plugin-react-native/blob/master/docs/rules/{rule_name}.md"),
+            Self::EslintReactNative(_) => "https://github.com/facebook/react-native/blob/main/packages/eslint-plugin-react-native/README.md".to_string(),
+            Self::EslintReactNativeIntellicode(rule_name) => format!("https://github.com/Intellicode/eslint-plugin-react-native/blob/master/docs/rules/{rule_name}.md"),
             Self::EslintReactPreferFunctionComponent(_) => "https://github.com/tatethurston/eslint-plugin-react-prefer-function-component".to_string(),
             Self::EslintReactRefresh(_) => "https://github.com/ArnaudBarre/eslint-plugin-react-refresh".to_string(),
             Self::EslintReactX(rule_name) => format!("https://eslint-react.xyz/docs/rules/{rule_name}"),

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -537,6 +537,18 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "@react-native/no-deep-imports" => {
+            if !options.include_nursery {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_react_native_deep_imports
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
         "@stylistic/jsx-self-closing-comp" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
@@ -3914,18 +3926,6 @@ pub(crate) fn migrate_eslint_any_rule(
             let rule = group
                 .unwrap_group_as_mut()
                 .no_react_native_literal_colors
-                .get_or_insert(Default::default());
-            rule.set_level(rule.level().max(rule_severity.into()));
-        }
-        "react-native/no-deep-imports" => {
-            if !options.include_nursery {
-                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
-                return false;
-            }
-            let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group
-                .unwrap_group_as_mut()
-                .no_react_native_deep_imports
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }

--- a/crates/biome_js_analyze/src/lint/nursery/no_react_native_literal_colors.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_react_native_literal_colors.rs
@@ -64,7 +64,7 @@ declare_lint_rule! {
         version: "2.4.13",
         name: "noReactNativeLiteralColors",
         language: "js",
-        sources: &[RuleSource::EslintReactNative("no-color-literals").same()],
+        sources: &[RuleSource::EslintReactNativeIntellicode("no-color-literals").same()],
         domains: &[RuleDomain::ReactNative],
         recommended: false,
     }

--- a/crates/biome_js_analyze/src/lint/nursery/no_react_native_raw_text.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_react_native_raw_text.rs
@@ -70,7 +70,7 @@ declare_lint_rule! {
         version: "2.4.13",
         name: "noReactNativeRawText",
         language: "jsx",
-        sources: &[RuleSource::EslintReactNative("no-raw-text").same()],
+        sources: &[RuleSource::EslintReactNativeIntellicode("no-raw-text").same()],
         domains: &[RuleDomain::ReactNative],
         recommended: true,
         severity: Severity::Error,

--- a/crates/biome_js_analyze/src/lint/nursery/use_react_native_platform_components.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_react_native_platform_components.rs
@@ -100,7 +100,7 @@ declare_lint_rule! {
         version: "2.4.13",
         name: "useReactNativePlatformComponents",
         language: "js",
-        sources: &[RuleSource::EslintReactNative("split-platform-components").inspired()],
+        sources: &[RuleSource::EslintReactNativeIntellicode("split-platform-components").inspired()],
         domains: &[RuleDomain::ReactNative],
         recommended: true,
         severity: Severity::Error,


### PR DESCRIPTION
## Summary

Closes #10123

Added a new rule source `EslintReactNativeIntellicode` to distinguish it from the official (facebook/react) one. Existing rules that are from the intellicode one are updated to use the new rule source.

## Test Plan

N/A

## Docs

N/A
