### PR TITLE
docs: fix duplicate-word typos in code comments

### DIFF
--- a/crates/biome_formatter/src/builders.rs
+++ b/crates/biome_formatter/src/builders.rs
@@ -136,7 +136,7 @@ pub const fn empty_line() -> Line {
 ///
 /// # Examples
 ///
-/// The line breaks are emitted as spaces if the enclosing `Group` fits on a a single line:
+/// The line breaks are emitted as spaces if the enclosing `Group` fits on a single line:
 /// ```
 /// use biome_formatter::{format, format_args};
 /// use biome_formatter::prelude::*;

--- a/crates/biome_js_analyze/src/suppression_action.rs
+++ b/crates/biome_js_analyze/src/suppression_action.rs
@@ -97,7 +97,7 @@ impl SuppressionAction for JsSuppressionAction {
         };
         // If the flag has been set to `true`, it means we are at the beginning of the file.
         if !should_insert_leading_newline {
-            // Still, if there's a a multiline comment, we want to try to attach the suppression comment
+            // Still, if there's a multiline comment, we want to try to attach the suppression comment
             // to the existing multiline comment without newlines.
             should_insert_leading_newline = current_token
                 .leading_trivia()


### PR DESCRIPTION
Two duplicate-word typos in code comments:

- `crates/biome_formatter/src/builders.rs:139` ("a a" -> "a")
- `crates/biome_js_analyze/src/suppression_action.rs:100` ("a a" -> "a")