### PR TITLE
fix(rage): print rules enabled by domains

### DIFF
--- a/.changeset/fix-rage-domain-rules.md
+++ b/.changeset/fix-rage-domain-rules.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10356](https://github.com/biomejs/biome/issues/10356): `biome rage --linter` now displays rules enabled through linter domains in the enabled rules list.

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -1,6 +1,8 @@
 use crate::commands::daemon::read_most_recent_log_file;
 use crate::service::enumerate_pipes;
 use crate::{CliDiagnostic, CliSession, VERSION, service};
+use biome_analyze::RuleFilter;
+use biome_configuration::analyzer::{DomainSelector, RuleDomainValue};
 use biome_configuration::{ConfigurationPathHint, Rules};
 use biome_console::fmt::{Display, Formatter};
 use biome_console::{
@@ -17,6 +19,7 @@ use biome_service::configuration::{LoadedConfiguration, load_configuration};
 use biome_service::settings::Settings;
 use biome_service::workspace::{RageEntry, RageParams, client};
 use camino::Utf8PathBuf;
+use std::collections::BTreeSet;
 use std::{env, io, ops::Deref};
 use terminal_size::terminal_size;
 use tokio::runtime::Runtime;
@@ -348,6 +351,10 @@ impl Display for RageConfiguration<'_> {
                     // Print linter configuration if --linter option is true
                     if self.linter {
                         let linter_configuration = configuration.get_linter_rules();
+                        let enabled_rules = linter_enabled_rules(
+                            &linter_configuration,
+                            configuration.get_linter_domains(),
+                        );
 
                         let javascript_linter = configuration.get_javascript_linter_configuration();
                         let json_linter = configuration.get_json_linter_configuration();
@@ -360,7 +367,7 @@ impl Display for RageConfiguration<'_> {
                             {KeyValuePair::new("CSS enabled", markup!({DisplayOption(css_linter.enabled)}))}
                             {KeyValuePair::new("GraphQL enabled", markup!({DisplayOption(graphql_linter.enabled)}))}
                             {KeyValuePair::new("Recommended", markup!({DisplayOption(linter_configuration.recommended)}))}
-                            {RageConfigurationLintRules("Enabled rules", linter_configuration)}
+                            {RageConfigurationLintRules("Enabled rules", enabled_rules)}
                         ).fmt(fmt)?;
                     }
                 }
@@ -376,7 +383,40 @@ impl Display for RageConfiguration<'_> {
     }
 }
 
-struct RageConfigurationLintRules<'a>(&'a str, Rules);
+fn linter_enabled_rules(
+    rules: &Rules,
+    domains: Option<&biome_configuration::analyzer::RuleDomains>,
+) -> BTreeSet<RuleFilter<'static>> {
+    let mut enabled_rules = rules
+        .as_enabled_rules()
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+    if let Some(domains) = domains {
+        let recommended_rules = Rules::default().as_enabled_rules();
+        for (domain, domain_value) in domains.iter() {
+            let domain_selector = DomainSelector(domain.as_str());
+            let domain_rules = domain_selector
+                .as_rule_filters()
+                .into_iter()
+                .filter(|rule| rule.group() != "nursery");
+            match domain_value {
+                RuleDomainValue::All => enabled_rules.extend(domain_rules),
+                RuleDomainValue::None => {
+                    for rule in domain_rules {
+                        enabled_rules.remove(&rule);
+                    }
+                }
+                RuleDomainValue::Recommended => enabled_rules
+                    .extend(domain_rules.filter(|rule| recommended_rules.contains(rule))),
+            }
+        }
+    }
+
+    enabled_rules
+}
+
+struct RageConfigurationLintRules<'a>(&'a str, BTreeSet<RuleFilter<'static>>);
 
 impl Display for RageConfigurationLintRules<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> io::Result<()> {
@@ -385,9 +425,7 @@ impl Display for RageConfigurationLintRules<'_> {
         let padding_rules = Padding::new(4);
         fmt.write_markup(markup! {{padding}{rules_str}":"})?;
         fmt.write_markup(markup! {{SOFT_LINE}})?;
-        let rules = self.1.as_enabled_rules();
-        let rules = rules.iter().collect::<std::collections::BTreeSet<_>>();
-        for rule in rules {
+        for rule in &self.1 {
             fmt.write_markup(markup! {{padding_rules}{rule}})?;
             fmt.write_markup(markup! {{SOFT_LINE}})?;
         }

--- a/crates/biome_cli/tests/commands/rage.rs
+++ b/crates/biome_cli/tests/commands/rage.rs
@@ -245,6 +245,43 @@ fn with_linter_configuration() {
     ));
 }
 
+#[test]
+#[serial]
+fn with_linter_domain_configuration() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+    fs.insert(
+        Utf8Path::new("biome.json").to_path_buf(),
+        r#"{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false
+    },
+    "domains": {
+      "qwik": "all"
+    }
+  }
+}"#,
+    );
+
+    let (fs, result) = run_rage(
+        fs,
+        &mut console,
+        Args::from(["rage", "--linter"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_rage_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "with_linter_domain_configuration",
+        fs,
+        console,
+        result,
+    ));
+}
+
 /// Runs the `rage` command mocking out the log directory.
 fn run_rage(
     fs: MemoryFileSystem,

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_domain_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_domain_configuration.snap
@@ -1,0 +1,79 @@
+---
+source: crates/biome_cli/tests/commands/rage.rs
+expression: content
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false
+    },
+    "domains": {
+      "qwik": "all"
+    }
+  }
+}
+```
+
+# Emitted Messages
+
+```block
+CLI:
+  Version:                      0.0.0
+  Color support:                **PLACEHOLDER**
+
+Platform:
+  CPU Architecture:             **PLACEHOLDER**
+  OS:                           **PLACEHOLDER**
+
+Environment:
+  BIOME_LOG_PATH:                    **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:             unset
+  BIOME_LOG_LEVEL:                   unset
+  BIOME_LOG_KIND:                    unset
+  BIOME_CONFIG_PATH:                 unset
+  BIOME_THREADS:                     unset
+  BIOME_WATCHER_KIND:                unset
+  BIOME_WATCHER_POLLING_INTERVAL:    unset
+  NO_COLOR:                     **PLACEHOLDER**
+  TERM:                         **PLACEHOLDER**
+  JS_RUNTIME_VERSION:           unset
+  JS_RUNTIME_NAME:              unset
+  NODE_PACKAGE_MANAGER:         unset
+
+Biome Configuration:
+  Status:                       Loaded successfully
+  Path:                         biome.json
+  Formatter enabled:            true
+  Linter enabled:               true
+  Assist enabled:               true
+  VCS enabled:                  false
+  HTML full support enabled:    unset
+
+Linter:
+  JavaScript enabled:           unset
+  JSON enabled:                 unset
+  CSS enabled:                  unset
+  GraphQL enabled:              unset
+  Recommended:                  false
+  Enabled rules:
+    correctness/noQwikUseVisibleTask
+    correctness/useImageSize
+    correctness/useJsxKeyInIterable
+    correctness/useQwikClasslist
+    correctness/useQwikMethodUsage
+    correctness/useQwikValidLexicalScope
+    suspicious/noReactSpecificProps
+
+Server:
+  Version:                      0.0.0
+  Name:                         biome_lsp
+  CPU Architecture:             **PLACEHOLDER**
+  OS:                           **PLACEHOLDER**
+
+Workspace:
+  Open Documents:               0
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
`biome rage --linter` previously wasn't showing rules enabled by domains. this fixes that

implemented with gpt 5.5

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #10356
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added a cli test

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
