### PR TITLE
fix(markdown_parser): break paragraph at sibling list marker without tab

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -1705,7 +1705,16 @@ fn at_block_interrupt_after_indent(p: &mut MarkdownParser) -> bool {
             p.bump(MD_TEXTUAL_LITERAL);
         }
         with_virtual_line_start(p, p.cur_range().start(), |p| {
-            at_block_interrupt(p) || textual_looks_like_list_marker(p)
+            if at_block_interrupt(p) || textual_looks_like_list_marker(p) {
+                return true;
+            }
+            // Mirror `parse_inline_item_list`'s break on non-1 ordered
+            // sibling markers (#10374): `textual_looks_like_list_marker`
+            // only matches `1.`/`1)` for ordered, so a `2.`-style sibling
+            // still folded into `MD_TEXTUAL_LITERAL` would otherwise let
+            // the prescan walk past the paragraph boundary and leak
+            // emphasis delimiters from the next list item.
+            p.at(MD_TEXTUAL_LITERAL) && textual_starts_with_ordered_marker(p.cur_text())
         })
     })
 }

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -1163,9 +1163,8 @@ fn break_for_list_interrupt_after_inline_newline(
     // Line sits at sibling/parent level. A list marker here ends the
     // current paragraph (CommonMark §5.2). Tabs need the broad token-aware
     // lookahead because `MD_TEXTUAL_LITERAL` can absorb the tab and any
-    // following marker (#10333); the non-tab path only needs to cover the
-    // gap in `parse_inline_item_list`'s own marker check — non-1 ordered
-    // siblings continuing an existing list (#10374).
+    // following marker; the non-tab path only needs to cover non-1 ordered
+    // siblings continuing an existing list.
     if indent < required_indent {
         if line_start_indent_contains_tab(p) {
             return line_starts_with_list_marker_after_indent(p, indent);
@@ -1709,11 +1708,9 @@ fn at_block_interrupt_after_indent(p: &mut MarkdownParser) -> bool {
                 return true;
             }
             // Mirror `parse_inline_item_list`'s break on non-1 ordered
-            // sibling markers (#10374): `textual_looks_like_list_marker`
-            // only matches `1.`/`1)` for ordered, so a `2.`-style sibling
-            // still folded into `MD_TEXTUAL_LITERAL` would otherwise let
-            // the prescan walk past the paragraph boundary and leak
-            // emphasis delimiters from the next list item.
+            // sibling markers: a marker still folded into `MD_TEXTUAL_LITERAL`
+            // would otherwise let the prescan walk past the paragraph boundary
+            // and leak emphasis delimiters from the next list item.
             p.at(MD_TEXTUAL_LITERAL) && textual_starts_with_ordered_marker(p.cur_text())
         })
     })

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -1160,11 +1160,17 @@ fn break_for_list_interrupt_after_inline_newline(
         return false;
     }
 
