### PR TITLE
docs: remove outdated Caveats section in `useImportExtensions`

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -130,13 +130,6 @@ declare_lint_rule! {
     /// `javascript.preferences.importModuleSpecifierEnding` and
     /// `typescript.preferences.importModuleSpecifierEnding`
     /// in your [settings](https://code.visualstudio.com/docs/getstarted/settings).
-    ///
-    /// ## Caveats
-    ///
-    /// If you are using TypeScript, TypeScript version 5.0 or later is
-    /// required, also make sure to set
-    /// [`allowImportingTsExtensions: true`](https://typescriptlang.org/tsconfig#allowImportingTsExtensions)
-    /// in your `tsconfig.json`.
     pub UseImportExtensions {
         version: "1.8.0",
         name: "useImportExtensions",


### PR DESCRIPTION
Fixes biomejs/website#794

This PR removes the `Caveats` section from the `useImportExtensions` rule documentation. The suggestion to enable `allowImportingTsExtensions` is outdated (due to explicit extension mapping support) and confusing as it blocks the emission of transpiled code. Furthermore, the caveat mentioning that the rule "does not yet check filesystem for file type" is no longer present in the codebase, so the entire section has been cleaned up.