### PR TITLE
feat(css_parser): parse interpolated scss nested properties

### DIFF
--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -4029,7 +4029,7 @@ pub fn scss_namespaced_variable(
     ))
 }
 pub fn scss_nesting_declaration(
-    name: CssIdentifier,
+    name: AnyCssDeclarationName,
     colon_token: SyntaxToken,
     value: ScssExpression,
     block: AnyCssDeclarationOrRuleBlock,

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -7954,7 +7954,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
-                    && CssIdentifier::can_cast(element.kind())
+                    && AnyCssDeclarationName::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/case/case.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/case/case.scss.snap
@@ -237,12 +237,10 @@ TABLE {}
 +    COLOR: RED;
    }
  
--  #{$Keep + 15px + Keep15PX + "15PX" + "15PX"}: {
+   #{$Keep + 15px + Keep15PX + "15PX" + "15PX"}: {
 -    color: RED;
--  }
-+  #{$Keep + 15PX + Keep15PX + '15PX' + "15PX"}: {
-+      COLOR: RED;
-+    }
++    COLOR: RED;
+   }
  }
  
  @mixin Keep($Keep: $Keep15IN, $Keep: Keepå1E1) {
@@ -368,9 +366,9 @@ $KeepTopLevelVar: val;
     COLOR: RED;
   }
 
-  #{$Keep + 15PX + Keep15PX + '15PX' + "15PX"}: {
-      COLOR: RED;
-    }
+  #{$Keep + 15px + Keep15PX + "15PX" + "15PX"}: {
+    COLOR: RED;
+  }
 }
 
 @mixin Keep($Keep: $Keep15IN, $Keep: Keepå1E1) {

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/interpolated-custom-property-nested-properties.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/interpolated-custom-property-nested-properties.scss
@@ -1,0 +1,12 @@
+$name:theme;
+$slot:color;
+
+.box{
+--#{$name}:{
+color:red;
+}
+
+--theme-#{$slot}:{
+background:blue;
+}
+}

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/interpolated-custom-property-nested-properties.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/interpolated-custom-property-nested-properties.scss.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/declaration/interpolated-custom-property-nested-properties.scss
+---
+
+# Input
+
+```scss
+$name:theme;
+$slot:color;
+
+.box{
+--#{$name}:{
+color:red;
+}
+
+--theme-#{$slot}:{
+background:blue;
+}
+}
+
+```
+
+
+# Formatted
+
+```scss
+$name: theme;
+$slot: color;
+
+.box {
+	--#{$name}: {
+		color: red;
+	}
+
+	--theme-#{$slot}: {
+		background: blue;
+	}
+}
+
+```