+    // Line sits at sibling/parent level. A list marker here ends the
+    // current paragraph (CommonMark §5.2). Tabs need the broad token-aware
+    // lookahead because `MD_TEXTUAL_LITERAL` can absorb the tab and any
+    // following marker (#10333); the non-tab path only needs to cover the
+    // gap in `parse_inline_item_list`'s own marker check — non-1 ordered
+    // siblings continuing an existing list (#10374).
     if indent < required_indent {
-        if !line_start_indent_contains_tab(p) {
-            return false;
+        if line_start_indent_contains_tab(p) {
+            return line_starts_with_list_marker_after_indent(p, indent);
         }
-        return line_starts_with_list_marker_after_indent(p, indent);
+        return line_starts_with_nonone_ordered_marker_after_indent(p, indent);
     }
 
     let skip = indent.min(required_indent);
@@ -1181,13 +1187,46 @@ fn break_for_list_interrupt_after_inline_newline(
 }
 
 /// True if current `MD_TEXTUAL_LITERAL`'s leading space/tab run contains a tab.
-/// Gates tab-only dedent recovery in [`break_for_list_interrupt_after_inline_newline`].
 fn line_start_indent_contains_tab(p: &MarkdownParser) -> bool {
     p.at(MD_TEXTUAL_LITERAL)
         && p.cur_text()
             .chars()
             .take_while(|c| *c == ' ' || *c == '\t')
             .any(|c| c == '\t')
+}
+
+/// Lookahead: after skipping `indent` columns of leading whitespace, does
+/// the next token begin a non-1 ordered marker followed by whitespace/EOL?
+/// Covers `parse_inline_item_list`'s blind spot (`textual_looks_like_list_marker`
+/// only matches `1.`/`1)` for ordered); `1.`/`1)` and bullets are left to the
+/// inline loop.
+fn line_starts_with_nonone_ordered_marker_after_indent(
+    p: &mut MarkdownParser,
+    indent: usize,
+) -> bool {
+    p.lookahead(|p| {
+        p.skip_line_indent(indent);
+        if p.at(MD_ORDERED_LIST_MARKER) {
+            let text = p.cur_text();
+            if text == "1." || text == "1)" {
+                return false;
+            }
+            p.bump(MD_ORDERED_LIST_MARKER);
+            return marker_followed_by_whitespace_or_eol(p);
+        }
+        if p.at(MD_TEXTUAL_LITERAL) {
+            let text = p.cur_text();
+            if text
+                .strip_prefix("1.")
+                .or_else(|| text.strip_prefix("1)"))
+                .is_some_and(|rest| rest.is_empty() || rest.starts_with([' ', '\t', '\n', '\r']))
+            {
+                return false;
+            }
+            return textual_starts_with_ordered_marker(text);
+        }
+        false
+    })
 }
 
 /// Lookahead: after skipping `indent` columns of leading whitespace, is the next

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space.md
@@ -1,0 +1,4 @@
+1.  first
+2.  second
+    1.   third
+    2.   fourth

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space.md.snap
@@ -1,0 +1,235 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```
+1.  first
+2.  second
+    1.   third
+    2.   fourth
+
+```
+
+
+## AST
+
+```
+MdDocument {
+    bom_token: missing (optional),
+    value: MdBlockList [
+        MdOrderedListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MD_ORDERED_LIST_MARKER@0..2 "1." [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@2..4 "  " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@4..9 "first" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@9..10 "\n" [] [],
+                                },
+                            ],
+                            hard_line: missing (optional),
+                        },
+                    ],
+                },
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MD_ORDERED_LIST_MARKER@10..12 "2." [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@12..14 "  " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@14..20 "second" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
+                                },
+                            ],
+                            hard_line: missing (optional),
+                        },
+                        MdContinuationIndent {
+                            indent: MdIndentTokenList [
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@21..22 " " [] [],
+                                },
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@22..23 " " [] [],
+                                },
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@23..24 " " [] [],
+                                },
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@24..25 " " [] [],
+                                },
+                            ],
+                        },
+                        MdOrderedListItem {
+                            md_bullet_list: MdBulletList [
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [],
+                                        marker: MD_ORDERED_LIST_MARKER@25..27 "1." [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@27..30 "   " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@30..35 "third" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@35..36 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                    ],
+                                },
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@36..37 " " [] [],
+                                            },
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@37..38 " " [] [],
+                                            },
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@38..39 " " [] [],
+                                            },
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@39..40 " " [] [],
+                                            },
+                                        ],
+                                        marker: MD_ORDERED_LIST_MARKER@40..42 "2." [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@42..45 "   " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@45..51 "fourth" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@51..52 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@52..52 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_DOCUMENT@0..52
+  0: (empty)
+  1: MD_BLOCK_LIST@0..52
+    0: MD_ORDERED_LIST_ITEM@0..52
+      0: MD_BULLET_LIST@0..52
+        0: MD_BULLET@0..10
+          0: MD_LIST_MARKER_PREFIX@0..4
+            0: MD_INDENT_TOKEN_LIST@0..0
+            1: MD_ORDERED_LIST_MARKER@0..2 "1." [] []
+            2: MD_LIST_POST_MARKER_SPACE@2..4 "  " [] []
+            3: MD_INDENT_TOKEN_LIST@4..4
+          1: MD_BLOCK_LIST@4..10
+            0: MD_PARAGRAPH@4..10
+              0: MD_INLINE_ITEM_LIST@4..10
+                0: MD_TEXTUAL@4..9
+                  0: MD_TEXTUAL_LITERAL@4..9 "first" [] []
+                1: MD_TEXTUAL@9..10
+                  0: MD_TEXTUAL_LITERAL@9..10 "\n" [] []
+              1: (empty)
+        1: MD_BULLET@10..52
+          0: MD_LIST_MARKER_PREFIX@10..14
+            0: MD_INDENT_TOKEN_LIST@10..10
+            1: MD_ORDERED_LIST_MARKER@10..12 "2." [] []
+            2: MD_LIST_POST_MARKER_SPACE@12..14 "  " [] []
+            3: MD_INDENT_TOKEN_LIST@14..14
+          1: MD_BLOCK_LIST@14..52
+            0: MD_PARAGRAPH@14..21
+              0: MD_INLINE_ITEM_LIST@14..21
+                0: MD_TEXTUAL@14..20
+                  0: MD_TEXTUAL_LITERAL@14..20 "second" [] []
+                1: MD_TEXTUAL@20..21
+                  0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
+              1: (empty)
+            1: MD_CONTINUATION_INDENT@21..25
+              0: MD_INDENT_TOKEN_LIST@21..25
+                0: MD_INDENT_TOKEN@21..22
+                  0: MD_INDENT_CHAR@21..22 " " [] []
+                1: MD_INDENT_TOKEN@22..23
+                  0: MD_INDENT_CHAR@22..23 " " [] []
+                2: MD_INDENT_TOKEN@23..24
+                  0: MD_INDENT_CHAR@23..24 " " [] []
+                3: MD_INDENT_TOKEN@24..25
+                  0: MD_INDENT_CHAR@24..25 " " [] []
+            2: MD_ORDERED_LIST_ITEM@25..52
+              0: MD_BULLET_LIST@25..52
+                0: MD_BULLET@25..36
+                  0: MD_LIST_MARKER_PREFIX@25..30
+                    0: MD_INDENT_TOKEN_LIST@25..25
+                    1: MD_ORDERED_LIST_MARKER@25..27 "1." [] []
+                    2: MD_LIST_POST_MARKER_SPACE@27..30 "   " [] []
+                    3: MD_INDENT_TOKEN_LIST@30..30
+                  1: MD_BLOCK_LIST@30..36
+                    0: MD_PARAGRAPH@30..36
+                      0: MD_INLINE_ITEM_LIST@30..36
+                        0: MD_TEXTUAL@30..35
+                          0: MD_TEXTUAL_LITERAL@30..35 "third" [] []
+                        1: MD_TEXTUAL@35..36
+                          0: MD_TEXTUAL_LITERAL@35..36 "\n" [] []
+                      1: (empty)
+                1: MD_BULLET@36..52
+                  0: MD_LIST_MARKER_PREFIX@36..45
+                    0: MD_INDENT_TOKEN_LIST@36..40
+                      0: MD_INDENT_TOKEN@36..37
+                        0: MD_INDENT_CHAR@36..37 " " [] []
+                      1: MD_INDENT_TOKEN@37..38
+                        0: MD_INDENT_CHAR@37..38 " " [] []
+                      2: MD_INDENT_TOKEN@38..39
+                        0: MD_INDENT_CHAR@38..39 " " [] []
+                      3: MD_INDENT_TOKEN@39..40
+                        0: MD_INDENT_CHAR@39..40 " " [] []
+                    1: MD_ORDERED_LIST_MARKER@40..42 "2." [] []
+                    2: MD_LIST_POST_MARKER_SPACE@42..45 "   " [] []
+                    3: MD_INDENT_TOKEN_LIST@45..45
+                  1: MD_BLOCK_LIST@45..52
+                    0: MD_PARAGRAPH@45..52
+                      0: MD_INLINE_ITEM_LIST@45..52
+                        0: MD_TEXTUAL@45..51
+                          0: MD_TEXTUAL_LITERAL@45..51 "fourth" [] []
+                        1: MD_TEXTUAL@51..52
+                          0: MD_TEXTUAL_LITERAL@51..52 "\n" [] []
+                      1: (empty)
+  2: EOF@52..52 "" [] []
+
+```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space_delimiter_cross.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space_delimiter_cross.md
@@ -1,0 +1,4 @@
+1.  first
+2.  second
+    1.   *third
+    2.   fourth*

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space_delimiter_cross.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space_delimiter_cross.md.snap
@@ -1,0 +1,245 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```
+1.  first
+2.  second
+    1.   *third
+    2.   fourth*
+
+```
+
+
+## AST
+
+```
+MdDocument {
+    bom_token: missing (optional),
+    value: MdBlockList [
+        MdOrderedListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MD_ORDERED_LIST_MARKER@0..2 "1." [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@2..4 "  " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@4..9 "first" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@9..10 "\n" [] [],
+                                },
+                            ],
+                            hard_line: missing (optional),
+                        },
+                    ],
+                },
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MD_ORDERED_LIST_MARKER@10..12 "2." [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@12..14 "  " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@14..20 "second" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
+                                },
+                            ],
+                            hard_line: missing (optional),
+                        },
+                        MdContinuationIndent {
+                            indent: MdIndentTokenList [
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@21..22 " " [] [],
+                                },
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@22..23 " " [] [],
+                                },
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@23..24 " " [] [],
+                                },
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@24..25 " " [] [],
+                                },
+                            ],
+                        },
+                        MdOrderedListItem {
+                            md_bullet_list: MdBulletList [
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [],
+                                        marker: MD_ORDERED_LIST_MARKER@25..27 "1." [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@27..30 "   " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@30..31 "*" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@31..36 "third" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@36..37 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                    ],
+                                },
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@37..38 " " [] [],
+                                            },
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@38..39 " " [] [],
+                                            },
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@39..40 " " [] [],
+                                            },
+                                            MdIndentToken {
+                                                md_indent_char_token: MD_INDENT_CHAR@40..41 " " [] [],
+                                            },
+                                        ],
+                                        marker: MD_ORDERED_LIST_MARKER@41..43 "2." [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@43..46 "   " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@46..52 "fourth" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@52..53 "*" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@53..54 "\n" [] [],
+                                                },
+                                            ],
+                                            hard_line: missing (optional),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@54..54 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_DOCUMENT@0..54
+  0: (empty)
+  1: MD_BLOCK_LIST@0..54
+    0: MD_ORDERED_LIST_ITEM@0..54
+      0: MD_BULLET_LIST@0..54
+        0: MD_BULLET@0..10
+          0: MD_LIST_MARKER_PREFIX@0..4
+            0: MD_INDENT_TOKEN_LIST@0..0
+            1: MD_ORDERED_LIST_MARKER@0..2 "1." [] []
+            2: MD_LIST_POST_MARKER_SPACE@2..4 "  " [] []
+            3: MD_INDENT_TOKEN_LIST@4..4
+          1: MD_BLOCK_LIST@4..10
+            0: MD_PARAGRAPH@4..10
+              0: MD_INLINE_ITEM_LIST@4..10
+                0: MD_TEXTUAL@4..9
+                  0: MD_TEXTUAL_LITERAL@4..9 "first" [] []
+                1: MD_TEXTUAL@9..10
+                  0: MD_TEXTUAL_LITERAL@9..10 "\n" [] []
+              1: (empty)
+        1: MD_BULLET@10..54
+          0: MD_LIST_MARKER_PREFIX@10..14
+            0: MD_INDENT_TOKEN_LIST@10..10
+            1: MD_ORDERED_LIST_MARKER@10..12 "2." [] []
+            2: MD_LIST_POST_MARKER_SPACE@12..14 "  " [] []
+            3: MD_INDENT_TOKEN_LIST@14..14
+          1: MD_BLOCK_LIST@14..54
+            0: MD_PARAGRAPH@14..21
+              0: MD_INLINE_ITEM_LIST@14..21
+                0: MD_TEXTUAL@14..20
+                  0: MD_TEXTUAL_LITERAL@14..20 "second" [] []
+                1: MD_TEXTUAL@20..21
+                  0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
+              1: (empty)
+            1: MD_CONTINUATION_INDENT@21..25
+              0: MD_INDENT_TOKEN_LIST@21..25
+                0: MD_INDENT_TOKEN@21..22
+                  0: MD_INDENT_CHAR@21..22 " " [] []
+                1: MD_INDENT_TOKEN@22..23
+                  0: MD_INDENT_CHAR@22..23 " " [] []
+                2: MD_INDENT_TOKEN@23..24
+                  0: MD_INDENT_CHAR@23..24 " " [] []
+                3: MD_INDENT_TOKEN@24..25
+                  0: MD_INDENT_CHAR@24..25 " " [] []
+            2: MD_ORDERED_LIST_ITEM@25..54
+              0: MD_BULLET_LIST@25..54
+                0: MD_BULLET@25..37
+                  0: MD_LIST_MARKER_PREFIX@25..30
+                    0: MD_INDENT_TOKEN_LIST@25..25
+                    1: MD_ORDERED_LIST_MARKER@25..27 "1." [] []
+                    2: MD_LIST_POST_MARKER_SPACE@27..30 "   " [] []
+                    3: MD_INDENT_TOKEN_LIST@30..30
+                  1: MD_BLOCK_LIST@30..37
+                    0: MD_PARAGRAPH@30..37
+                      0: MD_INLINE_ITEM_LIST@30..37
+                        0: MD_TEXTUAL@30..31
+                          0: MD_TEXTUAL_LITERAL@30..31 "*" [] []
+                        1: MD_TEXTUAL@31..36
+                          0: MD_TEXTUAL_LITERAL@31..36 "third" [] []
+                        2: MD_TEXTUAL@36..37
+                          0: MD_TEXTUAL_LITERAL@36..37 "\n" [] []
+                      1: (empty)
+                1: MD_BULLET@37..54
+                  0: MD_LIST_MARKER_PREFIX@37..46
+                    0: MD_INDENT_TOKEN_LIST@37..41
+                      0: MD_INDENT_TOKEN@37..38
+                        0: MD_INDENT_CHAR@37..38 " " [] []
+                      1: MD_INDENT_TOKEN@38..39
+                        0: MD_INDENT_CHAR@38..39 " " [] []
+                      2: MD_INDENT_TOKEN@39..40
+                        0: MD_INDENT_CHAR@39..40 " " [] []
+                      3: MD_INDENT_TOKEN@40..41
+                        0: MD_INDENT_CHAR@40..41 " " [] []
+                    1: MD_ORDERED_LIST_MARKER@41..43 "2." [] []
+                    2: MD_LIST_POST_MARKER_SPACE@43..46 "   " [] []
+                    3: MD_INDENT_TOKEN_LIST@46..46
+                  1: MD_BLOCK_LIST@46..54
+                    0: MD_PARAGRAPH@46..54
+                      0: MD_INLINE_ITEM_LIST@46..54
+                        0: MD_TEXTUAL@46..52
+                          0: MD_TEXTUAL_LITERAL@46..52 "fourth" [] []
+                        1: MD_TEXTUAL@52..53
+                          0: MD_TEXTUAL_LITERAL@52..53 "*" [] []
+                        2: MD_TEXTUAL@53..54
+                          0: MD_TEXTUAL_LITERAL@53..54 "\n" [] []
+                      1: (empty)
+  2: EOF@54..54 "" [] []
+
+```


### PR DESCRIPTION
> [!NOTE]
> I used Codex to help plan, implement, and validate this fix.

## Summary

Fixes #10374.

Break markdown list paragraphs when a sibling or parent list marker appears at the current item marker indent. The previous check only handled the tab-indented case, so a nested ordered sibling with wider post-marker spacing was parsed as paragraph text.

## Test Plan

- Added parser snapshot fixtures for the issue reproducer and delimiter-crossing regression.
- `just test-crate biome_markdown_parser`
- `just test-crate biome_markdown_formatter`
- `just test-markdown-conformance`

## Docs

N/A.