### PR TITLE
fix(linter): noProcessEnv detects imported env and Bun.env 🤖🤖🤖

### DIFF
--- a/.changeset/fix-no-process-env-imported-env.md
+++ b/.changeset/fix-no-process-env-imported-env.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10447](https://github.com/biomejs/biome/issues/10447): The `noProcessEnv` rule now detects environment variable access through `env` imported from `node:process` or `process`, and `Bun.env` usage.

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -8,9 +8,9 @@ use biome_rule_options::no_process_env::NoProcessEnvOptions;
 use crate::services::semantic::Semantic;
 
 declare_lint_rule! {
-    /// Disallow the use of `process.env`.
+    /// Disallow the use of `process.env`, `Bun.env`, and imported `env`.
     ///
-    /// The `process.env` object in Node.js stores configuration settings. Using it directly throughout a project can cause problems:
+    /// The `process.env` object in Node.js and `Bun.env` in Bun store configuration settings. Using them directly throughout a project can cause problems:
     ///
     /// 1. It's harder to maintain
     /// 2. It can lead to conflicts in team development
@@ -24,6 +24,17 @@ declare_lint_rule! {
     ///
     /// ```js,expect_diagnostic
     /// if (process.env.NODE_ENV === 'development') {
+    ///   // ...
+    /// }
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// import { env } from 'node:process';
+    /// console.log(env.HOME);
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// if (Bun.env.DEBUG === 'true') {
     ///   // ...
     /// }
     /// ```
@@ -58,19 +69,34 @@ impl Rule for NoProcessEnv {
         let model = ctx.model();
         let object = static_member_expr.object().ok()?;
         let member_expr = static_member_expr.member().ok()?;
-        if member_expr.as_js_name()?.to_trimmed_text().text() != "env" {
-            return None;
-        }
+        let member_name = member_expr.as_js_name()?.to_trimmed_text().text();
 
         let (reference, name) =
             global_identifier(&object.as_any_global_identifier_expression()?)?;
-        if name.text() != "process" {
-            return None;
+        let object_name = name.text();
+
+        // Case 1: process.env (existing behavior)
+        if object_name == "process" && member_name == "env" {
+            return match model.binding(&reference) {
+                None => Some(()),
+                Some(binding) => is_process_module_import(&binding).then_some(()),
+            };
         }
-        match model.binding(&reference) {
-            None => Some(()),
-            Some(binding) => is_process_module_import(&binding).then_some(()),
+
+        // Case 2: env.FOO where env is imported from 'node:process' or 'process'
+        if object_name == "env" {
+            if let Some(binding) = model.binding(&reference) {
+                return is_process_module_import(&binding).then_some(());
+            }
         }
+
+        // Case 3: Bun.env
+        if object_name == "Bun" && member_name == "env" {
+            // Check if Bun is a global (not bound to any import)
+            return model.binding(&reference).is_none().then_some(());
+        }
+
+        None
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
@@ -80,7 +106,7 @@ impl Rule for NoProcessEnv {
                 rule_category!(),
                 node.range(),
                 markup! {
-                    "Don't use "<Emphasis>"process.env"</Emphasis>"."
+                    "Don't use environment variables directly."
                 },
             )
             .note(markup! {

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidBunEnv.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidBunEnv.js
@@ -1,0 +1,6 @@
+// Test Bun.env usage
+console.log(Bun.env.DEBUG);
+const apiKey = Bun.env.API_KEY;
+if (Bun.env.NODE_ENV === 'production') {
+  console.log('prod');
+}

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnv.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnv.js
@@ -1,0 +1,8 @@
+// Test imported env from 'node:process'
+import { env } from 'node:process';
+console.log(env.HOME);
+const nodeEnv = env.NODE_ENV;
+
+// Test imported env from 'process'
+import { env as processEnv } from 'process';
+console.log(processEnv.PATH);

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validImportedEnvAndBun.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validImportedEnvAndBun.js
@@ -1,0 +1,13 @@
+/* should not generate diagnostics */
+
+// env from other modules should be allowed
+import { env } from './config';
+console.log(env.FOO);
+
+// Bun object from local scope should be allowed
+const Bun = { env: { FOO: 'bar' } };
+console.log(Bun.env.FOO);
+
+// Other Bun properties should be allowed
+console.log(Bun.version);
+console.log(Bun.serve);


### PR DESCRIPTION
## Summary

Fixes #10447

Extends the `noProcessEnv` rule to detect environment variable access through:
- `env` imported from `'node:process'` or `'process'`
- `Bun.env` usage

## Test Plan

Added test cases covering:
- `invalidImportedEnv.js` - Tests imported env detection from both 'node:process' and 'process'
- `invalidBunEnv.js` - Tests Bun.env detection
- `validImportedEnvAndBun.js` - Tests valid cases that should not trigger (env from other modules, local Bun object, other Bun properties)

The rule now catches all common patterns:
1. `process.env.FOO` (existing)
2. `env.FOO` where env is imported from process modules (new)
3. `Bun.env.FOO` (new)

## Docs

Rule documentation updated with examples for all three patterns.

> This PR was implemented with guidance from Claude Code AI assistant.