### PR TITLE
fix: incorrect build when using build or test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run cargo check
-        run: cargo check --workspace --all-targets --release
+        run: cargo check --workspace --all-targets --all-features --release
       - name: Run clippy
         run: cargo lint
 
@@ -76,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run udeps
-        run: cargo +nightly udeps --all-targets
+        run: cargo +nightly udeps --all-targets --all-features
 
   deny:
     name: Cargo Deny
@@ -110,7 +110,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests on ${{ matrix.os }}
-        run: cargo test --workspace --features=js_plugin
+        run: cargo test --workspace --all-features
 
   coverage:
     name: Test262 Coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests on ${{ matrix.os }}
-        run: cargo test --workspace --all-features
+        run: cargo test --workspace --features=js_plugin
 
   coverage:
     name: Test262 Coverage

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,6 +47,8 @@ jobs:
           cache-base: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run cargo check
+        run: cargo check --workspace --all-targets --all-features --release
       - name: Run clippy
         run: cargo lint
 
@@ -65,7 +67,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Detect unused dependencies using udeps
-        run: cargo +nightly udeps --all-targets
+        run: cargo +nightly udeps --all-targets --all-features
 
   deny:
     name: Cargo Deny
@@ -98,7 +100,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
-        run: cargo test --workspace --features=js_plugin
+        run: cargo test --workspace --all-features
 
   e2e-tests:
     name: End-to-end tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,8 +47,6 @@ jobs:
           cache-base: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run cargo check
-        run: cargo check --workspace --all-targets --all-features --release
       - name: Run clippy
         run: cargo lint
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -98,7 +98,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
-        run: cargo test --workspace --all-features
+        run: cargo test --workspace --features=js_plugin
 
   e2e-tests:
     name: End-to-end tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
-resolver = "2"
-members  = ["crates/*", "xtask/codegen", "xtask/coverage", "xtask/glue", "xtask/rules_check"]
+resolver        = "2"
+members         = ["crates/*", "xtask/codegen", "xtask/coverage", "xtask/glue", "xtask/rules_check"]
+default-members = ["crates/*"]
 
 [workspace.package]
 authors    = ["Biome Developers and Contributors"]

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -51,7 +51,7 @@ biome_rowan              = { workspace = true }
 biome_rule_options       = { workspace = true }
 biome_service            = { workspace = true, features = ["lang_graphql", "plugins"] }
 biome_text_edit          = { workspace = true }
-bpaf                     = { workspace = true, features = ["bright-color"] }
+bpaf                     = { workspace = true, features = ["bright-color", "docgen"] }
 camino                   = { workspace = true }
 crossbeam                = { workspace = true }
 papaya                   = { workspace = true }

--- a/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
@@ -370,14 +370,16 @@ Available options:
                               `off`, then the severity level of the rule is set to `error` if it is
                               a recommended rule or `warn` otherwise.
                               Example:
-                              ```shell biome check --only=correctness/noUnusedVariables
-                              --only=suspicious --only=test ```
+                              ```shell
+                              biome check --only=correctness/noUnusedVariables --only=suspicious --only=test
+                              ```
         --skip=<GROUP|RULE|DOMAIN|ACTION>  Skip the given lint rule, assist action, group of rules
                               and actions, or domain by setting the severity level of the rules to
                               `off`. This option takes precedence over `--only`.
                               Example:
-                              ```shell biome check --skip=correctness/noUnusedVariables
-                              --skip=suspicious --skip=project ```
+                              ```shell
+                              biome check --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+                              ```
     -h, --help                Prints help information
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_help/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/ci_help.snap
@@ -352,14 +352,16 @@ Available options:
                               `off`, then the severity level of the rule is set to `error` if it is
                               a recommended rule or `warn` otherwise.
                               Example:
-                              ```shell biome ci --only=correctness/noUnusedVariables
-                              --only=suspicious --only=test ```
+                              ```shell
+                              biome ci --only=correctness/noUnusedVariables --only=suspicious --only=test
+                              ```
         --skip=<GROUP|RULE|DOMAIN|ACTION>  Skip the given lint rule, assist action, group of rules
                               and actions, or domain by setting the severity level of the rules to
                               `off`. This option takes precedence over `--only`.
                               Example:
