### PR TITLE
feat(css_parser): add support for parsing and formatting unknown SCSS/CSS at-rules

### DIFF
--- a/crates/biome_css_analyze/src/lint/suspicious/no_unknown_at_rules.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_unknown_at_rules.rs
@@ -2,7 +2,7 @@ use biome_analyze::{
     Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
-use biome_css_syntax::{CssUnknownBlockAtRule, CssUnknownValueAtRule};
+use biome_css_syntax::{AnyCssUnknownAtRuleName, CssUnknownBlockAtRule, CssUnknownValueAtRule};
 use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, TextRange, declare_node_union};
 use biome_rule_options::no_unknown_at_rules::NoUnknownAtRulesOptions;
@@ -79,6 +79,16 @@ declare_node_union! {
   pub AnyUnknownAtRule = CssUnknownBlockAtRule | CssUnknownValueAtRule
 }
 
+/// Returns a static name for rules like `@unknown`; dynamic Sass names such as
+/// `@#{$rule-name}` are not comparable with the configured ignore list.
+fn static_unknown_at_rule_name(name: AnyCssUnknownAtRuleName) -> Option<(TextRange, String)> {
+    let identifier = name.as_css_identifier()?;
+    Some((
+        identifier.range(),
+        identifier.value_token().ok()?.text_trimmed().to_string(),
+    ))
+}
+
 /// Determines if the given unknown at-rule name should be ignored.
 fn should_ignore(name: &str, options: &NoUnknownAtRulesOptions) -> bool {
     for ignore_pattern in &options.ignore {
@@ -106,7 +116,7 @@ impl Rule for NoUnknownAtRules {
             AnyUnknownAtRule::CssUnknownBlockAtRule(rule) => rule.name().ok()?,
             AnyUnknownAtRule::CssUnknownValueAtRule(rule) => rule.name().ok()?,
         };
-        let name = rule.value_token().ok()?.text_trimmed().to_string();
+        let (range, name) = static_unknown_at_rule_name(rule)?;
 
         // Check if this unknown at-rule should be ignored
         if should_ignore(&name, ctx.options()) {
@@ -114,7 +124,7 @@ impl Rule for NoUnknownAtRules {
         }
 
         Some(NoUnknownAtRuleState {
-            range: rule.range(),
+            range,
             name,
         })
     }

--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -2902,7 +2902,7 @@ pub fn css_unknown_attr_unit(unit_token: SyntaxToken) -> CssUnknownAttrUnit {
     ))
 }
 pub fn css_unknown_block_at_rule(
-    name: CssIdentifier,
+    name: AnyCssUnknownAtRuleName,
     components: CssUnknownAtRuleComponentList,
     block: AnyCssDeclarationOrRuleBlock,
 ) -> CssUnknownBlockAtRule {
@@ -2934,7 +2934,7 @@ pub fn css_unknown_syntax_type_name(name_token: SyntaxToken) -> CssUnknownSyntax
     ))
 }
 pub fn css_unknown_value_at_rule(
-    name: CssIdentifier,
+    name: AnyCssUnknownAtRuleName,
     components: CssUnknownAtRuleComponentList,
     semicolon_token: SyntaxToken,
 ) -> CssUnknownValueAtRule {

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -5970,7 +5970,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
-                    && CssIdentifier::can_cast(element.kind())
+                    && AnyCssUnknownAtRuleName::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();
@@ -6048,7 +6048,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
-                    && CssIdentifier::can_cast(element.kind())
+                    && AnyCssUnknownAtRuleName::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_css_formatter/src/css/any/mod.rs
+++ b/crates/biome_css_formatter/src/css/any/mod.rs
@@ -108,6 +108,7 @@ pub(crate) mod syntax_single_component;
 pub(crate) mod syntax_type_name;
 pub(crate) mod ts_type;
 pub(crate) mod unicode_value;
+pub(crate) mod unknown_at_rule_name;
 pub(crate) mod url_modifier;
 pub(crate) mod url_value;
 pub(crate) mod value;

--- a/crates/biome_css_formatter/src/css/any/unknown_at_rule_name.rs
+++ b/crates/biome_css_formatter/src/css/any/unknown_at_rule_name.rs
@@ -1,0 +1,16 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
+
+use crate::prelude::*;
+use biome_css_syntax::AnyCssUnknownAtRuleName;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatAnyCssUnknownAtRuleName;
+impl FormatRule<AnyCssUnknownAtRuleName> for FormatAnyCssUnknownAtRuleName {
+    type Context = CssFormatContext;
+    fn fmt(&self, node: &AnyCssUnknownAtRuleName, f: &mut CssFormatter) -> FormatResult<()> {
+        match node {
+            AnyCssUnknownAtRuleName::CssIdentifier(node) => node.format().fmt(f),
+            AnyCssUnknownAtRuleName::ScssInterpolatedIdentifier(node) => node.format().fmt(f),
+            AnyCssUnknownAtRuleName::ScssInterpolation(node) => node.format().fmt(f),
+        }
+    }
+}

--- a/crates/biome_css_formatter/src/generated.rs
+++ b/crates/biome_css_formatter/src/generated.rs
@@ -15171,6 +15171,31 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssUnicodeValue {
         )
     }
 }
+impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssUnknownAtRuleName {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_css_syntax::AnyCssUnknownAtRuleName,
+        crate::css::any::unknown_at_rule_name::FormatAnyCssUnknownAtRuleName,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::css::any::unknown_at_rule_name::FormatAnyCssUnknownAtRuleName::default(),
+        )
+    }
+}
+impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssUnknownAtRuleName {
+    type Format = FormatOwnedWithRule<
+        biome_css_syntax::AnyCssUnknownAtRuleName,
+        crate::css::any::unknown_at_rule_name::FormatAnyCssUnknownAtRuleName,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::css::any::unknown_at_rule_name::FormatAnyCssUnknownAtRuleName::default(),
+        )
+    }
+}
 impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssUrlModifier {
     type Format<'a> = FormatRefWithRule<
         'a,

--- a/crates/biome_css_formatter/tests/specs/css/atrule/unknown.css
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/unknown.css
@@ -5,3 +5,5 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@future fn({ width:300px })   query{color:red}

--- a/crates/biome_css_formatter/tests/specs/css/atrule/unknown.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/unknown.css.snap
@@ -14,6 +14,8 @@ info: css/atrule/unknown.css
 @tailwind components;
 @tailwind utilities;
 
+@future fn({ width:300px })   query{color:red}
+
 ```
 
 
@@ -27,5 +29,9 @@ info: css/atrule/unknown.css
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@future fn({ width:300px })   query {
+	color: red;
+}
 
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/case/case.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/case/case.scss.snap
@@ -443,28 +443,3 @@ TABLE {
   }
 }
 ```
-
-# Errors
-```
-case.scss:7:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a string but instead found 'Keep'.
-  
-    5 │ // - Other things should mostly be lowercase.
-    6 │ 
-  > 7 │ @IMPORT Keep;
-      │         ^^^^
-    8 │ 
-    9 │ HTML#KeepId.KeepClass,
-  
-  i Expected a string here.
-  
-    5 │ // - Other things should mostly be lowercase.
-    6 │ 
-  > 7 │ @IMPORT Keep;
-      │         ^^^^
-    8 │ 
-    9 │ HTML#KeepId.KeepClass,
-  
-
-```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/case/case.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/case/case.scss.snap
@@ -443,3 +443,28 @@ TABLE {
   }
 }
 ```
+
+# Errors
+```
+case.scss:7:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a string but instead found 'Keep'.
+  
+    5 │ // - Other things should mostly be lowercase.
+    6 │ 
+  > 7 │ @IMPORT Keep;
+      │         ^^^^
+    8 │ 
+    9 │ HTML#KeepId.KeepClass,
+  
+  i Expected a string here.
+  
+    5 │ // - Other things should mostly be lowercase.
+    6 │ 
+  > 7 │ @IMPORT Keep;
+      │         ^^^^
+    8 │ 
+    9 │ HTML#KeepId.KeepClass,
+  
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/generic-css-at-rules.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/generic-css-at-rules.scss
@@ -1,0 +1,7 @@
+@IMPORT    Keep;
+
+@#{$rule-name}   #{$value};
+
+@unknown   #{meta.inspect($value)}{color:red}
+
+@unknown fn({ width: 300px })   #{$query}{color:red}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/generic-css-at-rules.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/generic-css-at-rules.scss
@@ -1,5 +1,3 @@
-@IMPORT    Keep;
-
 @#{$rule-name}   #{$value};
 
 @unknown   #{meta.inspect($value)}{color:red}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/generic-css-at-rules.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/generic-css-at-rules.scss.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
