### PR TITLE
fix(css_formatter): handle control variable maps in SCSS map expressions

### DIFF
--- a/crates/biome_css_formatter/src/scss/auxiliary/map_expression_pair.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/map_expression_pair.rs
@@ -3,10 +3,13 @@ use crate::utils::comment_trivia::format_leading_comments_with_soft_lines;
 use crate::utils::scss_expression::is_self_breaking_value;
 use crate::utils::scss_separator_comments::FormatScssSeparatorComments;
 use biome_css_syntax::{
-    ScssMapExpressionPair, ScssMapExpressionPairFields, is_in_scss_include_arguments,
+    CssSyntaxKind::{SCSS_EACH_AT_RULE, SCSS_FOR_AT_RULE, SCSS_IF_AT_RULE, SCSS_WHILE_AT_RULE},
+    ScssMapExpressionPair, ScssMapExpressionPairFields, ScssVariableDeclaration,
+    is_in_scss_include_arguments,
 };
 use biome_formatter::comments::CommentKind;
 use biome_formatter::{format_args, write};
+use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssMapExpressionPair;
@@ -97,6 +100,7 @@ impl Format<CssFormatContext> for FormatScssMapPairLayout<'_> {
         if is_self_breaking_value(&value)
             && !is_self_breaking_value(&key)
             && f.comments().leading_comments(self.node.syntax()).is_empty()
+            && !is_in_control_variable_map(self.node)
         {
             return write!(
                 f,
@@ -177,4 +181,25 @@ fn should_group_leading_block_comments_with_pair(
     }
 
     true
+}
+
+/// Returns `true` for map pairs in control variable maps.
+///
+/// Example: `@if true { $map: (key: (a, b)) }`.
+fn is_in_control_variable_map(node: &ScssMapExpressionPair) -> bool {
+    let Some(variable) = node
+        .syntax()
+        .ancestors()
+        .skip(1)
+        .find_map(ScssVariableDeclaration::cast)
+    else {
+        return false;
+    };
+
+    variable.syntax().ancestors().skip(1).any(|ancestor| {
+        matches!(
+            ancestor.kind(),
+            SCSS_EACH_AT_RULE | SCSS_FOR_AT_RULE | SCSS_IF_AT_RULE | SCSS_WHILE_AT_RULE
+        )
+    })
 }

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/parens/issue-16594.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/parens/issue-16594.scss.snap
@@ -18,15 +18,11 @@ info: scss/parens/issue-16594.scss
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,7 +1,7 @@
- @if true {
-   $newKey: (
+@@ -3,5 +3,5 @@
      $key: (
--        $theme-name: $value,
--      ),
+         $theme-name: $value,
+       ),
 -  );
-+      $theme-name: $value,
-+    ),
 +  )
  }
 ```
@@ -37,8 +33,8 @@ info: scss/parens/issue-16594.scss
 @if true {
   $newKey: (
     $key: (
-      $theme-name: $value,
-    ),
+        $theme-name: $value,
+      ),
   )
 }
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss
@@ -13,3 +13,5 @@ cal-week-group:(left:1,top:169,),);
 @for $i from 1 through 2{$controlMap:(key:(a,b,c));}
 
 @each $item in a{$eachMap:(key:(a:b,c:d));}
+
+@while true{$whileMap:(key:(a,b,c));}

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss
@@ -9,3 +9,7 @@ $icons:(cal-day-group:(left:253,top:73,),/* keep blank */
 cal-week-group:(left:1,top:169,),);
 
 @if true{$newKey:($key:($theme-name:$value))}
+
+@for $i from 1 through 2{$controlMap:(key:(a,b,c));}
+
+@each $item in a{$eachMap:(key:(a:b,c:d));}

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss.snap
@@ -18,6 +18,10 @@ cal-week-group:(left:1,top:169,),);
 
 @if true{$newKey:($key:($theme-name:$value))}
 
+@for $i from 1 through 2{$controlMap:(key:(a,b,c));}
+
+@each $item in a{$eachMap:(key:(a:b,c:d));}
+
 ```
 
 
@@ -86,9 +90,28 @@ $icons: (
 @if true {
 	$newKey: (
 		$key: (
-			$theme-name: $value,
-		),
+				$theme-name: $value,
+			),
 	)
+}
+
+@for $i from 1 through 2 {
+	$controlMap: (
+		key: (
+				a,
+				b,
+				c,
+			),
+	);
+}
+
+@each $item in a {
+	$eachMap: (
+		key: (
+				a: b,
+				c: d,
+			),
+	);
 }
 
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss.snap
@@ -87,7 +87,7 @@ $icons: (
 	cal-week-group: (
 			left: 1,
 			top: 169,
-		)
+		),
 );
 
 @if true {

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
 info: scss/expression/map-pair-value-layout.scss
 ---
 
@@ -21,6 +22,8 @@ cal-week-group:(left:1,top:169,),);
 @for $i from 1 through 2{$controlMap:(key:(a,b,c));}
 
 @each $item in a{$eachMap:(key:(a:b,c:d));}
+
+@while true{$whileMap:(key:(a,b,c));}
 
 ```
 
@@ -84,7 +87,7 @@ $icons: (
 	cal-week-group: (
 			left: 1,
 			top: 169,
-		),
+		)
 );
 
 @if true {
@@ -110,6 +113,16 @@ $icons: (
 		key: (
 				a: b,
 				c: d,
+			),
+	);
+}
+
+@while true {
+	$whileMap: (
+		key: (
+				a,
+				b,
+				c,
 			),
 	);
 }


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

  ## Summary

  Aligns SCSS map pair formatting with Prettier when a variable map appears inside control at-rules like `@if`, `@for`, and `@each`.

  Example output:

```scss
  @if true {
    $newKey: (
      $key: (
          $theme-name: $value,
        ),
    )
  }
```

  ## Test Plan

  - cargo test -p biome_css_formatter