### PR TITLE
docs: fix duplicate-word typo in HTML formatter comment 🤖🤖🤖

### DIFF
--- a/crates/biome_html_formatter/src/utils/children.rs
+++ b/crates/biome_html_formatter/src/utils/children.rs
@@ -152,7 +152,7 @@ impl HtmlChild {
 
 /// A debug helper for displaying a sequence of [HtmlChild] in a more human readable way. Can be activated in debug builds by setting `DEBUG_HTML_FORMATTER_CHILDREN=1` in the environment variables.
 ///
-/// This exists because just dbg! printing the the children can be very verbose, and its hard to tell what CssDisplay each element has, which is often the most important part when debugging whitespace sensitivity issues.
+/// This exists because just dbg! printing the children can be very verbose, and its hard to tell what CssDisplay each element has, which is often the most important part when debugging whitespace sensitivity issues.
 #[cfg(debug_assertions)]
 pub(crate) struct DisplayHtmlChildSequence<'a>(&'a [HtmlChild]);
 


### PR DESCRIPTION
> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## Summary

Fix a duplicate-word typo (`the the children` → `the children`) in a doc comment in `crates/biome_html_formatter/src/utils/children.rs` (line 155).

Same pattern as recently merged #10310 and #10371 (duplicate-word typos in code comments).

## Test Plan

- Pure doc-comment change; no runtime or test impact.
- `just check` not run locally to keep the toolchain footprint zero, since this is a one-character comment-only edit.

## Maintainer note

If you'd prefer not to land agent-authored typo PRs, please close with zero ceremony.