+info: scss/at-rule/generic-css-at-rules.scss
+---
+
+# Input
+
+```scss
+@IMPORT    Keep;
+
+@#{$rule-name}   #{$value};
+
+@unknown   #{meta.inspect($value)}{color:red}
+
+@unknown fn({ width: 300px })   #{$query}{color:red}
+
+```
+
+
+# Formatted
+
+```scss
+@IMPORT Keep;
+
+@#{$rule-name} #{$value};
+
+@unknown #{meta.inspect($value)} {
+	color: red;
+}
+
+@unknown fn({ width: 300px })   #{$query} {
+	color: red;
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/generic-css-at-rules.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/generic-css-at-rules.scss.snap
@@ -1,14 +1,11 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 249
 info: scss/at-rule/generic-css-at-rules.scss
 ---
 
 # Input
 
 ```scss
-@IMPORT    Keep;
-
 @#{$rule-name}   #{$value};
 
 @unknown   #{meta.inspect($value)}{color:red}
@@ -21,8 +18,6 @@ info: scss/at-rule/generic-css-at-rules.scss
 # Formatted
 
 ```scss
-@IMPORT Keep;
-
 @#{$rule-name} #{$value};
 
 @unknown #{meta.inspect($value)} {

--- a/crates/biome_css_parser/src/syntax/at_rule/mod.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/mod.rs
@@ -151,6 +151,10 @@ pub(crate) fn parse_any_at_rule(p: &mut CssParser) -> ParsedSyntax {
         T![layer] => parse_layer_at_rule(p),
         T![scope] => parse_scope_at_rule(p),
         T![supports] => parse_supports_at_rule(p),
+        T![import] if CssSyntaxFeatures::Scss.is_supported(p) && p.cur_text() != "import" => {
+            // `@IMPORT Keep;` is a plain CSS at-rule in SCSS, not Sass `@import`.
+            parse_unknown_at_rule(p)
+        }
         T![import] => CssSyntaxFeatures::Scss
             .parse_supported_syntax(p, parse_scss_import_at_rule)
             .or_else(|| parse_import_at_rule(p)),

--- a/crates/biome_css_parser/src/syntax/at_rule/mod.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/mod.rs
@@ -151,10 +151,6 @@ pub(crate) fn parse_any_at_rule(p: &mut CssParser) -> ParsedSyntax {
         T![layer] => parse_layer_at_rule(p),
         T![scope] => parse_scope_at_rule(p),
         T![supports] => parse_supports_at_rule(p),
-        T![import] if CssSyntaxFeatures::Scss.is_supported(p) && p.cur_text() != "import" => {
-            // `@IMPORT Keep;` is a plain CSS at-rule in SCSS, not Sass `@import`.
-            parse_unknown_at_rule(p)
-        }
         T![import] => CssSyntaxFeatures::Scss
             .parse_supported_syntax(p, parse_scss_import_at_rule)
             .or_else(|| parse_import_at_rule(p)),

--- a/crates/biome_css_parser/src/syntax/at_rule/unknown.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/unknown.rs
@@ -1,27 +1,33 @@
 use crate::parser::CssParser;
 use crate::syntax::block::parse_declaration_or_rule_list_block;
-use crate::syntax::{is_at_identifier, parse_regular_identifier};
+use crate::syntax::scss::{
+    is_at_scss_interpolation, parse_scss_identifier_or_interpolation,
+    parse_scss_regular_interpolation,
+};
+use crate::syntax::{CssSyntaxFeatures, is_at_identifier, parse_regular_identifier};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::T;
+use biome_parser::CompletedMarker;
+use biome_parser::ParserProgress;
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
 
-/// Checks if the parser is currently at an unknown CSS at-rule.
-///
-/// An unknown CSS at-rule is identified by being an identifier followed by optional parameters,
-/// such as `@my-custom-rule param;` or `@unknown-rule { /* CSS content */ }`.
 #[inline]
 pub(crate) fn is_at_unknown_at_rule(p: &mut CssParser) -> bool {
-    is_at_identifier(p)
+    is_at_identifier(p) || CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_interpolation(p)
 }
 
-/// Represents an unknown or unsupported CSS at-rule during parsing.
+/// Parses an unknown CSS at-rule, including Sass plain-CSS passthroughs.
 ///
-/// When encountered during parsing, `CssUnknownAtRule` serves as a fallback mechanism,
-/// allowing the parser to continue processing the stylesheet by treating the unsupported rule
-/// as part of an unformed tree. This enables graceful handling of CSS constructs that are not
-/// supported by the parser, ensuring that the stylesheet can still be processed without errors.
+/// Examples:
+/// ```scss
+/// @unknown #{$value};
+/// @#{$rule-name} #{$value};
+/// @unknown #{meta.inspect($value)} { color: red; }
+/// ```
+///
+/// Docs: https://sass-lang.com/documentation/at-rules/css/
 #[inline]
 pub(crate) fn parse_unknown_at_rule(p: &mut CssParser) -> ParsedSyntax {
     if !is_at_unknown_at_rule(p) {
@@ -30,21 +36,9 @@ pub(crate) fn parse_unknown_at_rule(p: &mut CssParser) -> ParsedSyntax {
 
     let m = p.start();
 
-    parse_regular_identifier(p).ok(); // we've checked that the next token is an identifier
-
-    {
-        let m = p.start();
-
-        // Skip all tokens until the end of the property value or the next property.
-        // EOF indicates the end of the file.
-        // '{' indicates the start of a block.
-        // ';' indicates the end of the property value.
-        while !(p.at(EOF) || p.at(T!['{']) || p.at(T![;])) {
-            p.bump_any();
-        }
-
-        m.complete(p, CSS_UNKNOWN_AT_RULE_COMPONENT_LIST);
-    }
+    // Guarded by `is_at_unknown_at_rule`.
+    parse_unknown_at_rule_name(p).ok();
+    parse_unknown_at_rule_components(p);
 
     let kind = if p.at(T!['{']) {
         parse_declaration_or_rule_list_block(p);
@@ -55,4 +49,94 @@ pub(crate) fn parse_unknown_at_rule(p: &mut CssParser) -> ParsedSyntax {
     };
 
     Present(m.complete(p, kind))
+}
+
+#[inline]
+fn parse_unknown_at_rule_name(p: &mut CssParser) -> ParsedSyntax {
+    if CssSyntaxFeatures::Scss.is_supported(p) {
+        parse_scss_identifier_or_interpolation(p)
+    } else {
+        parse_regular_identifier(p)
+    }
+}
+
+/// Parses the generic at-rule prelude before `;` or a top-level block.
+///
+/// Example: `@unknown fn({ width: 300px }) #{$query} {}` keeps the function
+/// body balanced while the final `{` starts the at-rule block.
+#[inline]
+fn parse_unknown_at_rule_components(p: &mut CssParser) -> CompletedMarker {
+    let m = p.start();
+    let mut progress = ParserProgress::default();
+    let mut balance = UnknownAtRuleComponentBalance::default();
+
+    while !balance.is_at_end(p) {
+        progress.assert_progressing(p);
+
+        if CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_interpolation(p) {
+            // `@unknown #{$value};`: keep interpolation structured inside the
+            // otherwise token-shaped generic prelude.
+            parse_scss_regular_interpolation(p).ok();
+        } else {
+            balance.bump(p);
+        }
+    }
+
+    m.complete(p, CSS_UNKNOWN_AT_RULE_COMPONENT_LIST)
+}
+
+/// Tracks nested delimiters inside an unknown at-rule prelude.
+///
+/// Example: in `@unknown fn({ width: 300px }) #{$query} {}`, the inner
+/// `{ width: 300px }` stays in the prelude and the top-level `{` starts the
+/// at-rule block.
+#[derive(Default)]
+struct UnknownAtRuleComponentBalance {
+    paren_depth: usize,
+    bracket_depth: usize,
+    curly_depth: usize,
+}
+
+impl UnknownAtRuleComponentBalance {
+    #[inline]
+    fn is_at_end(&self, p: &mut CssParser) -> bool {
+        if p.at(EOF) {
+            return true;
+        }
+
+        if !self.is_at_top_level() {
+            return false;
+        }
+
+        // `@unknown #{x} {}`: the top-level block starts after the prelude.
+        p.at(T!['{'])
+            // `@unknown #{x};`: a semicolon ends a value at-rule.
+            || p.at(T![;])
+            // `@mixin x { @unknown #{x} }`: the parent block closes a
+            // semicolonless value at-rule.
+            || p.at(T!['}'])
+            // `@unknown #{x}\n@media {}`: a new at-rule starts recovery for a
+            // missing semicolon.
+            || p.at(T![@]) && p.has_preceding_line_break()
+    }
+
+    #[inline]
+    fn is_at_top_level(&self) -> bool {
+        self.paren_depth == 0 && self.bracket_depth == 0 && self.curly_depth == 0
+    }
+
+    #[inline]
+    fn bump(&mut self, p: &mut CssParser) {
+        match p.cur() {
+            T!['('] => self.paren_depth += 1,
+            T![')'] => self.paren_depth = self.paren_depth.saturating_sub(1),
+            T!['['] => self.bracket_depth += 1,
+            T![']'] => self.bracket_depth = self.bracket_depth.saturating_sub(1),
+            T!['{'] => self.curly_depth += 1,
+            T!['}'] => self.curly_depth = self.curly_depth.saturating_sub(1),
+            _ => {}
+        }
+
+        p.bump_any();
+    }
 }

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/generic-css-at-rules.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/generic-css-at-rules.scss
@@ -1,0 +1,5 @@
+@#{$rule-name} #{$value}
+
+@mixin boundary {
+  @unknown #{$value}
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/generic-css-at-rules.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/generic-css-at-rules.scss.snap
@@ -1,0 +1,205 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+assertion_line: 206
+expression: snapshot
+---
+
+## Input
+
+```css
+@#{$rule-name} #{$value}
+
+@mixin boundary {
+  @unknown #{$value}
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssUnknownValueAtRule {
+                name: ScssInterpolation {
+                    hash_token: HASH@1..2 "#" [] [],
+                    l_curly_token: L_CURLY@2..3 "{" [] [],
+                    value: ScssExpression {
+                        items: ScssExpressionItemList [
+                            ScssVariable {
+                                dollar_token: DOLLAR@3..4 "$" [] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@4..13 "rule-name" [] [],
+                                },
+                            },
+                        ],
+                    },
+                    r_curly_token: R_CURLY@13..15 "}" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        ScssInterpolation {
+                            hash_token: HASH@15..16 "#" [] [],
+                            l_curly_token: L_CURLY@16..17 "{" [] [],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    ScssVariable {
+                                        dollar_token: DOLLAR@17..18 "$" [] [],
+                                        name: CssIdentifier {
+                                            value_token: IDENT@18..23 "value" [] [],
+                                        },
+                                    },
+                                ],
+                            },
+                            r_curly_token: R_CURLY@23..24 "}" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: missing (required),
+            },
+        },
+        CssAtRule {
+            at_token: AT@24..27 "@" [Newline("\n"), Newline("\n")] [],
+            rule: ScssMixinAtRule {
+                mixin_token: MIXIN_KW@27..33 "mixin" [] [Whitespace(" ")],
+                name: CssIdentifier {
+                    value_token: IDENT@33..42 "boundary" [] [Whitespace(" ")],
+                },
+                parameters: missing (optional),
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@42..43 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssAtRule {
+                            at_token: AT@43..47 "@" [Newline("\n"), Whitespace("  ")] [],
+                            rule: CssUnknownValueAtRule {
+                                name: CssIdentifier {
+                                    value_token: IDENT@47..55 "unknown" [] [Whitespace(" ")],
+                                },
+                                components: CssUnknownAtRuleComponentList {
+                                    items: [
+                                        ScssInterpolation {
+                                            hash_token: HASH@55..56 "#" [] [],
+                                            l_curly_token: L_CURLY@56..57 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@57..58 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@58..63 "value" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@63..64 "}" [] [],
+                                        },
+                                    ],
+                                },
+                                semicolon_token: missing (required),
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@64..66 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@66..67 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..67
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..66
+    0: CSS_AT_RULE@0..24
+      0: AT@0..1 "@" [] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@1..24
+        0: SCSS_INTERPOLATION@1..15
+          0: HASH@1..2 "#" [] []
+          1: L_CURLY@2..3 "{" [] []
+          2: SCSS_EXPRESSION@3..13
+            0: SCSS_EXPRESSION_ITEM_LIST@3..13
+              0: SCSS_VARIABLE@3..13
+                0: DOLLAR@3..4 "$" [] []
+                1: CSS_IDENTIFIER@4..13
+                  0: IDENT@4..13 "rule-name" [] []
+          3: R_CURLY@13..15 "}" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@15..24
+          0: SCSS_INTERPOLATION@15..24
+            0: HASH@15..16 "#" [] []
+            1: L_CURLY@16..17 "{" [] []
+            2: SCSS_EXPRESSION@17..23
+              0: SCSS_EXPRESSION_ITEM_LIST@17..23
+                0: SCSS_VARIABLE@17..23
+                  0: DOLLAR@17..18 "$" [] []
+                  1: CSS_IDENTIFIER@18..23
+                    0: IDENT@18..23 "value" [] []
+            3: R_CURLY@23..24 "}" [] []
+        2: (empty)
+    1: CSS_AT_RULE@24..66
+      0: AT@24..27 "@" [Newline("\n"), Newline("\n")] []
+      1: SCSS_MIXIN_AT_RULE@27..66
+        0: MIXIN_KW@27..33 "mixin" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@33..42
+          0: IDENT@33..42 "boundary" [] [Whitespace(" ")]
+        2: (empty)
+        3: CSS_DECLARATION_OR_RULE_BLOCK@42..66
+          0: L_CURLY@42..43 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@43..64
+            0: CSS_AT_RULE@43..64
+              0: AT@43..47 "@" [Newline("\n"), Whitespace("  ")] []
+              1: CSS_UNKNOWN_VALUE_AT_RULE@47..64
+                0: CSS_IDENTIFIER@47..55
+                  0: IDENT@47..55 "unknown" [] [Whitespace(" ")]
+                1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@55..64
+                  0: SCSS_INTERPOLATION@55..64
+                    0: HASH@55..56 "#" [] []
+                    1: L_CURLY@56..57 "{" [] []
+                    2: SCSS_EXPRESSION@57..63
+                      0: SCSS_EXPRESSION_ITEM_LIST@57..63
+                        0: SCSS_VARIABLE@57..63
+                          0: DOLLAR@57..58 "$" [] []
+                          1: CSS_IDENTIFIER@58..63
+                            0: IDENT@58..63 "value" [] []
+                    3: R_CURLY@63..64 "}" [] []
+                2: (empty)
+          2: R_CURLY@64..66 "}" [Newline("\n")] []
+  2: EOF@66..67 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+generic-css-at-rules.scss:3:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `;` but instead found `@`
+  
+    1 │ @#{$rule-name} #{$value}
+    2 │ 
+  > 3 │ @mixin boundary {
+      │ ^
+    4 │   @unknown #{$value}
+    5 │ }
+  
+  i Remove @
+  
+generic-css-at-rules.scss:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `;` but instead found `}`
+  
+    3 │ @mixin boundary {
+    4 │   @unknown #{$value}
+  > 5 │ }
+      │ ^
+    6 │ 
+  
+  i Remove }
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_unknown.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_unknown.css
@@ -5,3 +5,7 @@
 @fake base;
 @fake components;
 @fake utilities;
+
+@fake fn({ width: 300px }) query {
+	color: red;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_unknown.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/at_rule_unknown.css.snap
@@ -14,6 +14,10 @@ expression: snapshot
 @fake components;
 @fake utilities;
 
+@fake fn({ width: 300px }) query {
+	color: red;
+}
+
 ```
 
 
@@ -112,17 +116,62 @@ CssRoot {
                 semicolon_token: SEMICOLON@106..107 ";" [] [],
             },
         },
+        CssAtRule {
+            at_token: AT@107..110 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@110..115 "fake" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        IDENT@115..117 "fn" [] [],
+                        L_PAREN@117..118 "(" [] [],
+                        L_CURLY@118..120 "{" [] [Whitespace(" ")],
+                        IDENT@120..125 "width" [] [],
+                        COLON@125..127 ":" [] [Whitespace(" ")],
+                        CSS_DIMENSION_VALUE@127..130 "300" [] [],
+                        PX_KW@130..133 "px" [] [Whitespace(" ")],
+                        R_CURLY@133..134 "}" [] [],
+                        R_PAREN@134..136 ")" [] [Whitespace(" ")],
+                        IDENT@136..142 "query" [] [Whitespace(" ")],
+                    ],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@142..143 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@143..150 "color" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@150..152 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@152..155 "red" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@155..156 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@156..158 "}" [Newline("\n")] [],
+                },
+            },
+        },
     ],
