### PR TITLE
fix(lint): detect optional-chain inequality guards

### DIFF
--- a/.changeset/fluffy-papayas-obey.md
+++ b/.changeset/fluffy-papayas-obey.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10244](https://github.com/biomejs/biome/issues/10244): The `useOptionalChain` rule now detects negated guard inequality chains like `!foo || foo.bar !== "x"`.

--- a/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
@@ -133,6 +133,13 @@ impl Rule for UseOptionalChain {
                 ))
             }
             JsLogicalOperator::NullishCoalescing | JsLogicalOperator::LogicalOr => {
+                if matches!(operator, JsLogicalOperator::LogicalOr)
+                    && let Some(chain_nodes) =
+                        optional_chain_nodes_from_negated_or_inequality(logical, model)
+                {
+                    return Some(UseOptionalChainState::LogicalAnd(chain_nodes));
+                }
+
                 // Check for negated || chains like `!foo || !foo.bar`
                 if matches!(operator, JsLogicalOperator::LogicalOr) && is_negated_or_chain(logical)
                 {
@@ -532,6 +539,62 @@ fn is_negated_or_chain(logical: &JsLogicalExpression) -> bool {
         }
     }
     false
+}
+
+/// Match `!foo || foo.bar !== "value"` and the loose `!=` variant.
+///
+/// This intentionally stays narrower than general binary comparisons:
+/// optional chaining preserves the guard only when the compared value is static
+/// and non-nullish, so comparing `undefined` to that value remains truthy.
+fn optional_chain_nodes_from_negated_or_inequality(
+    logical: &JsLogicalExpression,
+    model: &SemanticModel,
+) -> Option<LogicalAndChainNodes> {
+    let guard = strip_negation(&logical.left().ok()?)?;
+    let binary = logical.right().ok()?.as_js_binary_expression()?.clone();
+    if !matches!(
+        binary.operator().ok()?,
+        JsBinaryOperator::StrictInequality | JsBinaryOperator::Inequality
+    ) {
+        return None;
+    }
+
+    let left = binary.left().ok()?;
+    let right = binary.right().ok()?;
+    let compared_chain = if is_static_non_nullish_value(&right) {
+        left
+    } else if is_static_non_nullish_value(&left) {
+        right
+    } else {
+        return None;
+    };
+
+    let mut chain = LogicalAndChain::from_expression(compared_chain).ok()?;
+    let guard_chain =
+        LogicalAndChain::from_expression(normalized_optional_chain_like(guard, model).ok()?)
+            .ok()?;
+    if !matches!(
+        chain.cmp_chain(&guard_chain).ok()?,
+        LogicalAndChainOrdering::SubChain
+    ) {
+        return None;
+    }
+
+    let mut tail = chain.buf.split_off(guard_chain.buf.len());
+    let optional_node = tail.pop_front()?;
+    Some(LogicalAndChainNodes {
+        nodes: VecDeque::from([optional_node]),
+        prefix: None,
+        negated: false,
+    })
+}
+
+fn is_static_non_nullish_value(expression: &AnyJsExpression) -> bool {
+    expression
+        .clone()
+        .omit_parentheses()
+        .as_static_value()
+        .is_some_and(|value| !value.is_null_or_undefined())
 }
 
 /// `LogicalAndChainOrdering` is the result of a comparison between two logical

--- a/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/invalidNegatedOrChain.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/invalidNegatedOrChain.js
@@ -10,3 +10,7 @@
 !a.b || !a.b();
 (!foo || !foo.bar) && (!baz || !baz.bar);
 !foo || !foo?.bar.baz;
+!foo || foo.bar !== "x";
+!foo || foo.bar != "x";
+!foo || "x" !== foo.bar;
+!foo || "x" != foo.bar;

--- a/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/invalidNegatedOrChain.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/invalidNegatedOrChain.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
 expression: invalidNegatedOrChain.js
 ---
 # Input
@@ -16,6 +17,10 @@ expression: invalidNegatedOrChain.js
 !a.b || !a.b();
 (!foo || !foo.bar) && (!baz || !baz.bar);
 !foo || !foo?.bar.baz;
