### PR TITLE
fix(css_formatter): improve comment handling in generic CSS properties

### DIFF
--- a/.changeset/preserve-css-declaration-comment-boundaries.md
+++ b/.changeset/preserve-css-declaration-comment-boundaries.md
@@ -4,19 +4,10 @@
 
 Fixed CSS and SCSS formatting for comments around declaration colons so comments between property names, colons, and values stay at the same boundary as Prettier.
 
-Previously, Biome could move these comments away from the colon boundary:
-
-```css
-.selector {
-  color: /* red, */
-    blue;
-}
-```
-
-Biome now preserves the comment placement:
-
-```css
-.selector {
-  color: /* red, */ blue;
-}
+```diff
+ .selector {
+-  color: /* red, */
+-    blue;
++  color: /* red, */ blue;
+ }
 ```

--- a/.changeset/preserve-css-declaration-comment-boundaries.md
+++ b/.changeset/preserve-css-declaration-comment-boundaries.md
@@ -1,0 +1,22 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed CSS and SCSS formatting for comments around declaration colons so comments between property names, colons, and values stay at the same boundary as Prettier.
+
+Previously, Biome could move these comments away from the colon boundary:
+
+```css
+.selector {
+  color: /* red, */
+    blue;
+}
+```
+
+Biome now preserves the comment placement:
+
+```css
+.selector {
+  color: /* red, */ blue;
+}
+```

--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -6,7 +6,7 @@ use crate::utils::scss_include_comments::{
 };
 use biome_css_syntax::{
     AnyCssDeclarationName, AnyCssRoot, CssComplexSelector, CssDeclarationOrRuleBlock, CssFunction,
-    CssGenericProperty, CssIdentifier, CssLanguage, CssSyntaxKind, ScssAtRootAtRule,
+    CssGenericComponentValueList, CssGenericProperty, CssIdentifier, CssLanguage, ScssAtRootAtRule,
     ScssAtRootSelector, ScssEachHeader, ScssEachValueList, ScssExpression, ScssExpressionItemList,
     ScssIfAtRule, ScssListExpression, ScssListExpressionElement, ScssMapExpression,
     ScssMapExpressionPair, T, TextLen, TextSize, is_in_scss_include_arguments,
@@ -324,7 +324,6 @@ fn handle_function_comment(
 fn handle_generic_property_comment(
     comment: DecoratedComment<CssLanguage>,
 ) -> CommentPlacement<CssLanguage> {
-    // Check if the comment is inside a CSS generic property (e.g., color: value)
     let Some(generic_property) = comment
         .enclosing_node()
         .ancestors()
@@ -339,46 +338,73 @@ fn handle_generic_property_comment(
 
     let comment_piece = comment.piece();
 
-    // Check if the comment is in the name's trailing trivia (before colon)
-    // Example: `color /* comment */: value`
+    if is_between_property_colon_and_value(&generic_property, comment_piece.text_range().start()) {
+        return CommentPlacement::trailing(generic_property.into_syntax(), comment);
+    }
+
     if let Some(name_token) = name.syntax().last_token() {
         for piece in name_token.trailing_trivia().pieces() {
-            if piece.is_comments() && piece.text() == comment_piece.text() {
-                // Our placement is slightly better than Prettier because it adds some spacing
-                return CommentPlacement::trailing(name.into_syntax(), comment);
+            if piece.is_comments() && piece.text_range() == comment_piece.text_range() {
+                // `color/* comment */: red` keeps the comment between name and colon.
+                return CommentPlacement::dangling(generic_property.into_syntax(), comment);
             }
         }
     }
 
     if let (Some(preceding), Some(following)) = (comment.preceding_node(), comment.following_node())
+        && preceding == name.syntax()
+        && following
+            .parent()
+            .and_then(CssGenericComponentValueList::cast)
+            .is_some()
     {
-        // If preceding is the property name and following is in the value list
-        if preceding == name.syntax()
-            && following
-                .parent()
-                .is_some_and(|p| p.kind() == CssSyntaxKind::CSS_GENERIC_COMPONENT_VALUE_LIST)
-        {
-            // Place comment as dangling on the property so it can be formatted inline
-            // between the colon and values
-            return CommentPlacement::trailing(generic_property.into_syntax(), comment);
-        }
+        return CommentPlacement::trailing(generic_property.into_syntax(), comment);
     }
 
     CommentPlacement::Default(comment)
+}
+
+fn is_between_property_colon_and_value(
+    property: &CssGenericProperty,
+    comment_start: TextSize,
+) -> bool {
+    // `color: /* comment */ red` belongs to the property colon boundary.
+    let Ok(colon) = property.colon_token() else {
+        return false;
+    };
+
+    let Some(value_start) = property
+        .value()
+        .ok()
+        .and_then(|value| value.syntax().first_token())
+        .map(|token| token.text_trimmed_range().start())
+    else {
+        return false;
+    };
+
+    comment_start >= colon.text_trimmed_range().end() && comment_start < value_start
 }
 
 fn handle_declaration_name_comment(
     comment: DecoratedComment<CssLanguage>,
 ) -> CommentPlacement<CssLanguage> {
     match comment.preceding_node() {
-        Some(following_node) if AnyCssDeclarationName::can_cast(following_node.kind()) => {
-            if following_node
+        Some(preceding_node) if AnyCssDeclarationName::can_cast(preceding_node.kind()) => {
+            if let Some(generic_property) =
+                preceding_node.parent().and_then(CssGenericProperty::cast)
+            {
+                // `color // comment\n: red` keeps the comment between name and colon.
+                return CommentPlacement::dangling(generic_property.into_syntax(), comment);
+            }
+
+            if preceding_node
                 .parent()