-    eof_token: EOF@107..108 "" [Newline("\n")] [],
+    eof_token: EOF@158..159 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..108
+0: CSS_ROOT@0..159
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..107
+  1: CSS_ROOT_ITEM_LIST@0..158
     0: CSS_QUALIFIED_RULE@0..59
       0: CSS_SELECTOR_LIST@0..11
         0: CSS_COMPOUND_SELECTOR@0..11
@@ -180,6 +229,37 @@ CssRoot {
         1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@97..106
           0: IDENT@97..106 "utilities" [] []
         2: SEMICOLON@106..107 ";" [] []
-  2: EOF@107..108 "" [Newline("\n")] []
+    4: CSS_AT_RULE@107..158
+      0: AT@107..110 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@110..158
+        0: CSS_IDENTIFIER@110..115
+          0: IDENT@110..115 "fake" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@115..142
+          0: IDENT@115..117 "fn" [] []
+          1: L_PAREN@117..118 "(" [] []
+          2: L_CURLY@118..120 "{" [] [Whitespace(" ")]
+          3: IDENT@120..125 "width" [] []
+          4: COLON@125..127 ":" [] [Whitespace(" ")]
+          5: CSS_DIMENSION_VALUE@127..130 "300" [] []
+          6: PX_KW@130..133 "px" [] [Whitespace(" ")]
+          7: R_CURLY@133..134 "}" [] []
+          8: R_PAREN@134..136 ")" [] [Whitespace(" ")]
+          9: IDENT@136..142 "query" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@142..158
+          0: L_CURLY@142..143 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@143..156
+            0: CSS_DECLARATION_WITH_SEMICOLON@143..156
+              0: CSS_DECLARATION@143..155
+                0: CSS_GENERIC_PROPERTY@143..155
+                  0: CSS_IDENTIFIER@143..150
+                    0: IDENT@143..150 "color" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@150..152 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@152..155
+                    0: CSS_IDENTIFIER@152..155
+                      0: IDENT@152..155 "red" [] []
+                1: (empty)
+              1: SEMICOLON@155..156 ";" [] []
+          2: R_CURLY@156..158 "}" [Newline("\n")] []
+  2: EOF@158..159 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/generic-css-at-rules.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/generic-css-at-rules.scss
@@ -1,5 +1,3 @@
-@IMPORT Keep;
-
 @#{$rule-name} #{$value};
 
 @unknown #{meta.inspect($value)} {

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/generic-css-at-rules.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/generic-css-at-rules.scss
@@ -1,0 +1,11 @@
+@IMPORT Keep;
+
+@#{$rule-name} #{$value};
+
+@unknown #{meta.inspect($value)} {
+  color: red;
+}
+
+@unknown fn({ width: 300px }) #{$query} {
+  color: red;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/generic-css-at-rules.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/generic-css-at-rules.scss.snap
@@ -1,0 +1,348 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+assertion_line: 206
+expression: snapshot
+---
+
+## Input
+
+```css
+@IMPORT Keep;
+
+@#{$rule-name} #{$value};
+
+@unknown #{meta.inspect($value)} {
+  color: red;
+}
+
+@unknown fn({ width: 300px }) #{$query} {
+  color: red;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@1..8 "IMPORT" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        IDENT@8..12 "Keep" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@12..13 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@13..16 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: ScssInterpolation {
+                    hash_token: HASH@16..17 "#" [] [],
+                    l_curly_token: L_CURLY@17..18 "{" [] [],
+                    value: ScssExpression {
+                        items: ScssExpressionItemList [
+                            ScssVariable {
+                                dollar_token: DOLLAR@18..19 "$" [] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@19..28 "rule-name" [] [],
+                                },
+                            },
+                        ],
+                    },
+                    r_curly_token: R_CURLY@28..30 "}" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        ScssInterpolation {
+                            hash_token: HASH@30..31 "#" [] [],
+                            l_curly_token: L_CURLY@31..32 "{" [] [],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    ScssVariable {
+                                        dollar_token: DOLLAR@32..33 "$" [] [],
+                                        name: CssIdentifier {
+                                            value_token: IDENT@33..38 "value" [] [],
+                                        },
+                                    },
+                                ],
+                            },
+                            r_curly_token: R_CURLY@38..39 "}" [] [],
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@39..40 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@40..43 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@43..51 "unknown" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        ScssInterpolation {
+                            hash_token: HASH@51..52 "#" [] [],
+                            l_curly_token: L_CURLY@52..53 "{" [] [],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    CssFunction {
+                                        name: ScssModuleMemberAccess {
+                                            module: CssIdentifier {
+                                                value_token: IDENT@53..57 "meta" [] [],
+                                            },
+                                            dot_token: DOT@57..58 "." [] [],
+                                            member: CssIdentifier {
+                                                value_token: IDENT@58..65 "inspect" [] [],
+                                            },
+                                        },
+                                        l_paren_token: L_PAREN@65..66 "(" [] [],
+                                        items: CssParameterList [
+                                            ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@66..67 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@67..72 "value" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@72..73 ")" [] [],
+                                    },
+                                ],
+                            },
+                            r_curly_token: R_CURLY@73..75 "}" [] [Whitespace(" ")],
+                        },
+                    ],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@75..76 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@76..84 "color" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    colon_token: COLON@84..86 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@86..89 "red" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@89..90 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@90..92 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@92..95 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@95..103 "unknown" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        IDENT@103..105 "fn" [] [],
+                        L_PAREN@105..106 "(" [] [],
+                        L_CURLY@106..108 "{" [] [Whitespace(" ")],
+                        IDENT@108..113 "width" [] [],
+                        COLON@113..115 ":" [] [Whitespace(" ")],
+                        CSS_DIMENSION_VALUE@115..118 "300" [] [],
+                        PX_KW@118..121 "px" [] [Whitespace(" ")],
+                        R_CURLY@121..122 "}" [] [],
+                        R_PAREN@122..124 ")" [] [Whitespace(" ")],
+                        ScssInterpolation {
+                            hash_token: HASH@124..125 "#" [] [],
+                            l_curly_token: L_CURLY@125..126 "{" [] [],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    ScssVariable {
+                                        dollar_token: DOLLAR@126..127 "$" [] [],
+                                        name: CssIdentifier {
+                                            value_token: IDENT@127..132 "query" [] [],
+                                        },
+                                    },
+                                ],
+                            },
+                            r_curly_token: R_CURLY@132..134 "}" [] [Whitespace(" ")],
+                        },
+                    ],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@134..135 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@135..143 "color" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    colon_token: COLON@143..145 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@145..148 "red" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@148..149 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@149..151 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@151..152 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..152
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..151
+    0: CSS_AT_RULE@0..13
+      0: AT@0..1 "@" [] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@1..13
+        0: CSS_IDENTIFIER@1..8
+          0: IDENT@1..8 "IMPORT" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@8..12
+          0: IDENT@8..12 "Keep" [] []
+        2: SEMICOLON@12..13 ";" [] []
+    1: CSS_AT_RULE@13..40
+      0: AT@13..16 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@16..40
+        0: SCSS_INTERPOLATION@16..30
+          0: HASH@16..17 "#" [] []
+          1: L_CURLY@17..18 "{" [] []
+          2: SCSS_EXPRESSION@18..28
+            0: SCSS_EXPRESSION_ITEM_LIST@18..28
+              0: SCSS_VARIABLE@18..28
+                0: DOLLAR@18..19 "$" [] []
+                1: CSS_IDENTIFIER@19..28
+                  0: IDENT@19..28 "rule-name" [] []
+          3: R_CURLY@28..30 "}" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@30..39
+          0: SCSS_INTERPOLATION@30..39
+            0: HASH@30..31 "#" [] []
+            1: L_CURLY@31..32 "{" [] []
+            2: SCSS_EXPRESSION@32..38
+              0: SCSS_EXPRESSION_ITEM_LIST@32..38
+                0: SCSS_VARIABLE@32..38
+                  0: DOLLAR@32..33 "$" [] []
+                  1: CSS_IDENTIFIER@33..38
+                    0: IDENT@33..38 "value" [] []
+            3: R_CURLY@38..39 "}" [] []
+        2: SEMICOLON@39..40 ";" [] []
+    2: CSS_AT_RULE@40..92
+      0: AT@40..43 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@43..92
+        0: CSS_IDENTIFIER@43..51
+          0: IDENT@43..51 "unknown" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@51..75
+          0: SCSS_INTERPOLATION@51..75
+            0: HASH@51..52 "#" [] []
+            1: L_CURLY@52..53 "{" [] []
+            2: SCSS_EXPRESSION@53..73
+              0: SCSS_EXPRESSION_ITEM_LIST@53..73
+                0: CSS_FUNCTION@53..73
+                  0: SCSS_MODULE_MEMBER_ACCESS@53..65
+                    0: CSS_IDENTIFIER@53..57
+                      0: IDENT@53..57 "meta" [] []
+                    1: DOT@57..58 "." [] []
+                    2: CSS_IDENTIFIER@58..65
+                      0: IDENT@58..65 "inspect" [] []
+                  1: L_PAREN@65..66 "(" [] []
+                  2: CSS_PARAMETER_LIST@66..72
+                    0: SCSS_EXPRESSION@66..72
+                      0: SCSS_EXPRESSION_ITEM_LIST@66..72
+                        0: SCSS_VARIABLE@66..72
+                          0: DOLLAR@66..67 "$" [] []
+                          1: CSS_IDENTIFIER@67..72
+                            0: IDENT@67..72 "value" [] []
+                  3: R_PAREN@72..73 ")" [] []
+            3: R_CURLY@73..75 "}" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@75..92
+          0: L_CURLY@75..76 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@76..90
+            0: CSS_DECLARATION_WITH_SEMICOLON@76..90
+              0: CSS_DECLARATION@76..89
+                0: CSS_GENERIC_PROPERTY@76..89
+                  0: CSS_IDENTIFIER@76..84
+                    0: IDENT@76..84 "color" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@84..86 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@86..89
+                    0: SCSS_EXPRESSION_ITEM_LIST@86..89
+                      0: CSS_IDENTIFIER@86..89
+                        0: IDENT@86..89 "red" [] []
+                1: (empty)
+              1: SEMICOLON@89..90 ";" [] []
+          2: R_CURLY@90..92 "}" [Newline("\n")] []
+    3: CSS_AT_RULE@92..151
+      0: AT@92..95 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@95..151
+        0: CSS_IDENTIFIER@95..103
+          0: IDENT@95..103 "unknown" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@103..134
+          0: IDENT@103..105 "fn" [] []
+          1: L_PAREN@105..106 "(" [] []
+          2: L_CURLY@106..108 "{" [] [Whitespace(" ")]
+          3: IDENT@108..113 "width" [] []
+          4: COLON@113..115 ":" [] [Whitespace(" ")]
+          5: CSS_DIMENSION_VALUE@115..118 "300" [] []
+          6: PX_KW@118..121 "px" [] [Whitespace(" ")]
+          7: R_CURLY@121..122 "}" [] []
+          8: R_PAREN@122..124 ")" [] [Whitespace(" ")]
+          9: SCSS_INTERPOLATION@124..134
+            0: HASH@124..125 "#" [] []
+            1: L_CURLY@125..126 "{" [] []
+            2: SCSS_EXPRESSION@126..132
+              0: SCSS_EXPRESSION_ITEM_LIST@126..132
+                0: SCSS_VARIABLE@126..132
+                  0: DOLLAR@126..127 "$" [] []
+                  1: CSS_IDENTIFIER@127..132
+                    0: IDENT@127..132 "query" [] []
+            3: R_CURLY@132..134 "}" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@134..151
+          0: L_CURLY@134..135 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@135..149
+            0: CSS_DECLARATION_WITH_SEMICOLON@135..149
+              0: CSS_DECLARATION@135..148
+                0: CSS_GENERIC_PROPERTY@135..148
+                  0: CSS_IDENTIFIER@135..143
+                    0: IDENT@135..143 "color" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@143..145 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@145..148
+                    0: SCSS_EXPRESSION_ITEM_LIST@145..148
+                      0: CSS_IDENTIFIER@145..148
+                        0: IDENT@145..148 "red" [] []
+                1: (empty)
+              1: SEMICOLON@148..149 ";" [] []
+          2: R_CURLY@149..151 "}" [Newline("\n")] []
+  2: EOF@151..152 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/generic-css-at-rules.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/generic-css-at-rules.scss.snap
@@ -1,14 +1,11 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
-assertion_line: 206
 expression: snapshot
 ---
 
 ## Input
 
 ```css