+!foo || foo.bar !== "x";
+!foo || foo.bar != "x";
+!foo || "x" !== foo.bar;
+!foo || "x" != foo.bar;
 
 ```
 
@@ -221,7 +226,7 @@ invalidNegatedOrChain.js:11:2 lint/complexity/useOptionalChain  FIXABLE  ━━�
   > 11 │ (!foo || !foo.bar) && (!baz || !baz.bar);
        │  ^^^^^^^^^^^^^^^^
     12 │ !foo || !foo?.bar.baz;
-    13 │ 
+    13 │ !foo || foo.bar !== "x";
   
   i Unsafe fix: Change to an optional chain.
   
@@ -230,7 +235,7 @@ invalidNegatedOrChain.js:11:2 lint/complexity/useOptionalChain  FIXABLE  ━━�
     11    │ - (!foo·||·!foo.bar)·&&·(!baz·||·!baz.bar);
        11 │ + (!foo?.bar)·&&·(!baz·||·!baz.bar);
     12 12 │   !foo || !foo?.bar.baz;
-    13 13 │   
+    13 13 │   !foo || foo.bar !== "x";
   
 
 ```
@@ -245,7 +250,7 @@ invalidNegatedOrChain.js:11:24 lint/complexity/useOptionalChain  FIXABLE  ━━
   > 11 │ (!foo || !foo.bar) && (!baz || !baz.bar);
        │                        ^^^^^^^^^^^^^^^^
     12 │ !foo || !foo?.bar.baz;
-    13 │ 
+    13 │ !foo || foo.bar !== "x";
   
   i Unsafe fix: Change to an optional chain.
   
@@ -254,7 +259,7 @@ invalidNegatedOrChain.js:11:24 lint/complexity/useOptionalChain  FIXABLE  ━━
     11    │ - (!foo·||·!foo.bar)·&&·(!baz·||·!baz.bar);
        11 │ + (!foo·||·!foo.bar)·&&·(!baz?.bar);
     12 12 │   !foo || !foo?.bar.baz;
