### PR TITLE
fix(useSortedClasses): keep required spaces in template literals

### DIFF
--- a/.changeset/sorted-classes-template-space.md
+++ b/.changeset/sorted-classes-template-space.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10297](https://github.com/biomejs/biome/issues/10297): the [`useSortedClasses`](https://biomejs.dev/linter/rules/use-sorted-classes/) unsafe fix no longer removes a leading or trailing space from a string literal inside a template literal substitution, which previously merged the class with the surrounding text.

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -195,14 +195,18 @@ impl Rule for UseSortedClasses {
     fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
         let node = ctx.query();
 
-        // Calculate the range offset to account for the ignored prefix and postfix.
-        let sort_range = if let Some(value) = node.value() {
-            let range = node.range();
-            let template_ctx = sort::get_template_literal_space_context(node);
-            let real_sort_range = get_sort_class_name_range(&value, &range, &template_ctx);
-            real_sort_range.unwrap_or(range)
-        } else {
-            node.range()
+        // Template chunk ranges match their text; other nodes include quote characters.
+        let sort_range = match node {
+            AnyClassStringLike::JsTemplateChunkElement(_) => {
+                let range = node.range();
+                node.value()
+                    .and_then(|value| {
+                        let template_ctx = sort::get_template_literal_space_context(node);
+                        get_sort_class_name_range(&value, &range, &template_ctx)
+                    })
+                    .unwrap_or(range)
+            }
+            _ => node.range(),
         };
 
         Some(RuleDiagnostic::new(

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
@@ -1,4 +1,7 @@
-use biome_js_syntax::{JsTemplateChunkElement, JsTemplateElement};
+use biome_js_syntax::{
+    JsStringLiteralExpression, JsSyntaxKind, JsSyntaxNode, JsTemplateChunkElement,
+    JsTemplateElement, is_transparent_expression_wrapper,
+};
 use biome_rowan::{AstNode, TextRange, TextSize, TokenText};
 use std::cmp::Ordering;
 
@@ -267,6 +270,24 @@ impl TemplateLiteralSpaceContext {
         })
     }
 
+    /// Like [`Self::from_chunk`], but for a string literal used as a `${...}` value;
+    /// the element directly adjacent to the substitution plays the role of the boundary.
+    pub(crate) fn from_string_literal(literal: &JsStringLiteralExpression) -> Option<Self> {
+        let element = enclosing_substitution(literal)?;
+        let inner = literal.inner_string_text().ok()?;
+        let value = inner.text();
+        if value.trim().is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            prefix_is_var: boundary_glues(element.syntax().prev_sibling(), Side::Leading),
+            postfix_is_var: boundary_glues(element.syntax().next_sibling(), Side::Trailing),
+            leading_space: value.starts_with(' '),
+            trailing_space: value.ends_with(' '),
+        })
+    }
+
     /// Skip first class from sorting when it's connected to a variable: `${var}px-2 m-4`
     #[inline]
     pub(crate) fn ignore_prefix(&self) -> bool {
@@ -295,6 +316,59 @@ impl TemplateLiteralSpaceContext {
     }
 }
 
+/// The `${...}` element this literal is directly the value of, else `None`.
+fn enclosing_substitution(literal: &JsStringLiteralExpression) -> Option<JsTemplateElement> {
+    let mut node = literal.syntax().parent()?;
+    loop {
+        if let Some(element) = JsTemplateElement::cast_ref(&node) {
+            return Some(element);
+        }
+        // The literal stays the substitution value only through a transparent wrapper
+        // or a branch of a conditional/logical expression.
+        let keeps_value = is_transparent_expression_wrapper(&node)
+            || matches!(
+                node.kind(),
+                JsSyntaxKind::JS_CONDITIONAL_EXPRESSION | JsSyntaxKind::JS_LOGICAL_EXPRESSION
+            );
+        if !keeps_value {
+            return None;
+        }
+        node = node.parent()?;
+    }
+}
+
+/// Which side of the value a neighbouring element sits on.
+#[derive(Debug, Clone, Copy)]
+enum Side {
+    Leading,
+    Trailing,
+}
+
+/// Returns `true` when the sibling would glue onto the value with no separating space:
+/// another `${...}` substitution, or a non-empty chunk whose touching edge has no space.
+fn boundary_glues(sibling: Option<JsSyntaxNode>, side: Side) -> bool {
+    let Some(sibling) = sibling else {
+        return false;
+    };
+    if JsTemplateElement::can_cast(sibling.kind()) {
+        return true;
+    }
+    let Some(chunk) = JsTemplateChunkElement::cast(sibling) else {
+        return false;
+    };
+    let Ok(token) = chunk.template_chunk_token() else {
+        return false;
+    };
+    let text = token.text_trimmed();
+    if text.is_empty() {
+        return false;
+    }
+    match side {
+        Side::Leading => !text.ends_with(' '),
+        Side::Trailing => !text.starts_with(' '),
+    }
+}
+
 /// Returns the template space context for the given node
 pub(crate) fn get_template_literal_space_context(
     node: &AnyClassStringLike,
@@ -302,6 +376,9 @@ pub(crate) fn get_template_literal_space_context(
     match node {
         AnyClassStringLike::JsTemplateChunkElement(chunk) => {
             TemplateLiteralSpaceContext::from_chunk(chunk)
+        }
+        AnyClassStringLike::JsStringLiteralExpression(literal) => {
+            TemplateLiteralSpaceContext::from_string_literal(literal)
         }
         _ => None,
     }

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_10297.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_10297.jsx
@@ -1,0 +1,10 @@
+<>
+	<span className={`map-panel-basemap-map-a${isActive ? ' active' : ''}`}>a</span>
+	<span className={`card${isActive ? ' p-4 flex' : ''}`}>b</span>
+	<span className={`${isActive ? 'p-4 flex ' : ''}base`}>c</span>
+	<span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+	<span className={`${someFunc('p-4 flex')}base`}>e</span>
+	<span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+	<span className={`${prefix}${isActive ? ' p-4 flex' : ''}`}>g</span>
+	<span className={`card${isActive && ' p-4 flex'}`}>h</span>
+</>

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_10297.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_10297.jsx.snap
@@ -1,0 +1,215 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_10297.jsx
+---
+# Input
+```jsx
+<>
+	<span className={`map-panel-basemap-map-a${isActive ? ' active' : ''}`}>a</span>
+	<span className={`card${isActive ? ' p-4 flex' : ''}`}>b</span>
+	<span className={`${isActive ? 'p-4 flex ' : ''}base`}>c</span>
+	<span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+	<span className={`${someFunc('p-4 flex')}base`}>e</span>
+	<span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+	<span className={`${prefix}${isActive ? ' p-4 flex' : ''}`}>g</span>
+	<span className={`card${isActive && ' p-4 flex'}`}>h</span>
+</>
+
+```
+
+# Diagnostics
+```
+issue_10297.jsx:3:37 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    1 │ <>
+    2 │ 	<span className={`map-panel-basemap-map-a${isActive ? ' active' : ''}`}>a</span>
+  > 3 │ 	<span className={`card${isActive ? ' p-4 flex' : ''}`}>b</span>
+      │ 	                                   ^^^^^^^^^^^
+    4 │ 	<span className={`${isActive ? 'p-4 flex ' : ''}base`}>c</span>
+    5 │ 	<span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+     1  1 │   <>
+     2  2 │     <span className={`map-panel-basemap-map-a${isActive ? ' active' : ''}`}>a</span>
+     3    │ - → <span·className={`card${isActive·?·'·p-4·flex'·:·''}`}>b</span>
+        3 │ + → <span·className={`card${isActive·?·'·flex·p-4'·:·''}`}>b</span>
+     4  4 │     <span className={`${isActive ? 'p-4 flex ' : ''}base`}>c</span>
+     5  5 │     <span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+  
+
+```
+
+```
+issue_10297.jsx:4:33 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    2 │ 	<span className={`map-panel-basemap-map-a${isActive ? ' active' : ''}`}>a</span>
+    3 │ 	<span className={`card${isActive ? ' p-4 flex' : ''}`}>b</span>
+  > 4 │ 	<span className={`${isActive ? 'p-4 flex ' : ''}base`}>c</span>
+      │ 	                               ^^^^^^^^^^^
+    5 │ 	<span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+    6 │ 	<span className={`${someFunc('p-4 flex')}base`}>e</span>
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+     2  2 │     <span className={`map-panel-basemap-map-a${isActive ? ' active' : ''}`}>a</span>
+     3  3 │     <span className={`card${isActive ? ' p-4 flex' : ''}`}>b</span>
+     4    │ - → <span·className={`${isActive·?·'p-4·flex·'·:·''}base`}>c</span>
+        4 │ + → <span·className={`${isActive·?·'flex·p-4·'·:·''}base`}>c</span>
+     5  5 │     <span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+     6  6 │     <span className={`${someFunc('p-4 flex')}base`}>e</span>
+  
+
+```
+
+```
+issue_10297.jsx:5:37 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    3 │ 	<span className={`card${isActive ? ' p-4 flex' : ''}`}>b</span>
+    4 │ 	<span className={`${isActive ? 'p-4 flex ' : ''}base`}>c</span>
+  > 5 │ 	<span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+      │ 	                                   ^^^^^^^^^^^^
+    6 │ 	<span className={`${someFunc('p-4 flex')}base`}>e</span>
+    7 │ 	<span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+     3  3 │     <span className={`card${isActive ? ' p-4 flex' : ''}`}>b</span>
+     4  4 │     <span className={`${isActive ? 'p-4 flex ' : ''}base`}>c</span>
+     5    │ - → <span·className={`wrap${isActive·?·'·p-4·flex·'·:·''}end`}>d</span>
+        5 │ + → <span·className={`wrap${isActive·?·'·flex·p-4·'·:·''}end`}>d</span>
+     6  6 │     <span className={`${someFunc('p-4 flex')}base`}>e</span>
+     7  7 │     <span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+  
+
+```
+
+```
+issue_10297.jsx:6:31 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    4 │ 	<span className={`${isActive ? 'p-4 flex ' : ''}base`}>c</span>
+    5 │ 	<span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+  > 6 │ 	<span className={`${someFunc('p-4 flex')}base`}>e</span>
+      │ 	                             ^^^^^^^^^^
+    7 │ 	<span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+    8 │ 	<span className={`${prefix}${isActive ? ' p-4 flex' : ''}`}>g</span>
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+     4  4 │     <span className={`${isActive ? 'p-4 flex ' : ''}base`}>c</span>
+     5  5 │     <span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+     6    │ - → <span·className={`${someFunc('p-4·flex')}base`}>e</span>
+        6 │ + → <span·className={`${someFunc('flex·p-4')}base`}>e</span>
+     7  7 │     <span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+     8  8 │     <span className={`${prefix}${isActive ? ' p-4 flex' : ''}`}>g</span>
+  
+
+```
+
+```
+issue_10297.jsx:7:33 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    5 │ 	<span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+    6 │ 	<span className={`${someFunc('p-4 flex')}base`}>e</span>
+  > 7 │ 	<span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+      │ 	                               ^^^^^^^^^^^^^^
+    8 │ 	<span className={`${prefix}${isActive ? ' p-4 flex' : ''}`}>g</span>
+    9 │ 	<span className={`card${isActive && ' p-4 flex'}`}>h</span>
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+     5  5 │     <span className={`wrap${isActive ? ' p-4 flex ' : ''}end`}>d</span>
+     6  6 │     <span className={`${someFunc('p-4 flex')}base`}>e</span>
+     7    │ - → <span·className={`${isActive·?·'p-4·flex·m-2'·:·''}base`}>f</span>
+        7 │ + → <span·className={`${isActive·?·'flex·p-4·m-2'·:·''}base`}>f</span>
+     8  8 │     <span className={`${prefix}${isActive ? ' p-4 flex' : ''}`}>g</span>
+     9  9 │     <span className={`card${isActive && ' p-4 flex'}`}>h</span>
+  
+
+```
+
+```
+issue_10297.jsx:8:42 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+     6 │ 	<span className={`${someFunc('p-4 flex')}base`}>e</span>
+     7 │ 	<span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+   > 8 │ 	<span className={`${prefix}${isActive ? ' p-4 flex' : ''}`}>g</span>
+       │ 	                                        ^^^^^^^^^^^
+     9 │ 	<span className={`card${isActive && ' p-4 flex'}`}>h</span>
+    10 │ </>
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+     6  6 │     <span className={`${someFunc('p-4 flex')}base`}>e</span>
+     7  7 │     <span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+     8    │ - → <span·className={`${prefix}${isActive·?·'·p-4·flex'·:·''}`}>g</span>
+        8 │ + → <span·className={`${prefix}${isActive·?·'·flex·p-4'·:·''}`}>g</span>
+     9  9 │     <span className={`card${isActive && ' p-4 flex'}`}>h</span>
+    10 10 │   </>
+  
+
+```
+
+```
+issue_10297.jsx:9:38 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+     7 │ 	<span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+     8 │ 	<span className={`${prefix}${isActive ? ' p-4 flex' : ''}`}>g</span>
+   > 9 │ 	<span className={`card${isActive && ' p-4 flex'}`}>h</span>
+       │ 	                                    ^^^^^^^^^^^
+    10 │ </>
+    11 │ 
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+     7  7 │     <span className={`${isActive ? 'p-4 flex m-2' : ''}base`}>f</span>
+     8  8 │     <span className={`${prefix}${isActive ? ' p-4 flex' : ''}`}>g</span>
+     9    │ - → <span·className={`card${isActive·&&·'·p-4·flex'}`}>h</span>
+        9 │ + → <span·className={`card${isActive·&&·'·flex·p-4'}`}>h</span>
+    10 10 │   </>
+    11 11 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_10297.tsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_10297.tsx
@@ -1,0 +1,3 @@
+<>
+	<span className={`card${' p-4 flex' as string}`}>a</span>
+</>

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_10297.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_10297.tsx.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_10297.tsx
+---
+# Input
+```tsx
+<>
+	<span className={`card${' p-4 flex' as string}`}>a</span>
+</>
+
+```
+
+# Diagnostics
+```
+issue_10297.tsx:2:26 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    1 │ <>
+  > 2 │ 	<span className={`card${' p-4 flex' as string}`}>a</span>
+      │ 	                        ^^^^^^^^^^^
+    3 │ </>
+    4 │ 
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+    1 1 │   <>
+    2   │ - → <span·className={`card${'·p-4·flex'·as·string}`}>a</span>
+      2 │ + → <span·className={`card${'·flex·p-4'·as·string}`}>a</span>
+    3 3 │   </>
+    4 4 │   
+  
+
+```


### PR DESCRIPTION
> This PR was created with AI assistance (Claude Code).

## Summary

Closes #10297

`useSortedClasses` removes the leading or trailing space from a class string inside a `${...}` substitution, like `${cond ? ' active' : ''}`, so the class runs straight into the text next to it. That merges two classes. The fix keeps the space when removing it would do so.

## Test Plan

Added spec cases to `issue_10297.jsx` and `issue_10297.tsx`.

## Docs

N/A