-@IMPORT Keep;
-
 @#{$rule-name} #{$value};
 
 @unknown #{meta.inspect($value)} {
@@ -31,318 +28,296 @@ CssRoot {
         CssAtRule {
             at_token: AT@0..1 "@" [] [],
             rule: CssUnknownValueAtRule {
-                name: CssIdentifier {
-                    value_token: IDENT@1..8 "IMPORT" [] [Whitespace(" ")],
-                },
-                components: CssUnknownAtRuleComponentList {
-                    items: [
-                        IDENT@8..12 "Keep" [] [],
-                    ],
-                },
-                semicolon_token: SEMICOLON@12..13 ";" [] [],
-            },
-        },
-        CssAtRule {
-            at_token: AT@13..16 "@" [Newline("\n"), Newline("\n")] [],
-            rule: CssUnknownValueAtRule {
                 name: ScssInterpolation {
-                    hash_token: HASH@16..17 "#" [] [],
-                    l_curly_token: L_CURLY@17..18 "{" [] [],
+                    hash_token: HASH@1..2 "#" [] [],
+                    l_curly_token: L_CURLY@2..3 "{" [] [],
                     value: ScssExpression {
                         items: ScssExpressionItemList [
                             ScssVariable {
-                                dollar_token: DOLLAR@18..19 "$" [] [],
+                                dollar_token: DOLLAR@3..4 "$" [] [],
                                 name: CssIdentifier {
-                                    value_token: IDENT@19..28 "rule-name" [] [],
+                                    value_token: IDENT@4..13 "rule-name" [] [],
                                 },
                             },
                         ],
                     },
-                    r_curly_token: R_CURLY@28..30 "}" [] [Whitespace(" ")],
+                    r_curly_token: R_CURLY@13..15 "}" [] [Whitespace(" ")],
                 },
                 components: CssUnknownAtRuleComponentList {
                     items: [
                         ScssInterpolation {
-                            hash_token: HASH@30..31 "#" [] [],
-                            l_curly_token: L_CURLY@31..32 "{" [] [],
+                            hash_token: HASH@15..16 "#" [] [],
+                            l_curly_token: L_CURLY@16..17 "{" [] [],
                             value: ScssExpression {
                                 items: ScssExpressionItemList [
                                     ScssVariable {
-                                        dollar_token: DOLLAR@32..33 "$" [] [],
+                                        dollar_token: DOLLAR@17..18 "$" [] [],
                                         name: CssIdentifier {
-                                            value_token: IDENT@33..38 "value" [] [],
+                                            value_token: IDENT@18..23 "value" [] [],
                                         },
                                     },
                                 ],
                             },
-                            r_curly_token: R_CURLY@38..39 "}" [] [],
+                            r_curly_token: R_CURLY@23..24 "}" [] [],
                         },
                     ],
                 },
-                semicolon_token: SEMICOLON@39..40 ";" [] [],
+                semicolon_token: SEMICOLON@24..25 ";" [] [],
             },
         },
         CssAtRule {
-            at_token: AT@40..43 "@" [Newline("\n"), Newline("\n")] [],
+            at_token: AT@25..28 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssUnknownBlockAtRule {
                 name: CssIdentifier {
-                    value_token: IDENT@43..51 "unknown" [] [Whitespace(" ")],
+                    value_token: IDENT@28..36 "unknown" [] [Whitespace(" ")],
                 },
                 components: CssUnknownAtRuleComponentList {
                     items: [
                         ScssInterpolation {
-                            hash_token: HASH@51..52 "#" [] [],
-                            l_curly_token: L_CURLY@52..53 "{" [] [],
+                            hash_token: HASH@36..37 "#" [] [],
+                            l_curly_token: L_CURLY@37..38 "{" [] [],
                             value: ScssExpression {
                                 items: ScssExpressionItemList [
                                     CssFunction {
                                         name: ScssModuleMemberAccess {
                                             module: CssIdentifier {
-                                                value_token: IDENT@53..57 "meta" [] [],
+                                                value_token: IDENT@38..42 "meta" [] [],
                                             },
-                                            dot_token: DOT@57..58 "." [] [],
+                                            dot_token: DOT@42..43 "." [] [],
                                             member: CssIdentifier {
-                                                value_token: IDENT@58..65 "inspect" [] [],
+                                                value_token: IDENT@43..50 "inspect" [] [],
                                             },
                                         },
-                                        l_paren_token: L_PAREN@65..66 "(" [] [],
+                                        l_paren_token: L_PAREN@50..51 "(" [] [],
                                         items: CssParameterList [
                                             ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     ScssVariable {
-                                                        dollar_token: DOLLAR@66..67 "$" [] [],
+                                                        dollar_token: DOLLAR@51..52 "$" [] [],
                                                         name: CssIdentifier {
-                                                            value_token: IDENT@67..72 "value" [] [],
+                                                            value_token: IDENT@52..57 "value" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
                                         ],
-                                        r_paren_token: R_PAREN@72..73 ")" [] [],
+                                        r_paren_token: R_PAREN@57..58 ")" [] [],
                                     },
                                 ],
                             },
-                            r_curly_token: R_CURLY@73..75 "}" [] [Whitespace(" ")],
+                            r_curly_token: R_CURLY@58..60 "}" [] [Whitespace(" ")],
                         },
                     ],
                 },
                 block: CssDeclarationOrRuleBlock {
-                    l_curly_token: L_CURLY@75..76 "{" [] [],
+                    l_curly_token: L_CURLY@60..61 "{" [] [],
                     items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
                                     name: CssIdentifier {
-                                        value_token: IDENT@76..84 "color" [Newline("\n"), Whitespace("  ")] [],
+                                        value_token: IDENT@61..69 "color" [Newline("\n"), Whitespace("  ")] [],
                                     },
-                                    colon_token: COLON@84..86 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@69..71 ":" [] [Whitespace(" ")],
                                     value: ScssExpression {
                                         items: ScssExpressionItemList [
                                             CssIdentifier {
-                                                value_token: IDENT@86..89 "red" [] [],
+                                                value_token: IDENT@71..74 "red" [] [],
                                             },
                                         ],
                                     },
                                 },
                                 important: missing (optional),
                             },
-                            semicolon_token: SEMICOLON@89..90 ";" [] [],
+                            semicolon_token: SEMICOLON@74..75 ";" [] [],
                         },
                     ],
-                    r_curly_token: R_CURLY@90..92 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@75..77 "}" [Newline("\n")] [],
                 },
             },
         },
         CssAtRule {
-            at_token: AT@92..95 "@" [Newline("\n"), Newline("\n")] [],
+            at_token: AT@77..80 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssUnknownBlockAtRule {
                 name: CssIdentifier {
-                    value_token: IDENT@95..103 "unknown" [] [Whitespace(" ")],
+                    value_token: IDENT@80..88 "unknown" [] [Whitespace(" ")],
                 },
                 components: CssUnknownAtRuleComponentList {
                     items: [
-                        IDENT@103..105 "fn" [] [],
-                        L_PAREN@105..106 "(" [] [],
-                        L_CURLY@106..108 "{" [] [Whitespace(" ")],
-                        IDENT@108..113 "width" [] [],
-                        COLON@113..115 ":" [] [Whitespace(" ")],
-                        CSS_DIMENSION_VALUE@115..118 "300" [] [],
-                        PX_KW@118..121 "px" [] [Whitespace(" ")],
-                        R_CURLY@121..122 "}" [] [],
-                        R_PAREN@122..124 ")" [] [Whitespace(" ")],
+                        IDENT@88..90 "fn" [] [],
+                        L_PAREN@90..91 "(" [] [],
+                        L_CURLY@91..93 "{" [] [Whitespace(" ")],
+                        IDENT@93..98 "width" [] [],
+                        COLON@98..100 ":" [] [Whitespace(" ")],
+                        CSS_DIMENSION_VALUE@100..103 "300" [] [],
+                        PX_KW@103..106 "px" [] [Whitespace(" ")],
+                        R_CURLY@106..107 "}" [] [],
+                        R_PAREN@107..109 ")" [] [Whitespace(" ")],
                         ScssInterpolation {
-                            hash_token: HASH@124..125 "#" [] [],
-                            l_curly_token: L_CURLY@125..126 "{" [] [],
+                            hash_token: HASH@109..110 "#" [] [],
+                            l_curly_token: L_CURLY@110..111 "{" [] [],
                             value: ScssExpression {
                                 items: ScssExpressionItemList [
                                     ScssVariable {
-                                        dollar_token: DOLLAR@126..127 "$" [] [],
+                                        dollar_token: DOLLAR@111..112 "$" [] [],
                                         name: CssIdentifier {
-                                            value_token: IDENT@127..132 "query" [] [],
+                                            value_token: IDENT@112..117 "query" [] [],
                                         },
                                     },
                                 ],
                             },
-                            r_curly_token: R_CURLY@132..134 "}" [] [Whitespace(" ")],
+                            r_curly_token: R_CURLY@117..119 "}" [] [Whitespace(" ")],
                         },
                     ],
                 },
                 block: CssDeclarationOrRuleBlock {
-                    l_curly_token: L_CURLY@134..135 "{" [] [],
+                    l_curly_token: L_CURLY@119..120 "{" [] [],
                     items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
                                     name: CssIdentifier {
-                                        value_token: IDENT@135..143 "color" [Newline("\n"), Whitespace("  ")] [],
+                                        value_token: IDENT@120..128 "color" [Newline("\n"), Whitespace("  ")] [],
                                     },
-                                    colon_token: COLON@143..145 ":" [] [Whitespace(" ")],
+                                    colon_token: COLON@128..130 ":" [] [Whitespace(" ")],
                                     value: ScssExpression {
                                         items: ScssExpressionItemList [
                                             CssIdentifier {
-                                                value_token: IDENT@145..148 "red" [] [],
+                                                value_token: IDENT@130..133 "red" [] [],
                                             },
                                         ],
                                     },
                                 },
                                 important: missing (optional),
                             },
-                            semicolon_token: SEMICOLON@148..149 ";" [] [],
+                            semicolon_token: SEMICOLON@133..134 ";" [] [],
                         },
                     ],