-                .is_some_and(|p| p.kind() == CssSyntaxKind::CSS_GENERIC_COMPONENT_VALUE_LIST)
+                .and_then(CssGenericComponentValueList::cast)
+                .is_some()
             {
                 CommentPlacement::Default(comment)
             } else {
-                CommentPlacement::leading(following_node.clone(), comment)
+                CommentPlacement::leading(preceding_node.clone(), comment)
             }
         }
         _ => CommentPlacement::Default(comment),

--- a/crates/biome_css_formatter/src/css/properties/generic_property.rs
+++ b/crates/biome_css_formatter/src/css/properties/generic_property.rs
@@ -1,31 +1,124 @@
 use crate::comments::FormatCssLeadingComment;
 use crate::prelude::*;
-use biome_css_syntax::{CssGenericProperty, CssGenericPropertyFields};
-use biome_formatter::{CstFormatContext, FormatRefWithRule, format_args, write};
+use crate::utils::component_value_list::{ValueListLayout, get_value_list_layout};
+use biome_css_syntax::{
+    AnyCssGenericPropertyValueOrExpression, CssGenericProperty, CssGenericPropertyFields,
+    CssLanguage,
+};
+use biome_formatter::comments::SourceComment;
+use biome_formatter::{FormatRefWithRule, format_args, write};
+use biome_rowan::SyntaxResult;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssGenericProperty;
 impl FormatNodeRule<CssGenericProperty> for FormatCssGenericProperty {
     fn fmt_fields(&self, node: &CssGenericProperty, f: &mut CssFormatter) -> FormatResult<()> {
-        let CssGenericPropertyFields {
-            name,
-            colon_token,
-            value,
-        } = node.as_fields();
+        let CssGenericPropertyFields { name, .. } = node.as_fields();
+        let colon_comments = CssPropertyColonComments::new(node);
 
-        write!(f, [name.format(), colon_token.format()])?;
+        write!(f, [name.format()])?;
+        colon_comments.fmt_colon_boundary(f)?;
+        colon_comments.fmt_value_boundary(f)
+    }
 
-        // Format trailing comments inline after the colon
-        let comments = f.context().comments().clone();
-        let trailing_comments = comments.trailing_comments(node.syntax());
+    fn fmt_dangling_comments(
+        &self,
+        _node: &CssGenericProperty,
+        _f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        // Printed by `CssPropertyColonComments` as `color/* a */: red`.
+        Ok(())
+    }
 
-        if !trailing_comments.is_empty() {
-            for comment in trailing_comments {
-                write!(f, [space()])?;
-                let format_comment = FormatRefWithRule::new(comment, FormatCssLeadingComment);
-                write!(f, [format_comment])?;
-                comment.mark_formatted();
+    fn fmt_trailing_comments(
+        &self,
+        _node: &CssGenericProperty,
+        _f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        // Printed by `CssPropertyColonComments` as `color:/* a */ red`.
+        Ok(())
+    }
+}
+
+/// Formats comments around a declaration colon.
+///
+/// Prettier preserves this boundary closely: `color/* a */:/* b */ red`.
+struct CssPropertyColonComments<'a> {
+    node: &'a CssGenericProperty,
+}
+
+impl<'a> CssPropertyColonComments<'a> {
+    fn new(node: &'a CssGenericProperty) -> Self {
+        Self { node }
+    }
+
+    /// Writes name/colon-boundary comments and the colon.
+    ///
+    /// Example: `color/* before */: red`.
+    fn fmt_colon_boundary(&self, f: &mut CssFormatter) -> FormatResult<()> {
+        let colon = self.node.colon_token();
+        // Clone the Rc-backed store so comment slices don't borrow `f` during writes.
+        let comments = f.comments().clone();
+        let colon_boundary_comments = comments.dangling_comments(self.node.syntax());
+
+        if colon_boundary_comments.is_empty() {
+            return write!(f, [colon.format()]);
+        }
+
+        for comment in colon_boundary_comments {
+            let formatted = FormatRefWithRule::new(comment, FormatCssLeadingComment);
+
+            if comment.kind().is_line() {
+                write!(f, [space(), formatted])?;
+            } else {
+                write!(f, [formatted])?;
             }
+
+            comment.mark_formatted();
+        }
+
+        // Prettier keeps `color // note\n: red` as a raw name/colon boundary.
+        let should_break_before_colon = colon_boundary_comments
+            .iter()
+            .any(|comment| comment.kind().is_line() || comment.lines_after() > 0);
+
+        if should_break_before_colon {
+            write!(
+                f,
+                [dedent_to_root(&format_args![
+                    hard_line_break(),
+                    colon.format()
+                ])]
+            )
+        } else {
+            write!(f, [colon.format()])
+        }
+    }
+
+    /// Writes colon/value-boundary comments and the value.
+    ///
+    /// Example: `color:/* after */ red`.
+    fn fmt_value_boundary(&self, f: &mut CssFormatter) -> FormatResult<()> {
+        let value = self.node.value();
+        // Clone the Rc-backed store so comment slices don't borrow `f` during writes.
+        let comments = f.comments().clone();
+        let value_boundary_comments = comments.trailing_comments(self.node.syntax());
+
+        if value_boundary_comments.is_empty() {
+            return write!(f, [space(), value.format()]);
+        }
+
+        for (index, comment) in value_boundary_comments.iter().enumerate() {
+            self.fmt_value_boundary_comment(index, comment, f)?;
+            comment.mark_formatted();
+        }
+
+        let should_break_before_value = value_boundary_comments
+            .iter()
+            .any(|comment| comment.kind().is_line())
+            || value_list_needs_multiline_layout(&value, f);
+
+        if should_break_before_value {
             write!(
                 f,
                 [indent(&format_args![hard_line_break(), &value.format()])]
@@ -35,12 +128,70 @@ impl FormatNodeRule<CssGenericProperty> for FormatCssGenericProperty {
         }
     }
 
-    fn fmt_trailing_comments(
+    fn fmt_value_boundary_comment(
         &self,
-        _node: &CssGenericProperty,
-        _f: &mut CssFormatter,
+        index: usize,
+        comment: &SourceComment<CssLanguage>,
+        f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        // Trailing comments are formatted inline in fmt_fields
-        Ok(())
+        let formatted = FormatRefWithRule::new(comment, FormatCssLeadingComment);
+
+        if comment.lines_before() > 0 {
+            if comment.kind().is_line() {
+                return write!(f, [hard_line_break(), formatted]);
+            }
+
+            // `color:\n/* note */ red` keeps the block comment at the raw column.
+            return write!(
+                f,
+                [dedent_to_root(&format_args![hard_line_break(), formatted])]
+            );
+        }
+
+        if index == 0 {
+            write!(f, [maybe_space(self.has_source_gap_after_colon(comment))])?;
+        } else {
+            write!(f, [space()])?;
+        }
+
+        write!(f, [formatted])
     }
+
+    /// Returns `true` for a source gap in `color: /* note */ red`.
+    fn has_source_gap_after_colon(&self, comment: &SourceComment<CssLanguage>) -> bool {
+        let Ok(colon_token) = self.node.colon_token() else {
+            return false;
+        };
+
+        let comment_start = comment.piece().text_range().start();
+
+        colon_token
+            .trailing_trivia()
+            .pieces()
+            .take_while(|piece| piece.text_range().end() <= comment_start)
+            .any(|piece| piece.is_whitespace() || piece.is_newline())
+    }
+}
+
+/// Returns `true` when the value list needs multiline layout.
+///
+/// Example: `font-family: /* note */ Hiragino Sans, sans-serif`.
+fn value_list_needs_multiline_layout(
+    value: &SyntaxResult<AnyCssGenericPropertyValueOrExpression>,
+    f: &CssFormatter,
+) -> bool {
+    let Some(list) = value
+        .as_ref()
+        .ok()
+        .and_then(|value| value.as_css_generic_component_value_list())
+    else {
+        return false;
+    };
+
+    matches!(
+        get_value_list_layout(list, f.comments(), f),
+        ValueListLayout::OnePerLine
+            | ValueListLayout::OneGroupPerLine
+            | ValueListLayout::OneGroupPerLineWithDanglingComments
+    )
 }

--- a/crates/biome_css_formatter/tests/specs/css/atrule/import.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/import.css.snap
@@ -328,7 +328,7 @@ st.css");
 @import url("./test.css") /* Comment */
 	layer(/* Comment */ /* Comment */ default) /* Comment */
 	supports(
-		/* Comment */ display /* Comment */ /* Comment */: flex /* Comment */
+		/* Comment */ display/* Comment */:/* Comment */ flex /* Comment */
 	) /* Comment */
 	screen /* Comment */ and /* Comment */ (
 		/* Comment */ /* Comment */ /* Comment */ min-width: 400px /* Comment */

--- a/crates/biome_css_formatter/tests/specs/css/comments/property-value-comment.css
+++ b/crates/biome_css_formatter/tests/specs/css/comments/property-value-comment.css
@@ -13,6 +13,22 @@
 	color/* red, */: blue;
 }
 
+/* Comment after property value should stay after the value */
+.selector {
+	color: red/* keep */;
+}
+
+/* Multiple after-colon comments stay near the colon */
+.selector {
+	color:/* first */ /* second */red;
+}
+
+/* Before-colon block comment can break before the colon */
+.selector {
+	color/* before */
+:red;
+}
+
 /* Comment before property name should still work */
 .selector {
   /* comment */

--- a/crates/biome_css_formatter/tests/specs/css/comments/property-value-comment.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/comments/property-value-comment.css.snap
@@ -21,6 +21,22 @@ info: css/comments/property-value-comment.css
 	color/* red, */: blue;
 }
 
+/* Comment after property value should stay after the value */
+.selector {
+	color: red/* keep */;
+}
+
+/* Multiple after-colon comments stay near the colon */
+.selector {
+	color:/* first */ /* second */red;
+}
+
+/* Before-colon block comment can break before the colon */
+.selector {
+	color/* before */
+:red;
+}
+
 /* Comment before property name should still work */
 .selector {
   /* comment */
@@ -42,13 +58,28 @@ info: css/comments/property-value-comment.css
 
 /* Another case */
 .selector {
-	color: /* red, */
-		blue;
+	color: /* red, */ blue;
 }
 
 /* Another case */
 .selector {
-	color /* red, */: blue;
+	color/* red, */: blue;
+}
+
+/* Comment after property value should stay after the value */
+.selector {
+	color: red /* keep */;
+}
+
+/* Multiple after-colon comments stay near the colon */
+.selector {
+	color:/* first */ /* second */ red;
+}
+
+/* Before-colon block comment can break before the colon */
+.selector {
+	color/* before */
+: red;
 }
 
 /* Comment before property name should still work */

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/at-rules.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/at-rules.css.snap
@@ -154,7 +154,7 @@ info: css/comments/at-rules.css
  }
  
  @page /* comment 61 */ {
-@@ -55,80 +46,85 @@
+@@ -55,80 +46,78 @@
  @page /* comment 64 */ vertical /* comment 65 */ {
  }
  
@@ -228,8 +228,7 @@ info: css/comments/at-rules.css
 -  )
 -  /* comment 165 */ {
 +@supports /* comment 160 */ (
-+    /* comment 161 */ display /* comment 162 */: /* comment 163 */
-+      flex /* comment 164 */
++    /* comment 161 */ display/* comment 162 */: /* comment 163 */ flex /* comment 164 */
 +  ) /* comment 165 */ {
  }
 -@supports /* comment 166 */ not /* comment 167 */
@@ -239,8 +238,7 @@ info: css/comments/at-rules.css
 -  )
 -  /* comment 172 */ {
 +@supports /* comment 166 */ not /* comment 167 */ (
-+    /* comment 168 */ display /* comment 169 */: /* comment 170 */
-+      flex /* comment 171 */
++    /* comment 168 */ display/* comment 169 */: /* comment 170 */ flex /* comment 171 */
 +  ) /* comment 172 */ {
  }
 -@supports /* comment 173 */
@@ -260,16 +258,13 @@ info: css/comments/at-rules.css
 -  )
 -  /* comment 190 */ {
 +@supports /* comment 173 */ (
-+    /* comment 174 */ display /* comment 175 */: /* comment 176 */
-+      table-cell /* comment 177 */
++    /* comment 174 */ display/* comment 175 */: /* comment 176 */ table-cell /* comment 177 */
 +  ) /* comment 178 */ and
 +  /* comment 179 */ (
-+    /* comment 180 */ display /* comment 181 */: /* comment 182 */
-+      list-item /* comment 183 */
++    /* comment 180 */ display/* comment 181 */: /* comment 182 */ list-item /* comment 183 */
 +  ) /* comment 184 */ and
 +  /* comment 185 */ (
-+    /* comment 186 */ display /* comment 187 */: /* comment 188 */
-+      run-in /* comment 189 */
++    /* comment 186 */ display/* comment 187 */: /* comment 188 */ run-in /* comment 189 */
 +  ) /* comment 190 */ {
  }
 -@supports /* comment 191 */
@@ -279,8 +274,7 @@ info: css/comments/at-rules.css
 -  )
 -  /* comment 196 */ {
 +@supports /* comment 191 */ (
-+    /* comment 192 */ --foo /* comment 193 */: /* comment 194 */
-+      green /* comment 195 */
++    /* comment 192 */ --foo/* comment 193 */: /* comment 194 */ green /* comment 195 */
 +  ) /* comment 196 */ {
  }
  
@@ -294,8 +288,7 @@ info: css/comments/at-rules.css
 -  /* comment 204 */
 -  @media /* comment 205 */ screen /* comment 206 */ and /* comment 207 */ (/* comment 208 */ min-width /* comment 209 */: /* comment 210 */ 900px /* comment 211 */) /* comment 212 */ {
 +/* comment 197 */ @supports /* comment 198 */ (
-+    /* comment 199 */ display /* comment 200 */: /* comment 201 */
-+      flex /* comment 202 */
++    /* comment 199 */ display/* comment 200 */: /* comment 201 */ flex /* comment 202 */
 +  ) /* comment 203 */ {
 +  /* comment 204 */ @media /* comment 205 */ screen /* comment 206 */ and /* comment 207 */ (
 +      /* comment 208 */ /* comment 209 */ /* comment 210 */ min-width: 900px /* comment 211 */
@@ -400,37 +393,30 @@ info: css/comments/at-rules.css
 } /* comment 159 */
 
 @supports /* comment 160 */ (
-    /* comment 161 */ display /* comment 162 */: /* comment 163 */
-      flex /* comment 164 */
+    /* comment 161 */ display/* comment 162 */: /* comment 163 */ flex /* comment 164 */
   ) /* comment 165 */ {
 }
 @supports /* comment 166 */ not /* comment 167 */ (
-    /* comment 168 */ display /* comment 169 */: /* comment 170 */
-      flex /* comment 171 */
+    /* comment 168 */ display/* comment 169 */: /* comment 170 */ flex /* comment 171 */
   ) /* comment 172 */ {
 }
 @supports /* comment 173 */ (
-    /* comment 174 */ display /* comment 175 */: /* comment 176 */
-      table-cell /* comment 177 */
+    /* comment 174 */ display/* comment 175 */: /* comment 176 */ table-cell /* comment 177 */
   ) /* comment 178 */ and
   /* comment 179 */ (
-    /* comment 180 */ display /* comment 181 */: /* comment 182 */
-      list-item /* comment 183 */
+    /* comment 180 */ display/* comment 181 */: /* comment 182 */ list-item /* comment 183 */
   ) /* comment 184 */ and
   /* comment 185 */ (
-    /* comment 186 */ display /* comment 187 */: /* comment 188 */
-      run-in /* comment 189 */
+    /* comment 186 */ display/* comment 187 */: /* comment 188 */ run-in /* comment 189 */
   ) /* comment 190 */ {
 }
 @supports /* comment 191 */ (
-    /* comment 192 */ --foo /* comment 193 */: /* comment 194 */
-      green /* comment 195 */
+    /* comment 192 */ --foo/* comment 193 */: /* comment 194 */ green /* comment 195 */
   ) /* comment 196 */ {
 }
 
 /* comment 197 */ @supports /* comment 198 */ (
-    /* comment 199 */ display /* comment 200 */: /* comment 201 */
-      flex /* comment 202 */
+    /* comment 199 */ display/* comment 200 */: /* comment 201 */ flex /* comment 202 */
   ) /* comment 203 */ {
   /* comment 204 */ @media /* comment 205 */ screen /* comment 206 */ and /* comment 207 */ (
       /* comment 208 */ /* comment 209 */ /* comment 210 */ min-width: 900px /* comment 211 */
@@ -458,6 +444,13 @@ info: css/comments/at-rules.css
    71:   /* comment 120 */ screen /* comment 121 */ /* comment 123 */ and /* comment 122 */ /* comment 124 */ (
    77:   ) /* comment 133 */ /* comment 135 */ and /* comment 134 */ /* comment 136 */ (
    83:   ) /* comment 145 */ /* comment 147 */ and /* comment 146 */ /* comment 148 */ (
-  125:   /* comment 204 */ @media /* comment 205 */ screen /* comment 206 */ and /* comment 207 */ (
-  126:       /* comment 208 */ /* comment 209 */ /* comment 210 */ min-width: 900px /* comment 211 */
+   93:     /* comment 161 */ display/* comment 162 */: /* comment 163 */ flex /* comment 164 */
+   97:     /* comment 168 */ display/* comment 169 */: /* comment 170 */ flex /* comment 171 */
+  101:     /* comment 174 */ display/* comment 175 */: /* comment 176 */ table-cell /* comment 177 */
+  104:     /* comment 180 */ display/* comment 181 */: /* comment 182 */ list-item /* comment 183 */
+  107:     /* comment 186 */ display/* comment 187 */: /* comment 188 */ run-in /* comment 189 */
+  111:     /* comment 192 */ --foo/* comment 193 */: /* comment 194 */ green /* comment 195 */
+  116:     /* comment 199 */ display/* comment 200 */: /* comment 201 */ flex /* comment 202 */
+  118:   /* comment 204 */ @media /* comment 205 */ screen /* comment 206 */ and /* comment 207 */ (
+  119:       /* comment 208 */ /* comment 209 */ /* comment 210 */ min-width: 900px /* comment 211 */
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/custom-properties.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/custom-properties.css.snap
@@ -28,16 +28,14 @@ font-size: 12px;
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,13 +1,14 @@
+@@ -1,13 +1,13 @@
  /* comment 1 */
  :root {
    /* comment 2 */
 -  --prop: {
 +  --prop : {
      /* comment 3 */
--    color/* comment 4 */: /* comment 5 */ #fff /* comment 6 */; /* comment 7 */
-+    color /* comment 4 */: /* comment 5 */
-+      #fff /* comment 6 */; /* comment 7 */
+     color/* comment 4 */: /* comment 5 */ #fff /* comment 6 */; /* comment 7 */
      /* comment 8 */
      font-size: 12px;
      /* comment 9 */
@@ -56,8 +54,7 @@ font-size: 12px;
   /* comment 2 */
   --prop : {
     /* comment 3 */
-    color /* comment 4 */: /* comment 5 */
-      #fff /* comment 6 */; /* comment 7 */
+    color/* comment 4 */: /* comment 5 */ #fff /* comment 6 */; /* comment 7 */
     /* comment 8 */
     font-size: 12px;
     /* comment 9 */

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
@@ -87,19 +87,18 @@ body
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,58 +1,54 @@
+@@ -1,58 +1,57 @@
  a {
    /* comment 1 */
 -  /* comment 2 */
 -  padding/* comment 3 */ : /* comment 4 */ 10px /* comment 5 */ 10px
 -    /* comment 6 */; /* comment 7 */
-+  /* comment 2 */ padding /* comment 3 */: /* comment 4 */
-+    10px /* comment 5 */ 10px /* comment 6 */; /* comment 7 */
++  /* comment 2 */ padding/* comment 3 */: /* comment 4 */ 10px /* comment 5 */
++    10px /* comment 6 */; /* comment 7 */
    /* comment 8 */
    transform: translate(/* comment 9 */ 10px /* comment 10 */);
 -  color: /* comment 11 */ red /* comment 12 */ !important /* comment 13 */ ; /* comment 14 */
-+  color: /* comment 11 */ /* comment 12 */
-+    red !important /* comment 13 */; /* comment 14 */
++  color: /* comment 11 */ /* comment 12 */ red !important /* comment 13 */; /* comment 14 */
    /* comment 15 */
  }
  
@@ -109,35 +108,32 @@ body
 -    local(/* comment 17 */ "Prettier" /* comment 18 */),
 -    /* comment 19 */ /* comment 20 */ url("http://prettier.com/font.woff")
 -      /* comment 21 */; /* comment 22 */
-+      local(/* comment 17 */ "Prettier" /* comment 18 */), /* comment 19 */
-+      /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
++    local(/* comment 17 */ "Prettier" /* comment 18 */), /* comment 19 */
++    /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
  }
  
  .foo {
 -  /* comment 23 */
 -  color/* comment 24 */:/* comment 25 */ blue /* comment 26 */; /* comment 27 */
--  transform/* comment 28 */:/* comment 29 */ translate(
-+  /* comment 23 */ color /* comment 24 */: /* comment 25 */
-+    blue /* comment 26 */; /* comment 27 */
-+  transform /* comment 28 */: /* comment 29 */
-+    translate(
-       /* comment 30 */ 10px /* comment 31 */
++  /* comment 23 */ color/* comment 24 */:/* comment 25 */ blue /* comment 26 */; /* comment 27 */
+   transform/* comment 28 */:/* comment 29 */ translate(
+-      /* comment 30 */ 10px /* comment 31 */
 -    )
 -    /* comment 32 */; /* comment 33 */
-+    ) /* comment 32 */; /* comment 33 */
++    /* comment 30 */ 10px /* comment 31 */
++  ) /* comment 32 */; /* comment 33 */
  }
  .foo {
 -  /* comment 34 */
 -  color/* comment 35 */ : /* comment 36 */ blue /* comment 37 */; /* comment 38 */
 -  transform/* comment 39 */ : /* comment 40 */ translate(
-+  /* comment 34 */ color /* comment 35 */: /* comment 36 */
-+    blue /* comment 37 */; /* comment 38 */
-+  transform /* comment 39 */: /* comment 40 */
-+    translate(
-       /* comment 41 */ 10px /* comment 42 */
+-      /* comment 41 */ 10px /* comment 42 */
 -    )
 -    /* comment 43 */; /* comment 44 */
-+    ) /* comment 43 */; /* comment 44 */
++  /* comment 34 */ color/* comment 35 */: /* comment 36 */ blue /* comment 37 */; /* comment 38 */
++  transform/* comment 39 */: /* comment 40 */ translate(
++    /* comment 41 */ 10px /* comment 42 */
++  ) /* comment 43 */; /* comment 44 */
  }
  .foo {
    /* comment 45 */
@@ -148,8 +144,12 @@ body
 -    /* comment 51 */
 -    /* comment 52 */ blue
 -    /* comment 53 */ /* comment 54 */ /* comment 55 */; /* comment 56 */
-+  /* comment 46 */ color /* comment 47 */: /* comment 48 */ /* comment 49 */ /* comment 50 */ /* comment 51 */ /* comment 52 */
-+    blue /* comment 53 */; /* comment 56 */
++  /* comment 46 */ color/* comment 47 */
++:
++/* comment 48 */
++/* comment 49 */ /* comment 50 */
++/* comment 51 */
++/* comment 52 */ blue /* comment 53 */; /* comment 56 */
 +  /* comment 54 */
 +  /* comment 55 */
    /* comment 57 */
@@ -163,14 +163,18 @@ body
 -        /* comment 69 */ /* comment 70 */
 -    )
 -    /* comment 71 */ /* comment 72 */ /* comment 73 */; /* comment 74 */
-+  /* comment 58 */ transform /* comment 59 */: /* comment 60 */ /* comment 61 */ /* comment 62 */ /* comment 63 */ /* comment 64 */
-+    translate(
-+      /* comment 65 */
-+      /* comment 66 */
-+      /* comment 67 */ 10px /* comment 68 */
-+      /* comment 69 */
-+      /* comment 70 */
-+    ) /* comment 71 */; /* comment 74 */
++  /* comment 58 */ transform/* comment 59 */
++:
++/* comment 60 */
++/* comment 61 */ /* comment 62 */
++/* comment 63 */
++/* comment 64 */ translate(
++    /* comment 65 */
++    /* comment 66 */
++    /* comment 67 */ 10px /* comment 68 */
++    /* comment 69 */
++    /* comment 70 */
++  ) /* comment 71 */; /* comment 74 */
 +  /* comment 72 */
 +  /* comment 73 */
    /* comment 75 */
@@ -183,53 +187,56 @@ body
 ```css
 a {
   /* comment 1 */
-  /* comment 2 */ padding /* comment 3 */: /* comment 4 */
-    10px /* comment 5 */ 10px /* comment 6 */; /* comment 7 */
+  /* comment 2 */ padding/* comment 3 */: /* comment 4 */ 10px /* comment 5 */
+    10px /* comment 6 */; /* comment 7 */
   /* comment 8 */
   transform: translate(/* comment 9 */ 10px /* comment 10 */);
-  color: /* comment 11 */ /* comment 12 */
-    red !important /* comment 13 */; /* comment 14 */
+  color: /* comment 11 */ /* comment 12 */ red !important /* comment 13 */; /* comment 14 */
   /* comment 15 */
 }
 
 @font-face {
   font-family: "Prettier";
   src: /* comment 16 */
-      local(/* comment 17 */ "Prettier" /* comment 18 */), /* comment 19 */
-      /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
+    local(/* comment 17 */ "Prettier" /* comment 18 */), /* comment 19 */
+    /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
 }
 
 .foo {
-  /* comment 23 */ color /* comment 24 */: /* comment 25 */
-    blue /* comment 26 */; /* comment 27 */
-  transform /* comment 28 */: /* comment 29 */
-    translate(
-      /* comment 30 */ 10px /* comment 31 */
-    ) /* comment 32 */; /* comment 33 */
+  /* comment 23 */ color/* comment 24 */:/* comment 25 */ blue /* comment 26 */; /* comment 27 */
+  transform/* comment 28 */:/* comment 29 */ translate(
+    /* comment 30 */ 10px /* comment 31 */
+  ) /* comment 32 */; /* comment 33 */
 }
 .foo {
-  /* comment 34 */ color /* comment 35 */: /* comment 36 */
-    blue /* comment 37 */; /* comment 38 */
-  transform /* comment 39 */: /* comment 40 */
-    translate(
-      /* comment 41 */ 10px /* comment 42 */
-    ) /* comment 43 */; /* comment 44 */
+  /* comment 34 */ color/* comment 35 */: /* comment 36 */ blue /* comment 37 */; /* comment 38 */
+  transform/* comment 39 */: /* comment 40 */ translate(
+    /* comment 41 */ 10px /* comment 42 */
+  ) /* comment 43 */; /* comment 44 */
 }
 .foo {
   /* comment 45 */
-  /* comment 46 */ color /* comment 47 */: /* comment 48 */ /* comment 49 */ /* comment 50 */ /* comment 51 */ /* comment 52 */
-    blue /* comment 53 */; /* comment 56 */
+  /* comment 46 */ color/* comment 47 */
+:
+/* comment 48 */
+/* comment 49 */ /* comment 50 */
+/* comment 51 */
+/* comment 52 */ blue /* comment 53 */; /* comment 56 */
   /* comment 54 */
   /* comment 55 */
   /* comment 57 */
-  /* comment 58 */ transform /* comment 59 */: /* comment 60 */ /* comment 61 */ /* comment 62 */ /* comment 63 */ /* comment 64 */
-    translate(
-      /* comment 65 */
-      /* comment 66 */
-      /* comment 67 */ 10px /* comment 68 */
-      /* comment 69 */
-      /* comment 70 */
-    ) /* comment 71 */; /* comment 74 */
+  /* comment 58 */ transform/* comment 59 */
+:
+/* comment 60 */
+/* comment 61 */ /* comment 62 */
+/* comment 63 */
+/* comment 64 */ translate(
+    /* comment 65 */
+    /* comment 66 */
+    /* comment 67 */ 10px /* comment 68 */
+    /* comment 69 */
+    /* comment 70 */
+  ) /* comment 71 */; /* comment 74 */
   /* comment 72 */
   /* comment 73 */
   /* comment 75 */
@@ -270,7 +277,8 @@ body {
 
 # Lines exceeding max width of 80 characters
 ```
-   16:       /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
-   37:   /* comment 46 */ color /* comment 47 */: /* comment 48 */ /* comment 49 */ /* comment 50 */ /* comment 51 */ /* comment 52 */
-   42:   /* comment 58 */ transform /* comment 59 */: /* comment 60 */ /* comment 61 */ /* comment 62 */ /* comment 63 */ /* comment 64 */
+    7:   color: /* comment 11 */ /* comment 12 */ red !important /* comment 13 */; /* comment 14 */
+   15:     /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
+   19:   /* comment 23 */ color/* comment 24 */:/* comment 25 */ blue /* comment 26 */; /* comment 27 */
+   25:   /* comment 34 */ color/* comment 35 */: /* comment 36 */ blue /* comment 37 */; /* comment 38 */
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/comments/between-decl.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/comments/between-decl.scss.snap
@@ -84,28 +84,17 @@ value;
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,16 +1,16 @@
- selector {
--  prop: // comment
--    value;
-+  // comment
-+  prop: value;
- 
--  prop: /* block */ value;
-+  /* block */ prop: value;
- 
-   prop: value;
- }
- 
- // #5603
+@@ -11,8 +11,8 @@
  .grid {
--  grid-template-areas: //
--    "header header header" //
-+  //
-+  grid-template-areas: "header header header" //
-     "sidebar content content" //
-     "footer footer footer";
+   grid-template-areas: //
+     "header header header" //
+-    "sidebar content content" //
+-    "footer footer footer";
++      "sidebar content content" //
++      "footer footer footer";
  
+   grid-template-areas: "header header header" //
+     "sidebar content content" //
 @@ -20,8 +20,7 @@
  }
  
@@ -116,73 +105,37 @@ value;
    "Noto Sans TC",
    "Noto Sans SC",
    "Noto Sans JP",
-@@ -41,27 +40,32 @@
- 
+@@ -42,8 +41,8 @@
  // #7109
  .test {
--  background:
+   background:
 -        /////// foo
 -        // bar
--    radial-gradient(circle farthest-corner at 5% 10%, #000000, transparent 50%);
 +  /////// foo
 +  // bar
-+
-+  background: radial-gradient(
-+    circle farthest-corner at 5% 10%,
-+    #000000,
-+    transparent 50%
-+  );
+     radial-gradient(circle farthest-corner at 5% 10%, #000000, transparent 50%);
  }
  
- // TODO: make these pretty
- selector {
--  prop:
--/* block */ value;
-+  /* block */
-+  prop: value;
- 
--  prop // inline
--: value;
-+  // inline
-+  prop: value;
- 
--  prop/* block */: value;
-+  prop /* block */: value;
- 
--  prop/* block */
--: value;
-+  /* block */
-+  prop: value;
- 
--  prop/* before */: // after
--    value;
-+  // after
-+  prop /* before */: value;
- 
--  prop/* before */: /* after*/ value;
-+  /* after*/
-+  prop /* before */: value;
- }
 ```
 
 # Output
 
 ```scss
 selector {
-  // comment
-  prop: value;
+  prop: // comment
+    value;
 
-  /* block */ prop: value;
+  prop: /* block */ value;
 
   prop: value;
 }
 
 // #5603
 .grid {
-  //
-  grid-template-areas: "header header header" //
-    "sidebar content content" //
-    "footer footer footer";
+  grid-template-areas: //
+    "header header header" //
+      "sidebar content content" //
+      "footer footer footer";
 
   grid-template-areas: "header header header" //
     "sidebar content content" //
@@ -210,33 +163,28 @@ $font-family-rich: // custom
 
 // #7109
 .test {
+  background:
   /////// foo
   // bar
-
-  background: radial-gradient(
-    circle farthest-corner at 5% 10%,
-    #000000,
-    transparent 50%
-  );
+    radial-gradient(circle farthest-corner at 5% 10%, #000000, transparent 50%);
 }
 
 // TODO: make these pretty
 selector {
-  /* block */
-  prop: value;
+  prop:
+/* block */ value;
 
-  // inline
-  prop: value;
+  prop // inline
+: value;
 
-  prop /* block */: value;
+  prop/* block */: value;
 
-  /* block */
-  prop: value;
+  prop/* block */
+: value;
 
-  // after
-  prop /* before */: value;
+  prop/* before */: // after
+    value;
 
-  /* after*/
-  prop /* before */: value;
+  prop/* before */: /* after*/ value;
 }
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/comments/declaration-comment-placement.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/comments/declaration-comment-placement.scss
@@ -1,0 +1,26 @@
+selector{prop:// comment
+value;}
+
+selector{prop:/* block */value;}
+
+selector{prop:
+/* block */value;}
+
+selector{prop
+// inline
+:value;}
+
+selector{prop/* block */:value;}
+
+selector{prop
+/* block */
+:value;}
+
+selector{prop/* before */:// after
+value;}
+
+selector{prop/* before */:/* after */value;}
+
+selector{prop:/* first */ /* second */value;}
+
+selector{prop:/* after */value/* keep */;}

--- a/crates/biome_css_formatter/tests/specs/scss/comments/declaration-comment-placement.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/comments/declaration-comment-placement.scss.snap
@@ -1,0 +1,87 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/comments/declaration-comment-placement.scss
+---
+
+# Input
+
+```scss
+selector{prop:// comment
+value;}
+
+selector{prop:/* block */value;}
+
+selector{prop:
+/* block */value;}
+
+selector{prop
+// inline
+:value;}
+
+selector{prop/* block */:value;}
+
+selector{prop
+/* block */
+:value;}
+
+selector{prop/* before */:// after
+value;}
+
+selector{prop/* before */:/* after */value;}
+
+selector{prop:/* first */ /* second */value;}
+
+selector{prop:/* after */value/* keep */;}
+
+```
+
+
+# Formatted
+
+```scss
+selector {
+	prop:// comment
+		value;
+}
+
+selector {
+	prop:/* block */ value;
+}
+
+selector {
+	prop:
+/* block */ value;
+}
+
+selector {
+	prop // inline
+: value;
+}
+
+selector {
+	prop/* block */: value;
+}
+
+selector {
+	prop/* block */
+: value;
+}
+
+selector {
+	prop/* before */:// after
+		value;
+}
+
+selector {
+	prop/* before */:/* after */ value;
+}
+
+selector {
+	prop:/* first */ /* second */ value;
+}
+
+selector {
+	prop:/* after */ value /* keep */;
+}
+
+```


### PR DESCRIPTION
 > This PR was created with AI assistance (Codex).

  ## Summary

  Improves CSS and SCSS formatting for comments around declaration colons so comments between property names, colons, and values stay attached to the same boundary as Prettier.

  Previously, Biome could format this as:

  ```css
  .selector {
    color: /* red, */
      blue;
  }
```
  Now it preserves the colon/value boundary:
  ```css
  .selector {
    color: /* red, */ blue;
  }
```

  ## Test Plan

  - cargo test -p biome_css_formatter