--- a/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
+++ b/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
@@ -8,7 +8,7 @@ use crate::syntax::scss::{
     SCSS_NESTING_VALUE_END_SET, complete_empty_scss_expression,
     is_at_scss_interpolated_dashed_identifier, is_at_scss_interpolated_identifier,
     is_at_scss_interpolated_property, parse_scss_interpolated_identifier,
-    parse_scss_optional_value_until,
+    parse_scss_interpolated_property_name, parse_scss_optional_value_until,
 };
 use crate::syntax::{CssSyntaxFeatures, is_at_dashed_identifier, is_at_identifier, try_parse};
 use biome_css_syntax::CssSyntaxKind::{
@@ -44,11 +44,19 @@ pub(crate) fn parse_scss_nesting_declaration(p: &mut CssParser) -> ParsedSyntax 
 
 #[inline]
 pub(crate) fn is_at_scss_nesting_declaration(p: &mut CssParser) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && !is_at_dashed_identifier(p)
-        && !is_at_scss_interpolated_dashed_identifier(p)
-        && !p.at(T![composes])
-        && (is_at_scss_interpolated_property(p) || (is_at_identifier(p) && p.nth_at(1, T![:])))
+    if !CssSyntaxFeatures::Scss.is_supported(p) || p.at(T![composes]) {
+        return false;
+    }
+
+    if is_at_scss_interpolated_dashed_identifier(p) {
+        return true;
+    }
+
+    if is_at_dashed_identifier(p) {
+        return false;
+    }
+
+    is_at_scss_interpolated_property(p) || (is_at_identifier(p) && p.nth_at(1, T![:]))
 }
 
 struct ScssNestingMarkers {
@@ -64,6 +72,10 @@ struct ScssNestingMarkers {
 /// nesting entrypoints.
 #[inline]
 fn parse_scss_nesting_declaration_candidate(p: &mut CssParser) -> Option<(ParsedSyntax, bool)> {
+    if !is_at_scss_nesting_declaration(p) {
+        return None;
+    }
+
     let (markers, could_be_selector) = parse_scss_nesting_declaration_prefix(p)?;
     let syntax = parse_scss_nesting_declaration_after_prefix(p, markers);
 
@@ -106,12 +118,18 @@ fn parse_scss_nesting_declaration_after_prefix(
 /// is not actually followed by `:`.
 #[inline]
 fn parse_scss_nesting_declaration_prefix(p: &mut CssParser) -> Option<(ScssNestingMarkers, bool)> {
+    if !is_at_scss_nesting_declaration(p) {
+        return None;
+    }
+
     let declaration = p.start();
     let property = p.start();
 
-    // Guarded by `is_at_scss_nesting_declaration`, so a name parse cannot fail
-    // here. The only real rejection point in this prefix parser is a missing `:`.
-    parse_scss_interpolated_identifier(p).ok();
+    if is_at_scss_interpolated_property(p) {
+        parse_scss_interpolated_property_name(p).ok();
+    } else if is_at_scss_interpolated_identifier(p) {
+        parse_scss_interpolated_identifier(p).ok();
+    }
 
     if !p.at(T![:]) {
         declaration.abandon(p);

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/interpolated-custom-property-unclosed.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/interpolated-custom-property-unclosed.scss.snap
@@ -39,53 +39,41 @@ CssRoot {
                 items: CssDeclarationOrRuleList [
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
-                            property: CssBogusProperty {
-                                items: [
-                                    CssBogusSupportsCondition {
-                                        items: [
-                                            CssBogus {
-                                                items: [
-                                                    ScssInterpolatedIdentifierHyphen {
-                                                        minus_token: MINUS@6..10 "-" [Newline("\n"), Whitespace("  ")] [],
-                                                    },
-                                                    ScssInterpolatedIdentifierHyphen {
-                                                        minus_token: MINUS@10..11 "-" [] [],
-                                                    },
-                                                    CssBogus {
-                                                        items: [
-                                                            HASH@11..12 "#" [] [],
-                                                            L_CURLY@12..13 "{" [] [],
-                                                            CssBogus {
-                                                                items: [
-                                                                    CssBogus {
-                                                                        items: [
-                                                                            ScssVariable {
-                                                                                dollar_token: DOLLAR@13..14 "$" [] [],
-                                                                                name: CssIdentifier {
-                                                                                    value_token: IDENT@14..18 "prop" [] [],
-                                                                                },
-                                                                            },
-                                                                            CssBogusPropertyValue {
-                                                                                items: [
-                                                                                    COLON@18..20 ":" [] [Whitespace(" ")],
-                                                                                    CSS_DIMENSION_VALUE@20..22 "10" [] [],
-                                                                                    PX_KW@22..24 "px" [] [],
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    },
-                                                                ],
-                                                            },
-                                                        ],
+                            property: CssGenericProperty {
+                                name: ScssInterpolatedDashedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        ScssInterpolatedIdentifierHyphen {
+                                            minus_token: MINUS@6..10 "-" [Newline("\n"), Whitespace("  ")] [],
+                                        },
+                                        ScssInterpolatedIdentifierHyphen {
+                                            minus_token: MINUS@10..11 "-" [] [],
+                                        },
+                                        ScssInterpolation {
+                                            hash_token: HASH@11..12 "#" [] [],
+                                            l_curly_token: L_CURLY@12..13 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@13..14 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@14..18 "prop" [] [],
+                                                        },
                                                     },
                                                 ],
                                             },
-                                        ],
-                                    },
-                                    ScssExpression {
-                                        items: ScssExpressionItemList [],
-                                    },
-                                ],
+                                            r_curly_token: missing (required),
+                                        },
+                                    ],
+                                },
+                                colon_token: COLON@18..20 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@20..22 "10" [] [],
+                                            unit_token: IDENT@22..24 "px" [] [],
+                                        },
+                                    ],
+                                },
                             },
                             important: missing (optional),
                         },
@@ -121,28 +109,29 @@ CssRoot {
         1: CSS_DECLARATION_OR_RULE_LIST@6..25
           0: CSS_DECLARATION_WITH_SEMICOLON@6..25
             0: CSS_DECLARATION@6..24
-              0: CSS_BOGUS_PROPERTY@6..24
-                0: CSS_BOGUS_SUPPORTS_CONDITION@6..24
-                  0: CSS_BOGUS@6..24
+              0: CSS_GENERIC_PROPERTY@6..24
+                0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@6..18
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@6..18
                     0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@6..10
                       0: MINUS@6..10 "-" [Newline("\n"), Whitespace("  ")] []
                     1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@10..11
                       0: MINUS@10..11 "-" [] []
-                    2: CSS_BOGUS@11..24
+                    2: SCSS_INTERPOLATION@11..18
                       0: HASH@11..12 "#" [] []
                       1: L_CURLY@12..13 "{" [] []
-                      2: CSS_BOGUS@13..24
-                        0: CSS_BOGUS@13..24
+                      2: SCSS_EXPRESSION@13..18
+                        0: SCSS_EXPRESSION_ITEM_LIST@13..18
                           0: SCSS_VARIABLE@13..18
                             0: DOLLAR@13..14 "$" [] []
                             1: CSS_IDENTIFIER@14..18
                               0: IDENT@14..18 "prop" [] []
-                          1: CSS_BOGUS_PROPERTY_VALUE@18..24
-                            0: COLON@18..20 ":" [] [Whitespace(" ")]
-                            1: CSS_DIMENSION_VALUE@20..22 "10" [] []
-                            2: PX_KW@22..24 "px" [] []
-                1: SCSS_EXPRESSION@24..24
-                  0: SCSS_EXPRESSION_ITEM_LIST@24..24
+                      3: (empty)
+                1: COLON@18..20 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@20..24
+                  0: SCSS_EXPRESSION_ITEM_LIST@20..24
+                    0: CSS_REGULAR_DIMENSION@20..24
+                      0: CSS_NUMBER_LITERAL@20..22 "10" [] []
+                      1: IDENT@22..24 "px" [] []
               1: (empty)
             1: SEMICOLON@24..25 ";" [] []
         2: R_CURLY@25..27 "}" [Newline("\n")] []
@@ -155,11 +144,11 @@ CssRoot {
 ```
 interpolated-custom-property-unclosed.scss:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a SCSS expression but instead found ': 10px'.
+  × Expected a SCSS expression but instead found ':'.
   
     1 │ .box {
   > 2 │   --#{$prop: 10px;
-      │            ^^^^^^
+      │            ^
     3 │ }
     4 │ 
   
@@ -167,20 +156,8 @@ interpolated-custom-property-unclosed.scss:2:12 parse ━━━━━━━━�
   
     1 │ .box {
   > 2 │   --#{$prop: 10px;
-      │            ^^^^^^
+      │            ^
     3 │ }
     4 │ 
-  
-interpolated-custom-property-unclosed.scss:2:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `}` but instead found `;`
-  
-    1 │ .box {
-  > 2 │   --#{$prop: 10px;
-      │                  ^
-    3 │ }
-    4 │ 
-  
-  i Remove ;
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/declaration/interpolated-custom-property-nested-properties.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/declaration/interpolated-custom-property-nested-properties.scss
@@ -1,0 +1,7 @@
+$name: theme;
+
+a {
+  --#{$name}: {
+    color: red;
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/declaration/interpolated-custom-property-nested-properties.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/declaration/interpolated-custom-property-nested-properties.scss.snap
@@ -1,0 +1,194 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+$name: theme;
+
+a {
+  --#{$name}: {
+    color: red;
+  }
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@0..1 "$" [] [],
+                name: CssIdentifier {
+                    value_token: IDENT@1..5 "name" [] [],
+                },
+            },
+            colon_token: COLON@5..7 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssIdentifier {
+                        value_token: IDENT@7..12 "theme" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@12..13 ";" [] [],
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: CssTypeSelector {
+                        namespace: missing (optional),
+                        ident: CssIdentifier {
+                            value_token: IDENT@13..17 "a" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                        },
+                    },
+                    sub_selectors: CssSubSelectorList [],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@17..18 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    ScssNestingDeclaration {
+                        name: ScssInterpolatedDashedIdentifier {
+                            items: ScssInterpolatedIdentifierPartList [
+                                ScssInterpolatedIdentifierHyphen {
+                                    minus_token: MINUS@18..22 "-" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                ScssInterpolatedIdentifierHyphen {
+                                    minus_token: MINUS@22..23 "-" [] [],
+                                },
+                                ScssInterpolation {
+                                    hash_token: HASH@23..24 "#" [] [],
+                                    l_curly_token: L_CURLY@24..25 "{" [] [],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            ScssVariable {
+                                                dollar_token: DOLLAR@25..26 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@26..30 "name" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    r_curly_token: R_CURLY@30..31 "}" [] [],
+                                },
+                            ],
+                        },
+                        colon_token: COLON@31..33 ":" [] [Whitespace(" ")],
+                        value: ScssExpression {
+                            items: ScssExpressionItemList [],
+                        },
+                        block: CssDeclarationOrRuleBlock {
+                            l_curly_token: L_CURLY@33..34 "{" [] [],
+                            items: CssDeclarationOrRuleList [
+                                CssDeclarationWithSemicolon {
+                                    declaration: CssDeclaration {
+                                        property: CssGenericProperty {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@34..44 "color" [Newline("\n"), Whitespace("    ")] [],
+                                            },
+                                            colon_token: COLON@44..46 ":" [] [Whitespace(" ")],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@46..49 "red" [] [],
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                        important: missing (optional),
+                                    },
+                                    semicolon_token: SEMICOLON@49..50 ";" [] [],
+                                },
+                            ],
+                            r_curly_token: R_CURLY@50..54 "}" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@54..56 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@56..57 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..57
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..56
+    0: SCSS_VARIABLE_DECLARATION@0..13
+      0: SCSS_VARIABLE@0..5
+        0: DOLLAR@0..1 "$" [] []
+        1: CSS_IDENTIFIER@1..5
+          0: IDENT@1..5 "name" [] []
+      1: COLON@5..7 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@7..12
+        0: SCSS_EXPRESSION_ITEM_LIST@7..12
+          0: CSS_IDENTIFIER@7..12
+            0: IDENT@7..12 "theme" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@12..12
+      4: SEMICOLON@12..13 ";" [] []
+    1: CSS_QUALIFIED_RULE@13..56
+      0: CSS_SELECTOR_LIST@13..17
+        0: CSS_COMPOUND_SELECTOR@13..17
+          0: CSS_NESTED_SELECTOR_LIST@13..13
+          1: CSS_TYPE_SELECTOR@13..17
+            0: (empty)
+            1: CSS_IDENTIFIER@13..17
+              0: IDENT@13..17 "a" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+          2: CSS_SUB_SELECTOR_LIST@17..17
+      1: CSS_DECLARATION_OR_RULE_BLOCK@17..56
+        0: L_CURLY@17..18 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@18..54
+          0: SCSS_NESTING_DECLARATION@18..54
+            0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@18..31
+              0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@18..31
+                0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@18..22
+                  0: MINUS@18..22 "-" [Newline("\n"), Whitespace("  ")] []
+                1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@22..23
+                  0: MINUS@22..23 "-" [] []
+                2: SCSS_INTERPOLATION@23..31
+                  0: HASH@23..24 "#" [] []
+                  1: L_CURLY@24..25 "{" [] []
+                  2: SCSS_EXPRESSION@25..30
+                    0: SCSS_EXPRESSION_ITEM_LIST@25..30
+                      0: SCSS_VARIABLE@25..30
+                        0: DOLLAR@25..26 "$" [] []
+                        1: CSS_IDENTIFIER@26..30
+                          0: IDENT@26..30 "name" [] []
+                  3: R_CURLY@30..31 "}" [] []
+            1: COLON@31..33 ":" [] [Whitespace(" ")]
+            2: SCSS_EXPRESSION@33..33
+              0: SCSS_EXPRESSION_ITEM_LIST@33..33
+            3: CSS_DECLARATION_OR_RULE_BLOCK@33..54
+              0: L_CURLY@33..34 "{" [] []
+              1: CSS_DECLARATION_OR_RULE_LIST@34..50
+                0: CSS_DECLARATION_WITH_SEMICOLON@34..50
+                  0: CSS_DECLARATION@34..49
+                    0: CSS_GENERIC_PROPERTY@34..49
+                      0: CSS_IDENTIFIER@34..44
+                        0: IDENT@34..44 "color" [Newline("\n"), Whitespace("    ")] []
+                      1: COLON@44..46 ":" [] [Whitespace(" ")]
+                      2: SCSS_EXPRESSION@46..49
+                        0: SCSS_EXPRESSION_ITEM_LIST@46..49
+                          0: CSS_IDENTIFIER@46..49
+                            0: IDENT@46..49 "red" [] []
+                    1: (empty)
+                  1: SEMICOLON@49..50 ";" [] []
+              2: R_CURLY@50..54 "}" [Newline("\n"), Whitespace("  ")] []
+        2: R_CURLY@54..56 "}" [Newline("\n")] []
+  2: EOF@56..57 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -11304,7 +11304,7 @@ impl ScssNestingDeclaration {
             block: self.block(),
         }
     }
-    pub fn name(&self) -> SyntaxResult<CssIdentifier> {
+    pub fn name(&self) -> SyntaxResult<AnyCssDeclarationName> {
         support::required_node(&self.syntax, 0usize)
     }
     pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -11327,7 +11327,7 @@ impl Serialize for ScssNestingDeclaration {
 }
 #[derive(Serialize)]
 pub struct ScssNestingDeclarationFields {
-    pub name: SyntaxResult<CssIdentifier>,
+    pub name: SyntaxResult<AnyCssDeclarationName>,
     pub colon_token: SyntaxResult<SyntaxToken>,
     pub value: SyntaxResult<ScssExpression>,
     pub block: SyntaxResult<AnyCssDeclarationOrRuleBlock>,

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -4530,7 +4530,7 @@ impl ScssNamespacedVariable {
     }
 }
 impl ScssNestingDeclaration {
-    pub fn with_name(self, element: CssIdentifier) -> Self {
+    pub fn with_name(self, element: AnyCssDeclarationName) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -3156,7 +3156,7 @@ ScssNamespacedVariable =
 // font: { family: sans-serif; size: 12px; }
 // ^^^^
 ScssNestingDeclaration =
-	name: CssIdentifier
+	name: AnyCssDeclarationName
 	':'
 	value: ScssExpression
 	block: AnyCssDeclarationOrRuleBlock


### PR DESCRIPTION
> This PR was implemented with guidance from Codex AI assistant.

## Summary

Allows SCSS nested-property declarations to use interpolated custom property names:

```scss
$name: theme;

.box {
  --#{$name}: {
    color: red;
  }

  --theme-#{$slot}: {
    background: blue;
  }
}
```
Test Plan
cargo test -p biome_css_parser 
cargo test -p biome_css_formatter 