-                    r_curly_token: R_CURLY@149..151 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@134..136 "}" [Newline("\n")] [],
                 },
             },
         },
     ],
-    eof_token: EOF@151..152 "" [Newline("\n")] [],
+    eof_token: EOF@136..137 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..152
+0: CSS_ROOT@0..137
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..151
-    0: CSS_AT_RULE@0..13
+  1: CSS_ROOT_ITEM_LIST@0..136
+    0: CSS_AT_RULE@0..25
       0: AT@0..1 "@" [] []
-      1: CSS_UNKNOWN_VALUE_AT_RULE@1..13
-        0: CSS_IDENTIFIER@1..8
-          0: IDENT@1..8 "IMPORT" [] [Whitespace(" ")]
-        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@8..12
-          0: IDENT@8..12 "Keep" [] []
-        2: SEMICOLON@12..13 ";" [] []
-    1: CSS_AT_RULE@13..40
-      0: AT@13..16 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_UNKNOWN_VALUE_AT_RULE@16..40
-        0: SCSS_INTERPOLATION@16..30
-          0: HASH@16..17 "#" [] []
-          1: L_CURLY@17..18 "{" [] []
-          2: SCSS_EXPRESSION@18..28
-            0: SCSS_EXPRESSION_ITEM_LIST@18..28
-              0: SCSS_VARIABLE@18..28
-                0: DOLLAR@18..19 "$" [] []
-                1: CSS_IDENTIFIER@19..28
-                  0: IDENT@19..28 "rule-name" [] []
-          3: R_CURLY@28..30 "}" [] [Whitespace(" ")]
-        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@30..39
-          0: SCSS_INTERPOLATION@30..39
-            0: HASH@30..31 "#" [] []
-            1: L_CURLY@31..32 "{" [] []
-            2: SCSS_EXPRESSION@32..38
-              0: SCSS_EXPRESSION_ITEM_LIST@32..38
-                0: SCSS_VARIABLE@32..38
-                  0: DOLLAR@32..33 "$" [] []
-                  1: CSS_IDENTIFIER@33..38
-                    0: IDENT@33..38 "value" [] []
-            3: R_CURLY@38..39 "}" [] []
-        2: SEMICOLON@39..40 ";" [] []
-    2: CSS_AT_RULE@40..92
-      0: AT@40..43 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_UNKNOWN_BLOCK_AT_RULE@43..92
-        0: CSS_IDENTIFIER@43..51
-          0: IDENT@43..51 "unknown" [] [Whitespace(" ")]
-        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@51..75
-          0: SCSS_INTERPOLATION@51..75
-            0: HASH@51..52 "#" [] []
-            1: L_CURLY@52..53 "{" [] []
-            2: SCSS_EXPRESSION@53..73
-              0: SCSS_EXPRESSION_ITEM_LIST@53..73
-                0: CSS_FUNCTION@53..73
-                  0: SCSS_MODULE_MEMBER_ACCESS@53..65
-                    0: CSS_IDENTIFIER@53..57
-                      0: IDENT@53..57 "meta" [] []
-                    1: DOT@57..58 "." [] []
-                    2: CSS_IDENTIFIER@58..65
-                      0: IDENT@58..65 "inspect" [] []
-                  1: L_PAREN@65..66 "(" [] []
-                  2: CSS_PARAMETER_LIST@66..72
-                    0: SCSS_EXPRESSION@66..72
-                      0: SCSS_EXPRESSION_ITEM_LIST@66..72
-                        0: SCSS_VARIABLE@66..72
-                          0: DOLLAR@66..67 "$" [] []
-                          1: CSS_IDENTIFIER@67..72
-                            0: IDENT@67..72 "value" [] []
-                  3: R_PAREN@72..73 ")" [] []
-            3: R_CURLY@73..75 "}" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_OR_RULE_BLOCK@75..92
-          0: L_CURLY@75..76 "{" [] []
-          1: CSS_DECLARATION_OR_RULE_LIST@76..90
-            0: CSS_DECLARATION_WITH_SEMICOLON@76..90
-              0: CSS_DECLARATION@76..89
-                0: CSS_GENERIC_PROPERTY@76..89
-                  0: CSS_IDENTIFIER@76..84
-                    0: IDENT@76..84 "color" [Newline("\n"), Whitespace("  ")] []
-                  1: COLON@84..86 ":" [] [Whitespace(" ")]
-                  2: SCSS_EXPRESSION@86..89
-                    0: SCSS_EXPRESSION_ITEM_LIST@86..89
-                      0: CSS_IDENTIFIER@86..89
-                        0: IDENT@86..89 "red" [] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@1..25
+        0: SCSS_INTERPOLATION@1..15
+          0: HASH@1..2 "#" [] []
+          1: L_CURLY@2..3 "{" [] []
+          2: SCSS_EXPRESSION@3..13
+            0: SCSS_EXPRESSION_ITEM_LIST@3..13
+              0: SCSS_VARIABLE@3..13
+                0: DOLLAR@3..4 "$" [] []
+                1: CSS_IDENTIFIER@4..13
+                  0: IDENT@4..13 "rule-name" [] []
+          3: R_CURLY@13..15 "}" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@15..24
+          0: SCSS_INTERPOLATION@15..24
+            0: HASH@15..16 "#" [] []
+            1: L_CURLY@16..17 "{" [] []
+            2: SCSS_EXPRESSION@17..23
+              0: SCSS_EXPRESSION_ITEM_LIST@17..23
+                0: SCSS_VARIABLE@17..23
+                  0: DOLLAR@17..18 "$" [] []
+                  1: CSS_IDENTIFIER@18..23
+                    0: IDENT@18..23 "value" [] []
+            3: R_CURLY@23..24 "}" [] []
+        2: SEMICOLON@24..25 ";" [] []
+    1: CSS_AT_RULE@25..77
+      0: AT@25..28 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@28..77
+        0: CSS_IDENTIFIER@28..36
+          0: IDENT@28..36 "unknown" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@36..60
+          0: SCSS_INTERPOLATION@36..60
+            0: HASH@36..37 "#" [] []
+            1: L_CURLY@37..38 "{" [] []
+            2: SCSS_EXPRESSION@38..58
+              0: SCSS_EXPRESSION_ITEM_LIST@38..58
+                0: CSS_FUNCTION@38..58
+                  0: SCSS_MODULE_MEMBER_ACCESS@38..50
+                    0: CSS_IDENTIFIER@38..42
+                      0: IDENT@38..42 "meta" [] []
+                    1: DOT@42..43 "." [] []
+                    2: CSS_IDENTIFIER@43..50
+                      0: IDENT@43..50 "inspect" [] []
+                  1: L_PAREN@50..51 "(" [] []
+                  2: CSS_PARAMETER_LIST@51..57
+                    0: SCSS_EXPRESSION@51..57
+                      0: SCSS_EXPRESSION_ITEM_LIST@51..57
+                        0: SCSS_VARIABLE@51..57
+                          0: DOLLAR@51..52 "$" [] []
+                          1: CSS_IDENTIFIER@52..57
+                            0: IDENT@52..57 "value" [] []
+                  3: R_PAREN@57..58 ")" [] []
+            3: R_CURLY@58..60 "}" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@60..77
+          0: L_CURLY@60..61 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@61..75
+            0: CSS_DECLARATION_WITH_SEMICOLON@61..75
+              0: CSS_DECLARATION@61..74
+                0: CSS_GENERIC_PROPERTY@61..74
+                  0: CSS_IDENTIFIER@61..69
+                    0: IDENT@61..69 "color" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@69..71 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@71..74
+                    0: SCSS_EXPRESSION_ITEM_LIST@71..74
+                      0: CSS_IDENTIFIER@71..74
+                        0: IDENT@71..74 "red" [] []
                 1: (empty)
