### PR TITLE
fix(css_formatter): preserve scss identifier interpolation spacing

### DIFF
--- a/crates/biome_css_formatter/src/scss/auxiliary/interpolation.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/interpolation.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use biome_css_syntax::{ScssInterpolation, ScssInterpolationFields};
+use biome_css_syntax::{
+    AnyScssExpression, CssSyntaxKind, CssSyntaxToken, ScssInterpolatedIdentifier,
+    ScssInterpolation, ScssInterpolationFields,
+};
 use biome_formatter::{format_args, write};
 
 #[derive(Debug, Clone, Default)]
@@ -12,6 +15,45 @@ impl FormatNodeRule<ScssInterpolation> for FormatScssInterpolation {
             value,
             r_curly_token,
         } = node.as_fields();
+        let hash_token = hash_token?;
+        let l_curly_token = l_curly_token?;
+        let value = value?;
+        let r_curly_token = r_curly_token?;
+
+        if should_preserve_identifier_interpolation_spacing(node) {
+            let has_gap_after_opening = has_source_gap_after_opening_curly(&l_curly_token, &value);
+            let has_gap_before_closing =
+                has_source_gap_before_closing_curly(&value, &r_curly_token);
+
+            if has_gap_after_opening || has_gap_before_closing {
+                let gap_after_opening = format_with(|f| {
+                    if has_gap_after_opening {
+                        write!(f, [soft_line_break_or_space()])
+                    } else {
+                        Ok(())
+                    }
+                });
+                let gap_before_closing = format_with(|f| {
+                    if has_gap_before_closing {
+                        write!(f, [soft_line_break_or_space()])
+                    } else {
+                        Ok(())
+                    }
+                });
+
+                return write!(
+                    f,
+                    [group(&format_args![
+                        hash_token.format(),
+                        l_curly_token.format(),
+                        gap_after_opening,
+                        value.format(),
+                        gap_before_closing,
+                        r_curly_token.format()
+                    ])]
+                );
+            }
+        }
 
         write!(
             f,
@@ -23,4 +65,57 @@ impl FormatNodeRule<ScssInterpolation> for FormatScssInterpolation {
             ])]
         )
     }
+}
+
+/// Preserves source gaps inside selector and property-name interpolation.
+///
+/// Prettier keeps `.icon-#{ $name}` but prints `value: #{$name}`.
+fn should_preserve_identifier_interpolation_spacing(node: &ScssInterpolation) -> bool {
+    let Some(identifier) = node
+        .syntax()
+        .ancestors()
+        .skip(1)
+        .find_map(ScssInterpolatedIdentifier::cast)
+    else {
+        return false;
+    };
+
+    identifier.syntax().parent().is_some_and(|parent| {
+        matches!(
+            parent.kind(),
+            CssSyntaxKind::CSS_CLASS_SELECTOR
+                | CssSyntaxKind::CSS_GENERIC_PROPERTY
+                | CssSyntaxKind::CSS_ID_SELECTOR
+                | CssSyntaxKind::CSS_TYPE_SELECTOR
+                | CssSyntaxKind::SCSS_PLACEHOLDER_SELECTOR
+        )
+    })
+}
+
+/// Detects spacing after `{`.
+///
+/// Examples: `#{ $name}` and `#{\n$name}` keep a gap after `{`.
+fn has_source_gap_after_opening_curly(
+    l_curly_token: &CssSyntaxToken,
+    value: &AnyScssExpression,
+) -> bool {
+    l_curly_token.has_trailing_whitespace()
+        || value
+            .syntax()
+            .first_token()
+            .is_some_and(|token| token.has_leading_whitespace_or_newline())
+}
+
+/// Detects spacing before `}`.
+///
+/// Examples: `#{$name }` and `#{$name\n}` keep a gap before `}`.
+fn has_source_gap_before_closing_curly(
+    value: &AnyScssExpression,
+    r_curly_token: &CssSyntaxToken,
+) -> bool {
+    value
+        .syntax()
+        .last_token()
+        .is_some_and(|token| token.has_trailing_whitespace())
+        || r_curly_token.has_leading_whitespace_or_newline()
 }

--- a/crates/biome_css_formatter/tests/specs/scss/expression/identifier-interpolation-spacing.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/identifier-interpolation-spacing.scss
@@ -1,0 +1,16 @@
+@each $name in $names {
+  .text #{ $name } {}
+  .text #{$name} {}
+  .text-#{ $name } {}
+  .text-#{$name} {}
+  .text-#{ $name} {}
+  .text-#{$name } {}
+  #id-#{ $name } {}
+  #id-#{$name} {}
+  tag-#{ $name } {}
+  tag-#{$name} {}
+  %placeholder-#{ $name } {}
+  %placeholder-#{$name} {}
+}
+
+a{#{ $prop }:red; #{$prop}:blue; #{ $left}:green; #{$right }:yellow; margin-#{ $side }:1px; margin-#{$side}:2px; padding-#{ $side}:3px; padding-#{$side }:4px; value:#{ $value }; value-spaced:#{ $value}; value-right:#{$value };}

--- a/crates/biome_css_formatter/tests/specs/scss/expression/identifier-interpolation-spacing.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/identifier-interpolation-spacing.scss.snap
@@ -1,0 +1,73 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/expression/identifier-interpolation-spacing.scss
+---
+
+# Input
+
+```scss
+@each $name in $names {
+  .text #{ $name } {}
+  .text #{$name} {}
+  .text-#{ $name } {}
+  .text-#{$name} {}
+  .text-#{ $name} {}
+  .text-#{$name } {}
+  #id-#{ $name } {}
+  #id-#{$name} {}
+  tag-#{ $name } {}
+  tag-#{$name} {}
+  %placeholder-#{ $name } {}
+  %placeholder-#{$name} {}
+}
+
+a{#{ $prop }:red; #{$prop}:blue; #{ $left}:green; #{$right }:yellow; margin-#{ $side }:1px; margin-#{$side}:2px; padding-#{ $side}:3px; padding-#{$side }:4px; value:#{ $value }; value-spaced:#{ $value}; value-right:#{$value };}
+
+```
+
+
+# Formatted
+
+```scss
+@each $name in $names {
+	.text #{ $name } {
+	}
+	.text #{$name} {
+	}
+	.text-#{ $name } {
+	}
+	.text-#{$name} {
+	}
+	.text-#{ $name} {
+	}
+	.text-#{$name } {
+	}
+	#id-#{ $name } {
+	}
+	#id-#{$name} {
+	}
+	tag-#{ $name } {
+	}
+	tag-#{$name} {
+	}
+	%placeholder-#{ $name } {
+	}
+	%placeholder-#{$name} {
+	}
+}
+
+a {
+	#{ $prop }: red;
+	#{$prop}: blue;
+	#{ $left}: green;
+	#{$right }: yellow;
+	margin-#{ $side }: 1px;
+	margin-#{$side}: 2px;
+	padding-#{ $side}: 3px;
+	padding-#{$side }: 4px;
+	value: #{$value};
+	value-spaced: #{$value};
+	value-right: #{$value};
+}
+
+```


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

  ## Summary

  Improves SCSS formatter parity with Prettier for identifier interpolation spacing.

  Selector and property-name interpolations now preserve source spacing inside `#{...}` independently on each side, while value interpolation still normalizes to tight output.

```scss
  .text-#{ $name} {}
  .text-#{$name } {}

  a {
  	#{ $left}: green;
  	#{$right }: yellow;
  	value-spaced: #{$value};
  	value-right: #{$value};
  }
```

  ## Test Plan

cargo test -p formatter