### PR TITLE
docs: remove redundant default phrase in `useConsistentObjectDefinitions` rule

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_consistent_object_definitions.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_object_definitions.rs
@@ -15,7 +15,7 @@ use biome_rule_options::use_consistent_object_definitions::{
 };
 
 declare_lint_rule! {
-    /// Require the consistent declaration of object literals. Defaults to explicit definitions.
+    /// Require the consistent declaration of object literals.
     ///
     /// ECMAScript 6 provides two ways to define an object literal: `{foo: foo}` and `{foo}`.
     /// The two styles are functionally equivalent.

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3093,7 +3093,7 @@ See https://biomejs.dev/linter/rules/use-consistent-member-accessibility
 	 */
 	useConsistentMemberAccessibility?: UseConsistentMemberAccessibilityConfiguration;
 	/**
-	* Require the consistent declaration of object literals. Defaults to explicit definitions.
+	* Require the consistent declaration of object literals.
 See https://biomejs.dev/linter/rules/use-consistent-object-definitions 
 	 */
 	useConsistentObjectDefinitions?: UseConsistentObjectDefinitionsConfiguration;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -13032,7 +13032,7 @@
 					]
 				},
 				"useConsistentObjectDefinitions": {
-					"description": "Require the consistent declaration of object literals. Defaults to explicit definitions.\nSee https://biomejs.dev/linter/rules/use-consistent-object-definitions",
+					"description": "Require the consistent declaration of object literals.\nSee https://biomejs.dev/linter/rules/use-consistent-object-definitions",
 					"anyOf": [
 						{ "$ref": "#/$defs/UseConsistentObjectDefinitionsConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
Fixes biomejs/website#2354

This PR addresses the first part of the issue by removing the redundant `Defaults to explicit definitions.` phrase from the `useConsistentObjectDefinitions` rule description, as the defaults are already documented in the Options table.

Regarding the second part of the issue (the missing error output for the `syntax: explicit` invalid example): upon checking the currently generated markdown on the live website, the diagnostic output for both `foo` and `bar()` is already being generated correctly. It appears this was resolved by a previous update to the codegen or parser. Therefore, no additional changes were needed for the examples.