### PR TITLE
fix(js_analyze): noUnusedFunctionParameters mention parameter name

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.5/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "biomejs/biome" }],
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "biomejs/biome"
+    }
+  ],
   "commit": false,
   "fixed": [
     [
@@ -24,7 +29,6 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@biomejs/aria-data",
-    "@biomejs/benchmark",
     "@biomejs/plugin-api",
     "tailwindcss-config-analyzer",
     "@biomejs/prettier-compare"

--- a/.changeset/poor-bikes-uncut.md
+++ b/.changeset/poor-bikes-uncut.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10361](https://github.com/biomejs/biome/issues/10361): [`noUnusedFunctionParameters`](https://biomejs.dev/linter/rules/no-unused-function-parameters/) now mentions the parameter name in the diagnostic.

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_function_parameters.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_function_parameters.rs
@@ -188,12 +188,13 @@ impl Rule for NoUnusedFunctionParameters {
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
         let binding = ctx.query();
+        let binding_name = binding.name_token().ok()?;
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
                 binding.range(),
                 markup! {
-                    "This "<Emphasis>"parameter"</Emphasis>" is unused."
+                    "This "<Emphasis>"parameter"</Emphasis>" "<Emphasis>{binding_name.text_trimmed()}</Emphasis>" is unused."
                 },
             )
             .note(markup! {

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedFunctionParameters/invalid.ignoreRestSiblingsFalse.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedFunctionParameters/invalid.ignoreRestSiblingsFalse.ts.snap
@@ -18,7 +18,7 @@ function withObjectSpreadTwoSiblings({a, b, ...rest}) {
 ```
 invalid.ignoreRestSiblingsFalse.ts:1:38 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
   > 1 │ function withObjectSpreadOneSibling({a, ...rest}) {
       │                                      ^
@@ -33,7 +33,7 @@ invalid.ignoreRestSiblingsFalse.ts:1:38 lint/correctness/noUnusedFunctionParamet
 ```
 invalid.ignoreRestSiblingsFalse.ts:5:39 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
     3 │ }
     4 │ 
@@ -50,7 +50,7 @@ invalid.ignoreRestSiblingsFalse.ts:5:39 lint/correctness/noUnusedFunctionParamet
 ```
 invalid.ignoreRestSiblingsFalse.ts:5:42 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter b is unused.
   
     3 │ }
     4 │ 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedFunctionParameters/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedFunctionParameters/invalid.js.snap
@@ -44,7 +44,7 @@ function withArraySpread([a, ...rest]) {
 ```
 invalid.js:1:14 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter myVar is unused.
   
   > 1 │ function foo(myVar) {
       │              ^^^^^
@@ -66,7 +66,7 @@ invalid.js:1:14 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━�
 ```
 invalid.js:6:15 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter k is unused.
   
     5 │ const data = [[1, 1], [2, 4], [3, 9], [4, 16], [5, 25]];
   > 6 │ data.filter(([k, v]) => v > 10);
@@ -91,7 +91,7 @@ invalid.js:6:15 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━�
 ```
 invalid.js:8:33 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter b is unused.
   
      6 │ data.filter(([k, v]) => v > 10);
      7 │ 
@@ -108,7 +108,7 @@ invalid.js:8:33 lint/correctness/noUnusedFunctionParameters ━━━━━━�
 ```
 invalid.js:10:22 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter reject is unused.
   
      8 │ [{ a: 1, b: 2, c: 3 }].map(({a, b, c}) => a + c);
      9 │ 
@@ -134,7 +134,7 @@ invalid.js:10:22 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━
 ```
 invalid.js:15:13 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
     14 │ // parameter a is not used
   > 15 │ {(function (a) { })}
@@ -159,7 +159,7 @@ invalid.js:15:13 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━
 ```
 invalid.js:16:14 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
     14 │ // parameter a is not used
     15 │ {(function (a) { })}
@@ -176,7 +176,7 @@ invalid.js:16:14 lint/correctness/noUnusedFunctionParameters ━━━━━━�
 ```
 invalid.js:17:14 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
     15 │ {(function (a) { })}
     16 │ {(function ({a}) { })}
@@ -202,7 +202,7 @@ invalid.js:17:14 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━
 ```
 invalid.js:18:12 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
     16 │ {(function ({a}) { })}
     17 │ {(function ([a]) { })}
@@ -228,7 +228,7 @@ invalid.js:18:12 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━
 ```
 invalid.js:23:15 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter b is unused.
   
     22 │ // parameter b is not used
   > 23 │ (function (a, b) {
@@ -253,7 +253,7 @@ invalid.js:23:15 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━
 ```
 invalid.js:27:28 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter x is unused.
   
     25 │ })
     26 │ 
@@ -270,7 +270,7 @@ invalid.js:27:28 lint/correctness/noUnusedFunctionParameters ━━━━━━�
 ```
 invalid.js:31:27 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
     29 │ }
     30 │ 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedFunctionParameters/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedFunctionParameters/invalid.ts.snap
@@ -22,7 +22,7 @@ function withTwoUnused({ a, b, c }): unknown {
 ```
 invalid.ts:2:4 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
     1 │ class D {
   > 2 │ 	f(a: D): D | undefined { return; }
@@ -46,7 +46,7 @@ invalid.ts:2:4 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━�
 ```
 invalid.ts:5:26 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
     3 │ }
     4 │ 
@@ -63,7 +63,7 @@ invalid.ts:5:26 lint/correctness/noUnusedFunctionParameters ━━━━━━�
 ```
 invalid.ts:9:26 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter a is unused.
   
      7 │ }
      8 │ 
@@ -80,7 +80,7 @@ invalid.ts:9:26 lint/correctness/noUnusedFunctionParameters ━━━━━━�
 ```
 invalid.ts:9:32 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter c is unused.
   
      7 │ }
      8 │ 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedFunctionParameters/issue6692.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedFunctionParameters/issue6692.js.snap
@@ -12,7 +12,7 @@ function _A(A) {}
 ```
 issue6692.js:1:13 lint/correctness/noUnusedFunctionParameters ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This parameter is unused.
+  ! This parameter A is unused.
   
   > 1 │ function _A(A) {}
       │             ^


### PR DESCRIPTION
## Summary

noUnusedFunctionParameters now mentions the parameter name in the diagnostic, matching the diagnostic style of noUnusedVariables

Closes #10361

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
