### PR TITLE
ci: analyzer walltime - add benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   merge_group:
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
     branches:
       - main
       - next
@@ -196,13 +196,18 @@ jobs:
       contents: read
       pull-requests: write
     name: Bench JS / ${{ matrix.package }}
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: ${{ matrix.runner || 'depot-ubuntu-24.04-arm-16' }}
     strategy:
       matrix:
-        package:
-          - biome_js_parser
-          - biome_js_formatter
-          - biome_js_analyze
+        include:
+          - package: biome_js_parser
+          - package: biome_js_formatter
+          - package: biome_js_analyze
+            bench: "--bench js_analyzer --bench use_sorted_classes_parser"
+          - package: biome_js_analyze
+            bench: "--bench js_analyzer_walltime"
+            mode: walltime
+            runner: codspeed-macro-arm
     steps: &bench_steps
       - name: Checkout PR Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -229,8 +234,8 @@ jobs:
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
         timeout-minutes: 50
         with:
-          mode: simulation
-          run: cargo codspeed run
+          mode: ${{ matrix.mode || 'simulation' }}
+          run: cargo codspeed run ${{ matrix.bench }}
           token: ${{ secrets.CODSPEED_TOKEN }}
 
   json:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -195,7 +195,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    name: Bench JS / ${{ matrix.package }}
+    name: Bench JS / ${{ matrix.package }} / ${{ matrix.mode || 'simulation'}}
     runs-on: ${{ matrix.runner || 'depot-ubuntu-24.04-arm-16' }}
     strategy:
       matrix:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -207,7 +207,7 @@ jobs:
           - package: biome_js_analyze
             bench: "--bench js_analyzer_walltime"
             mode: walltime
-            runner: codspeed-macro-arm
+            runner: codspeed-macro
     steps: &bench_steps
       - name: Checkout PR Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -17,6 +17,10 @@ name    = "js_analyzer"
 
 [[bench]]
 harness = false
+name    = "js_analyzer_walltime"
+
+[[bench]]
+harness = false
 name    = "use_sorted_classes_parser"
 
 [dependencies]

--- a/crates/biome_js_analyze/benches/js_analyzer_walltime.rs
+++ b/crates/biome_js_analyze/benches/js_analyzer_walltime.rs
@@ -1,0 +1,84 @@
+use biome_analyze::options::JsxRuntime;
+use biome_analyze::{
+    ActionFilter, AnalysisFilter, AnalyzerConfiguration, AnalyzerOptions, ControlFlow, Never,
+    RuleCategoriesBuilder,
+};
+use biome_js_parser::JsParserOptions;
+use biome_js_syntax::JsFileSource;
+use biome_test_utils::BenchCase;
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use std::collections::HashMap;
+
+#[cfg(target_os = "windows")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(all(
+    any(target_os = "macos", target_os = "linux"),
+    not(target_env = "musl"),
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+fn bench_analyzer_walltime(criterion: &mut Criterion) {
+    let mut all_suites = HashMap::new();
+    all_suites.insert("ts", "https://cdn.jsdelivr.net/gh/angular/angular@3bafda20c30edb42e5cb3c2424edca2f7224ffde/packages/compiler/src/expression_parser/parser.ts");
+    let mut libs = vec![];
+    libs.extend(all_suites.values().flat_map(|suite| suite.lines()));
+
+    let mut group = criterion.benchmark_group("js_analyzer_walltime");
+
+    for lib in libs {
+        let test_case = BenchCase::try_from(lib);
+
+        match test_case {
+            Ok(test_case) => {
+                let code = test_case.code();
+                group.throughput(criterion::Throughput::Bytes(code.len() as u64));
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(test_case.filename()),
+                    code,
+                    |b, _| {
+                        let file_source =
+                            JsFileSource::try_from(test_case.path()).unwrap_or_default();
+                        let parse =
+                            biome_js_parser::parse(code, file_source, JsParserOptions::default());
+
+                        let filter = AnalysisFilter {
+                            categories: RuleCategoriesBuilder::default()
+                                .with_syntax()
+                                .with_lint()
+                                .with_assist()
+                                .build(),
+                            ..AnalysisFilter::default()
+                        };
+                        let options = AnalyzerOptions::default().with_configuration(
+                            AnalyzerConfiguration::default()
+                                .with_jsx_runtime(JsxRuntime::default()),
+                        );
+                        b.iter(|| {
+                            biome_js_analyze::analyze(
+                                &parse.tree(),
+                                filter,
+                                &options,
+                                &[],
+                                Default::default(),
+                                |event| {
+                                    black_box(event.diagnostic());
+                                    black_box(event.actions(ActionFilter::all()));
+                                    ControlFlow::<Never>::Continue(())
+                                },
+                            );
+                        });
+                    },
+                );
+            }
+            Err(e) => println!("{e:?}"),
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(js_analyzer_walltime, bench_analyzer_walltime);
+criterion_main!(js_analyzer_walltime);


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a single benchmark using codspeed walltime using their runners. It's a new thing, and we have 600 minutes per month for now, so let's try slow and add one file at the time to see how it goes.

The reason why we want to add walltime to their runners is because we want to make sure benchmarks don't run on different hardware.

I helped myself with a coding agent to find a possible solution.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Green CI

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