-              1: SEMICOLON@89..90 ";" [] []
-          2: R_CURLY@90..92 "}" [Newline("\n")] []
-    3: CSS_AT_RULE@92..151
-      0: AT@92..95 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_UNKNOWN_BLOCK_AT_RULE@95..151
-        0: CSS_IDENTIFIER@95..103
-          0: IDENT@95..103 "unknown" [] [Whitespace(" ")]
-        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@103..134
-          0: IDENT@103..105 "fn" [] []
-          1: L_PAREN@105..106 "(" [] []
-          2: L_CURLY@106..108 "{" [] [Whitespace(" ")]
-          3: IDENT@108..113 "width" [] []
-          4: COLON@113..115 ":" [] [Whitespace(" ")]
-          5: CSS_DIMENSION_VALUE@115..118 "300" [] []
-          6: PX_KW@118..121 "px" [] [Whitespace(" ")]
-          7: R_CURLY@121..122 "}" [] []
-          8: R_PAREN@122..124 ")" [] [Whitespace(" ")]
-          9: SCSS_INTERPOLATION@124..134
-            0: HASH@124..125 "#" [] []
-            1: L_CURLY@125..126 "{" [] []
-            2: SCSS_EXPRESSION@126..132
-              0: SCSS_EXPRESSION_ITEM_LIST@126..132
-                0: SCSS_VARIABLE@126..132
-                  0: DOLLAR@126..127 "$" [] []
-                  1: CSS_IDENTIFIER@127..132
-                    0: IDENT@127..132 "query" [] []
-            3: R_CURLY@132..134 "}" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_OR_RULE_BLOCK@134..151
-          0: L_CURLY@134..135 "{" [] []
-          1: CSS_DECLARATION_OR_RULE_LIST@135..149
-            0: CSS_DECLARATION_WITH_SEMICOLON@135..149
-              0: CSS_DECLARATION@135..148
-                0: CSS_GENERIC_PROPERTY@135..148
-                  0: CSS_IDENTIFIER@135..143
-                    0: IDENT@135..143 "color" [Newline("\n"), Whitespace("  ")] []
-                  1: COLON@143..145 ":" [] [Whitespace(" ")]
-                  2: SCSS_EXPRESSION@145..148
-                    0: SCSS_EXPRESSION_ITEM_LIST@145..148
-                      0: CSS_IDENTIFIER@145..148
-                        0: IDENT@145..148 "red" [] []
+              1: SEMICOLON@74..75 ";" [] []
+          2: R_CURLY@75..77 "}" [Newline("\n")] []
+    2: CSS_AT_RULE@77..136
+      0: AT@77..80 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@80..136
+        0: CSS_IDENTIFIER@80..88
+          0: IDENT@80..88 "unknown" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@88..119
+          0: IDENT@88..90 "fn" [] []
+          1: L_PAREN@90..91 "(" [] []
+          2: L_CURLY@91..93 "{" [] [Whitespace(" ")]
+          3: IDENT@93..98 "width" [] []
+          4: COLON@98..100 ":" [] [Whitespace(" ")]
+          5: CSS_DIMENSION_VALUE@100..103 "300" [] []
+          6: PX_KW@103..106 "px" [] [Whitespace(" ")]
+          7: R_CURLY@106..107 "}" [] []
+          8: R_PAREN@107..109 ")" [] [Whitespace(" ")]
+          9: SCSS_INTERPOLATION@109..119
+            0: HASH@109..110 "#" [] []
+            1: L_CURLY@110..111 "{" [] []
+            2: SCSS_EXPRESSION@111..117
+              0: SCSS_EXPRESSION_ITEM_LIST@111..117
+                0: SCSS_VARIABLE@111..117
+                  0: DOLLAR@111..112 "$" [] []
+                  1: CSS_IDENTIFIER@112..117
+                    0: IDENT@112..117 "query" [] []
+            3: R_CURLY@117..119 "}" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@119..136
+          0: L_CURLY@119..120 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@120..134
+            0: CSS_DECLARATION_WITH_SEMICOLON@120..134
+              0: CSS_DECLARATION@120..133
+                0: CSS_GENERIC_PROPERTY@120..133
+                  0: CSS_IDENTIFIER@120..128
+                    0: IDENT@120..128 "color" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@128..130 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@130..133
+                    0: SCSS_EXPRESSION_ITEM_LIST@130..133
+                      0: CSS_IDENTIFIER@130..133
+                        0: IDENT@130..133 "red" [] []
                 1: (empty)
