### PR TITLE
fix(service): correct FileExistsParams typo

### DIFF
--- a/crates/biome_cli/src/runner/process_file.rs
+++ b/crates/biome_cli/src/runner/process_file.rs
@@ -10,7 +10,7 @@ use biome_service::diagnostics::FileTooLarge;
 use biome_service::file_handlers::DocumentFileSource;
 use biome_service::projects::ProjectKey;
 use biome_service::workspace::{
-    FeaturesSupported, FileExitsParams, FileFeaturesResult, SupportKind, SupportsFeatureParams,
+    FeaturesSupported, FileExistsParams, FileFeaturesResult, SupportKind, SupportsFeatureParams,
 };
 use biome_service::workspace::{FileContent, FileGuard, OpenFileParams};
 use biome_service::{Workspace, WorkspaceError};
@@ -270,7 +270,7 @@ impl<'ctx, 'app> WorkspaceFile<'ctx, 'app> {
         let guard = FileGuard::new(ctx.workspace(), ctx.project_key(), path.clone())
             .with_file_path_and_code(path.to_string(), category!("internalError/fs"))?;
 
-        if ctx.workspace().file_exists(FileExitsParams {
+        if ctx.workspace().file_exists(FileExistsParams {
             file_path: path.clone(),
         })? {
             Ok(Self { guard, path, file })

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -1471,11 +1471,11 @@ pub struct CloseProjectParams {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct FileExitsParams {
+pub struct FileExistsParams {
     pub file_path: BiomePath,
 }
 
-impl From<BiomePath> for FileExitsParams {
+impl From<BiomePath> for FileExistsParams {
     fn from(path: BiomePath) -> Self {
         Self { file_path: path }
     }
@@ -1570,7 +1570,7 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// ### Error
     ///
     /// It throws an error only if there's an issue with the client transport.
-    fn file_exists(&self, params: FileExitsParams) -> Result<bool, WorkspaceError>;
+    fn file_exists(&self, params: FileExistsParams) -> Result<bool, WorkspaceError>;
 
     /// Checks whether a certain feature is supported for the given file path.
     ///

--- a/crates/biome_service/src/workspace/client.rs
+++ b/crates/biome_service/src/workspace/client.rs
@@ -1,5 +1,5 @@
 use super::{
-    ChangeFileParams, ChangeFileResult, CloseFileParams, FileExitsParams, FixFileParams,
+    ChangeFileParams, ChangeFileResult, CloseFileParams, FileExistsParams, FixFileParams,
     FixFileResult, FormatFileParams, FormatOnTypeParams, FormatRangeParams,
     GetControlFlowGraphParams, GetFormatterIRParams, GetModuleGraphParams, GetModuleGraphResult,
     GetSemanticModelParams, GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams,
@@ -131,7 +131,7 @@ where
         self.request("biome/open_file", params)
     }
 
-    fn file_exists(&self, params: FileExitsParams) -> Result<bool, WorkspaceError> {
+    fn file_exists(&self, params: FileExistsParams) -> Result<bool, WorkspaceError> {
         self.request("biome/file_exists", params)
     }
 

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -21,7 +21,7 @@ use crate::workspace::document::{AnyEmbeddedSnippet, DocumentServices, JsDocumen
 use crate::workspace::{
     ChangeFileParams, ChangeFileResult, CheckFileSizeParams, CheckFileSizeResult, CloseFileParams,
     CloseProjectParams, CssDocumentServices, DropPatternParams, FeaturesBuilder, FileContent,
-    FileExitsParams, FileFeaturesResult, FixFileParams, FixFileResult, FormatFileParams,
+    FileExistsParams, FileFeaturesResult, FixFileParams, FixFileResult, FormatFileParams,
     FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFileContentParams,
     GetFormatterIRParams, GetModuleGraphParams, GetModuleGraphResult, GetRegisteredTypesParams,
     GetSemanticModelParams, GetSyntaxTreeParams, GetSyntaxTreeResult, GetTypeInfoParams,
@@ -1378,7 +1378,7 @@ impl Workspace for WorkspaceServer {
         Ok(OpenFileResult { diagnostics })
     }
 
-    fn file_exists(&self, params: FileExitsParams) -> Result<bool, WorkspaceError> {
+    fn file_exists(&self, params: FileExistsParams) -> Result<bool, WorkspaceError> {
         Ok(self
             .documents
             .pin()

--- a/crates/biome_wasm/src/lib.rs
+++ b/crates/biome_wasm/src/lib.rs
@@ -4,7 +4,7 @@ use js_sys::Error;
 use wasm_bindgen::prelude::*;
 
 use biome_service::workspace::{
-    self, ChangeFileParams, CloseFileParams, DropPatternParams, FileExitsParams, FixFileParams,
+    self, ChangeFileParams, CloseFileParams, DropPatternParams, FileExistsParams, FixFileParams,
     FormatFileParams, FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams,
     GetFileContentParams, GetFormatterIRParams, GetModuleGraphParams, GetRegisteredTypesParams,
     GetSemanticModelParams, GetSyntaxTreeParams, GetTypeInfoParams, OpenProjectParams,
@@ -215,8 +215,8 @@ impl Workspace {
     }
 
     #[wasm_bindgen(js_name = fileExists)]
-    pub fn file_exists(&self, params: IFileExitsParams) -> Result<bool, Error> {
-        let params: FileExitsParams =
+    pub fn file_exists(&self, params: IFileExistsParams) -> Result<bool, Error> {
+        let params: FileExistsParams =
             serde_wasm_bindgen::from_value(params.into()).map_err(into_error)?;
         self.inner.file_exists(params).map_err(into_error)
     }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -9956,7 +9956,7 @@ export interface CloseFileParams {
 	path: BiomePath;
 	projectKey: ProjectKey;
 }
-export interface FileExitsParams {
+export interface FileExistsParams {
 	filePath: BiomePath;
 }
 export interface PathIsIgnoredParams {
@@ -10350,7 +10350,7 @@ export interface Workspace {
 	openFile(params: OpenFileParams): Promise<OpenFileResult>;
 	changeFile(params: ChangeFileParams): Promise<ChangeFileResult>;
 	closeFile(params: CloseFileParams): Promise<null>;
-	fileExists(params: FileExitsParams): Promise<boolean>;
+	fileExists(params: FileExistsParams): Promise<boolean>;
 	isPathIgnored(params: PathIsIgnoredParams): Promise<boolean>;
 	updateModuleGraph(params: UpdateModuleGraphParams): Promise<null>;
 	getSyntaxTree(params: GetSyntaxTreeParams): Promise<GetSyntaxTreeResult>;


### PR DESCRIPTION
## Summary

This PR changes `FileExitsParams` to `FileExistsParams`, fixing the typo.

## Test Plan

Build works with no errors.

## Docs

This will automatically be updated in the code-generated docs.