-    13 13 │   
+    13 13 │   !foo || foo.bar !== "x";
   
 
 ```
@@ -268,11 +273,106 @@ invalidNegatedOrChain.js:12:1 lint/complexity/useOptionalChain  FIXABLE  ━━�
     11 │ (!foo || !foo.bar) && (!baz || !baz.bar);
   > 12 │ !foo || !foo?.bar.baz;
        │ ^^^^^^^^^^^^^^^^^^^^^
-    13 │ 
+    13 │ !foo || foo.bar !== "x";
+    14 │ !foo || foo.bar != "x";
   
   i Unsafe fix: Change to an optional chain.
   
     12 │ !foo·||·!foo?.bar.baz;
        │     --------          
+
+```
+
+```
+invalidNegatedOrChain.js:13:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    11 │ (!foo || !foo.bar) && (!baz || !baz.bar);
+    12 │ !foo || !foo?.bar.baz;
+  > 13 │ !foo || foo.bar !== "x";
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ !foo || foo.bar != "x";
+    15 │ !foo || "x" !== foo.bar;
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    11 11 │   (!foo || !foo.bar) && (!baz || !baz.bar);
+    12 12 │   !foo || !foo?.bar.baz;
+    13    │ - !foo·||·foo.bar·!==·"x";
+       13 │ + foo?.bar·!==·"x";
+    14 14 │   !foo || foo.bar != "x";
+    15 15 │   !foo || "x" !== foo.bar;
+  
+
+```
+
+```
+invalidNegatedOrChain.js:14:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    12 │ !foo || !foo?.bar.baz;
+    13 │ !foo || foo.bar !== "x";
+  > 14 │ !foo || foo.bar != "x";
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    15 │ !foo || "x" !== foo.bar;
+    16 │ !foo || "x" != foo.bar;
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    12 12 │   !foo || !foo?.bar.baz;
+    13 13 │   !foo || foo.bar !== "x";
+    14    │ - !foo·||·foo.bar·!=·"x";
+       14 │ + foo?.bar·!=·"x";
+    15 15 │   !foo || "x" !== foo.bar;
+    16 16 │   !foo || "x" != foo.bar;
+  
+
+```
+
+```
+invalidNegatedOrChain.js:15:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    13 │ !foo || foo.bar !== "x";
+    14 │ !foo || foo.bar != "x";
+  > 15 │ !foo || "x" !== foo.bar;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
+    16 │ !foo || "x" != foo.bar;
+    17 │ 
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    13 13 │   !foo || foo.bar !== "x";
+    14 14 │   !foo || foo.bar != "x";
+    15    │ - !foo·||·"x"·!==·foo.bar;
+       15 │ + "x"·!==·foo?.bar;
+    16 16 │   !foo || "x" != foo.bar;
+    17 17 │   
+  
+
+```
+
+```
+invalidNegatedOrChain.js:16:1 lint/complexity/useOptionalChain  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Change to an optional chain.
+  
+    14 │ !foo || foo.bar != "x";
+    15 │ !foo || "x" !== foo.bar;
+  > 16 │ !foo || "x" != foo.bar;
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    17 │ 
+  
+  i Unsafe fix: Change to an optional chain.
+  
+    14 14 │   !foo || foo.bar != "x";
+    15 15 │   !foo || "x" !== foo.bar;
+    16    │ - !foo·||·"x"·!=·foo.bar;
+       16 │ + "x"·!=·foo?.bar;
+    17 17 │   
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/validNegatedOrChain.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/validNegatedOrChain.js
@@ -13,3 +13,25 @@ a || !a.b;
 
 // Mixed operators
 !a || !a.b && !a.b.c;
+
+// Equality comparisons are not equivalent when the base is nullish
+!foo || foo.bar === "x";
+!foo || foo.bar == "x";
+
+// Ordering comparisons are not equivalent when the base is nullish
+!foo || foo.bar > 0;
+!foo || foo.bar <= 0;
+
+// Dynamic comparison values are outside the supported static-safe shape
+!foo || foo.bar !== baz;
+
+// Nullish comparison values are outside the supported static-safe shape
+!foo || foo.bar !== undefined;
+!foo || foo.bar !== null;
+!foo || foo.bar != null;
+
+// Mismatched chains are not equivalent
+!foo || bar.baz !== "x";
+
+// The guard must be a negated base
+foo || foo.bar !== "x";

--- a/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/validNegatedOrChain.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/validNegatedOrChain.js.snap
@@ -20,4 +20,26 @@ a || !a.b;
 // Mixed operators
 !a || !a.b && !a.b.c;
 
+// Equality comparisons are not equivalent when the base is nullish
+!foo || foo.bar === "x";
+!foo || foo.bar == "x";
+
+// Ordering comparisons are not equivalent when the base is nullish
+!foo || foo.bar > 0;
+!foo || foo.bar <= 0;
+
+// Dynamic comparison values are outside the supported static-safe shape
+!foo || foo.bar !== baz;
+
+// Nullish comparison values are outside the supported static-safe shape
+!foo || foo.bar !== undefined;
+!foo || foo.bar !== null;
+!foo || foo.bar != null;
+
+// Mismatched chains are not equivalent
+!foo || bar.baz !== "x";
+
+// The guard must be a negated base
+foo || foo.bar !== "x";
+
 ```


### PR DESCRIPTION
## Summary

Fixes #10244.

The `useOptionalChain` rule now reports negated guard inequality chains such as `!foo || foo.bar !== "x"`, while keeping the new path limited to `!==` / `!=` comparisons against static non-nullish values.

## Test Plan

- `cargo test -p biome_js_analyze -- use_optional_chain --show-output` (failed before the implementation after adding the regression fixtures)
- `INSTA_UPDATE=always cargo test -p biome_js_analyze -- use_optional_chain --show-output`
- `just test-lintrule useOptionalChain`
- `cargo fmt --check`
- `git diff --check` (fails only on generated `invalidNegatedOrChain.js.snap` diagnostic trailing whitespace; removing it makes the snapshot test fail)
- `git diff --check -- . ':(exclude)crates/biome_js_analyze/tests/specs/complexity/useOptionalChain/invalidNegatedOrChain.js.snap'`

## Docs

Added a patch changeset for `@biomejs/biome`. No docs site PR is needed.

AI assistance disclosure: Codex was used to inspect the rule path, implement the narrow change, and run local verification. I reviewed the final diff and the listed command results locally.
