### PR TITLE
test(markdown_parser): add CST list invariants

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -1319,6 +1319,35 @@ fn line_indent_from_current(p: &MarkdownParser) -> usize {
     column - start_col
 }
 
+/// Measure indentation between the current virtual line start and cursor.
+///
+/// This is needed after consuming a quote prefix: the lexer can leave the
+/// remaining indentation bundled with the following marker token, so token
+/// walking alone cannot recover the already-consumed quote-prefix boundary.
+fn virtual_line_indent_before_current(p: &MarkdownParser) -> Option<usize> {
+    let virtual_start: usize = p.state().virtual_line_start?.into();
+    let current: usize = p.cur_range().start().into();
+    if virtual_start >= current {
+        return None;
+    }
+
+    let source = p.source().source_text();
+    let text = source.get(virtual_start..current)?;
+    if !text.chars().all(|c| c == ' ' || c == '\t') {
+        return None;
+    }
+
+    let mut column = 0usize;
+    for c in text.chars() {
+        match c {
+            ' ' => column += 1,
+            '\t' => column += TAB_STOP_SPACES - (column % TAB_STOP_SPACES),
+            _ => return None,
+        }
+    }
+    Some(column)
+}
+
 fn quote_only_line_indent_at_current(p: &MarkdownParser, depth: usize) -> Option<usize> {
     if depth == 0 {
         return None;
@@ -2369,6 +2398,17 @@ fn emit_current_line_indent_list_bytes(p: &mut MarkdownParser, mut byte_count: u
     let list_m = p.start();
     while byte_count > 0 && p.at(MD_TEXTUAL_LITERAL) {
         let text = p.cur_text();
+        if !text.is_empty()
+            && text.starts_with([' ', '\t'])
+            && !text.chars().all(|c| c == ' ' || c == '\t')
+        {
+            let old_range = p.cur_range();
+            p.re_lex(MarkdownReLexContext::ListPostMarker);
+            if p.cur_range() == old_range {
+                break;
+            }
+            continue;
+        }
         if !text.chars().all(|c| c == ' ' || c == '\t') {
             break;
         }
@@ -2593,8 +2633,11 @@ fn check_continuation_indent(
         };
     }
 
-    let indent = line_indent_from_current(p);
-
+    let indent = line_indent_from_current(p).max(
+        virtual_line_indent_before_current(p)
+            .filter(|_| line_started_with_quote_prefix)
+            .unwrap_or(0),
+    );
     if indent < state.marker_indent {
         // Below the marker indent. Lazy continuation is still allowed for
         // plain-text lines per CommonMark §5.2; list item starts and block

--- a/crates/biome_markdown_parser/tests/cst_invariants.rs
+++ b/crates/biome_markdown_parser/tests/cst_invariants.rs
@@ -1,0 +1,79 @@
+use biome_markdown_parser::parse_markdown;
+use biome_markdown_syntax::{MdContinuationIndent, MdListMarkerPrefix, MdOrderedListItem};
+use biome_rowan::{AstNode, AstNodeList};
+
+fn indent_len(indent: impl AstNodeList) -> usize {
+    indent.len()
+}
+
+fn continuation_indents(input: &str) -> Vec<usize> {
+    let parsed = parse_markdown(input);
+
+    parsed
+        .syntax()
+        .descendants()
+        .filter_map(MdContinuationIndent::cast)
+        .map(|indent| indent_len(indent.indent()))
+        .collect()
+}
+
+fn marker_prefix(input: &str, marker_text: &str) -> MdListMarkerPrefix {
+    let parsed = parse_markdown(input);
+
+    parsed
+        .syntax()
+        .descendants()
+        .filter_map(MdListMarkerPrefix::cast)
+        .find(|prefix| {
+            prefix
+                .marker()
+                .is_ok_and(|marker| marker.text_trimmed() == marker_text)
+        })
+        .unwrap_or_else(|| panic!("expected ordered marker prefix {marker_text:?} in {input:?}"))
+}
+
+fn ordered_list_item_count(input: &str) -> usize {
+    let parsed = parse_markdown(input);
+
+    parsed
+        .syntax()
+        .descendants()
+        .filter_map(MdOrderedListItem::cast)
+        .count()
+}
+
+#[test]
+fn nested_ordered_marker_keeps_parent_continuation_indent() {
+    let input = "+ outer\n   1. nested\n";
+
+    assert_eq!(continuation_indents(input), [3]);
+    assert_eq!(
+        indent_len(marker_prefix(input, "1.").pre_marker_indent()),
+        0
+    );
+}
+
+#[test]
+fn nested_bullet_marker_keeps_parent_continuation_indent() {
+    let input = "+ outer\n   - nested\n";
+
+    assert_eq!(continuation_indents(input), [3]);
+    assert_eq!(indent_len(marker_prefix(input, "-").pre_marker_indent()), 0);
+}
+
+#[test]
+fn non_one_ordered_marker_does_not_interrupt_paragraph_continuation() {
+    let input = "+ outer\n  2. still paragraph\n";
+
+    assert_eq!(ordered_list_item_count(input), 0);
+}
+
+#[test]
+fn quote_prefixed_nested_ordered_marker_does_not_steal_parent_indent() {
+    let input = "> + outer\n>   1. nested\n";
+
+    assert_eq!(
+        indent_len(marker_prefix(input, "1.").pre_marker_indent()),
+        0
+    );
+}

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_sublist_after_list_item.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_sublist_after_list_item.md.snap
@@ -52,17 +52,17 @@ MdDocument {
                                     post_marker_space_token: MD_QUOTE_POST_MARKER_SPACE@12..13 " " [] [],
                                 },
                                 MdContinuationIndent {
-                                    indent: MdIndentTokenList [],
+                                    indent: MdIndentTokenList [
+                                        MdIndentToken {
+                                            md_indent_char_token: MD_INDENT_CHAR@13..15 "  " [] [],
+                                        },
+                                    ],
                                 },
                                 MdOrderedListItem {
                                     md_bullet_list: MdBulletList [
                                         MdBullet {
                                             prefix: MdListMarkerPrefix {
-                                                pre_marker_indent: MdIndentTokenList [
-                                                    MdIndentToken {
-                                                        md_indent_char_token: MD_INDENT_CHAR@13..15 "  " [] [],
-                                                    },
-                                                ],
+                                                pre_marker_indent: MdIndentTokenList [],
                                                 marker: MD_ORDERED_LIST_MARKER@15..17 "1." [] [],
                                                 post_marker_space_token: MD_LIST_POST_MARKER_SPACE@17..18 " " [] [],
                                                 content_indent: MdIndentTokenList [],
@@ -126,15 +126,15 @@ MdDocument {
                   0: MD_QUOTE_INDENT_LIST@11..11
                   1: R_ANGLE@11..12 ">" [] []
                   2: MD_QUOTE_POST_MARKER_SPACE@12..13 " " [] []
-                2: MD_CONTINUATION_INDENT@13..13
-                  0: MD_INDENT_TOKEN_LIST@13..13
-                3: MD_ORDERED_LIST_ITEM@13..24
-                  0: MD_BULLET_LIST@13..24
-                    0: MD_BULLET@13..24
-                      0: MD_LIST_MARKER_PREFIX@13..18
-                        0: MD_INDENT_TOKEN_LIST@13..15
-                          0: MD_INDENT_TOKEN@13..15
-                            0: MD_INDENT_CHAR@13..15 "  " [] []
+                2: MD_CONTINUATION_INDENT@13..15
+                  0: MD_INDENT_TOKEN_LIST@13..15
+                    0: MD_INDENT_TOKEN@13..15
+                      0: MD_INDENT_CHAR@13..15 "  " [] []
+                3: MD_ORDERED_LIST_ITEM@15..24
+                  0: MD_BULLET_LIST@15..24
+                    0: MD_BULLET@15..24
+                      0: MD_LIST_MARKER_PREFIX@15..18
+                        0: MD_INDENT_TOKEN_LIST@15..15
                         1: MD_ORDERED_LIST_MARKER@15..17 "1." [] []
                         2: MD_LIST_POST_MARKER_SPACE@17..18 " " [] []
                         3: MD_INDENT_TOKEN_LIST@18..18


### PR DESCRIPTION
> [!NOTE]
> I used Codex to help plan, implement, and validate this fix.

## Summary

Follow-up to #10349. Adds active CST invariants for Markdown list continuation so parent continuation indentation is not folded into child marker prefixes, and fixes the quoted nested ordered-list variant.

## Test Plan

Added CST invariant tests for ordered, bullet, quoted, and non-`1` ordered marker continuation cases. Updated the quoted ordered sublist parser snapshot to reflect the intended CST shape.

Verified with:
- `just test-crate biome_markdown_parser`
- `just test-markdown-conformance`
- `just f && just l`
- Differential fuzz against commonmark.js
- CST sweep across the markdown fuzz corpora

## Docs

N/A