### PR TITLE
fix(inference): pass correct scope on return statements

### DIFF
--- a/.changeset/fuzzy-turkeys-walk.md
+++ b/.changeset/fuzzy-turkeys-walk.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10411](https://github.com/biomejs/biome/issues/10411): [`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/) no longer causes a stack overflow when a nested function returns an object with shorthand properties that shadow destructured variables from an outer scope.

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -27,16 +27,18 @@ fn project_layout_with_top_level_dependencies(dependencies: Dependencies) -> Arc
 }
 
 // use this test check if your snippet produces the diagnostics you wish, without using a snapshot
-#[ignore]
 #[test]
 fn quick_test() {
     const FILENAME: &str = "dummyFile.ts";
-    const SOURCE: &str = r#"import * as postcssModules from "postcss-modules"
+    const SOURCE: &str = r#"export function foo(_arg: string) {
+  const { bar, ...params } = something();
+  return console.log(bar, params);
 
-type PostcssOptions = Parameters<postcssModules>[0]
-
-export function f(options: PostcssOptions) {
-	console.log(options)
+  function something() {
+    const obj: Record<string, string> = { bar: "bar" };
+    const { bar, baz } = obj;
+    return { bar, baz };
+  }
 }
 "#;
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/shadowedDestructuredVarsValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/shadowedDestructuredVarsValid.ts
@@ -1,0 +1,27 @@
+/* should not generate diagnostics */
+
+// Shadowed destructured variable with shorthand return in nested function.
+// The inner `bar` from `const { bar, baz } = obj` must not be confused with
+// the outer `bar` from `const { bar, ...params } = something()`.
+export function foo(_arg: string) {
+  const { bar, ...params } = something();
+  return console.log(bar, params);
+
+  function something() {
+    const obj: Record<string, string> = { bar: "bar" };
+    const { bar, baz } = obj;
+    return { bar, baz };
+  }
+}
+
+// Same scenario but with renamed destructuring (never triggered the bug).
+export function fooRenamed(_arg: string) {
+  const { bar: beer, ...params } = something();
+  return console.log(beer, params);
+
+  function something() {
+    const obj: Record<string, string> = { bar: "bar" };
+    const { bar, baz } = obj;
+    return { bar, baz };
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/shadowedDestructuredVarsValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/shadowedDestructuredVarsValid.ts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: shadowedDestructuredVarsValid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+// Shadowed destructured variable with shorthand return in nested function.
+// The inner `bar` from `const { bar, baz } = obj` must not be confused with
+// the outer `bar` from `const { bar, ...params } = something()`.
+export function foo(_arg: string) {
+  const { bar, ...params } = something();
+  return console.log(bar, params);
+
+  function something() {
+    const obj: Record<string, string> = { bar: "bar" };
+    const { bar, baz } = obj;
+    return { bar, baz };
+  }
+}
+
+// Same scenario but with renamed destructuring (never triggered the bug).
+export function fooRenamed(_arg: string) {
+  const { bar: beer, ...params } = something();
+  return console.log(beer, params);
+
+  function something() {
+    const obj: Record<string, string> = { bar: "bar" };
+    const { bar, baz } = obj;
+    return { bar, baz };
+  }
+}
+
+```

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -2861,7 +2861,11 @@ fn type_from_function_body(
         .map(|return_statement| {
             return_statement.argument().map_or(
                 TypeData::Reference(GLOBAL_UNDEFINED_ID.into()),
-                |argument| resolver.resolve_expression(scope_id, &argument).into_owned(),
+                |argument| {
+                    resolver
+                        .resolve_expression(scope_id, &argument)
+                        .into_owned()
+                },
             )
         })
         .collect();

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -2861,7 +2861,7 @@ fn type_from_function_body(
         .map(|return_statement| {
             return_statement.argument().map_or(
                 TypeData::Reference(GLOBAL_UNDEFINED_ID.into()),
-                |argument| TypeData::from_any_js_expression(resolver, scope_id, &argument),
+                |argument| resolver.resolve_expression(scope_id, &argument).into_owned(),
             )
         })
         .collect();


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/10411

I used an AI agent to track down and fix the issue. The problem was caused by the fact that when resolving the return statement, we were using `TypeData::from_any_js_expression`, which used an outer scope. 

In this case, `bar` was shadowed by the outer `bar`, causing a stack overflow when resolving its type (it kept resolving itself)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a new test

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
