### PR TITLE
fix(cli): preserve raw stdin format output 🤖🤖🤖

### DIFF
--- a/.changeset/preserve-stdin-unicode.md
+++ b/.changeset/preserve-stdin-unicode.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10395](https://github.com/biomejs/biome/issues/10395): `biome format --stdin-file-path` no longer corrupts single-codepoint non-ASCII characters when stdout is redirected.

--- a/crates/biome_cli/src/runner/impls/process_file/format.rs
+++ b/crates/biome_cli/src/runner/impls/process_file/format.rs
@@ -185,7 +185,7 @@ impl ProcessFile for FormatProcessFile {
         })?;
 
         if file_features.is_ignored() {
-            console.append(markup! {{content}});
+            console.append_raw(content);
             return Ok(());
         }
 
@@ -198,7 +198,7 @@ impl ProcessFile for FormatProcessFile {
             } else {
                 console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
             }
-            console.append(markup! {{content}});
+            console.append_raw(content);
             return Ok(());
         };
         if file_features.supports_format() {
@@ -227,9 +227,7 @@ impl ProcessFile for FormatProcessFile {
             } else {
                 code
             };
-            console.append(markup! {
-                {output}
-            });
+            console.append_raw(&output);
             workspace
                 .close_file(CloseFileParams {
                     project_key,
@@ -237,9 +235,7 @@ impl ProcessFile for FormatProcessFile {
                 })
                 .map_err(|err| err.into())
         } else {
-            console.append(markup! {
-                {content}
-            });
+            console.append_raw(content);
             console.error(markup! {
                 <Warn>"The content was not formatted because the formatter is currently disabled."</Warn>
             });

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -6,7 +6,7 @@ use crate::snap_test::{SnapshotPayload, assert_file_contents, markup_to_string};
 use crate::{
     CUSTOM_FORMAT_BEFORE, FORMATTED, LINT_ERROR, UNFORMATTED, assert_cli_snapshot, run_cli,
 };
-use biome_console::{BufferConsole, MarkupBuf, markup};
+use biome_console::{BufferConsole, Console, LogLevel, Markup, MarkupBuf, markup};
 use biome_fs::{FileSystemExt, MemoryFileSystem};
 use bpaf::Args;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -58,6 +58,47 @@ import     { type     something } from "file.svelte";
 const hello  :      string      = "world";
 </script>
 <div></div>"#;
+
+#[derive(Default)]
+struct SanitizingConsole {
+    input: Option<String>,
+    output: String,
+}
+
+impl SanitizingConsole {
+    fn with_input(input: &str) -> Self {
+        Self {
+            input: Some(input.to_string()),
+            output: String::new(),
+        }
+    }
+
+    fn into_output(self) -> String {
+        self.output
+    }
+}
+
+impl Console for SanitizingConsole {
+    fn println(&mut self, level: LogLevel, args: Markup) {
+        self.print(level, args);
+        self.output.push('\n');
+    }
+
+    fn print(&mut self, _level: LogLevel, args: Markup) {
+        let content = markup_to_string(markup! {
+            {args.to_owned()}
+        });
+        self.output.push_str(&content);
+    }
+
+    fn print_raw(&mut self, _level: LogLevel, content: &str) {
+        self.output.push_str(content);
+    }
+
+    fn read(&mut self) -> Option<String> {
+        self.input.take()
+    }
+}
 
 const APPLY_TRAILING_COMMAS_BEFORE: &str = r#"
 const a = [
@@ -1186,6 +1227,22 @@ fn format_stdin_successfully() {
         console,
         result,
     ));
+}
+
+#[test]
+fn format_stdin_preserves_single_codepoint_unicode_when_stdout_is_sanitized() {
+    let fs = MemoryFileSystem::default();
+    let input = "const a = \"\u{26a0}\";\nconst b = \"\u{2714}\";\n";
+    let mut console = SanitizingConsole::with_input(input);
+
+    let (_, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--stdin-file-path", "probe.ts"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+    assert_eq!(console.into_output(), input);
 }
 
 #[test]

--- a/crates/biome_console/src/lib.rs
+++ b/crates/biome_console/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::use_self)]
 
+use markup::MarkupNodeBuf;
 use std::io;
 use std::io::{IsTerminal, Read, Write};
 use std::panic::RefUnwindSafe;
@@ -37,6 +38,15 @@ pub trait Console: Send + Sync + RefUnwindSafe {
     /// Prints a message (formatted using [markup!]) to the console.
     fn print(&mut self, level: LogLevel, args: Markup);
 
+    /// Prints unformatted content to the console.
+    ///
+    /// This bypasses markup rendering and should only be used for source code
+    /// or other byte-sensitive output.
+    fn print_raw(&mut self, level: LogLevel, content: &str) {
+        use crate as biome_console;
+        self.print(level, markup! {{content}});
+    }
+
     /// It reads from a source, and if this source contains something, it's converted into a [String]
     fn read(&mut self) -> Option<String>;
 
@@ -63,6 +73,9 @@ pub trait ConsoleExt: Console {
     ///
     /// It doesn't add any line
     fn append(&mut self, args: Markup);
+
+    /// Prints unformatted content with level [LogLevel::Log].
+    fn append_raw(&mut self, content: &str);
 }
 
 impl<T: Console + ?Sized> ConsoleExt for T {
@@ -76,6 +89,10 @@ impl<T: Console + ?Sized> ConsoleExt for T {
 
     fn append(&mut self, args: Markup) {
         self.print(LogLevel::Log, args);
+    }
+
+    fn append_raw(&mut self, content: &str) {
+        self.print_raw(LogLevel::Log, content);
     }
 }
 
@@ -174,6 +191,15 @@ impl Console for EnvConsole {
         write!(out, "").unwrap();
     }
 
+    fn print_raw(&mut self, level: LogLevel, content: &str) {
+        let mut out = match level {
+            LogLevel::Error => self.err.lock(),
+            LogLevel::Log => self.out.lock(),
+        };
+
+        out.write_all(content.as_bytes()).unwrap();
+    }
+
     fn read(&mut self) -> Option<String> {
         // Here we check if stdin is redirected. If not, we bail.
         //
@@ -226,6 +252,17 @@ impl Console for BufferConsole {
             content: args.to_owned(),
         });
     }
+
+    fn print_raw(&mut self, level: LogLevel, content: &str) {
+        self.out_buffer.push(Message {
+            level,
+            content: MarkupBuf(vec![MarkupNodeBuf {
+                elements: Vec::new(),
+                content: content.to_string(),
+            }]),
+        });
+    }
+
     fn read(&mut self) -> Option<String> {
         if self.in_buffer.is_empty() {
             None
@@ -256,6 +293,16 @@ impl Console for FileBufferConsole {
         self.out.push(Message {
             level,
             content: args.to_owned(),
+        });
+    }
+
+    fn print_raw(&mut self, level: LogLevel, content: &str) {
+        self.out.push(Message {
+            level,
+            content: MarkupBuf(vec![MarkupNodeBuf {
+                elements: Vec::new(),
+                content: content.to_string(),
+            }]),
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes #10395

`biome format --stdin-file-path` now writes formatted source output as raw text instead of markup-rendered console content, so redirected stdout preserves single-codepoint non-ASCII characters.

> This PR was created with AI assistance (OpenAI GPT-5.5 via Hermes Agent).

## Test Plan

- `cargo test -p biome_cli format_stdin_preserves_single_codepoint_unicode_when_stdout_is_sanitized -- --nocapture`
- `cargo fmt --check`
- `git diff --check`

## Docs

Not applicable; this is a CLI output bug fix with a patch changeset.