-              1: SEMICOLON@148..149 ";" [] []
-          2: R_CURLY@149..151 "}" [Newline("\n")] []
-  2: EOF@151..152 "" [Newline("\n")] []
+              1: SEMICOLON@133..134 ";" [] []
+          2: R_CURLY@134..136 "}" [Newline("\n")] []
+  2: EOF@136..137 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -8510,7 +8510,7 @@ impl CssUnknownBlockAtRule {
             block: self.block(),
         }
     }
-    pub fn name(&self) -> SyntaxResult<CssIdentifier> {
+    pub fn name(&self) -> SyntaxResult<AnyCssUnknownAtRuleName> {
         support::required_node(&self.syntax, 0usize)
     }
     pub fn components(&self) -> SyntaxResult<CssUnknownAtRuleComponentList> {
@@ -8530,7 +8530,7 @@ impl Serialize for CssUnknownBlockAtRule {
 }
 #[derive(Serialize)]
 pub struct CssUnknownBlockAtRuleFields {
-    pub name: SyntaxResult<CssIdentifier>,
+    pub name: SyntaxResult<AnyCssUnknownAtRuleName>,
     pub components: SyntaxResult<CssUnknownAtRuleComponentList>,
     pub block: SyntaxResult<AnyCssDeclarationOrRuleBlock>,
 }
@@ -8630,7 +8630,7 @@ impl CssUnknownValueAtRule {
             semicolon_token: self.semicolon_token(),
         }
     }
-    pub fn name(&self) -> SyntaxResult<CssIdentifier> {
+    pub fn name(&self) -> SyntaxResult<AnyCssUnknownAtRuleName> {
         support::required_node(&self.syntax, 0usize)
     }
     pub fn components(&self) -> SyntaxResult<CssUnknownAtRuleComponentList> {
@@ -8650,7 +8650,7 @@ impl Serialize for CssUnknownValueAtRule {
 }
 #[derive(Serialize)]
 pub struct CssUnknownValueAtRuleFields {
-    pub name: SyntaxResult<CssIdentifier>,
+    pub name: SyntaxResult<AnyCssUnknownAtRuleName>,
     pub components: SyntaxResult<CssUnknownAtRuleComponentList>,
     pub semicolon_token: SyntaxResult<SyntaxToken>,
 }
@@ -16271,6 +16271,32 @@ impl AnyCssUnicodeValue {
     pub fn as_css_unicode_range_wildcard(&self) -> Option<&CssUnicodeRangeWildcard> {
         match &self {
             Self::CssUnicodeRangeWildcard(item) => Some(item),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, Serialize)]
+pub enum AnyCssUnknownAtRuleName {
+    CssIdentifier(CssIdentifier),
+    ScssInterpolatedIdentifier(ScssInterpolatedIdentifier),
+    ScssInterpolation(ScssInterpolation),
+}
+impl AnyCssUnknownAtRuleName {
+    pub fn as_css_identifier(&self) -> Option<&CssIdentifier> {
+        match &self {
+            Self::CssIdentifier(item) => Some(item),
+            _ => None,
+        }
+    }
+    pub fn as_scss_interpolated_identifier(&self) -> Option<&ScssInterpolatedIdentifier> {
+        match &self {
+            Self::ScssInterpolatedIdentifier(item) => Some(item),
+            _ => None,
+        }
+    }
+    pub fn as_scss_interpolation(&self) -> Option<&ScssInterpolation> {
+        match &self {
+            Self::ScssInterpolation(item) => Some(item),
             _ => None,
         }
     }
@@ -41984,6 +42010,82 @@ impl From<AnyCssUnicodeValue> for SyntaxElement {
         node.into()
     }
 }
+impl From<CssIdentifier> for AnyCssUnknownAtRuleName {
+    fn from(node: CssIdentifier) -> Self {
+        Self::CssIdentifier(node)
+    }
+}
+impl From<ScssInterpolatedIdentifier> for AnyCssUnknownAtRuleName {
+    fn from(node: ScssInterpolatedIdentifier) -> Self {
+        Self::ScssInterpolatedIdentifier(node)
+    }
+}
+impl From<ScssInterpolation> for AnyCssUnknownAtRuleName {
+    fn from(node: ScssInterpolation) -> Self {
+        Self::ScssInterpolation(node)
+    }
+}
+impl AstNode for AnyCssUnknownAtRuleName {
+    type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = CssIdentifier::KIND_SET
+        .union(ScssInterpolatedIdentifier::KIND_SET)
+        .union(ScssInterpolation::KIND_SET);
+    fn can_cast(kind: SyntaxKind) -> bool {
+        matches!(
+            kind,
+            CSS_IDENTIFIER | SCSS_INTERPOLATED_IDENTIFIER | SCSS_INTERPOLATION
+        )
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        let res = match syntax.kind() {
+            CSS_IDENTIFIER => Self::CssIdentifier(CssIdentifier { syntax }),
+            SCSS_INTERPOLATED_IDENTIFIER => {
+                Self::ScssInterpolatedIdentifier(ScssInterpolatedIdentifier { syntax })
+            }
+            SCSS_INTERPOLATION => Self::ScssInterpolation(ScssInterpolation { syntax }),
+            _ => return None,
+        };
+        Some(res)
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        match self {
+            Self::CssIdentifier(it) => it.syntax(),
+            Self::ScssInterpolatedIdentifier(it) => it.syntax(),
+            Self::ScssInterpolation(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            Self::CssIdentifier(it) => it.into_syntax(),
+            Self::ScssInterpolatedIdentifier(it) => it.into_syntax(),
+            Self::ScssInterpolation(it) => it.into_syntax(),
+        }
+    }
+}
+impl std::fmt::Debug for AnyCssUnknownAtRuleName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CssIdentifier(it) => std::fmt::Debug::fmt(it, f),
+            Self::ScssInterpolatedIdentifier(it) => std::fmt::Debug::fmt(it, f),
+            Self::ScssInterpolation(it) => std::fmt::Debug::fmt(it, f),
+        }
+    }
+}
+impl From<AnyCssUnknownAtRuleName> for SyntaxNode {
+    fn from(n: AnyCssUnknownAtRuleName) -> Self {
+        match n {
+            AnyCssUnknownAtRuleName::CssIdentifier(it) => it.into_syntax(),
+            AnyCssUnknownAtRuleName::ScssInterpolatedIdentifier(it) => it.into_syntax(),
+            AnyCssUnknownAtRuleName::ScssInterpolation(it) => it.into_syntax(),
+        }
+    }
+}
+impl From<AnyCssUnknownAtRuleName> for SyntaxElement {
+    fn from(n: AnyCssUnknownAtRuleName) -> Self {
+        let node: SyntaxNode = n.into();
+        node.into()
+    }
+}
 impl From<CssBogusUrlModifier> for AnyCssUrlModifier {
     fn from(node: CssBogusUrlModifier) -> Self {
         Self::CssBogusUrlModifier(node)
@@ -44937,6 +45039,11 @@ impl std::fmt::Display for AnyCssType {
     }
 }
 impl std::fmt::Display for AnyCssUnicodeValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for AnyCssUnknownAtRuleName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -3380,7 +3380,7 @@ impl CssUnknownAttrUnit {
     }
 }
 impl CssUnknownBlockAtRule {
-    pub fn with_name(self, element: CssIdentifier) -> Self {
+    pub fn with_name(self, element: AnyCssUnknownAtRuleName) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
@@ -3422,7 +3422,7 @@ impl CssUnknownSyntaxTypeName {
     }
 }
 impl CssUnknownValueAtRule {
-    pub fn with_name(self, element: CssIdentifier) -> Self {
+    pub fn with_name(self, element: AnyCssUnknownAtRuleName) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -2004,14 +2004,19 @@ CssValueAtRuleGenericValue = SyntaxElement*
 /// as part of an unformed tree. This enables graceful handling of CSS constructs that are not
 /// supported by the parser, ensuring that the stylesheet can still be processed without errors.
 CssUnknownBlockAtRule =
-	name: CssIdentifier
+	name: AnyCssUnknownAtRuleName
 	components: CssUnknownAtRuleComponentList
 	block: AnyCssDeclarationOrRuleBlock
 
 CssUnknownValueAtRule =
-	name: CssIdentifier
+	name: AnyCssUnknownAtRuleName
 	components: CssUnknownAtRuleComponentList
 	';'
+
+AnyCssUnknownAtRuleName =
+	CssIdentifier
+	| ScssInterpolatedIdentifier
+	| ScssInterpolation
 
 CssUnknownAtRuleComponentList = SyntaxElement*
 


### PR DESCRIPTION
 > This PR was implemented with assistance from OpenAI Codex.

  ## Summary

  Adds parser and formatter support for generic unknown at-rules.

  ```scss
  @#{$rule-name} #{$value};

  @unknown #{meta.inspect($value)} {
    color: red;
  }

  @unknown fn({ width: 300px }) #{$query} {
    color: red;
  }
```

  ## Test Plan

  - cargo test -p biome_css_parser 
  - cargo test -p biome_css_formatter
