### PR TITLE
fix(vcs): respect nested .gitignore overrides and ancestor matches in is_git_ignore

### DIFF
--- a/.changeset/fix-gitignore-matched-path-parents.md
+++ b/.changeset/fix-gitignore-matched-path-parents.md
@@ -2,7 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed multiple issues in how `vcs.useIgnoreFile` evaluates `.gitignore` files:
-
-- Files inside an ignored directory are now correctly ignored when their full path is checked directly. Previously, a `.gitignore` rule like `node_modules` only matched the directory itself, not files beneath it (an issue with absolute paths sent by the LSP and with symlinked dependency trees).
-- Nested `.gitignore` files now correctly override their parents. A negation pattern (`!path`) in a deeper `.gitignore` is no longer overridden by an exclude pattern in the project root `.gitignore`.
+Fixed [`#9105`](https://github.com/biomejs/biome/issues/9105): `vcs.useIgnoreFile` now evaluates `.gitignore` files correctly, including nested overrides and full-path matching under ignored directories.

--- a/.changeset/fix-gitignore-matched-path-parents.md
+++ b/.changeset/fix-gitignore-matched-path-parents.md
@@ -1,0 +1,8 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed multiple issues in how `vcs.useIgnoreFile` evaluates `.gitignore` files:
+
+- Files inside an ignored directory are now correctly ignored when their full path is checked directly. Previously, a `.gitignore` rule like `node_modules` only matched the directory itself, not files beneath it (an issue with absolute paths sent by the LSP and with symlinked dependency trees).
+- Nested `.gitignore` files now correctly override their parents. A negation pattern (`!path`) in a deeper `.gitignore` is no longer overridden by an exclude pattern in the project root `.gitignore`.

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1115,20 +1115,36 @@ impl VcsIgnoredPatterns {
         path: &Utf8Path,
         is_dir: bool,
     ) -> bool {
-        let root_ignored = {
-            let path = path.strip_prefix(root.path()).unwrap_or(path);
-            root.matched(path, is_dir).is_ignore()
-        };
+        let mut last_decision: Option<bool> = None;
 
-        let nested_ignored = nested.iter().any(|gitignore| {
-            if let Ok(stripped_path) = path.strip_prefix(gitignore.path()) {
-                gitignore.matched(stripped_path, is_dir).is_ignore()
-            } else {
-                false
+        if let Ok(stripped) = path.strip_prefix(root.path()) {
+            let m = root.matched_path_or_any_parents(stripped, is_dir);
+            if m.is_ignore() {
+                last_decision = Some(true);
+            } else if m.is_whitelist() {
+                last_decision = Some(false);
             }
-        });
+        }
 
-        root_ignored || nested_ignored
+        let mut applicable: Vec<&Gitignore> = nested
+            .iter()
+            .filter(|gitignore| path.strip_prefix(gitignore.path()).is_ok())
+            .collect();
+        applicable.sort_by_key(|gitignore| gitignore.path().as_os_str().len());
+
+        for gitignore in applicable {
+            let Ok(stripped) = path.strip_prefix(gitignore.path()) else {
+                continue;
+            };
+            let m = gitignore.matched_path_or_any_parents(stripped, is_dir);
+            if m.is_ignore() {
+                last_decision = Some(true);
+            } else if m.is_whitelist() {
+                last_decision = Some(false);
+            }
+        }
+
+        last_decision.unwrap_or(false)
     }
 
     pub fn insert_git_match(&mut self, git_ignore: Gitignore) {

--- a/crates/biome_service/src/settings.tests.rs
+++ b/crates/biome_service/src/settings.tests.rs
@@ -1,6 +1,6 @@
 use crate::scanner::ScanKind;
 use crate::settings::{
-    LanguageSettings, ModuleGraphResolutionKind, ServiceLanguage, Settings,
+    LanguageSettings, ModuleGraphResolutionKind, ServiceLanguage, Settings, VcsSettings,
     to_json_language_settings,
 };
 use crate::workspace::DocumentFileSource;
@@ -9,6 +9,7 @@ use biome_configuration::analyzer::{GroupPlainConfiguration, SeverityOrGroup, St
 use biome_configuration::javascript::JsxRuntime;
 use biome_configuration::json::{JsonAssistConfiguration, JsonLinterConfiguration};
 use biome_configuration::max_size::MaxSize;
+use biome_configuration::vcs::{VcsClientKind, VcsEnabled, VcsUseIgnoreFile};
 use biome_configuration::{
     Configuration, FormatterConfiguration, JsConfiguration, JsonConfiguration, LinterConfiguration,
     OverrideFilesConfiguration, OverrideGlobs, OverrideLinterConfiguration, OverridePattern,
@@ -294,4 +295,69 @@ fn test_project_scan_disables_module_graph_type_inference() {
         !project_kind.is_modules_and_types(),
         "Project scan should NOT enable type inference"
     );
+}
+
+fn enabled_git_vcs_settings() -> VcsSettings {
+    VcsSettings {
+        client_kind: Some(VcsClientKind::Git),
+        enabled: Some(VcsEnabled::from(true)),
+        use_ignore_file: Some(VcsUseIgnoreFile::from(true)),
+        ..VcsSettings::default()
+    }
+}
+
+#[test]
+fn vcs_ignores_files_below_ignored_directory() {
+    let mut vcs = enabled_git_vcs_settings();
+    vcs.store_root_ignore_patterns(Utf8Path::new("/project"), &["node_modules"])
+        .unwrap();
+
+    let path = Utf8Path::new("/project/apps/miniapp/node_modules/react-router/dist/index.js");
+    assert!(vcs.is_ignored(path, false, None));
+}
+
+#[test]
+fn vcs_nested_whitelist_overrides_root_ignore() {
+    let mut vcs = enabled_git_vcs_settings();
+    vcs.store_root_ignore_patterns(Utf8Path::new("/project"), &["*.log"])
+        .unwrap();
+    vcs.store_nested_ignore_patterns(Utf8Path::new("/project/subdir"), &["!important.log"])
+        .unwrap();
+
+    let path = Utf8Path::new("/project/subdir/important.log");
+    assert!(!vcs.is_ignored(path, false, None));
+}
+
+#[test]
+fn vcs_root_whitelist_keeps_path_included() {
+    let mut vcs = enabled_git_vcs_settings();
+    vcs.store_root_ignore_patterns(Utf8Path::new("/project"), &["/*", "!src"])
+        .unwrap();
+
+    let path = Utf8Path::new("/project/src/index.ts");
+    assert!(!vcs.is_ignored(path, false, None));
+}
+
+#[test]
+fn vcs_deeper_nested_overrides_shallower_nested() {
+    let mut vcs = enabled_git_vcs_settings();
+    vcs.store_root_ignore_patterns(Utf8Path::new("/project"), &[])
+        .unwrap();
+    vcs.store_nested_ignore_patterns(Utf8Path::new("/project/a"), &["important.log"])
+        .unwrap();
+    vcs.store_nested_ignore_patterns(Utf8Path::new("/project/a/b"), &["!important.log"])
+        .unwrap();
+
+    let path = Utf8Path::new("/project/a/b/important.log");
+    assert!(!vcs.is_ignored(path, false, None));
+}
+
+#[test]
+fn vcs_path_outside_repo_is_not_ignored() {
+    let mut vcs = enabled_git_vcs_settings();
+    vcs.store_root_ignore_patterns(Utf8Path::new("/project"), &["node_modules"])
+        .unwrap();
+
+    let path = Utf8Path::new("/elsewhere/src/index.ts");
+    assert!(!vcs.is_ignored(path, false, None));
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #9105.

`is_git_ignore` in `crates/biome_service/src/settings.rs` had three issues:

1. It used `Gitignore::matched()`, which only checks the path itself. A root rule like `node_modules` therefore did not match files under it when the full file path was passed in directly (this happens with absolute paths from the LSP and with symlinked paths whose canonical target lives under `node_modules/...`). Switched to `matched_path_or_any_parents()`.
2. Root and nested results were combined with `||`, so a negation in a nested `.gitignore` (`!keep.log`) was lost when the root excluded the same file (`*.log`). The new code walks gitignores outermost-first and keeps the last non-`None` match, so a deeper rule wins, which matches git's behavior.
3. `matched_path_or_any_parents` panics if the path is not under the gitignore root. The previous `unwrap_or(path)` could pass an unrelated path through, so we now only call it when `strip_prefix` succeeds.

PR #9675 fixed (1) but was closed without merging. This PR also covers (2) — raised in CodeRabbit's review on that PR — and (3).

## Test Plan

`cargo test -p biome_service --lib settings::tests::` — 16 passed, 0 failed.

Five new tests in `settings.tests.rs` cover each scenario above and the original case from #9105 (`/*` followed by `!src`).

## Docs

No public API change. The user-visible behavior is described in the changeset.

---

I used Cursor + Claude to investigate the bug and draft the regression tests. I reviewed every change manually before submitting.