### PR TITLE
fix(css_parser): parse CSS custom functions in SCSS

### DIFF
--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/function.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/function.scss
@@ -7,3 +7,7 @@ $rest...
 @return
 $value * $ratio;
 }
+
+@function --highlight  ( ) {
+result:var(--highlight,#{$highlight});
+}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/function.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/function.scss.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: css/scss/at-rule/function.scss
+assertion_line: 249
+info: scss/at-rule/function.scss
 ---
 
 # Input
@@ -16,6 +17,10 @@ $rest...
 $value * $ratio;
 }
 
+@function --highlight  ( ) {
+result:var(--highlight,#{$highlight});
+}
+
 ```
 
 
@@ -24,6 +29,10 @@ $value * $ratio;
 ```scss
 @function double($value: 2, $ratio: 1.5, $rest...) {
 	@return $value * $ratio;
+}
+
+@function --highlight() {
+	result: var(--highlight, #{$highlight});
 }
 
 ```

--- a/crates/biome_css_parser/src/syntax/at_rule/mod.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/mod.rs
@@ -72,7 +72,6 @@ use crate::syntax::at_rule::view_transition::{
     parse_view_transition_at_rule, parse_view_transition_at_rule_declarator,
 };
 
-use crate::syntax::CssSyntaxFeatures;
 use crate::syntax::parse_error::{expected_any_at_rule, tailwind_disabled};
 use crate::syntax::scss::{
     parse_bogus_scss_else_at_rule, parse_scss_at_root_at_rule, parse_scss_content_at_rule,
@@ -82,6 +81,7 @@ use crate::syntax::scss::{
     parse_scss_include_at_rule, parse_scss_mixin_at_rule, parse_scss_return_at_rule,
     parse_scss_use_at_rule, parse_scss_warn_at_rule, parse_scss_while_at_rule,
 };
+use crate::syntax::{CssSyntaxFeatures, is_nth_at_dashed_identifier};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::T;
 
@@ -132,6 +132,12 @@ pub(crate) fn parse_any_at_rule(p: &mut CssParser) -> ParsedSyntax {
         T![font_face] => parse_font_face_at_rule(p),
         T![font_feature_values] => parse_font_feature_values_at_rule(p),
         T![font_palette_values] => parse_font_palette_values_at_rule(p),
+        T![function]
+            if CssSyntaxFeatures::Scss.is_supported(p) && is_nth_at_dashed_identifier(p, 1) =>
+        {
+            // `@function --highlight()` is plain CSS in SCSS; `double()` stays Sass.
+            parse_function_at_rule(p)
+        }
         T![function] => {
             if CssSyntaxFeatures::Scss.is_supported(p) {
                 parse_scss_function_at_rule(p)

--- a/crates/biome_css_parser/src/syntax/mod.rs
+++ b/crates/biome_css_parser/src/syntax/mod.rs
@@ -711,7 +711,12 @@ pub(crate) fn parse_custom_identifier_with_keywords(
 
 #[inline]
 pub(crate) fn is_at_dashed_identifier(p: &mut CssParser) -> bool {
-    is_at_identifier(p) && p.cur_text().starts_with("--")
+    is_nth_at_dashed_identifier(p, 0)
+}
+
+#[inline]
+pub(crate) fn is_nth_at_dashed_identifier(p: &mut CssParser, n: usize) -> bool {
+    is_nth_at_identifier(p, n) && p.nth_text(n).is_some_and(|text| text.starts_with("--"))
 }
 
 /// Dashed identifiers are any identifiers that start with two dashes (`--`).

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/function_at_rule.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/function_at_rule.rs
@@ -8,9 +8,9 @@ use biome_css_syntax::T;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::*;
 
-/// Parses the SCSS `@function` at-rule.
+/// Parses Sass `@function name(...)` at-rules.
 ///
-/// # Example
+/// Dashed `@function --name(...)` is routed to CSS custom-function parsing.
 ///
 /// ```scss
 /// @function double($value: 2) {
@@ -19,6 +19,7 @@ use biome_parser::prelude::*;
 /// ```
 ///
 /// Docs: https://sass-lang.com/documentation/at-rules/function/
+/// Docs: https://sass-lang.com/documentation/breaking-changes/css-function-mixin/
 #[inline]
 pub(crate) fn parse_scss_function_at_rule(p: &mut CssParser) -> ParsedSyntax {
     if !is_at_scss_function_at_rule(p) {

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/plain-css-function.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/plain-css-function.scss
@@ -1,0 +1,7 @@
+@function --missing-parens {
+  result: red;
+}
+
+@function --bad-param(param) {
+  result: red;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/plain-css-function.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/plain-css-function.scss.snap
@@ -1,0 +1,223 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+assertion_line: 206
+expression: snapshot
+---
+
+## Input
+
+```css
+@function --missing-parens {
+  result: red;
+}
+
+@function --bad-param(param) {
+  result: red;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssFunctionAtRule {
+                declarator: CssFunctionAtRuleDeclarator {
+                    function_token: FUNCTION_KW@1..10 "function" [] [Whitespace(" ")],
+                    name: CssDashedIdentifier {
+                        value_token: IDENT@10..27 "--missing-parens" [] [Whitespace(" ")],
+                    },
+                    l_paren_token: missing (required),
+                    parameters: CssFunctionParameterList [],
+                    r_paren_token: missing (required),
+                    returns: missing (optional),
+                },
+                block: CssDeclarationOrAtRuleBlock {
+                    l_curly_token: L_CURLY@27..28 "{" [] [],
+                    items: CssDeclarationOrAtRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@28..37 "result" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    colon_token: COLON@37..39 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@39..42 "red" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@42..43 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@43..45 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@45..48 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssFunctionAtRule {
+                declarator: CssFunctionAtRuleDeclarator {
+                    function_token: FUNCTION_KW@48..57 "function" [] [Whitespace(" ")],
+                    name: CssDashedIdentifier {
+                        value_token: IDENT@57..68 "--bad-param" [] [],
+                    },
+                    l_paren_token: L_PAREN@68..69 "(" [] [],
+                    parameters: CssFunctionParameterList [
+                        CssBogusFunctionParameter {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        IDENT@69..74 "param" [] [],
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    r_paren_token: R_PAREN@74..76 ")" [] [Whitespace(" ")],
+                    returns: missing (optional),
+                },
+                block: CssDeclarationOrAtRuleBlock {
+                    l_curly_token: L_CURLY@76..77 "{" [] [],
+                    items: CssDeclarationOrAtRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@77..86 "result" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    colon_token: COLON@86..88 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@88..91 "red" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@91..92 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@92..94 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@94..95 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..95
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..94
+    0: CSS_AT_RULE@0..45
+      0: AT@0..1 "@" [] []
+      1: CSS_FUNCTION_AT_RULE@1..45
+        0: CSS_FUNCTION_AT_RULE_DECLARATOR@1..27
+          0: FUNCTION_KW@1..10 "function" [] [Whitespace(" ")]
+          1: CSS_DASHED_IDENTIFIER@10..27
+            0: IDENT@10..27 "--missing-parens" [] [Whitespace(" ")]
+          2: (empty)
+          3: CSS_FUNCTION_PARAMETER_LIST@27..27
+          4: (empty)
+          5: (empty)
+        1: CSS_DECLARATION_OR_AT_RULE_BLOCK@27..45
+          0: L_CURLY@27..28 "{" [] []
+          1: CSS_DECLARATION_OR_AT_RULE_LIST@28..43
+            0: CSS_DECLARATION_WITH_SEMICOLON@28..43
+              0: CSS_DECLARATION@28..42
+                0: CSS_GENERIC_PROPERTY@28..42
+                  0: CSS_IDENTIFIER@28..37
+                    0: IDENT@28..37 "result" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@37..39 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@39..42
+                    0: SCSS_EXPRESSION_ITEM_LIST@39..42
+                      0: CSS_IDENTIFIER@39..42
+                        0: IDENT@39..42 "red" [] []
+                1: (empty)
+              1: SEMICOLON@42..43 ";" [] []
+          2: R_CURLY@43..45 "}" [Newline("\n")] []
+    1: CSS_AT_RULE@45..94
+      0: AT@45..48 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_FUNCTION_AT_RULE@48..94
+        0: CSS_FUNCTION_AT_RULE_DECLARATOR@48..76
+          0: FUNCTION_KW@48..57 "function" [] [Whitespace(" ")]
+          1: CSS_DASHED_IDENTIFIER@57..68
+            0: IDENT@57..68 "--bad-param" [] []
+          2: L_PAREN@68..69 "(" [] []
+          3: CSS_FUNCTION_PARAMETER_LIST@69..74
+            0: CSS_BOGUS_FUNCTION_PARAMETER@69..74
+              0: CSS_BOGUS@69..74
+                0: IDENT@69..74 "param" [] []
+          4: R_PAREN@74..76 ")" [] [Whitespace(" ")]
+          5: (empty)
+        1: CSS_DECLARATION_OR_AT_RULE_BLOCK@76..94
+          0: L_CURLY@76..77 "{" [] []
+          1: CSS_DECLARATION_OR_AT_RULE_LIST@77..92
+            0: CSS_DECLARATION_WITH_SEMICOLON@77..92
+              0: CSS_DECLARATION@77..91
+                0: CSS_GENERIC_PROPERTY@77..91
+                  0: CSS_IDENTIFIER@77..86
+                    0: IDENT@77..86 "result" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@86..88 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@88..91
+                    0: SCSS_EXPRESSION_ITEM_LIST@88..91
+                      0: CSS_IDENTIFIER@88..91
+                        0: IDENT@88..91 "red" [] []
+                1: (empty)
+              1: SEMICOLON@91..92 ";" [] []
+          2: R_CURLY@92..94 "}" [Newline("\n")] []
+  2: EOF@94..95 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+plain-css-function.scss:1:28 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `(` but instead found `{`
+  
+  > 1 │ @function --missing-parens {
+      │                            ^
+    2 │   result: red;
+    3 │ }
+  
+  i Remove {
+  
+plain-css-function.scss:5:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a dashed identifier but instead found 'param'.
+  
+    3 │ }
+    4 │ 
+  > 5 │ @function --bad-param(param) {
+      │                       ^^^^^
+    6 │   result: red;
+    7 │ }
+  
+  i Expected a dashed identifier here.
+  
+    3 │ }
+    4 │ 
+  > 5 │ @function --bad-param(param) {
+      │                       ^^^^^
+    6 │   result: red;
+    7 │ }
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/plain-css-function.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/plain-css-function.scss
@@ -1,0 +1,9 @@
+$highlight: #ddf;
+
+@function --highlight() {
+  result: var(--highlight, #{$highlight});
+}
+
+@function double($value) {
+  @return $value * 2;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/plain-css-function.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/plain-css-function.scss.snap
@@ -1,0 +1,285 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+assertion_line: 206
+expression: snapshot
+---
+
+## Input
+
+```css
+$highlight: #ddf;
+
+@function --highlight() {
+  result: var(--highlight, #{$highlight});
+}
+
+@function double($value) {
+  @return $value * 2;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@0..1 "$" [] [],
+                name: CssIdentifier {
+                    value_token: IDENT@1..10 "highlight" [] [],
+                },
+            },
+            colon_token: COLON@10..12 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssColor {
+                        hash_token: HASH@12..13 "#" [] [],
+                        value_token: CSS_COLOR_LITERAL@13..16 "ddf" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@16..17 ";" [] [],
+        },
+        CssAtRule {
+            at_token: AT@17..20 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssFunctionAtRule {
+                declarator: CssFunctionAtRuleDeclarator {
+                    function_token: FUNCTION_KW@20..29 "function" [] [Whitespace(" ")],
+                    name: CssDashedIdentifier {
+                        value_token: IDENT@29..40 "--highlight" [] [],
+                    },
+                    l_paren_token: L_PAREN@40..41 "(" [] [],
+                    parameters: CssFunctionParameterList [],
+                    r_paren_token: R_PAREN@41..43 ")" [] [Whitespace(" ")],
+                    returns: missing (optional),
+                },
+                block: CssDeclarationOrAtRuleBlock {
+                    l_curly_token: L_CURLY@43..44 "{" [] [],
+                    items: CssDeclarationOrAtRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@44..53 "result" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    colon_token: COLON@53..55 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssFunction {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@55..58 "var" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@58..59 "(" [] [],
+                                                items: CssParameterList [
+                                                    ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssDashedIdentifier {
+                                                                value_token: IDENT@59..70 "--highlight" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    COMMA@70..72 "," [] [Whitespace(" ")],
+                                                    ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssInterpolation {
+                                                                hash_token: HASH@72..73 "#" [] [],
+                                                                l_curly_token: L_CURLY@73..74 "{" [] [],
+                                                                value: ScssExpression {
+                                                                    items: ScssExpressionItemList [
+                                                                        ScssVariable {
+                                                                            dollar_token: DOLLAR@74..75 "$" [] [],
+                                                                            name: CssIdentifier {
+                                                                                value_token: IDENT@75..84 "highlight" [] [],
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                },
+                                                                r_curly_token: R_CURLY@84..85 "}" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                ],
+                                                r_paren_token: R_PAREN@85..86 ")" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@86..87 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@87..89 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@89..92 "@" [Newline("\n"), Newline("\n")] [],
+            rule: ScssFunctionAtRule {
+                function_token: FUNCTION_KW@92..101 "function" [] [Whitespace(" ")],
+                name: CssIdentifier {
+                    value_token: IDENT@101..107 "double" [] [],
+                },
+                parameters: ScssParameterList {
+                    l_paren_token: L_PAREN@107..108 "(" [] [],
+                    items: ScssParameterItemList [
+                        ScssParameter {
+                            name: ScssVariable {
+                                dollar_token: DOLLAR@108..109 "$" [] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@109..114 "value" [] [],
+                                },
+                            },
+                            default_value: missing (optional),
+                            ellipsis_token: missing (optional),
+                        },
+                    ],
+                    r_paren_token: R_PAREN@114..116 ")" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@116..117 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssAtRule {
+                            at_token: AT@117..121 "@" [Newline("\n"), Whitespace("  ")] [],
+                            rule: ScssReturnAtRule {
+                                return_token: RETURN_KW@121..128 "return" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssBinaryExpression {
+                                            left: ScssVariable {
+                                                dollar_token: DOLLAR@128..129 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@129..135 "value" [] [Whitespace(" ")],
+                                                },
+                                            },
+                                            operator: STAR@135..137 "*" [] [Whitespace(" ")],
+                                            right: CssNumber {
+                                                value_token: CSS_NUMBER_LITERAL@137..138 "2" [] [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                semicolon_token: SEMICOLON@138..139 ";" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@139..141 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@141..142 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..142
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..141
+    0: SCSS_VARIABLE_DECLARATION@0..17
+      0: SCSS_VARIABLE@0..10
+        0: DOLLAR@0..1 "$" [] []
+        1: CSS_IDENTIFIER@1..10
+          0: IDENT@1..10 "highlight" [] []
+      1: COLON@10..12 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@12..16
+        0: SCSS_EXPRESSION_ITEM_LIST@12..16
+          0: CSS_COLOR@12..16
+            0: HASH@12..13 "#" [] []
+            1: CSS_COLOR_LITERAL@13..16 "ddf" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@16..16
+      4: SEMICOLON@16..17 ";" [] []
+    1: CSS_AT_RULE@17..89
+      0: AT@17..20 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_FUNCTION_AT_RULE@20..89
+        0: CSS_FUNCTION_AT_RULE_DECLARATOR@20..43
+          0: FUNCTION_KW@20..29 "function" [] [Whitespace(" ")]
+          1: CSS_DASHED_IDENTIFIER@29..40
+            0: IDENT@29..40 "--highlight" [] []
+          2: L_PAREN@40..41 "(" [] []
+          3: CSS_FUNCTION_PARAMETER_LIST@41..41
+          4: R_PAREN@41..43 ")" [] [Whitespace(" ")]
+          5: (empty)
+        1: CSS_DECLARATION_OR_AT_RULE_BLOCK@43..89
+          0: L_CURLY@43..44 "{" [] []
+          1: CSS_DECLARATION_OR_AT_RULE_LIST@44..87
+            0: CSS_DECLARATION_WITH_SEMICOLON@44..87
+              0: CSS_DECLARATION@44..86
+                0: CSS_GENERIC_PROPERTY@44..86
+                  0: CSS_IDENTIFIER@44..53
+                    0: IDENT@44..53 "result" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@53..55 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@55..86
+                    0: SCSS_EXPRESSION_ITEM_LIST@55..86
+                      0: CSS_FUNCTION@55..86
+                        0: CSS_IDENTIFIER@55..58
+                          0: IDENT@55..58 "var" [] []
+                        1: L_PAREN@58..59 "(" [] []
+                        2: CSS_PARAMETER_LIST@59..85
+                          0: SCSS_EXPRESSION@59..70
+                            0: SCSS_EXPRESSION_ITEM_LIST@59..70
+                              0: CSS_DASHED_IDENTIFIER@59..70
+                                0: IDENT@59..70 "--highlight" [] []
+                          1: COMMA@70..72 "," [] [Whitespace(" ")]
+                          2: SCSS_EXPRESSION@72..85
+                            0: SCSS_EXPRESSION_ITEM_LIST@72..85
+                              0: SCSS_INTERPOLATION@72..85
+                                0: HASH@72..73 "#" [] []
+                                1: L_CURLY@73..74 "{" [] []
+                                2: SCSS_EXPRESSION@74..84
+                                  0: SCSS_EXPRESSION_ITEM_LIST@74..84
+                                    0: SCSS_VARIABLE@74..84
+                                      0: DOLLAR@74..75 "$" [] []
+                                      1: CSS_IDENTIFIER@75..84
+                                        0: IDENT@75..84 "highlight" [] []
+                                3: R_CURLY@84..85 "}" [] []
+                        3: R_PAREN@85..86 ")" [] []
+                1: (empty)
+              1: SEMICOLON@86..87 ";" [] []
+          2: R_CURLY@87..89 "}" [Newline("\n")] []
+    2: CSS_AT_RULE@89..141
+      0: AT@89..92 "@" [Newline("\n"), Newline("\n")] []
+      1: SCSS_FUNCTION_AT_RULE@92..141
+        0: FUNCTION_KW@92..101 "function" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@101..107
+          0: IDENT@101..107 "double" [] []
+        2: SCSS_PARAMETER_LIST@107..116
+          0: L_PAREN@107..108 "(" [] []
+          1: SCSS_PARAMETER_ITEM_LIST@108..114
+            0: SCSS_PARAMETER@108..114
+              0: SCSS_VARIABLE@108..114
+                0: DOLLAR@108..109 "$" [] []
+                1: CSS_IDENTIFIER@109..114
+                  0: IDENT@109..114 "value" [] []
+              1: (empty)
+              2: (empty)
+          2: R_PAREN@114..116 ")" [] [Whitespace(" ")]
+        3: CSS_DECLARATION_OR_RULE_BLOCK@116..141
+          0: L_CURLY@116..117 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@117..139
+            0: CSS_AT_RULE@117..139
+              0: AT@117..121 "@" [Newline("\n"), Whitespace("  ")] []
+              1: SCSS_RETURN_AT_RULE@121..139
+                0: RETURN_KW@121..128 "return" [] [Whitespace(" ")]
+                1: SCSS_EXPRESSION@128..138
+                  0: SCSS_EXPRESSION_ITEM_LIST@128..138
+                    0: SCSS_BINARY_EXPRESSION@128..138
+                      0: SCSS_VARIABLE@128..135
+                        0: DOLLAR@128..129 "$" [] []
+                        1: CSS_IDENTIFIER@129..135
+                          0: IDENT@129..135 "value" [] [Whitespace(" ")]
+                      1: STAR@135..137 "*" [] [Whitespace(" ")]
+                      2: CSS_NUMBER@137..138
+                        0: CSS_NUMBER_LITERAL@137..138 "2" [] []
+                2: SEMICOLON@138..139 ";" [] []
+          2: R_CURLY@139..141 "}" [Newline("\n")] []
+  2: EOF@141..142 "" [Newline("\n")] []
+
+```

--- a/crates/biome_parser/src/lexer.rs
+++ b/crates/biome_parser/src/lexer.rs
@@ -812,12 +812,13 @@ impl<'t, Lex: LexerWithCheckpoint<'t>> Iterator for LookaheadIterator<'_, 't, Le
         let kind = lexer.next_token(Lex::LexContext::default());
         // Lex the next token and cache it in the lookahead cache. Needed to cache it right away
         // because of the diagnostic.
-        self.buffered.lookahead.push_back(lexer.checkpoint());
+        let checkpoint = lexer.checkpoint();
+        debug_assert_eq!(kind, checkpoint.current_kind);
+        let lookahead = LookaheadToken::from(&checkpoint);
 
-        Some(LookaheadToken {
-            kind,
-            flags: lexer.current_flags(),
-        })
+        self.buffered.lookahead.push_back(checkpoint);
+
+        Some(lookahead)
     }
 }
 
@@ -826,12 +827,18 @@ impl<'t, Lex: LexerWithCheckpoint<'t>> FusedIterator for LookaheadIterator<'_, '
 #[derive(Debug)]
 pub struct LookaheadToken<Kind> {
     kind: Kind,
+    current_start: TextSize,
+    position: TextSize,
     flags: TokenFlags,
 }
 
 impl<Kind: SyntaxKind> LookaheadToken<Kind> {
     pub fn kind(&self) -> Kind {
         self.kind
+    }
+
+    pub fn text_range(&self) -> TextRange {
+        TextRange::new(self.current_start, self.position)
     }
 
     pub fn has_preceding_line_break(&self) -> bool {
@@ -847,6 +854,8 @@ impl<Kind: SyntaxKind> From<&LexerCheckpoint<Kind>> for LookaheadToken<Kind> {
     fn from(checkpoint: &LexerCheckpoint<Kind>) -> Self {
         Self {
             kind: checkpoint.current_kind,
+            current_start: checkpoint.current_start,
+            position: checkpoint.position,
             flags: checkpoint.current_flags,
         }
     }

--- a/crates/biome_parser/src/lib.rs
+++ b/crates/biome_parser/src/lib.rs
@@ -17,7 +17,7 @@ use biome_rowan::{
     TextRange, TextSize,
 };
 pub use marker::{CompletedMarker, Marker};
-use std::any::type_name;
+use std::{any::type_name, ops::Range};
 pub use token_set::TokenSet;
 
 pub mod diagnostic;
@@ -202,6 +202,18 @@ pub trait Parser: Sized {
     /// Get the source code of the parser's current token.
     fn cur_text(&self) -> &str {
         &self.source().text()[self.cur_range()]
+    }
+
+    /// Get the source code of the parser's nth token.
+    fn nth_text<'l, Lex>(&mut self, n: usize) -> Option<&str>
+    where
+        Lex: LexerWithCheckpoint<'l, Kind = Self::Kind>,
+        Self::Source: NthToken<Lex> + TokenSourceWithBufferedLexer<Lex>,
+    {
+        let range = self.source_mut().nth_range(n)?;
+        let range: Range<usize> = range.into();
+
+        self.source().text().get(range)
     }
 
     /// Checks if the parser is currently at a specific token

--- a/crates/biome_parser/src/token_source.rs
+++ b/crates/biome_parser/src/token_source.rs
@@ -120,6 +120,9 @@ pub trait NthToken<Lex>: TokenSource {
     /// Gets the kind of the nth non-trivia token
     fn nth(&mut self, n: usize) -> Self::Kind;
 
+    /// Gets the range of the nth non-trivia token.
+    fn nth_range(&mut self, n: usize) -> Option<TextRange>;
+
     /// Returns true if the nth non-trivia token is preceded by a line break
     fn has_nth_preceding_line_break(&mut self, n: usize) -> bool;
 
@@ -140,6 +143,17 @@ where
             self.lexer()
                 .nth_non_trivia(n)
                 .map_or(T::Kind::EOF, |lookahead| lookahead.kind())
+        }
+    }
+
+    /// Gets the range of the nth non-trivia token.
+    fn nth_range(&mut self, n: usize) -> Option<TextRange> {
+        if n == 0 {
+            Some(self.current_range())
+        } else {
+            self.lexer()
+                .nth_non_trivia(n)
+                .map(|lookahead| lookahead.text_range())
         }
     }
 


### PR DESCRIPTION
  ## Summary

  Adds SCSS parser support for plain CSS custom `@function` rules while keeping Sass functions on the existing Sass parser path.

  ```scss
  @function --highlight() {
  	result: var(--highlight, #{$highlight});
  }

  @function double($value) {
  	@return $value * 2;
  }
```

  > This PR was implemented with assistance from OpenAI Codex.

  ## Test Plan

  - cargo test -p biome_css_parser