-                              ```shell biome ci --skip=correctness/noUnusedVariables
-                              --skip=suspicious --skip=project ```
+                              ```shell
+                              biome ci --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+                              ```
     -h, --help                Prints help information
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_help/explain_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/explain_help.snap
@@ -7,8 +7,12 @@ expression: redactor(content)
 ```block
 Shows documentation of various aspects of the CLI.
 ### Examples
-```shell biome explain noDebugger ```
-```shell biome explain daemon-logs ```
+```shell
+biome explain noDebugger
+```
+```shell
+biome explain daemon-logs
+```
 
 Usage: explain NAME
 

--- a/crates/biome_cli/tests/snapshots/main_cases_help/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/lint_help.snap
@@ -111,14 +111,16 @@ Available options:
                               `off`, then the severity level of the rule is set to `error` if it is
                               a recommended rule or `warn` otherwise.
                               Example:
-                              ```shell biome lint --only=correctness/noUnusedVariables
-                              --only=suspicious --only=test ```
+                              ```shell
+                              biome lint --only=correctness/noUnusedVariables --only=suspicious --only=test
+                              ```
         --skip=<GROUP|RULE|DOMAIN|ACTION>  Skip the given lint rule, assist action, group of rules
                               and actions, or domain by setting the severity level of the rules to
                               `off`. This option takes precedence over `--only`.
                               Example:
-                              ```shell biome lint --skip=correctness/noUnusedVariables
-                              --skip=suspicious --skip=project ```
+                              ```shell
+                              biome lint --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+                              ```
         --stdin-file-path=PATH  Use this option when you want to format code piped from `stdin`, and
                               print the output to `stdout`.
                               The file doesn't need to exist on disk, what matters is the extension

--- a/crates/biome_configuration/Cargo.toml
+++ b/crates/biome_configuration/Cargo.toml
@@ -62,7 +62,8 @@ mimalloc = { workspace = true }
 [features]
 cli          = ["dep:bpaf"]
 lang_graphql = ["biome_configuration_macros/lang_graphql"]
-markdown     = []
+lang_md      = []
+lang_yaml    = []
 plugins      = ["dep:biome_plugin_loader"]
 schema       = [
   "biome_analyze/schema",
@@ -77,7 +78,6 @@ schema       = [
   "dep:schemars",
 ]
 test-utils   = []
-yaml         = []
 
 [lints]
 workspace = true

--- a/crates/biome_configuration/Cargo.toml
+++ b/crates/biome_configuration/Cargo.toml
@@ -76,6 +76,7 @@ schema       = [
   "biome_plugin_loader/schema",
   "biome_rule_options/schema",
   "dep:schemars",
+  "lang_graphql"
 ]
 test-utils   = []
 

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -13,15 +13,18 @@ pub mod editorconfig;
 mod extends;
 pub mod formatter;
 pub mod generated;
+#[cfg(feature = "lang_graphql")]
 pub mod graphql;
 pub mod grit;
 pub mod html;
 pub mod javascript;
 pub mod json;
+#[cfg(feature = "lang_md")]
 pub mod markdown;
 pub mod max_size;
 mod overrides;
 pub mod vcs;
+#[cfg(feature = "lang_yaml")]
 pub mod yaml;
 
 #[cfg(feature = "cli")]
@@ -40,8 +43,9 @@ pub use crate::grit::GritConfiguration;
 pub use crate::grit::grit_configuration;
 use crate::javascript::{JsFormatterConfiguration, JsLinterConfiguration};
 use crate::json::{JsonFormatterConfiguration, JsonLinterConfiguration};
+#[cfg(feature = "lang_md")]
 pub use crate::markdown::MarkdownConfiguration;
-#[cfg(feature = "cli")]
+#[cfg(all(feature = "cli", feature = "lang_md"))]
 pub use crate::markdown::markdown_configuration;
 use crate::max_size::MaxSize;
 use crate::vcs::VcsConfiguration;
@@ -72,9 +76,6 @@ pub use css::css_configuration;
 pub use formatter::FormatterConfiguration;
 #[cfg(feature = "cli")]
 pub use formatter::formatter_configuration;
-pub use graphql::GraphqlConfiguration;
-#[cfg(feature = "cli")]
-pub use graphql::graphql_configuration;
 pub use html::HtmlConfiguration;
 #[cfg(feature = "cli")]
 pub use html::html_configuration;
@@ -190,7 +191,7 @@ pub struct Configuration {
         bpaf(external(markdown_configuration), optional, hide)
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg(feature = "markdown")]
+    #[cfg(feature = "lang_md")]
     pub markdown: Option<MarkdownConfiguration>,
 
     /// Specific configuration for the YAML language
@@ -199,13 +200,20 @@ pub struct Configuration {
         bpaf(external(crate::yaml::yaml_configuration), optional, hide)
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg(feature = "yaml")]
+    #[cfg(feature = "lang_yaml")]
     pub yaml: Option<crate::yaml::YamlConfiguration>,
 
     /// Specific configuration for the GraphQL language
-    #[cfg_attr(feature = "cli", bpaf(external(graphql_configuration), optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub graphql: Option<GraphqlConfiguration>,
+    #[cfg(feature = "lang_graphql")]
+    #[cfg_attr(
+        all(feature = "cli", feature = "lang_graphql"),
+        bpaf(external(crate::graphql::graphql_configuration), optional)
+    )]
+    #[cfg_attr(
+        all(feature = "lang_graphql"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
+    pub graphql: Option<crate::graphql::GraphqlConfiguration>,
 
     /// Specific configuration for the GraphQL language
     #[cfg_attr(feature = "cli", bpaf(external(grit_configuration), optional))]

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -37,6 +37,7 @@ pub use crate::diagnostics::BiomeDiagnostic;
 pub use crate::diagnostics::CantLoadExtendFile;
 use crate::extends::Extends;
 pub use crate::generated::{push_to_analyzer_assist, push_to_analyzer_rules};
+#[cfg(feature = "lang_graphql")]
 use crate::graphql::{GraphqlFormatterConfiguration, GraphqlLinterConfiguration};
 pub use crate::grit::GritConfiguration;
 #[cfg(feature = "cli")]
@@ -444,6 +445,7 @@ impl Configuration {
             .unwrap_or_default()
     }
 
+    #[cfg(feature = "lang_graphql")]
     pub fn get_graphql_formatter_configuration(&self) -> GraphqlFormatterConfiguration {
         self.graphql
             .as_ref()
@@ -452,6 +454,7 @@ impl Configuration {
             .unwrap_or_default()
     }
 
+    #[cfg(feature = "lang_graphql")]
     pub fn get_graphql_linter_configuration(&self) -> GraphqlLinterConfiguration {
         self.graphql
             .as_ref()

--- a/crates/biome_configuration/src/markdown.rs
+++ b/crates/biome_configuration/src/markdown.rs
@@ -31,22 +31,22 @@ pub type MarkdownParseInterpolation = Bool<false>;
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MarkdownFormatterConfiguration {
     /// Control the formatter for Markdown (and its super languages) files.
-    #[cfg_attr(all(feature = "cli", feature = "markdown"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_md"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<MarkdownFormatterEnabled>,
 
     /// The indent style applied to Markdown files.
-    #[cfg_attr(all(feature = "cli", feature = "markdown"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_md"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_style: Option<IndentStyle>,
 
     /// The size of the indentation applied to Markdown files. Defaults to 2.
-    #[cfg_attr(all(feature = "cli", feature = "markdown"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_md"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_width: Option<IndentWidth>,
 
     /// What's the max width of a line applied to Markdown files. Defaults to 80.
-    #[cfg_attr(all(feature = "cli", feature = "markdown"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_md"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_width: Option<LineWidth>,
 
@@ -60,12 +60,12 @@ pub struct MarkdownFormatterConfiguration {
     /// Disable the option at your own risk.
     ///
     /// Defaults to true.
-    #[cfg_attr(all(feature = "cli", feature = "markdown"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_md"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trailing_newline: Option<TrailingNewline>,
 
     /// The type of line ending applied to Markdown (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
-    #[cfg_attr(all(feature = "cli", feature = "markdown"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_md"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_ending: Option<LineEnding>,
 }

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -3,10 +3,7 @@ use crate::analyzer::{LinterEnabled, RuleDomains};
 use crate::formatter::{FormatWithErrorsEnabled, FormatterEnabled};
 use crate::html::HtmlConfiguration;
 use crate::max_size::MaxSize;
-use crate::{
-    CssConfiguration, GraphqlConfiguration, GritConfiguration, JsConfiguration, JsonConfiguration,
-    Rules,
-};
+use crate::{CssConfiguration, GritConfiguration, JsConfiguration, JsonConfiguration, Rules};
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::{
     AttributePosition, BracketSameLine, BracketSpacing, Expand, IndentStyle, IndentWidth,
@@ -46,8 +43,12 @@ pub struct OverridePattern {
     pub css: Option<CssConfiguration>,
 
     /// Specific configuration for the Graphql language
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub graphql: Option<GraphqlConfiguration>,
+    #[cfg(feature = "lang_graphql")]
+    #[cfg_attr(
+        feature = "lang_graphql",
+        serde(skip_serializing_if = "Option::is_none")
+    )]
+    pub graphql: Option<crate::graphql::GraphqlConfiguration>,
 
     /// Specific configuration for the GritQL language
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/biome_configuration/src/yaml.rs
+++ b/crates/biome_configuration/src/yaml.rs
@@ -31,17 +31,17 @@ pub type YamlParseInterpolation = Bool<false>;
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct YamlFormatterConfiguration {
     /// Control the formatter for Yaml (and its super languages) files.
-    #[cfg_attr(all(feature = "cli", feature = "yaml"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_yaml"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<YamlFormatterEnabled>,
 
     /// The size of the indentation applied to Yaml files. Defaults to 2.
-    #[cfg_attr(all(feature = "cli", feature = "yaml"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_yaml"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_width: Option<IndentWidth>,
 
     /// What's the max width of a line applied to Yaml files. Defaults to 80.
-    #[cfg_attr(all(feature = "cli", feature = "yaml"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_yaml"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_width: Option<LineWidth>,
 
@@ -55,12 +55,12 @@ pub struct YamlFormatterConfiguration {
     /// Disable the option at your own risk.
     ///
     /// Defaults to true.
-    #[cfg_attr(all(feature = "cli", feature = "yaml"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_yaml"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trailing_newline: Option<TrailingNewline>,
 
     /// The type of line ending applied to Yaml (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
-    #[cfg_attr(all(feature = "cli", feature = "yaml"), bpaf(hide))]
+    #[cfg_attr(all(feature = "cli", feature = "lang_yaml"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_ending: Option<LineEnding>,
 }

--- a/crates/biome_graphql_formatter/Cargo.toml
+++ b/crates/biome_graphql_formatter/Cargo.toml
@@ -34,7 +34,7 @@ biome_formatter_test = { path = "../biome_formatter_test" }
 biome_fs             = { path = "../biome_fs" }
 biome_graphql_parser = { path = "../biome_graphql_parser" }
 biome_parser         = { path = "../biome_parser" }
-biome_service        = { path = "../biome_service" }
+biome_service        = { path = "../biome_service", features = ["lang_graphql"] }
 biome_test_utils     = { path = "../biome_test_utils" }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }

--- a/crates/biome_graphql_formatter/tests/spec_test.rs
+++ b/crates/biome_graphql_formatter/tests/spec_test.rs
@@ -1,5 +1,5 @@
 use biome_configuration::graphql::GraphqlFormatterConfiguration;
-use biome_configuration::{Configuration, GraphqlConfiguration};
+use biome_configuration::{Configuration, graphql::GraphqlConfiguration};
 use biome_formatter_test::spec::{SpecSnapshot, SpecTestFile};
 use camino::Utf8Path;
 

--- a/crates/biome_markdown_formatter/tests/spec_test.rs
+++ b/crates/biome_markdown_formatter/tests/spec_test.rs
@@ -1,5 +1,5 @@
 use biome_configuration::markdown::MarkdownFormatterConfiguration;
-use biome_configuration::{Configuration, MarkdownConfiguration};
+use biome_configuration::{Configuration, markdown::MarkdownConfiguration};
 use biome_formatter_test::spec::{SpecSnapshot, SpecTestFile};
 use camino::Utf8Path;
 

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -109,13 +109,13 @@ lang_grit    = [
   "dep:biome_grit_syntax",
 ]
 lang_md      = [
-  "biome_configuration/markdown",
+  "biome_configuration/lang_md",
   "dep:biome_markdown_formatter",
   "dep:biome_markdown_parser",
   "dep:biome_markdown_syntax"
 ]
 lang_yaml    = [
-  "biome_configuration/yaml",
+  "biome_configuration/lang_yaml",
   "dep:biome_yaml_formatter",
   "dep:biome_yaml_parser",
   "dep:biome_yaml_syntax"

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -253,7 +253,6 @@ impl DocumentFileSource {
         }
         #[cfg(feature = "lang_yaml")]
         if let Ok(file_source) = biome_yaml_syntax::YamlFileSource::try_from_extension(extension) {
-            dbg!("try_from_extension:", &file_source);
             return Ok(file_source.into());
         }
         Err(FileSourceError::UnknownExtension)
@@ -1333,7 +1332,6 @@ impl Features {
 
     /// Returns the [Capabilities] associated with a document source.
     pub(crate) fn get_capabilities(&self, language_hint: DocumentFileSource) -> Capabilities {
-        dbg!(language_hint);
         match language_hint {
             // TODO: remove match once we remove vue/astro/svelte handlers
             DocumentFileSource::Js(source) => match source.as_embedding_kind() {

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -253,6 +253,7 @@ impl DocumentFileSource {
         }
         #[cfg(feature = "lang_yaml")]
         if let Ok(file_source) = biome_yaml_syntax::YamlFileSource::try_from_extension(extension) {
+            dbg!("try_from_extension:", &file_source);
             return Ok(file_source.into());
         }
         Err(FileSourceError::UnknownExtension)
@@ -1332,6 +1333,7 @@ impl Features {
 
     /// Returns the [Capabilities] associated with a document source.
     pub(crate) fn get_capabilities(&self, language_hint: DocumentFileSource) -> Capabilities {
+        dbg!(language_hint);
         match language_hint {
             // TODO: remove match once we remove vue/astro/svelte handlers
             DocumentFileSource::Js(source) => match source.as_embedding_kind() {

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -793,8 +793,10 @@ impl From<CssConfiguration> for LanguageSettings<CssLanguage> {
 }
 
 #[cfg(feature = "lang_graphql")]
-impl From<biome_configuration::GraphqlConfiguration> for LanguageSettings<GraphqlLanguage> {
-    fn from(graphql: biome_configuration::GraphqlConfiguration) -> Self {
+impl From<biome_configuration::graphql::GraphqlConfiguration>
+    for LanguageSettings<GraphqlLanguage>
+{
+    fn from(graphql: biome_configuration::graphql::GraphqlConfiguration) -> Self {
         let mut language_setting: Self = Self::default();
 
         if let Some(formatter) = graphql.formatter {
@@ -2131,7 +2133,7 @@ fn to_css_language_settings(
 
 #[cfg(feature = "lang_graphql")]
 fn to_graphql_language_settings(
-    mut conf: biome_configuration::GraphqlConfiguration,
+    mut conf: biome_configuration::graphql::GraphqlConfiguration,
     _parent_settings: &LanguageSettings<GraphqlLanguage>,
 ) -> LanguageSettings<GraphqlLanguage> {
     let mut language_setting: LanguageSettings<GraphqlLanguage> = LanguageSettings::default();

--- a/crates/biome_yaml_formatter/Cargo.toml
+++ b/crates/biome_yaml_formatter/Cargo.toml
@@ -33,7 +33,7 @@ biome_formatter      = { path = "../biome_formatter", features = ["countme"] }
 biome_formatter_test = { path = "../biome_formatter_test" }
 biome_fs             = { path = "../biome_fs" }
 biome_parser         = { path = "../biome_parser" }
-biome_service        = { path = "../biome_service" }
+biome_service        = { path = "../biome_service", features = ["lang_yaml"] }
 biome_yaml_parser    = { path = "../biome_yaml_parser" }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }

--- a/crates/biome_yaml_formatter/Cargo.toml
+++ b/crates/biome_yaml_formatter/Cargo.toml
@@ -28,7 +28,7 @@ schemars          = { workspace = true, optional = true }
 serde             = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
-biome_configuration  = { path = "../biome_configuration/", features = ["yaml"] }
+biome_configuration  = { path = "../biome_configuration/", features = ["lang_yaml"] }
 biome_formatter      = { path = "../biome_formatter", features = ["countme"] }
 biome_formatter_test = { path = "../biome_formatter_test" }
 biome_fs             = { path = "../biome_fs" }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1947,6 +1947,11 @@ See https://biomejs.dev/linter/rules/use-exhaustive-dependencies
 	 */
 	useExhaustiveDependencies?: UseExhaustiveDependenciesConfiguration;
 	/**
+	* Enforce specifying the name of GraphQL operations.
+See https://biomejs.dev/linter/rules/use-graphql-named-operations 
+	 */
+	useGraphqlNamedOperations?: UseGraphqlNamedOperationsConfiguration;
+	/**
 	* Enforce that all React hooks are being called from the Top Level component functions.
 See https://biomejs.dev/linter/rules/use-hook-at-top-level 
 	 */
@@ -2077,20 +2082,50 @@ See https://biomejs.dev/linter/rules/no-drizzle-update-without-where
 	 */
 	noDrizzleUpdateWithoutWhere?: NoDrizzleUpdateWithoutWhereConfiguration;
 	/**
+	* Require all argument names for fields & directives to be unique.
+See https://biomejs.dev/linter/rules/no-duplicate-argument-names 
+	 */
+	noDuplicateArgumentNames?: NoDuplicateArgumentNamesConfiguration;
+	/**
 	* Disallow duplication of attributes.
 See https://biomejs.dev/linter/rules/no-duplicate-attributes 
 	 */
 	noDuplicateAttributes?: NoDuplicateAttributesConfiguration;
+	/**
+	* Require all enum value names to be unique.
+See https://biomejs.dev/linter/rules/no-duplicate-enum-value-names 
+	 */
+	noDuplicateEnumValueNames?: NoDuplicateEnumValueNamesConfiguration;
 	/**
 	* Disallow duplicate enum member values.
 See https://biomejs.dev/linter/rules/no-duplicate-enum-values 
 	 */
 	noDuplicateEnumValues?: NoDuplicateEnumValuesConfiguration;
 	/**
+	* Require all fields of a type to be unique.
+See https://biomejs.dev/linter/rules/no-duplicate-field-definition-names 
+	 */
+	noDuplicateFieldDefinitionNames?: NoDuplicateFieldDefinitionNamesConfiguration;
+	/**
+	* Enforce unique operation names across a GraphQL document.
+See https://biomejs.dev/linter/rules/no-duplicate-graphql-operation-name 
+	 */
+	noDuplicateGraphqlOperationName?: NoDuplicateGraphqlOperationNameConfiguration;
+	/**
+	* Require fields within an input object to be unique.
+See https://biomejs.dev/linter/rules/no-duplicate-input-field-names 
+	 */
+	noDuplicateInputFieldNames?: NoDuplicateInputFieldNamesConfiguration;
+	/**
 	* Disallow duplicate selectors.
 See https://biomejs.dev/linter/rules/no-duplicate-selectors 
 	 */
 	noDuplicateSelectors?: NoDuplicateSelectorsConfiguration;
+	/**
+	* Require all variable definitions to be unique.
+See https://biomejs.dev/linter/rules/no-duplicate-variable-names 
+	 */
+	noDuplicateVariableNames?: NoDuplicateVariableNamesConfiguration;
 	/**
 	* Disallow JSX prop spreading the same identifier multiple times.
 See https://biomejs.dev/linter/rules/no-duplicated-spread-props 
@@ -2307,6 +2342,11 @@ See https://biomejs.dev/linter/rules/no-return-assign
 	 */
 	noReturnAssign?: NoReturnAssignConfiguration;
 	/**
+	* Disallow the usage of specified root types.
+See https://biomejs.dev/linter/rules/no-root-type 
+	 */
+	noRootType?: NoRootTypeConfiguration;
+	/**
 	* Disallow javascript: URLs in HTML.
 See https://biomejs.dev/linter/rules/no-script-url 
 	 */
@@ -2431,6 +2471,11 @@ See https://biomejs.dev/linter/rules/use-consistent-enum-value-type
 	 */
 	useConsistentEnumValueType?: UseConsistentEnumValueTypeConfiguration;
 	/**
+	* Require all descriptions to follow the same style (either block or inline) to  maintain consistency and improve readability across the schema.
+See https://biomejs.dev/linter/rules/use-consistent-graphql-descriptions 
+	 */
+	useConsistentGraphqlDescriptions?: UseConsistentGraphqlDescriptionsConfiguration;
+	/**
 	* Enforce consistent use of either method signatures or function properties within interfaces and type aliases.
 See https://biomejs.dev/linter/rules/use-consistent-method-signatures 
 	 */
@@ -2510,6 +2555,21 @@ See https://biomejs.dev/linter/rules/use-imports-first
 See https://biomejs.dev/linter/rules/use-inline-script-id 
 	 */
 	useInlineScriptId?: UseInlineScriptIdConfiguration;
+	/**
+	* Require mutation argument to be always called "input".
+See https://biomejs.dev/linter/rules/use-input-name 
+	 */
+	useInputName?: UseInputNameConfiguration;
+	/**
+	* Disallow anonymous operations when more than one operation specified in document.
+See https://biomejs.dev/linter/rules/use-lone-anonymous-operation 
+	 */
+	useLoneAnonymousOperation?: UseLoneAnonymousOperationConfiguration;
+	/**
+	* Require queries, mutations, subscriptions or fragments each to be located in separate files.
+See https://biomejs.dev/linter/rules/use-lone-executable-definition 
+	 */
+	useLoneExecutableDefinition?: UseLoneExecutableDefinitionConfiguration;
 	/**
 	* Prefer Math.min() and Math.max() over ternaries for simple comparisons.
 See https://biomejs.dev/linter/rules/use-math-min-max 
@@ -3048,6 +3108,11 @@ See https://biomejs.dev/linter/rules/use-default-switch-clause
 	 */
 	useDefaultSwitchClause?: UseDefaultSwitchClauseConfiguration;
 	/**
+	* Require specifying the reason argument when using @deprecated directive.
+See https://biomejs.dev/linter/rules/use-deprecated-reason 
+	 */
+	useDeprecatedReason?: UseDeprecatedReasonConfiguration;
+	/**
 	* Require that each enum member value be explicitly initialized.
 See https://biomejs.dev/linter/rules/use-enum-initializers 
 	 */
@@ -3087,6 +3152,11 @@ See https://biomejs.dev/linter/rules/use-for-of
 See https://biomejs.dev/linter/rules/use-fragment-syntax 
 	 */
 	useFragmentSyntax?: UseFragmentSyntaxConfiguration;
+	/**
+	* Validates that all enum values are capitalized.
+See https://biomejs.dev/linter/rules/use-graphql-naming-convention 
+	 */
+	useGraphqlNamingConvention?: UseGraphqlNamingConventionConfiguration;
 	/**
 	* Enforce that getters and setters for the same property are adjacent in class and object definitions.
 See https://biomejs.dev/linter/rules/use-grouped-accessor-pairs 
@@ -3337,6 +3407,11 @@ See https://biomejs.dev/linter/rules/no-duplicate-dependencies
 See https://biomejs.dev/linter/rules/no-duplicate-else-if 
 	 */
 	noDuplicateElseIf?: NoDuplicateElseIfConfiguration;
+	/**
+	* No duplicated fields in GraphQL operations.
+See https://biomejs.dev/linter/rules/no-duplicate-fields 
+	 */
+	noDuplicateFields?: NoDuplicateFieldsConfiguration;
 	/**
 	* Disallow duplicate names within font families.
 See https://biomejs.dev/linter/rules/no-duplicate-font-names 
@@ -3651,6 +3726,11 @@ See https://biomejs.dev/linter/rules/use-biome-ignore-folder
 See https://biomejs.dev/linter/rules/use-default-switch-clause-last 
 	 */
 	useDefaultSwitchClauseLast?: UseDefaultSwitchClauseLastConfiguration;
+	/**
+	* Require the @deprecated directive to specify a deletion date.
+See https://biomejs.dev/linter/rules/use-deprecated-date 
+	 */
+	useDeprecatedDate?: UseDeprecatedDateConfiguration;
 	/**
 	* Enforce passing a message value when creating a built-in error.
 See https://biomejs.dev/linter/rules/use-error-message 
@@ -4160,6 +4240,9 @@ export type NoVueSetupPropsReactivityLossConfiguration =
 export type UseExhaustiveDependenciesConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseExhaustiveDependenciesOptions;
+export type UseGraphqlNamedOperationsConfiguration =
+	| RulePlainConfiguration
+	| RuleWithUseGraphqlNamedOperationsOptions;
 export type UseHookAtTopLevelConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseHookAtTopLevelOptions;
@@ -4235,15 +4318,33 @@ export type NoDrizzleDeleteWithoutWhereConfiguration =
 export type NoDrizzleUpdateWithoutWhereConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoDrizzleUpdateWithoutWhereOptions;
+export type NoDuplicateArgumentNamesConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoDuplicateArgumentNamesOptions;
 export type NoDuplicateAttributesConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoDuplicateAttributesOptions;
+export type NoDuplicateEnumValueNamesConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoDuplicateEnumValueNamesOptions;
 export type NoDuplicateEnumValuesConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoDuplicateEnumValuesOptions;
+export type NoDuplicateFieldDefinitionNamesConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoDuplicateFieldDefinitionNamesOptions;
+export type NoDuplicateGraphqlOperationNameConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoDuplicateGraphqlOperationNameOptions;
+export type NoDuplicateInputFieldNamesConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoDuplicateInputFieldNamesOptions;
 export type NoDuplicateSelectorsConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoDuplicateSelectorsOptions;
+export type NoDuplicateVariableNamesConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoDuplicateVariableNamesOptions;
 export type NoDuplicatedSpreadPropsConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoDuplicatedSpreadPropsOptions;
@@ -4373,6 +4474,9 @@ export type NoRedundantDefaultExportConfiguration =
 export type NoReturnAssignConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoReturnAssignOptions;
+export type NoRootTypeConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoRootTypeOptions;
 export type NoScriptUrlConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoScriptUrlOptions;
@@ -4445,6 +4549,9 @@ export type UseBaselineConfiguration =
 export type UseConsistentEnumValueTypeConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseConsistentEnumValueTypeOptions;
+export type UseConsistentGraphqlDescriptionsConfiguration =
+	| RulePlainConfiguration
+	| RuleWithUseConsistentGraphqlDescriptionsOptions;
 export type UseConsistentMethodSignaturesConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseConsistentMethodSignaturesOptions;
@@ -4493,6 +4600,15 @@ export type UseImportsFirstConfiguration =
 export type UseInlineScriptIdConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseInlineScriptIdOptions;
+export type UseInputNameConfiguration =
+	| RulePlainConfiguration
+	| RuleWithUseInputNameOptions;
+export type UseLoneAnonymousOperationConfiguration =
+	| RulePlainConfiguration
+	| RuleWithUseLoneAnonymousOperationOptions;
+export type UseLoneExecutableDefinitionConfiguration =
+	| RulePlainConfiguration
+	| RuleWithUseLoneExecutableDefinitionOptions;
 export type UseMathMinMaxConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseMathMinMaxOptions;
@@ -4799,6 +4915,9 @@ export type UseDefaultParameterLastConfiguration =
 export type UseDefaultSwitchClauseConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseDefaultSwitchClauseOptions;
+export type UseDeprecatedReasonConfiguration =
+	| RulePlainConfiguration
+	| RuleWithUseDeprecatedReasonOptions;
 export type UseEnumInitializersConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseEnumInitializersOptions;
@@ -4823,6 +4942,9 @@ export type UseForOfConfiguration =
 export type UseFragmentSyntaxConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseFragmentSyntaxOptions;
+export type UseGraphqlNamingConventionConfiguration =
+	| RulePlainConfiguration
+	| RuleWithUseGraphqlNamingConventionOptions;
 export type UseGroupedAccessorPairsConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseGroupedAccessorPairsOptions;
@@ -4970,6 +5092,9 @@ export type NoDuplicateDependenciesConfiguration =
 export type NoDuplicateElseIfConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoDuplicateElseIfOptions;
+export type NoDuplicateFieldsConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoDuplicateFieldsOptions;
 export type NoDuplicateFontNamesConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoDuplicateFontNamesOptions;
@@ -5154,6 +5279,9 @@ export type UseBiomeIgnoreFolderConfiguration =
 export type UseDefaultSwitchClauseLastConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseDefaultSwitchClauseLastOptions;
+export type UseDeprecatedDateConfiguration =
+	| RulePlainConfiguration
+	| RuleWithUseDeprecatedDateOptions;
 export type UseErrorMessageConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseErrorMessageOptions;
@@ -5855,6 +5983,11 @@ export interface RuleWithUseExhaustiveDependenciesOptions {
 	level: RulePlainConfiguration;
 	options?: UseExhaustiveDependenciesOptions;
 }
+export interface RuleWithUseGraphqlNamedOperationsOptions {
+	fix?: FixKind;
+	level: RulePlainConfiguration;
+	options?: UseGraphqlNamedOperationsOptions;
+}
 export interface RuleWithUseHookAtTopLevelOptions {
 	level: RulePlainConfiguration;
 	options?: UseHookAtTopLevelOptions;
@@ -5962,17 +6095,41 @@ export interface RuleWithNoDrizzleUpdateWithoutWhereOptions {
 	level: RulePlainConfiguration;
 	options?: NoDrizzleUpdateWithoutWhereOptions;
 }
+export interface RuleWithNoDuplicateArgumentNamesOptions {
+	level: RulePlainConfiguration;
+	options?: NoDuplicateArgumentNamesOptions;
+}
 export interface RuleWithNoDuplicateAttributesOptions {
 	level: RulePlainConfiguration;
 	options?: NoDuplicateAttributesOptions;
+}
+export interface RuleWithNoDuplicateEnumValueNamesOptions {
+	level: RulePlainConfiguration;
+	options?: NoDuplicateEnumValueNamesOptions;
 }
 export interface RuleWithNoDuplicateEnumValuesOptions {
 	level: RulePlainConfiguration;
 	options?: NoDuplicateEnumValuesOptions;
 }
+export interface RuleWithNoDuplicateFieldDefinitionNamesOptions {
+	level: RulePlainConfiguration;
+	options?: NoDuplicateFieldDefinitionNamesOptions;
+}
+export interface RuleWithNoDuplicateGraphqlOperationNameOptions {
+	level: RulePlainConfiguration;
+	options?: NoDuplicateGraphqlOperationNameOptions;
+}
+export interface RuleWithNoDuplicateInputFieldNamesOptions {
+	level: RulePlainConfiguration;
+	options?: NoDuplicateInputFieldNamesOptions;
+}
 export interface RuleWithNoDuplicateSelectorsOptions {
 	level: RulePlainConfiguration;
 	options?: NoDuplicateSelectorsOptions;
+}
+export interface RuleWithNoDuplicateVariableNamesOptions {
+	level: RulePlainConfiguration;
+	options?: NoDuplicateVariableNamesOptions;
 }
 export interface RuleWithNoDuplicatedSpreadPropsOptions {
 	level: RulePlainConfiguration;
@@ -6156,6 +6313,10 @@ export interface RuleWithNoReturnAssignOptions {
 	level: RulePlainConfiguration;
 	options?: NoReturnAssignOptions;
 }
+export interface RuleWithNoRootTypeOptions {
+	level: RulePlainConfiguration;
+	options?: NoRootTypeOptions;
+}
 export interface RuleWithNoScriptUrlOptions {
 	level: RulePlainConfiguration;
 	options?: NoScriptUrlOptions;
@@ -6256,6 +6417,10 @@ export interface RuleWithUseConsistentEnumValueTypeOptions {
 	level: RulePlainConfiguration;
 	options?: UseConsistentEnumValueTypeOptions;
 }
+export interface RuleWithUseConsistentGraphqlDescriptionsOptions {
+	level: RulePlainConfiguration;
+	options?: UseConsistentGraphqlDescriptionsOptions;
+}
 export interface RuleWithUseConsistentMethodSignaturesOptions {
 	fix?: FixKind;
 	level: RulePlainConfiguration;
@@ -6325,6 +6490,18 @@ export interface RuleWithUseImportsFirstOptions {
 export interface RuleWithUseInlineScriptIdOptions {
 	level: RulePlainConfiguration;
 	options?: UseInlineScriptIdOptions;
+}
+export interface RuleWithUseInputNameOptions {
+	level: RulePlainConfiguration;
+	options?: UseInputNameOptions;
+}
+export interface RuleWithUseLoneAnonymousOperationOptions {
+	level: RulePlainConfiguration;
+	options?: UseLoneAnonymousOperationOptions;
+}
+export interface RuleWithUseLoneExecutableDefinitionOptions {
+	level: RulePlainConfiguration;
+	options?: UseLoneExecutableDefinitionOptions;
 }
 export interface RuleWithUseMathMinMaxOptions {
 	fix?: FixKind;
@@ -6780,6 +6957,10 @@ export interface RuleWithUseDefaultSwitchClauseOptions {
 	level: RulePlainConfiguration;
 	options?: UseDefaultSwitchClauseOptions;
 }
+export interface RuleWithUseDeprecatedReasonOptions {
+	level: RulePlainConfiguration;
+	options?: UseDeprecatedReasonOptions;
+}
 export interface RuleWithUseEnumInitializersOptions {
 	fix?: FixKind;
 	level: RulePlainConfiguration;
@@ -6816,6 +6997,10 @@ export interface RuleWithUseFragmentSyntaxOptions {
 	fix?: FixKind;
 	level: RulePlainConfiguration;
 	options?: UseFragmentSyntaxOptions;
+}
+export interface RuleWithUseGraphqlNamingConventionOptions {
+	level: RulePlainConfiguration;
+	options?: UseGraphqlNamingConventionOptions;
 }
 export interface RuleWithUseGroupedAccessorPairsOptions {
 	level: RulePlainConfiguration;
@@ -7037,6 +7222,10 @@ export interface RuleWithNoDuplicateDependenciesOptions {
 export interface RuleWithNoDuplicateElseIfOptions {
 	level: RulePlainConfiguration;
 	options?: NoDuplicateElseIfOptions;
+}
+export interface RuleWithNoDuplicateFieldsOptions {
+	level: RulePlainConfiguration;
+	options?: NoDuplicateFieldsOptions;
 }
 export interface RuleWithNoDuplicateFontNamesOptions {
 	level: RulePlainConfiguration;
@@ -7305,6 +7494,10 @@ export interface RuleWithUseBiomeIgnoreFolderOptions {
 export interface RuleWithUseDefaultSwitchClauseLastOptions {
 	level: RulePlainConfiguration;
 	options?: UseDefaultSwitchClauseLastOptions;
+}
+export interface RuleWithUseDeprecatedDateOptions {
+	level: RulePlainConfiguration;
+	options?: UseDeprecatedDateOptions;
 }
 export interface RuleWithUseErrorMessageOptions {
 	level: RulePlainConfiguration;
@@ -7634,6 +7827,7 @@ export interface UseExhaustiveDependenciesOptions {
 	 */
 	reportUnnecessaryDependencies?: boolean;
 }
+export type UseGraphqlNamedOperationsOptions = {};
 export interface UseHookAtTopLevelOptions {
 	/**
 	* List of function names that should not be treated as hooks.
@@ -7709,9 +7903,15 @@ export interface NoDrizzleUpdateWithoutWhereOptions {
 	 */
 	drizzleObjectName?: string[];
 }
+export type NoDuplicateArgumentNamesOptions = {};
 export type NoDuplicateAttributesOptions = {};
+export type NoDuplicateEnumValueNamesOptions = {};
 export type NoDuplicateEnumValuesOptions = {};
+export type NoDuplicateFieldDefinitionNamesOptions = {};
+export type NoDuplicateGraphqlOperationNameOptions = {};
+export type NoDuplicateInputFieldNamesOptions = {};
 export type NoDuplicateSelectorsOptions = {};
+export type NoDuplicateVariableNamesOptions = {};
 export type NoDuplicatedSpreadPropsOptions = {};
 export type NoEmptyObjectKeysOptions = {};
 export type NoEqualsToNullOptions = {};
@@ -7792,6 +7992,13 @@ export interface NoReactNativeRawTextOptions {
 export type NoReactStringRefsOptions = {};
 export type NoRedundantDefaultExportOptions = {};
 export type NoReturnAssignOptions = {};
+export interface NoRootTypeOptions {
+	/**
+	* A list of disallowed root types (e.g. "mutation" and/or "subscription").
+The values of the list are case-insensitive. 
+	 */
+	disallow?: string[];
+}
 export type NoScriptUrlOptions = {};
 export interface NoShadowOptions {
 	/**
@@ -7910,6 +8117,12 @@ export interface UseBaselineOptions {
 	available?: AvailabilityTarget;
 }
 export type UseConsistentEnumValueTypeOptions = {};
+export interface UseConsistentGraphqlDescriptionsOptions {
+	/**
+	 * The description style to enforce. Defaults to "block"
+	 */
+	style?: UseConsistentGraphqlDescriptionsStyle;
+}
 /**
  * Options type for `useConsistentMethodSignatures`.
  */
@@ -7978,6 +8191,14 @@ export type UseGlobalThisOptions = {};
 export type UseIframeSandboxOptions = {};
 export type UseImportsFirstOptions = {};
 export type UseInlineScriptIdOptions = {};
+export interface UseInputNameOptions {
+	/**
+	 * Check that the input type name follows the convention <mutationName>Input
+	 */
+	checkInputType?: CheckInputType;
+}
+export type UseLoneAnonymousOperationOptions = {};
+export type UseLoneExecutableDefinitionOptions = {};
 export type UseMathMinMaxOptions = {};
 export type UseNamedCaptureGroupOptions = {};
 export interface UseNullishCoalescingOptions {
@@ -8271,6 +8492,7 @@ export interface UseConsistentTypeDefinitionsOptions {
 export type UseConstOptions = {};
 export type UseDefaultParameterLastOptions = {};
 export type UseDefaultSwitchClauseOptions = {};
+export type UseDeprecatedReasonOptions = {};
 export type UseEnumInitializersOptions = {};
 export type UseExplicitLengthCheckOptions = {};
 export type UseExponentiationOperatorOptions = {};
@@ -8297,6 +8519,7 @@ This does not affect other [Case].
 }
 export type UseForOfOptions = {};
 export type UseFragmentSyntaxOptions = {};
+export type UseGraphqlNamingConventionOptions = {};
 export type UseGroupedAccessorPairsOptions = {};
 export interface UseImportTypeOptions {
 	/**
@@ -8407,6 +8630,7 @@ export type NoDuplicateClassMembersOptions = {};
 export type NoDuplicateCustomPropertiesOptions = {};
 export type NoDuplicateDependenciesOptions = {};
 export type NoDuplicateElseIfOptions = {};
+export type NoDuplicateFieldsOptions = {};
 export type NoDuplicateFontNamesOptions = {};
 export type NoDuplicateJsxPropsOptions = {};
 export type NoDuplicateObjectKeysOptions = {};
@@ -8492,6 +8716,9 @@ export type UseAdjacentOverloadSignaturesOptions = {};
 export type UseAwaitOptions = {};
 export type UseBiomeIgnoreFolderOptions = {};
 export type UseDefaultSwitchClauseLastOptions = {};
+export interface UseDeprecatedDateOptions {
+	argumentName?: string;
+}
 export type UseErrorMessageOptions = {};
 export type UseGetterReturnOptions = {};
 export type UseGoogleFontDisplayOptions = {};
@@ -8554,6 +8781,10 @@ export type Regex = string;
   that year (i.e. became newly available after that year). 
 	 */
 export type AvailabilityTarget = AvailabilityNamed | number;
+/**
+ * The GraphQL description style to enforce.
+ */
+export type UseConsistentGraphqlDescriptionsStyle = "block" | "inline";
 export type MethodSignatureStyle = "property" | "method";
 /**
  * The function to use for tests
@@ -8563,6 +8794,7 @@ export interface DestructuringConfig {
 	array?: boolean;
 	object?: boolean;
 }
+export type CheckInputType = "off" | "loose" | "strict";
 /**
  * Controls how `useThisInClassMethods` treats classes that implement interfaces.
  */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -423,6 +423,25 @@
 			"type": "boolean"
 		},
 		"BracketSpacing": { "type": "boolean" },
+		"CheckInputType": {
+			"oneOf": [
+				{
+					"description": "Don't check the input type",
+					"type": "string",
+					"const": "off"
+				},
+				{
+					"description": "Check the input type (case-insensitive)",
+					"type": "string",
+					"const": "loose"
+				},
+				{
+					"description": "Check the input type (case-sensitive)",
+					"type": "string",
+					"const": "strict"
+				}
+			]
+		},
 		"Complexity": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",
@@ -1236,6 +1255,13 @@
 					"description": "Enforce correct dependency usage within React hooks.\nSee https://biomejs.dev/linter/rules/use-exhaustive-dependencies",
 					"anyOf": [
 						{ "$ref": "#/$defs/UseExhaustiveDependenciesConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useGraphqlNamedOperations": {
+					"description": "Enforce specifying the name of GraphQL operations.\nSee https://biomejs.dev/linter/rules/use-graphql-named-operations",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseGraphqlNamedOperationsConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3231,6 +3257,16 @@
 			},
 			"additionalProperties": false
 		},
+		"NoDuplicateArgumentNamesConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoDuplicateArgumentNamesOptions" }
+			]
+		},
+		"NoDuplicateArgumentNamesOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
 		"NoDuplicateAtImportRulesConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },
@@ -3323,6 +3359,16 @@
 			"type": "object",
 			"additionalProperties": false
 		},
+		"NoDuplicateEnumValueNamesConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoDuplicateEnumValueNamesOptions" }
+			]
+		},
+		"NoDuplicateEnumValueNamesOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
 		"NoDuplicateEnumValuesConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },
@@ -3333,6 +3379,26 @@
 			"type": "object",
 			"additionalProperties": false
 		},
+		"NoDuplicateFieldDefinitionNamesConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoDuplicateFieldDefinitionNamesOptions" }
+			]
+		},
+		"NoDuplicateFieldDefinitionNamesOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"NoDuplicateFieldsConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoDuplicateFieldsOptions" }
+			]
+		},
+		"NoDuplicateFieldsOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
 		"NoDuplicateFontNamesConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },
@@ -3340,6 +3406,26 @@
 			]
 		},
 		"NoDuplicateFontNamesOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"NoDuplicateGraphqlOperationNameConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoDuplicateGraphqlOperationNameOptions" }
+			]
+		},
+		"NoDuplicateGraphqlOperationNameOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"NoDuplicateInputFieldNamesConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoDuplicateInputFieldNamesOptions" }
+			]
+		},
+		"NoDuplicateInputFieldNamesOptions": {
 			"type": "object",
 			"additionalProperties": false
 		},
@@ -3410,6 +3496,16 @@
 			]
 		},
 		"NoDuplicateTestHooksOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"NoDuplicateVariableNamesConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoDuplicateVariableNamesOptions" }
+			]
+		},
+		"NoDuplicateVariableNamesOptions": {
 			"type": "object",
 			"additionalProperties": false
 		},
@@ -4928,6 +5024,23 @@
 			"type": "object",
 			"additionalProperties": false
 		},
+		"NoRootTypeConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoRootTypeOptions" }
+			]
+		},
+		"NoRootTypeOptions": {
+			"type": "object",
+			"properties": {
+				"disallow": {
+					"description": "A list of disallowed root types (e.g. \"mutation\" and/or \"subscription\").\nThe values of the list are case-insensitive.",
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
 		"NoScriptUrlConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },
@@ -6093,10 +6206,24 @@
 						{ "type": "null" }
 					]
 				},
+				"noDuplicateArgumentNames": {
+					"description": "Require all argument names for fields & directives to be unique.\nSee https://biomejs.dev/linter/rules/no-duplicate-argument-names",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoDuplicateArgumentNamesConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noDuplicateAttributes": {
 					"description": "Disallow duplication of attributes.\nSee https://biomejs.dev/linter/rules/no-duplicate-attributes",
 					"anyOf": [
 						{ "$ref": "#/$defs/NoDuplicateAttributesConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateEnumValueNames": {
+					"description": "Require all enum value names to be unique.\nSee https://biomejs.dev/linter/rules/no-duplicate-enum-value-names",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoDuplicateEnumValueNamesConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -6107,10 +6234,38 @@
 						{ "type": "null" }
 					]
 				},
+				"noDuplicateFieldDefinitionNames": {
+					"description": "Require all fields of a type to be unique.\nSee https://biomejs.dev/linter/rules/no-duplicate-field-definition-names",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoDuplicateFieldDefinitionNamesConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateGraphqlOperationName": {
+					"description": "Enforce unique operation names across a GraphQL document.\nSee https://biomejs.dev/linter/rules/no-duplicate-graphql-operation-name",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoDuplicateGraphqlOperationNameConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateInputFieldNames": {
+					"description": "Require fields within an input object to be unique.\nSee https://biomejs.dev/linter/rules/no-duplicate-input-field-names",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoDuplicateInputFieldNamesConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noDuplicateSelectors": {
 					"description": "Disallow duplicate selectors.\nSee https://biomejs.dev/linter/rules/no-duplicate-selectors",
 					"anyOf": [
 						{ "$ref": "#/$defs/NoDuplicateSelectorsConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateVariableNames": {
+					"description": "Require all variable definitions to be unique.\nSee https://biomejs.dev/linter/rules/no-duplicate-variable-names",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoDuplicateVariableNamesConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -6415,6 +6570,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noRootType": {
+					"description": "Disallow the usage of specified root types.\nSee https://biomejs.dev/linter/rules/no-root-type",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoRootTypeConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noScriptUrl": {
 					"description": "Disallow javascript: URLs in HTML.\nSee https://biomejs.dev/linter/rules/no-script-url",
 					"anyOf": [
@@ -6587,6 +6749,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useConsistentGraphqlDescriptions": {
+					"description": "Require all descriptions to follow the same style (either block or inline) to  maintain consistency and improve readability across the schema.\nSee https://biomejs.dev/linter/rules/use-consistent-graphql-descriptions",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseConsistentGraphqlDescriptionsConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useConsistentMethodSignatures": {
 					"description": "Enforce consistent use of either method signatures or function properties within interfaces and type aliases.\nSee https://biomejs.dev/linter/rules/use-consistent-method-signatures",
 					"anyOf": [
@@ -6696,6 +6865,27 @@
 					"description": "Enforce id attribute on next/script components with inline content or dangerouslySetInnerHTML.\nSee https://biomejs.dev/linter/rules/use-inline-script-id",
 					"anyOf": [
 						{ "$ref": "#/$defs/UseInlineScriptIdConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useInputName": {
+					"description": "Require mutation argument to be always called \"input\".\nSee https://biomejs.dev/linter/rules/use-input-name",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseInputNameConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useLoneAnonymousOperation": {
+					"description": "Disallow anonymous operations when more than one operation specified in document.\nSee https://biomejs.dev/linter/rules/use-lone-anonymous-operation",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseLoneAnonymousOperationConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useLoneExecutableDefinition": {
+					"description": "Require queries, mutations, subscriptions or fragments each to be located in separate files.\nSee https://biomejs.dev/linter/rules/use-lone-executable-definition",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseLoneExecutableDefinitionConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -8079,6 +8269,15 @@
 			"additionalProperties": false,
 			"required": ["level"]
 		},
+		"RuleWithNoDuplicateArgumentNamesOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoDuplicateArgumentNamesOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
 		"RuleWithNoDuplicateAtImportRulesOptions": {
 			"type": "object",
 			"properties": {
@@ -8142,6 +8341,15 @@
 			"additionalProperties": false,
 			"required": ["level"]
 		},
+		"RuleWithNoDuplicateEnumValueNamesOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoDuplicateEnumValueNamesOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
 		"RuleWithNoDuplicateEnumValuesOptions": {
 			"type": "object",
 			"properties": {
@@ -8151,11 +8359,47 @@
 			"additionalProperties": false,
 			"required": ["level"]
 		},
+		"RuleWithNoDuplicateFieldDefinitionNamesOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoDuplicateFieldDefinitionNamesOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithNoDuplicateFieldsOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoDuplicateFieldsOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
 		"RuleWithNoDuplicateFontNamesOptions": {
 			"type": "object",
 			"properties": {
 				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
 				"options": { "$ref": "#/$defs/NoDuplicateFontNamesOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithNoDuplicateGraphqlOperationNameOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoDuplicateGraphqlOperationNameOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithNoDuplicateInputFieldNamesOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoDuplicateInputFieldNamesOptions" }
 			},
 			"additionalProperties": false,
 			"required": ["level"]
@@ -8221,6 +8465,15 @@
 			"properties": {
 				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
 				"options": { "$ref": "#/$defs/NoDuplicateTestHooksOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithNoDuplicateVariableNamesOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoDuplicateVariableNamesOptions" }
 			},
 			"additionalProperties": false,
 			"required": ["level"]
@@ -9526,6 +9779,15 @@
 			"additionalProperties": false,
 			"required": ["level"]
 		},
+		"RuleWithNoRootTypeOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoRootTypeOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
 		"RuleWithNoScriptUrlOptions": {
 			"type": "object",
 			"properties": {
@@ -10720,6 +10982,15 @@
 			"additionalProperties": false,
 			"required": ["level"]
 		},
+		"RuleWithUseConsistentGraphqlDescriptionsOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/UseConsistentGraphqlDescriptionsOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
 		"RuleWithUseConsistentMemberAccessibilityOptions": {
 			"type": "object",
 			"properties": {
@@ -10813,6 +11084,24 @@
 			"properties": {
 				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
 				"options": { "$ref": "#/$defs/UseDefaultSwitchClauseOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithUseDeprecatedDateOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/UseDeprecatedDateOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithUseDeprecatedReasonOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/UseDeprecatedReasonOptions" }
 			},
 			"additionalProperties": false,
 			"required": ["level"]
@@ -11072,6 +11361,25 @@
 			"additionalProperties": false,
 			"required": ["level"]
 		},
+		"RuleWithUseGraphqlNamedOperationsOptions": {
+			"type": "object",
+			"properties": {
+				"fix": { "anyOf": [{ "$ref": "#/$defs/FixKind" }, { "type": "null" }] },
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/UseGraphqlNamedOperationsOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithUseGraphqlNamingConventionOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/UseGraphqlNamingConventionOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
 		"RuleWithUseGroupedAccessorPairsOptions": {
 			"type": "object",
 			"properties": {
@@ -11192,6 +11500,15 @@
 			"additionalProperties": false,
 			"required": ["level"]
 		},
+		"RuleWithUseInputNameOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/UseInputNameOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
 		"RuleWithUseIsArrayOptions": {
 			"type": "object",
 			"properties": {
@@ -11273,6 +11590,24 @@
 				"fix": { "anyOf": [{ "$ref": "#/$defs/FixKind" }, { "type": "null" }] },
 				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
 				"options": { "$ref": "#/$defs/UseLiteralKeysOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithUseLoneAnonymousOperationOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/UseLoneAnonymousOperationOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithUseLoneExecutableDefinitionOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/UseLoneExecutableDefinitionOptions" }
 			},
 			"additionalProperties": false,
 			"required": ["level"]
@@ -12718,6 +13053,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useDeprecatedReason": {
+					"description": "Require specifying the reason argument when using @deprecated directive.\nSee https://biomejs.dev/linter/rules/use-deprecated-reason",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseDeprecatedReasonConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useEnumInitializers": {
 					"description": "Require that each enum member value be explicitly initialized.\nSee https://biomejs.dev/linter/rules/use-enum-initializers",
 					"anyOf": [
@@ -12771,6 +13113,13 @@
 					"description": "This rule enforces the use of \\<>...\\</> over \\<Fragment>...\\</Fragment>.\nSee https://biomejs.dev/linter/rules/use-fragment-syntax",
 					"anyOf": [
 						{ "$ref": "#/$defs/UseFragmentSyntaxConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useGraphqlNamingConvention": {
+					"description": "Validates that all enum values are capitalized.\nSee https://biomejs.dev/linter/rules/use-graphql-naming-convention",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseGraphqlNamingConventionConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -13121,6 +13470,13 @@
 					"description": "Disallow duplicate conditions in if-else-if chains.\nSee https://biomejs.dev/linter/rules/no-duplicate-else-if",
 					"anyOf": [
 						{ "$ref": "#/$defs/NoDuplicateElseIfConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateFields": {
+					"description": "No duplicated fields in GraphQL operations.\nSee https://biomejs.dev/linter/rules/no-duplicate-fields",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoDuplicateFieldsConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -13564,6 +13920,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useDeprecatedDate": {
+					"description": "Require the @deprecated directive to specify a deletion date.\nSee https://biomejs.dev/linter/rules/use-deprecated-date",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseDeprecatedDateConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useErrorMessage": {
 					"description": "Enforce passing a message value when creating a built-in error.\nSee https://biomejs.dev/linter/rules/use-error-message",
 					"anyOf": [
@@ -13991,6 +14354,31 @@
 			"type": "object",
 			"additionalProperties": false
 		},
+		"UseConsistentGraphqlDescriptionsConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithUseConsistentGraphqlDescriptionsOptions" }
+			]
+		},
+		"UseConsistentGraphqlDescriptionsOptions": {
+			"type": "object",
+			"properties": {
+				"style": {
+					"description": "The description style to enforce. Defaults to \"block\"",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseConsistentGraphqlDescriptionsStyle" },
+						{ "type": "null" }
+					],
+					"default": null
+				}
+			},
+			"additionalProperties": false
+		},
+		"UseConsistentGraphqlDescriptionsStyle": {
+			"description": "The GraphQL description style to enforce.",
+			"type": "string",
+			"enum": ["block", "inline"]
+		},
 		"UseConsistentMemberAccessibilityConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },
@@ -14126,6 +14514,27 @@
 			"additionalProperties": false
 		},
 		"UseDefaultSwitchClauseOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"UseDeprecatedDateConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithUseDeprecatedDateOptions" }
+			]
+		},
+		"UseDeprecatedDateOptions": {
+			"type": "object",
+			"properties": { "argumentName": { "type": ["string", "null"] } },
+			"additionalProperties": false
+		},
+		"UseDeprecatedReasonConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithUseDeprecatedReasonOptions" }
+			]
+		},
+		"UseDeprecatedReasonOptions": {
 			"type": "object",
 			"additionalProperties": false
 		},
@@ -14452,6 +14861,26 @@
 			"type": "object",
 			"additionalProperties": false
 		},
+		"UseGraphqlNamedOperationsConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithUseGraphqlNamedOperationsOptions" }
+			]
+		},
+		"UseGraphqlNamedOperationsOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"UseGraphqlNamingConventionConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithUseGraphqlNamingConventionOptions" }
+			]
+		},
+		"UseGraphqlNamingConventionOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
 		"UseGroupedAccessorPairsConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },
@@ -14603,6 +15032,22 @@
 			"type": "object",
 			"additionalProperties": false
 		},
+		"UseInputNameConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithUseInputNameOptions" }
+			]
+		},
+		"UseInputNameOptions": {
+			"type": "object",
+			"properties": {
+				"checkInputType": {
+					"description": "Check that the input type name follows the convention <mutationName>Input",
+					"anyOf": [{ "$ref": "#/$defs/CheckInputType" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
 		"UseIsArrayConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },
@@ -14696,6 +15141,26 @@
 			]
 		},
 		"UseLiteralKeysOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"UseLoneAnonymousOperationConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithUseLoneAnonymousOperationOptions" }
+			]
+		},
+		"UseLoneAnonymousOperationOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"UseLoneExecutableDefinitionConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithUseLoneExecutableDefinitionOptions" }
+			]
+		},
+		"UseLoneExecutableDefinitionOptions": {
 			"type": "object",
 			"additionalProperties": false
 		},


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes https://github.com/biomejs/ecosystem-ci/actions/runs/26150750124/job/76919240014 where YAML was incorrectly analysed.

This PR fixes an issue that was caused by using `cargo build` and `cargo test` without `-p` or `--bin`. When doing so, cargo was pulling ALL members of the workspace, and eventually all features were enabled.

I added `default-members`, which solves the problem.

I updated the workflows to add `--all-features` to the tests and linting.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

I managed to reproduce the issue via `cargo build -b biome` and then using the binary in a pet project.
I confirmed that the change fixes the problem.

Green CI.

Fortunately this issue doesn't affect production, but it broke the ecosystem CI

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
