### PR TITLE
fix(css_parser): gate SCSS syntax in CSS

### DIFF
--- a/crates/biome_css_formatter/Cargo.toml
+++ b/crates/biome_css_formatter/Cargo.toml
@@ -31,7 +31,7 @@ biome_string_case = { workspace = true }
 biome_suppression = { workspace = true }
 
 [dev-dependencies]
-biome_configuration  = { path = "../biome_configuration" }
+biome_configuration  = { path = "../biome_configuration", features = ["lang_css"] }
 biome_css_parser     = { path = "../biome_css_parser" }
 biome_css_syntax     = { path = "../biome_css_syntax", features = ["scss"] }
 biome_formatter      = { path = "../biome_formatter", features = ["countme"] }
@@ -39,7 +39,7 @@ biome_formatter_test = { path = "../biome_formatter_test", features = ["lang_css
 biome_fs             = { path = "../biome_fs" }
 biome_languages      = { path = "../biome_languages" }
 biome_parser         = { path = "../biome_parser" }
-biome_service        = { path = "../biome_service", features = ["lang_css"] }
+biome_service        = { path = "../biome_service", features = ["lang_css", "report_scss_exclusive_syntax"] }
 biome_test_utils     = { path = "../biome_test_utils", features = ["lang_css"] }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }

--- a/crates/biome_css_formatter/tests/language.rs
+++ b/crates/biome_css_formatter/tests/language.rs
@@ -27,7 +27,8 @@ impl TestFormatLanguage for CssTestFormatLanguage {
         let options = CssParserOptions::default()
             .allow_wrong_line_comments()
             .allow_css_modules()
-            .allow_tailwind_directives();
+            .allow_tailwind_directives()
+            .report_scss_exclusive_syntax();
 
         parse_css(text, self.source_type, options).into()
     }

--- a/crates/biome_css_formatter/tests/specs/prettier/css/atrule/extend.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/atrule/extend.css.snap
@@ -166,17 +166,7 @@ a.important
 ```diff
 --- Prettier
 +++ Biome
-@@ -27,7 +27,8 @@
- 
-   font-weight: bold;
- }
--%message-shared {
-+%
-+message-shared {
-   border: 1px solid #ccc;
-   padding: 10px;
-   color: #333;
-@@ -60,36 +61,46 @@
+@@ -60,36 +60,46 @@
    @extend .notice !optional;
  }
  a.important {
@@ -268,8 +258,7 @@ a.important
 
   font-weight: bold;
 }
-%
-message-shared {
+%message-shared {
   border: 1px solid #ccc;
   padding: 10px;
   color: #333;
@@ -351,19 +340,11 @@ a.important {
 ```
 extend.css:50:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a qualified rule, or an at rule but instead found '%'.
+  × SCSS placeholder selectors are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
   
     49 │ }
   > 50 │ %message-shared {
-       │ ^
-    51 │     border: 1px solid #ccc;
-    52 │     padding: 10px;
-  
-  i Expected a qualified rule, or an at rule here.
-  
-    49 │ }
-  > 50 │ %message-shared {
-       │ ^
+       │ ^^^^^^^^^^^^^^^
     51 │     border: 1px solid #ccc;
     52 │     padding: 10px;
   
@@ -372,5 +353,5 @@ extend.css:50:1 parse ━━━━━━━━━━━━━━━━━━━�
 
 # Lines exceeding max width of 80 characters
 ```
-  105:   @extend .very-very-very-very-very-very-very-very-very-very-very-very-very-long-selector, .very-very-very-very-very-very-very-very-very-very-very-very-very-long-selector;
+  104:   @extend .very-very-very-very-very-very-very-very-very-very-very-very-very-long-selector, .very-very-very-very-very-very-very-very-very-very-very-very-very-long-selector;
 ```

--- a/crates/biome_css_parser/Cargo.toml
+++ b/crates/biome_css_parser/Cargo.toml
@@ -28,11 +28,11 @@ smallvec            = { workspace = true }
 tracing             = { workspace = true }
 
 [dev-dependencies]
-biome_configuration = { path = "../biome_configuration" }
+biome_configuration = { path = "../biome_configuration", features = ["lang_css"] }
 biome_css_syntax    = { path = "../biome_css_syntax", features = ["scss"] }
 biome_deserialize   = { path = "../biome_deserialize" }
 biome_fs            = { path = "../biome_fs" }
-biome_service       = { path = "../biome_service" }
+biome_service       = { path = "../biome_service", features = ["lang_css"] }
 biome_test_utils    = { path = "../biome_test_utils" }
 camino              = { workspace = true }
 criterion           = { package = "codspeed-criterion-compat", version = "=3.0.5" }

--- a/crates/biome_css_parser/src/parser.rs
+++ b/crates/biome_css_parser/src/parser.rs
@@ -39,6 +39,13 @@ pub struct CssParserOptions {
     /// Enables parsing of Tailwind CSS 4.0 directives and functions.
     /// Defaults to `false`.
     pub tailwind_directives: bool,
+
+    /// Reports SCSS-exclusive syntax diagnostics in CSS files.
+    ///
+    /// This is an internal option for parser/formatter tests and callers that
+    /// want to report SCSS-specific diagnostics in CSS files.
+    #[doc(hidden)]
+    pub report_scss_exclusive_syntax: bool,
 }
 
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
@@ -76,6 +83,13 @@ impl CssParserOptions {
         self
     }
 
+    /// Enables reporting of SCSS-exclusive syntax diagnostics in CSS files.
+    #[doc(hidden)]
+    pub fn report_scss_exclusive_syntax(mut self) -> Self {
+        self.report_scss_exclusive_syntax = true;
+        self
+    }
+
     /// Checks if parsing of CSS Modules features is disabled.
     pub fn is_css_modules_disabled(&self) -> bool {
         !self.is_css_modules_enabled()
@@ -89,6 +103,10 @@ impl CssParserOptions {
     /// Checks if parsing of Tailwind CSS 4.0 directives is enabled.
     pub fn is_tailwind_directives_enabled(&self) -> bool {
         self.tailwind_directives
+    }
+
+    pub(crate) fn should_report_scss_exclusive_syntax(&self) -> bool {
+        self.report_scss_exclusive_syntax
     }
 
     pub fn is_css_modules_enabled(&self) -> bool {

--- a/crates/biome_css_parser/src/syntax/at_rule/feature.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/feature.rs
@@ -3,12 +3,14 @@ use crate::syntax::parse_error::expected_component_value;
 use crate::syntax::parse_error::expected_identifier;
 use crate::syntax::parse_error::scss_only_syntax_error;
 use crate::syntax::scss::{
-    is_at_scss_binary_operator, is_at_scss_interpolated_identifier, is_at_scss_interpolation,
-    is_at_scss_variable, parse_scss_expression_from_head, parse_scss_interpolated_name,
+    is_at_scss_binary_operator, is_at_scss_interpolation, is_at_scss_variable,
+    is_nth_at_scss_interpolation, parse_scss_expression_from_head, parse_scss_interpolated_name,
     parse_scss_interpolated_query_feature, parse_scss_interpolation_or_identifier,
     parse_scss_variable,
 };
-use crate::syntax::{CssSyntaxFeatures, is_at_any_value, is_at_identifier, parse_any_value};
+use crate::syntax::{
+    CssSyntaxFeatures, is_at_any_value, is_at_identifier, parse_any_value, parse_regular_identifier,
+};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T, TextRange};
 use biome_parser::diagnostic::{ParseDiagnostic, ToDiagnostic, expect_one_of};
@@ -20,7 +22,13 @@ use biome_parser::{CompletedMarker, Marker, Parser, SyntaxFeature, TokenSet, tok
 #[inline]
 pub fn parse_any_query_feature(p: &mut CssParser) -> ParsedSyntax {
     if is_at_scss_interpolation(p) {
-        parse_scss_interpolated_query_feature(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolated_query_feature,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated query features", marker.range(p))
+            },
+        )
     } else if is_at_query_feature_name(p) {
         parse_named_query_feature(p)
     } else if is_at_any_query_feature_value(p) {
@@ -32,7 +40,7 @@ pub fn parse_any_query_feature(p: &mut CssParser) -> ParsedSyntax {
 
 #[inline]
 fn is_at_query_feature_name(p: &mut CssParser) -> bool {
-    is_at_scss_variable(p) || is_at_scss_interpolated_identifier(p) || is_at_identifier(p)
+    is_at_scss_variable(p) || is_at_identifier(p) || is_at_scss_interpolation(p)
 }
 
 /// Parses a query feature that starts with a feature name.
@@ -61,8 +69,16 @@ pub(crate) fn parse_query_feature_name(p: &mut CssParser) -> ParsedSyntax {
         CssSyntaxFeatures::Scss.parse_exclusive_syntax(p, parse_scss_variable, |p, m| {
             scss_only_syntax_error(p, "SCSS variables", m.range(p))
         })
+    } else if is_at_scss_interpolated_query_feature_name(p) {
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolated_name,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated query feature names", marker.range(p))
+            },
+        )
     } else {
-        parse_scss_interpolated_name(p)
+        parse_regular_identifier(p)
     }
 }
 
@@ -165,7 +181,13 @@ pub(crate) fn is_at_any_query_feature_value(p: &mut CssParser) -> bool {
 #[inline]
 fn parse_any_query_feature_value(p: &mut CssParser) -> ParsedSyntax {
     if is_at_scss_interpolation(p) {
-        parse_scss_interpolation_or_identifier(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolation_or_identifier,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated query feature values", marker.range(p))
+            },
+        )
     } else {
         // The concrete query-feature value grammar is narrower than `AnyCssValue`,
         // but this shared value parser gives us the right recovery for the current
@@ -235,6 +257,14 @@ fn is_scss_query_feature_value_head(kind: CssSyntaxKind) -> bool {
         kind,
         SCSS_INTERPOLATED_IDENTIFIER | SCSS_INTERPOLATION | SCSS_VARIABLE
     )
+}
+
+#[inline]
+fn is_at_scss_interpolated_query_feature_name(p: &mut CssParser) -> bool {
+    is_at_scss_interpolation(p)
+        || is_at_identifier(p)
+            && is_nth_at_scss_interpolation(p, 1)
+            && !p.has_nth_preceding_whitespace(1)
 }
 
 pub(crate) fn expected_any_query_feature(p: &CssParser, range: TextRange) -> ParseDiagnostic {

--- a/crates/biome_css_parser/src/syntax/at_rule/keyframes.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/keyframes.rs
@@ -22,6 +22,7 @@ use crate::syntax::{
 };
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
+use biome_parser::SyntaxFeature;
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
 use biome_parser::parse_recovery::{ParseRecovery, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
@@ -192,7 +193,9 @@ fn parse_keyframes_identifier(p: &mut CssParser) -> ParsedSyntax {
 /// `@keyframes $name`, `@keyframes #{$name}`, and `@keyframes fade-#{$name}`.
 fn parse_keyframes_name(p: &mut CssParser) -> ParsedSyntax {
     if is_at_scss_keyframes_name(p) {
-        parse_scss_keyframes_name(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(p, parse_scss_keyframes_name, |p, marker| {
+            scss_only_syntax_error(p, "SCSS keyframes names", marker.range(p))
+        })
     } else {
         parse_keyframes_identifier(p)
     }
@@ -418,7 +421,13 @@ fn parse_keyframes_item_selector(p: &mut CssParser) -> ParsedSyntax {
     }
 
     if is_at_scss_keyframes_selector(p) {
-        parse_scss_keyframes_selector(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_keyframes_selector,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated keyframe selectors", marker.range(p))
+            },
+        )
     } else if is_at_timeline_range_name(p) {
         parse_keyframes_range_selector(p)
     } else if is_at_percentage_dimension(p) {

--- a/crates/biome_css_parser/src/syntax/at_rule/media.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/media.rs
@@ -3,6 +3,7 @@ use crate::parser::CssParser;
 use crate::syntax::at_rule::error::{AnyInParensChainParseRecovery, AnyInParensParseRecovery};
 use crate::syntax::at_rule::feature::{expected_any_query_feature, parse_any_query_feature};
 use crate::syntax::block::parse_conditional_block;
+use crate::syntax::parse_error::scss_only_syntax_error;
 use crate::syntax::scss::{
     is_at_scss_interpolated_media_in_parens, is_at_scss_media_condition, is_at_scss_media_query,
     parse_scss_interpolated_media_in_parens, parse_scss_media_condition, parse_scss_media_query,
@@ -10,11 +11,12 @@ use crate::syntax::scss::{
 };
 use crate::syntax::util::skip_possible_tailwind_syntax;
 use crate::syntax::{
-    is_at_identifier, is_at_metavariable, is_nth_at_identifier, parse_metavariable,
-    parse_regular_identifier,
+    CssSyntaxFeatures, is_at_identifier, is_at_metavariable, is_nth_at_identifier,
+    parse_metavariable, parse_regular_identifier,
 };
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
+use biome_parser::SyntaxFeature;
 use biome_parser::diagnostic::expected_any;
 use biome_parser::parse_lists::ParseSeparatedList;
 use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
@@ -125,7 +127,13 @@ pub(crate) fn parse_any_media_query(p: &mut CssParser) -> ParsedSyntax {
     if is_at_media_type_query(p) {
         parse_any_media_type_query(p)
     } else if is_at_scss_media_query(p) {
-        parse_scss_media_query_or_condition_query(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_media_query_or_condition_query,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated media queries", marker.range(p))
+            },
+        )
     } else if is_at_metavariable(p) {
         parse_metavariable(p)
     } else if is_at_any_media_condition(p) {
@@ -164,7 +172,13 @@ pub(crate) fn parse_any_media_condition(p: &mut CssParser) -> ParsedSyntax {
     if is_at_media_not_condition(p) {
         parse_media_not_condition(p)
     } else if is_at_scss_media_condition(p) {
-        parse_scss_media_condition(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_media_condition,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated media conditions", marker.range(p))
+            },
+        )
     } else {
         parse_any_media_condition_operand(p).map(|lhs| match p.cur() {
             T![and] => parse_media_and_condition(p, lhs),
@@ -340,7 +354,9 @@ fn is_at_any_media_condition_operand(p: &mut CssParser) -> bool {
 #[inline]
 pub fn parse_any_media_condition_operand(p: &mut CssParser) -> ParsedSyntax {
     if is_at_scss_media_query(p) {
-        parse_scss_media_query(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(p, parse_scss_media_query, |p, marker| {
+            scss_only_syntax_error(p, "SCSS interpolated media queries", marker.range(p))
+        })
     } else {
         parse_any_media_in_parens(p)
     }
@@ -358,7 +374,11 @@ fn is_at_any_media_in_parens(p: &mut CssParser) -> bool {
 #[inline]
 pub(crate) fn parse_any_media_in_parens(p: &mut CssParser) -> ParsedSyntax {
     if is_at_scss_interpolated_media_in_parens(p) {
-        return parse_scss_interpolated_media_in_parens(p);
+        if CssSyntaxFeatures::Scss.is_supported(p) {
+            return parse_scss_interpolated_media_in_parens(p);
+        }
+
+        return parse_media_feature_in_parens(p);
     }
 
     if !is_at_any_media_in_parens(p) {
@@ -374,15 +394,34 @@ pub(crate) fn parse_any_media_in_parens(p: &mut CssParser) -> ParsedSyntax {
             .ok();
         CSS_MEDIA_CONDITION_IN_PARENS
     } else {
-        parse_any_query_feature(p)
-            .or_recover(p, &AnyInParensParseRecovery, expected_any_query_feature)
-            .ok();
+        recover_media_feature_in_parens_body(p);
         CSS_MEDIA_FEATURE_IN_PARENS
     };
 
     p.expect(T![')']);
 
     Present(m.complete(p, kind))
+}
+
+#[inline]
+fn parse_media_feature_in_parens(p: &mut CssParser) -> ParsedSyntax {
+    if !is_at_any_media_in_parens(p) {
+        return Absent;
+    }
+
+    let m = p.start();
+    p.bump(T!['(']);
+    recover_media_feature_in_parens_body(p);
+    p.expect(T![')']);
+
+    Present(m.complete(p, CSS_MEDIA_FEATURE_IN_PARENS))
+}
+
+#[inline]
+fn recover_media_feature_in_parens_body(p: &mut CssParser) {
+    parse_any_query_feature(p)
+        .or_recover(p, &AnyInParensParseRecovery, expected_any_query_feature)
+        .ok();
 }
 
 fn expected_any_media_condition(p: &CssParser, range: TextRange) -> ParseDiagnostic {

--- a/crates/biome_css_parser/src/syntax/at_rule/mod.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/mod.rs
@@ -66,15 +66,17 @@ use crate::syntax::at_rule::tailwind::{
     parse_reference_at_rule, parse_slot_at_rule, parse_source_at_rule, parse_theme_at_rule,
     parse_utility_at_rule, parse_variant_at_rule,
 };
-use crate::syntax::at_rule::unknown::{is_at_unknown_at_rule, parse_unknown_at_rule};
+use crate::syntax::at_rule::unknown::{
+    is_at_unknown_at_rule, parse_scss_interpolated_unknown_at_rule, parse_unknown_at_rule,
+};
 use crate::syntax::at_rule::value::parse_value_at_rule;
 use crate::syntax::at_rule::view_transition::{
     parse_view_transition_at_rule, parse_view_transition_at_rule_declarator,
 };
 
-use crate::syntax::parse_error::{expected_any_at_rule, tailwind_disabled};
-use crate::syntax::scss::is_nth_at_scss_interpolated_dashed_identifier;
+use crate::syntax::parse_error::{expected_any_at_rule, scss_only_syntax_error, tailwind_disabled};
 use crate::syntax::scss::{
+    is_at_scss_interpolation, is_nth_at_scss_interpolated_dashed_identifier,
     parse_bogus_scss_else_at_rule, parse_scss_at_root_at_rule, parse_scss_content_at_rule,
     parse_scss_debug_at_rule, parse_scss_each_at_rule, parse_scss_error_at_rule,
     parse_scss_extend_at_rule, parse_scss_for_at_rule, parse_scss_forward_at_rule,
@@ -258,6 +260,13 @@ pub(crate) fn parse_any_at_rule(p: &mut CssParser) -> ParsedSyntax {
                 tailwind_disabled(p, m.range(p))
             })
             .or_else(|| parse_unknown_at_rule(p)),
+        _ if is_at_scss_interpolation(p) => CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolated_unknown_at_rule,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated at-rule names", marker.range(p))
+            },
+        ),
         _ if is_at_unknown_at_rule(p) => parse_unknown_at_rule(p),
         _ => Absent,
     }

--- a/crates/biome_css_parser/src/syntax/at_rule/page.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/page.rs
@@ -9,7 +9,8 @@ use crate::syntax::declaration::parse_declaration_with_semicolon;
 use crate::syntax::parse_error::scss_only_syntax_error;
 use crate::syntax::scss::{
     is_at_scss_nesting_declaration, is_at_scss_variable_declaration,
-    parse_scss_variable_declaration, try_parse_scss_nesting_declaration,
+    parse_exclusive_scss_nested_property_declaration, parse_scss_variable_declaration,
+    try_parse_scss_nesting_declaration,
 };
 use crate::syntax::{
     CssSyntaxFeatures, is_at_any_declaration_with_semicolon, is_at_identifier,
@@ -188,7 +189,7 @@ impl ParseBlockBody for PageBlock {
     fn is_at_element(&self, p: &mut CssParser) -> bool {
         at_margin_rule(p)
             || is_at_at_rule(p)
-           // SCSS allows variable declarations and nested properties inside any block.
+            // SCSS allows variable declarations and nested properties inside any block.
             || is_at_scss_variable_declaration(p)
             || is_at_scss_nesting_declaration(p)
             || is_at_any_declaration_with_semicolon(p)
@@ -223,20 +224,27 @@ impl ParseNodeList for PageAtRuleItemList {
                 },
             )
         } else if is_at_scss_nesting_declaration(p) {
-            if let Ok(declaration) = try_parse_scss_nesting_declaration(p, T!['}']) {
-                return declaration;
-            }
+            if CssSyntaxFeatures::Scss.is_supported(p) {
+                if let Ok(declaration) = try_parse_scss_nesting_declaration(p, T!['}']) {
+                    return declaration;
+                }
 
-            if is_at_qualified_rule(p)
-                && let Present(mut syntax) = parse_qualified_rule(p)
+                if is_at_qualified_rule(p)
+                    && let Present(mut syntax) = parse_qualified_rule(p)
+                {
+                    let range = syntax.range(p);
+                    p.error(expected_any_page_at_rule_item(p, range));
+                    syntax.change_kind(p, CSS_BOGUS);
+                    return Present(syntax);
+                }
+
+                parse_declaration_with_semicolon(p)
+            } else if let Present(declaration) = parse_exclusive_scss_nested_property_declaration(p)
             {
-                let range = syntax.range(p);
-                p.error(expected_any_page_at_rule_item(p, range));
-                syntax.change_kind(p, CSS_BOGUS);
-                return Present(syntax);
+                Present(declaration)
+            } else {
+                parse_any_declaration_with_semicolon(p)
             }
-
-            parse_declaration_with_semicolon(p)
         } else if is_at_any_declaration_with_semicolon(p) {
             parse_any_declaration_with_semicolon(p)
         } else if is_at_qualified_rule(p) {

--- a/crates/biome_css_parser/src/syntax/at_rule/supports/mod.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/supports/mod.rs
@@ -13,7 +13,7 @@ use crate::syntax::property::{
     parse_generic_property_name, parse_property_value_with_end_set,
 };
 use crate::syntax::scss::{
-    is_at_scss_supports_interpolated_condition, is_nth_at_scss_interpolated_property,
+    is_at_scss_supports_interpolated_condition, is_nth_at_scss_interpolated_property_name,
     parse_scss_supports_interpolated_condition,
 };
 use crate::syntax::selector::parse_selector;
@@ -231,8 +231,6 @@ fn parse_any_supports_condition_in_parens(
     } else if is_at_supports_condition_in_parens(p) {
         parse_supports_condition_in_parens(p)
     } else if is_at_scss_supports_interpolated_condition(p) {
-        // TODO(#10456): Add CSS-mode error fixtures for this SCSS-exclusive
-        // branch after the shared SCSS interpolation gating lands.
         CssSyntaxFeatures::Scss.parse_exclusive_syntax(
             p,
             parse_scss_supports_interpolated_condition,
@@ -306,7 +304,8 @@ fn parse_supports_feature_selector(p: &mut CssParser) -> ParsedSyntax {
 #[inline]
 fn is_at_supports_feature_declaration(p: &mut CssParser) -> bool {
     p.at(T!['('])
-        && (is_nth_at_direct_generic_property(p, 1) || is_nth_at_scss_interpolated_property(p, 1))
+        && (is_nth_at_direct_generic_property(p, 1)
+            || is_nth_at_scss_interpolated_property_name(p, 1))
 }
 
 #[inline]

--- a/crates/biome_css_parser/src/syntax/at_rule/unknown.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/unknown.rs
@@ -7,15 +7,14 @@ use crate::syntax::scss::{
 use crate::syntax::{CssSyntaxFeatures, is_at_identifier, parse_regular_identifier};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::T;
-use biome_parser::CompletedMarker;
-use biome_parser::ParserProgress;
 use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
+use biome_parser::{CompletedMarker, Marker, ParserProgress};
 
 #[inline]
 pub(crate) fn is_at_unknown_at_rule(p: &mut CssParser) -> bool {
-    is_at_identifier(p) || CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_interpolation(p)
+    is_at_identifier(p)
 }
 
 /// Parses an unknown CSS at-rule, including Sass plain-CSS passthroughs.
@@ -37,9 +36,37 @@ pub(crate) fn parse_unknown_at_rule(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
 
     // Guarded by `is_at_unknown_at_rule`.
-    parse_unknown_at_rule_name(p).ok();
+    parse_regular_identifier(p).ok();
     parse_unknown_at_rule_components(p);
 
+    complete_unknown_at_rule(p, m)
+}
+
+/// Parses an unknown SCSS at-rule with an interpolated name.
+///
+/// Example:
+/// ```scss
+/// @#{$rule-name} #{$value};
+/// ```
+///
+/// Docs: https://sass-lang.com/documentation/at-rules/css/
+#[inline]
+pub(crate) fn parse_scss_interpolated_unknown_at_rule(p: &mut CssParser) -> ParsedSyntax {
+    if !is_at_scss_interpolation(p) {
+        return Absent;
+    }
+
+    let m = p.start();
+
+    // Guarded by `is_at_scss_interpolation`.
+    parse_scss_interpolation_or_identifier(p).ok();
+    parse_scss_unknown_at_rule_components(p);
+
+    complete_unknown_at_rule(p, m)
+}
+
+#[inline]
+fn complete_unknown_at_rule(p: &mut CssParser, m: Marker) -> ParsedSyntax {
     let kind = if p.at(T!['{']) {
         parse_declaration_or_rule_list_block(p);
         CSS_UNKNOWN_BLOCK_AT_RULE
@@ -51,38 +78,62 @@ pub(crate) fn parse_unknown_at_rule(p: &mut CssParser) -> ParsedSyntax {
     Present(m.complete(p, kind))
 }
 
-#[inline]
-fn parse_unknown_at_rule_name(p: &mut CssParser) -> ParsedSyntax {
-    if CssSyntaxFeatures::Scss.is_supported(p) {
-        parse_scss_interpolation_or_identifier(p)
-    } else {
-        parse_regular_identifier(p)
-    }
-}
-
 /// Parses the generic at-rule prelude before `;` or a top-level block.
 ///
 /// Example: `@unknown fn({ width: 300px }) #{$query} {}` keeps the function
 /// body balanced while the final `{` starts the at-rule block.
 #[inline]
 fn parse_unknown_at_rule_components(p: &mut CssParser) -> CompletedMarker {
+    parse_unknown_at_rule_components_with(p, consume_unknown_at_rule_component)
+}
+
+#[inline]
+fn parse_scss_unknown_at_rule_components(p: &mut CssParser) -> CompletedMarker {
+    parse_unknown_at_rule_components_with(p, consume_scss_unknown_at_rule_component)
+}
+
+#[inline]
+fn parse_unknown_at_rule_components_with(
+    p: &mut CssParser,
+    mut parse_component: impl FnMut(&mut CssParser) -> bool,
+) -> CompletedMarker {
     let m = p.start();
     let mut progress = ParserProgress::default();
     let mut balance = UnknownAtRuleComponentBalance::default();
 
     while !balance.is_at_end(p) {
         progress.assert_progressing(p);
-
-        if CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_interpolation(p) {
-            // `@unknown #{$value};`: keep interpolation structured inside the
-            // otherwise token-shaped generic prelude.
-            parse_scss_regular_interpolation(p).ok();
-        } else {
+        if !parse_component(p) {
             balance.bump(p);
         }
     }
 
     m.complete(p, CSS_UNKNOWN_AT_RULE_COMPONENT_LIST)
+}
+
+#[inline]
+fn consume_unknown_at_rule_component(p: &mut CssParser) -> bool {
+    if CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_interpolation(p) {
+        // `@unknown #{$value};`: keep interpolation structured inside the
+        // otherwise token-shaped generic prelude.
+        parse_scss_regular_interpolation(p).ok();
+        true
+    } else {
+        false
+    }
+}
+
+#[inline]
+fn consume_scss_unknown_at_rule_component(p: &mut CssParser) -> bool {
+    if is_at_scss_interpolation(p) {
+        // `@#{$name} #{$value};`: this parser is called from the SCSS-exclusive
+        // at-rule name entrypoint, so interpolation stays structured even when
+        // SCSS is unsupported and the caller will report the exclusive syntax.
+        parse_scss_regular_interpolation(p).ok();
+        true
+    } else {
+        false
+    }
 }
 
 /// Tracks nested delimiters inside an unknown at-rule prelude.

--- a/crates/biome_css_parser/src/syntax/block/declaration_or_at_rule_list_block.rs
+++ b/crates/biome_css_parser/src/syntax/block/declaration_or_at_rule_list_block.rs
@@ -3,7 +3,7 @@ use crate::syntax::at_rule::{is_at_at_rule, parse_at_rule};
 use crate::syntax::block::ParseBlockBody;
 use crate::syntax::parse_error::{expected_any_declaration_or_at_rule, scss_only_syntax_error};
 use crate::syntax::scss::{
-    is_at_scss_interpolated_property, is_at_scss_nesting_declaration,
+    is_at_scss_interpolated_property_name, is_at_scss_nesting_declaration,
     is_at_scss_variable_declaration, parse_scss_interpolated_property_declaration,
     parse_scss_variable_declaration,
 };
@@ -42,7 +42,7 @@ fn is_at_declaration_or_at_rule_item(p: &mut CssParser) -> bool {
     is_at_at_rule(p)
         || is_at_scss_variable_declaration(p)
         || is_at_scss_nesting_declaration(p)
-        || is_at_scss_interpolated_property(p)
+        || is_at_scss_interpolated_property_name(p)
         || is_at_any_declaration_with_semicolon(p)
 }
 
@@ -74,8 +74,20 @@ impl ParseNodeList for DeclarationOrAtRuleList {
                     scss_only_syntax_error(p, "SCSS variable declarations", marker.range(p))
                 },
             )
-        } else if is_at_scss_nesting_declaration(p) || is_at_scss_interpolated_property(p) {
+        } else if CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_nesting_declaration(p) {
             parse_scss_interpolated_property_declaration(p)
+        } else if is_at_scss_interpolated_property_name(p) {
+            CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+                p,
+                parse_scss_interpolated_property_declaration,
+                |p, marker| {
+                    scss_only_syntax_error(
+                        p,
+                        "SCSS interpolated property declarations",
+                        marker.range(p),
+                    )
+                },
+            )
         } else if is_at_any_declaration_with_semicolon(p) {
             parse_any_declaration_with_semicolon(p)
         } else {

--- a/crates/biome_css_parser/src/syntax/block/declaration_or_at_rule_list_block.rs
+++ b/crates/biome_css_parser/src/syntax/block/declaration_or_at_rule_list_block.rs
@@ -4,8 +4,8 @@ use crate::syntax::block::ParseBlockBody;
 use crate::syntax::parse_error::{expected_any_declaration_or_at_rule, scss_only_syntax_error};
 use crate::syntax::scss::{
     is_at_scss_interpolated_property_name, is_at_scss_nesting_declaration,
-    is_at_scss_variable_declaration, parse_scss_interpolated_property_declaration,
-    parse_scss_variable_declaration,
+    is_at_scss_variable_declaration, parse_exclusive_scss_nested_property_declaration,
+    parse_scss_interpolated_property_declaration, parse_scss_variable_declaration,
 };
 use crate::syntax::{
     CssSyntaxFeatures, is_at_any_declaration_with_semicolon, parse_any_declaration_with_semicolon,
@@ -74,8 +74,28 @@ impl ParseNodeList for DeclarationOrAtRuleList {
                     scss_only_syntax_error(p, "SCSS variable declarations", marker.range(p))
                 },
             )
-        } else if CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_nesting_declaration(p) {
-            parse_scss_interpolated_property_declaration(p)
+        } else if is_at_scss_nesting_declaration(p) {
+            if CssSyntaxFeatures::Scss.is_supported(p) {
+                parse_scss_interpolated_property_declaration(p)
+            } else if let ParsedSyntax::Present(declaration) =
+                parse_exclusive_scss_nested_property_declaration(p)
+            {
+                ParsedSyntax::Present(declaration)
+            } else if is_at_scss_interpolated_property_name(p) {
+                CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+                    p,
+                    parse_scss_interpolated_property_declaration,
+                    |p, marker| {
+                        scss_only_syntax_error(
+                            p,
+                            "SCSS interpolated property declarations",
+                            marker.range(p),
+                        )
+                    },
+                )
+            } else {
+                parse_any_declaration_with_semicolon(p)
+            }
         } else if is_at_scss_interpolated_property_name(p) {
             CssSyntaxFeatures::Scss.parse_exclusive_syntax(
                 p,

--- a/crates/biome_css_parser/src/syntax/block/declaration_or_rule_list_block.rs
+++ b/crates/biome_css_parser/src/syntax/block/declaration_or_rule_list_block.rs
@@ -5,9 +5,9 @@ use crate::syntax::declaration::parse_declaration_with_semicolon;
 use crate::syntax::parse_error::{expected_any_declaration_or_at_rule, scss_only_syntax_error};
 use crate::syntax::scss::{
     is_at_scss_interpolated_property_name, is_at_scss_nesting_declaration,
-    is_at_scss_variable_declaration, parse_scss_interpolated_property_declaration,
-    parse_scss_nesting_declaration, parse_scss_variable_declaration,
-    try_parse_scss_nesting_declaration,
+    is_at_scss_variable_declaration, parse_exclusive_scss_nested_property_declaration,
+    parse_scss_interpolated_property_declaration, parse_scss_nesting_declaration,
+    parse_scss_variable_declaration, try_parse_scss_nesting_declaration,
 };
 use crate::syntax::{
     CssSyntaxFeatures, is_at_any_declaration_with_semicolon, is_at_metavariable,
@@ -221,6 +221,12 @@ impl ParseNodeList for DeclarationOrRuleList {
             // If parsing as a declaration was successful, return the parsed declaration.
             if let Ok(declaration) = declaration {
                 return declaration;
+            }
+
+            if let ParsedSyntax::Present(declaration) =
+                parse_exclusive_scss_nested_property_declaration(p)
+            {
+                return ParsedSyntax::Present(declaration);
             }
 
             // If the speculative parse failed and we encountered an if() function,

--- a/crates/biome_css_parser/src/syntax/block/declaration_or_rule_list_block.rs
+++ b/crates/biome_css_parser/src/syntax/block/declaration_or_rule_list_block.rs
@@ -4,9 +4,10 @@ use crate::syntax::block::ParseBlockBody;
 use crate::syntax::declaration::parse_declaration_with_semicolon;
 use crate::syntax::parse_error::{expected_any_declaration_or_at_rule, scss_only_syntax_error};
 use crate::syntax::scss::{
-    is_at_scss_interpolated_property, is_at_scss_nesting_declaration,
-    is_at_scss_variable_declaration, parse_scss_nesting_declaration,
-    parse_scss_variable_declaration, try_parse_scss_nesting_declaration,
+    is_at_scss_interpolated_property_name, is_at_scss_nesting_declaration,
+    is_at_scss_variable_declaration, parse_scss_interpolated_property_declaration,
+    parse_scss_nesting_declaration, parse_scss_variable_declaration,
+    try_parse_scss_nesting_declaration,
 };
 use crate::syntax::{
     CssSyntaxFeatures, is_at_any_declaration_with_semicolon, is_at_metavariable,
@@ -49,7 +50,7 @@ fn is_at_declaration_or_rule_item(p: &mut CssParser) -> bool {
         || is_at_nested_qualified_rule(p)
         || is_at_scss_nesting_declaration(p)
         || is_at_scss_variable_declaration(p)
-        || is_at_scss_interpolated_property(p)
+        || is_at_scss_interpolated_property_name(p)
         || is_at_any_declaration_with_semicolon(p)
         || is_at_metavariable(p)
 }
@@ -59,6 +60,48 @@ fn is_at_top_level_qualified_rule(p: &mut CssParser) -> bool {
     !p.state().is_nesting_block
         && matches!(p.source_type.as_embedding_kind(), CssEmbeddingKind::Styled)
         && is_at_qualified_rule(p)
+}
+
+/// Parses SCSS interpolation-led block items.
+///
+/// Examples: `#{$selector} {}` and `--#{$prop}: red;`.
+#[inline]
+fn parse_scss_interpolated_block_item(p: &mut CssParser, end_kind: CssSyntaxKind) -> ParsedSyntax {
+    // `#{$selector} {}` and `--#{$prop}: red;` share an interpolation start.
+    if is_at_nested_qualified_rule(p)
+        && let Ok(rule) = try_parse_nested_qualified_rule_without_selector_recovery(p, end_kind)
+    {
+        return rule;
+    }
+
+    parse_declaration_with_semicolon(p)
+}
+
+/// Parses SCSS interpolation-led block items in CSS recovery mode.
+///
+/// Examples: `#{$selector} {}` and `--#{$prop}: red;`.
+#[inline]
+fn parse_exclusive_scss_interpolated_block_item(
+    p: &mut CssParser,
+    end_kind: CssSyntaxKind,
+) -> ParsedSyntax {
+    if is_at_nested_qualified_rule(p)
+        && let Ok(rule) = try_parse_nested_qualified_rule_without_selector_recovery(p, end_kind)
+    {
+        return rule;
+    }
+
+    CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+        p,
+        parse_scss_interpolated_property_declaration,
+        |p, marker| {
+            scss_only_syntax_error(
+                p,
+                "SCSS interpolated property declarations",
+                marker.range(p),
+            )
+        },
+    )
 }
 
 struct DeclarationOrRuleListParseRecovery {
@@ -99,7 +142,7 @@ impl ParseNodeList for DeclarationOrRuleList {
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
         if is_at_at_rule(p) {
             parse_at_rule(p)
-        } else if is_at_scss_nesting_declaration(p) {
+        } else if CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_nesting_declaration(p) {
             // Match Sass's declaration-first strategy for ambiguous `name:ident` and
             // `name::...` forms, but do the ambiguity check inside the same speculative
             // declaration parse so we don't pay a separate probe pass first.
@@ -122,17 +165,12 @@ impl ParseNodeList for DeclarationOrRuleList {
                     scss_only_syntax_error(p, "SCSS variable declarations", marker.range(p))
                 },
             )
-        } else if is_at_scss_interpolated_property(p) {
-            // The remaining interpolation-bearing property names here are the
-            // dashed/custom-property forms that `is_at_scss_nesting_declaration`
-            // intentionally excludes, such as `--theme-#{$slot}: red;`.
-            if let Ok(rule) =
-                try_parse_nested_qualified_rule_without_selector_recovery(p, self.end_kind)
-            {
-                return rule;
+        } else if is_at_scss_interpolated_property_name(p) {
+            if CssSyntaxFeatures::Scss.is_supported(p) {
+                parse_scss_interpolated_block_item(p, self.end_kind)
+            } else {
+                parse_exclusive_scss_interpolated_block_item(p, self.end_kind)
             }
-
-            parse_declaration_with_semicolon(p)
         } else if is_at_any_declaration_with_semicolon(p) {
             // if we are at a declaration,
             // we still can have a nested qualified rule or a declaration

--- a/crates/biome_css_parser/src/syntax/declaration.rs
+++ b/crates/biome_css_parser/src/syntax/declaration.rs
@@ -5,7 +5,7 @@ use crate::syntax::property::{
     is_at_any_property, parse_any_property, parse_any_property_with_value_end_set,
 };
 use crate::syntax::scss::{
-    is_at_scss_interpolated_property, is_at_scss_nesting_declaration,
+    is_at_scss_interpolated_property_name, is_at_scss_nesting_declaration,
     is_at_scss_variable_declaration, parse_scss_interpolated_property_declaration,
     parse_scss_variable_declaration,
 };
@@ -25,8 +25,20 @@ impl ParseNodeList for DeclarationList {
     const LIST_KIND: Self::Kind = CSS_DECLARATION_LIST;
 
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
-        if is_at_scss_nesting_declaration(p) || is_at_scss_interpolated_property(p) {
+        if CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_nesting_declaration(p) {
             parse_scss_interpolated_property_declaration(p)
+        } else if is_at_scss_interpolated_property_name(p) {
+            CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+                p,
+                parse_scss_interpolated_property_declaration,
+                |p, marker| {
+                    scss_only_syntax_error(
+                        p,
+                        "SCSS interpolated property declarations",
+                        marker.range(p),
+                    )
+                },
+            )
         } else {
             parse_any_declaration_with_semicolon(p)
         }

--- a/crates/biome_css_parser/src/syntax/mod.rs
+++ b/crates/biome_css_parser/src/syntax/mod.rs
@@ -23,11 +23,13 @@ use crate::syntax::scss::{
     add_scss_variable_member_function_name_diagnostic, is_at_any_scss_value, is_at_scss_function,
     is_at_scss_interpolated_dashed_identifier, is_at_scss_interpolated_function_or_value,
     is_at_scss_interpolated_string, is_at_scss_module_member_access,
-    is_at_scss_parent_selector_value, is_at_scss_variable, is_at_scss_variable_declaration,
-    parse_scss_bracketed_value_expression_item, parse_scss_function,
-    parse_scss_interpolated_dashed_identifier, parse_scss_interpolated_function_or_value,
-    parse_scss_interpolated_string, parse_scss_module_member_access,
-    parse_scss_parent_selector_value, parse_scss_variable, parse_scss_variable_declaration,
+    is_at_scss_parent_selector_value, is_at_scss_suffixed_interpolated_value, is_at_scss_variable,
+    is_at_scss_variable_declaration, parse_scss_bracketed_value_expression_item,
+    parse_scss_function, parse_scss_interpolated_dashed_identifier,
+    parse_scss_interpolated_function_or_value, parse_scss_interpolated_string,
+    parse_scss_module_member_access, parse_scss_parent_selector_value,
+    parse_scss_suffixed_interpolated_value_until, parse_scss_variable,
+    parse_scss_variable_declaration,
 };
 use crate::syntax::selector::SelectorList;
 use crate::syntax::selector::is_nth_at_selector;
@@ -351,9 +353,34 @@ pub(crate) fn is_at_any_value_with_context(
     p: &mut CssParser,
     context: ValueParsingContext,
 ) -> bool {
-    (context.is_scss_exclusive_syntax_allowed() && is_at_any_scss_value(p))
-        || is_at_any_function_with_context(p, context)
+    is_at_any_function_with_context(p, context)
         || is_at_any_non_function_css_value(p)
+        || is_at_exclusive_scss_value_with_context(p, context)
+}
+
+#[inline]
+fn is_at_exclusive_scss_value_with_context(
+    p: &mut CssParser,
+    context: ValueParsingContext,
+) -> bool {
+    if context.is_full_scss_parsing_allowed() {
+        is_at_any_scss_value(p)
+    } else if context.is_scss_exclusive_syntax_allowed() {
+        is_at_fast_scss_exclusive_value(p)
+    } else {
+        false
+    }
+}
+
+#[inline]
+fn is_at_fast_scss_exclusive_value(p: &mut CssParser) -> bool {
+    is_at_scss_variable(p)
+        || is_at_scss_module_member_access(p)
+        || is_at_scss_suffixed_interpolated_value(p)
+        || is_at_scss_interpolated_dashed_identifier(p)
+        || is_at_scss_interpolated_function_or_value(p)
+        || is_at_scss_parent_selector_value(p)
+        || is_at_scss_interpolated_string(p)
 }
 
 #[inline]
@@ -389,8 +416,8 @@ pub(crate) enum ValueParsingMode {
     ScssAware,
     /// Restricts parsing to CSS syntax branches only.
     ///
-    /// Used by `<general-enclosed>` fallbacks to avoid SCSS-only diagnostics
-    /// for unknown-but-valid CSS constructs.
+    /// Used by `<general-enclosed>` fallbacks to avoid SCSS-only recovery for
+    /// unknown-but-valid CSS constructs.
     CssOnly,
 }
 
@@ -398,15 +425,15 @@ pub(crate) enum ValueParsingMode {
 ///
 /// Shared value parsing distinguishes between:
 /// - CSS-only parsing with no SCSS branches
-/// - SCSS-exclusive routing for diagnostics and recovery, without committing to
-///   full SCSS semantics for ambiguous syntax
+/// - SCSS-exclusive routing and recovery, without committing to full SCSS
+///   semantics for ambiguous syntax
 /// - full SCSS parsing where ambiguous syntax may be interpreted as SCSS
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum ScssCapability {
     /// Shared parsing must stay on CSS-only branches.
     Disabled,
-    /// SCSS-exclusive syntax may be recognized for routing, diagnostics, and
-    /// recovery, but ambiguous syntax must not commit to full SCSS semantics.
+    /// SCSS-exclusive syntax may be recognized for routing and recovery, but
+    /// ambiguous syntax must not commit to full SCSS semantics.
     ExclusiveOnly,
     /// Full SCSS parsing is enabled.
     Full,
@@ -424,16 +451,24 @@ pub(crate) enum FunctionCallContext {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) struct ValueParsingContext {
     mode: ValueParsingMode,
-    scss_feature_supported: bool,
+    scss_capability: ScssCapability,
     function_call_context: FunctionCallContext,
 }
 
 impl ValueParsingContext {
     #[inline]
     pub(crate) fn new(p: &CssParser, mode: ValueParsingMode) -> Self {
+        let scss_capability = match mode {
+            ValueParsingMode::CssOnly => ScssCapability::Disabled,
+            ValueParsingMode::ScssAware if CssSyntaxFeatures::Scss.is_supported(p) => {
+                ScssCapability::Full
+            }
+            ValueParsingMode::ScssAware => ScssCapability::ExclusiveOnly,
+        };
+
         Self {
             mode,
-            scss_feature_supported: CssSyntaxFeatures::Scss.is_supported(p),
+            scss_capability,
             function_call_context: FunctionCallContext::LooseRecovery,
         }
     }
@@ -451,23 +486,19 @@ impl ValueParsingContext {
     /// Returns the current SCSS capability level for shared value parsing.
     #[inline]
     pub(crate) const fn scss_capability(self) -> ScssCapability {
-        match (self.mode, self.scss_feature_supported) {
-            (ValueParsingMode::CssOnly, _) => ScssCapability::Disabled,
-            (ValueParsingMode::ScssAware, false) => ScssCapability::ExclusiveOnly,
-            (ValueParsingMode::ScssAware, true) => ScssCapability::Full,
-        }
+        self.scss_capability
     }
 
-    /// Returns whether SCSS-exclusive branches may be used for routing,
-    /// diagnostics, and recovery.
+    /// Returns whether SCSS-exclusive branches may be used for routing and
+    /// recovery.
     ///
     /// Use this at mixed CSS/SCSS boundaries when the parser needs to:
     /// - recognize SCSS-only syntax so it can route into
     ///   `parse_exclusive_syntax(...)`
     /// - build a more accurate recovery tree for unsupported SCSS syntax in a
     ///   CSS file
-    /// - emit an SCSS-only diagnostic instead of falling through to a generic
-    ///   CSS error
+    /// - report unsupported SCSS syntax without falling through to unrelated CSS
+    ///   errors
     ///
     /// This is the right check for exclusive SCSS forms such as qualified
     /// names, interpolation-led values, or SCSS-only URL modifiers. It should
@@ -476,6 +507,18 @@ impl ValueParsingContext {
     #[inline]
     pub(crate) const fn is_scss_exclusive_syntax_allowed(self) -> bool {
         !matches!(self.scss_capability(), ScssCapability::Disabled)
+    }
+
+    /// Returns whether shared value parsing may recover a Sass qualified function
+    /// head such as `color.adjust(...)`.
+    ///
+    /// This stays enabled in normal CSS parsing so qualified Sass function heads
+    /// produce one unsupported-syntax diagnostic instead of cascading through the
+    /// regular CSS value parser. It is still disabled for explicit CSS-only
+    /// fallback parsing.
+    #[inline]
+    pub(crate) const fn is_scss_qualified_function_recovery_allowed(self) -> bool {
+        matches!(self.mode, ValueParsingMode::ScssAware)
     }
 
     /// Returns whether ambiguous syntax may commit to full SCSS semantics.
@@ -514,12 +557,9 @@ pub(crate) fn parse_any_value_with_context(
     p: &mut CssParser,
     context: ValueParsingContext,
 ) -> ParsedSyntax {
-    if context.is_scss_exclusive_syntax_allowed() && is_at_any_scss_value(p) {
+    if is_at_exclusive_scss_value_with_context(p, context) {
         parse_any_exclusive_scss_value(p)
     } else if is_at_any_function_with_context(p, context) {
-        // CSS functions stay on this branch. SCSS-only function heads
-        // (`namespace.fn(...)`, interpolation-led heads, etc.) are claimed above
-        // so CSS mode still rejects them while SCSS mode parses them as functions.
         parse_any_function_with_context(p, context)
     } else {
         parse_any_non_function_css_value(p)
@@ -570,6 +610,16 @@ fn parse_any_exclusive_scss_value(p: &mut CssParser) -> ParsedSyntax {
         CssSyntaxFeatures::Scss.parse_exclusive_syntax(p, parse_scss_function, |p, m| {
             scss_only_syntax_error(p, "SCSS qualified function names", m.range(p))
         })
+    } else if is_at_scss_suffixed_interpolated_value(p) {
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            |p| {
+                parse_scss_suffixed_interpolated_value_until(p, |p| {
+                    p.has_preceding_whitespace() || p.has_preceding_line_break()
+                })
+            },
+            |p, m| scss_only_syntax_error(p, "SCSS interpolated values", m.range(p)),
+        )
     } else if is_at_scss_variable(p) {
         CssSyntaxFeatures::Scss.parse_exclusive_syntax(p, parse_scss_variable, |p, m| {
             scss_only_syntax_error(p, "SCSS variables", m.range(p))
@@ -584,7 +634,11 @@ fn parse_any_exclusive_scss_value(p: &mut CssParser) -> ParsedSyntax {
                 add_scss_variable_member_function_name_diagnostic(p, has_dollar_member, marker)
             })
     } else if is_at_scss_interpolated_dashed_identifier(p) {
-        parse_scss_interpolated_dashed_identifier(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolated_dashed_identifier,
+            |p, m| scss_only_syntax_error(p, "SCSS interpolated dashed identifiers", m.range(p)),
+        )
     } else if is_at_scss_interpolated_function_or_value(p) {
         CssSyntaxFeatures::Scss.parse_exclusive_syntax(
             p,
@@ -592,9 +646,15 @@ fn parse_any_exclusive_scss_value(p: &mut CssParser) -> ParsedSyntax {
             |p, m| scss_only_syntax_error(p, "SCSS interpolated values", m.range(p)),
         )
     } else if is_at_scss_parent_selector_value(p) {
-        parse_scss_parent_selector_value(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_parent_selector_value,
+            |p, m| scss_only_syntax_error(p, "SCSS parent selector values", m.range(p)),
+        )
     } else if is_at_scss_interpolated_string(p) {
-        parse_scss_interpolated_string(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(p, parse_scss_interpolated_string, |p, m| {
+            scss_only_syntax_error(p, "SCSS interpolated strings", m.range(p))
+        })
     } else {
         Absent
     }
@@ -964,7 +1024,52 @@ mod tests {
     use biome_parser::Parser;
     use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 
-    use super::{parse_regular_identifier, parse_regular_number, try_parse};
+    use super::{
+        ScssCapability, ValueParsingContext, ValueParsingMode, parse_regular_identifier,
+        parse_regular_number, try_parse,
+    };
+
+    #[test]
+    fn css_parser_context_allows_scss_exclusive_value_recovery() {
+        let css_parser = CssParser::new(
+            ".selector { width: 10px; }",
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        );
+        assert_eq!(
+            ValueParsingContext::new(&css_parser, ValueParsingMode::ScssAware).scss_capability(),
+            ScssCapability::ExclusiveOnly
+        );
+        assert!(
+            ValueParsingContext::new(&css_parser, ValueParsingMode::ScssAware)
+                .is_scss_qualified_function_recovery_allowed()
+        );
+        assert!(
+            !ValueParsingContext::new(&css_parser, ValueParsingMode::CssOnly)
+                .is_scss_qualified_function_recovery_allowed()
+        );
+
+        let reporting_css_parser = CssParser::new(
+            ".selector { color: $color; }",
+            CssFileSource::css(),
+            CssParserOptions::default().report_scss_exclusive_syntax(),
+        );
+        assert_eq!(
+            ValueParsingContext::new(&reporting_css_parser, ValueParsingMode::ScssAware)
+                .scss_capability(),
+            ScssCapability::ExclusiveOnly
+        );
+
+        let scss_parser = CssParser::new(
+            ".selector { color: $color; }",
+            CssFileSource::scss(),
+            CssParserOptions::default(),
+        );
+        assert_eq!(
+            ValueParsingContext::new(&scss_parser, ValueParsingMode::ScssAware).scss_capability(),
+            ScssCapability::Full
+        );
+    }
 
     #[test]
     fn try_parse_rewinds_to_checkpoint() {

--- a/crates/biome_css_parser/src/syntax/parse_error.rs
+++ b/crates/biome_css_parser/src/syntax/parse_error.rs
@@ -252,12 +252,20 @@ pub(crate) fn scss_only_syntax_error(
     syntax: &str,
     range: TextRange,
 ) -> ParseDiagnostic {
+    if !p.options().should_report_scss_exclusive_syntax() {
+        return unsupported_css_syntax(p, range);
+    }
+
     p.err_builder(
         format!(
             "{syntax} are an SCSS only feature. Convert your file to an SCSS file or remove the syntax."
         ),
         range,
     )
+}
+
+pub(crate) fn unsupported_css_syntax(p: &CssParser, range: TextRange) -> ParseDiagnostic {
+    p.err_builder("This syntax is not supported in CSS.", range)
 }
 
 pub(crate) fn inconsistent_scss_bracketed_list_separators(

--- a/crates/biome_css_parser/src/syntax/property/mod.rs
+++ b/crates/biome_css_parser/src/syntax/property/mod.rs
@@ -7,10 +7,10 @@ use crate::syntax::css_modules::{
     composes_not_allowed, expected_classes_list, expected_composes_import_source,
 };
 use crate::syntax::parse_error::{
-    expected_component_value, expected_identifier, tailwind_disabled,
+    expected_component_value, expected_identifier, scss_only_syntax_error, tailwind_disabled,
 };
 use crate::syntax::scss::{
-    is_at_scss_interpolated_property, parse_required_scss_value_until,
+    is_at_scss_interpolated_property_name, parse_required_scss_value_until,
     parse_scss_interpolated_property_name,
 };
 use crate::syntax::{
@@ -282,7 +282,7 @@ impl ParseRecovery for ComposesClassListParseRecovery {
 /// ```
 #[inline]
 pub(crate) fn is_at_generic_property(p: &mut CssParser) -> bool {
-    is_at_direct_generic_property(p) || is_at_scss_interpolated_property(p)
+    is_at_direct_generic_property(p) || is_at_scss_interpolated_property_name(p)
 }
 
 /// Detects the direct, non-interpolated property-name forms handled by the
@@ -339,8 +339,14 @@ pub(crate) fn parse_generic_property_name(p: &mut CssParser) -> ParsedSyntax {
         };
     }
 
-    if CssSyntaxFeatures::Scss.is_supported(p) {
-        return parse_scss_interpolated_property_name(p).or_else(|| parse_plain_property_name(p));
+    if is_at_scss_interpolated_property_name(p) {
+        return CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolated_property_name,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated property names", marker.range(p))
+            },
+        );
     }
 
     parse_plain_property_name(p)

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/keyframes.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/keyframes.rs
@@ -1,19 +1,18 @@
 use crate::parser::CssParser;
+use crate::syntax::is_nth_at_identifier;
 use crate::syntax::scss::{
     is_at_scss_interpolation, is_at_scss_variable, is_nth_at_scss_interpolation,
     parse_scss_interpolated_name, parse_scss_regular_interpolation, parse_scss_variable,
 };
-use crate::syntax::{CssSyntaxFeatures, is_nth_at_identifier};
 use biome_css_syntax::CssSyntaxKind::{SCSS_KEYFRAMES_NAME, SCSS_KEYFRAMES_SELECTOR};
 use biome_css_syntax::T;
 use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
-use biome_parser::prelude::SyntaxFeature;
 
 #[inline]
 pub(crate) fn is_at_scss_keyframes_selector(p: &mut CssParser) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_interpolation(p)
+    is_at_scss_interpolation(p)
 }
 
 /// Parses an interpolated keyframe selector.
@@ -46,10 +45,9 @@ pub(crate) fn parse_scss_keyframes_selector(p: &mut CssParser) -> ParsedSyntax {
 
 #[inline]
 pub(crate) fn is_at_scss_keyframes_name(p: &mut CssParser) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && (is_at_scss_variable(p)
-            || is_at_scss_interpolation(p)
-            || is_at_identifier_with_interpolation_suffix(p))
+    is_at_scss_variable(p)
+        || is_at_scss_interpolation(p)
+        || is_at_identifier_with_interpolation_suffix(p)
 }
 
 /// Parses a dynamic SCSS keyframes name.

--- a/crates/biome_css_parser/src/syntax/scss/declaration/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/declaration/mod.rs
@@ -8,8 +8,8 @@ use biome_css_syntax::T;
 use biome_parser::prelude::ParsedSyntax;
 
 pub(crate) use nesting::{
-    is_at_scss_nesting_declaration, parse_scss_nesting_declaration,
-    try_parse_scss_nesting_declaration,
+    is_at_scss_nesting_declaration, parse_exclusive_scss_nested_property_declaration,
+    parse_scss_nesting_declaration, try_parse_scss_nesting_declaration,
 };
 pub(crate) use variable::{is_at_scss_variable_declaration, parse_scss_variable_declaration};
 pub(crate) use variable_modifier::is_at_scss_variable_modifier;

--- a/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
+++ b/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
@@ -3,11 +3,11 @@ use crate::syntax::block::parse_declaration_or_rule_list_block;
 use crate::syntax::declaration::{
     complete_declaration_with_semicolon, parse_declaration_important,
 };
-use crate::syntax::parse_error::expected_component_value;
+use crate::syntax::parse_error::{expected_component_value, scss_only_syntax_error};
 use crate::syntax::scss::{
     SCSS_NESTING_VALUE_END_SET, complete_empty_scss_expression,
     is_at_scss_interpolated_dashed_identifier, is_at_scss_interpolated_identifier,
-    is_at_scss_interpolated_property, parse_scss_interpolated_identifier,
+    is_at_scss_interpolated_property_name, parse_scss_interpolated_identifier,
     parse_scss_interpolated_property_name, parse_scss_optional_value_until,
 };
 use crate::syntax::{CssSyntaxFeatures, is_at_dashed_identifier, is_at_identifier, try_parse};
@@ -44,7 +44,7 @@ pub(crate) fn parse_scss_nesting_declaration(p: &mut CssParser) -> ParsedSyntax 
 
 #[inline]
 pub(crate) fn is_at_scss_nesting_declaration(p: &mut CssParser) -> bool {
-    if !CssSyntaxFeatures::Scss.is_supported(p) || p.at(T![composes]) {
+    if p.at(T![composes]) {
         return false;
     }
 
@@ -56,7 +56,7 @@ pub(crate) fn is_at_scss_nesting_declaration(p: &mut CssParser) -> bool {
         return false;
     }
 
-    is_at_scss_interpolated_property(p) || (is_at_identifier(p) && p.nth_at(1, T![:]))
+    is_at_scss_interpolated_property_name(p) || (is_at_identifier(p) && p.nth_at(1, T![:]))
 }
 
 struct ScssNestingMarkers {
@@ -125,7 +125,7 @@ fn parse_scss_nesting_declaration_prefix(p: &mut CssParser) -> Option<(ScssNesti
     let declaration = p.start();
     let property = p.start();
 
-    if is_at_scss_interpolated_property(p) {
+    if is_at_scss_interpolated_property_name(p) {
         parse_scss_interpolated_property_name(p).ok();
     } else if is_at_scss_interpolated_identifier(p) {
         parse_scss_interpolated_identifier(p).ok();
@@ -223,4 +223,29 @@ pub(crate) fn try_parse_scss_nesting_declaration(
             _ => Err(()),
         }
     })
+}
+
+/// Parses only the SCSS nested-property block form, rewinding for regular
+/// declarations that share the same `name:` prefix.
+#[inline]
+fn try_parse_scss_nested_property_declaration(p: &mut CssParser) -> Result<ParsedSyntax, ()> {
+    try_parse(p, |p| {
+        let Some((syntax, could_be_selector)) = parse_scss_nesting_declaration_candidate(p) else {
+            return Err(());
+        };
+
+        match syntax.kind(p) {
+            Some(SCSS_NESTING_DECLARATION) if !could_be_selector => Ok(syntax),
+            _ => Err(()),
+        }
+    })
+}
+
+#[inline]
+pub(crate) fn parse_exclusive_scss_nested_property_declaration(p: &mut CssParser) -> ParsedSyntax {
+    CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+        p,
+        |p| try_parse_scss_nested_property_declaration(p).unwrap_or(Absent),
+        |p, marker| scss_only_syntax_error(p, "SCSS nested property declarations", marker.range(p)),
+    )
 }

--- a/crates/biome_css_parser/src/syntax/scss/expression/interpolation.rs
+++ b/crates/biome_css_parser/src/syntax/scss/expression/interpolation.rs
@@ -1,12 +1,11 @@
 use crate::lexer::CssLexContext;
 use crate::parser::CssParser;
-use crate::syntax::CssSyntaxFeatures;
 use crate::syntax::selector::selector_lex_context;
 use biome_css_syntax::CssSyntaxKind::SCSS_INTERPOLATION;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::*;
-use biome_parser::{SyntaxFeature, TokenSet, token_set};
+use biome_parser::{TokenSet, token_set};
 
 use super::list::parse_scss_inner_expression_until;
 use crate::syntax::scss::expected_scss_expression;
@@ -71,5 +70,5 @@ pub(crate) fn is_at_scss_interpolation(p: &mut CssParser) -> bool {
 
 #[inline]
 pub(crate) fn is_nth_at_scss_interpolation(p: &mut CssParser, n: usize) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p) && p.nth_at(n, T![#]) && p.nth_at(n + 1, T!['{'])
+    p.nth_at(n, T![#]) && p.nth_at(n + 1, T!['{']) && !p.has_nth_preceding_whitespace(n + 1)
 }

--- a/crates/biome_css_parser/src/syntax/scss/expression/operand.rs
+++ b/crates/biome_css_parser/src/syntax/scss/expression/operand.rs
@@ -1,15 +1,12 @@
 use crate::parser::CssParser;
+use crate::syntax::parse_regular_identifier;
 use crate::syntax::scss::{
-    add_scss_variable_member_function_name_diagnostic, is_at_scss_interpolation,
-    is_at_scss_namespaced_variable, is_at_scss_variable, parse_scss_function_call_from_name,
+    add_scss_variable_member_function_name_diagnostic, is_at_scss_interpolated_value_head,
+    is_at_scss_interpolation, is_at_scss_namespaced_variable, parse_scss_function_call_from_name,
     parse_scss_interpolated_function_or_value_until, parse_scss_interpolated_value,
-    parse_scss_variable,
+    parse_scss_suffixed_interpolated_value_until, parse_scss_variable,
 };
-use crate::syntax::value::dimension::{is_at_any_dimension, parse_any_dimension};
-use crate::syntax::{parse_regular_identifier, parse_regular_number};
-use biome_css_syntax::CssSyntaxKind::{
-    CSS_NUMBER_LITERAL, SCSS_MODULE_MEMBER_ACCESS, SCSS_NAMESPACED_VARIABLE,
-};
+use biome_css_syntax::CssSyntaxKind::{SCSS_MODULE_MEMBER_ACCESS, SCSS_NAMESPACED_VARIABLE};
 use biome_css_syntax::T;
 use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
@@ -50,15 +47,18 @@ pub(super) fn parse_scss_expression_operand(
         return parse_scss_module_variable_operand(p);
     }
 
-    if is_at_scss_interpolatable_value(p) {
-        return parse_scss_interpolatable_value(p);
+    if is_at_scss_interpolated_value_head(p) {
+        return parse_scss_suffixed_interpolated_value_until(
+            p,
+            is_at_scss_expression_interpolated_value_boundary,
+        );
     }
 
     parse_scss_regular_expression_operand(p, options)
 }
 
-/// Parses `module.$name` as either a standalone module-member operand or an
-/// interpolatable namespaced variable.
+/// Parses `module.$name` as either a standalone module-member operand or a
+/// suffixed interpolated namespaced variable.
 ///
 /// Example:
 /// ```scss
@@ -85,7 +85,7 @@ fn parse_scss_module_variable_operand(p: &mut CssParser) -> ParsedSyntax {
         return parse_scss_function_call_from_name(p, name);
     }
 
-    if !is_at_scss_expression_interpolated_value_suffix(p) {
+    if is_at_scss_expression_interpolated_value_boundary(p) || !is_at_scss_interpolation(p) {
         return Present(head.complete(p, SCSS_MODULE_MEMBER_ACCESS));
     }
 
@@ -95,68 +95,6 @@ fn parse_scss_module_variable_operand(p: &mut CssParser) -> ParsedSyntax {
         head,
         is_at_scss_expression_interpolated_value_boundary,
     ))
-}
-
-/// Parses an interpolatable value such as `$value#{suffix}`, `10px#{suffix}`,
-/// or `10#{unit}`.
-///
-/// Examples:
-/// ```scss
-/// $value#{suffix}
-/// 10px#{suffix}
-/// 10#{unit}
-/// ```
-///
-/// Docs: https://sass-lang.com/documentation/interpolation
-#[inline]
-fn parse_scss_interpolatable_value(p: &mut CssParser) -> ParsedSyntax {
-    let first_part = match parse_scss_interpolatable_value_first_part(p) {
-        Present(first_part) => first_part,
-        Absent => return Absent,
-    };
-
-    // Return only the parsed head for `$value`, `$value #{suffix}`, `$value / 2`,
-    // and `3%4`; only interpolation suffixes like `$value#{suffix}` continue.
-    if !is_at_scss_expression_interpolated_value_suffix(p) {
-        return Present(first_part);
-    }
-
-    Present(parse_scss_interpolated_value(
-        p,
-        first_part,
-        is_at_scss_expression_interpolated_value_boundary,
-    ))
-}
-
-/// Parses the first part that can still accept adjacent interpolation.
-///
-/// Examples:
-/// ```scss
-/// $value#{suffix}
-/// 10px#{suffix}
-/// 10#{unit}
-/// ```
-#[inline]
-fn parse_scss_interpolatable_value_first_part(p: &mut CssParser) -> ParsedSyntax {
-    if is_at_scss_variable(p) {
-        parse_scss_variable(p)
-    } else if is_at_any_dimension(p) {
-        parse_any_dimension(p)
-    } else if p.at(CSS_NUMBER_LITERAL) {
-        parse_regular_number(p)
-    } else {
-        Absent
-    }
-}
-
-#[inline]
-fn is_at_scss_interpolatable_value(p: &mut CssParser) -> bool {
-    is_at_scss_variable(p) || is_at_any_dimension(p) || p.at(CSS_NUMBER_LITERAL)
-}
-
-#[inline]
-fn is_at_scss_expression_interpolated_value_suffix(p: &mut CssParser) -> bool {
-    !is_at_scss_expression_interpolated_value_boundary(p) && is_at_scss_interpolation(p)
 }
 
 /// Stops expression value chains before a space, line break, or operator.

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_dashed.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_dashed.rs
@@ -7,12 +7,11 @@ use crate::syntax::scss::identifiers::interpolated_identifier::{
 use crate::syntax::scss::{
     is_at_scss_interpolation, is_nth_at_scss_interpolated_identifier, is_nth_at_scss_interpolation,
 };
-use crate::syntax::{CssSyntaxFeatures, is_at_dashed_identifier, parse_regular_identifier};
+use crate::syntax::{is_at_dashed_identifier, parse_regular_identifier};
 use biome_css_syntax::CssSyntaxKind::SCSS_INTERPOLATED_DASHED_IDENTIFIER;
 use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
-use biome_parser::prelude::SyntaxFeature;
 
 #[inline]
 pub(crate) fn is_at_scss_interpolated_dashed_identifier(p: &mut CssParser) -> bool {
@@ -22,8 +21,7 @@ pub(crate) fn is_at_scss_interpolated_dashed_identifier(p: &mut CssParser) -> bo
 
 #[inline]
 pub(crate) fn is_nth_at_scss_interpolated_dashed_identifier(p: &mut CssParser, n: usize) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && is_nth_at_identifier_hyphen_part(p, n)
+    is_nth_at_identifier_hyphen_part(p, n)
         && is_nth_at_identifier_hyphen_part(p, n + 1)
         && !p.has_nth_preceding_whitespace(n + 1)
         && is_nth_at_scss_interpolated_identifier(p, n + 2)
@@ -69,8 +67,7 @@ pub(crate) fn parse_scss_interpolated_dashed_identifier(p: &mut CssParser) -> Pa
 
 #[inline]
 fn is_at_dashed_identifier_with_interpolation_suffix(p: &mut CssParser) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && is_at_dashed_identifier(p)
+    is_at_dashed_identifier(p)
         && is_nth_at_scss_interpolation(p, 1)
         && !p.has_nth_preceding_whitespace(1)
 }

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_identifier.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_identifier.rs
@@ -1,13 +1,13 @@
 use crate::parser::CssParser;
+use crate::syntax::is_nth_at_identifier;
 use crate::syntax::scss::is_nth_at_scss_interpolation;
-use crate::syntax::{CssSyntaxFeatures, is_nth_at_identifier};
 use biome_css_syntax::CssSyntaxKind::{
     EOF, SCSS_INTERPOLATED_IDENTIFIER_HYPHEN, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST,
 };
 use biome_css_syntax::T;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
-use biome_parser::{CompletedMarker, Parser, ParserProgress, SyntaxFeature};
+use biome_parser::{CompletedMarker, Parser, ParserProgress};
 
 #[inline]
 pub(crate) fn is_at_scss_interpolated_identifier(p: &mut CssParser) -> bool {
@@ -16,8 +16,7 @@ pub(crate) fn is_at_scss_interpolated_identifier(p: &mut CssParser) -> bool {
 
 #[inline]
 pub(crate) fn is_nth_at_scss_interpolated_identifier(p: &mut CssParser, n: usize) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && (is_nth_at_identifier(p, n) || is_nth_at_scss_interpolation(p, n))
+    is_nth_at_identifier(p, n) || is_nth_at_scss_interpolation(p, n)
 }
 
 /// Returns `true` when the current token continues an interpolated identifier
@@ -58,7 +57,7 @@ pub(super) fn parse_scss_interpolated_identifier_parts(
 
 #[inline]
 fn is_at_adjacent_identifier(p: &mut CssParser) -> bool {
-    !p.has_preceding_whitespace() && is_at_scss_interpolated_identifier(p)
+    !p.has_preceding_whitespace() && is_nth_at_scss_interpolated_identifier(p, 0)
 }
 
 /// Returns `true` when `-` belongs to the current interpolated identifier,

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_regular.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_regular.rs
@@ -6,7 +6,9 @@ use crate::syntax::scss::identifiers::interpolated_identifier::{
     is_nth_at_identifier_hyphen_part, parse_identifier_hyphen_part,
     parse_scss_interpolated_identifier_parts,
 };
-use crate::syntax::scss::{is_at_scss_interpolation, is_nth_at_scss_interpolation};
+use crate::syntax::scss::{
+    is_at_scss_interpolation, is_nth_at_scss_interpolated_identifier, is_nth_at_scss_interpolation,
+};
 use biome_css_syntax::CssSyntaxKind::{SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATION};
 use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
@@ -52,7 +54,7 @@ pub(crate) fn parse_scss_interpolated_name(p: &mut CssParser) -> ParsedSyntax {
 /// Docs: https://sass-lang.com/documentation/interpolation
 #[inline]
 pub(crate) fn parse_scss_interpolated_identifier(p: &mut CssParser) -> ParsedSyntax {
-    if !is_at_scss_interpolated_identifier(p) {
+    if !is_nth_at_scss_interpolated_identifier(p, 0) {
         return Absent;
     }
 
@@ -116,7 +118,7 @@ pub(crate) fn parse_scss_hyphen_interpolated_identifier(p: &mut CssParser) -> Pa
 /// Docs: https://sass-lang.com/documentation/interpolation
 #[inline]
 pub(crate) fn parse_scss_interpolation_or_identifier(p: &mut CssParser) -> ParsedSyntax {
-    if !is_at_scss_interpolated_identifier(p) {
+    if !is_nth_at_scss_interpolated_identifier(p, 0) {
         return Absent;
     }
 

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_selector.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_selector.rs
@@ -1,16 +1,39 @@
 use crate::parser::CssParser;
+use crate::syntax::is_nth_at_identifier;
 use crate::syntax::scss::expression::parse_scss_selector_interpolation;
 use crate::syntax::scss::identifiers::interpolated_identifier::{
     is_at_identifier_continuation, is_at_scss_interpolated_identifier,
     parse_scss_interpolated_identifier_parts,
 };
-use crate::syntax::scss::is_at_scss_interpolation;
+use crate::syntax::scss::{is_at_scss_interpolation, is_nth_at_scss_interpolation};
 use crate::syntax::selector::{
     parse_selector_custom_identifier_fragment, parse_selector_identifier_fragment,
 };
 use biome_css_syntax::CssSyntaxKind::{SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATION};
+use biome_css_syntax::T;
+use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
+
+#[inline]
+pub(crate) fn is_at_scss_interpolated_selector_identifier(p: &mut CssParser) -> bool {
+    is_nth_at_scss_interpolated_selector_identifier(p, 0)
+}
+
+#[inline]
+pub(crate) fn is_nth_at_scss_interpolated_selector_identifier(p: &mut CssParser, n: usize) -> bool {
+    is_nth_at_scss_interpolation(p, n)
+        || is_nth_at_identifier(p, n) && is_nth_at_scss_selector_identifier_suffix(p, n + 1)
+}
+
+#[inline]
+fn is_nth_at_scss_selector_identifier_suffix(p: &mut CssParser, n: usize) -> bool {
+    !p.has_nth_preceding_whitespace(n)
+        && (is_nth_at_scss_interpolation(p, n)
+            || p.nth_at(n, T![-])
+                && !p.has_nth_preceding_whitespace(n + 1)
+                && is_nth_at_scss_interpolation(p, n + 1))
+}
 
 /// Parses SCSS-interpolated selector name slots.
 ///

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_selector.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_selector.rs
@@ -15,17 +15,33 @@ use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 
+/// Returns whether the current token can start an SCSS-interpolated selector
+/// identifier.
+///
+/// Examples: `#{$tag}` and `button-#{$variant}`.
 #[inline]
 pub(crate) fn is_at_scss_interpolated_selector_identifier(p: &mut CssParser) -> bool {
     is_nth_at_scss_interpolated_selector_identifier(p, 0)
 }
 
+/// Returns whether the token at `n` can start an SCSS-interpolated selector
+/// identifier.
+///
+/// This is intentionally selector-specific: selector names may be built from an
+/// interpolation alone (`#{$tag}`) or from a plain identifier followed by an
+/// adjacent interpolation suffix (`button#{$state}` or `button-#{$state}`).
 #[inline]
 pub(crate) fn is_nth_at_scss_interpolated_selector_identifier(p: &mut CssParser, n: usize) -> bool {
     is_nth_at_scss_interpolation(p, n)
         || is_nth_at_identifier(p, n) && is_nth_at_scss_selector_identifier_suffix(p, n + 1)
 }
 
+/// Returns whether the token at `n` continues a selector identifier with SCSS
+/// interpolation and no separating whitespace.
+///
+/// The suffix can be a direct interpolation (`#{$state}`) or a hyphen followed
+/// by interpolation (`-#{$state}`), matching selector names such as
+/// `button#{$state}` and `button-#{$state}`.
 #[inline]
 fn is_nth_at_scss_selector_identifier_suffix(p: &mut CssParser, n: usize) -> bool {
     !p.has_nth_preceding_whitespace(n)

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use interpolated_regular::{
     parse_scss_interpolation_or_identifier,
 };
 pub(crate) use interpolated_selector::{
+    is_at_scss_interpolated_selector_identifier, is_nth_at_scss_interpolated_selector_identifier,
     parse_scss_selector_custom_identifier, parse_scss_selector_identifier,
 };
 pub(crate) use module_member_access::{

--- a/crates/biome_css_parser/src/syntax/scss/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/mod.rs
@@ -25,8 +25,9 @@ pub(crate) use at_rule::{
 };
 pub(crate) use declaration::{
     is_at_scss_nesting_declaration, is_at_scss_variable_declaration, is_at_scss_variable_modifier,
-    parse_scss_interpolated_property_declaration, parse_scss_nesting_declaration,
-    parse_scss_variable_declaration, try_parse_scss_nesting_declaration,
+    parse_exclusive_scss_nested_property_declaration, parse_scss_interpolated_property_declaration,
+    parse_scss_nesting_declaration, parse_scss_variable_declaration,
+    try_parse_scss_nesting_declaration,
 };
 pub(crate) use expression::{
     SCSS_UNARY_OPERATOR_TOKEN_SET, complete_empty_scss_expression, is_at_scss_binary_operator,
@@ -41,20 +42,21 @@ pub(crate) use function_name::{
 };
 pub(crate) use identifiers::{
     is_at_scss_interpolated_dashed_identifier, is_at_scss_interpolated_identifier,
-    is_at_scss_module_member_access, is_at_scss_namespaced_variable, is_at_scss_variable,
+    is_at_scss_interpolated_selector_identifier, is_at_scss_module_member_access,
+    is_at_scss_namespaced_variable, is_at_scss_variable,
     is_nth_at_scss_hyphen_interpolated_identifier, is_nth_at_scss_interpolated_dashed_identifier,
-    is_nth_at_scss_interpolated_identifier, is_nth_at_scss_module_member_access,
-    parse_scss_hyphen_interpolated_identifier, parse_scss_interpolated_dashed_identifier,
-    parse_scss_interpolated_identifier, parse_scss_interpolated_name,
-    parse_scss_interpolation_or_identifier, parse_scss_module_member_access,
-    parse_scss_namespaced_variable, parse_scss_selector_custom_identifier,
-    parse_scss_selector_identifier, parse_scss_variable,
+    is_nth_at_scss_interpolated_identifier, is_nth_at_scss_interpolated_selector_identifier,
+    is_nth_at_scss_module_member_access, parse_scss_hyphen_interpolated_identifier,
+    parse_scss_interpolated_dashed_identifier, parse_scss_interpolated_identifier,
+    parse_scss_interpolated_name, parse_scss_interpolation_or_identifier,
+    parse_scss_module_member_access, parse_scss_namespaced_variable,
+    parse_scss_selector_custom_identifier, parse_scss_selector_identifier, parse_scss_variable,
 };
 pub(crate) use parse_error::{
     expected_scss_expression, expected_scss_variable_modifier, scss_ellipsis_not_allowed,
 };
 pub(crate) use property::{
-    is_at_scss_interpolated_property, is_nth_at_scss_interpolated_property,
+    is_at_scss_interpolated_property_name, is_nth_at_scss_interpolated_property_name,
     parse_scss_interpolated_property_name,
 };
 pub(crate) use selector::{
@@ -71,10 +73,12 @@ pub(crate) use token_sets::{
 };
 pub(crate) use value::{
     is_at_any_scss_value, is_at_scss_function, is_at_scss_interpolated_function_or_value,
-    is_at_scss_interpolated_string, is_at_scss_parent_selector_value, is_nth_at_scss_function,
-    parse_any_scss_value_with_context, parse_scss_bracketed_value_expression_item,
-    parse_scss_function, parse_scss_function_call_from_name,
-    parse_scss_interpolated_function_or_value, parse_scss_interpolated_function_or_value_until,
-    parse_scss_interpolated_string, parse_scss_interpolated_value,
-    parse_scss_parent_selector_value,
+    is_at_scss_interpolated_string, is_at_scss_interpolated_value_head,
+    is_at_scss_parent_selector_value, is_at_scss_suffixed_interpolated_value,
+    is_nth_at_scss_function, parse_any_scss_value_with_context,
+    parse_scss_bracketed_value_expression_item, parse_scss_function,
+    parse_scss_function_call_from_name, parse_scss_interpolated_function_or_value,
+    parse_scss_interpolated_function_or_value_until, parse_scss_interpolated_string,
+    parse_scss_interpolated_value, parse_scss_parent_selector_value,
+    parse_scss_suffixed_interpolated_value_until,
 };

--- a/crates/biome_css_parser/src/syntax/scss/property.rs
+++ b/crates/biome_css_parser/src/syntax/scss/property.rs
@@ -1,6 +1,5 @@
 use crate::parser::CssParser;
-use crate::syntax::{CssSyntaxFeatures, is_nth_at_identifier};
-use biome_parser::SyntaxFeature;
+use crate::syntax::is_nth_at_identifier;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::Absent;
 
@@ -27,28 +26,25 @@ use super::{
 /// --#{$prop}: 10px;
 /// ```
 #[inline]
-pub(crate) fn is_at_scss_interpolated_property(p: &mut CssParser) -> bool {
-    is_nth_at_scss_interpolated_property(p, 0)
+pub(crate) fn is_at_scss_interpolated_property_name(p: &mut CssParser) -> bool {
+    is_nth_at_scss_interpolated_property_name(p, 0)
 }
 
 #[inline]
-pub(crate) fn is_nth_at_scss_interpolated_property(p: &mut CssParser, n: usize) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && (
-            // `--#{$prop}: 10px;`
-            is_nth_at_scss_interpolated_dashed_identifier(p, n)
-            // `-#{$prefix}-radius: 4px;`
-            || is_nth_at_scss_hyphen_interpolated_identifier(p, n)
-            // `#{$name}: 1px;`
-            || is_nth_at_scss_interpolation(p, n)
-            // `margin-#{$side}: 1px;`
-            || (is_nth_at_identifier(p, n) && is_nth_at_scss_interpolation(p, n + 1))
-        )
+pub(crate) fn is_nth_at_scss_interpolated_property_name(p: &mut CssParser, n: usize) -> bool {
+    // `--#{$prop}: 10px;`
+    is_nth_at_scss_interpolated_dashed_identifier(p, n)
+        // `-#{$prefix}-radius: 4px;`
+        || is_nth_at_scss_hyphen_interpolated_identifier(p, n)
+        // `#{$name}: 1px;`
+        || is_nth_at_scss_interpolation(p, n)
+        // `margin-#{$side}: 1px;`
+        || (is_nth_at_identifier(p, n) && is_nth_at_scss_interpolation(p, n + 1))
 }
 
 #[inline]
 pub(crate) fn parse_scss_interpolated_property_name(p: &mut CssParser) -> ParsedSyntax {
-    if !is_at_scss_interpolated_property(p) {
+    if !is_at_scss_interpolated_property_name(p) {
         return Absent;
     }
 

--- a/crates/biome_css_parser/src/syntax/scss/selector/attribute.rs
+++ b/crates/biome_css_parser/src/syntax/scss/selector/attribute.rs
@@ -1,5 +1,4 @@
 use crate::parser::CssParser;
-use crate::syntax::CssSyntaxFeatures;
 use crate::syntax::is_at_identifier;
 use crate::syntax::scss::{
     is_at_scss_interpolation, is_nth_at_scss_interpolation, parse_scss_interpolated_identifier,
@@ -7,15 +6,13 @@ use crate::syntax::scss::{
 use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::Absent;
-use biome_parser::prelude::SyntaxFeature;
 
 #[inline]
 pub(crate) fn is_at_scss_interpolated_attribute_identifier(p: &mut CssParser) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && (is_at_scss_interpolation(p)
-            || is_at_identifier(p)
-                && is_nth_at_scss_interpolation(p, 1)
-                && !p.has_nth_preceding_whitespace(1))
+    is_at_scss_interpolation(p)
+        || is_at_identifier(p)
+            && is_nth_at_scss_interpolation(p, 1)
+            && !p.has_nth_preceding_whitespace(1)
 }
 
 /// Parses an interpolated attribute selector modifier.

--- a/crates/biome_css_parser/src/syntax/scss/selector/interpolated_pseudo.rs
+++ b/crates/biome_css_parser/src/syntax/scss/selector/interpolated_pseudo.rs
@@ -1,6 +1,5 @@
 use super::pseudo_class_nth::is_nth_at_scss_pseudo_class_nth_value_with_interpolation;
 use crate::parser::CssParser;
-use crate::syntax::CssSyntaxFeatures;
 use crate::syntax::scss::is_at_scss_interpolation;
 use crate::syntax::selector::relative_selector::{
     RelativeSelectorList, is_at_relative_selector_combinator,
@@ -21,15 +20,14 @@ use biome_css_syntax::T;
 use biome_parser::parse_lists::ParseSeparatedList;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::*;
-use biome_parser::{Parser, SyntaxFeature, token_set};
+use biome_parser::{Parser, token_set};
 
 #[inline]
 pub(crate) fn is_at_scss_interpolated_pseudo_class_function_arguments(p: &mut CssParser) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && (is_at_scss_interpolated_pseudo_relative_selector_arguments(p)
-            || is_at_scss_interpolated_pseudo_nth_arguments(p)
-            || is_at_scss_interpolated_pseudo_selector_arguments(p)
-            || is_at_scss_interpolated_pseudo_value_arguments(p))
+    is_at_scss_interpolated_pseudo_relative_selector_arguments(p)
+        || is_at_scss_interpolated_pseudo_nth_arguments(p)
+        || is_at_scss_interpolated_pseudo_selector_arguments(p)
+        || is_at_scss_interpolated_pseudo_value_arguments(p)
 }
 
 /// Parses typed arguments for an interpolated pseudo-class function.
@@ -135,9 +133,8 @@ fn parse_scss_interpolated_pseudo_class_value_arguments(p: &mut CssParser) -> Pa
 
 #[inline]
 pub(crate) fn is_at_scss_interpolated_pseudo_element_function_arguments(p: &mut CssParser) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && (is_at_scss_interpolated_pseudo_selector_arguments(p)
-            || is_at_scss_interpolated_pseudo_value_arguments(p))
+    is_at_scss_interpolated_pseudo_selector_arguments(p)
+        || is_at_scss_interpolated_pseudo_value_arguments(p)
 }
 
 /// Parses typed arguments for an interpolated pseudo-element function.

--- a/crates/biome_css_parser/src/syntax/scss/selector/parent_selector.rs
+++ b/crates/biome_css_parser/src/syntax/scss/selector/parent_selector.rs
@@ -1,18 +1,18 @@
 use crate::parser::CssParser;
+use crate::syntax::is_nth_at_identifier;
 use crate::syntax::scss::expression::parse_scss_selector_interpolation;
 use crate::syntax::scss::{is_at_scss_interpolation, is_nth_at_scss_interpolation};
 use crate::syntax::selector::{parse_selector_identifier_fragment, selector_lex_context};
-use crate::syntax::{CssSyntaxFeatures, is_nth_at_identifier};
 use biome_css_syntax::CssSyntaxKind::{
     CSS_DIMENSION_VALUE, CSS_NUMBER, CSS_NUMBER_LITERAL, SCSS_PARENT_SELECTOR_SUFFIX,
     SCSS_PARENT_SELECTOR_SUFFIX_HYPHEN, SCSS_PARENT_SELECTOR_SUFFIX_PART_LIST,
 };
 use biome_css_syntax::{CssSyntaxKind, T};
+use biome_parser::Parser;
 use biome_parser::parse_lists::ParseNodeList;
 use biome_parser::parse_recovery::{RecoveryError, RecoveryResult};
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
-use biome_parser::{Parser, SyntaxFeature};
 
 /// Parses the suffix in an SCSS parent selector after `&` has been consumed.
 ///
@@ -42,9 +42,7 @@ pub(crate) fn parse_scss_parent_selector_suffix(p: &mut CssParser) -> ParsedSynt
 
 #[inline]
 pub(crate) fn is_at_scss_parent_selector_suffix(p: &mut CssParser) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && !p.has_preceding_whitespace()
-        && is_at_scss_parent_selector_suffix_part(p)
+    !p.has_preceding_whitespace() && is_at_scss_parent_selector_suffix_part(p)
 }
 
 /// Parses adjacent suffix parts in `&-#{$state}` until whitespace or selector

--- a/crates/biome_css_parser/src/syntax/scss/selector/placeholder.rs
+++ b/crates/biome_css_parser/src/syntax/scss/selector/placeholder.rs
@@ -1,19 +1,16 @@
 use crate::parser::CssParser;
-use crate::syntax::CssSyntaxFeatures;
 use crate::syntax::parse_error::expected_identifier;
 use crate::syntax::scss::is_nth_at_scss_interpolated_identifier;
 use crate::syntax::selector::parse_selector_custom_identifier;
 use biome_css_syntax::CssSyntaxKind::SCSS_PLACEHOLDER_SELECTOR;
 use biome_css_syntax::T;
+use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::*;
-use biome_parser::{Parser, SyntaxFeature};
 
 #[inline]
 pub(crate) fn is_nth_at_scss_placeholder_selector(p: &mut CssParser, n: usize) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p)
-        && p.nth_at(n, T![%])
-        && is_nth_at_scss_interpolated_identifier(p, n + 1)
+    p.nth_at(n, T![%]) && is_nth_at_scss_interpolated_identifier(p, n + 1)
 }
 
 /// Parses an SCSS placeholder selector such as `%toolbelt`.

--- a/crates/biome_css_parser/src/syntax/scss/selector/pseudo_class_nth.rs
+++ b/crates/biome_css_parser/src/syntax/scss/selector/pseudo_class_nth.rs
@@ -1,6 +1,5 @@
 use crate::lexer::CssLexContext;
 use crate::parser::CssParser;
-use crate::syntax::CssSyntaxFeatures;
 use crate::syntax::parse_error::expected_number;
 use crate::syntax::parse_number;
 use crate::syntax::scss::{
@@ -18,14 +17,10 @@ use biome_parser::parse_lists::ParseNodeList;
 use biome_parser::parse_recovery::{RecoveryError, RecoveryResult};
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::*;
-use biome_parser::{CompletedMarker, Parser, SyntaxFeature};
+use biome_parser::{CompletedMarker, Parser};
 
 #[inline]
 pub(crate) fn is_at_scss_pseudo_class_nth(p: &mut CssParser) -> bool {
-    if !CssSyntaxFeatures::Scss.is_supported(p) {
-        return false;
-    }
-
     let n = if p.at_ts(PSEUDO_CLASS_NTH_SIGN_SET) {
         1
     } else {

--- a/crates/biome_css_parser/src/syntax/scss/value/any.rs
+++ b/crates/biome_css_parser/src/syntax/scss/value/any.rs
@@ -2,10 +2,12 @@ use crate::parser::CssParser;
 use crate::syntax::scss::{
     add_scss_variable_member_function_name_diagnostic, is_at_scss_interpolated_dashed_identifier,
     is_at_scss_interpolated_function_or_value, is_at_scss_interpolated_string,
-    is_at_scss_module_member_access, is_at_scss_parent_selector_value, is_at_scss_variable,
+    is_at_scss_module_member_access, is_at_scss_parent_selector_value,
+    is_at_scss_suffixed_interpolated_value, is_at_scss_variable,
     parse_scss_function_call_from_name, parse_scss_interpolated_dashed_identifier,
     parse_scss_interpolated_function_or_value, parse_scss_interpolated_string,
-    parse_scss_module_member_access, parse_scss_parent_selector_value, parse_scss_variable,
+    parse_scss_module_member_access, parse_scss_parent_selector_value,
+    parse_scss_suffixed_interpolated_value_until, parse_scss_variable,
 };
 use crate::syntax::{FunctionCallContext, ValueParsingContext};
 use biome_css_syntax::T;
@@ -17,6 +19,7 @@ use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 pub(crate) fn is_at_any_scss_value(p: &mut CssParser) -> bool {
     is_at_scss_variable(p)
         || is_at_scss_module_member_access(p)
+        || is_at_scss_suffixed_interpolated_value(p)
         || is_at_scss_interpolated_dashed_identifier(p)
         || is_at_scss_interpolated_function_or_value(p)
         || is_at_scss_parent_selector_value(p)
@@ -53,7 +56,11 @@ pub(crate) fn parse_any_scss_value_with_context(
         return Absent;
     }
 
-    if is_at_scss_variable(p) {
+    if is_at_scss_suffixed_interpolated_value(p) {
+        parse_scss_suffixed_interpolated_value_until(p, |p| {
+            p.has_preceding_whitespace() || p.has_preceding_line_break()
+        })
+    } else if is_at_scss_variable(p) {
         parse_scss_variable(p)
     } else if is_at_scss_module_member_access(p) {
         let has_dollar_member = p.nth_at(2, T![$]);

--- a/crates/biome_css_parser/src/syntax/scss/value/interpolated_string.rs
+++ b/crates/biome_css_parser/src/syntax/scss/value/interpolated_string.rs
@@ -1,6 +1,5 @@
 use crate::lexer::{CssLexContext, CssStringQuote};
 use crate::parser::CssParser;
-use crate::syntax::CssSyntaxFeatures;
 use crate::syntax::parse_error::expected_string;
 use crate::syntax::scss::expression::{
     parse_scss_inner_expression_in_string_until, parse_scss_interpolation_prefix,
@@ -12,7 +11,6 @@ use biome_css_syntax::CssSyntaxKind::{
 };
 use biome_css_syntax::{CssSyntaxKind, T, TextRange};
 use biome_parser::Parser;
-use biome_parser::SyntaxFeature;
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::parse_lists::ParseNodeList;
 use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
@@ -25,7 +23,7 @@ const SCSS_INTERPOLATION_END_TOKEN_SET: biome_parser::TokenSet<CssSyntaxKind> =
 
 #[inline]
 pub(crate) fn is_at_scss_interpolated_string(p: &mut CssParser) -> bool {
-    CssSyntaxFeatures::Scss.is_supported(p) && p.at(SCSS_STRING_QUOTE)
+    p.at(SCSS_STRING_QUOTE)
 }
 
 /// Parses an SCSS string with embedded interpolations such as

--- a/crates/biome_css_parser/src/syntax/scss/value/interpolated_value.rs
+++ b/crates/biome_css_parser/src/syntax/scss/value/interpolated_value.rs
@@ -31,6 +31,35 @@ fn is_at_identifier_with_interpolation_suffix(p: &mut CssParser) -> bool {
         && !p.has_nth_preceding_whitespace(1)
 }
 
+#[inline]
+pub(crate) fn is_at_scss_interpolated_value_head(p: &mut CssParser) -> bool {
+    is_at_scss_namespaced_variable(p)
+        || is_at_scss_variable(p)
+        || is_at_any_dimension(p)
+        || p.at(CSS_NUMBER_LITERAL)
+}
+
+#[inline]
+pub(crate) fn is_at_scss_suffixed_interpolated_value(p: &mut CssParser) -> bool {
+    if is_at_scss_namespaced_variable(p) {
+        is_nth_at_adjacent_interpolation_suffix(p, 4)
+    } else if is_at_scss_variable(p) {
+        is_nth_at_adjacent_interpolation_suffix(p, 2)
+    } else if is_at_any_dimension(p) {
+        // `10px#{suffix}`: dimension heads include the unit token.
+        is_nth_at_adjacent_interpolation_suffix(p, 2)
+    } else if p.at(CSS_NUMBER_LITERAL) {
+        is_nth_at_adjacent_interpolation_suffix(p, 1)
+    } else {
+        false
+    }
+}
+
+#[inline]
+fn is_nth_at_adjacent_interpolation_suffix(p: &mut CssParser, n: usize) -> bool {
+    is_nth_at_scss_interpolation(p, n) && !p.has_nth_preceding_whitespace(n)
+}
+
 /// Parses an SCSS interpolation-led value and upgrades it to a function call
 /// when the interpolation-shaped name is followed by `(`.
 ///
@@ -106,6 +135,61 @@ pub(crate) fn parse_scss_interpolated_function_or_value_until(
     }
 }
 
+/// Parses a value head that may be followed by an adjacent interpolation suffix.
+///
+/// This keeps expression operands, regular SCSS values, and CSS-mode SCSS
+/// recovery on the same boundary-aware parser.
+///
+/// Examples:
+/// ```scss
+/// $value#{suffix}
+/// module.$value#{suffix}
+/// 10#{unit}
+/// 10px#{suffix}
+/// ```
+///
+/// Docs: https://sass-lang.com/documentation/interpolation
+#[inline]
+pub(crate) fn parse_scss_suffixed_interpolated_value_until(
+    p: &mut CssParser,
+    should_stop: impl Fn(&mut CssParser) -> bool,
+) -> ParsedSyntax {
+    if !is_at_scss_interpolated_value_head(p) {
+        return Absent;
+    }
+
+    let head = match parse_scss_interpolated_value_head(p) {
+        Present(head) => head,
+        Absent => return Absent,
+    };
+
+    // `10 / 2` and `$value / 2` must leave the operator to Sass precedence;
+    // only adjacent interpolation suffixes like `10#{unit}` continue here.
+    if should_stop(p) || !is_at_scss_interpolation(p) {
+        return Present(head);
+    }
+
+    Present(parse_scss_interpolated_value(p, head, should_stop))
+}
+
+/// Parses the head before an adjacent interpolation suffix.
+///
+/// Examples: `$value`, `module.$value`, `10`, `10px`
+#[inline]
+fn parse_scss_interpolated_value_head(p: &mut CssParser) -> ParsedSyntax {
+    if is_at_scss_namespaced_variable(p) {
+        parse_scss_namespaced_variable(p)
+    } else if is_at_scss_variable(p) {
+        parse_scss_variable(p)
+    } else if is_at_any_dimension(p) {
+        parse_any_dimension(p)
+    } else if p.at(CSS_NUMBER_LITERAL) {
+        parse_regular_number(p)
+    } else {
+        Absent
+    }
+}
+
 /// Returns true when the current token can continue an interpolated SCSS value
 /// after a head has already been parsed.
 ///
@@ -142,10 +226,10 @@ pub(crate) fn is_at_scss_interpolated_value_suffix(p: &mut CssParser) -> bool {
 #[inline]
 pub(crate) fn parse_scss_interpolated_value(
     p: &mut CssParser,
-    first_part: CompletedMarker,
+    head: CompletedMarker,
     should_stop: impl Fn(&mut CssParser) -> bool,
 ) -> CompletedMarker {
-    let list = first_part.precede(p);
+    let list = head.precede(p);
     let mut progress = ParserProgress::default();
 
     // The caller owns the stop condition because expression parsing must stop

--- a/crates/biome_css_parser/src/syntax/scss/value/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/value/mod.rs
@@ -25,8 +25,10 @@ pub(crate) use interpolated_string::{
     is_at_scss_interpolated_string, parse_scss_interpolated_string,
 };
 pub(crate) use interpolated_value::{
-    is_at_scss_interpolated_function_or_value, parse_scss_interpolated_function_or_value,
+    is_at_scss_interpolated_function_or_value, is_at_scss_interpolated_value_head,
+    is_at_scss_suffixed_interpolated_value, parse_scss_interpolated_function_or_value,
     parse_scss_interpolated_function_or_value_until, parse_scss_interpolated_value,
+    parse_scss_suffixed_interpolated_value_until,
 };
 pub(crate) use parent_selector::{
     is_at_scss_parent_selector_value, parse_scss_parent_selector_value,

--- a/crates/biome_css_parser/src/syntax/scss/value/parent_selector.rs
+++ b/crates/biome_css_parser/src/syntax/scss/value/parent_selector.rs
@@ -1,18 +1,14 @@
 use crate::parser::CssParser;
-use crate::syntax::CssSyntaxFeatures;
 use biome_css_syntax::CssSyntaxKind::SCSS_PARENT_SELECTOR_VALUE;
 use biome_css_syntax::T;
 use biome_parser::Parser;
-use biome_parser::SyntaxFeature;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 
 /// Detects the SCSS parent selector value `&`.
 #[inline]
 pub(crate) fn is_at_scss_parent_selector_value(p: &mut CssParser) -> bool {
-    // `&` is a generic token in CSS parsing/recovery. Keep the SCSS gate here so
-    // plain CSS doesn't accidentally route through SCSS-only diagnostics.
-    CssSyntaxFeatures::Scss.is_supported(p) && p.at(T![&])
+    p.at(T![&])
 }
 
 /// Parses the SCSS parent selector value `&`.

--- a/crates/biome_css_parser/src/syntax/selector/attribute.rs
+++ b/crates/biome_css_parser/src/syntax/selector/attribute.rs
@@ -1,6 +1,7 @@
 use crate::parser::CssParser;
 use crate::syntax::parse_error::{
     expected_any_attribute_matcher_name, expected_any_attribute_modifier, expected_identifier,
+    scss_only_syntax_error,
 };
 use crate::syntax::scss::{
     is_at_scss_interpolated_attribute_identifier, is_at_scss_interpolated_string,
@@ -8,14 +9,16 @@ use crate::syntax::scss::{
     parse_scss_interpolated_string,
 };
 use crate::syntax::selector::{is_nth_at_namespace, parse_namespace, selector_lex_context};
-use crate::syntax::{is_at_identifier, is_at_string, parse_regular_identifier, parse_string};
+use crate::syntax::{
+    CssSyntaxFeatures, is_at_identifier, is_at_string, parse_regular_identifier, parse_string,
+};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::diagnostic::expected_token;
 use biome_parser::parse_recovery::ParseRecoveryTokenSet;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
-use biome_parser::{Parser, TokenSet, token_set};
+use biome_parser::{Parser, SyntaxFeature, TokenSet, token_set};
 
 const ATTRIBUTE_SELECTOR_RECOVERY_SET: TokenSet<CssSyntaxKind> = token_set![T![')'], T!['{']];
 #[inline]
@@ -88,7 +91,13 @@ fn parse_attribute_name_identifier(p: &mut CssParser) -> ParsedSyntax {
     if is_at_scss_interpolated_attribute_identifier(p) {
         // `[lang=#{$locale}]` keeps `lang` as CssIdentifier; only
         // `[data-#{$name}=x]` needs an interpolated attribute name.
-        parse_scss_interpolated_identifier(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolated_identifier,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated attribute names", marker.range(p))
+            },
+        )
     } else {
         parse_regular_identifier(p)
     }
@@ -154,7 +163,13 @@ fn parse_attribute_modifier(p: &mut CssParser) -> ParsedSyntax {
     }
 
     if is_at_scss_interpolated_attribute_identifier(p) {
-        parse_scss_interpolated_attribute_modifier(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolated_attribute_modifier,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated attribute modifiers", marker.range(p))
+            },
+        )
     } else {
         parse_attribute_modifier_keyword(p)
     }
@@ -188,9 +203,17 @@ fn parse_attribute_matcher_value(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
 
     if is_at_scss_interpolated_attribute_identifier(p) {
-        parse_scss_interpolated_identifier(p).ok();
+        CssSyntaxFeatures::Scss
+            .parse_exclusive_syntax(p, parse_scss_interpolated_identifier, |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated attribute values", marker.range(p))
+            })
+            .ok();
     } else if is_at_scss_interpolated_string(p) {
-        parse_scss_interpolated_string(p).ok();
+        CssSyntaxFeatures::Scss
+            .parse_exclusive_syntax(p, parse_scss_interpolated_string, |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated strings", marker.range(p))
+            })
+            .ok();
     } else if is_at_string(p) {
         parse_string(p).ok();
     } else {

--- a/crates/biome_css_parser/src/syntax/selector/mod.rs
+++ b/crates/biome_css_parser/src/syntax/selector/mod.rs
@@ -9,9 +9,10 @@ use crate::lexer::CssLexContext;
 use crate::parser::CssParser;
 use crate::syntax::parse_error::{
     expected_any_sub_selector, expected_compound_selector, expected_identifier, expected_selector,
+    scss_only_syntax_error,
 };
 use crate::syntax::scss::{
-    is_at_scss_interpolated_identifier, is_nth_at_scss_interpolated_identifier,
+    is_at_scss_interpolated_selector_identifier, is_nth_at_scss_interpolated_selector_identifier,
     is_nth_at_scss_placeholder_selector, parse_scss_placeholder_selector,
     parse_scss_selector_custom_identifier, parse_scss_selector_identifier,
 };
@@ -319,7 +320,7 @@ fn is_nth_at_simple_selector(p: &mut CssParser, n: usize) -> bool {
     is_nth_at_namespace(p, n)
         || p.nth_at(n, T![*])
         || is_nth_at_identifier(p, n)
-        || is_nth_at_scss_interpolated_identifier(p, n)
+        || is_nth_at_scss_interpolated_selector_identifier(p, n)
         || is_nth_at_scss_placeholder_selector(p, n)
 }
 
@@ -335,7 +336,11 @@ fn parse_simple_selector(p: &mut CssParser) -> ParsedSyntax {
     }
 
     if is_nth_at_scss_placeholder_selector(p, 0) {
-        return parse_scss_placeholder_selector(p);
+        return CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_placeholder_selector,
+            |p, marker| scss_only_syntax_error(p, "SCSS placeholder selectors", marker.range(p)),
+        );
     }
 
     let namespace = parse_namespace(p);
@@ -537,7 +542,7 @@ fn parse_type_selector(p: &mut CssParser, namespace: ParsedSyntax) -> ParsedSynt
 /// callers still own the surrounding selector node.
 #[inline]
 fn is_at_selector_identifier(p: &mut CssParser) -> bool {
-    is_at_identifier(p) || is_at_scss_interpolated_identifier(p)
+    is_at_identifier(p) || is_at_scss_interpolated_selector_identifier(p)
 }
 
 /// Parses an identifier within a selector context in CSS.
@@ -549,6 +554,14 @@ fn is_at_selector_identifier(p: &mut CssParser) -> bool {
 fn parse_selector_identifier(p: &mut CssParser) -> ParsedSyntax {
     if CssSyntaxFeatures::Scss.is_supported(p) {
         parse_scss_selector_identifier(p)
+    } else if is_at_scss_interpolated_selector_identifier(p) {
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_selector_identifier,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated selector names", marker.range(p))
+            },
+        )
     } else {
         parse_selector_identifier_fragment(p)
     }
@@ -567,6 +580,14 @@ pub(crate) fn parse_selector_identifier_fragment(p: &mut CssParser) -> ParsedSyn
 pub(crate) fn parse_selector_custom_identifier(p: &mut CssParser) -> ParsedSyntax {
     if CssSyntaxFeatures::Scss.is_supported(p) {
         parse_scss_selector_custom_identifier(p)
+    } else if is_at_scss_interpolated_selector_identifier(p) {
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_selector_custom_identifier,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated selector names", marker.range(p))
+            },
+        )
     } else {
         parse_selector_custom_identifier_fragment(p)
     }

--- a/crates/biome_css_parser/src/syntax/selector/nested_selector.rs
+++ b/crates/biome_css_parser/src/syntax/selector/nested_selector.rs
@@ -1,15 +1,16 @@
 use crate::parser::CssParser;
+use crate::syntax::CssSyntaxFeatures;
 use crate::syntax::scss::{is_at_scss_parent_selector_suffix, parse_scss_parent_selector_suffix};
 use crate::syntax::selector::selector_lex_context;
 use biome_css_syntax::CssSyntaxKind::{
     CSS_NESTED_SELECTOR, CSS_NESTED_SELECTOR_LIST, SCSS_PARENT_SELECTOR,
 };
 use biome_css_syntax::{CssSyntaxKind, T};
-use biome_parser::Parser;
 use biome_parser::parse_lists::ParseNodeList;
 use biome_parser::parse_recovery::{RecoveryError, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
+use biome_parser::{Parser, SyntaxFeature};
 
 pub(crate) struct NestedSelectorList;
 impl ParseNodeList for NestedSelectorList {
@@ -54,9 +55,7 @@ fn parse_nested_selector(p: &mut CssParser) -> ParsedSyntax {
     let context = selector_lex_context(p);
     p.bump_with_context(T![&], context);
 
-    // `&-100\.200`: suffix ownership is decided after `&` switches the lexer
-    // into selector context, where numeric and escaped suffix parts are visible.
-    if is_at_scss_parent_selector_suffix(p) {
+    if CssSyntaxFeatures::Scss.is_supported(p) && is_at_scss_parent_selector_suffix(p) {
         // Guarded above, so `&-#{$state}` must parse an adjacent suffix.
         parse_scss_parent_selector_suffix(p).ok();
         return Present(m.complete(p, SCSS_PARENT_SELECTOR));

--- a/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_nth.rs
+++ b/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_nth.rs
@@ -1,14 +1,16 @@
 use crate::lexer::CssLexContext;
 use crate::parser::CssParser;
 use crate::syntax::parse_error::{
-    expected_any_pseudo_class_nth, expected_number, expected_selector,
+    expected_any_pseudo_class_nth, expected_number, expected_selector, scss_only_syntax_error,
 };
 use crate::syntax::scss::{is_at_scss_pseudo_class_nth, parse_scss_pseudo_class_nth};
 use crate::syntax::selector::{
     SELECTOR_FUNCTION_RECOVERY_SET, SelectorList, eat_or_recover_selector_function_close_token,
     recover_selector_function_parameter,
 };
-use crate::syntax::{parse_number, parse_regular_identifier, parse_regular_number};
+use crate::syntax::{
+    CssSyntaxFeatures, parse_number, parse_regular_identifier, parse_regular_number,
+};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::CssSyntaxKind::{
     CSS_NTH_OFFSET, CSS_PSEUDO_CLASS_FUNCTION_NTH, CSS_PSEUDO_CLASS_NTH,
@@ -19,7 +21,7 @@ use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::ParseSeparatedList;
 use biome_parser::parsed_syntax::ParsedSyntax;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
-use biome_parser::{Parser, TokenSet, token_set};
+use biome_parser::{Parser, SyntaxFeature, TokenSet, token_set};
 
 const PSEUDO_CLASS_FUNCTION_NTH_SET: TokenSet<CssSyntaxKind> = token_set![
     T![nth_child],
@@ -124,7 +126,13 @@ fn parse_pseudo_class_nth(p: &mut CssParser) -> ParsedSyntax {
     }
 
     if is_at_scss_pseudo_class_nth(p) {
-        return parse_scss_pseudo_class_nth(p);
+        return CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_pseudo_class_nth,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated nth arguments", marker.range(p))
+            },
+        );
     }
 
     let m = p.start();

--- a/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_value_list.rs
+++ b/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_value_list.rs
@@ -1,18 +1,20 @@
 use crate::parser::CssParser;
-use crate::syntax::parse_error::expected_identifier;
+use crate::syntax::parse_error::{expected_identifier, scss_only_syntax_error};
 use crate::syntax::scss::{
-    is_at_scss_interpolated_identifier, is_at_scss_interpolated_string,
+    is_at_scss_interpolated_string, is_at_scss_interpolation, is_nth_at_scss_interpolation,
     parse_scss_interpolated_string, parse_scss_interpolation_or_identifier,
 };
 use crate::syntax::selector::eat_or_recover_selector_function_close_token;
-use crate::syntax::{is_at_identifier, is_at_string, parse_regular_identifier, parse_string};
+use crate::syntax::{
+    CssSyntaxFeatures, is_at_identifier, is_at_string, parse_regular_identifier, parse_string,
+};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::ParseSeparatedList;
 use biome_parser::parse_recovery::{RecoveryError, RecoveryResult};
 use biome_parser::parsed_syntax::ParsedSyntax;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
-use biome_parser::{Parser, TokenSet, token_set};
+use biome_parser::{Parser, SyntaxFeature, TokenSet, token_set};
 
 const PSEUDO_CLASS_FUNCTION_VALUE_LIST_SET: TokenSet<CssSyntaxKind> = token_set![T![lang]];
 
@@ -86,7 +88,7 @@ impl ParseSeparatedList for PseudoValueList {
 pub(crate) fn is_at_pseudo_value(p: &mut CssParser) -> bool {
     is_at_identifier(p)
         || is_at_string(p)
-        || is_at_scss_interpolated_identifier(p)
+        || is_at_scss_interpolated_pseudo_value_identifier(p)
         || is_at_scss_interpolated_string(p)
 }
 
@@ -98,12 +100,30 @@ fn parse_pseudo_value(p: &mut CssParser) -> ParsedSyntax {
     }
 
     if is_at_scss_interpolated_string(p) {
-        parse_scss_interpolated_string(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolated_string,
+            |p, marker| scss_only_syntax_error(p, "SCSS interpolated strings", marker.range(p)),
+        )
     } else if is_at_string(p) {
         parse_string(p)
-    } else if is_at_scss_interpolated_identifier(p) {
-        parse_scss_interpolation_or_identifier(p)
+    } else if is_at_scss_interpolated_pseudo_value_identifier(p) {
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            parse_scss_interpolation_or_identifier,
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated pseudo values", marker.range(p))
+            },
+        )
     } else {
         parse_regular_identifier(p)
     }
+}
+
+#[inline]
+fn is_at_scss_interpolated_pseudo_value_identifier(p: &mut CssParser) -> bool {
+    is_at_scss_interpolation(p)
+        || is_at_identifier(p)
+            && is_nth_at_scss_interpolation(p, 1)
+            && !p.has_nth_preceding_whitespace(1)
 }

--- a/crates/biome_css_parser/src/syntax/value/function/call.rs
+++ b/crates/biome_css_parser/src/syntax/value/function/call.rs
@@ -119,7 +119,7 @@ fn is_nth_at_function_with_context(
     };
 
     is_nth_at_identifier(p, n) && is_function_paren
-        || (context.is_scss_exclusive_syntax_allowed()
+        || (context.is_scss_qualified_function_recovery_allowed()
             // Sass module calls are always source-tight: `math.pow(...)`.
             && is_nth_at_scss_module_member_access(p, n)
             && is_nth_at_source_tight_l_paren(p, n + 3))
@@ -162,7 +162,7 @@ fn parse_function_with_context(p: &mut CssParser, context: ValueParsingContext) 
 
     let m = p.start();
 
-    if context.is_scss_exclusive_syntax_allowed() && is_at_scss_module_member_access(p) {
+    if context.is_scss_qualified_function_recovery_allowed() && is_at_scss_module_member_access(p) {
         CssSyntaxFeatures::Scss
             .parse_exclusive_syntax(p, parse_scss_function_name, |p, marker| {
                 scss_only_syntax_error(p, "SCSS qualified function names", marker.range(p))

--- a/crates/biome_css_parser/src/syntax/value/if.rs
+++ b/crates/biome_css_parser/src/syntax/value/if.rs
@@ -1,7 +1,6 @@
 use biome_css_syntax::CssSyntaxKind;
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::T;
-use biome_parser::Parser;
 use biome_parser::TokenSet;
 use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
 use biome_parser::parse_recovery::ParseRecovery;
@@ -10,6 +9,7 @@ use biome_parser::parse_recovery::RecoveryResult;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::{CompletedMarker, ParsedSyntax};
 use biome_parser::token_set;
+use biome_parser::{Parser, SyntaxFeature};
 
 use crate::parser::CssParser;
 use crate::syntax::CssSyntaxFeatures;
@@ -33,7 +33,6 @@ use crate::syntax::scss::{expected_scss_expression, parse_scss_expression_until}
 use crate::syntax::value::parse_error::expected_if_branch;
 use crate::syntax::value::parse_error::expected_if_test_boolean_expr_group;
 use crate::syntax::value::parse_error::expected_if_test_boolean_not_expr;
-use biome_parser::SyntaxFeature;
 
 const IF_BRANCH_RECOVERY_TOKEN_SET: TokenSet<CssSyntaxKind> =
     token_set![T![;], T![')'], T!['}'], EOF];

--- a/crates/biome_css_parser/src/syntax/value/url.rs
+++ b/crates/biome_css_parser/src/syntax/value/url.rs
@@ -11,8 +11,10 @@ use crate::syntax::value::function::{
     is_nth_at_css_function, is_nth_at_function, parse_css_function, parse_function,
 };
 use crate::syntax::value::parse_error::expected_url_modifier;
-use crate::syntax::{CssSyntaxFeatures, ValueParsingContext, ValueParsingMode};
-use crate::syntax::{is_at_identifier, is_at_string, parse_regular_identifier, parse_string};
+use crate::syntax::{
+    CssSyntaxFeatures, ValueParsingContext, ValueParsingMode, is_at_identifier, is_at_string,
+    parse_regular_identifier, parse_string,
+};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parse_lists::ParseNodeList;
@@ -228,7 +230,9 @@ fn parse_url_value_with_context(p: &mut CssParser, context: ValueParsingContext)
     } else if is_at_string(p) {
         parse_string(p)
     } else if is_at_scss_interpolated_string(p) {
-        parse_scss_interpolated_string(p)
+        CssSyntaxFeatures::Scss.parse_exclusive_syntax(p, parse_scss_interpolated_string, |p, m| {
+            scss_only_syntax_error(p, "SCSS interpolated strings", m.range(p))
+        })
     } else {
         parse_url_value_raw(p)
     }

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css
@@ -1,0 +1,93 @@
+@supports (variable: $value) {
+  .variable {}
+}
+
+@supports (variable-interpolation: $value#{suffix}) {
+  .variable-interpolation {}
+}
+
+@supports (module-member: module.$value) {
+  .module-member {}
+}
+
+@supports (module-member-interpolation: module.$value#{suffix}) {
+  .module-member-interpolation {}
+}
+
+@supports (qualified-function: module.fn(1)) {
+  .qualified-function {}
+}
+
+@supports (interpolation: #{$value}) {
+  .interpolation {}
+}
+
+@supports (adjacent-interpolations: #{$a}#{$b}) {
+  .adjacent-interpolations {}
+}
+
+@supports (number-interpolation: 10#{unit}) {
+  .number-interpolation {}
+}
+
+@supports (dimension-interpolation: 10px#{suffix}) {
+  .dimension-interpolation {}
+}
+
+@supports (interpolated-name: foo#{$bar}) {
+  .interpolated-name {}
+}
+
+@supports (interpolated-custom-property: --#{$name}) {
+  .interpolated-custom-property {}
+}
+
+@supports (interpolated-custom-property-suffix: --theme-#{$slot}) {
+  .interpolated-custom-property-suffix {}
+}
+
+@supports (#{$name}: red) {
+  .supports-interpolated-property {}
+}
+
+@supports (--#{$name}: red) {
+  .supports-interpolated-custom-property {}
+}
+
+@media (aspect-ratio: module.fn(1)) {
+  .media-qualified-function {}
+}
+
+@media (resolution: #{$a}#{$b}) {
+  .media-adjacent-interpolations {}
+}
+
+@media #{$query} {
+  .media-query {}
+}
+
+@media (#{$min} <= width) {
+  .media-reverse-range {}
+}
+
+@media (#{$min} <= width <= #{$max}) {
+  .media-interval-range {}
+}
+
+@page {
+  font: {
+    size: 12px;
+  }
+}
+
+@keyframes loader {
+  #{$i}% {
+    opacity: 1;
+  }
+}
+
+@#{$rule-name} #{$value};
+
+@#{$block-rule} #{$value} {
+  color: red;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css
@@ -80,6 +80,12 @@
   }
 }
 
+@function --nested-property() {
+  font: {
+    size: 12px;
+  }
+}
+
 @keyframes loader {
   #{$i}% {
     opacity: 1;

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css.snap
@@ -1,0 +1,3077 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@supports (variable: $value) {
+  .variable {}
+}
+
+@supports (variable-interpolation: $value#{suffix}) {
+  .variable-interpolation {}
+}
+
+@supports (module-member: module.$value) {
+  .module-member {}
+}
+
+@supports (module-member-interpolation: module.$value#{suffix}) {
+  .module-member-interpolation {}
+}
+
+@supports (qualified-function: module.fn(1)) {
+  .qualified-function {}
+}
+
+@supports (interpolation: #{$value}) {
+  .interpolation {}
+}
+
+@supports (adjacent-interpolations: #{$a}#{$b}) {
+  .adjacent-interpolations {}
+}
+
+@supports (number-interpolation: 10#{unit}) {
+  .number-interpolation {}
+}
+
+@supports (dimension-interpolation: 10px#{suffix}) {
+  .dimension-interpolation {}
+}
+
+@supports (interpolated-name: foo#{$bar}) {
+  .interpolated-name {}
+}
+
+@supports (interpolated-custom-property: --#{$name}) {
+  .interpolated-custom-property {}
+}
+
+@supports (interpolated-custom-property-suffix: --theme-#{$slot}) {
+  .interpolated-custom-property-suffix {}
+}
+
+@supports (#{$name}: red) {
+  .supports-interpolated-property {}
+}
+
+@supports (--#{$name}: red) {
+  .supports-interpolated-custom-property {}
+}
+
+@media (aspect-ratio: module.fn(1)) {
+  .media-qualified-function {}
+}
+
+@media (resolution: #{$a}#{$b}) {
+  .media-adjacent-interpolations {}
+}
+
+@media #{$query} {
+  .media-query {}
+}
+
+@media (#{$min} <= width) {
+  .media-reverse-range {}
+}
+
+@media (#{$min} <= width <= #{$max}) {
+  .media-interval-range {}
+}
+
+@page {
+  font: {
+    size: 12px;
+  }
+}
+
+@keyframes loader {
+  #{$i}% {
+    opacity: 1;
+  }
+}
+
+@#{$rule-name} #{$value};
+
+@#{$block-rule} #{$value} {
+  color: red;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@1..10 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@10..11 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@11..19 "variable" [] [],
+                                    },
+                                    COLON@19..21 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    DOLLAR@21..22 "$" [] [],
+                                                    CssIdentifier {
+                                                        value_token: IDENT@22..27 "value" [] [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@27..29 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@29..30 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@30..34 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@34..43 "variable" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@43..44 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@44..45 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@45..47 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@47..50 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@50..59 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@59..60 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@60..82 "variable-interpolation" [] [],
+                                    },
+                                    COLON@82..84 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedValuePartList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@84..85 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@85..90 "value" [] [],
+                                                            },
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@90..91 "#" [] [],
+                                                            l_curly_token: L_CURLY@91..92 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@92..98 "suffix" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@98..99 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@99..101 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@101..102 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@102..106 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@106..129 "variable-interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@129..130 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@130..131 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@131..133 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@133..136 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@136..145 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@145..146 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@146..159 "module-member" [] [],
+                                    },
+                                    COLON@159..161 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@161..167 "module" [] [],
+                                                    },
+                                                    DOT@167..168 "." [] [],
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@168..169 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@169..174 "value" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@174..176 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@176..177 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@177..181 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@181..195 "module-member" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@195..196 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@196..197 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@197..199 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@199..202 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@202..211 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@211..212 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@212..239 "module-member-interpolation" [] [],
+                                    },
+                                    COLON@239..241 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedValuePartList [
+                                                        ScssNamespacedVariable {
+                                                            namespace: CssIdentifier {
+                                                                value_token: IDENT@241..247 "module" [] [],
+                                                            },
+                                                            dot_token: DOT@247..248 "." [] [],
+                                                            name: ScssVariable {
+                                                                dollar_token: DOLLAR@248..249 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@249..254 "value" [] [],
+                                                                },
+                                                            },
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@254..255 "#" [] [],
+                                                            l_curly_token: L_CURLY@255..256 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@256..262 "suffix" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@262..263 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@263..265 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@265..266 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@266..270 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@270..298 "module-member-interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@298..299 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@299..300 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@300..302 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@302..305 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@305..314 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@314..315 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@315..333 "qualified-function" [] [],
+                                    },
+                                    COLON@333..335 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssModuleMemberAccess {
+                                                        module: CssIdentifier {
+                                                            value_token: IDENT@335..341 "module" [] [],
+                                                        },
+                                                        dot_token: DOT@341..342 "." [] [],
+                                                        member: CssIdentifier {
+                                                            value_token: IDENT@342..344 "fn" [] [],
+                                                        },
+                                                    },
+                                                    L_PAREN@344..345 "(" [] [],
+                                                    CssParameterList [
+                                                        CssListOfComponentValuesExpression {
+                                                            css_component_value_list: CssComponentValueList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@345..346 "1" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                    R_PAREN@346..347 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@347..349 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@349..350 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@350..354 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@354..373 "qualified-function" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@373..374 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@374..375 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@375..377 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@377..380 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@380..389 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@389..390 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@390..403 "interpolation" [] [],
+                                    },
+                                    COLON@403..405 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogus {
+                                                items: [
+                                                    HASH@405..406 "#" [] [],
+                                                    L_CURLY@406..407 "{" [] [],
+                                                    ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@407..408 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@408..413 "value" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_CURLY@413..414 "}" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@414..416 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@416..417 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@417..421 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@421..435 "interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@435..436 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@436..437 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@437..439 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@439..442 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@442..451 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@451..452 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@452..475 "adjacent-interpolations" [] [],
+                                    },
+                                    COLON@475..477 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedIdentifierPartList [
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@477..478 "#" [] [],
+                                                            l_curly_token: L_CURLY@478..479 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@479..480 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@480..481 "a" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@481..482 "}" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@482..483 "#" [] [],
+                                                            l_curly_token: L_CURLY@483..484 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@484..485 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@485..486 "b" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@486..487 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@487..489 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@489..490 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@490..494 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@494..518 "adjacent-interpolations" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@518..519 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@519..520 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@520..522 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@522..525 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@525..534 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@534..535 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@535..555 "number-interpolation" [] [],
+                                    },
+                                    COLON@555..557 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedValuePartList [
+                                                        CssNumber {
+                                                            value_token: CSS_NUMBER_LITERAL@557..559 "10" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@559..560 "#" [] [],
+                                                            l_curly_token: L_CURLY@560..561 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@561..565 "unit" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@565..566 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@566..568 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@568..569 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@569..573 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@573..594 "number-interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@594..595 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@595..596 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@596..598 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@598..601 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@601..610 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@610..611 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@611..634 "dimension-interpolation" [] [],
+                                    },
+                                    COLON@634..636 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedValuePartList [
+                                                        CssRegularDimension {
+                                                            value_token: CSS_NUMBER_LITERAL@636..638 "10" [] [],
+                                                            unit_token: IDENT@638..640 "px" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@640..641 "#" [] [],
+                                                            l_curly_token: L_CURLY@641..642 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@642..648 "suffix" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@648..649 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@649..651 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@651..652 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@652..656 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@656..680 "dimension-interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@680..681 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@681..682 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@682..684 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@684..687 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@687..696 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@696..697 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@697..714 "interpolated-name" [] [],
+                                    },
+                                    COLON@714..716 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedIdentifierPartList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@716..719 "foo" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@719..720 "#" [] [],
+                                                            l_curly_token: L_CURLY@720..721 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@721..722 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@722..725 "bar" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@725..726 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@726..728 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@728..729 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@729..733 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@733..751 "interpolated-name" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@751..752 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@752..753 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@753..755 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@755..758 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@758..767 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@767..768 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@768..796 "interpolated-custom-property" [] [],
+                                    },
+                                    COLON@796..798 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedIdentifierPartList [
+                                                        ScssInterpolatedIdentifierHyphen {
+                                                            minus_token: MINUS@798..799 "-" [] [],
+                                                        },
+                                                        ScssInterpolatedIdentifierHyphen {
+                                                            minus_token: MINUS@799..800 "-" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@800..801 "#" [] [],
+                                                            l_curly_token: L_CURLY@801..802 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@802..803 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@803..807 "name" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@807..808 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@808..810 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@810..811 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@811..815 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@815..844 "interpolated-custom-property" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@844..845 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@845..846 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@846..848 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@848..851 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@851..860 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@860..861 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@861..896 "interpolated-custom-property-suffix" [] [],
+                                    },
+                                    COLON@896..898 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedIdentifierPartList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@898..906 "--theme-" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@906..907 "#" [] [],
+                                                            l_curly_token: L_CURLY@907..908 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@908..909 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@909..913 "slot" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@913..914 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@914..916 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@916..917 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@917..921 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@921..957 "interpolated-custom-property-suffix" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@957..958 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@958..959 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@959..961 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@961..964 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@964..973 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@973..974 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssBogusSupportsCondition {
+                                        items: [
+                                            ScssInterpolatedIdentifierPartList [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@974..975 "#" [] [],
+                                                    l_curly_token: L_CURLY@975..976 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@976..977 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@977..981 "name" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@981..982 "}" [] [],
+                                                },
+                                            ],
+                                        ],
+                                    },
+                                    COLON@982..984 ":" [] [Whitespace(" ")],
+                                    CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@984..987 "red" [] [],
+                                        },
+                                    ],
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@987..989 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@989..990 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@990..994 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@994..1025 "supports-interpolated-property" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1025..1026 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1026..1027 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1027..1029 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1029..1032 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@1032..1041 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@1041..1042 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssBogusSupportsCondition {
+                                        items: [
+                                            ScssInterpolatedIdentifierPartList [
+                                                ScssInterpolatedIdentifierHyphen {
+                                                    minus_token: MINUS@1042..1043 "-" [] [],
+                                                },
+                                                ScssInterpolatedIdentifierHyphen {
+                                                    minus_token: MINUS@1043..1044 "-" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@1044..1045 "#" [] [],
+                                                    l_curly_token: L_CURLY@1045..1046 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@1046..1047 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@1047..1051 "name" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@1051..1052 "}" [] [],
+                                                },
+                                            ],
+                                        ],
+                                    },
+                                    COLON@1052..1054 ":" [] [Whitespace(" ")],
+                                    CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@1054..1057 "red" [] [],
+                                        },
+                                    ],
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@1057..1059 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@1059..1060 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@1060..1064 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@1064..1102 "supports-interpolated-custom-property" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1102..1103 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1103..1104 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1104..1106 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1106..1109 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1109..1115 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        L_PAREN@1115..1116 "(" [] [],
+                                        CssBogus {
+                                            items: [
+                                                CssIdentifier {
+                                                    value_token: IDENT@1116..1128 "aspect-ratio" [] [],
+                                                },
+                                                COLON@1128..1130 ":" [] [Whitespace(" ")],
+                                                CssBogusSupportsCondition {
+                                                    items: [
+                                                        ScssModuleMemberAccess {
+                                                            module: CssIdentifier {
+                                                                value_token: IDENT@1130..1136 "module" [] [],
+                                                            },
+                                                            dot_token: DOT@1136..1137 "." [] [],
+                                                            member: CssIdentifier {
+                                                                value_token: IDENT@1137..1139 "fn" [] [],
+                                                            },
+                                                        },
+                                                        L_PAREN@1139..1140 "(" [] [],
+                                                        CssParameterList [
+                                                            CssListOfComponentValuesExpression {
+                                                                css_component_value_list: CssComponentValueList [
+                                                                    CssNumber {
+                                                                        value_token: CSS_NUMBER_LITERAL@1140..1141 "1" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                        R_PAREN@1141..1142 ")" [] [],
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                        R_PAREN@1142..1144 ")" [] [Whitespace(" ")],
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@1144..1145 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@1145..1149 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@1149..1174 "media-qualified-function" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1174..1175 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1175..1176 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1176..1178 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1178..1181 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1181..1187 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        L_PAREN@1187..1188 "(" [] [],
+                                        CssBogus {
+                                            items: [
+                                                CssIdentifier {
+                                                    value_token: IDENT@1188..1198 "resolution" [] [],
+                                                },
+                                                COLON@1198..1200 ":" [] [Whitespace(" ")],
+                                                CssBogusSupportsCondition {
+                                                    items: [
+                                                        ScssInterpolatedIdentifierPartList [
+                                                            ScssInterpolation {
+                                                                hash_token: HASH@1200..1201 "#" [] [],
+                                                                l_curly_token: L_CURLY@1201..1202 "{" [] [],
+                                                                value: ScssExpression {
+                                                                    items: ScssExpressionItemList [
+                                                                        ScssVariable {
+                                                                            dollar_token: DOLLAR@1202..1203 "$" [] [],
+                                                                            name: CssIdentifier {
+                                                                                value_token: IDENT@1203..1204 "a" [] [],
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                },
+                                                                r_curly_token: R_CURLY@1204..1205 "}" [] [],
+                                                            },
+                                                            ScssInterpolation {
+                                                                hash_token: HASH@1205..1206 "#" [] [],
+                                                                l_curly_token: L_CURLY@1206..1207 "{" [] [],
+                                                                value: ScssExpression {
+                                                                    items: ScssExpressionItemList [
+                                                                        ScssVariable {
+                                                                            dollar_token: DOLLAR@1207..1208 "$" [] [],
+                                                                            name: CssIdentifier {
+                                                                                value_token: IDENT@1208..1209 "b" [] [],
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                },
+                                                                r_curly_token: R_CURLY@1209..1210 "}" [] [],
+                                                            },
+                                                        ],
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                        R_PAREN@1210..1212 ")" [] [Whitespace(" ")],
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@1212..1213 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@1213..1217 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@1217..1247 "media-adjacent-interpolations" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1247..1248 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1248..1249 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1249..1251 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1251..1254 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1254..1260 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                ScssInterpolation {
+                                    hash_token: HASH@1260..1261 "#" [] [],
+                                    l_curly_token: L_CURLY@1261..1262 "{" [] [],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            ScssVariable {
+                                                dollar_token: DOLLAR@1262..1263 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@1263..1268 "query" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    r_curly_token: R_CURLY@1268..1270 "}" [] [Whitespace(" ")],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@1270..1271 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@1271..1275 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@1275..1287 "media-query" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1287..1288 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1288..1289 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1289..1291 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1291..1294 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1294..1300 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        L_PAREN@1300..1301 "(" [] [],
+                                        CssBogus {
+                                            items: [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@1301..1302 "#" [] [],
+                                                    l_curly_token: L_CURLY@1302..1303 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@1303..1304 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@1304..1307 "min" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@1307..1309 "}" [] [Whitespace(" ")],
+                                                },
+                                                CssQueryFeatureRangeComparison {
+                                                    operator: LTEQ@1309..1312 "<=" [] [Whitespace(" ")],
+                                                },
+                                                CssIdentifier {
+                                                    value_token: IDENT@1312..1317 "width" [] [],
+                                                },
+                                            ],
+                                        },
+                                        R_PAREN@1317..1319 ")" [] [Whitespace(" ")],
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@1319..1320 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@1320..1324 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@1324..1344 "media-reverse-range" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1344..1345 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1345..1346 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1346..1348 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1348..1351 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1351..1357 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        L_PAREN@1357..1358 "(" [] [],
+                                        CssBogus {
+                                            items: [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@1358..1359 "#" [] [],
+                                                    l_curly_token: L_CURLY@1359..1360 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@1360..1361 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@1361..1364 "min" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@1364..1366 "}" [] [Whitespace(" ")],
+                                                },
+                                                CssQueryFeatureRangeComparison {
+                                                    operator: LTEQ@1366..1369 "<=" [] [Whitespace(" ")],
+                                                },
+                                                CssIdentifier {
+                                                    value_token: IDENT@1369..1375 "width" [] [Whitespace(" ")],
+                                                },
+                                                CssQueryFeatureRangeComparison {
+                                                    operator: LTEQ@1375..1378 "<=" [] [Whitespace(" ")],
+                                                },
+                                                CssBogus {
+                                                    items: [
+                                                        HASH@1378..1379 "#" [] [],
+                                                        L_CURLY@1379..1380 "{" [] [],
+                                                        ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssVariable {
+                                                                    dollar_token: DOLLAR@1380..1381 "$" [] [],
+                                                                    name: CssIdentifier {
+                                                                        value_token: IDENT@1381..1384 "max" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        R_CURLY@1384..1385 "}" [] [],
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                        R_PAREN@1385..1387 ")" [] [Whitespace(" ")],
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@1387..1388 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@1388..1392 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@1392..1413 "media-interval-range" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1413..1414 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1414..1415 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1415..1417 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1417..1420 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssPageAtRule {
+                page_token: PAGE_KW@1420..1425 "page" [] [Whitespace(" ")],
+                selectors: CssPageSelectorList [],
+                block: CssPageAtRuleBlock {
+                    l_curly_token: L_CURLY@1425..1426 "{" [] [],
+                    items: CssPageAtRuleItemList [
+                        CssBogus {
+                            items: [
+                                CssIdentifier {
+                                    value_token: IDENT@1426..1433 "font" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                COLON@1433..1435 ":" [] [Whitespace(" ")],
+                                ScssExpression {
+                                    items: ScssExpressionItemList [],
+                                },
+                                CssDeclarationOrRuleBlock {
+                                    l_curly_token: L_CURLY@1435..1436 "{" [] [],
+                                    items: CssDeclarationOrRuleList [
+                                        CssDeclarationWithSemicolon {
+                                            declaration: CssDeclaration {
+                                                property: CssGenericProperty {
+                                                    name: CssIdentifier {
+                                                        value_token: IDENT@1436..1445 "size" [Newline("\n"), Whitespace("    ")] [],
+                                                    },
+                                                    colon_token: COLON@1445..1447 ":" [] [Whitespace(" ")],
+                                                    value: CssGenericComponentValueList [
+                                                        CssRegularDimension {
+                                                            value_token: CSS_NUMBER_LITERAL@1447..1449 "12" [] [],
+                                                            unit_token: IDENT@1449..1451 "px" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                                important: missing (optional),
+                                            },
+                                            semicolon_token: SEMICOLON@1451..1452 ";" [] [],
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@1452..1456 "}" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                            ],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1456..1458 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1458..1461 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssKeyframesAtRule {
+                keyframes_token: KEYFRAMES_KW@1461..1471 "keyframes" [] [Whitespace(" ")],
+                name: CssCustomIdentifier {
+                    value_token: IDENT@1471..1478 "loader" [] [Whitespace(" ")],
+                },
+                block: CssKeyframesBlock {
+                    l_curly_token: L_CURLY@1478..1479 "{" [] [],
+                    items: CssKeyframesItemList [
+                        CssKeyframesItem {
+                            selectors: CssKeyframesSelectorList [
+                                CssBogusSelector {
+                                    items: [
+                                        ScssInterpolation {
+                                            hash_token: HASH@1479..1483 "#" [Newline("\n"), Whitespace("  ")] [],
+                                            l_curly_token: L_CURLY@1483..1484 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@1484..1485 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@1485..1486 "i" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@1486..1487 "}" [] [],
+                                        },
+                                        PERCENT@1487..1489 "%" [] [Whitespace(" ")],
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationBlock {
+                                l_curly_token: L_CURLY@1489..1490 "{" [] [],
+                                declarations: CssDeclarationList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@1490..1502 "opacity" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@1502..1504 ":" [] [Whitespace(" ")],
+                                                value: CssGenericComponentValueList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1504..1505 "1" [] [],
+                                                    },
+                                                ],
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@1505..1506 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@1506..1510 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1510..1512 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1512..1515 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssBogusAtRule {
+                items: [
+                    ScssInterpolation {
+                        hash_token: HASH@1515..1516 "#" [] [],
+                        l_curly_token: L_CURLY@1516..1517 "{" [] [],
+                        value: ScssExpression {
+                            items: ScssExpressionItemList [
+                                ScssVariable {
+                                    dollar_token: DOLLAR@1517..1518 "$" [] [],
+                                    name: CssIdentifier {
+                                        value_token: IDENT@1518..1527 "rule-name" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                        r_curly_token: R_CURLY@1527..1529 "}" [] [Whitespace(" ")],
+                    },
+                    CssUnknownAtRuleComponentList {
+                        items: [
+                            ScssInterpolation {
+                                hash_token: HASH@1529..1530 "#" [] [],
+                                l_curly_token: L_CURLY@1530..1531 "{" [] [],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssVariable {
+                                            dollar_token: DOLLAR@1531..1532 "$" [] [],
+                                            name: CssIdentifier {
+                                                value_token: IDENT@1532..1537 "value" [] [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                r_curly_token: R_CURLY@1537..1538 "}" [] [],
+                            },
+                        ],
+                    },
+                    SEMICOLON@1538..1539 ";" [] [],
+                ],
+            },
+        },
+        CssAtRule {
+            at_token: AT@1539..1542 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssBogusAtRule {
+                items: [
+                    ScssInterpolation {
+                        hash_token: HASH@1542..1543 "#" [] [],
+                        l_curly_token: L_CURLY@1543..1544 "{" [] [],
+                        value: ScssExpression {
+                            items: ScssExpressionItemList [
+                                ScssVariable {
+                                    dollar_token: DOLLAR@1544..1545 "$" [] [],
+                                    name: CssIdentifier {
+                                        value_token: IDENT@1545..1555 "block-rule" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                        r_curly_token: R_CURLY@1555..1557 "}" [] [Whitespace(" ")],
+                    },
+                    CssUnknownAtRuleComponentList {
+                        items: [
+                            ScssInterpolation {
+                                hash_token: HASH@1557..1558 "#" [] [],
+                                l_curly_token: L_CURLY@1558..1559 "{" [] [],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssVariable {
+                                            dollar_token: DOLLAR@1559..1560 "$" [] [],
+                                            name: CssIdentifier {
+                                                value_token: IDENT@1560..1565 "value" [] [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                r_curly_token: R_CURLY@1565..1567 "}" [] [Whitespace(" ")],
+                            },
+                        ],
+                    },
+                    CssDeclarationOrRuleBlock {
+                        l_curly_token: L_CURLY@1567..1568 "{" [] [],
+                        items: CssDeclarationOrRuleList [
+                            CssDeclarationWithSemicolon {
+                                declaration: CssDeclaration {
+                                    property: CssGenericProperty {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@1568..1576 "color" [Newline("\n"), Whitespace("  ")] [],
+                                        },
+                                        colon_token: COLON@1576..1578 ":" [] [Whitespace(" ")],
+                                        value: CssGenericComponentValueList [
+                                            CssIdentifier {
+                                                value_token: IDENT@1578..1581 "red" [] [],
+                                            },
+                                        ],
+                                    },
+                                    important: missing (optional),
+                                },
+                                semicolon_token: SEMICOLON@1581..1582 ";" [] [],
+                            },
+                        ],
+                        r_curly_token: R_CURLY@1582..1584 "}" [Newline("\n")] [],
+                    },
+                ],
+            },
+        },
+    ],
+    eof_token: EOF@1584..1585 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..1585
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..1584
+    0: CSS_AT_RULE@0..47
+      0: AT@0..1 "@" [] []
+      1: CSS_SUPPORTS_AT_RULE@1..47
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@1..29
+          0: SUPPORTS_KW@1..10 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@10..29
+            0: L_PAREN@10..11 "(" [] []
+            1: CSS_DECLARATION@11..27
+              0: CSS_BOGUS_PROPERTY@11..27
+                0: CSS_IDENTIFIER@11..19
+                  0: IDENT@11..19 "variable" [] []
+                1: COLON@19..21 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@21..27
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@21..27
+                    0: DOLLAR@21..22 "$" [] []
+                    1: CSS_IDENTIFIER@22..27
+                      0: IDENT@22..27 "value" [] []
+              1: (empty)
+            2: R_PAREN@27..29 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@29..47
+          0: L_CURLY@29..30 "{" [] []
+          1: CSS_RULE_LIST@30..45
+            0: CSS_QUALIFIED_RULE@30..45
+              0: CSS_SELECTOR_LIST@30..43
+                0: CSS_COMPOUND_SELECTOR@30..43
+                  0: CSS_NESTED_SELECTOR_LIST@30..30
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@30..43
+                    0: CSS_CLASS_SELECTOR@30..43
+                      0: DOT@30..34 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@34..43
+                        0: IDENT@34..43 "variable" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@43..45
+                0: L_CURLY@43..44 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@44..44
+                2: R_CURLY@44..45 "}" [] []
+          2: R_CURLY@45..47 "}" [Newline("\n")] []
+    1: CSS_AT_RULE@47..133
+      0: AT@47..50 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@50..133
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@50..101
+          0: SUPPORTS_KW@50..59 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@59..101
+            0: L_PAREN@59..60 "(" [] []
+            1: CSS_DECLARATION@60..99
+              0: CSS_BOGUS_PROPERTY@60..99
+                0: CSS_IDENTIFIER@60..82
+                  0: IDENT@60..82 "variable-interpolation" [] []
+                1: COLON@82..84 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@84..99
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@84..99
+                    0: SCSS_INTERPOLATED_VALUE_PART_LIST@84..99
+                      0: SCSS_VARIABLE@84..90
+                        0: DOLLAR@84..85 "$" [] []
+                        1: CSS_IDENTIFIER@85..90
+                          0: IDENT@85..90 "value" [] []
+                      1: SCSS_INTERPOLATION@90..99
+                        0: HASH@90..91 "#" [] []
+                        1: L_CURLY@91..92 "{" [] []
+                        2: SCSS_EXPRESSION@92..98
+                          0: SCSS_EXPRESSION_ITEM_LIST@92..98
+                            0: CSS_IDENTIFIER@92..98
+                              0: IDENT@92..98 "suffix" [] []
+                        3: R_CURLY@98..99 "}" [] []
+              1: (empty)
+            2: R_PAREN@99..101 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@101..133
+          0: L_CURLY@101..102 "{" [] []
+          1: CSS_RULE_LIST@102..131
+            0: CSS_QUALIFIED_RULE@102..131
+              0: CSS_SELECTOR_LIST@102..129
+                0: CSS_COMPOUND_SELECTOR@102..129
+                  0: CSS_NESTED_SELECTOR_LIST@102..102
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@102..129
+                    0: CSS_CLASS_SELECTOR@102..129
+                      0: DOT@102..106 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@106..129
+                        0: IDENT@106..129 "variable-interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@129..131
+                0: L_CURLY@129..130 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@130..130
+                2: R_CURLY@130..131 "}" [] []
+          2: R_CURLY@131..133 "}" [Newline("\n")] []
+    2: CSS_AT_RULE@133..199
+      0: AT@133..136 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@136..199
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@136..176
+          0: SUPPORTS_KW@136..145 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@145..176
+            0: L_PAREN@145..146 "(" [] []
+            1: CSS_DECLARATION@146..174
+              0: CSS_BOGUS_PROPERTY@146..174
+                0: CSS_IDENTIFIER@146..159
+                  0: IDENT@146..159 "module-member" [] []
+                1: COLON@159..161 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@161..174
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@161..174
+                    0: CSS_IDENTIFIER@161..167
+                      0: IDENT@161..167 "module" [] []
+                    1: DOT@167..168 "." [] []
+                    2: SCSS_VARIABLE@168..174
+                      0: DOLLAR@168..169 "$" [] []
+                      1: CSS_IDENTIFIER@169..174
+                        0: IDENT@169..174 "value" [] []
+              1: (empty)
+            2: R_PAREN@174..176 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@176..199
+          0: L_CURLY@176..177 "{" [] []
+          1: CSS_RULE_LIST@177..197
+            0: CSS_QUALIFIED_RULE@177..197
+              0: CSS_SELECTOR_LIST@177..195
+                0: CSS_COMPOUND_SELECTOR@177..195
+                  0: CSS_NESTED_SELECTOR_LIST@177..177
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@177..195
+                    0: CSS_CLASS_SELECTOR@177..195
+                      0: DOT@177..181 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@181..195
+                        0: IDENT@181..195 "module-member" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@195..197
+                0: L_CURLY@195..196 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@196..196
+                2: R_CURLY@196..197 "}" [] []
+          2: R_CURLY@197..199 "}" [Newline("\n")] []
+    3: CSS_AT_RULE@199..302
+      0: AT@199..202 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@202..302
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@202..265
+          0: SUPPORTS_KW@202..211 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@211..265
+            0: L_PAREN@211..212 "(" [] []
+            1: CSS_DECLARATION@212..263
+              0: CSS_BOGUS_PROPERTY@212..263
+                0: CSS_IDENTIFIER@212..239
+                  0: IDENT@212..239 "module-member-interpolation" [] []
+                1: COLON@239..241 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@241..263
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@241..263
+                    0: SCSS_INTERPOLATED_VALUE_PART_LIST@241..263
+                      0: SCSS_NAMESPACED_VARIABLE@241..254
+                        0: CSS_IDENTIFIER@241..247
+                          0: IDENT@241..247 "module" [] []
+                        1: DOT@247..248 "." [] []
+                        2: SCSS_VARIABLE@248..254
+                          0: DOLLAR@248..249 "$" [] []
+                          1: CSS_IDENTIFIER@249..254
+                            0: IDENT@249..254 "value" [] []
+                      1: SCSS_INTERPOLATION@254..263
+                        0: HASH@254..255 "#" [] []
+                        1: L_CURLY@255..256 "{" [] []
+                        2: SCSS_EXPRESSION@256..262
+                          0: SCSS_EXPRESSION_ITEM_LIST@256..262
+                            0: CSS_IDENTIFIER@256..262
+                              0: IDENT@256..262 "suffix" [] []
+                        3: R_CURLY@262..263 "}" [] []
+              1: (empty)
+            2: R_PAREN@263..265 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@265..302
+          0: L_CURLY@265..266 "{" [] []
+          1: CSS_RULE_LIST@266..300
+            0: CSS_QUALIFIED_RULE@266..300
+              0: CSS_SELECTOR_LIST@266..298
+                0: CSS_COMPOUND_SELECTOR@266..298
+                  0: CSS_NESTED_SELECTOR_LIST@266..266
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@266..298
+                    0: CSS_CLASS_SELECTOR@266..298
+                      0: DOT@266..270 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@270..298
+                        0: IDENT@270..298 "module-member-interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@298..300
+                0: L_CURLY@298..299 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@299..299
+                2: R_CURLY@299..300 "}" [] []
+          2: R_CURLY@300..302 "}" [Newline("\n")] []
+    4: CSS_AT_RULE@302..377
+      0: AT@302..305 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@305..377
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@305..349
+          0: SUPPORTS_KW@305..314 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@314..349
+            0: L_PAREN@314..315 "(" [] []
+            1: CSS_DECLARATION@315..347
+              0: CSS_BOGUS_PROPERTY@315..347
+                0: CSS_IDENTIFIER@315..333
+                  0: IDENT@315..333 "qualified-function" [] []
+                1: COLON@333..335 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@335..347
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@335..347
+                    0: SCSS_MODULE_MEMBER_ACCESS@335..344
+                      0: CSS_IDENTIFIER@335..341
+                        0: IDENT@335..341 "module" [] []
+                      1: DOT@341..342 "." [] []
+                      2: CSS_IDENTIFIER@342..344
+                        0: IDENT@342..344 "fn" [] []
+                    1: L_PAREN@344..345 "(" [] []
+                    2: CSS_PARAMETER_LIST@345..346
+                      0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@345..346
+                        0: CSS_COMPONENT_VALUE_LIST@345..346
+                          0: CSS_NUMBER@345..346
+                            0: CSS_NUMBER_LITERAL@345..346 "1" [] []
+                    3: R_PAREN@346..347 ")" [] []
+              1: (empty)
+            2: R_PAREN@347..349 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@349..377
+          0: L_CURLY@349..350 "{" [] []
+          1: CSS_RULE_LIST@350..375
+            0: CSS_QUALIFIED_RULE@350..375
+              0: CSS_SELECTOR_LIST@350..373
+                0: CSS_COMPOUND_SELECTOR@350..373
+                  0: CSS_NESTED_SELECTOR_LIST@350..350
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@350..373
+                    0: CSS_CLASS_SELECTOR@350..373
+                      0: DOT@350..354 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@354..373
+                        0: IDENT@354..373 "qualified-function" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@373..375
+                0: L_CURLY@373..374 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@374..374
+                2: R_CURLY@374..375 "}" [] []
+          2: R_CURLY@375..377 "}" [Newline("\n")] []
+    5: CSS_AT_RULE@377..439
+      0: AT@377..380 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@380..439
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@380..416
+          0: SUPPORTS_KW@380..389 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@389..416
+            0: L_PAREN@389..390 "(" [] []
+            1: CSS_DECLARATION@390..414
+              0: CSS_BOGUS_PROPERTY@390..414
+                0: CSS_IDENTIFIER@390..403
+                  0: IDENT@390..403 "interpolation" [] []
+                1: COLON@403..405 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@405..414
+                  0: CSS_BOGUS@405..414
+                    0: HASH@405..406 "#" [] []
+                    1: L_CURLY@406..407 "{" [] []
+                    2: SCSS_EXPRESSION@407..413
+                      0: SCSS_EXPRESSION_ITEM_LIST@407..413
+                        0: SCSS_VARIABLE@407..413
+                          0: DOLLAR@407..408 "$" [] []
+                          1: CSS_IDENTIFIER@408..413
+                            0: IDENT@408..413 "value" [] []
+                    3: R_CURLY@413..414 "}" [] []
+              1: (empty)
+            2: R_PAREN@414..416 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@416..439
+          0: L_CURLY@416..417 "{" [] []
+          1: CSS_RULE_LIST@417..437
+            0: CSS_QUALIFIED_RULE@417..437
+              0: CSS_SELECTOR_LIST@417..435
+                0: CSS_COMPOUND_SELECTOR@417..435
+                  0: CSS_NESTED_SELECTOR_LIST@417..417
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@417..435
+                    0: CSS_CLASS_SELECTOR@417..435
+                      0: DOT@417..421 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@421..435
+                        0: IDENT@421..435 "interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@435..437
+                0: L_CURLY@435..436 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@436..436
+                2: R_CURLY@436..437 "}" [] []
+          2: R_CURLY@437..439 "}" [Newline("\n")] []
+    6: CSS_AT_RULE@439..522
+      0: AT@439..442 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@442..522
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@442..489
+          0: SUPPORTS_KW@442..451 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@451..489
+            0: L_PAREN@451..452 "(" [] []
+            1: CSS_DECLARATION@452..487
+              0: CSS_BOGUS_PROPERTY@452..487
+                0: CSS_IDENTIFIER@452..475
+                  0: IDENT@452..475 "adjacent-interpolations" [] []
+                1: COLON@475..477 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@477..487
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@477..487
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@477..487
+                      0: SCSS_INTERPOLATION@477..482
+                        0: HASH@477..478 "#" [] []
+                        1: L_CURLY@478..479 "{" [] []
+                        2: SCSS_EXPRESSION@479..481
+                          0: SCSS_EXPRESSION_ITEM_LIST@479..481
+                            0: SCSS_VARIABLE@479..481
+                              0: DOLLAR@479..480 "$" [] []
+                              1: CSS_IDENTIFIER@480..481
+                                0: IDENT@480..481 "a" [] []
+                        3: R_CURLY@481..482 "}" [] []
+                      1: SCSS_INTERPOLATION@482..487
+                        0: HASH@482..483 "#" [] []
+                        1: L_CURLY@483..484 "{" [] []
+                        2: SCSS_EXPRESSION@484..486
+                          0: SCSS_EXPRESSION_ITEM_LIST@484..486
+                            0: SCSS_VARIABLE@484..486
+                              0: DOLLAR@484..485 "$" [] []
+                              1: CSS_IDENTIFIER@485..486
+                                0: IDENT@485..486 "b" [] []
+                        3: R_CURLY@486..487 "}" [] []
+              1: (empty)
+            2: R_PAREN@487..489 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@489..522
+          0: L_CURLY@489..490 "{" [] []
+          1: CSS_RULE_LIST@490..520
+            0: CSS_QUALIFIED_RULE@490..520
+              0: CSS_SELECTOR_LIST@490..518
+                0: CSS_COMPOUND_SELECTOR@490..518
+                  0: CSS_NESTED_SELECTOR_LIST@490..490
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@490..518
+                    0: CSS_CLASS_SELECTOR@490..518
+                      0: DOT@490..494 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@494..518
+                        0: IDENT@494..518 "adjacent-interpolations" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@518..520
+                0: L_CURLY@518..519 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@519..519
+                2: R_CURLY@519..520 "}" [] []
+          2: R_CURLY@520..522 "}" [Newline("\n")] []
+    7: CSS_AT_RULE@522..598
+      0: AT@522..525 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@525..598
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@525..568
+          0: SUPPORTS_KW@525..534 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@534..568
+            0: L_PAREN@534..535 "(" [] []
+            1: CSS_DECLARATION@535..566
+              0: CSS_BOGUS_PROPERTY@535..566
+                0: CSS_IDENTIFIER@535..555
+                  0: IDENT@535..555 "number-interpolation" [] []
+                1: COLON@555..557 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@557..566
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@557..566
+                    0: SCSS_INTERPOLATED_VALUE_PART_LIST@557..566
+                      0: CSS_NUMBER@557..559
+                        0: CSS_NUMBER_LITERAL@557..559 "10" [] []
+                      1: SCSS_INTERPOLATION@559..566
+                        0: HASH@559..560 "#" [] []
+                        1: L_CURLY@560..561 "{" [] []
+                        2: SCSS_EXPRESSION@561..565
+                          0: SCSS_EXPRESSION_ITEM_LIST@561..565
+                            0: CSS_IDENTIFIER@561..565
+                              0: IDENT@561..565 "unit" [] []
+                        3: R_CURLY@565..566 "}" [] []
+              1: (empty)
+            2: R_PAREN@566..568 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@568..598
+          0: L_CURLY@568..569 "{" [] []
+          1: CSS_RULE_LIST@569..596
+            0: CSS_QUALIFIED_RULE@569..596
+              0: CSS_SELECTOR_LIST@569..594
+                0: CSS_COMPOUND_SELECTOR@569..594
+                  0: CSS_NESTED_SELECTOR_LIST@569..569
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@569..594
+                    0: CSS_CLASS_SELECTOR@569..594
+                      0: DOT@569..573 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@573..594
+                        0: IDENT@573..594 "number-interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@594..596
+                0: L_CURLY@594..595 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@595..595
+                2: R_CURLY@595..596 "}" [] []
+          2: R_CURLY@596..598 "}" [Newline("\n")] []
+    8: CSS_AT_RULE@598..684
+      0: AT@598..601 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@601..684
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@601..651
+          0: SUPPORTS_KW@601..610 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@610..651
+            0: L_PAREN@610..611 "(" [] []
+            1: CSS_DECLARATION@611..649
+              0: CSS_BOGUS_PROPERTY@611..649
+                0: CSS_IDENTIFIER@611..634
+                  0: IDENT@611..634 "dimension-interpolation" [] []
+                1: COLON@634..636 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@636..649
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@636..649
+                    0: SCSS_INTERPOLATED_VALUE_PART_LIST@636..649
+                      0: CSS_REGULAR_DIMENSION@636..640
+                        0: CSS_NUMBER_LITERAL@636..638 "10" [] []
+                        1: IDENT@638..640 "px" [] []
+                      1: SCSS_INTERPOLATION@640..649
+                        0: HASH@640..641 "#" [] []
+                        1: L_CURLY@641..642 "{" [] []
+                        2: SCSS_EXPRESSION@642..648
+                          0: SCSS_EXPRESSION_ITEM_LIST@642..648
+                            0: CSS_IDENTIFIER@642..648
+                              0: IDENT@642..648 "suffix" [] []
+                        3: R_CURLY@648..649 "}" [] []
+              1: (empty)
+            2: R_PAREN@649..651 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@651..684
+          0: L_CURLY@651..652 "{" [] []
+          1: CSS_RULE_LIST@652..682
+            0: CSS_QUALIFIED_RULE@652..682
+              0: CSS_SELECTOR_LIST@652..680
+                0: CSS_COMPOUND_SELECTOR@652..680
+                  0: CSS_NESTED_SELECTOR_LIST@652..652
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@652..680
+                    0: CSS_CLASS_SELECTOR@652..680
+                      0: DOT@652..656 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@656..680
+                        0: IDENT@656..680 "dimension-interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@680..682
+                0: L_CURLY@680..681 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@681..681
+                2: R_CURLY@681..682 "}" [] []
+          2: R_CURLY@682..684 "}" [Newline("\n")] []
+    9: CSS_AT_RULE@684..755
+      0: AT@684..687 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@687..755
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@687..728
+          0: SUPPORTS_KW@687..696 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@696..728
+            0: L_PAREN@696..697 "(" [] []
+            1: CSS_DECLARATION@697..726
+              0: CSS_BOGUS_PROPERTY@697..726
+                0: CSS_IDENTIFIER@697..714
+                  0: IDENT@697..714 "interpolated-name" [] []
+                1: COLON@714..716 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@716..726
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@716..726
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@716..726
+                      0: CSS_IDENTIFIER@716..719
+                        0: IDENT@716..719 "foo" [] []
+                      1: SCSS_INTERPOLATION@719..726
+                        0: HASH@719..720 "#" [] []
+                        1: L_CURLY@720..721 "{" [] []
+                        2: SCSS_EXPRESSION@721..725
+                          0: SCSS_EXPRESSION_ITEM_LIST@721..725
+                            0: SCSS_VARIABLE@721..725
+                              0: DOLLAR@721..722 "$" [] []
+                              1: CSS_IDENTIFIER@722..725
+                                0: IDENT@722..725 "bar" [] []
+                        3: R_CURLY@725..726 "}" [] []
+              1: (empty)
+            2: R_PAREN@726..728 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@728..755
+          0: L_CURLY@728..729 "{" [] []
+          1: CSS_RULE_LIST@729..753
+            0: CSS_QUALIFIED_RULE@729..753
+              0: CSS_SELECTOR_LIST@729..751
+                0: CSS_COMPOUND_SELECTOR@729..751
+                  0: CSS_NESTED_SELECTOR_LIST@729..729
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@729..751
+                    0: CSS_CLASS_SELECTOR@729..751
+                      0: DOT@729..733 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@733..751
+                        0: IDENT@733..751 "interpolated-name" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@751..753
+                0: L_CURLY@751..752 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@752..752
+                2: R_CURLY@752..753 "}" [] []
+          2: R_CURLY@753..755 "}" [Newline("\n")] []
+    10: CSS_AT_RULE@755..848
+      0: AT@755..758 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@758..848
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@758..810
+          0: SUPPORTS_KW@758..767 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@767..810
+            0: L_PAREN@767..768 "(" [] []
+            1: CSS_DECLARATION@768..808
+              0: CSS_BOGUS_PROPERTY@768..808
+                0: CSS_IDENTIFIER@768..796
+                  0: IDENT@768..796 "interpolated-custom-property" [] []
+                1: COLON@796..798 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@798..808
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@798..808
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@798..808
+                      0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@798..799
+                        0: MINUS@798..799 "-" [] []
+                      1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@799..800
+                        0: MINUS@799..800 "-" [] []
+                      2: SCSS_INTERPOLATION@800..808
+                        0: HASH@800..801 "#" [] []
+                        1: L_CURLY@801..802 "{" [] []
+                        2: SCSS_EXPRESSION@802..807
+                          0: SCSS_EXPRESSION_ITEM_LIST@802..807
+                            0: SCSS_VARIABLE@802..807
+                              0: DOLLAR@802..803 "$" [] []
+                              1: CSS_IDENTIFIER@803..807
+                                0: IDENT@803..807 "name" [] []
+                        3: R_CURLY@807..808 "}" [] []
+              1: (empty)
+            2: R_PAREN@808..810 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@810..848
+          0: L_CURLY@810..811 "{" [] []
+          1: CSS_RULE_LIST@811..846
+            0: CSS_QUALIFIED_RULE@811..846
+              0: CSS_SELECTOR_LIST@811..844
+                0: CSS_COMPOUND_SELECTOR@811..844
+                  0: CSS_NESTED_SELECTOR_LIST@811..811
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@811..844
+                    0: CSS_CLASS_SELECTOR@811..844
+                      0: DOT@811..815 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@815..844
+                        0: IDENT@815..844 "interpolated-custom-property" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@844..846
+                0: L_CURLY@844..845 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@845..845
+                2: R_CURLY@845..846 "}" [] []
+          2: R_CURLY@846..848 "}" [Newline("\n")] []
+    11: CSS_AT_RULE@848..961
+      0: AT@848..851 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@851..961
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@851..916
+          0: SUPPORTS_KW@851..860 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@860..916
+            0: L_PAREN@860..861 "(" [] []
+            1: CSS_DECLARATION@861..914
+              0: CSS_BOGUS_PROPERTY@861..914
+                0: CSS_IDENTIFIER@861..896
+                  0: IDENT@861..896 "interpolated-custom-property-suffix" [] []
+                1: COLON@896..898 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@898..914
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@898..914
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@898..914
+                      0: CSS_IDENTIFIER@898..906
+                        0: IDENT@898..906 "--theme-" [] []
+                      1: SCSS_INTERPOLATION@906..914
+                        0: HASH@906..907 "#" [] []
+                        1: L_CURLY@907..908 "{" [] []
+                        2: SCSS_EXPRESSION@908..913
+                          0: SCSS_EXPRESSION_ITEM_LIST@908..913
+                            0: SCSS_VARIABLE@908..913
+                              0: DOLLAR@908..909 "$" [] []
+                              1: CSS_IDENTIFIER@909..913
+                                0: IDENT@909..913 "slot" [] []
+                        3: R_CURLY@913..914 "}" [] []
+              1: (empty)
+            2: R_PAREN@914..916 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@916..961
+          0: L_CURLY@916..917 "{" [] []
+          1: CSS_RULE_LIST@917..959
+            0: CSS_QUALIFIED_RULE@917..959
+              0: CSS_SELECTOR_LIST@917..957
+                0: CSS_COMPOUND_SELECTOR@917..957
+                  0: CSS_NESTED_SELECTOR_LIST@917..917
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@917..957
+                    0: CSS_CLASS_SELECTOR@917..957
+                      0: DOT@917..921 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@921..957
+                        0: IDENT@921..957 "interpolated-custom-property-suffix" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@957..959
+                0: L_CURLY@957..958 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@958..958
+                2: R_CURLY@958..959 "}" [] []
+          2: R_CURLY@959..961 "}" [Newline("\n")] []
+    12: CSS_AT_RULE@961..1029
+      0: AT@961..964 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@964..1029
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@964..989
+          0: SUPPORTS_KW@964..973 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@973..989
+            0: L_PAREN@973..974 "(" [] []
+            1: CSS_DECLARATION@974..987
+              0: CSS_BOGUS_PROPERTY@974..987
+                0: CSS_BOGUS_SUPPORTS_CONDITION@974..982
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@974..982
+                    0: SCSS_INTERPOLATION@974..982
+                      0: HASH@974..975 "#" [] []
+                      1: L_CURLY@975..976 "{" [] []
+                      2: SCSS_EXPRESSION@976..981
+                        0: SCSS_EXPRESSION_ITEM_LIST@976..981
+                          0: SCSS_VARIABLE@976..981
+                            0: DOLLAR@976..977 "$" [] []
+                            1: CSS_IDENTIFIER@977..981
+                              0: IDENT@977..981 "name" [] []
+                      3: R_CURLY@981..982 "}" [] []
+                1: COLON@982..984 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@984..987
+                  0: CSS_IDENTIFIER@984..987
+                    0: IDENT@984..987 "red" [] []
+              1: (empty)
+            2: R_PAREN@987..989 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@989..1029
+          0: L_CURLY@989..990 "{" [] []
+          1: CSS_RULE_LIST@990..1027
+            0: CSS_QUALIFIED_RULE@990..1027
+              0: CSS_SELECTOR_LIST@990..1025
+                0: CSS_COMPOUND_SELECTOR@990..1025
+                  0: CSS_NESTED_SELECTOR_LIST@990..990
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@990..1025
+                    0: CSS_CLASS_SELECTOR@990..1025
+                      0: DOT@990..994 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@994..1025
+                        0: IDENT@994..1025 "supports-interpolated-property" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1025..1027
+                0: L_CURLY@1025..1026 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1026..1026
+                2: R_CURLY@1026..1027 "}" [] []
+          2: R_CURLY@1027..1029 "}" [Newline("\n")] []
+    13: CSS_AT_RULE@1029..1106
+      0: AT@1029..1032 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@1032..1106
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@1032..1059
+          0: SUPPORTS_KW@1032..1041 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@1041..1059
+            0: L_PAREN@1041..1042 "(" [] []
+            1: CSS_DECLARATION@1042..1057
+              0: CSS_BOGUS_PROPERTY@1042..1057
+                0: CSS_BOGUS_SUPPORTS_CONDITION@1042..1052
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1042..1052
+                    0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@1042..1043
+                      0: MINUS@1042..1043 "-" [] []
+                    1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@1043..1044
+                      0: MINUS@1043..1044 "-" [] []
+                    2: SCSS_INTERPOLATION@1044..1052
+                      0: HASH@1044..1045 "#" [] []
+                      1: L_CURLY@1045..1046 "{" [] []
+                      2: SCSS_EXPRESSION@1046..1051
+                        0: SCSS_EXPRESSION_ITEM_LIST@1046..1051
+                          0: SCSS_VARIABLE@1046..1051
+                            0: DOLLAR@1046..1047 "$" [] []
+                            1: CSS_IDENTIFIER@1047..1051
+                              0: IDENT@1047..1051 "name" [] []
+                      3: R_CURLY@1051..1052 "}" [] []
+                1: COLON@1052..1054 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@1054..1057
+                  0: CSS_IDENTIFIER@1054..1057
+                    0: IDENT@1054..1057 "red" [] []
+              1: (empty)
+            2: R_PAREN@1057..1059 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@1059..1106
+          0: L_CURLY@1059..1060 "{" [] []
+          1: CSS_RULE_LIST@1060..1104
+            0: CSS_QUALIFIED_RULE@1060..1104
+              0: CSS_SELECTOR_LIST@1060..1102
+                0: CSS_COMPOUND_SELECTOR@1060..1102
+                  0: CSS_NESTED_SELECTOR_LIST@1060..1060
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@1060..1102
+                    0: CSS_CLASS_SELECTOR@1060..1102
+                      0: DOT@1060..1064 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@1064..1102
+                        0: IDENT@1064..1102 "supports-interpolated-custom-property" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1102..1104
+                0: L_CURLY@1102..1103 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1103..1103
+                2: R_CURLY@1103..1104 "}" [] []
+          2: R_CURLY@1104..1106 "}" [Newline("\n")] []
+    14: CSS_AT_RULE@1106..1178
+      0: AT@1106..1109 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@1109..1178
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1109..1144
+          0: MEDIA_KW@1109..1115 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@1115..1144
+            0: CSS_BOGUS_MEDIA_QUERY@1115..1144
+              0: CSS_BOGUS@1115..1144
+                0: L_PAREN@1115..1116 "(" [] []
+                1: CSS_BOGUS@1116..1142
+                  0: CSS_IDENTIFIER@1116..1128
+                    0: IDENT@1116..1128 "aspect-ratio" [] []
+                  1: COLON@1128..1130 ":" [] [Whitespace(" ")]
+                  2: CSS_BOGUS_SUPPORTS_CONDITION@1130..1142
+                    0: SCSS_MODULE_MEMBER_ACCESS@1130..1139
+                      0: CSS_IDENTIFIER@1130..1136
+                        0: IDENT@1130..1136 "module" [] []
+                      1: DOT@1136..1137 "." [] []
+                      2: CSS_IDENTIFIER@1137..1139
+                        0: IDENT@1137..1139 "fn" [] []
+                    1: L_PAREN@1139..1140 "(" [] []
+                    2: CSS_PARAMETER_LIST@1140..1141
+                      0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@1140..1141
+                        0: CSS_COMPONENT_VALUE_LIST@1140..1141
+                          0: CSS_NUMBER@1140..1141
+                            0: CSS_NUMBER_LITERAL@1140..1141 "1" [] []
+                    3: R_PAREN@1141..1142 ")" [] []
+                2: R_PAREN@1142..1144 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@1144..1178
+          0: L_CURLY@1144..1145 "{" [] []
+          1: CSS_RULE_LIST@1145..1176
+            0: CSS_QUALIFIED_RULE@1145..1176
+              0: CSS_SELECTOR_LIST@1145..1174
+                0: CSS_COMPOUND_SELECTOR@1145..1174
+                  0: CSS_NESTED_SELECTOR_LIST@1145..1145
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@1145..1174
+                    0: CSS_CLASS_SELECTOR@1145..1174
+                      0: DOT@1145..1149 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@1149..1174
+                        0: IDENT@1149..1174 "media-qualified-function" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1174..1176
+                0: L_CURLY@1174..1175 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1175..1175
+                2: R_CURLY@1175..1176 "}" [] []
+          2: R_CURLY@1176..1178 "}" [Newline("\n")] []
+    15: CSS_AT_RULE@1178..1251
+      0: AT@1178..1181 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@1181..1251
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1181..1212
+          0: MEDIA_KW@1181..1187 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@1187..1212
+            0: CSS_BOGUS_MEDIA_QUERY@1187..1212
+              0: CSS_BOGUS@1187..1212
+                0: L_PAREN@1187..1188 "(" [] []
+                1: CSS_BOGUS@1188..1210
+                  0: CSS_IDENTIFIER@1188..1198
+                    0: IDENT@1188..1198 "resolution" [] []
+                  1: COLON@1198..1200 ":" [] [Whitespace(" ")]
+                  2: CSS_BOGUS_SUPPORTS_CONDITION@1200..1210
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1200..1210
+                      0: SCSS_INTERPOLATION@1200..1205
+                        0: HASH@1200..1201 "#" [] []
+                        1: L_CURLY@1201..1202 "{" [] []
+                        2: SCSS_EXPRESSION@1202..1204
+                          0: SCSS_EXPRESSION_ITEM_LIST@1202..1204
+                            0: SCSS_VARIABLE@1202..1204
+                              0: DOLLAR@1202..1203 "$" [] []
+                              1: CSS_IDENTIFIER@1203..1204
+                                0: IDENT@1203..1204 "a" [] []
+                        3: R_CURLY@1204..1205 "}" [] []
+                      1: SCSS_INTERPOLATION@1205..1210
+                        0: HASH@1205..1206 "#" [] []
+                        1: L_CURLY@1206..1207 "{" [] []
+                        2: SCSS_EXPRESSION@1207..1209
+                          0: SCSS_EXPRESSION_ITEM_LIST@1207..1209
+                            0: SCSS_VARIABLE@1207..1209
+                              0: DOLLAR@1207..1208 "$" [] []
+                              1: CSS_IDENTIFIER@1208..1209
+                                0: IDENT@1208..1209 "b" [] []
+                        3: R_CURLY@1209..1210 "}" [] []
+                2: R_PAREN@1210..1212 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@1212..1251
+          0: L_CURLY@1212..1213 "{" [] []
+          1: CSS_RULE_LIST@1213..1249
+            0: CSS_QUALIFIED_RULE@1213..1249
+              0: CSS_SELECTOR_LIST@1213..1247
+                0: CSS_COMPOUND_SELECTOR@1213..1247
+                  0: CSS_NESTED_SELECTOR_LIST@1213..1213
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@1213..1247
+                    0: CSS_CLASS_SELECTOR@1213..1247
+                      0: DOT@1213..1217 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@1217..1247
+                        0: IDENT@1217..1247 "media-adjacent-interpolations" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1247..1249
+                0: L_CURLY@1247..1248 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1248..1248
+                2: R_CURLY@1248..1249 "}" [] []
+          2: R_CURLY@1249..1251 "}" [Newline("\n")] []
+    16: CSS_AT_RULE@1251..1291
+      0: AT@1251..1254 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@1254..1291
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1254..1270
+          0: MEDIA_KW@1254..1260 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@1260..1270
+            0: CSS_BOGUS_MEDIA_QUERY@1260..1270
+              0: SCSS_INTERPOLATION@1260..1270
+                0: HASH@1260..1261 "#" [] []
+                1: L_CURLY@1261..1262 "{" [] []
+                2: SCSS_EXPRESSION@1262..1268
+                  0: SCSS_EXPRESSION_ITEM_LIST@1262..1268
+                    0: SCSS_VARIABLE@1262..1268
+                      0: DOLLAR@1262..1263 "$" [] []
+                      1: CSS_IDENTIFIER@1263..1268
+                        0: IDENT@1263..1268 "query" [] []
+                3: R_CURLY@1268..1270 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@1270..1291
+          0: L_CURLY@1270..1271 "{" [] []
+          1: CSS_RULE_LIST@1271..1289
+            0: CSS_QUALIFIED_RULE@1271..1289
+              0: CSS_SELECTOR_LIST@1271..1287
+                0: CSS_COMPOUND_SELECTOR@1271..1287
+                  0: CSS_NESTED_SELECTOR_LIST@1271..1271
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@1271..1287
+                    0: CSS_CLASS_SELECTOR@1271..1287
+                      0: DOT@1271..1275 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@1275..1287
+                        0: IDENT@1275..1287 "media-query" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1287..1289
+                0: L_CURLY@1287..1288 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1288..1288
+                2: R_CURLY@1288..1289 "}" [] []
+          2: R_CURLY@1289..1291 "}" [Newline("\n")] []
+    17: CSS_AT_RULE@1291..1348
+      0: AT@1291..1294 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@1294..1348
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1294..1319
+          0: MEDIA_KW@1294..1300 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@1300..1319
+            0: CSS_BOGUS_MEDIA_QUERY@1300..1319
+              0: CSS_BOGUS@1300..1319
+                0: L_PAREN@1300..1301 "(" [] []
+                1: CSS_BOGUS@1301..1317
+                  0: SCSS_INTERPOLATION@1301..1309
+                    0: HASH@1301..1302 "#" [] []
+                    1: L_CURLY@1302..1303 "{" [] []
+                    2: SCSS_EXPRESSION@1303..1307
+                      0: SCSS_EXPRESSION_ITEM_LIST@1303..1307
+                        0: SCSS_VARIABLE@1303..1307
+                          0: DOLLAR@1303..1304 "$" [] []
+                          1: CSS_IDENTIFIER@1304..1307
+                            0: IDENT@1304..1307 "min" [] []
+                    3: R_CURLY@1307..1309 "}" [] [Whitespace(" ")]
+                  1: CSS_QUERY_FEATURE_RANGE_COMPARISON@1309..1312
+                    0: LTEQ@1309..1312 "<=" [] [Whitespace(" ")]
+                  2: CSS_IDENTIFIER@1312..1317
+                    0: IDENT@1312..1317 "width" [] []
+                2: R_PAREN@1317..1319 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@1319..1348
+          0: L_CURLY@1319..1320 "{" [] []
+          1: CSS_RULE_LIST@1320..1346
+            0: CSS_QUALIFIED_RULE@1320..1346
+              0: CSS_SELECTOR_LIST@1320..1344
+                0: CSS_COMPOUND_SELECTOR@1320..1344
+                  0: CSS_NESTED_SELECTOR_LIST@1320..1320
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@1320..1344
+                    0: CSS_CLASS_SELECTOR@1320..1344
+                      0: DOT@1320..1324 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@1324..1344
+                        0: IDENT@1324..1344 "media-reverse-range" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1344..1346
+                0: L_CURLY@1344..1345 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1345..1345
+                2: R_CURLY@1345..1346 "}" [] []
+          2: R_CURLY@1346..1348 "}" [Newline("\n")] []
+    18: CSS_AT_RULE@1348..1417
+      0: AT@1348..1351 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@1351..1417
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1351..1387
+          0: MEDIA_KW@1351..1357 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@1357..1387
+            0: CSS_BOGUS_MEDIA_QUERY@1357..1387
+              0: CSS_BOGUS@1357..1387
+                0: L_PAREN@1357..1358 "(" [] []
+                1: CSS_BOGUS@1358..1385
+                  0: SCSS_INTERPOLATION@1358..1366
+                    0: HASH@1358..1359 "#" [] []
+                    1: L_CURLY@1359..1360 "{" [] []
+                    2: SCSS_EXPRESSION@1360..1364
+                      0: SCSS_EXPRESSION_ITEM_LIST@1360..1364
+                        0: SCSS_VARIABLE@1360..1364
+                          0: DOLLAR@1360..1361 "$" [] []
+                          1: CSS_IDENTIFIER@1361..1364
+                            0: IDENT@1361..1364 "min" [] []
+                    3: R_CURLY@1364..1366 "}" [] [Whitespace(" ")]
+                  1: CSS_QUERY_FEATURE_RANGE_COMPARISON@1366..1369
+                    0: LTEQ@1366..1369 "<=" [] [Whitespace(" ")]
+                  2: CSS_IDENTIFIER@1369..1375
+                    0: IDENT@1369..1375 "width" [] [Whitespace(" ")]
+                  3: CSS_QUERY_FEATURE_RANGE_COMPARISON@1375..1378
+                    0: LTEQ@1375..1378 "<=" [] [Whitespace(" ")]
+                  4: CSS_BOGUS@1378..1385
+                    0: HASH@1378..1379 "#" [] []
+                    1: L_CURLY@1379..1380 "{" [] []
+                    2: SCSS_EXPRESSION@1380..1384
+                      0: SCSS_EXPRESSION_ITEM_LIST@1380..1384
+                        0: SCSS_VARIABLE@1380..1384
+                          0: DOLLAR@1380..1381 "$" [] []
+                          1: CSS_IDENTIFIER@1381..1384
+                            0: IDENT@1381..1384 "max" [] []
+                    3: R_CURLY@1384..1385 "}" [] []
+                2: R_PAREN@1385..1387 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@1387..1417
+          0: L_CURLY@1387..1388 "{" [] []
+          1: CSS_RULE_LIST@1388..1415
+            0: CSS_QUALIFIED_RULE@1388..1415
+              0: CSS_SELECTOR_LIST@1388..1413
+                0: CSS_COMPOUND_SELECTOR@1388..1413
+                  0: CSS_NESTED_SELECTOR_LIST@1388..1388
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@1388..1413
+                    0: CSS_CLASS_SELECTOR@1388..1413
+                      0: DOT@1388..1392 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@1392..1413
+                        0: IDENT@1392..1413 "media-interval-range" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1413..1415
+                0: L_CURLY@1413..1414 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1414..1414
+                2: R_CURLY@1414..1415 "}" [] []
+          2: R_CURLY@1415..1417 "}" [Newline("\n")] []
+    19: CSS_AT_RULE@1417..1458
+      0: AT@1417..1420 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_PAGE_AT_RULE@1420..1458
+        0: PAGE_KW@1420..1425 "page" [] [Whitespace(" ")]
+        1: CSS_PAGE_SELECTOR_LIST@1425..1425
+        2: CSS_PAGE_AT_RULE_BLOCK@1425..1458
+          0: L_CURLY@1425..1426 "{" [] []
+          1: CSS_PAGE_AT_RULE_ITEM_LIST@1426..1456
+            0: CSS_BOGUS@1426..1456
+              0: CSS_IDENTIFIER@1426..1433
+                0: IDENT@1426..1433 "font" [Newline("\n"), Whitespace("  ")] []
+              1: COLON@1433..1435 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@1435..1435
+                0: SCSS_EXPRESSION_ITEM_LIST@1435..1435
+              3: CSS_DECLARATION_OR_RULE_BLOCK@1435..1456
+                0: L_CURLY@1435..1436 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1436..1452
+                  0: CSS_DECLARATION_WITH_SEMICOLON@1436..1452
+                    0: CSS_DECLARATION@1436..1451
+                      0: CSS_GENERIC_PROPERTY@1436..1451
+                        0: CSS_IDENTIFIER@1436..1445
+                          0: IDENT@1436..1445 "size" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@1445..1447 ":" [] [Whitespace(" ")]
+                        2: CSS_GENERIC_COMPONENT_VALUE_LIST@1447..1451
+                          0: CSS_REGULAR_DIMENSION@1447..1451
+                            0: CSS_NUMBER_LITERAL@1447..1449 "12" [] []
+                            1: IDENT@1449..1451 "px" [] []
+                      1: (empty)
+                    1: SEMICOLON@1451..1452 ";" [] []
+                2: R_CURLY@1452..1456 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@1456..1458 "}" [Newline("\n")] []
+    20: CSS_AT_RULE@1458..1512
+      0: AT@1458..1461 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_KEYFRAMES_AT_RULE@1461..1512
+        0: KEYFRAMES_KW@1461..1471 "keyframes" [] [Whitespace(" ")]
+        1: CSS_CUSTOM_IDENTIFIER@1471..1478
+          0: IDENT@1471..1478 "loader" [] [Whitespace(" ")]
+        2: CSS_KEYFRAMES_BLOCK@1478..1512
+          0: L_CURLY@1478..1479 "{" [] []
+          1: CSS_KEYFRAMES_ITEM_LIST@1479..1510
+            0: CSS_KEYFRAMES_ITEM@1479..1510
+              0: CSS_KEYFRAMES_SELECTOR_LIST@1479..1489
+                0: CSS_BOGUS_SELECTOR@1479..1489
+                  0: SCSS_INTERPOLATION@1479..1487
+                    0: HASH@1479..1483 "#" [Newline("\n"), Whitespace("  ")] []
+                    1: L_CURLY@1483..1484 "{" [] []
+                    2: SCSS_EXPRESSION@1484..1486
+                      0: SCSS_EXPRESSION_ITEM_LIST@1484..1486
+                        0: SCSS_VARIABLE@1484..1486
+                          0: DOLLAR@1484..1485 "$" [] []
+                          1: CSS_IDENTIFIER@1485..1486
+                            0: IDENT@1485..1486 "i" [] []
+                    3: R_CURLY@1486..1487 "}" [] []
+                  1: PERCENT@1487..1489 "%" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_BLOCK@1489..1510
+                0: L_CURLY@1489..1490 "{" [] []
+                1: CSS_DECLARATION_LIST@1490..1506
+                  0: CSS_DECLARATION_WITH_SEMICOLON@1490..1506
+                    0: CSS_DECLARATION@1490..1505
+                      0: CSS_GENERIC_PROPERTY@1490..1505
+                        0: CSS_IDENTIFIER@1490..1502
+                          0: IDENT@1490..1502 "opacity" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@1502..1504 ":" [] [Whitespace(" ")]
+                        2: CSS_GENERIC_COMPONENT_VALUE_LIST@1504..1505
+                          0: CSS_NUMBER@1504..1505
+                            0: CSS_NUMBER_LITERAL@1504..1505 "1" [] []
+                      1: (empty)
+                    1: SEMICOLON@1505..1506 ";" [] []
+                2: R_CURLY@1506..1510 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@1510..1512 "}" [Newline("\n")] []
+    21: CSS_AT_RULE@1512..1539
+      0: AT@1512..1515 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_BOGUS_AT_RULE@1515..1539
+        0: SCSS_INTERPOLATION@1515..1529
+          0: HASH@1515..1516 "#" [] []
+          1: L_CURLY@1516..1517 "{" [] []
+          2: SCSS_EXPRESSION@1517..1527
+            0: SCSS_EXPRESSION_ITEM_LIST@1517..1527
+              0: SCSS_VARIABLE@1517..1527
+                0: DOLLAR@1517..1518 "$" [] []
+                1: CSS_IDENTIFIER@1518..1527
+                  0: IDENT@1518..1527 "rule-name" [] []
+          3: R_CURLY@1527..1529 "}" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@1529..1538
+          0: SCSS_INTERPOLATION@1529..1538
+            0: HASH@1529..1530 "#" [] []
+            1: L_CURLY@1530..1531 "{" [] []
+            2: SCSS_EXPRESSION@1531..1537
+              0: SCSS_EXPRESSION_ITEM_LIST@1531..1537
+                0: SCSS_VARIABLE@1531..1537
+                  0: DOLLAR@1531..1532 "$" [] []
+                  1: CSS_IDENTIFIER@1532..1537
+                    0: IDENT@1532..1537 "value" [] []
+            3: R_CURLY@1537..1538 "}" [] []
+        2: SEMICOLON@1538..1539 ";" [] []
+    22: CSS_AT_RULE@1539..1584
+      0: AT@1539..1542 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_BOGUS_AT_RULE@1542..1584
+        0: SCSS_INTERPOLATION@1542..1557
+          0: HASH@1542..1543 "#" [] []
+          1: L_CURLY@1543..1544 "{" [] []
+          2: SCSS_EXPRESSION@1544..1555
+            0: SCSS_EXPRESSION_ITEM_LIST@1544..1555
+              0: SCSS_VARIABLE@1544..1555
+                0: DOLLAR@1544..1545 "$" [] []
+                1: CSS_IDENTIFIER@1545..1555
+                  0: IDENT@1545..1555 "block-rule" [] []
+          3: R_CURLY@1555..1557 "}" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@1557..1567
+          0: SCSS_INTERPOLATION@1557..1567
+            0: HASH@1557..1558 "#" [] []
+            1: L_CURLY@1558..1559 "{" [] []
+            2: SCSS_EXPRESSION@1559..1565
+              0: SCSS_EXPRESSION_ITEM_LIST@1559..1565
+                0: SCSS_VARIABLE@1559..1565
+                  0: DOLLAR@1559..1560 "$" [] []
+                  1: CSS_IDENTIFIER@1560..1565
+                    0: IDENT@1560..1565 "value" [] []
+            3: R_CURLY@1565..1567 "}" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@1567..1584
+          0: L_CURLY@1567..1568 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@1568..1582
+            0: CSS_DECLARATION_WITH_SEMICOLON@1568..1582
+              0: CSS_DECLARATION@1568..1581
+                0: CSS_GENERIC_PROPERTY@1568..1581
+                  0: CSS_IDENTIFIER@1568..1576
+                    0: IDENT@1568..1576 "color" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@1576..1578 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@1578..1581
+                    0: CSS_IDENTIFIER@1578..1581
+                      0: IDENT@1578..1581 "red" [] []
+                1: (empty)
+              1: SEMICOLON@1581..1582 ";" [] []
+          2: R_CURLY@1582..1584 "}" [Newline("\n")] []
+  2: EOF@1584..1585 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+scss_exclusive_values.css:1:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS variables are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+  > 1 │ @supports (variable: $value) {
+      │                      ^^^^^^
+    2 │   .variable {}
+    3 │ }
+  
+scss_exclusive_values.css:5:36 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    3 │ }
+    4 │ 
+  > 5 │ @supports (variable-interpolation: $value#{suffix}) {
+      │                                    ^^^^^^^^^^^^^^^
+    6 │   .variable-interpolation {}
+    7 │ }
+  
+scss_exclusive_values.css:9:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS module member accesses are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+     7 │ }
+     8 │ 
+   > 9 │ @supports (module-member: module.$value) {
+       │                           ^^^^^^^^^^^^^
+    10 │   .module-member {}
+    11 │ }
+  
+scss_exclusive_values.css:13:41 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    11 │ }
+    12 │ 
+  > 13 │ @supports (module-member-interpolation: module.$value#{suffix}) {
+       │                                         ^^^^^^^^^^^^^^^^^^^^^^
+    14 │   .module-member-interpolation {}
+    15 │ }
+  
+scss_exclusive_values.css:17:32 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS qualified function names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    15 │ }
+    16 │ 
+  > 17 │ @supports (qualified-function: module.fn(1)) {
+       │                                ^^^^^^^^^^^^
+    18 │   .qualified-function {}
+    19 │ }
+  
+scss_exclusive_values.css:21:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    19 │ }
+    20 │ 
+  > 21 │ @supports (interpolation: #{$value}) {
+       │                           ^^^^^^^^^
+    22 │   .interpolation {}
+    23 │ }
+  
+scss_exclusive_values.css:25:37 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    23 │ }
+    24 │ 
+  > 25 │ @supports (adjacent-interpolations: #{$a}#{$b}) {
+       │                                     ^^^^^^^^^^
+    26 │   .adjacent-interpolations {}
+    27 │ }
+  
+scss_exclusive_values.css:29:34 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    27 │ }
+    28 │ 
+  > 29 │ @supports (number-interpolation: 10#{unit}) {
+       │                                  ^^^^^^^^^
+    30 │   .number-interpolation {}
+    31 │ }
+  
+scss_exclusive_values.css:33:37 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    31 │ }
+    32 │ 
+  > 33 │ @supports (dimension-interpolation: 10px#{suffix}) {
+       │                                     ^^^^^^^^^^^^^
+    34 │   .dimension-interpolation {}
+    35 │ }
+  
+scss_exclusive_values.css:37:31 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    35 │ }
+    36 │ 
+  > 37 │ @supports (interpolated-name: foo#{$bar}) {
+       │                               ^^^^^^^^^^
+    38 │   .interpolated-name {}
+    39 │ }
+  
+scss_exclusive_values.css:41:42 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated dashed identifiers are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    39 │ }
+    40 │ 
+  > 41 │ @supports (interpolated-custom-property: --#{$name}) {
+       │                                          ^^^^^^^^^^
+    42 │   .interpolated-custom-property {}
+    43 │ }
+  
+scss_exclusive_values.css:45:49 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated dashed identifiers are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    43 │ }
+    44 │ 
+  > 45 │ @supports (interpolated-custom-property-suffix: --theme-#{$slot}) {
+       │                                                 ^^^^^^^^^^^^^^^^
+    46 │   .interpolated-custom-property-suffix {}
+    47 │ }
+  
+scss_exclusive_values.css:49:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated property names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    47 │ }
+    48 │ 
+  > 49 │ @supports (#{$name}: red) {
+       │            ^^^^^^^^
+    50 │   .supports-interpolated-property {}
+    51 │ }
+  
+scss_exclusive_values.css:53:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated property names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    51 │ }
+    52 │ 
+  > 53 │ @supports (--#{$name}: red) {
+       │            ^^^^^^^^^^
+    54 │   .supports-interpolated-custom-property {}
+    55 │ }
+  
+scss_exclusive_values.css:57:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS qualified function names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    55 │ }
+    56 │ 
+  > 57 │ @media (aspect-ratio: module.fn(1)) {
+       │                       ^^^^^^^^^^^^
+    58 │   .media-qualified-function {}
+    59 │ }
+  
+scss_exclusive_values.css:61:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated query feature values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    59 │ }
+    60 │ 
+  > 61 │ @media (resolution: #{$a}#{$b}) {
+       │                     ^^^^^^^^^^
+    62 │   .media-adjacent-interpolations {}
+    63 │ }
+  
+scss_exclusive_values.css:65:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated media queries are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    63 │ }
+    64 │ 
+  > 65 │ @media #{$query} {
+       │        ^^^^^^^^^
+    66 │   .media-query {}
+    67 │ }
+  
+scss_exclusive_values.css:69:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated query features are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    67 │ }
+    68 │ 
+  > 69 │ @media (#{$min} <= width) {
+       │         ^^^^^^^^^^^^^^^^
+    70 │   .media-reverse-range {}
+    71 │ }
+  
+scss_exclusive_values.css:73:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated query features are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    71 │ }
+    72 │ 
+  > 73 │ @media (#{$min} <= width <= #{$max}) {
+       │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    74 │   .media-interval-range {}
+    75 │ }
+  
+scss_exclusive_values.css:78:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS nested property declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    77 │ @page {
+  > 78 │   font: {
+       │   ^^^^^^^
+  > 79 │     size: 12px;
+  > 80 │   }
+       │   ^
+    81 │ }
+    82 │ 
+  
+scss_exclusive_values.css:84:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated keyframe selectors are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    83 │ @keyframes loader {
+  > 84 │   #{$i}% {
+       │   ^^^^^^
+    85 │     opacity: 1;
+    86 │   }
+  
+scss_exclusive_values.css:89:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated at-rule names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    87 │ }
+    88 │ 
+  > 89 │ @#{$rule-name} #{$value};
+       │  ^^^^^^^^^^^^^^^^^^^^^^^^
+    90 │ 
+    91 │ @#{$block-rule} #{$value} {
+  
+scss_exclusive_values.css:91:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated at-rule names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    89 │ @#{$rule-name} #{$value};
+    90 │ 
+  > 91 │ @#{$block-rule} #{$value} {
+       │  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 92 │   color: red;
+  > 93 │ }
+       │ ^
+    94 │ 
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css.snap
@@ -88,6 +88,12 @@ expression: snapshot
   }
 }
 
+@function --nested-property() {
+  font: {
+    size: 12px;
+  }
+}
+
 @keyframes loader {
   #{$i}% {
     opacity: 1;
@@ -1620,183 +1626,245 @@ CssRoot {
         },
         CssAtRule {
             at_token: AT@1458..1461 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssBogusAtRule {
+                items: [
+                    CssFunctionAtRuleDeclarator {
+                        function_token: FUNCTION_KW@1461..1470 "function" [] [Whitespace(" ")],
+                        name: CssDashedIdentifier {
+                            value_token: IDENT@1470..1487 "--nested-property" [] [],
+                        },
+                        l_paren_token: L_PAREN@1487..1488 "(" [] [],
+                        parameters: CssFunctionParameterList [],
+                        r_paren_token: R_PAREN@1488..1490 ")" [] [Whitespace(" ")],
+                        returns: missing (optional),
+                    },
+                    CssBogusBlock {
+                        items: [
+                            L_CURLY@1490..1491 "{" [] [],
+                            CssBogus {
+                                items: [
+                                    CssBogus {
+                                        items: [
+                                            CssIdentifier {
+                                                value_token: IDENT@1491..1498 "font" [Newline("\n"), Whitespace("  ")] [],
+                                            },
+                                            COLON@1498..1500 ":" [] [Whitespace(" ")],
+                                            ScssExpression {
+                                                items: ScssExpressionItemList [],
+                                            },
+                                            CssDeclarationOrRuleBlock {
+                                                l_curly_token: L_CURLY@1500..1501 "{" [] [],
+                                                items: CssDeclarationOrRuleList [
+                                                    CssDeclarationWithSemicolon {
+                                                        declaration: CssDeclaration {
+                                                            property: CssGenericProperty {
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@1501..1510 "size" [Newline("\n"), Whitespace("    ")] [],
+                                                                },
+                                                                colon_token: COLON@1510..1512 ":" [] [Whitespace(" ")],
+                                                                value: CssGenericComponentValueList [
+                                                                    CssRegularDimension {
+                                                                        value_token: CSS_NUMBER_LITERAL@1512..1514 "12" [] [],
+                                                                        unit_token: IDENT@1514..1516 "px" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            important: missing (optional),
+                                                        },
+                                                        semicolon_token: SEMICOLON@1516..1517 ";" [] [],
+                                                    },
+                                                ],
+                                                r_curly_token: R_CURLY@1517..1521 "}" [Newline("\n"), Whitespace("  ")] [],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            R_CURLY@1521..1523 "}" [Newline("\n")] [],
+                        ],
+                    },
+                ],
+            },
+        },
+        CssAtRule {
+            at_token: AT@1523..1526 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssKeyframesAtRule {
-                keyframes_token: KEYFRAMES_KW@1461..1471 "keyframes" [] [Whitespace(" ")],
+                keyframes_token: KEYFRAMES_KW@1526..1536 "keyframes" [] [Whitespace(" ")],
                 name: CssCustomIdentifier {
-                    value_token: IDENT@1471..1478 "loader" [] [Whitespace(" ")],
+                    value_token: IDENT@1536..1543 "loader" [] [Whitespace(" ")],
                 },
                 block: CssKeyframesBlock {
-                    l_curly_token: L_CURLY@1478..1479 "{" [] [],
+                    l_curly_token: L_CURLY@1543..1544 "{" [] [],
                     items: CssKeyframesItemList [
                         CssKeyframesItem {
                             selectors: CssKeyframesSelectorList [
                                 CssBogusSelector {
                                     items: [
                                         ScssInterpolation {
-                                            hash_token: HASH@1479..1483 "#" [Newline("\n"), Whitespace("  ")] [],
-                                            l_curly_token: L_CURLY@1483..1484 "{" [] [],
+                                            hash_token: HASH@1544..1548 "#" [Newline("\n"), Whitespace("  ")] [],
+                                            l_curly_token: L_CURLY@1548..1549 "{" [] [],
                                             value: ScssExpression {
                                                 items: ScssExpressionItemList [
                                                     ScssVariable {
-                                                        dollar_token: DOLLAR@1484..1485 "$" [] [],
+                                                        dollar_token: DOLLAR@1549..1550 "$" [] [],
                                                         name: CssIdentifier {
-                                                            value_token: IDENT@1485..1486 "i" [] [],
+                                                            value_token: IDENT@1550..1551 "i" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            r_curly_token: R_CURLY@1486..1487 "}" [] [],
+                                            r_curly_token: R_CURLY@1551..1552 "}" [] [],
                                         },
-                                        PERCENT@1487..1489 "%" [] [Whitespace(" ")],
+                                        PERCENT@1552..1554 "%" [] [Whitespace(" ")],
                                     ],
                                 },
                             ],
                             block: CssDeclarationBlock {
-                                l_curly_token: L_CURLY@1489..1490 "{" [] [],
+                                l_curly_token: L_CURLY@1554..1555 "{" [] [],
                                 declarations: CssDeclarationList [
                                     CssDeclarationWithSemicolon {
                                         declaration: CssDeclaration {
                                             property: CssGenericProperty {
                                                 name: CssIdentifier {
-                                                    value_token: IDENT@1490..1502 "opacity" [Newline("\n"), Whitespace("    ")] [],
+                                                    value_token: IDENT@1555..1567 "opacity" [Newline("\n"), Whitespace("    ")] [],
                                                 },
-                                                colon_token: COLON@1502..1504 ":" [] [Whitespace(" ")],
+                                                colon_token: COLON@1567..1569 ":" [] [Whitespace(" ")],
                                                 value: CssGenericComponentValueList [
                                                     CssNumber {
-                                                        value_token: CSS_NUMBER_LITERAL@1504..1505 "1" [] [],
+                                                        value_token: CSS_NUMBER_LITERAL@1569..1570 "1" [] [],
                                                     },
                                                 ],
                                             },
                                             important: missing (optional),
                                         },
-                                        semicolon_token: SEMICOLON@1505..1506 ";" [] [],
+                                        semicolon_token: SEMICOLON@1570..1571 ";" [] [],
                                     },
                                 ],
-                                r_curly_token: R_CURLY@1506..1510 "}" [Newline("\n"), Whitespace("  ")] [],
+                                r_curly_token: R_CURLY@1571..1575 "}" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                     ],
-                    r_curly_token: R_CURLY@1510..1512 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@1575..1577 "}" [Newline("\n")] [],
                 },
             },
         },
         CssAtRule {
-            at_token: AT@1512..1515 "@" [Newline("\n"), Newline("\n")] [],
+            at_token: AT@1577..1580 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssBogusAtRule {
                 items: [
                     ScssInterpolation {
-                        hash_token: HASH@1515..1516 "#" [] [],
-                        l_curly_token: L_CURLY@1516..1517 "{" [] [],
+                        hash_token: HASH@1580..1581 "#" [] [],
+                        l_curly_token: L_CURLY@1581..1582 "{" [] [],
                         value: ScssExpression {
                             items: ScssExpressionItemList [
                                 ScssVariable {
-                                    dollar_token: DOLLAR@1517..1518 "$" [] [],
+                                    dollar_token: DOLLAR@1582..1583 "$" [] [],
                                     name: CssIdentifier {
-                                        value_token: IDENT@1518..1527 "rule-name" [] [],
+                                        value_token: IDENT@1583..1592 "rule-name" [] [],
                                     },
                                 },
                             ],
                         },
-                        r_curly_token: R_CURLY@1527..1529 "}" [] [Whitespace(" ")],
+                        r_curly_token: R_CURLY@1592..1594 "}" [] [Whitespace(" ")],
                     },
                     CssUnknownAtRuleComponentList {
                         items: [
                             ScssInterpolation {
-                                hash_token: HASH@1529..1530 "#" [] [],
-                                l_curly_token: L_CURLY@1530..1531 "{" [] [],
+                                hash_token: HASH@1594..1595 "#" [] [],
+                                l_curly_token: L_CURLY@1595..1596 "{" [] [],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssVariable {
-                                            dollar_token: DOLLAR@1531..1532 "$" [] [],
+                                            dollar_token: DOLLAR@1596..1597 "$" [] [],
                                             name: CssIdentifier {
-                                                value_token: IDENT@1532..1537 "value" [] [],
+                                                value_token: IDENT@1597..1602 "value" [] [],
                                             },
                                         },
                                     ],
                                 },
-                                r_curly_token: R_CURLY@1537..1538 "}" [] [],
+                                r_curly_token: R_CURLY@1602..1603 "}" [] [],
                             },
                         ],
                     },
-                    SEMICOLON@1538..1539 ";" [] [],
+                    SEMICOLON@1603..1604 ";" [] [],
                 ],
             },
         },
         CssAtRule {
-            at_token: AT@1539..1542 "@" [Newline("\n"), Newline("\n")] [],
+            at_token: AT@1604..1607 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssBogusAtRule {
                 items: [
                     ScssInterpolation {
-                        hash_token: HASH@1542..1543 "#" [] [],
-                        l_curly_token: L_CURLY@1543..1544 "{" [] [],
+                        hash_token: HASH@1607..1608 "#" [] [],
+                        l_curly_token: L_CURLY@1608..1609 "{" [] [],
                         value: ScssExpression {
                             items: ScssExpressionItemList [
                                 ScssVariable {
-                                    dollar_token: DOLLAR@1544..1545 "$" [] [],
+                                    dollar_token: DOLLAR@1609..1610 "$" [] [],
                                     name: CssIdentifier {
-                                        value_token: IDENT@1545..1555 "block-rule" [] [],
+                                        value_token: IDENT@1610..1620 "block-rule" [] [],
                                     },
                                 },
                             ],
                         },
-                        r_curly_token: R_CURLY@1555..1557 "}" [] [Whitespace(" ")],
+                        r_curly_token: R_CURLY@1620..1622 "}" [] [Whitespace(" ")],
                     },
                     CssUnknownAtRuleComponentList {
                         items: [
                             ScssInterpolation {
-                                hash_token: HASH@1557..1558 "#" [] [],
-                                l_curly_token: L_CURLY@1558..1559 "{" [] [],
+                                hash_token: HASH@1622..1623 "#" [] [],
+                                l_curly_token: L_CURLY@1623..1624 "{" [] [],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssVariable {
-                                            dollar_token: DOLLAR@1559..1560 "$" [] [],
+                                            dollar_token: DOLLAR@1624..1625 "$" [] [],
                                             name: CssIdentifier {
-                                                value_token: IDENT@1560..1565 "value" [] [],
+                                                value_token: IDENT@1625..1630 "value" [] [],
                                             },
                                         },
                                     ],
                                 },
-                                r_curly_token: R_CURLY@1565..1567 "}" [] [Whitespace(" ")],
+                                r_curly_token: R_CURLY@1630..1632 "}" [] [Whitespace(" ")],
                             },
                         ],
                     },
                     CssDeclarationOrRuleBlock {
-                        l_curly_token: L_CURLY@1567..1568 "{" [] [],
+                        l_curly_token: L_CURLY@1632..1633 "{" [] [],
                         items: CssDeclarationOrRuleList [
                             CssDeclarationWithSemicolon {
                                 declaration: CssDeclaration {
                                     property: CssGenericProperty {
                                         name: CssIdentifier {
-                                            value_token: IDENT@1568..1576 "color" [Newline("\n"), Whitespace("  ")] [],
+                                            value_token: IDENT@1633..1641 "color" [Newline("\n"), Whitespace("  ")] [],
                                         },
-                                        colon_token: COLON@1576..1578 ":" [] [Whitespace(" ")],
+                                        colon_token: COLON@1641..1643 ":" [] [Whitespace(" ")],
                                         value: CssGenericComponentValueList [
                                             CssIdentifier {
-                                                value_token: IDENT@1578..1581 "red" [] [],
+                                                value_token: IDENT@1643..1646 "red" [] [],
                                             },
                                         ],
                                     },
                                     important: missing (optional),
                                 },
-                                semicolon_token: SEMICOLON@1581..1582 ";" [] [],
+                                semicolon_token: SEMICOLON@1646..1647 ";" [] [],
                             },
                         ],
-                        r_curly_token: R_CURLY@1582..1584 "}" [Newline("\n")] [],
+                        r_curly_token: R_CURLY@1647..1649 "}" [Newline("\n")] [],
                     },
                 ],
             },
         },
     ],
-    eof_token: EOF@1584..1585 "" [Newline("\n")] [],
+    eof_token: EOF@1649..1650 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..1585
+0: CSS_ROOT@0..1650
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..1584
+  1: CSS_ROOT_ITEM_LIST@0..1649
     0: CSS_AT_RULE@0..47
       0: AT@0..1 "@" [] []
       1: CSS_SUPPORTS_AT_RULE@1..47
@@ -2710,110 +2778,147 @@ CssRoot {
                     1: SEMICOLON@1451..1452 ";" [] []
                 2: R_CURLY@1452..1456 "}" [Newline("\n"), Whitespace("  ")] []
           2: R_CURLY@1456..1458 "}" [Newline("\n")] []
-    20: CSS_AT_RULE@1458..1512
+    20: CSS_AT_RULE@1458..1523
       0: AT@1458..1461 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_KEYFRAMES_AT_RULE@1461..1512
-        0: KEYFRAMES_KW@1461..1471 "keyframes" [] [Whitespace(" ")]
-        1: CSS_CUSTOM_IDENTIFIER@1471..1478
-          0: IDENT@1471..1478 "loader" [] [Whitespace(" ")]
-        2: CSS_KEYFRAMES_BLOCK@1478..1512
-          0: L_CURLY@1478..1479 "{" [] []
-          1: CSS_KEYFRAMES_ITEM_LIST@1479..1510
-            0: CSS_KEYFRAMES_ITEM@1479..1510
-              0: CSS_KEYFRAMES_SELECTOR_LIST@1479..1489
-                0: CSS_BOGUS_SELECTOR@1479..1489
-                  0: SCSS_INTERPOLATION@1479..1487
-                    0: HASH@1479..1483 "#" [Newline("\n"), Whitespace("  ")] []
-                    1: L_CURLY@1483..1484 "{" [] []
-                    2: SCSS_EXPRESSION@1484..1486
-                      0: SCSS_EXPRESSION_ITEM_LIST@1484..1486
-                        0: SCSS_VARIABLE@1484..1486
-                          0: DOLLAR@1484..1485 "$" [] []
-                          1: CSS_IDENTIFIER@1485..1486
-                            0: IDENT@1485..1486 "i" [] []
-                    3: R_CURLY@1486..1487 "}" [] []
-                  1: PERCENT@1487..1489 "%" [] [Whitespace(" ")]
-              1: CSS_DECLARATION_BLOCK@1489..1510
-                0: L_CURLY@1489..1490 "{" [] []
-                1: CSS_DECLARATION_LIST@1490..1506
-                  0: CSS_DECLARATION_WITH_SEMICOLON@1490..1506
-                    0: CSS_DECLARATION@1490..1505
-                      0: CSS_GENERIC_PROPERTY@1490..1505
-                        0: CSS_IDENTIFIER@1490..1502
-                          0: IDENT@1490..1502 "opacity" [Newline("\n"), Whitespace("    ")] []
-                        1: COLON@1502..1504 ":" [] [Whitespace(" ")]
-                        2: CSS_GENERIC_COMPONENT_VALUE_LIST@1504..1505
-                          0: CSS_NUMBER@1504..1505
-                            0: CSS_NUMBER_LITERAL@1504..1505 "1" [] []
+      1: CSS_BOGUS_AT_RULE@1461..1523
+        0: CSS_FUNCTION_AT_RULE_DECLARATOR@1461..1490
+          0: FUNCTION_KW@1461..1470 "function" [] [Whitespace(" ")]
+          1: CSS_DASHED_IDENTIFIER@1470..1487
+            0: IDENT@1470..1487 "--nested-property" [] []
+          2: L_PAREN@1487..1488 "(" [] []
+          3: CSS_FUNCTION_PARAMETER_LIST@1488..1488
+          4: R_PAREN@1488..1490 ")" [] [Whitespace(" ")]
+          5: (empty)
+        1: CSS_BOGUS_BLOCK@1490..1523
+          0: L_CURLY@1490..1491 "{" [] []
+          1: CSS_BOGUS@1491..1521
+            0: CSS_BOGUS@1491..1521
+              0: CSS_IDENTIFIER@1491..1498
+                0: IDENT@1491..1498 "font" [Newline("\n"), Whitespace("  ")] []
+              1: COLON@1498..1500 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@1500..1500
+                0: SCSS_EXPRESSION_ITEM_LIST@1500..1500
+              3: CSS_DECLARATION_OR_RULE_BLOCK@1500..1521
+                0: L_CURLY@1500..1501 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1501..1517
+                  0: CSS_DECLARATION_WITH_SEMICOLON@1501..1517
+                    0: CSS_DECLARATION@1501..1516
+                      0: CSS_GENERIC_PROPERTY@1501..1516
+                        0: CSS_IDENTIFIER@1501..1510
+                          0: IDENT@1501..1510 "size" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@1510..1512 ":" [] [Whitespace(" ")]
+                        2: CSS_GENERIC_COMPONENT_VALUE_LIST@1512..1516
+                          0: CSS_REGULAR_DIMENSION@1512..1516
+                            0: CSS_NUMBER_LITERAL@1512..1514 "12" [] []
+                            1: IDENT@1514..1516 "px" [] []
                       1: (empty)
-                    1: SEMICOLON@1505..1506 ";" [] []
-                2: R_CURLY@1506..1510 "}" [Newline("\n"), Whitespace("  ")] []
-          2: R_CURLY@1510..1512 "}" [Newline("\n")] []
-    21: CSS_AT_RULE@1512..1539
-      0: AT@1512..1515 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_BOGUS_AT_RULE@1515..1539
-        0: SCSS_INTERPOLATION@1515..1529
-          0: HASH@1515..1516 "#" [] []
-          1: L_CURLY@1516..1517 "{" [] []
-          2: SCSS_EXPRESSION@1517..1527
-            0: SCSS_EXPRESSION_ITEM_LIST@1517..1527
-              0: SCSS_VARIABLE@1517..1527
-                0: DOLLAR@1517..1518 "$" [] []
-                1: CSS_IDENTIFIER@1518..1527
-                  0: IDENT@1518..1527 "rule-name" [] []
-          3: R_CURLY@1527..1529 "}" [] [Whitespace(" ")]
-        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@1529..1538
-          0: SCSS_INTERPOLATION@1529..1538
-            0: HASH@1529..1530 "#" [] []
-            1: L_CURLY@1530..1531 "{" [] []
-            2: SCSS_EXPRESSION@1531..1537
-              0: SCSS_EXPRESSION_ITEM_LIST@1531..1537
-                0: SCSS_VARIABLE@1531..1537
-                  0: DOLLAR@1531..1532 "$" [] []
-                  1: CSS_IDENTIFIER@1532..1537
-                    0: IDENT@1532..1537 "value" [] []
-            3: R_CURLY@1537..1538 "}" [] []
-        2: SEMICOLON@1538..1539 ";" [] []
-    22: CSS_AT_RULE@1539..1584
-      0: AT@1539..1542 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_BOGUS_AT_RULE@1542..1584
-        0: SCSS_INTERPOLATION@1542..1557
-          0: HASH@1542..1543 "#" [] []
-          1: L_CURLY@1543..1544 "{" [] []
-          2: SCSS_EXPRESSION@1544..1555
-            0: SCSS_EXPRESSION_ITEM_LIST@1544..1555
-              0: SCSS_VARIABLE@1544..1555
-                0: DOLLAR@1544..1545 "$" [] []
-                1: CSS_IDENTIFIER@1545..1555
-                  0: IDENT@1545..1555 "block-rule" [] []
-          3: R_CURLY@1555..1557 "}" [] [Whitespace(" ")]
-        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@1557..1567
-          0: SCSS_INTERPOLATION@1557..1567
-            0: HASH@1557..1558 "#" [] []
-            1: L_CURLY@1558..1559 "{" [] []
-            2: SCSS_EXPRESSION@1559..1565
-              0: SCSS_EXPRESSION_ITEM_LIST@1559..1565
-                0: SCSS_VARIABLE@1559..1565
-                  0: DOLLAR@1559..1560 "$" [] []
-                  1: CSS_IDENTIFIER@1560..1565
-                    0: IDENT@1560..1565 "value" [] []
-            3: R_CURLY@1565..1567 "}" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_OR_RULE_BLOCK@1567..1584
-          0: L_CURLY@1567..1568 "{" [] []
-          1: CSS_DECLARATION_OR_RULE_LIST@1568..1582
-            0: CSS_DECLARATION_WITH_SEMICOLON@1568..1582
-              0: CSS_DECLARATION@1568..1581
-                0: CSS_GENERIC_PROPERTY@1568..1581
-                  0: CSS_IDENTIFIER@1568..1576
-                    0: IDENT@1568..1576 "color" [Newline("\n"), Whitespace("  ")] []
-                  1: COLON@1576..1578 ":" [] [Whitespace(" ")]
-                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@1578..1581
-                    0: CSS_IDENTIFIER@1578..1581
-                      0: IDENT@1578..1581 "red" [] []
+                    1: SEMICOLON@1516..1517 ";" [] []
+                2: R_CURLY@1517..1521 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@1521..1523 "}" [Newline("\n")] []
+    21: CSS_AT_RULE@1523..1577
+      0: AT@1523..1526 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_KEYFRAMES_AT_RULE@1526..1577
+        0: KEYFRAMES_KW@1526..1536 "keyframes" [] [Whitespace(" ")]
+        1: CSS_CUSTOM_IDENTIFIER@1536..1543
+          0: IDENT@1536..1543 "loader" [] [Whitespace(" ")]
+        2: CSS_KEYFRAMES_BLOCK@1543..1577
+          0: L_CURLY@1543..1544 "{" [] []
+          1: CSS_KEYFRAMES_ITEM_LIST@1544..1575
+            0: CSS_KEYFRAMES_ITEM@1544..1575
+              0: CSS_KEYFRAMES_SELECTOR_LIST@1544..1554
+                0: CSS_BOGUS_SELECTOR@1544..1554
+                  0: SCSS_INTERPOLATION@1544..1552
+                    0: HASH@1544..1548 "#" [Newline("\n"), Whitespace("  ")] []
+                    1: L_CURLY@1548..1549 "{" [] []
+                    2: SCSS_EXPRESSION@1549..1551
+                      0: SCSS_EXPRESSION_ITEM_LIST@1549..1551
+                        0: SCSS_VARIABLE@1549..1551
+                          0: DOLLAR@1549..1550 "$" [] []
+                          1: CSS_IDENTIFIER@1550..1551
+                            0: IDENT@1550..1551 "i" [] []
+                    3: R_CURLY@1551..1552 "}" [] []
+                  1: PERCENT@1552..1554 "%" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_BLOCK@1554..1575
+                0: L_CURLY@1554..1555 "{" [] []
+                1: CSS_DECLARATION_LIST@1555..1571
+                  0: CSS_DECLARATION_WITH_SEMICOLON@1555..1571
+                    0: CSS_DECLARATION@1555..1570
+                      0: CSS_GENERIC_PROPERTY@1555..1570
+                        0: CSS_IDENTIFIER@1555..1567
+                          0: IDENT@1555..1567 "opacity" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@1567..1569 ":" [] [Whitespace(" ")]
+                        2: CSS_GENERIC_COMPONENT_VALUE_LIST@1569..1570
+                          0: CSS_NUMBER@1569..1570
+                            0: CSS_NUMBER_LITERAL@1569..1570 "1" [] []
+                      1: (empty)
+                    1: SEMICOLON@1570..1571 ";" [] []
+                2: R_CURLY@1571..1575 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@1575..1577 "}" [Newline("\n")] []
+    22: CSS_AT_RULE@1577..1604
+      0: AT@1577..1580 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_BOGUS_AT_RULE@1580..1604
+        0: SCSS_INTERPOLATION@1580..1594
+          0: HASH@1580..1581 "#" [] []
+          1: L_CURLY@1581..1582 "{" [] []
+          2: SCSS_EXPRESSION@1582..1592
+            0: SCSS_EXPRESSION_ITEM_LIST@1582..1592
+              0: SCSS_VARIABLE@1582..1592
+                0: DOLLAR@1582..1583 "$" [] []
+                1: CSS_IDENTIFIER@1583..1592
+                  0: IDENT@1583..1592 "rule-name" [] []
+          3: R_CURLY@1592..1594 "}" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@1594..1603
+          0: SCSS_INTERPOLATION@1594..1603
+            0: HASH@1594..1595 "#" [] []
+            1: L_CURLY@1595..1596 "{" [] []
+            2: SCSS_EXPRESSION@1596..1602
+              0: SCSS_EXPRESSION_ITEM_LIST@1596..1602
+                0: SCSS_VARIABLE@1596..1602
+                  0: DOLLAR@1596..1597 "$" [] []
+                  1: CSS_IDENTIFIER@1597..1602
+                    0: IDENT@1597..1602 "value" [] []
+            3: R_CURLY@1602..1603 "}" [] []
+        2: SEMICOLON@1603..1604 ";" [] []
+    23: CSS_AT_RULE@1604..1649
+      0: AT@1604..1607 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_BOGUS_AT_RULE@1607..1649
+        0: SCSS_INTERPOLATION@1607..1622
+          0: HASH@1607..1608 "#" [] []
+          1: L_CURLY@1608..1609 "{" [] []
+          2: SCSS_EXPRESSION@1609..1620
+            0: SCSS_EXPRESSION_ITEM_LIST@1609..1620
+              0: SCSS_VARIABLE@1609..1620
+                0: DOLLAR@1609..1610 "$" [] []
+                1: CSS_IDENTIFIER@1610..1620
+                  0: IDENT@1610..1620 "block-rule" [] []
+          3: R_CURLY@1620..1622 "}" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@1622..1632
+          0: SCSS_INTERPOLATION@1622..1632
+            0: HASH@1622..1623 "#" [] []
+            1: L_CURLY@1623..1624 "{" [] []
+            2: SCSS_EXPRESSION@1624..1630
+              0: SCSS_EXPRESSION_ITEM_LIST@1624..1630
+                0: SCSS_VARIABLE@1624..1630
+                  0: DOLLAR@1624..1625 "$" [] []
+                  1: CSS_IDENTIFIER@1625..1630
+                    0: IDENT@1625..1630 "value" [] []
+            3: R_CURLY@1630..1632 "}" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@1632..1649
+          0: L_CURLY@1632..1633 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@1633..1647
+            0: CSS_DECLARATION_WITH_SEMICOLON@1633..1647
+              0: CSS_DECLARATION@1633..1646
+                0: CSS_GENERIC_PROPERTY@1633..1646
+                  0: CSS_IDENTIFIER@1633..1641
+                    0: IDENT@1633..1641 "color" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@1641..1643 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@1643..1646
+                    0: CSS_IDENTIFIER@1643..1646
+                      0: IDENT@1643..1646 "red" [] []
                 1: (empty)
-              1: SEMICOLON@1581..1582 ";" [] []
-          2: R_CURLY@1582..1584 "}" [Newline("\n")] []
-  2: EOF@1584..1585 "" [Newline("\n")] []
+              1: SEMICOLON@1646..1647 ";" [] []
+          2: R_CURLY@1647..1649 "}" [Newline("\n")] []
+  2: EOF@1649..1650 "" [Newline("\n")] []
 
 ```
 
@@ -3042,36 +3147,49 @@ scss_exclusive_values.css:78:3 parse ━━━━━━━━━━━━━━�
   
 scss_exclusive_values.css:84:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × SCSS interpolated keyframe selectors are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  × SCSS nested property declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
   
-    83 │ @keyframes loader {
-  > 84 │   #{$i}% {
-       │   ^^^^^^
-    85 │     opacity: 1;
-    86 │   }
-  
-scss_exclusive_values.css:89:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × SCSS interpolated at-rule names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
-  
+    83 │ @function --nested-property() {
+  > 84 │   font: {
+       │   ^^^^^^^
+  > 85 │     size: 12px;
+  > 86 │   }
+       │   ^
     87 │ }
     88 │ 
-  > 89 │ @#{$rule-name} #{$value};
-       │  ^^^^^^^^^^^^^^^^^^^^^^^^
-    90 │ 
-    91 │ @#{$block-rule} #{$value} {
   
-scss_exclusive_values.css:91:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+scss_exclusive_values.css:90:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated keyframe selectors are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    89 │ @keyframes loader {
+  > 90 │   #{$i}% {
+       │   ^^^^^^
+    91 │     opacity: 1;
+    92 │   }
+  
+scss_exclusive_values.css:95:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × SCSS interpolated at-rule names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
   
-    89 │ @#{$rule-name} #{$value};
-    90 │ 
-  > 91 │ @#{$block-rule} #{$value} {
-       │  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 92 │   color: red;
-  > 93 │ }
-       │ ^
+    93 │ }
     94 │ 
+  > 95 │ @#{$rule-name} #{$value};
+       │  ^^^^^^^^^^^^^^^^^^^^^^^^
+    96 │ 
+    97 │ @#{$block-rule} #{$value} {
+  
+scss_exclusive_values.css:97:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated at-rule names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+     95 │ @#{$rule-name} #{$value};
+     96 │ 
+   > 97 │ @#{$block-rule} #{$value} {
+        │  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 98 │   color: red;
+   > 99 │ }
+        │ ^
+    100 │ 
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/error/property/scss_exclusive_values.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/property/scss_exclusive_values.css
@@ -1,0 +1,42 @@
+.unsupported-scss {
+  variable: $value;
+  variable-interpolation: $value#{suffix};
+  module-member: module.$value;
+  module-member-interpolation: module.$value#{suffix};
+  qualified-function: module.fn(1);
+  interpolation: #{$value};
+  adjacent-interpolations: #{$a}#{$b};
+  number-interpolation: 10#{unit};
+  dimension-interpolation: 10px#{suffix};
+  interpolated-name: foo#{$bar};
+  interpolated-string: "#{$value}";
+  interpolated-custom-property: --#{$name};
+  interpolated-custom-property-suffix: --theme-#{$slot};
+}
+
+.function-arguments {
+  variable: fn($value);
+  variable-interpolation: fn($value#{suffix});
+  module-member: fn(module.$value);
+  module-member-interpolation: fn(module.$value#{suffix});
+  qualified-function: fn(module.fn(1));
+  interpolation: fn(#{$value});
+  adjacent-interpolations: fn(#{$a}#{$b});
+  number-interpolation: fn(10#{unit});
+  dimension-interpolation: fn(10px#{suffix});
+  interpolated-name: fn(foo#{$bar});
+  interpolated-string: fn("#{$value}");
+  interpolated-custom-property: fn(--#{$name});
+  interpolated-custom-property-suffix: fn(--theme-#{$slot});
+}
+
+.property-names {
+  #{$name}: 1px;
+  margin-#{$side}: 1px;
+  --#{$prop}: 10px;
+  --theme-#{$slot}: red;
+}
+
+.malformed-css {
+  color: calc(# {value});
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/property/scss_exclusive_values.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/property/scss_exclusive_values.css
@@ -37,6 +37,12 @@
   --theme-#{$slot}: red;
 }
 
+.nested-properties {
+  font: {
+    family: sans-serif;
+  }
+}
+
 .malformed-css {
   color: calc(# {value});
 }

--- a/crates/biome_css_parser/tests/css_test_suite/error/property/scss_exclusive_values.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/property/scss_exclusive_values.css.snap
@@ -1,0 +1,2829 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+.unsupported-scss {
+  variable: $value;
+  variable-interpolation: $value#{suffix};
+  module-member: module.$value;
+  module-member-interpolation: module.$value#{suffix};
+  qualified-function: module.fn(1);
+  interpolation: #{$value};
+  adjacent-interpolations: #{$a}#{$b};
+  number-interpolation: 10#{unit};
+  dimension-interpolation: 10px#{suffix};
+  interpolated-name: foo#{$bar};
+  interpolated-string: "#{$value}";
+  interpolated-custom-property: --#{$name};
+  interpolated-custom-property-suffix: --theme-#{$slot};
+}
+
+.function-arguments {
+  variable: fn($value);
+  variable-interpolation: fn($value#{suffix});
+  module-member: fn(module.$value);
+  module-member-interpolation: fn(module.$value#{suffix});
+  qualified-function: fn(module.fn(1));
+  interpolation: fn(#{$value});
+  adjacent-interpolations: fn(#{$a}#{$b});
+  number-interpolation: fn(10#{unit});
+  dimension-interpolation: fn(10px#{suffix});
+  interpolated-name: fn(foo#{$bar});
+  interpolated-string: fn("#{$value}");
+  interpolated-custom-property: fn(--#{$name});
+  interpolated-custom-property-suffix: fn(--theme-#{$slot});
+}
+
+.property-names {
+  #{$name}: 1px;
+  margin-#{$side}: 1px;
+  --#{$prop}: 10px;
+  --theme-#{$slot}: red;
+}
+
+.malformed-css {
+  color: calc(# {value});
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@0..1 "." [] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1..18 "unsupported-scss" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@18..19 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@19..30 "variable" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@30..32 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    DOLLAR@32..33 "$" [] [],
+                                                    CssIdentifier {
+                                                        value_token: IDENT@33..38 "value" [] [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@38..39 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@39..64 "variable-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@64..66 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedValuePartList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@66..67 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@67..72 "value" [] [],
+                                                            },
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@72..73 "#" [] [],
+                                                            l_curly_token: L_CURLY@73..74 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@74..80 "suffix" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@80..81 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@81..82 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@82..98 "module-member" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@98..100 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@100..106 "module" [] [],
+                                                    },
+                                                    DOT@106..107 "." [] [],
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@107..108 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@108..113 "value" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@113..114 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@114..144 "module-member-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@144..146 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedValuePartList [
+                                                        ScssNamespacedVariable {
+                                                            namespace: CssIdentifier {
+                                                                value_token: IDENT@146..152 "module" [] [],
+                                                            },
+                                                            dot_token: DOT@152..153 "." [] [],
+                                                            name: ScssVariable {
+                                                                dollar_token: DOLLAR@153..154 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@154..159 "value" [] [],
+                                                                },
+                                                            },
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@159..160 "#" [] [],
+                                                            l_curly_token: L_CURLY@160..161 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@161..167 "suffix" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@167..168 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@168..169 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@169..190 "qualified-function" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@190..192 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssModuleMemberAccess {
+                                                        module: CssIdentifier {
+                                                            value_token: IDENT@192..198 "module" [] [],
+                                                        },
+                                                        dot_token: DOT@198..199 "." [] [],
+                                                        member: CssIdentifier {
+                                                            value_token: IDENT@199..201 "fn" [] [],
+                                                        },
+                                                    },
+                                                    L_PAREN@201..202 "(" [] [],
+                                                    CssParameterList [
+                                                        CssListOfComponentValuesExpression {
+                                                            css_component_value_list: CssComponentValueList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@202..203 "1" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                    R_PAREN@203..204 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@204..205 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@205..221 "interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@221..223 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogus {
+                                                items: [
+                                                    HASH@223..224 "#" [] [],
+                                                    L_CURLY@224..225 "{" [] [],
+                                                    ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@225..226 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@226..231 "value" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_CURLY@231..232 "}" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@232..233 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@233..259 "adjacent-interpolations" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@259..261 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedIdentifierPartList [
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@261..262 "#" [] [],
+                                                            l_curly_token: L_CURLY@262..263 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@263..264 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@264..265 "a" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@265..266 "}" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@266..267 "#" [] [],
+                                                            l_curly_token: L_CURLY@267..268 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@268..269 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@269..270 "b" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@270..271 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@271..272 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@272..295 "number-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@295..297 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedValuePartList [
+                                                        CssNumber {
+                                                            value_token: CSS_NUMBER_LITERAL@297..299 "10" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@299..300 "#" [] [],
+                                                            l_curly_token: L_CURLY@300..301 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@301..305 "unit" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@305..306 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@306..307 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@307..333 "dimension-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@333..335 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedValuePartList [
+                                                        CssRegularDimension {
+                                                            value_token: CSS_NUMBER_LITERAL@335..337 "10" [] [],
+                                                            unit_token: IDENT@337..339 "px" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@339..340 "#" [] [],
+                                                            l_curly_token: L_CURLY@340..341 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@341..347 "suffix" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@347..348 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@348..349 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@349..369 "interpolated-name" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@369..371 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedIdentifierPartList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@371..374 "foo" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@374..375 "#" [] [],
+                                                            l_curly_token: L_CURLY@375..376 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@376..377 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@377..380 "bar" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@380..381 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@381..382 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@382..404 "interpolated-string" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@404..406 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssString {
+                                        value_token: CSS_STRING_LITERAL@406..417 "\"#{$value}\"" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@417..418 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@418..449 "interpolated-custom-property" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@449..451 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedIdentifierPartList [
+                                                        ScssInterpolatedIdentifierHyphen {
+                                                            minus_token: MINUS@451..452 "-" [] [],
+                                                        },
+                                                        ScssInterpolatedIdentifierHyphen {
+                                                            minus_token: MINUS@452..453 "-" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@453..454 "#" [] [],
+                                                            l_curly_token: L_CURLY@454..455 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@455..456 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@456..460 "name" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@460..461 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@461..462 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@462..500 "interpolated-custom-property-suffix" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@500..502 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    ScssInterpolatedIdentifierPartList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@502..510 "--theme-" [] [],
+                                                        },
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@510..511 "#" [] [],
+                                                            l_curly_token: L_CURLY@511..512 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@512..513 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@513..517 "slot" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@517..518 "}" [] [],
+                                                        },
+                                                    ],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@518..519 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@519..521 "}" [Newline("\n")] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@521..524 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@524..543 "function-arguments" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@543..544 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@544..555 "variable" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@555..557 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@557..559 "fn" [] [],
+                                                    },
+                                                    L_PAREN@559..560 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    DOLLAR@560..561 "$" [] [],
+                                                                                    CssIdentifier {
+                                                                                        value_token: IDENT@561..566 "value" [] [],
+                                                                                    },
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@566..567 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@567..568 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@568..593 "variable-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@593..595 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@595..597 "fn" [] [],
+                                                    },
+                                                    L_PAREN@597..598 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    ScssInterpolatedValuePartList [
+                                                                                        ScssVariable {
+                                                                                            dollar_token: DOLLAR@598..599 "$" [] [],
+                                                                                            name: CssIdentifier {
+                                                                                                value_token: IDENT@599..604 "value" [] [],
+                                                                                            },
+                                                                                        },
+                                                                                        ScssInterpolation {
+                                                                                            hash_token: HASH@604..605 "#" [] [],
+                                                                                            l_curly_token: L_CURLY@605..606 "{" [] [],
+                                                                                            value: ScssExpression {
+                                                                                                items: ScssExpressionItemList [
+                                                                                                    CssIdentifier {
+                                                                                                        value_token: IDENT@606..612 "suffix" [] [],
+                                                                                                    },
+                                                                                                ],
+                                                                                            },
+                                                                                            r_curly_token: R_CURLY@612..613 "}" [] [],
+                                                                                        },
+                                                                                    ],
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@613..614 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@614..615 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@615..631 "module-member" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@631..633 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@633..635 "fn" [] [],
+                                                    },
+                                                    L_PAREN@635..636 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    CssIdentifier {
+                                                                                        value_token: IDENT@636..642 "module" [] [],
+                                                                                    },
+                                                                                    DOT@642..643 "." [] [],
+                                                                                    ScssVariable {
+                                                                                        dollar_token: DOLLAR@643..644 "$" [] [],
+                                                                                        name: CssIdentifier {
+                                                                                            value_token: IDENT@644..649 "value" [] [],
+                                                                                        },
+                                                                                    },
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@649..650 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@650..651 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@651..681 "module-member-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@681..683 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@683..685 "fn" [] [],
+                                                    },
+                                                    L_PAREN@685..686 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    ScssInterpolatedValuePartList [
+                                                                                        ScssNamespacedVariable {
+                                                                                            namespace: CssIdentifier {
+                                                                                                value_token: IDENT@686..692 "module" [] [],
+                                                                                            },
+                                                                                            dot_token: DOT@692..693 "." [] [],
+                                                                                            name: ScssVariable {
+                                                                                                dollar_token: DOLLAR@693..694 "$" [] [],
+                                                                                                name: CssIdentifier {
+                                                                                                    value_token: IDENT@694..699 "value" [] [],
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        ScssInterpolation {
+                                                                                            hash_token: HASH@699..700 "#" [] [],
+                                                                                            l_curly_token: L_CURLY@700..701 "{" [] [],
+                                                                                            value: ScssExpression {
+                                                                                                items: ScssExpressionItemList [
+                                                                                                    CssIdentifier {
+                                                                                                        value_token: IDENT@701..707 "suffix" [] [],
+                                                                                                    },
+                                                                                                ],
+                                                                                            },
+                                                                                            r_curly_token: R_CURLY@707..708 "}" [] [],
+                                                                                        },
+                                                                                    ],
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@708..709 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@709..710 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@710..731 "qualified-function" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@731..733 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@733..735 "fn" [] [],
+                                                    },
+                                                    L_PAREN@735..736 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    ScssModuleMemberAccess {
+                                                                                        module: CssIdentifier {
+                                                                                            value_token: IDENT@736..742 "module" [] [],
+                                                                                        },
+                                                                                        dot_token: DOT@742..743 "." [] [],
+                                                                                        member: CssIdentifier {
+                                                                                            value_token: IDENT@743..745 "fn" [] [],
+                                                                                        },
+                                                                                    },
+                                                                                    L_PAREN@745..746 "(" [] [],
+                                                                                    CssParameterList [
+                                                                                        CssListOfComponentValuesExpression {
+                                                                                            css_component_value_list: CssComponentValueList [
+                                                                                                CssNumber {
+                                                                                                    value_token: CSS_NUMBER_LITERAL@746..747 "1" [] [],
+                                                                                                },
+                                                                                            ],
+                                                                                        },
+                                                                                    ],
+                                                                                    R_PAREN@747..748 ")" [] [],
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@748..749 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@749..750 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@750..766 "interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@766..768 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@768..770 "fn" [] [],
+                                                    },
+                                                    L_PAREN@770..771 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogus {
+                                                                                items: [
+                                                                                    HASH@771..772 "#" [] [],
+                                                                                    L_CURLY@772..773 "{" [] [],
+                                                                                    ScssExpression {
+                                                                                        items: ScssExpressionItemList [
+                                                                                            ScssVariable {
+                                                                                                dollar_token: DOLLAR@773..774 "$" [] [],
+                                                                                                name: CssIdentifier {
+                                                                                                    value_token: IDENT@774..779 "value" [] [],
+                                                                                                },
+                                                                                            },
+                                                                                        ],
+                                                                                    },
+                                                                                    R_CURLY@779..780 "}" [] [],
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@780..781 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@781..782 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@782..808 "adjacent-interpolations" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@808..810 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@810..812 "fn" [] [],
+                                                    },
+                                                    L_PAREN@812..813 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    ScssInterpolatedIdentifierPartList [
+                                                                                        ScssInterpolation {
+                                                                                            hash_token: HASH@813..814 "#" [] [],
+                                                                                            l_curly_token: L_CURLY@814..815 "{" [] [],
+                                                                                            value: ScssExpression {
+                                                                                                items: ScssExpressionItemList [
+                                                                                                    ScssVariable {
+                                                                                                        dollar_token: DOLLAR@815..816 "$" [] [],
+                                                                                                        name: CssIdentifier {
+                                                                                                            value_token: IDENT@816..817 "a" [] [],
+                                                                                                        },
+                                                                                                    },
+                                                                                                ],
+                                                                                            },
+                                                                                            r_curly_token: R_CURLY@817..818 "}" [] [],
+                                                                                        },
+                                                                                        ScssInterpolation {
+                                                                                            hash_token: HASH@818..819 "#" [] [],
+                                                                                            l_curly_token: L_CURLY@819..820 "{" [] [],
+                                                                                            value: ScssExpression {
+                                                                                                items: ScssExpressionItemList [
+                                                                                                    ScssVariable {
+                                                                                                        dollar_token: DOLLAR@820..821 "$" [] [],
+                                                                                                        name: CssIdentifier {
+                                                                                                            value_token: IDENT@821..822 "b" [] [],
+                                                                                                        },
+                                                                                                    },
+                                                                                                ],
+                                                                                            },
+                                                                                            r_curly_token: R_CURLY@822..823 "}" [] [],
+                                                                                        },
+                                                                                    ],
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@823..824 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@824..825 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@825..848 "number-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@848..850 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@850..852 "fn" [] [],
+                                                    },
+                                                    L_PAREN@852..853 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    ScssInterpolatedValuePartList [
+                                                                                        CssNumber {
+                                                                                            value_token: CSS_NUMBER_LITERAL@853..855 "10" [] [],
+                                                                                        },
+                                                                                        ScssInterpolation {
+                                                                                            hash_token: HASH@855..856 "#" [] [],
+                                                                                            l_curly_token: L_CURLY@856..857 "{" [] [],
+                                                                                            value: ScssExpression {
+                                                                                                items: ScssExpressionItemList [
+                                                                                                    CssIdentifier {
+                                                                                                        value_token: IDENT@857..861 "unit" [] [],
+                                                                                                    },
+                                                                                                ],
+                                                                                            },
+                                                                                            r_curly_token: R_CURLY@861..862 "}" [] [],
+                                                                                        },
+                                                                                    ],
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@862..863 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@863..864 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@864..890 "dimension-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@890..892 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@892..894 "fn" [] [],
+                                                    },
+                                                    L_PAREN@894..895 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    ScssInterpolatedValuePartList [
+                                                                                        CssRegularDimension {
+                                                                                            value_token: CSS_NUMBER_LITERAL@895..897 "10" [] [],
+                                                                                            unit_token: IDENT@897..899 "px" [] [],
+                                                                                        },
+                                                                                        ScssInterpolation {
+                                                                                            hash_token: HASH@899..900 "#" [] [],
+                                                                                            l_curly_token: L_CURLY@900..901 "{" [] [],
+                                                                                            value: ScssExpression {
+                                                                                                items: ScssExpressionItemList [
+                                                                                                    CssIdentifier {
+                                                                                                        value_token: IDENT@901..907 "suffix" [] [],
+                                                                                                    },
+                                                                                                ],
+                                                                                            },
+                                                                                            r_curly_token: R_CURLY@907..908 "}" [] [],
+                                                                                        },
+                                                                                    ],
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@908..909 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@909..910 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@910..930 "interpolated-name" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@930..932 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@932..934 "fn" [] [],
+                                                    },
+                                                    L_PAREN@934..935 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    ScssInterpolatedIdentifierPartList [
+                                                                                        CssIdentifier {
+                                                                                            value_token: IDENT@935..938 "foo" [] [],
+                                                                                        },
+                                                                                        ScssInterpolation {
+                                                                                            hash_token: HASH@938..939 "#" [] [],
+                                                                                            l_curly_token: L_CURLY@939..940 "{" [] [],
+                                                                                            value: ScssExpression {
+                                                                                                items: ScssExpressionItemList [
+                                                                                                    ScssVariable {
+                                                                                                        dollar_token: DOLLAR@940..941 "$" [] [],
+                                                                                                        name: CssIdentifier {
+                                                                                                            value_token: IDENT@941..944 "bar" [] [],
+                                                                                                        },
+                                                                                                    },
+                                                                                                ],
+                                                                                            },
+                                                                                            r_curly_token: R_CURLY@944..945 "}" [] [],
+                                                                                        },
+                                                                                    ],
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@945..946 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@946..947 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@947..969 "interpolated-string" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@969..971 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssFunction {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@971..973 "fn" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@973..974 "(" [] [],
+                                        items: CssParameterList [
+                                            CssListOfComponentValuesExpression {
+                                                css_component_value_list: CssComponentValueList [
+                                                    CssString {
+                                                        value_token: CSS_STRING_LITERAL@974..985 "\"#{$value}\"" [] [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@985..986 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@986..987 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@987..1018 "interpolated-custom-property" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@1018..1020 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1020..1022 "fn" [] [],
+                                                    },
+                                                    L_PAREN@1022..1023 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    MINUS@1023..1024 "-" [] [],
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            MINUS@1024..1025 "-" [] [],
+                                                                            CssBogus {
+                                                                                items: [
+                                                                                    CssBogus {
+                                                                                        items: [
+                                                                                            CssBogus {
+                                                                                                items: [
+                                                                                                    HASH@1025..1026 "#" [] [],
+                                                                                                    L_CURLY@1026..1027 "{" [] [],
+                                                                                                    ScssExpression {
+                                                                                                        items: ScssExpressionItemList [
+                                                                                                            ScssVariable {
+                                                                                                                dollar_token: DOLLAR@1027..1028 "$" [] [],
+                                                                                                                name: CssIdentifier {
+                                                                                                                    value_token: IDENT@1028..1032 "name" [] [],
+                                                                                                                },
+                                                                                                            },
+                                                                                                        ],
+                                                                                                    },
+                                                                                                    R_CURLY@1032..1033 "}" [] [],
+                                                                                                ],
+                                                                                            },
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@1033..1034 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1034..1035 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@1035..1073 "interpolated-custom-property-suffix" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    COLON@1073..1075 ":" [] [Whitespace(" ")],
+                                    CssBogus {
+                                        items: [
+                                            CssBogusSupportsCondition {
+                                                items: [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1075..1077 "fn" [] [],
+                                                    },
+                                                    L_PAREN@1077..1078 "(" [] [],
+                                                    CssBogus {
+                                                        items: [
+                                                            CssBogus {
+                                                                items: [
+                                                                    CssBogus {
+                                                                        items: [
+                                                                            CssBogusSupportsCondition {
+                                                                                items: [
+                                                                                    ScssInterpolatedIdentifierPartList [
+                                                                                        CssIdentifier {
+                                                                                            value_token: IDENT@1078..1086 "--theme-" [] [],
+                                                                                        },
+                                                                                        ScssInterpolation {
+                                                                                            hash_token: HASH@1086..1087 "#" [] [],
+                                                                                            l_curly_token: L_CURLY@1087..1088 "{" [] [],
+                                                                                            value: ScssExpression {
+                                                                                                items: ScssExpressionItemList [
+                                                                                                    ScssVariable {
+                                                                                                        dollar_token: DOLLAR@1088..1089 "$" [] [],
+                                                                                                        name: CssIdentifier {
+                                                                                                            value_token: IDENT@1089..1093 "slot" [] [],
+                                                                                                        },
+                                                                                                    },
+                                                                                                ],
+                                                                                            },
+                                                                                            r_curly_token: R_CURLY@1093..1094 "}" [] [],
+                                                                                        },
+                                                                                    ],
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_PAREN@1094..1095 ")" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1095..1096 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@1096..1098 "}" [Newline("\n")] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@1098..1101 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1101..1116 "property-names" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@1116..1117 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssBogus {
+                        items: [
+                            CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@1117..1121 "#" [Newline("\n"), Whitespace("  ")] [],
+                                                l_curly_token: L_CURLY@1121..1122 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@1122..1123 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@1123..1127 "name" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@1127..1128 "}" [] [],
+                                            },
+                                        ],
+                                    },
+                                    colon_token: COLON@1128..1130 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssRegularDimension {
+                                                value_token: CSS_NUMBER_LITERAL@1130..1131 "1" [] [],
+                                                unit_token: IDENT@1131..1133 "px" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            SEMICOLON@1133..1134 ";" [] [],
+                        ],
+                    },
+                    CssBogus {
+                        items: [
+                            CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@1134..1144 "margin-" [Newline("\n"), Whitespace("  ")] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@1144..1145 "#" [] [],
+                                                l_curly_token: L_CURLY@1145..1146 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@1146..1147 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@1147..1151 "side" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@1151..1152 "}" [] [],
+                                            },
+                                        ],
+                                    },
+                                    colon_token: COLON@1152..1154 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssRegularDimension {
+                                                value_token: CSS_NUMBER_LITERAL@1154..1155 "1" [] [],
+                                                unit_token: IDENT@1155..1157 "px" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            SEMICOLON@1157..1158 ";" [] [],
+                        ],
+                    },
+                    CssBogus {
+                        items: [
+                            CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: ScssInterpolatedDashedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolatedIdentifierHyphen {
+                                                minus_token: MINUS@1158..1162 "-" [Newline("\n"), Whitespace("  ")] [],
+                                            },
+                                            ScssInterpolatedIdentifierHyphen {
+                                                minus_token: MINUS@1162..1163 "-" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@1163..1164 "#" [] [],
+                                                l_curly_token: L_CURLY@1164..1165 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@1165..1166 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@1166..1170 "prop" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@1170..1171 "}" [] [],
+                                            },
+                                        ],
+                                    },
+                                    colon_token: COLON@1171..1173 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssRegularDimension {
+                                                value_token: CSS_NUMBER_LITERAL@1173..1175 "10" [] [],
+                                                unit_token: IDENT@1175..1177 "px" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            SEMICOLON@1177..1178 ";" [] [],
+                        ],
+                    },
+                    CssBogus {
+                        items: [
+                            CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: ScssInterpolatedDashedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@1178..1189 "--theme-" [Newline("\n"), Whitespace("  ")] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@1189..1190 "#" [] [],
+                                                l_curly_token: L_CURLY@1190..1191 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@1191..1192 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@1192..1196 "slot" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@1196..1197 "}" [] [],
+                                            },
+                                        ],
+                                    },
+                                    colon_token: COLON@1197..1199 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@1199..1202 "red" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            SEMICOLON@1202..1203 ";" [] [],
+                        ],
+                    },
+                ],
+                r_curly_token: R_CURLY@1203..1205 "}" [Newline("\n")] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@1205..1208 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1208..1222 "malformed-css" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@1222..1223 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1223..1231 "color" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@1231..1233 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssFunction {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@1233..1237 "calc" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@1237..1238 "(" [] [],
+                                        items: CssParameterList [
+                                            CssListOfComponentValuesExpression {
+                                                css_component_value_list: CssComponentValueList [
+                                                    CssColor {
+                                                        hash_token: HASH@1238..1240 "#" [] [Whitespace(" ")],
+                                                        value_token: missing (required),
+                                                    },
+                                                ],
+                                            },
+                                            missing separator,
+                                            CssCommaSeparatedValue {
+                                                l_curly_token: L_CURLY@1240..1241 "{" [] [],
+                                                items: CssGenericComponentValueList [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1241..1246 "value" [] [],
+                                                    },
+                                                ],
+                                                r_curly_token: R_CURLY@1246..1247 "}" [] [],
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@1247..1248 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1248..1249 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@1249..1251 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@1251..1252 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..1252
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..1251
+    0: CSS_QUALIFIED_RULE@0..521
+      0: CSS_SELECTOR_LIST@0..18
+        0: CSS_COMPOUND_SELECTOR@0..18
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@0..18
+            0: CSS_CLASS_SELECTOR@0..18
+              0: DOT@0..1 "." [] []
+              1: CSS_CUSTOM_IDENTIFIER@1..18
+                0: IDENT@1..18 "unsupported-scss" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@18..521
+        0: L_CURLY@18..19 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@19..519
+          0: CSS_DECLARATION_WITH_SEMICOLON@19..39
+            0: CSS_DECLARATION@19..38
+              0: CSS_BOGUS_PROPERTY@19..38
+                0: CSS_IDENTIFIER@19..30
+                  0: IDENT@19..30 "variable" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@30..32 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@32..38
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@32..38
+                    0: DOLLAR@32..33 "$" [] []
+                    1: CSS_IDENTIFIER@33..38
+                      0: IDENT@33..38 "value" [] []
+              1: (empty)
+            1: SEMICOLON@38..39 ";" [] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@39..82
+            0: CSS_DECLARATION@39..81
+              0: CSS_BOGUS_PROPERTY@39..81
+                0: CSS_IDENTIFIER@39..64
+                  0: IDENT@39..64 "variable-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@64..66 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@66..81
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@66..81
+                    0: SCSS_INTERPOLATED_VALUE_PART_LIST@66..81
+                      0: SCSS_VARIABLE@66..72
+                        0: DOLLAR@66..67 "$" [] []
+                        1: CSS_IDENTIFIER@67..72
+                          0: IDENT@67..72 "value" [] []
+                      1: SCSS_INTERPOLATION@72..81
+                        0: HASH@72..73 "#" [] []
+                        1: L_CURLY@73..74 "{" [] []
+                        2: SCSS_EXPRESSION@74..80
+                          0: SCSS_EXPRESSION_ITEM_LIST@74..80
+                            0: CSS_IDENTIFIER@74..80
+                              0: IDENT@74..80 "suffix" [] []
+                        3: R_CURLY@80..81 "}" [] []
+              1: (empty)
+            1: SEMICOLON@81..82 ";" [] []
+          2: CSS_DECLARATION_WITH_SEMICOLON@82..114
+            0: CSS_DECLARATION@82..113
+              0: CSS_BOGUS_PROPERTY@82..113
+                0: CSS_IDENTIFIER@82..98
+                  0: IDENT@82..98 "module-member" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@98..100 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@100..113
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@100..113
+                    0: CSS_IDENTIFIER@100..106
+                      0: IDENT@100..106 "module" [] []
+                    1: DOT@106..107 "." [] []
+                    2: SCSS_VARIABLE@107..113
+                      0: DOLLAR@107..108 "$" [] []
+                      1: CSS_IDENTIFIER@108..113
+                        0: IDENT@108..113 "value" [] []
+              1: (empty)
+            1: SEMICOLON@113..114 ";" [] []
+          3: CSS_DECLARATION_WITH_SEMICOLON@114..169
+            0: CSS_DECLARATION@114..168
+              0: CSS_BOGUS_PROPERTY@114..168
+                0: CSS_IDENTIFIER@114..144
+                  0: IDENT@114..144 "module-member-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@144..146 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@146..168
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@146..168
+                    0: SCSS_INTERPOLATED_VALUE_PART_LIST@146..168
+                      0: SCSS_NAMESPACED_VARIABLE@146..159
+                        0: CSS_IDENTIFIER@146..152
+                          0: IDENT@146..152 "module" [] []
+                        1: DOT@152..153 "." [] []
+                        2: SCSS_VARIABLE@153..159
+                          0: DOLLAR@153..154 "$" [] []
+                          1: CSS_IDENTIFIER@154..159
+                            0: IDENT@154..159 "value" [] []
+                      1: SCSS_INTERPOLATION@159..168
+                        0: HASH@159..160 "#" [] []
+                        1: L_CURLY@160..161 "{" [] []
+                        2: SCSS_EXPRESSION@161..167
+                          0: SCSS_EXPRESSION_ITEM_LIST@161..167
+                            0: CSS_IDENTIFIER@161..167
+                              0: IDENT@161..167 "suffix" [] []
+                        3: R_CURLY@167..168 "}" [] []
+              1: (empty)
+            1: SEMICOLON@168..169 ";" [] []
+          4: CSS_DECLARATION_WITH_SEMICOLON@169..205
+            0: CSS_DECLARATION@169..204
+              0: CSS_BOGUS_PROPERTY@169..204
+                0: CSS_IDENTIFIER@169..190
+                  0: IDENT@169..190 "qualified-function" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@190..192 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@192..204
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@192..204
+                    0: SCSS_MODULE_MEMBER_ACCESS@192..201
+                      0: CSS_IDENTIFIER@192..198
+                        0: IDENT@192..198 "module" [] []
+                      1: DOT@198..199 "." [] []
+                      2: CSS_IDENTIFIER@199..201
+                        0: IDENT@199..201 "fn" [] []
+                    1: L_PAREN@201..202 "(" [] []
+                    2: CSS_PARAMETER_LIST@202..203
+                      0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@202..203
+                        0: CSS_COMPONENT_VALUE_LIST@202..203
+                          0: CSS_NUMBER@202..203
+                            0: CSS_NUMBER_LITERAL@202..203 "1" [] []
+                    3: R_PAREN@203..204 ")" [] []
+              1: (empty)
+            1: SEMICOLON@204..205 ";" [] []
+          5: CSS_DECLARATION_WITH_SEMICOLON@205..233
+            0: CSS_DECLARATION@205..232
+              0: CSS_BOGUS_PROPERTY@205..232
+                0: CSS_IDENTIFIER@205..221
+                  0: IDENT@205..221 "interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@221..223 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@223..232
+                  0: CSS_BOGUS@223..232
+                    0: HASH@223..224 "#" [] []
+                    1: L_CURLY@224..225 "{" [] []
+                    2: SCSS_EXPRESSION@225..231
+                      0: SCSS_EXPRESSION_ITEM_LIST@225..231
+                        0: SCSS_VARIABLE@225..231
+                          0: DOLLAR@225..226 "$" [] []
+                          1: CSS_IDENTIFIER@226..231
+                            0: IDENT@226..231 "value" [] []
+                    3: R_CURLY@231..232 "}" [] []
+              1: (empty)
+            1: SEMICOLON@232..233 ";" [] []
+          6: CSS_DECLARATION_WITH_SEMICOLON@233..272
+            0: CSS_DECLARATION@233..271
+              0: CSS_BOGUS_PROPERTY@233..271
+                0: CSS_IDENTIFIER@233..259
+                  0: IDENT@233..259 "adjacent-interpolations" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@259..261 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@261..271
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@261..271
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@261..271
+                      0: SCSS_INTERPOLATION@261..266
+                        0: HASH@261..262 "#" [] []
+                        1: L_CURLY@262..263 "{" [] []
+                        2: SCSS_EXPRESSION@263..265
+                          0: SCSS_EXPRESSION_ITEM_LIST@263..265
+                            0: SCSS_VARIABLE@263..265
+                              0: DOLLAR@263..264 "$" [] []
+                              1: CSS_IDENTIFIER@264..265
+                                0: IDENT@264..265 "a" [] []
+                        3: R_CURLY@265..266 "}" [] []
+                      1: SCSS_INTERPOLATION@266..271
+                        0: HASH@266..267 "#" [] []
+                        1: L_CURLY@267..268 "{" [] []
+                        2: SCSS_EXPRESSION@268..270
+                          0: SCSS_EXPRESSION_ITEM_LIST@268..270
+                            0: SCSS_VARIABLE@268..270
+                              0: DOLLAR@268..269 "$" [] []
+                              1: CSS_IDENTIFIER@269..270
+                                0: IDENT@269..270 "b" [] []
+                        3: R_CURLY@270..271 "}" [] []
+              1: (empty)
+            1: SEMICOLON@271..272 ";" [] []
+          7: CSS_DECLARATION_WITH_SEMICOLON@272..307
+            0: CSS_DECLARATION@272..306
+              0: CSS_BOGUS_PROPERTY@272..306
+                0: CSS_IDENTIFIER@272..295
+                  0: IDENT@272..295 "number-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@295..297 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@297..306
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@297..306
+                    0: SCSS_INTERPOLATED_VALUE_PART_LIST@297..306
+                      0: CSS_NUMBER@297..299
+                        0: CSS_NUMBER_LITERAL@297..299 "10" [] []
+                      1: SCSS_INTERPOLATION@299..306
+                        0: HASH@299..300 "#" [] []
+                        1: L_CURLY@300..301 "{" [] []
+                        2: SCSS_EXPRESSION@301..305
+                          0: SCSS_EXPRESSION_ITEM_LIST@301..305
+                            0: CSS_IDENTIFIER@301..305
+                              0: IDENT@301..305 "unit" [] []
+                        3: R_CURLY@305..306 "}" [] []
+              1: (empty)
+            1: SEMICOLON@306..307 ";" [] []
+          8: CSS_DECLARATION_WITH_SEMICOLON@307..349
+            0: CSS_DECLARATION@307..348
+              0: CSS_BOGUS_PROPERTY@307..348
+                0: CSS_IDENTIFIER@307..333
+                  0: IDENT@307..333 "dimension-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@333..335 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@335..348
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@335..348
+                    0: SCSS_INTERPOLATED_VALUE_PART_LIST@335..348
+                      0: CSS_REGULAR_DIMENSION@335..339
+                        0: CSS_NUMBER_LITERAL@335..337 "10" [] []
+                        1: IDENT@337..339 "px" [] []
+                      1: SCSS_INTERPOLATION@339..348
+                        0: HASH@339..340 "#" [] []
+                        1: L_CURLY@340..341 "{" [] []
+                        2: SCSS_EXPRESSION@341..347
+                          0: SCSS_EXPRESSION_ITEM_LIST@341..347
+                            0: CSS_IDENTIFIER@341..347
+                              0: IDENT@341..347 "suffix" [] []
+                        3: R_CURLY@347..348 "}" [] []
+              1: (empty)
+            1: SEMICOLON@348..349 ";" [] []
+          9: CSS_DECLARATION_WITH_SEMICOLON@349..382
+            0: CSS_DECLARATION@349..381
+              0: CSS_BOGUS_PROPERTY@349..381
+                0: CSS_IDENTIFIER@349..369
+                  0: IDENT@349..369 "interpolated-name" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@369..371 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@371..381
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@371..381
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@371..381
+                      0: CSS_IDENTIFIER@371..374
+                        0: IDENT@371..374 "foo" [] []
+                      1: SCSS_INTERPOLATION@374..381
+                        0: HASH@374..375 "#" [] []
+                        1: L_CURLY@375..376 "{" [] []
+                        2: SCSS_EXPRESSION@376..380
+                          0: SCSS_EXPRESSION_ITEM_LIST@376..380
+                            0: SCSS_VARIABLE@376..380
+                              0: DOLLAR@376..377 "$" [] []
+                              1: CSS_IDENTIFIER@377..380
+                                0: IDENT@377..380 "bar" [] []
+                        3: R_CURLY@380..381 "}" [] []
+              1: (empty)
+            1: SEMICOLON@381..382 ";" [] []
+          10: CSS_DECLARATION_WITH_SEMICOLON@382..418
+            0: CSS_DECLARATION@382..417
+              0: CSS_GENERIC_PROPERTY@382..417
+                0: CSS_IDENTIFIER@382..404
+                  0: IDENT@382..404 "interpolated-string" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@404..406 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@406..417
+                  0: CSS_STRING@406..417
+                    0: CSS_STRING_LITERAL@406..417 "\"#{$value}\"" [] []
+              1: (empty)
+            1: SEMICOLON@417..418 ";" [] []
+          11: CSS_DECLARATION_WITH_SEMICOLON@418..462
+            0: CSS_DECLARATION@418..461
+              0: CSS_BOGUS_PROPERTY@418..461
+                0: CSS_IDENTIFIER@418..449
+                  0: IDENT@418..449 "interpolated-custom-property" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@449..451 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@451..461
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@451..461
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@451..461
+                      0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@451..452
+                        0: MINUS@451..452 "-" [] []
+                      1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@452..453
+                        0: MINUS@452..453 "-" [] []
+                      2: SCSS_INTERPOLATION@453..461
+                        0: HASH@453..454 "#" [] []
+                        1: L_CURLY@454..455 "{" [] []
+                        2: SCSS_EXPRESSION@455..460
+                          0: SCSS_EXPRESSION_ITEM_LIST@455..460
+                            0: SCSS_VARIABLE@455..460
+                              0: DOLLAR@455..456 "$" [] []
+                              1: CSS_IDENTIFIER@456..460
+                                0: IDENT@456..460 "name" [] []
+                        3: R_CURLY@460..461 "}" [] []
+              1: (empty)
+            1: SEMICOLON@461..462 ";" [] []
+          12: CSS_DECLARATION_WITH_SEMICOLON@462..519
+            0: CSS_DECLARATION@462..518
+              0: CSS_BOGUS_PROPERTY@462..518
+                0: CSS_IDENTIFIER@462..500
+                  0: IDENT@462..500 "interpolated-custom-property-suffix" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@500..502 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@502..518
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@502..518
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@502..518
+                      0: CSS_IDENTIFIER@502..510
+                        0: IDENT@502..510 "--theme-" [] []
+                      1: SCSS_INTERPOLATION@510..518
+                        0: HASH@510..511 "#" [] []
+                        1: L_CURLY@511..512 "{" [] []
+                        2: SCSS_EXPRESSION@512..517
+                          0: SCSS_EXPRESSION_ITEM_LIST@512..517
+                            0: SCSS_VARIABLE@512..517
+                              0: DOLLAR@512..513 "$" [] []
+                              1: CSS_IDENTIFIER@513..517
+                                0: IDENT@513..517 "slot" [] []
+                        3: R_CURLY@517..518 "}" [] []
+              1: (empty)
+            1: SEMICOLON@518..519 ";" [] []
+        2: R_CURLY@519..521 "}" [Newline("\n")] []
+    1: CSS_QUALIFIED_RULE@521..1098
+      0: CSS_SELECTOR_LIST@521..543
+        0: CSS_COMPOUND_SELECTOR@521..543
+          0: CSS_NESTED_SELECTOR_LIST@521..521
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@521..543
+            0: CSS_CLASS_SELECTOR@521..543
+              0: DOT@521..524 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@524..543
+                0: IDENT@524..543 "function-arguments" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@543..1098
+        0: L_CURLY@543..544 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@544..1096
+          0: CSS_DECLARATION_WITH_SEMICOLON@544..568
+            0: CSS_DECLARATION@544..567
+              0: CSS_BOGUS_PROPERTY@544..567
+                0: CSS_IDENTIFIER@544..555
+                  0: IDENT@544..555 "variable" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@555..557 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@557..567
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@557..567
+                    0: CSS_IDENTIFIER@557..559
+                      0: IDENT@557..559 "fn" [] []
+                    1: L_PAREN@559..560 "(" [] []
+                    2: CSS_BOGUS@560..566
+                      0: CSS_BOGUS@560..566
+                        0: CSS_BOGUS@560..566
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@560..566
+                            0: DOLLAR@560..561 "$" [] []
+                            1: CSS_IDENTIFIER@561..566
+                              0: IDENT@561..566 "value" [] []
+                    3: R_PAREN@566..567 ")" [] []
+              1: (empty)
+            1: SEMICOLON@567..568 ";" [] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@568..615
+            0: CSS_DECLARATION@568..614
+              0: CSS_BOGUS_PROPERTY@568..614
+                0: CSS_IDENTIFIER@568..593
+                  0: IDENT@568..593 "variable-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@593..595 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@595..614
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@595..614
+                    0: CSS_IDENTIFIER@595..597
+                      0: IDENT@595..597 "fn" [] []
+                    1: L_PAREN@597..598 "(" [] []
+                    2: CSS_BOGUS@598..613
+                      0: CSS_BOGUS@598..613
+                        0: CSS_BOGUS@598..613
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@598..613
+                            0: SCSS_INTERPOLATED_VALUE_PART_LIST@598..613
+                              0: SCSS_VARIABLE@598..604
+                                0: DOLLAR@598..599 "$" [] []
+                                1: CSS_IDENTIFIER@599..604
+                                  0: IDENT@599..604 "value" [] []
+                              1: SCSS_INTERPOLATION@604..613
+                                0: HASH@604..605 "#" [] []
+                                1: L_CURLY@605..606 "{" [] []
+                                2: SCSS_EXPRESSION@606..612
+                                  0: SCSS_EXPRESSION_ITEM_LIST@606..612
+                                    0: CSS_IDENTIFIER@606..612
+                                      0: IDENT@606..612 "suffix" [] []
+                                3: R_CURLY@612..613 "}" [] []
+                    3: R_PAREN@613..614 ")" [] []
+              1: (empty)
+            1: SEMICOLON@614..615 ";" [] []
+          2: CSS_DECLARATION_WITH_SEMICOLON@615..651
+            0: CSS_DECLARATION@615..650
+              0: CSS_BOGUS_PROPERTY@615..650
+                0: CSS_IDENTIFIER@615..631
+                  0: IDENT@615..631 "module-member" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@631..633 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@633..650
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@633..650
+                    0: CSS_IDENTIFIER@633..635
+                      0: IDENT@633..635 "fn" [] []
+                    1: L_PAREN@635..636 "(" [] []
+                    2: CSS_BOGUS@636..649
+                      0: CSS_BOGUS@636..649
+                        0: CSS_BOGUS@636..649
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@636..649
+                            0: CSS_IDENTIFIER@636..642
+                              0: IDENT@636..642 "module" [] []
+                            1: DOT@642..643 "." [] []
+                            2: SCSS_VARIABLE@643..649
+                              0: DOLLAR@643..644 "$" [] []
+                              1: CSS_IDENTIFIER@644..649
+                                0: IDENT@644..649 "value" [] []
+                    3: R_PAREN@649..650 ")" [] []
+              1: (empty)
+            1: SEMICOLON@650..651 ";" [] []
+          3: CSS_DECLARATION_WITH_SEMICOLON@651..710
+            0: CSS_DECLARATION@651..709
+              0: CSS_BOGUS_PROPERTY@651..709
+                0: CSS_IDENTIFIER@651..681
+                  0: IDENT@651..681 "module-member-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@681..683 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@683..709
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@683..709
+                    0: CSS_IDENTIFIER@683..685
+                      0: IDENT@683..685 "fn" [] []
+                    1: L_PAREN@685..686 "(" [] []
+                    2: CSS_BOGUS@686..708
+                      0: CSS_BOGUS@686..708
+                        0: CSS_BOGUS@686..708
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@686..708
+                            0: SCSS_INTERPOLATED_VALUE_PART_LIST@686..708
+                              0: SCSS_NAMESPACED_VARIABLE@686..699
+                                0: CSS_IDENTIFIER@686..692
+                                  0: IDENT@686..692 "module" [] []
+                                1: DOT@692..693 "." [] []
+                                2: SCSS_VARIABLE@693..699
+                                  0: DOLLAR@693..694 "$" [] []
+                                  1: CSS_IDENTIFIER@694..699
+                                    0: IDENT@694..699 "value" [] []
+                              1: SCSS_INTERPOLATION@699..708
+                                0: HASH@699..700 "#" [] []
+                                1: L_CURLY@700..701 "{" [] []
+                                2: SCSS_EXPRESSION@701..707
+                                  0: SCSS_EXPRESSION_ITEM_LIST@701..707
+                                    0: CSS_IDENTIFIER@701..707
+                                      0: IDENT@701..707 "suffix" [] []
+                                3: R_CURLY@707..708 "}" [] []
+                    3: R_PAREN@708..709 ")" [] []
+              1: (empty)
+            1: SEMICOLON@709..710 ";" [] []
+          4: CSS_DECLARATION_WITH_SEMICOLON@710..750
+            0: CSS_DECLARATION@710..749
+              0: CSS_BOGUS_PROPERTY@710..749
+                0: CSS_IDENTIFIER@710..731
+                  0: IDENT@710..731 "qualified-function" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@731..733 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@733..749
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@733..749
+                    0: CSS_IDENTIFIER@733..735
+                      0: IDENT@733..735 "fn" [] []
+                    1: L_PAREN@735..736 "(" [] []
+                    2: CSS_BOGUS@736..748
+                      0: CSS_BOGUS@736..748
+                        0: CSS_BOGUS@736..748
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@736..748
+                            0: SCSS_MODULE_MEMBER_ACCESS@736..745
+                              0: CSS_IDENTIFIER@736..742
+                                0: IDENT@736..742 "module" [] []
+                              1: DOT@742..743 "." [] []
+                              2: CSS_IDENTIFIER@743..745
+                                0: IDENT@743..745 "fn" [] []
+                            1: L_PAREN@745..746 "(" [] []
+                            2: CSS_PARAMETER_LIST@746..747
+                              0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@746..747
+                                0: CSS_COMPONENT_VALUE_LIST@746..747
+                                  0: CSS_NUMBER@746..747
+                                    0: CSS_NUMBER_LITERAL@746..747 "1" [] []
+                            3: R_PAREN@747..748 ")" [] []
+                    3: R_PAREN@748..749 ")" [] []
+              1: (empty)
+            1: SEMICOLON@749..750 ";" [] []
+          5: CSS_DECLARATION_WITH_SEMICOLON@750..782
+            0: CSS_DECLARATION@750..781
+              0: CSS_BOGUS_PROPERTY@750..781
+                0: CSS_IDENTIFIER@750..766
+                  0: IDENT@750..766 "interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@766..768 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@768..781
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@768..781
+                    0: CSS_IDENTIFIER@768..770
+                      0: IDENT@768..770 "fn" [] []
+                    1: L_PAREN@770..771 "(" [] []
+                    2: CSS_BOGUS@771..780
+                      0: CSS_BOGUS@771..780
+                        0: CSS_BOGUS@771..780
+                          0: CSS_BOGUS@771..780
+                            0: HASH@771..772 "#" [] []
+                            1: L_CURLY@772..773 "{" [] []
+                            2: SCSS_EXPRESSION@773..779
+                              0: SCSS_EXPRESSION_ITEM_LIST@773..779
+                                0: SCSS_VARIABLE@773..779
+                                  0: DOLLAR@773..774 "$" [] []
+                                  1: CSS_IDENTIFIER@774..779
+                                    0: IDENT@774..779 "value" [] []
+                            3: R_CURLY@779..780 "}" [] []
+                    3: R_PAREN@780..781 ")" [] []
+              1: (empty)
+            1: SEMICOLON@781..782 ";" [] []
+          6: CSS_DECLARATION_WITH_SEMICOLON@782..825
+            0: CSS_DECLARATION@782..824
+              0: CSS_BOGUS_PROPERTY@782..824
+                0: CSS_IDENTIFIER@782..808
+                  0: IDENT@782..808 "adjacent-interpolations" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@808..810 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@810..824
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@810..824
+                    0: CSS_IDENTIFIER@810..812
+                      0: IDENT@810..812 "fn" [] []
+                    1: L_PAREN@812..813 "(" [] []
+                    2: CSS_BOGUS@813..823
+                      0: CSS_BOGUS@813..823
+                        0: CSS_BOGUS@813..823
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@813..823
+                            0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@813..823
+                              0: SCSS_INTERPOLATION@813..818
+                                0: HASH@813..814 "#" [] []
+                                1: L_CURLY@814..815 "{" [] []
+                                2: SCSS_EXPRESSION@815..817
+                                  0: SCSS_EXPRESSION_ITEM_LIST@815..817
+                                    0: SCSS_VARIABLE@815..817
+                                      0: DOLLAR@815..816 "$" [] []
+                                      1: CSS_IDENTIFIER@816..817
+                                        0: IDENT@816..817 "a" [] []
+                                3: R_CURLY@817..818 "}" [] []
+                              1: SCSS_INTERPOLATION@818..823
+                                0: HASH@818..819 "#" [] []
+                                1: L_CURLY@819..820 "{" [] []
+                                2: SCSS_EXPRESSION@820..822
+                                  0: SCSS_EXPRESSION_ITEM_LIST@820..822
+                                    0: SCSS_VARIABLE@820..822
+                                      0: DOLLAR@820..821 "$" [] []
+                                      1: CSS_IDENTIFIER@821..822
+                                        0: IDENT@821..822 "b" [] []
+                                3: R_CURLY@822..823 "}" [] []
+                    3: R_PAREN@823..824 ")" [] []
+              1: (empty)
+            1: SEMICOLON@824..825 ";" [] []
+          7: CSS_DECLARATION_WITH_SEMICOLON@825..864
+            0: CSS_DECLARATION@825..863
+              0: CSS_BOGUS_PROPERTY@825..863
+                0: CSS_IDENTIFIER@825..848
+                  0: IDENT@825..848 "number-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@848..850 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@850..863
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@850..863
+                    0: CSS_IDENTIFIER@850..852
+                      0: IDENT@850..852 "fn" [] []
+                    1: L_PAREN@852..853 "(" [] []
+                    2: CSS_BOGUS@853..862
+                      0: CSS_BOGUS@853..862
+                        0: CSS_BOGUS@853..862
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@853..862
+                            0: SCSS_INTERPOLATED_VALUE_PART_LIST@853..862
+                              0: CSS_NUMBER@853..855
+                                0: CSS_NUMBER_LITERAL@853..855 "10" [] []
+                              1: SCSS_INTERPOLATION@855..862
+                                0: HASH@855..856 "#" [] []
+                                1: L_CURLY@856..857 "{" [] []
+                                2: SCSS_EXPRESSION@857..861
+                                  0: SCSS_EXPRESSION_ITEM_LIST@857..861
+                                    0: CSS_IDENTIFIER@857..861
+                                      0: IDENT@857..861 "unit" [] []
+                                3: R_CURLY@861..862 "}" [] []
+                    3: R_PAREN@862..863 ")" [] []
+              1: (empty)
+            1: SEMICOLON@863..864 ";" [] []
+          8: CSS_DECLARATION_WITH_SEMICOLON@864..910
+            0: CSS_DECLARATION@864..909
+              0: CSS_BOGUS_PROPERTY@864..909
+                0: CSS_IDENTIFIER@864..890
+                  0: IDENT@864..890 "dimension-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@890..892 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@892..909
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@892..909
+                    0: CSS_IDENTIFIER@892..894
+                      0: IDENT@892..894 "fn" [] []
+                    1: L_PAREN@894..895 "(" [] []
+                    2: CSS_BOGUS@895..908
+                      0: CSS_BOGUS@895..908
+                        0: CSS_BOGUS@895..908
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@895..908
+                            0: SCSS_INTERPOLATED_VALUE_PART_LIST@895..908
+                              0: CSS_REGULAR_DIMENSION@895..899
+                                0: CSS_NUMBER_LITERAL@895..897 "10" [] []
+                                1: IDENT@897..899 "px" [] []
+                              1: SCSS_INTERPOLATION@899..908
+                                0: HASH@899..900 "#" [] []
+                                1: L_CURLY@900..901 "{" [] []
+                                2: SCSS_EXPRESSION@901..907
+                                  0: SCSS_EXPRESSION_ITEM_LIST@901..907
+                                    0: CSS_IDENTIFIER@901..907
+                                      0: IDENT@901..907 "suffix" [] []
+                                3: R_CURLY@907..908 "}" [] []
+                    3: R_PAREN@908..909 ")" [] []
+              1: (empty)
+            1: SEMICOLON@909..910 ";" [] []
+          9: CSS_DECLARATION_WITH_SEMICOLON@910..947
+            0: CSS_DECLARATION@910..946
+              0: CSS_BOGUS_PROPERTY@910..946
+                0: CSS_IDENTIFIER@910..930
+                  0: IDENT@910..930 "interpolated-name" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@930..932 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@932..946
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@932..946
+                    0: CSS_IDENTIFIER@932..934
+                      0: IDENT@932..934 "fn" [] []
+                    1: L_PAREN@934..935 "(" [] []
+                    2: CSS_BOGUS@935..945
+                      0: CSS_BOGUS@935..945
+                        0: CSS_BOGUS@935..945
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@935..945
+                            0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@935..945
+                              0: CSS_IDENTIFIER@935..938
+                                0: IDENT@935..938 "foo" [] []
+                              1: SCSS_INTERPOLATION@938..945
+                                0: HASH@938..939 "#" [] []
+                                1: L_CURLY@939..940 "{" [] []
+                                2: SCSS_EXPRESSION@940..944
+                                  0: SCSS_EXPRESSION_ITEM_LIST@940..944
+                                    0: SCSS_VARIABLE@940..944
+                                      0: DOLLAR@940..941 "$" [] []
+                                      1: CSS_IDENTIFIER@941..944
+                                        0: IDENT@941..944 "bar" [] []
+                                3: R_CURLY@944..945 "}" [] []
+                    3: R_PAREN@945..946 ")" [] []
+              1: (empty)
+            1: SEMICOLON@946..947 ";" [] []
+          10: CSS_DECLARATION_WITH_SEMICOLON@947..987
+            0: CSS_DECLARATION@947..986
+              0: CSS_GENERIC_PROPERTY@947..986
+                0: CSS_IDENTIFIER@947..969
+                  0: IDENT@947..969 "interpolated-string" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@969..971 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@971..986
+                  0: CSS_FUNCTION@971..986
+                    0: CSS_IDENTIFIER@971..973
+                      0: IDENT@971..973 "fn" [] []
+                    1: L_PAREN@973..974 "(" [] []
+                    2: CSS_PARAMETER_LIST@974..985
+                      0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@974..985
+                        0: CSS_COMPONENT_VALUE_LIST@974..985
+                          0: CSS_STRING@974..985
+                            0: CSS_STRING_LITERAL@974..985 "\"#{$value}\"" [] []
+                    3: R_PAREN@985..986 ")" [] []
+              1: (empty)
+            1: SEMICOLON@986..987 ";" [] []
+          11: CSS_DECLARATION_WITH_SEMICOLON@987..1035
+            0: CSS_DECLARATION@987..1034
+              0: CSS_BOGUS_PROPERTY@987..1034
+                0: CSS_IDENTIFIER@987..1018
+                  0: IDENT@987..1018 "interpolated-custom-property" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@1018..1020 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@1020..1034
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@1020..1034
+                    0: CSS_IDENTIFIER@1020..1022
+                      0: IDENT@1020..1022 "fn" [] []
+                    1: L_PAREN@1022..1023 "(" [] []
+                    2: CSS_BOGUS@1023..1033
+                      0: CSS_BOGUS@1023..1033
+                        0: MINUS@1023..1024 "-" [] []
+                        1: CSS_BOGUS@1024..1033
+                          0: MINUS@1024..1025 "-" [] []
+                          1: CSS_BOGUS@1025..1033
+                            0: CSS_BOGUS@1025..1033
+                              0: CSS_BOGUS@1025..1033
+                                0: HASH@1025..1026 "#" [] []
+                                1: L_CURLY@1026..1027 "{" [] []
+                                2: SCSS_EXPRESSION@1027..1032
+                                  0: SCSS_EXPRESSION_ITEM_LIST@1027..1032
+                                    0: SCSS_VARIABLE@1027..1032
+                                      0: DOLLAR@1027..1028 "$" [] []
+                                      1: CSS_IDENTIFIER@1028..1032
+                                        0: IDENT@1028..1032 "name" [] []
+                                3: R_CURLY@1032..1033 "}" [] []
+                    3: R_PAREN@1033..1034 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1034..1035 ";" [] []
+          12: CSS_DECLARATION_WITH_SEMICOLON@1035..1096
+            0: CSS_DECLARATION@1035..1095
+              0: CSS_BOGUS_PROPERTY@1035..1095
+                0: CSS_IDENTIFIER@1035..1073
+                  0: IDENT@1035..1073 "interpolated-custom-property-suffix" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@1073..1075 ":" [] [Whitespace(" ")]
+                2: CSS_BOGUS@1075..1095
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@1075..1095
+                    0: CSS_IDENTIFIER@1075..1077
+                      0: IDENT@1075..1077 "fn" [] []
+                    1: L_PAREN@1077..1078 "(" [] []
+                    2: CSS_BOGUS@1078..1094
+                      0: CSS_BOGUS@1078..1094
+                        0: CSS_BOGUS@1078..1094
+                          0: CSS_BOGUS_SUPPORTS_CONDITION@1078..1094
+                            0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1078..1094
+                              0: CSS_IDENTIFIER@1078..1086
+                                0: IDENT@1078..1086 "--theme-" [] []
+                              1: SCSS_INTERPOLATION@1086..1094
+                                0: HASH@1086..1087 "#" [] []
+                                1: L_CURLY@1087..1088 "{" [] []
+                                2: SCSS_EXPRESSION@1088..1093
+                                  0: SCSS_EXPRESSION_ITEM_LIST@1088..1093
+                                    0: SCSS_VARIABLE@1088..1093
+                                      0: DOLLAR@1088..1089 "$" [] []
+                                      1: CSS_IDENTIFIER@1089..1093
+                                        0: IDENT@1089..1093 "slot" [] []
+                                3: R_CURLY@1093..1094 "}" [] []
+                    3: R_PAREN@1094..1095 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1095..1096 ";" [] []
+        2: R_CURLY@1096..1098 "}" [Newline("\n")] []
+    2: CSS_QUALIFIED_RULE@1098..1205
+      0: CSS_SELECTOR_LIST@1098..1116
+        0: CSS_COMPOUND_SELECTOR@1098..1116
+          0: CSS_NESTED_SELECTOR_LIST@1098..1098
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@1098..1116
+            0: CSS_CLASS_SELECTOR@1098..1116
+              0: DOT@1098..1101 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@1101..1116
+                0: IDENT@1101..1116 "property-names" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1116..1205
+        0: L_CURLY@1116..1117 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@1117..1203
+          0: CSS_BOGUS@1117..1134
+            0: CSS_DECLARATION@1117..1133
+              0: CSS_GENERIC_PROPERTY@1117..1133
+                0: SCSS_INTERPOLATED_IDENTIFIER@1117..1128
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1117..1128
+                    0: SCSS_INTERPOLATION@1117..1128
+                      0: HASH@1117..1121 "#" [Newline("\n"), Whitespace("  ")] []
+                      1: L_CURLY@1121..1122 "{" [] []
+                      2: SCSS_EXPRESSION@1122..1127
+                        0: SCSS_EXPRESSION_ITEM_LIST@1122..1127
+                          0: SCSS_VARIABLE@1122..1127
+                            0: DOLLAR@1122..1123 "$" [] []
+                            1: CSS_IDENTIFIER@1123..1127
+                              0: IDENT@1123..1127 "name" [] []
+                      3: R_CURLY@1127..1128 "}" [] []
+                1: COLON@1128..1130 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1130..1133
+                  0: SCSS_EXPRESSION_ITEM_LIST@1130..1133
+                    0: CSS_REGULAR_DIMENSION@1130..1133
+                      0: CSS_NUMBER_LITERAL@1130..1131 "1" [] []
+                      1: IDENT@1131..1133 "px" [] []
+              1: (empty)
+            1: SEMICOLON@1133..1134 ";" [] []
+          1: CSS_BOGUS@1134..1158
+            0: CSS_DECLARATION@1134..1157
+              0: CSS_GENERIC_PROPERTY@1134..1157
+                0: SCSS_INTERPOLATED_IDENTIFIER@1134..1152
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1134..1152
+                    0: CSS_IDENTIFIER@1134..1144
+                      0: IDENT@1134..1144 "margin-" [Newline("\n"), Whitespace("  ")] []
+                    1: SCSS_INTERPOLATION@1144..1152
+                      0: HASH@1144..1145 "#" [] []
+                      1: L_CURLY@1145..1146 "{" [] []
+                      2: SCSS_EXPRESSION@1146..1151
+                        0: SCSS_EXPRESSION_ITEM_LIST@1146..1151
+                          0: SCSS_VARIABLE@1146..1151
+                            0: DOLLAR@1146..1147 "$" [] []
+                            1: CSS_IDENTIFIER@1147..1151
+                              0: IDENT@1147..1151 "side" [] []
+                      3: R_CURLY@1151..1152 "}" [] []
+                1: COLON@1152..1154 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1154..1157
+                  0: SCSS_EXPRESSION_ITEM_LIST@1154..1157
+                    0: CSS_REGULAR_DIMENSION@1154..1157
+                      0: CSS_NUMBER_LITERAL@1154..1155 "1" [] []
+                      1: IDENT@1155..1157 "px" [] []
+              1: (empty)
+            1: SEMICOLON@1157..1158 ";" [] []
+          2: CSS_BOGUS@1158..1178
+            0: CSS_DECLARATION@1158..1177
+              0: CSS_GENERIC_PROPERTY@1158..1177
+                0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@1158..1171
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1158..1171
+                    0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@1158..1162
+                      0: MINUS@1158..1162 "-" [Newline("\n"), Whitespace("  ")] []
+                    1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@1162..1163
+                      0: MINUS@1162..1163 "-" [] []
+                    2: SCSS_INTERPOLATION@1163..1171
+                      0: HASH@1163..1164 "#" [] []
+                      1: L_CURLY@1164..1165 "{" [] []
+                      2: SCSS_EXPRESSION@1165..1170
+                        0: SCSS_EXPRESSION_ITEM_LIST@1165..1170
+                          0: SCSS_VARIABLE@1165..1170
+                            0: DOLLAR@1165..1166 "$" [] []
+                            1: CSS_IDENTIFIER@1166..1170
+                              0: IDENT@1166..1170 "prop" [] []
+                      3: R_CURLY@1170..1171 "}" [] []
+                1: COLON@1171..1173 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1173..1177
+                  0: SCSS_EXPRESSION_ITEM_LIST@1173..1177
+                    0: CSS_REGULAR_DIMENSION@1173..1177
+                      0: CSS_NUMBER_LITERAL@1173..1175 "10" [] []
+                      1: IDENT@1175..1177 "px" [] []
+              1: (empty)
+            1: SEMICOLON@1177..1178 ";" [] []
+          3: CSS_BOGUS@1178..1203
+            0: CSS_DECLARATION@1178..1202
+              0: CSS_GENERIC_PROPERTY@1178..1202
+                0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@1178..1197
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1178..1197
+                    0: CSS_IDENTIFIER@1178..1189
+                      0: IDENT@1178..1189 "--theme-" [Newline("\n"), Whitespace("  ")] []
+                    1: SCSS_INTERPOLATION@1189..1197
+                      0: HASH@1189..1190 "#" [] []
+                      1: L_CURLY@1190..1191 "{" [] []
+                      2: SCSS_EXPRESSION@1191..1196
+                        0: SCSS_EXPRESSION_ITEM_LIST@1191..1196
+                          0: SCSS_VARIABLE@1191..1196
+                            0: DOLLAR@1191..1192 "$" [] []
+                            1: CSS_IDENTIFIER@1192..1196
+                              0: IDENT@1192..1196 "slot" [] []
+                      3: R_CURLY@1196..1197 "}" [] []
+                1: COLON@1197..1199 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1199..1202
+                  0: SCSS_EXPRESSION_ITEM_LIST@1199..1202
+                    0: CSS_IDENTIFIER@1199..1202
+                      0: IDENT@1199..1202 "red" [] []
+              1: (empty)
+            1: SEMICOLON@1202..1203 ";" [] []
+        2: R_CURLY@1203..1205 "}" [Newline("\n")] []
+    3: CSS_QUALIFIED_RULE@1205..1251
+      0: CSS_SELECTOR_LIST@1205..1222
+        0: CSS_COMPOUND_SELECTOR@1205..1222
+          0: CSS_NESTED_SELECTOR_LIST@1205..1205
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@1205..1222
+            0: CSS_CLASS_SELECTOR@1205..1222
+              0: DOT@1205..1208 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@1208..1222
+                0: IDENT@1208..1222 "malformed-css" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1222..1251
+        0: L_CURLY@1222..1223 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@1223..1249
+          0: CSS_DECLARATION_WITH_SEMICOLON@1223..1249
+            0: CSS_DECLARATION@1223..1248
+              0: CSS_GENERIC_PROPERTY@1223..1248
+                0: CSS_IDENTIFIER@1223..1231
+                  0: IDENT@1223..1231 "color" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@1231..1233 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@1233..1248
+                  0: CSS_FUNCTION@1233..1248
+                    0: CSS_IDENTIFIER@1233..1237
+                      0: IDENT@1233..1237 "calc" [] []
+                    1: L_PAREN@1237..1238 "(" [] []
+                    2: CSS_PARAMETER_LIST@1238..1247
+                      0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@1238..1240
+                        0: CSS_COMPONENT_VALUE_LIST@1238..1240
+                          0: CSS_COLOR@1238..1240
+                            0: HASH@1238..1240 "#" [] [Whitespace(" ")]
+                            1: (empty)
+                      1: (empty)
+                      2: CSS_COMMA_SEPARATED_VALUE@1240..1247
+                        0: L_CURLY@1240..1241 "{" [] []
+                        1: CSS_GENERIC_COMPONENT_VALUE_LIST@1241..1246
+                          0: CSS_IDENTIFIER@1241..1246
+                            0: IDENT@1241..1246 "value" [] []
+                        2: R_CURLY@1246..1247 "}" [] []
+                    3: R_PAREN@1247..1248 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1248..1249 ";" [] []
+        2: R_CURLY@1249..1251 "}" [Newline("\n")] []
+  2: EOF@1251..1252 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+scss_exclusive_values.css:2:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS variables are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    1 │ .unsupported-scss {
+  > 2 │   variable: $value;
+      │             ^^^^^^
+    3 │   variable-interpolation: $value#{suffix};
+    4 │   module-member: module.$value;
+  
+scss_exclusive_values.css:3:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    1 │ .unsupported-scss {
+    2 │   variable: $value;
+  > 3 │   variable-interpolation: $value#{suffix};
+      │                           ^^^^^^^^^^^^^^^
+    4 │   module-member: module.$value;
+    5 │   module-member-interpolation: module.$value#{suffix};
+  
+scss_exclusive_values.css:4:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS module member accesses are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    2 │   variable: $value;
+    3 │   variable-interpolation: $value#{suffix};
+  > 4 │   module-member: module.$value;
+      │                  ^^^^^^^^^^^^^
+    5 │   module-member-interpolation: module.$value#{suffix};
+    6 │   qualified-function: module.fn(1);
+  
+scss_exclusive_values.css:5:32 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    3 │   variable-interpolation: $value#{suffix};
+    4 │   module-member: module.$value;
+  > 5 │   module-member-interpolation: module.$value#{suffix};
+      │                                ^^^^^^^^^^^^^^^^^^^^^^
+    6 │   qualified-function: module.fn(1);
+    7 │   interpolation: #{$value};
+  
+scss_exclusive_values.css:6:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS qualified function names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    4 │   module-member: module.$value;
+    5 │   module-member-interpolation: module.$value#{suffix};
+  > 6 │   qualified-function: module.fn(1);
+      │                       ^^^^^^^^^^^^
+    7 │   interpolation: #{$value};
+    8 │   adjacent-interpolations: #{$a}#{$b};
+  
+scss_exclusive_values.css:7:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    5 │   module-member-interpolation: module.$value#{suffix};
+    6 │   qualified-function: module.fn(1);
+  > 7 │   interpolation: #{$value};
+      │                  ^^^^^^^^^
+    8 │   adjacent-interpolations: #{$a}#{$b};
+    9 │   number-interpolation: 10#{unit};
+  
+scss_exclusive_values.css:8:28 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+     6 │   qualified-function: module.fn(1);
+     7 │   interpolation: #{$value};
+   > 8 │   adjacent-interpolations: #{$a}#{$b};
+       │                            ^^^^^^^^^^
+     9 │   number-interpolation: 10#{unit};
+    10 │   dimension-interpolation: 10px#{suffix};
+  
+scss_exclusive_values.css:9:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+     7 │   interpolation: #{$value};
+     8 │   adjacent-interpolations: #{$a}#{$b};
+   > 9 │   number-interpolation: 10#{unit};
+       │                         ^^^^^^^^^
+    10 │   dimension-interpolation: 10px#{suffix};
+    11 │   interpolated-name: foo#{$bar};
+  
+scss_exclusive_values.css:10:28 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+     8 │   adjacent-interpolations: #{$a}#{$b};
+     9 │   number-interpolation: 10#{unit};
+  > 10 │   dimension-interpolation: 10px#{suffix};
+       │                            ^^^^^^^^^^^^^
+    11 │   interpolated-name: foo#{$bar};
+    12 │   interpolated-string: "#{$value}";
+  
+scss_exclusive_values.css:11:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+     9 │   number-interpolation: 10#{unit};
+    10 │   dimension-interpolation: 10px#{suffix};
+  > 11 │   interpolated-name: foo#{$bar};
+       │                      ^^^^^^^^^^
+    12 │   interpolated-string: "#{$value}";
+    13 │   interpolated-custom-property: --#{$name};
+  
+scss_exclusive_values.css:13:33 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated dashed identifiers are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    11 │   interpolated-name: foo#{$bar};
+    12 │   interpolated-string: "#{$value}";
+  > 13 │   interpolated-custom-property: --#{$name};
+       │                                 ^^^^^^^^^^
+    14 │   interpolated-custom-property-suffix: --theme-#{$slot};
+    15 │ }
+  
+scss_exclusive_values.css:14:40 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated dashed identifiers are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    12 │   interpolated-string: "#{$value}";
+    13 │   interpolated-custom-property: --#{$name};
+  > 14 │   interpolated-custom-property-suffix: --theme-#{$slot};
+       │                                        ^^^^^^^^^^^^^^^^
+    15 │ }
+    16 │ 
+  
+scss_exclusive_values.css:18:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS variables are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    17 │ .function-arguments {
+  > 18 │   variable: fn($value);
+       │                ^^^^^^
+    19 │   variable-interpolation: fn($value#{suffix});
+    20 │   module-member: fn(module.$value);
+  
+scss_exclusive_values.css:19:30 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    17 │ .function-arguments {
+    18 │   variable: fn($value);
+  > 19 │   variable-interpolation: fn($value#{suffix});
+       │                              ^^^^^^^^^^^^^^^
+    20 │   module-member: fn(module.$value);
+    21 │   module-member-interpolation: fn(module.$value#{suffix});
+  
+scss_exclusive_values.css:20:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS module member accesses are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    18 │   variable: fn($value);
+    19 │   variable-interpolation: fn($value#{suffix});
+  > 20 │   module-member: fn(module.$value);
+       │                     ^^^^^^^^^^^^^
+    21 │   module-member-interpolation: fn(module.$value#{suffix});
+    22 │   qualified-function: fn(module.fn(1));
+  
+scss_exclusive_values.css:21:35 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    19 │   variable-interpolation: fn($value#{suffix});
+    20 │   module-member: fn(module.$value);
+  > 21 │   module-member-interpolation: fn(module.$value#{suffix});
+       │                                   ^^^^^^^^^^^^^^^^^^^^^^
+    22 │   qualified-function: fn(module.fn(1));
+    23 │   interpolation: fn(#{$value});
+  
+scss_exclusive_values.css:22:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS qualified function names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    20 │   module-member: fn(module.$value);
+    21 │   module-member-interpolation: fn(module.$value#{suffix});
+  > 22 │   qualified-function: fn(module.fn(1));
+       │                          ^^^^^^^^^^^^
+    23 │   interpolation: fn(#{$value});
+    24 │   adjacent-interpolations: fn(#{$a}#{$b});
+  
+scss_exclusive_values.css:23:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    21 │   module-member-interpolation: fn(module.$value#{suffix});
+    22 │   qualified-function: fn(module.fn(1));
+  > 23 │   interpolation: fn(#{$value});
+       │                     ^^^^^^^^^
+    24 │   adjacent-interpolations: fn(#{$a}#{$b});
+    25 │   number-interpolation: fn(10#{unit});
+  
+scss_exclusive_values.css:24:31 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    22 │   qualified-function: fn(module.fn(1));
+    23 │   interpolation: fn(#{$value});
+  > 24 │   adjacent-interpolations: fn(#{$a}#{$b});
+       │                               ^^^^^^^^^^
+    25 │   number-interpolation: fn(10#{unit});
+    26 │   dimension-interpolation: fn(10px#{suffix});
+  
+scss_exclusive_values.css:25:28 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    23 │   interpolation: fn(#{$value});
+    24 │   adjacent-interpolations: fn(#{$a}#{$b});
+  > 25 │   number-interpolation: fn(10#{unit});
+       │                            ^^^^^^^^^
+    26 │   dimension-interpolation: fn(10px#{suffix});
+    27 │   interpolated-name: fn(foo#{$bar});
+  
+scss_exclusive_values.css:26:31 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    24 │   adjacent-interpolations: fn(#{$a}#{$b});
+    25 │   number-interpolation: fn(10#{unit});
+  > 26 │   dimension-interpolation: fn(10px#{suffix});
+       │                               ^^^^^^^^^^^^^
+    27 │   interpolated-name: fn(foo#{$bar});
+    28 │   interpolated-string: fn("#{$value}");
+  
+scss_exclusive_values.css:27:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    25 │   number-interpolation: fn(10#{unit});
+    26 │   dimension-interpolation: fn(10px#{suffix});
+  > 27 │   interpolated-name: fn(foo#{$bar});
+       │                         ^^^^^^^^^^
+    28 │   interpolated-string: fn("#{$value}");
+    29 │   interpolated-custom-property: fn(--#{$name});
+  
+scss_exclusive_values.css:29:38 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    27 │   interpolated-name: fn(foo#{$bar});
+    28 │   interpolated-string: fn("#{$value}");
+  > 29 │   interpolated-custom-property: fn(--#{$name});
+       │                                      ^^^^^^^^
+    30 │   interpolated-custom-property-suffix: fn(--theme-#{$slot});
+    31 │ }
+  
+scss_exclusive_values.css:30:43 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated dashed identifiers are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    28 │   interpolated-string: fn("#{$value}");
+    29 │   interpolated-custom-property: fn(--#{$name});
+  > 30 │   interpolated-custom-property-suffix: fn(--theme-#{$slot});
+       │                                           ^^^^^^^^^^^^^^^^
+    31 │ }
+    32 │ 
+  
+scss_exclusive_values.css:34:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated property declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    33 │ .property-names {
+  > 34 │   #{$name}: 1px;
+       │   ^^^^^^^^^^^^^^
+    35 │   margin-#{$side}: 1px;
+    36 │   --#{$prop}: 10px;
+  
+scss_exclusive_values.css:35:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated property declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    33 │ .property-names {
+    34 │   #{$name}: 1px;
+  > 35 │   margin-#{$side}: 1px;
+       │   ^^^^^^^^^^^^^^^^^^^^^
+    36 │   --#{$prop}: 10px;
+    37 │   --theme-#{$slot}: red;
+  
+scss_exclusive_values.css:36:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated property declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    34 │   #{$name}: 1px;
+    35 │   margin-#{$side}: 1px;
+  > 36 │   --#{$prop}: 10px;
+       │   ^^^^^^^^^^^^^^^^^
+    37 │   --theme-#{$slot}: red;
+    38 │ }
+  
+scss_exclusive_values.css:37:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated property declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    35 │   margin-#{$side}: 1px;
+    36 │   --#{$prop}: 10px;
+  > 37 │   --theme-#{$slot}: red;
+       │   ^^^^^^^^^^^^^^^^^^^^^^
+    38 │ }
+    39 │ 
+  
+scss_exclusive_values.css:41:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a color but instead found '#'.
+  
+    40 │ .malformed-css {
+  > 41 │   color: calc(# {value});
+       │               ^
+    42 │ }
+    43 │ 
+  
+  i Expected a color here.
+  
+    40 │ .malformed-css {
+  > 41 │   color: calc(# {value});
+       │               ^
+    42 │ }
+    43 │ 
+  
+  i Ensure the color is specified in a valid hexadecimal format. Examples: #000, #000f, #ffffff, #ffffffff
+  
+scss_exclusive_values.css:41:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected value or character.
+  
+    40 │ .malformed-css {
+  > 41 │   color: calc(# {value});
+       │                 ^
+    42 │ }
+    43 │ 
+  
+  i Expected one of:
+  
+  - identifier
+  - string
+  - number
+  - dimension
+  - ratio
+  - custom property
+  - function
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/property/scss_exclusive_values.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/property/scss_exclusive_values.css.snap
@@ -45,6 +45,12 @@ expression: snapshot
   --theme-#{$slot}: red;
 }
 
+.nested-properties {
+  font: {
+    family: sans-serif;
+  }
+}
+
 .malformed-css {
   color: calc(# {value});
 }
@@ -1569,71 +1575,127 @@ CssRoot {
                         CssClassSelector {
                             dot_token: DOT@1205..1208 "." [Newline("\n"), Newline("\n")] [],
                             name: CssCustomIdentifier {
-                                value_token: IDENT@1208..1222 "malformed-css" [] [Whitespace(" ")],
+                                value_token: IDENT@1208..1226 "nested-properties" [] [Whitespace(" ")],
                             },
                         },
                     ],
                 },
             ],
             block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@1222..1223 "{" [] [],
+                l_curly_token: L_CURLY@1226..1227 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssBogus {
+                        items: [
+                            CssIdentifier {
+                                value_token: IDENT@1227..1234 "font" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                            COLON@1234..1236 ":" [] [Whitespace(" ")],
+                            ScssExpression {
+                                items: ScssExpressionItemList [],
+                            },
+                            CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1236..1237 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@1237..1248 "family" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@1248..1250 ":" [] [Whitespace(" ")],
+                                                value: CssGenericComponentValueList [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@1250..1260 "sans-serif" [] [],
+                                                    },
+                                                ],
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@1260..1261 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@1261..1265 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        ],
+                    },
+                ],
+                r_curly_token: R_CURLY@1265..1267 "}" [Newline("\n")] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@1267..1270 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1270..1284 "malformed-css" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@1284..1285 "{" [] [],
                 items: CssDeclarationOrRuleList [
                     CssDeclarationWithSemicolon {
                         declaration: CssDeclaration {
                             property: CssGenericProperty {
                                 name: CssIdentifier {
-                                    value_token: IDENT@1223..1231 "color" [Newline("\n"), Whitespace("  ")] [],
+                                    value_token: IDENT@1285..1293 "color" [Newline("\n"), Whitespace("  ")] [],
                                 },
-                                colon_token: COLON@1231..1233 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@1293..1295 ":" [] [Whitespace(" ")],
                                 value: CssGenericComponentValueList [
                                     CssFunction {
                                         name: CssIdentifier {
-                                            value_token: IDENT@1233..1237 "calc" [] [],
+                                            value_token: IDENT@1295..1299 "calc" [] [],
                                         },
-                                        l_paren_token: L_PAREN@1237..1238 "(" [] [],
+                                        l_paren_token: L_PAREN@1299..1300 "(" [] [],
                                         items: CssParameterList [
                                             CssListOfComponentValuesExpression {
                                                 css_component_value_list: CssComponentValueList [
                                                     CssColor {
-                                                        hash_token: HASH@1238..1240 "#" [] [Whitespace(" ")],
+                                                        hash_token: HASH@1300..1302 "#" [] [Whitespace(" ")],
                                                         value_token: missing (required),
                                                     },
                                                 ],
                                             },
                                             missing separator,
                                             CssCommaSeparatedValue {
-                                                l_curly_token: L_CURLY@1240..1241 "{" [] [],
+                                                l_curly_token: L_CURLY@1302..1303 "{" [] [],
                                                 items: CssGenericComponentValueList [
                                                     CssIdentifier {
-                                                        value_token: IDENT@1241..1246 "value" [] [],
+                                                        value_token: IDENT@1303..1308 "value" [] [],
                                                     },
                                                 ],
-                                                r_curly_token: R_CURLY@1246..1247 "}" [] [],
+                                                r_curly_token: R_CURLY@1308..1309 "}" [] [],
                                             },
                                         ],
-                                        r_paren_token: R_PAREN@1247..1248 ")" [] [],
+                                        r_paren_token: R_PAREN@1309..1310 ")" [] [],
                                     },
                                 ],
                             },
                             important: missing (optional),
                         },
-                        semicolon_token: SEMICOLON@1248..1249 ";" [] [],
+                        semicolon_token: SEMICOLON@1310..1311 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@1249..1251 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@1311..1313 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@1251..1252 "" [Newline("\n")] [],
+    eof_token: EOF@1313..1314 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..1252
+0: CSS_ROOT@0..1314
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..1251
+  1: CSS_ROOT_ITEM_LIST@0..1313
     0: CSS_QUALIFIED_RULE@0..521
       0: CSS_SELECTOR_LIST@0..18
         0: CSS_COMPOUND_SELECTOR@0..18
@@ -2433,48 +2495,83 @@ CssRoot {
               1: (empty)
             1: SEMICOLON@1202..1203 ";" [] []
         2: R_CURLY@1203..1205 "}" [Newline("\n")] []
-    3: CSS_QUALIFIED_RULE@1205..1251
-      0: CSS_SELECTOR_LIST@1205..1222
-        0: CSS_COMPOUND_SELECTOR@1205..1222
+    3: CSS_QUALIFIED_RULE@1205..1267
+      0: CSS_SELECTOR_LIST@1205..1226
+        0: CSS_COMPOUND_SELECTOR@1205..1226
           0: CSS_NESTED_SELECTOR_LIST@1205..1205
           1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@1205..1222
-            0: CSS_CLASS_SELECTOR@1205..1222
+          2: CSS_SUB_SELECTOR_LIST@1205..1226
+            0: CSS_CLASS_SELECTOR@1205..1226
               0: DOT@1205..1208 "." [Newline("\n"), Newline("\n")] []
-              1: CSS_CUSTOM_IDENTIFIER@1208..1222
-                0: IDENT@1208..1222 "malformed-css" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@1222..1251
-        0: L_CURLY@1222..1223 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@1223..1249
-          0: CSS_DECLARATION_WITH_SEMICOLON@1223..1249
-            0: CSS_DECLARATION@1223..1248
-              0: CSS_GENERIC_PROPERTY@1223..1248
-                0: CSS_IDENTIFIER@1223..1231
-                  0: IDENT@1223..1231 "color" [Newline("\n"), Whitespace("  ")] []
-                1: COLON@1231..1233 ":" [] [Whitespace(" ")]
-                2: CSS_GENERIC_COMPONENT_VALUE_LIST@1233..1248
-                  0: CSS_FUNCTION@1233..1248
-                    0: CSS_IDENTIFIER@1233..1237
-                      0: IDENT@1233..1237 "calc" [] []
-                    1: L_PAREN@1237..1238 "(" [] []
-                    2: CSS_PARAMETER_LIST@1238..1247
-                      0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@1238..1240
-                        0: CSS_COMPONENT_VALUE_LIST@1238..1240
-                          0: CSS_COLOR@1238..1240
-                            0: HASH@1238..1240 "#" [] [Whitespace(" ")]
+              1: CSS_CUSTOM_IDENTIFIER@1208..1226
+                0: IDENT@1208..1226 "nested-properties" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1226..1267
+        0: L_CURLY@1226..1227 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@1227..1265
+          0: CSS_BOGUS@1227..1265
+            0: CSS_IDENTIFIER@1227..1234
+              0: IDENT@1227..1234 "font" [Newline("\n"), Whitespace("  ")] []
+            1: COLON@1234..1236 ":" [] [Whitespace(" ")]
+            2: SCSS_EXPRESSION@1236..1236
+              0: SCSS_EXPRESSION_ITEM_LIST@1236..1236
+            3: CSS_DECLARATION_OR_RULE_BLOCK@1236..1265
+              0: L_CURLY@1236..1237 "{" [] []
+              1: CSS_DECLARATION_OR_RULE_LIST@1237..1261
+                0: CSS_DECLARATION_WITH_SEMICOLON@1237..1261
+                  0: CSS_DECLARATION@1237..1260
+                    0: CSS_GENERIC_PROPERTY@1237..1260
+                      0: CSS_IDENTIFIER@1237..1248
+                        0: IDENT@1237..1248 "family" [Newline("\n"), Whitespace("    ")] []
+                      1: COLON@1248..1250 ":" [] [Whitespace(" ")]
+                      2: CSS_GENERIC_COMPONENT_VALUE_LIST@1250..1260
+                        0: CSS_IDENTIFIER@1250..1260
+                          0: IDENT@1250..1260 "sans-serif" [] []
+                    1: (empty)
+                  1: SEMICOLON@1260..1261 ";" [] []
+              2: R_CURLY@1261..1265 "}" [Newline("\n"), Whitespace("  ")] []
+        2: R_CURLY@1265..1267 "}" [Newline("\n")] []
+    4: CSS_QUALIFIED_RULE@1267..1313
+      0: CSS_SELECTOR_LIST@1267..1284
+        0: CSS_COMPOUND_SELECTOR@1267..1284
+          0: CSS_NESTED_SELECTOR_LIST@1267..1267
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@1267..1284
+            0: CSS_CLASS_SELECTOR@1267..1284
+              0: DOT@1267..1270 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@1270..1284
+                0: IDENT@1270..1284 "malformed-css" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1284..1313
+        0: L_CURLY@1284..1285 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@1285..1311
+          0: CSS_DECLARATION_WITH_SEMICOLON@1285..1311
+            0: CSS_DECLARATION@1285..1310
+              0: CSS_GENERIC_PROPERTY@1285..1310
+                0: CSS_IDENTIFIER@1285..1293
+                  0: IDENT@1285..1293 "color" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@1293..1295 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@1295..1310
+                  0: CSS_FUNCTION@1295..1310
+                    0: CSS_IDENTIFIER@1295..1299
+                      0: IDENT@1295..1299 "calc" [] []
+                    1: L_PAREN@1299..1300 "(" [] []
+                    2: CSS_PARAMETER_LIST@1300..1309
+                      0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@1300..1302
+                        0: CSS_COMPONENT_VALUE_LIST@1300..1302
+                          0: CSS_COLOR@1300..1302
+                            0: HASH@1300..1302 "#" [] [Whitespace(" ")]
                             1: (empty)
                       1: (empty)
-                      2: CSS_COMMA_SEPARATED_VALUE@1240..1247
-                        0: L_CURLY@1240..1241 "{" [] []
-                        1: CSS_GENERIC_COMPONENT_VALUE_LIST@1241..1246
-                          0: CSS_IDENTIFIER@1241..1246
-                            0: IDENT@1241..1246 "value" [] []
-                        2: R_CURLY@1246..1247 "}" [] []
-                    3: R_PAREN@1247..1248 ")" [] []
+                      2: CSS_COMMA_SEPARATED_VALUE@1302..1309
+                        0: L_CURLY@1302..1303 "{" [] []
+                        1: CSS_GENERIC_COMPONENT_VALUE_LIST@1303..1308
+                          0: CSS_IDENTIFIER@1303..1308
+                            0: IDENT@1303..1308 "value" [] []
+                        2: R_CURLY@1308..1309 "}" [] []
+                    3: R_PAREN@1309..1310 ")" [] []
               1: (empty)
-            1: SEMICOLON@1248..1249 ";" [] []
-        2: R_CURLY@1249..1251 "}" [Newline("\n")] []
-  2: EOF@1251..1252 "" [Newline("\n")] []
+            1: SEMICOLON@1310..1311 ";" [] []
+        2: R_CURLY@1311..1313 "}" [Newline("\n")] []
+  2: EOF@1313..1314 "" [Newline("\n")] []
 
 ```
 
@@ -2786,35 +2883,48 @@ scss_exclusive_values.css:37:3 parse ━━━━━━━━━━━━━━�
     38 │ }
     39 │ 
   
-scss_exclusive_values.css:41:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+scss_exclusive_values.css:41:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS nested property declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    40 │ .nested-properties {
+  > 41 │   font: {
+       │   ^^^^^^^
+  > 42 │     family: sans-serif;
+  > 43 │   }
+       │   ^
+    44 │ }
+    45 │ 
+  
+scss_exclusive_values.css:47:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a color but instead found '#'.
   
-    40 │ .malformed-css {
-  > 41 │   color: calc(# {value});
+    46 │ .malformed-css {
+  > 47 │   color: calc(# {value});
        │               ^
-    42 │ }
-    43 │ 
+    48 │ }
+    49 │ 
   
   i Expected a color here.
   
-    40 │ .malformed-css {
-  > 41 │   color: calc(# {value});
+    46 │ .malformed-css {
+  > 47 │   color: calc(# {value});
        │               ^
-    42 │ }
-    43 │ 
+    48 │ }
+    49 │ 
   
   i Ensure the color is specified in a valid hexadecimal format. Examples: #000, #000f, #ffffff, #ffffffff
   
-scss_exclusive_values.css:41:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+scss_exclusive_values.css:47:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unexpected value or character.
   
-    40 │ .malformed-css {
-  > 41 │   color: calc(# {value});
+    46 │ .malformed-css {
+  > 47 │   color: calc(# {value});
        │                 ^
-    42 │ }
-    43 │ 
+    48 │ }
+    49 │ 
   
   i Expected one of:
   

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/scss-variable-declaration-in-css.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/scss-variable-declaration-in-css.css
@@ -1,0 +1,13 @@
+$root: 1;
+
+.rule {
+  $local: 2;
+}
+
+@page {
+  $page: 3;
+}
+
+@font-face {
+  $font: 4;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/scss-variable-declaration-in-css.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/scss-variable-declaration-in-css.css.snap
@@ -1,0 +1,302 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+$root: 1;
+
+.rule {
+  $local: 2;
+}
+
+@page {
+  $page: 3;
+}
+
+@font-face {
+  $font: 4;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssBogus {
+            items: [
+                ScssVariable {
+                    dollar_token: DOLLAR@0..1 "$" [] [],
+                    name: CssIdentifier {
+                        value_token: IDENT@1..5 "root" [] [],
+                    },
+                },
+                COLON@5..7 ":" [] [Whitespace(" ")],
+                ScssExpression {
+                    items: ScssExpressionItemList [
+                        CssNumber {
+                            value_token: CSS_NUMBER_LITERAL@7..8 "1" [] [],
+                        },
+                    ],
+                },
+                ScssVariableModifierList [],
+                SEMICOLON@8..9 ";" [] [],
+            ],
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@9..12 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@12..17 "rule" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@17..18 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssBogus {
+                        items: [
+                            ScssVariable {
+                                dollar_token: DOLLAR@18..22 "$" [Newline("\n"), Whitespace("  ")] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@22..27 "local" [] [],
+                                },
+                            },
+                            COLON@27..29 ":" [] [Whitespace(" ")],
+                            ScssExpression {
+                                items: ScssExpressionItemList [
+                                    CssNumber {
+                                        value_token: CSS_NUMBER_LITERAL@29..30 "2" [] [],
+                                    },
+                                ],
+                            },
+                            ScssVariableModifierList [],
+                            SEMICOLON@30..31 ";" [] [],
+                        ],
+                    },
+                ],
+                r_curly_token: R_CURLY@31..33 "}" [Newline("\n")] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@33..36 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssPageAtRule {
+                page_token: PAGE_KW@36..41 "page" [] [Whitespace(" ")],
+                selectors: CssPageSelectorList [],
+                block: CssPageAtRuleBlock {
+                    l_curly_token: L_CURLY@41..42 "{" [] [],
+                    items: CssPageAtRuleItemList [
+                        CssBogus {
+                            items: [
+                                ScssVariable {
+                                    dollar_token: DOLLAR@42..46 "$" [Newline("\n"), Whitespace("  ")] [],
+                                    name: CssIdentifier {
+                                        value_token: IDENT@46..50 "page" [] [],
+                                    },
+                                },
+                                COLON@50..52 ":" [] [Whitespace(" ")],
+                                ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@52..53 "3" [] [],
+                                        },
+                                    ],
+                                },
+                                ScssVariableModifierList [],
+                                SEMICOLON@53..54 ";" [] [],
+                            ],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@54..56 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@56..59 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssFontFaceAtRule {
+                declarator: CssFontFaceAtRuleDeclarator {
+                    font_face_token: FONT_FACE_KW@59..69 "font-face" [] [Whitespace(" ")],
+                },
+                block: CssBogusBlock {
+                    items: [
+                        L_CURLY@69..70 "{" [] [],
+                        CssBogus {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        ScssVariable {
+                                            dollar_token: DOLLAR@70..74 "$" [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssIdentifier {
+                                                value_token: IDENT@74..78 "font" [] [],
+                                            },
+                                        },
+                                        COLON@78..80 ":" [] [Whitespace(" ")],
+                                        ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssNumber {
+                                                    value_token: CSS_NUMBER_LITERAL@80..81 "4" [] [],
+                                                },
+                                            ],
+                                        },
+                                        ScssVariableModifierList [],
+                                        SEMICOLON@81..82 ";" [] [],
+                                    ],
+                                },
+                            ],
+                        },
+                        R_CURLY@82..84 "}" [Newline("\n")] [],
+                    ],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@84..85 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..85
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..84
+    0: CSS_BOGUS@0..9
+      0: SCSS_VARIABLE@0..5
+        0: DOLLAR@0..1 "$" [] []
+        1: CSS_IDENTIFIER@1..5
+          0: IDENT@1..5 "root" [] []
+      1: COLON@5..7 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@7..8
+        0: SCSS_EXPRESSION_ITEM_LIST@7..8
+          0: CSS_NUMBER@7..8
+            0: CSS_NUMBER_LITERAL@7..8 "1" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@8..8
+      4: SEMICOLON@8..9 ";" [] []
+    1: CSS_QUALIFIED_RULE@9..33
+      0: CSS_SELECTOR_LIST@9..17
+        0: CSS_COMPOUND_SELECTOR@9..17
+          0: CSS_NESTED_SELECTOR_LIST@9..9
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@9..17
+            0: CSS_CLASS_SELECTOR@9..17
+              0: DOT@9..12 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@12..17
+                0: IDENT@12..17 "rule" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@17..33
+        0: L_CURLY@17..18 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@18..31
+          0: CSS_BOGUS@18..31
+            0: SCSS_VARIABLE@18..27
+              0: DOLLAR@18..22 "$" [Newline("\n"), Whitespace("  ")] []
+              1: CSS_IDENTIFIER@22..27
+                0: IDENT@22..27 "local" [] []
+            1: COLON@27..29 ":" [] [Whitespace(" ")]
+            2: SCSS_EXPRESSION@29..30
+              0: SCSS_EXPRESSION_ITEM_LIST@29..30
+                0: CSS_NUMBER@29..30
+                  0: CSS_NUMBER_LITERAL@29..30 "2" [] []
+            3: SCSS_VARIABLE_MODIFIER_LIST@30..30
+            4: SEMICOLON@30..31 ";" [] []
+        2: R_CURLY@31..33 "}" [Newline("\n")] []
+    2: CSS_AT_RULE@33..56
+      0: AT@33..36 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_PAGE_AT_RULE@36..56
+        0: PAGE_KW@36..41 "page" [] [Whitespace(" ")]
+        1: CSS_PAGE_SELECTOR_LIST@41..41
+        2: CSS_PAGE_AT_RULE_BLOCK@41..56
+          0: L_CURLY@41..42 "{" [] []
+          1: CSS_PAGE_AT_RULE_ITEM_LIST@42..54
+            0: CSS_BOGUS@42..54
+              0: SCSS_VARIABLE@42..50
+                0: DOLLAR@42..46 "$" [Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@46..50
+                  0: IDENT@46..50 "page" [] []
+              1: COLON@50..52 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@52..53
+                0: SCSS_EXPRESSION_ITEM_LIST@52..53
+                  0: CSS_NUMBER@52..53
+                    0: CSS_NUMBER_LITERAL@52..53 "3" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@53..53
+              4: SEMICOLON@53..54 ";" [] []
+          2: R_CURLY@54..56 "}" [Newline("\n")] []
+    3: CSS_AT_RULE@56..84
+      0: AT@56..59 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_FONT_FACE_AT_RULE@59..84
+        0: CSS_FONT_FACE_AT_RULE_DECLARATOR@59..69
+          0: FONT_FACE_KW@59..69 "font-face" [] [Whitespace(" ")]
+        1: CSS_BOGUS_BLOCK@69..84
+          0: L_CURLY@69..70 "{" [] []
+          1: CSS_BOGUS@70..82
+            0: CSS_BOGUS@70..82
+              0: SCSS_VARIABLE@70..78
+                0: DOLLAR@70..74 "$" [Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@74..78
+                  0: IDENT@74..78 "font" [] []
+              1: COLON@78..80 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@80..81
+                0: SCSS_EXPRESSION_ITEM_LIST@80..81
+                  0: CSS_NUMBER@80..81
+                    0: CSS_NUMBER_LITERAL@80..81 "4" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@81..81
+              4: SEMICOLON@81..82 ";" [] []
+          2: R_CURLY@82..84 "}" [Newline("\n")] []
+  2: EOF@84..85 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+scss-variable-declaration-in-css.css:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS variable declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+  > 1 │ $root: 1;
+      │ ^^^^^^^^^
+    2 │ 
+    3 │ .rule {
+  
+scss-variable-declaration-in-css.css:4:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS variable declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    3 │ .rule {
+  > 4 │   $local: 2;
+      │   ^^^^^^^^^^
+    5 │ }
+    6 │ 
+  
+scss-variable-declaration-in-css.css:8:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS variable declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+     7 │ @page {
+   > 8 │   $page: 3;
+       │   ^^^^^^^^^
+     9 │ }
+    10 │ 
+  
+scss-variable-declaration-in-css.css:12:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS variable declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    11 │ @font-face {
+  > 12 │   $font: 4;
+       │   ^^^^^^^^^
+    13 │ }
+    14 │ 
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/scss_exclusive_values.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/scss_exclusive_values.css
@@ -1,0 +1,13 @@
+.attribute-names[data-#{$name}=x] {}
+
+.attribute-modifier[title="x" #{$mod}] {}
+
+.pseudo-value:lang(#{$locale}) {}
+
+.nth:nth-child(#{$i}) {}
+
+%placeholder {}
+
+#{$tag} {}
+
+.button-#{$state} {}

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/scss_exclusive_values.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/scss_exclusive_values.css.snap
@@ -1,0 +1,671 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+.attribute-names[data-#{$name}=x] {}
+
+.attribute-modifier[title="x" #{$mod}] {}
+
+.pseudo-value:lang(#{$locale}) {}
+
+.nth:nth-child(#{$i}) {}
+
+%placeholder {}
+
+#{$tag} {}
+
+.button-#{$state} {}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@0..1 "." [] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1..16 "attribute-names" [] [],
+                            },
+                        },
+                        CssBogusSubSelector {
+                            items: [
+                                L_BRACK@16..17 "[" [] [],
+                                CssBogus {
+                                    items: [
+                                        CssBogusSupportsCondition {
+                                            items: [
+                                                ScssInterpolatedIdentifierPartList [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@17..22 "data-" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@22..23 "#" [] [],
+                                                        l_curly_token: L_CURLY@23..24 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssVariable {
+                                                                    dollar_token: DOLLAR@24..25 "$" [] [],
+                                                                    name: CssIdentifier {
+                                                                        value_token: IDENT@25..29 "name" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@29..30 "}" [] [],
+                                                    },
+                                                ],
+                                            ],
+                                        },
+                                    ],
+                                },
+                                CssAttributeMatcher {
+                                    operator: EQ@30..31 "=" [] [],
+                                    value: CssAttributeMatcherValue {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@31..32 "x" [] [],
+                                        },
+                                    },
+                                    modifier: missing (optional),
+                                },
+                                R_BRACK@32..34 "]" [] [Whitespace(" ")],
+                            ],
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@34..35 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@35..36 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@36..39 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@39..57 "attribute-modifier" [] [],
+                            },
+                        },
+                        CssBogusSubSelector {
+                            items: [
+                                L_BRACK@57..58 "[" [] [],
+                                CssAttributeName {
+                                    namespace: missing (optional),
+                                    name: CssIdentifier {
+                                        value_token: IDENT@58..63 "title" [] [],
+                                    },
+                                },
+                                CssBogus {
+                                    items: [
+                                        EQ@63..64 "=" [] [],
+                                        CssAttributeMatcherValue {
+                                            name: CssString {
+                                                value_token: CSS_STRING_LITERAL@64..68 "\"x\"" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                        CssBogusSupportsCondition {
+                                            items: [
+                                                ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@68..69 "#" [] [],
+                                                        l_curly_token: L_CURLY@69..70 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssVariable {
+                                                                    dollar_token: DOLLAR@70..71 "$" [] [],
+                                                                    name: CssIdentifier {
+                                                                        value_token: IDENT@71..74 "mod" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@74..75 "}" [] [],
+                                                    },
+                                                ],
+                                            ],
+                                        },
+                                    ],
+                                },
+                                R_BRACK@75..77 "]" [] [Whitespace(" ")],
+                            ],
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@77..78 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@78..79 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@79..82 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@82..94 "pseudo-value" [] [],
+                            },
+                        },
+                        CssPseudoClassSelector {
+                            colon_token: COLON@94..95 ":" [] [],
+                            class: CssBogusPseudoClass {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@95..99 "lang" [] [],
+                                    },
+                                    L_PAREN@99..100 "(" [] [],
+                                    CssBogus {
+                                        items: [
+                                            CssBogus {
+                                                items: [
+                                                    HASH@100..101 "#" [] [],
+                                                    L_CURLY@101..102 "{" [] [],
+                                                    ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@102..103 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@103..109 "locale" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    R_CURLY@109..110 "}" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                    R_PAREN@110..112 ")" [] [Whitespace(" ")],
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@112..113 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@113..114 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@114..117 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@117..120 "nth" [] [],
+                            },
+                        },
+                        CssPseudoClassSelector {
+                            colon_token: COLON@120..121 ":" [] [],
+                            class: CssBogusPseudoClass {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@121..130 "nth-child" [] [],
+                                    },
+                                    L_PAREN@130..131 "(" [] [],
+                                    CssBogus {
+                                        items: [
+                                            CssBogus {
+                                                items: [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@131..132 "#" [] [],
+                                                        l_curly_token: L_CURLY@132..133 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssVariable {
+                                                                    dollar_token: DOLLAR@133..134 "$" [] [],
+                                                                    name: CssIdentifier {
+                                                                        value_token: IDENT@134..135 "i" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@135..136 "}" [] [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                    R_PAREN@136..138 ")" [] [Whitespace(" ")],
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@138..139 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@139..140 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssBogusSelector {
+                    items: [
+                        CssNestedSelectorList [],
+                        CssBogus {
+                            items: [
+                                PERCENT@140..143 "%" [Newline("\n"), Newline("\n")] [],
+                                CssCustomIdentifier {
+                                    value_token: IDENT@143..155 "placeholder" [] [Whitespace(" ")],
+                                },
+                            ],
+                        },
+                        CssSubSelectorList [],
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@155..156 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@156..157 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssBogusSelector {
+                    items: [
+                        CssNestedSelectorList [],
+                        CssBogus {
+                            items: [
+                                CssBogusSupportsCondition {
+                                    items: [
+                                        ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@157..160 "#" [Newline("\n"), Newline("\n")] [],
+                                                l_curly_token: L_CURLY@160..161 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@161..162 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@162..165 "tag" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@165..167 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    ],
+                                },
+                            ],
+                        },
+                        CssSubSelectorList [],
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@167..168 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@168..169 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssBogusSubSelector {
+                            items: [
+                                DOT@169..172 "." [Newline("\n"), Newline("\n")] [],
+                                CssBogusSupportsCondition {
+                                    items: [
+                                        ScssInterpolatedIdentifierPartList [
+                                            CssCustomIdentifier {
+                                                value_token: IDENT@172..179 "button-" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@179..180 "#" [] [],
+                                                l_curly_token: L_CURLY@180..181 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@181..182 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@182..187 "state" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@187..189 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@189..190 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@190..191 "}" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@191..192 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..192
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..191
+    0: CSS_QUALIFIED_RULE@0..36
+      0: CSS_SELECTOR_LIST@0..34
+        0: CSS_COMPOUND_SELECTOR@0..34
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@0..34
+            0: CSS_CLASS_SELECTOR@0..16
+              0: DOT@0..1 "." [] []
+              1: CSS_CUSTOM_IDENTIFIER@1..16
+                0: IDENT@1..16 "attribute-names" [] []
+            1: CSS_BOGUS_SUB_SELECTOR@16..34
+              0: L_BRACK@16..17 "[" [] []
+              1: CSS_BOGUS@17..30
+                0: CSS_BOGUS_SUPPORTS_CONDITION@17..30
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@17..30
+                    0: CSS_IDENTIFIER@17..22
+                      0: IDENT@17..22 "data-" [] []
+                    1: SCSS_INTERPOLATION@22..30
+                      0: HASH@22..23 "#" [] []
+                      1: L_CURLY@23..24 "{" [] []
+                      2: SCSS_EXPRESSION@24..29
+                        0: SCSS_EXPRESSION_ITEM_LIST@24..29
+                          0: SCSS_VARIABLE@24..29
+                            0: DOLLAR@24..25 "$" [] []
+                            1: CSS_IDENTIFIER@25..29
+                              0: IDENT@25..29 "name" [] []
+                      3: R_CURLY@29..30 "}" [] []
+              2: CSS_ATTRIBUTE_MATCHER@30..32
+                0: EQ@30..31 "=" [] []
+                1: CSS_ATTRIBUTE_MATCHER_VALUE@31..32
+                  0: CSS_IDENTIFIER@31..32
+                    0: IDENT@31..32 "x" [] []
+                2: (empty)
+              3: R_BRACK@32..34 "]" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@34..36
+        0: L_CURLY@34..35 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@35..35
+        2: R_CURLY@35..36 "}" [] []
+    1: CSS_QUALIFIED_RULE@36..79
+      0: CSS_SELECTOR_LIST@36..77
+        0: CSS_COMPOUND_SELECTOR@36..77
+          0: CSS_NESTED_SELECTOR_LIST@36..36
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@36..77
+            0: CSS_CLASS_SELECTOR@36..57
+              0: DOT@36..39 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@39..57
+                0: IDENT@39..57 "attribute-modifier" [] []
+            1: CSS_BOGUS_SUB_SELECTOR@57..77
+              0: L_BRACK@57..58 "[" [] []
+              1: CSS_ATTRIBUTE_NAME@58..63
+                0: (empty)
+                1: CSS_IDENTIFIER@58..63
+                  0: IDENT@58..63 "title" [] []
+              2: CSS_BOGUS@63..75
+                0: EQ@63..64 "=" [] []
+                1: CSS_ATTRIBUTE_MATCHER_VALUE@64..68
+                  0: CSS_STRING@64..68
+                    0: CSS_STRING_LITERAL@64..68 "\"x\"" [] [Whitespace(" ")]
+                2: CSS_BOGUS_SUPPORTS_CONDITION@68..75
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@68..75
+                    0: SCSS_INTERPOLATION@68..75
+                      0: HASH@68..69 "#" [] []
+                      1: L_CURLY@69..70 "{" [] []
+                      2: SCSS_EXPRESSION@70..74
+                        0: SCSS_EXPRESSION_ITEM_LIST@70..74
+                          0: SCSS_VARIABLE@70..74
+                            0: DOLLAR@70..71 "$" [] []
+                            1: CSS_IDENTIFIER@71..74
+                              0: IDENT@71..74 "mod" [] []
+                      3: R_CURLY@74..75 "}" [] []
+              3: R_BRACK@75..77 "]" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@77..79
+        0: L_CURLY@77..78 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@78..78
+        2: R_CURLY@78..79 "}" [] []
+    2: CSS_QUALIFIED_RULE@79..114
+      0: CSS_SELECTOR_LIST@79..112
+        0: CSS_COMPOUND_SELECTOR@79..112
+          0: CSS_NESTED_SELECTOR_LIST@79..79
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@79..112
+            0: CSS_CLASS_SELECTOR@79..94
+              0: DOT@79..82 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@82..94
+                0: IDENT@82..94 "pseudo-value" [] []
+            1: CSS_PSEUDO_CLASS_SELECTOR@94..112
+              0: COLON@94..95 ":" [] []
+              1: CSS_BOGUS_PSEUDO_CLASS@95..112
+                0: CSS_IDENTIFIER@95..99
+                  0: IDENT@95..99 "lang" [] []
+                1: L_PAREN@99..100 "(" [] []
+                2: CSS_BOGUS@100..110
+                  0: CSS_BOGUS@100..110
+                    0: HASH@100..101 "#" [] []
+                    1: L_CURLY@101..102 "{" [] []
+                    2: SCSS_EXPRESSION@102..109
+                      0: SCSS_EXPRESSION_ITEM_LIST@102..109
+                        0: SCSS_VARIABLE@102..109
+                          0: DOLLAR@102..103 "$" [] []
+                          1: CSS_IDENTIFIER@103..109
+                            0: IDENT@103..109 "locale" [] []
+                    3: R_CURLY@109..110 "}" [] []
+                3: R_PAREN@110..112 ")" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@112..114
+        0: L_CURLY@112..113 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@113..113
+        2: R_CURLY@113..114 "}" [] []
+    3: CSS_QUALIFIED_RULE@114..140
+      0: CSS_SELECTOR_LIST@114..138
+        0: CSS_COMPOUND_SELECTOR@114..138
+          0: CSS_NESTED_SELECTOR_LIST@114..114
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@114..138
+            0: CSS_CLASS_SELECTOR@114..120
+              0: DOT@114..117 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@117..120
+                0: IDENT@117..120 "nth" [] []
+            1: CSS_PSEUDO_CLASS_SELECTOR@120..138
+              0: COLON@120..121 ":" [] []
+              1: CSS_BOGUS_PSEUDO_CLASS@121..138
+                0: CSS_IDENTIFIER@121..130
+                  0: IDENT@121..130 "nth-child" [] []
+                1: L_PAREN@130..131 "(" [] []
+                2: CSS_BOGUS@131..136
+                  0: CSS_BOGUS@131..136
+                    0: SCSS_INTERPOLATION@131..136
+                      0: HASH@131..132 "#" [] []
+                      1: L_CURLY@132..133 "{" [] []
+                      2: SCSS_EXPRESSION@133..135
+                        0: SCSS_EXPRESSION_ITEM_LIST@133..135
+                          0: SCSS_VARIABLE@133..135
+                            0: DOLLAR@133..134 "$" [] []
+                            1: CSS_IDENTIFIER@134..135
+                              0: IDENT@134..135 "i" [] []
+                      3: R_CURLY@135..136 "}" [] []
+                3: R_PAREN@136..138 ")" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@138..140
+        0: L_CURLY@138..139 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@139..139
+        2: R_CURLY@139..140 "}" [] []
+    4: CSS_QUALIFIED_RULE@140..157
+      0: CSS_SELECTOR_LIST@140..155
+        0: CSS_BOGUS_SELECTOR@140..155
+          0: CSS_NESTED_SELECTOR_LIST@140..140
+          1: CSS_BOGUS@140..155
+            0: PERCENT@140..143 "%" [Newline("\n"), Newline("\n")] []
+            1: CSS_CUSTOM_IDENTIFIER@143..155
+              0: IDENT@143..155 "placeholder" [] [Whitespace(" ")]
+          2: CSS_SUB_SELECTOR_LIST@155..155
+      1: CSS_DECLARATION_OR_RULE_BLOCK@155..157
+        0: L_CURLY@155..156 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@156..156
+        2: R_CURLY@156..157 "}" [] []
+    5: CSS_QUALIFIED_RULE@157..169
+      0: CSS_SELECTOR_LIST@157..167
+        0: CSS_BOGUS_SELECTOR@157..167
+          0: CSS_NESTED_SELECTOR_LIST@157..157
+          1: CSS_BOGUS@157..167
+            0: CSS_BOGUS_SUPPORTS_CONDITION@157..167
+              0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@157..167
+                0: SCSS_INTERPOLATION@157..167
+                  0: HASH@157..160 "#" [Newline("\n"), Newline("\n")] []
+                  1: L_CURLY@160..161 "{" [] []
+                  2: SCSS_EXPRESSION@161..165
+                    0: SCSS_EXPRESSION_ITEM_LIST@161..165
+                      0: SCSS_VARIABLE@161..165
+                        0: DOLLAR@161..162 "$" [] []
+                        1: CSS_IDENTIFIER@162..165
+                          0: IDENT@162..165 "tag" [] []
+                  3: R_CURLY@165..167 "}" [] [Whitespace(" ")]
+          2: CSS_SUB_SELECTOR_LIST@167..167
+      1: CSS_DECLARATION_OR_RULE_BLOCK@167..169
+        0: L_CURLY@167..168 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@168..168
+        2: R_CURLY@168..169 "}" [] []
+    6: CSS_QUALIFIED_RULE@169..191
+      0: CSS_SELECTOR_LIST@169..189
+        0: CSS_COMPOUND_SELECTOR@169..189
+          0: CSS_NESTED_SELECTOR_LIST@169..169
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@169..189
+            0: CSS_BOGUS_SUB_SELECTOR@169..189
+              0: DOT@169..172 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_BOGUS_SUPPORTS_CONDITION@172..189
+                0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@172..189
+                  0: CSS_CUSTOM_IDENTIFIER@172..179
+                    0: IDENT@172..179 "button-" [] []
+                  1: SCSS_INTERPOLATION@179..189
+                    0: HASH@179..180 "#" [] []
+                    1: L_CURLY@180..181 "{" [] []
+                    2: SCSS_EXPRESSION@181..187
+                      0: SCSS_EXPRESSION_ITEM_LIST@181..187
+                        0: SCSS_VARIABLE@181..187
+                          0: DOLLAR@181..182 "$" [] []
+                          1: CSS_IDENTIFIER@182..187
+                            0: IDENT@182..187 "state" [] []
+                    3: R_CURLY@187..189 "}" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@189..191
+        0: L_CURLY@189..190 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@190..190
+        2: R_CURLY@190..191 "}" [] []
+  2: EOF@191..192 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+scss_exclusive_values.css:1:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated attribute names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+  > 1 │ .attribute-names[data-#{$name}=x] {}
+      │                  ^^^^^^^^^^^^^
+    2 │ 
+    3 │ .attribute-modifier[title="x" #{$mod}] {}
+  
+scss_exclusive_values.css:3:31 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated attribute modifiers are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    1 │ .attribute-names[data-#{$name}=x] {}
+    2 │ 
+  > 3 │ .attribute-modifier[title="x" #{$mod}] {}
+      │                               ^^^^^^^
+    4 │ 
+    5 │ .pseudo-value:lang(#{$locale}) {}
+  
+scss_exclusive_values.css:5:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated pseudo values are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    3 │ .attribute-modifier[title="x" #{$mod}] {}
+    4 │ 
+  > 5 │ .pseudo-value:lang(#{$locale}) {}
+      │                    ^^^^^^^^^^
+    6 │ 
+    7 │ .nth:nth-child(#{$i}) {}
+  
+scss_exclusive_values.css:7:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated nth arguments are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    5 │ .pseudo-value:lang(#{$locale}) {}
+    6 │ 
+  > 7 │ .nth:nth-child(#{$i}) {}
+      │                ^^^^^
+    8 │ 
+    9 │ %placeholder {}
+  
+scss_exclusive_values.css:9:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS placeholder selectors are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+     7 │ .nth:nth-child(#{$i}) {}
+     8 │ 
+   > 9 │ %placeholder {}
+       │ ^^^^^^^^^^^^
+    10 │ 
+    11 │ #{$tag} {}
+  
+scss_exclusive_values.css:11:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated selector names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+     9 │ %placeholder {}
+    10 │ 
+  > 11 │ #{$tag} {}
+       │ ^^^^^^^
+    12 │ 
+    13 │ .button-#{$state} {}
+  
+scss_exclusive_values.css:13:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated selector names are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    11 │ #{$tag} {}
+    12 │ 
+  > 13 │ .button-#{$state} {}
+       │  ^^^^^^^^^^^^^^^^
+    14 │ 
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/scss-named-at-rules-unknown.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/scss-named-at-rules-unknown.css
@@ -1,0 +1,37 @@
+@debug value;
+@warn value;
+@error value;
+@return value;
+@use "theme";
+@forward "theme";
+@include button;
+@content;
+@extend .button;
+
+@at-root .item {
+	color: red;
+}
+
+@mixin button {
+	color: red;
+}
+
+@if condition {
+	color: red;
+}
+
+@else {
+	color: red;
+}
+
+@for item from 1 through 3 {
+	color: red;
+}
+
+@each item in list {
+	color: red;
+}
+
+@while condition {
+	color: red;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/scss-named-at-rules-unknown.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/scss-named-at-rules-unknown.css.snap
@@ -1,0 +1,683 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@debug value;
+@warn value;
+@error value;
+@return value;
+@use "theme";
+@forward "theme";
+@include button;
+@content;
+@extend .button;
+
+@at-root .item {
+	color: red;
+}
+
+@mixin button {
+	color: red;
+}
+
+@if condition {
+	color: red;
+}
+
+@else {
+	color: red;
+}
+
+@for item from 1 through 3 {
+	color: red;
+}
+
+@each item in list {
+	color: red;
+}
+
+@while condition {
+	color: red;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@1..7 "debug" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        VALUE_KW@7..12 "value" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@12..13 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@13..15 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@15..20 "warn" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        VALUE_KW@20..25 "value" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@25..26 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@26..28 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@28..34 "error" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        VALUE_KW@34..39 "value" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@39..40 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@40..42 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@42..49 "return" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        VALUE_KW@49..54 "value" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@54..55 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@55..57 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@57..61 "use" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        CSS_STRING_LITERAL@61..68 "\"theme\"" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@68..69 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@69..71 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@71..79 "forward" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        CSS_STRING_LITERAL@79..86 "\"theme\"" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@86..87 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@87..89 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@89..97 "include" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        IDENT@97..103 "button" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@103..104 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@104..106 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@106..113 "content" [] [],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [],
+                },
+                semicolon_token: SEMICOLON@113..114 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@114..116 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@116..123 "extend" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        DOT@123..124 "." [] [],
+                        IDENT@124..130 "button" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@130..131 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@131..134 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@134..142 "at-root" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        DOT@142..143 "." [] [],
+                        IDENT@143..148 "item" [] [Whitespace(" ")],
+                    ],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@148..149 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@149..156 "color" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@156..158 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@158..161 "red" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@161..162 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@162..164 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@164..167 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@167..173 "mixin" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        IDENT@173..180 "button" [] [Whitespace(" ")],
+                    ],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@180..181 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@181..188 "color" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@188..190 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@190..193 "red" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@193..194 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@194..196 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@196..199 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@199..202 "if" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        IDENT@202..212 "condition" [] [Whitespace(" ")],
+                    ],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@212..213 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@213..220 "color" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@220..222 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@222..225 "red" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@225..226 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@226..228 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@228..231 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@231..236 "else" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@236..237 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@237..244 "color" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@244..246 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@246..249 "red" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@249..250 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@250..252 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@252..255 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@255..259 "for" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        IDENT@259..264 "item" [] [Whitespace(" ")],
+                        FROM_KW@264..269 "from" [] [Whitespace(" ")],
+                        CSS_NUMBER_LITERAL@269..271 "1" [] [Whitespace(" ")],
+                        THROUGH_KW@271..279 "through" [] [Whitespace(" ")],
+                        CSS_NUMBER_LITERAL@279..281 "3" [] [Whitespace(" ")],
+                    ],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@281..282 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@282..289 "color" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@289..291 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@291..294 "red" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@294..295 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@295..297 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@297..300 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@300..305 "each" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        IDENT@305..310 "item" [] [Whitespace(" ")],
+                        IN_KW@310..313 "in" [] [Whitespace(" ")],
+                        IDENT@313..318 "list" [] [Whitespace(" ")],
+                    ],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@318..319 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@319..326 "color" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@326..328 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@328..331 "red" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@331..332 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@332..334 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@334..337 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssUnknownBlockAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@337..343 "while" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        IDENT@343..353 "condition" [] [Whitespace(" ")],
+                    ],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@353..354 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@354..361 "color" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@361..363 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@363..366 "red" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@366..367 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@367..369 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@369..370 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..370
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..369
+    0: CSS_AT_RULE@0..13
+      0: AT@0..1 "@" [] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@1..13
+        0: CSS_IDENTIFIER@1..7
+          0: IDENT@1..7 "debug" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@7..12
+          0: VALUE_KW@7..12 "value" [] []
+        2: SEMICOLON@12..13 ";" [] []
+    1: CSS_AT_RULE@13..26
+      0: AT@13..15 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@15..26
+        0: CSS_IDENTIFIER@15..20
+          0: IDENT@15..20 "warn" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@20..25
+          0: VALUE_KW@20..25 "value" [] []
+        2: SEMICOLON@25..26 ";" [] []
+    2: CSS_AT_RULE@26..40
+      0: AT@26..28 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@28..40
+        0: CSS_IDENTIFIER@28..34
+          0: IDENT@28..34 "error" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@34..39
+          0: VALUE_KW@34..39 "value" [] []
+        2: SEMICOLON@39..40 ";" [] []
+    3: CSS_AT_RULE@40..55
+      0: AT@40..42 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@42..55
+        0: CSS_IDENTIFIER@42..49
+          0: IDENT@42..49 "return" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@49..54
+          0: VALUE_KW@49..54 "value" [] []
+        2: SEMICOLON@54..55 ";" [] []
+    4: CSS_AT_RULE@55..69
+      0: AT@55..57 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@57..69
+        0: CSS_IDENTIFIER@57..61
+          0: IDENT@57..61 "use" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@61..68
+          0: CSS_STRING_LITERAL@61..68 "\"theme\"" [] []
+        2: SEMICOLON@68..69 ";" [] []
+    5: CSS_AT_RULE@69..87
+      0: AT@69..71 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@71..87
+        0: CSS_IDENTIFIER@71..79
+          0: IDENT@71..79 "forward" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@79..86
+          0: CSS_STRING_LITERAL@79..86 "\"theme\"" [] []
+        2: SEMICOLON@86..87 ";" [] []
+    6: CSS_AT_RULE@87..104
+      0: AT@87..89 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@89..104
+        0: CSS_IDENTIFIER@89..97
+          0: IDENT@89..97 "include" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@97..103
+          0: IDENT@97..103 "button" [] []
+        2: SEMICOLON@103..104 ";" [] []
+    7: CSS_AT_RULE@104..114
+      0: AT@104..106 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@106..114
+        0: CSS_IDENTIFIER@106..113
+          0: IDENT@106..113 "content" [] []
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@113..113
+        2: SEMICOLON@113..114 ";" [] []
+    8: CSS_AT_RULE@114..131
+      0: AT@114..116 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@116..131
+        0: CSS_IDENTIFIER@116..123
+          0: IDENT@116..123 "extend" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@123..130
+          0: DOT@123..124 "." [] []
+          1: IDENT@124..130 "button" [] []
+        2: SEMICOLON@130..131 ";" [] []
+    9: CSS_AT_RULE@131..164
+      0: AT@131..134 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@134..164
+        0: CSS_IDENTIFIER@134..142
+          0: IDENT@134..142 "at-root" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@142..148
+          0: DOT@142..143 "." [] []
+          1: IDENT@143..148 "item" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@148..164
+          0: L_CURLY@148..149 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@149..162
+            0: CSS_DECLARATION_WITH_SEMICOLON@149..162
+              0: CSS_DECLARATION@149..161
+                0: CSS_GENERIC_PROPERTY@149..161
+                  0: CSS_IDENTIFIER@149..156
+                    0: IDENT@149..156 "color" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@156..158 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@158..161
+                    0: CSS_IDENTIFIER@158..161
+                      0: IDENT@158..161 "red" [] []
+                1: (empty)
+              1: SEMICOLON@161..162 ";" [] []
+          2: R_CURLY@162..164 "}" [Newline("\n")] []
+    10: CSS_AT_RULE@164..196
+      0: AT@164..167 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@167..196
+        0: CSS_IDENTIFIER@167..173
+          0: IDENT@167..173 "mixin" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@173..180
+          0: IDENT@173..180 "button" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@180..196
+          0: L_CURLY@180..181 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@181..194
+            0: CSS_DECLARATION_WITH_SEMICOLON@181..194
+              0: CSS_DECLARATION@181..193
+                0: CSS_GENERIC_PROPERTY@181..193
+                  0: CSS_IDENTIFIER@181..188
+                    0: IDENT@181..188 "color" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@188..190 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@190..193
+                    0: CSS_IDENTIFIER@190..193
+                      0: IDENT@190..193 "red" [] []
+                1: (empty)
+              1: SEMICOLON@193..194 ";" [] []
+          2: R_CURLY@194..196 "}" [Newline("\n")] []
+    11: CSS_AT_RULE@196..228
+      0: AT@196..199 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@199..228
+        0: CSS_IDENTIFIER@199..202
+          0: IDENT@199..202 "if" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@202..212
+          0: IDENT@202..212 "condition" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@212..228
+          0: L_CURLY@212..213 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@213..226
+            0: CSS_DECLARATION_WITH_SEMICOLON@213..226
+              0: CSS_DECLARATION@213..225
+                0: CSS_GENERIC_PROPERTY@213..225
+                  0: CSS_IDENTIFIER@213..220
+                    0: IDENT@213..220 "color" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@220..222 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@222..225
+                    0: CSS_IDENTIFIER@222..225
+                      0: IDENT@222..225 "red" [] []
+                1: (empty)
+              1: SEMICOLON@225..226 ";" [] []
+          2: R_CURLY@226..228 "}" [Newline("\n")] []
+    12: CSS_AT_RULE@228..252
+      0: AT@228..231 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@231..252
+        0: CSS_IDENTIFIER@231..236
+          0: IDENT@231..236 "else" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@236..236
+        2: CSS_DECLARATION_OR_RULE_BLOCK@236..252
+          0: L_CURLY@236..237 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@237..250
+            0: CSS_DECLARATION_WITH_SEMICOLON@237..250
+              0: CSS_DECLARATION@237..249
+                0: CSS_GENERIC_PROPERTY@237..249
+                  0: CSS_IDENTIFIER@237..244
+                    0: IDENT@237..244 "color" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@244..246 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@246..249
+                    0: CSS_IDENTIFIER@246..249
+                      0: IDENT@246..249 "red" [] []
+                1: (empty)
+              1: SEMICOLON@249..250 ";" [] []
+          2: R_CURLY@250..252 "}" [Newline("\n")] []
+    13: CSS_AT_RULE@252..297
+      0: AT@252..255 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@255..297
+        0: CSS_IDENTIFIER@255..259
+          0: IDENT@255..259 "for" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@259..281
+          0: IDENT@259..264 "item" [] [Whitespace(" ")]
+          1: FROM_KW@264..269 "from" [] [Whitespace(" ")]
+          2: CSS_NUMBER_LITERAL@269..271 "1" [] [Whitespace(" ")]
+          3: THROUGH_KW@271..279 "through" [] [Whitespace(" ")]
+          4: CSS_NUMBER_LITERAL@279..281 "3" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@281..297
+          0: L_CURLY@281..282 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@282..295
+            0: CSS_DECLARATION_WITH_SEMICOLON@282..295
+              0: CSS_DECLARATION@282..294
+                0: CSS_GENERIC_PROPERTY@282..294
+                  0: CSS_IDENTIFIER@282..289
+                    0: IDENT@282..289 "color" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@289..291 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@291..294
+                    0: CSS_IDENTIFIER@291..294
+                      0: IDENT@291..294 "red" [] []
+                1: (empty)
+              1: SEMICOLON@294..295 ";" [] []
+          2: R_CURLY@295..297 "}" [Newline("\n")] []
+    14: CSS_AT_RULE@297..334
+      0: AT@297..300 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@300..334
+        0: CSS_IDENTIFIER@300..305
+          0: IDENT@300..305 "each" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@305..318
+          0: IDENT@305..310 "item" [] [Whitespace(" ")]
+          1: IN_KW@310..313 "in" [] [Whitespace(" ")]
+          2: IDENT@313..318 "list" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@318..334
+          0: L_CURLY@318..319 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@319..332
+            0: CSS_DECLARATION_WITH_SEMICOLON@319..332
+              0: CSS_DECLARATION@319..331
+                0: CSS_GENERIC_PROPERTY@319..331
+                  0: CSS_IDENTIFIER@319..326
+                    0: IDENT@319..326 "color" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@326..328 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@328..331
+                    0: CSS_IDENTIFIER@328..331
+                      0: IDENT@328..331 "red" [] []
+                1: (empty)
+              1: SEMICOLON@331..332 ";" [] []
+          2: R_CURLY@332..334 "}" [Newline("\n")] []
+    15: CSS_AT_RULE@334..369
+      0: AT@334..337 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_UNKNOWN_BLOCK_AT_RULE@337..369
+        0: CSS_IDENTIFIER@337..343
+          0: IDENT@337..343 "while" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@343..353
+          0: IDENT@343..353 "condition" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@353..369
+          0: L_CURLY@353..354 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@354..367
+            0: CSS_DECLARATION_WITH_SEMICOLON@354..367
+              0: CSS_DECLARATION@354..366
+                0: CSS_GENERIC_PROPERTY@354..366
+                  0: CSS_IDENTIFIER@354..361
+                    0: IDENT@354..361 "color" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@361..363 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@363..366
+                    0: CSS_IDENTIFIER@363..366
+                      0: IDENT@363..366 "red" [] []
+                1: (empty)
+              1: SEMICOLON@366..367 ";" [] []
+          2: R_CURLY@367..369 "}" [Newline("\n")] []
+  2: EOF@369..370 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/nesting/nesting.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/nesting/nesting.css
@@ -174,3 +174,8 @@ article {
 		}
 	}
 }
+
+.foo {
+	color: blue;
+	&_title { color: green; }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/nesting/nesting.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/nesting/nesting.css.snap
@@ -183,6 +183,11 @@ article {
 	}
 }
 
+.foo {
+	color: blue;
+	&_title { color: green; }
+}
+
 ```
 
 
@@ -3163,17 +3168,100 @@ CssRoot {
                 r_curly_token: R_CURLY@1953..1955 "}" [Newline("\n")] [],
             },
         },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@1955..1958 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1958..1962 "foo" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@1962..1963 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1963..1970 "color" [Newline("\n"), Whitespace("\t")] [],
+                                },
+                                colon_token: COLON@1970..1972 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssIdentifier {
+                                        value_token: IDENT@1972..1976 "blue" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1976..1977 ";" [] [],
+                    },
+                    CssNestedQualifiedRule {
+                        prelude: CssRelativeSelectorList [
+                            CssRelativeSelector {
+                                combinator: missing (optional),
+                                selector: CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [
+                                        CssNestedSelector {
+                                            amp_token: AMP@1977..1980 "&" [Newline("\n"), Whitespace("\t")] [],
+                                        },
+                                    ],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@1980..1987 "_title" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [],
+                                },
+                            },
+                        ],
+                        block: CssDeclarationOrRuleBlock {
+                            l_curly_token: L_CURLY@1987..1989 "{" [] [Whitespace(" ")],
+                            items: CssDeclarationOrRuleList [
+                                CssDeclarationWithSemicolon {
+                                    declaration: CssDeclaration {
+                                        property: CssGenericProperty {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@1989..1994 "color" [] [],
+                                            },
+                                            colon_token: COLON@1994..1996 ":" [] [Whitespace(" ")],
+                                            value: CssGenericComponentValueList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@1996..2001 "green" [] [],
+                                                },
+                                            ],
+                                        },
+                                        important: missing (optional),
+                                    },
+                                    semicolon_token: SEMICOLON@2001..2003 ";" [] [Whitespace(" ")],
+                                },
+                            ],
+                            r_curly_token: R_CURLY@2003..2004 "}" [] [],
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@2004..2006 "}" [Newline("\n")] [],
+            },
+        },
     ],
-    eof_token: EOF@1955..1956 "" [Newline("\n")] [],
+    eof_token: EOF@2006..2007 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..1956
+0: CSS_ROOT@0..2007
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..1955
+  1: CSS_ROOT_ITEM_LIST@0..2006
     0: CSS_QUALIFIED_RULE@0..219
       0: CSS_SELECTOR_LIST@0..17
         0: CSS_COMPOUND_SELECTOR@0..17
@@ -5099,6 +5187,59 @@ CssRoot {
                       2: R_CURLY@1946..1950 "}" [Newline("\n"), Whitespace("\t\t")] []
                 2: R_CURLY@1950..1953 "}" [Newline("\n"), Whitespace("\t")] []
         2: R_CURLY@1953..1955 "}" [Newline("\n")] []
-  2: EOF@1955..1956 "" [Newline("\n")] []
+    25: CSS_QUALIFIED_RULE@1955..2006
+      0: CSS_SELECTOR_LIST@1955..1962
+        0: CSS_COMPOUND_SELECTOR@1955..1962
+          0: CSS_NESTED_SELECTOR_LIST@1955..1955
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@1955..1962
+            0: CSS_CLASS_SELECTOR@1955..1962
+              0: DOT@1955..1958 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@1958..1962
+                0: IDENT@1958..1962 "foo" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1962..2006
+        0: L_CURLY@1962..1963 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@1963..2004
+          0: CSS_DECLARATION_WITH_SEMICOLON@1963..1977
+            0: CSS_DECLARATION@1963..1976
+              0: CSS_GENERIC_PROPERTY@1963..1976
+                0: CSS_IDENTIFIER@1963..1970
+                  0: IDENT@1963..1970 "color" [Newline("\n"), Whitespace("\t")] []
+                1: COLON@1970..1972 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@1972..1976
+                  0: CSS_IDENTIFIER@1972..1976
+                    0: IDENT@1972..1976 "blue" [] []
+              1: (empty)
+            1: SEMICOLON@1976..1977 ";" [] []
+          1: CSS_NESTED_QUALIFIED_RULE@1977..2004
+            0: CSS_RELATIVE_SELECTOR_LIST@1977..1987
+              0: CSS_RELATIVE_SELECTOR@1977..1987
+                0: (empty)
+                1: CSS_COMPOUND_SELECTOR@1977..1987
+                  0: CSS_NESTED_SELECTOR_LIST@1977..1980
+                    0: CSS_NESTED_SELECTOR@1977..1980
+                      0: AMP@1977..1980 "&" [Newline("\n"), Whitespace("\t")] []
+                  1: CSS_TYPE_SELECTOR@1980..1987
+                    0: (empty)
+                    1: CSS_IDENTIFIER@1980..1987
+                      0: IDENT@1980..1987 "_title" [] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@1987..1987
+            1: CSS_DECLARATION_OR_RULE_BLOCK@1987..2004
+              0: L_CURLY@1987..1989 "{" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_LIST@1989..2003
+                0: CSS_DECLARATION_WITH_SEMICOLON@1989..2003
+                  0: CSS_DECLARATION@1989..2001
+                    0: CSS_GENERIC_PROPERTY@1989..2001
+                      0: CSS_IDENTIFIER@1989..1994
+                        0: IDENT@1989..1994 "color" [] []
+                      1: COLON@1994..1996 ":" [] [Whitespace(" ")]
+                      2: CSS_GENERIC_COMPONENT_VALUE_LIST@1996..2001
+                        0: CSS_IDENTIFIER@1996..2001
+                          0: IDENT@1996..2001 "green" [] []
+                    1: (empty)
+                  1: SEMICOLON@2001..2003 ";" [] [Whitespace(" ")]
+              2: R_CURLY@2003..2004 "}" [] []
+        2: R_CURLY@2004..2006 "}" [Newline("\n")] []
+  2: EOF@2006..2007 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/exclusive-value-gates.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/exclusive-value-gates.scss
@@ -1,0 +1,59 @@
+@supports (variable: $value) {
+  .variable {}
+}
+
+@supports (variable-interpolation: $value#{suffix}) {
+  .variable-interpolation {}
+}
+
+@supports (module-member: module.$value) {
+  .module-member {}
+}
+
+@supports (module-member-interpolation: module.$value#{suffix}) {
+  .module-member-interpolation {}
+}
+
+@supports (qualified-function: module.fn(1)) {
+  .qualified-function {}
+}
+
+@supports (interpolation: #{$value}) {
+  .interpolation {}
+}
+
+@supports (adjacent-interpolations: #{$a}#{$b}) {
+  .adjacent-interpolations {}
+}
+
+@supports (number-interpolation: 10#{unit}) {
+  .number-interpolation {}
+}
+
+@supports (dimension-interpolation: 10px#{suffix}) {
+  .dimension-interpolation {}
+}
+
+@supports (interpolated-name: foo#{$bar}) {
+  .interpolated-name {}
+}
+
+@supports (interpolated-string: "#{$value}") {
+  .interpolated-string {}
+}
+
+@supports (interpolated-custom-property: --#{$name}) {
+  .interpolated-custom-property {}
+}
+
+@supports (interpolated-custom-property-suffix: --theme-#{$slot}) {
+  .interpolated-custom-property-suffix {}
+}
+
+@media (aspect-ratio: module.fn(1)) {
+  .media-qualified-function {}
+}
+
+@media (resolution: #{$a}#{$b}) {
+  .media-adjacent-interpolations {}
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/exclusive-value-gates.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/exclusive-value-gates.scss.snap
@@ -1,0 +1,1904 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@supports (variable: $value) {
+  .variable {}
+}
+
+@supports (variable-interpolation: $value#{suffix}) {
+  .variable-interpolation {}
+}
+
+@supports (module-member: module.$value) {
+  .module-member {}
+}
+
+@supports (module-member-interpolation: module.$value#{suffix}) {
+  .module-member-interpolation {}
+}
+
+@supports (qualified-function: module.fn(1)) {
+  .qualified-function {}
+}
+
+@supports (interpolation: #{$value}) {
+  .interpolation {}
+}
+
+@supports (adjacent-interpolations: #{$a}#{$b}) {
+  .adjacent-interpolations {}
+}
+
+@supports (number-interpolation: 10#{unit}) {
+  .number-interpolation {}
+}
+
+@supports (dimension-interpolation: 10px#{suffix}) {
+  .dimension-interpolation {}
+}
+
+@supports (interpolated-name: foo#{$bar}) {
+  .interpolated-name {}
+}
+
+@supports (interpolated-string: "#{$value}") {
+  .interpolated-string {}
+}
+
+@supports (interpolated-custom-property: --#{$name}) {
+  .interpolated-custom-property {}
+}
+
+@supports (interpolated-custom-property-suffix: --theme-#{$slot}) {
+  .interpolated-custom-property-suffix {}
+}
+
+@media (aspect-ratio: module.fn(1)) {
+  .media-qualified-function {}
+}
+
+@media (resolution: #{$a}#{$b}) {
+  .media-adjacent-interpolations {}
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@1..10 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@10..11 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@11..19 "variable" [] [],
+                                },
+                                colon_token: COLON@19..21 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssVariable {
+                                            dollar_token: DOLLAR@21..22 "$" [] [],
+                                            name: CssIdentifier {
+                                                value_token: IDENT@22..27 "value" [] [],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@27..29 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@29..30 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@30..34 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@34..43 "variable" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@43..44 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@44..45 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@45..47 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@47..50 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@50..59 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@59..60 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@60..82 "variable-interpolation" [] [],
+                                },
+                                colon_token: COLON@82..84 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedValue {
+                                            items: ScssInterpolatedValuePartList [
+                                                ScssVariable {
+                                                    dollar_token: DOLLAR@84..85 "$" [] [],
+                                                    name: CssIdentifier {
+                                                        value_token: IDENT@85..90 "value" [] [],
+                                                    },
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@90..91 "#" [] [],
+                                                    l_curly_token: L_CURLY@91..92 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssIdentifier {
+                                                                value_token: IDENT@92..98 "suffix" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@98..99 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@99..101 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@101..102 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@102..106 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@106..129 "variable-interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@129..130 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@130..131 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@131..133 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@133..136 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@136..145 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@145..146 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@146..159 "module-member" [] [],
+                                },
+                                colon_token: COLON@159..161 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssModuleMemberAccess {
+                                            module: CssIdentifier {
+                                                value_token: IDENT@161..167 "module" [] [],
+                                            },
+                                            dot_token: DOT@167..168 "." [] [],
+                                            member: ScssVariable {
+                                                dollar_token: DOLLAR@168..169 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@169..174 "value" [] [],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@174..176 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@176..177 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@177..181 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@181..195 "module-member" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@195..196 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@196..197 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@197..199 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@199..202 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@202..211 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@211..212 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@212..239 "module-member-interpolation" [] [],
+                                },
+                                colon_token: COLON@239..241 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedValue {
+                                            items: ScssInterpolatedValuePartList [
+                                                ScssNamespacedVariable {
+                                                    namespace: CssIdentifier {
+                                                        value_token: IDENT@241..247 "module" [] [],
+                                                    },
+                                                    dot_token: DOT@247..248 "." [] [],
+                                                    name: ScssVariable {
+                                                        dollar_token: DOLLAR@248..249 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@249..254 "value" [] [],
+                                                        },
+                                                    },
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@254..255 "#" [] [],
+                                                    l_curly_token: L_CURLY@255..256 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssIdentifier {
+                                                                value_token: IDENT@256..262 "suffix" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@262..263 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@263..265 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@265..266 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@266..270 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@270..298 "module-member-interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@298..299 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@299..300 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@300..302 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@302..305 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@305..314 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@314..315 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@315..333 "qualified-function" [] [],
+                                },
+                                colon_token: COLON@333..335 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: ScssModuleMemberAccess {
+                                                module: CssIdentifier {
+                                                    value_token: IDENT@335..341 "module" [] [],
+                                                },
+                                                dot_token: DOT@341..342 "." [] [],
+                                                member: CssIdentifier {
+                                                    value_token: IDENT@342..344 "fn" [] [],
+                                                },
+                                            },
+                                            l_paren_token: L_PAREN@344..345 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssNumber {
+                                                            value_token: CSS_NUMBER_LITERAL@345..346 "1" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@346..347 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@347..349 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@349..350 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@350..354 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@354..373 "qualified-function" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@373..374 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@374..375 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@375..377 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@377..380 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@380..389 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@389..390 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@390..403 "interpolation" [] [],
+                                },
+                                colon_token: COLON@403..405 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@405..406 "#" [] [],
+                                            l_curly_token: L_CURLY@406..407 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@407..408 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@408..413 "value" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@413..414 "}" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@414..416 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@416..417 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@417..421 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@421..435 "interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@435..436 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@436..437 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@437..439 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@439..442 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@442..451 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@451..452 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@452..475 "adjacent-interpolations" [] [],
+                                },
+                                colon_token: COLON@475..477 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@477..478 "#" [] [],
+                                                    l_curly_token: L_CURLY@478..479 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@479..480 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@480..481 "a" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@481..482 "}" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@482..483 "#" [] [],
+                                                    l_curly_token: L_CURLY@483..484 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@484..485 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@485..486 "b" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@486..487 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@487..489 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@489..490 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@490..494 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@494..518 "adjacent-interpolations" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@518..519 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@519..520 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@520..522 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@522..525 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@525..534 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@534..535 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@535..555 "number-interpolation" [] [],
+                                },
+                                colon_token: COLON@555..557 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedValue {
+                                            items: ScssInterpolatedValuePartList [
+                                                CssNumber {
+                                                    value_token: CSS_NUMBER_LITERAL@557..559 "10" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@559..560 "#" [] [],
+                                                    l_curly_token: L_CURLY@560..561 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssIdentifier {
+                                                                value_token: IDENT@561..565 "unit" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@565..566 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@566..568 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@568..569 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@569..573 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@573..594 "number-interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@594..595 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@595..596 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@596..598 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@598..601 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@601..610 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@610..611 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@611..634 "dimension-interpolation" [] [],
+                                },
+                                colon_token: COLON@634..636 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedValue {
+                                            items: ScssInterpolatedValuePartList [
+                                                CssRegularDimension {
+                                                    value_token: CSS_NUMBER_LITERAL@636..638 "10" [] [],
+                                                    unit_token: IDENT@638..640 "px" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@640..641 "#" [] [],
+                                                    l_curly_token: L_CURLY@641..642 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssIdentifier {
+                                                                value_token: IDENT@642..648 "suffix" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@648..649 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@649..651 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@651..652 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@652..656 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@656..680 "dimension-interpolation" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@680..681 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@681..682 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@682..684 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@684..687 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@687..696 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@696..697 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@697..714 "interpolated-name" [] [],
+                                },
+                                colon_token: COLON@714..716 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@716..719 "foo" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@719..720 "#" [] [],
+                                                    l_curly_token: L_CURLY@720..721 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@721..722 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@722..725 "bar" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@725..726 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@726..728 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@728..729 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@729..733 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@733..751 "interpolated-name" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@751..752 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@752..753 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@753..755 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@755..758 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@758..767 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@767..768 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@768..787 "interpolated-string" [] [],
+                                },
+                                colon_token: COLON@787..789 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedString {
+                                            opening_quote_token: SCSS_STRING_QUOTE@789..790 "\"" [] [],
+                                            parts: ScssInterpolatedStringPartList [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@790..791 "#" [] [],
+                                                    l_curly_token: L_CURLY@791..792 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@792..793 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@793..798 "value" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@798..799 "}" [] [],
+                                                },
+                                            ],
+                                            closing_quote_token: SCSS_STRING_QUOTE@799..800 "\"" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@800..802 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@802..803 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@803..807 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@807..827 "interpolated-string" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@827..828 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@828..829 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@829..831 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@831..834 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@834..843 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@843..844 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@844..872 "interpolated-custom-property" [] [],
+                                },
+                                colon_token: COLON@872..874 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedDashedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                ScssInterpolatedIdentifierHyphen {
+                                                    minus_token: MINUS@874..875 "-" [] [],
+                                                },
+                                                ScssInterpolatedIdentifierHyphen {
+                                                    minus_token: MINUS@875..876 "-" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@876..877 "#" [] [],
+                                                    l_curly_token: L_CURLY@877..878 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@878..879 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@879..883 "name" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@883..884 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@884..886 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@886..887 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@887..891 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@891..920 "interpolated-custom-property" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@920..921 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@921..922 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@922..924 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@924..927 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@927..936 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@936..937 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@937..972 "interpolated-custom-property-suffix" [] [],
+                                },
+                                colon_token: COLON@972..974 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedDashedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@974..982 "--theme-" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@982..983 "#" [] [],
+                                                    l_curly_token: L_CURLY@983..984 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@984..985 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@985..989 "slot" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@989..990 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@990..992 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@992..993 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@993..997 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@997..1033 "interpolated-custom-property-suffix" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1033..1034 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1034..1035 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1035..1037 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1037..1040 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1040..1046 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaFeatureInParens {
+                                l_paren_token: L_PAREN@1046..1047 "(" [] [],
+                                feature: CssQueryFeaturePlain {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@1047..1059 "aspect-ratio" [] [],
+                                    },
+                                    colon_token: COLON@1059..1061 ":" [] [Whitespace(" ")],
+                                    value: CssFunction {
+                                        name: ScssModuleMemberAccess {
+                                            module: CssIdentifier {
+                                                value_token: IDENT@1061..1067 "module" [] [],
+                                            },
+                                            dot_token: DOT@1067..1068 "." [] [],
+                                            member: CssIdentifier {
+                                                value_token: IDENT@1068..1070 "fn" [] [],
+                                            },
+                                        },
+                                        l_paren_token: L_PAREN@1070..1071 "(" [] [],
+                                        items: CssParameterList [
+                                            ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    CssNumber {
+                                                        value_token: CSS_NUMBER_LITERAL@1071..1072 "1" [] [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@1072..1073 ")" [] [],
+                                    },
+                                },
+                                r_paren_token: R_PAREN@1073..1075 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@1075..1076 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@1076..1080 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@1080..1105 "media-qualified-function" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1105..1106 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1106..1107 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1107..1109 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@1109..1112 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1112..1118 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaFeatureInParens {
+                                l_paren_token: L_PAREN@1118..1119 "(" [] [],
+                                feature: CssQueryFeaturePlain {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@1119..1129 "resolution" [] [],
+                                    },
+                                    colon_token: COLON@1129..1131 ":" [] [Whitespace(" ")],
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@1131..1132 "#" [] [],
+                                                l_curly_token: L_CURLY@1132..1133 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@1133..1134 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@1134..1135 "a" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@1135..1136 "}" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@1136..1137 "#" [] [],
+                                                l_curly_token: L_CURLY@1137..1138 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@1138..1139 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@1139..1140 "b" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@1140..1141 "}" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                r_paren_token: R_PAREN@1141..1143 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@1143..1144 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@1144..1148 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@1148..1178 "media-adjacent-interpolations" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@1178..1179 "{" [] [],
+                                items: CssDeclarationOrRuleList [],
+                                r_curly_token: R_CURLY@1179..1180 "}" [] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@1180..1182 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@1182..1183 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..1183
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..1182
+    0: CSS_AT_RULE@0..47
+      0: AT@0..1 "@" [] []
+      1: CSS_SUPPORTS_AT_RULE@1..47
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@1..29
+          0: SUPPORTS_KW@1..10 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@10..29
+            0: L_PAREN@10..11 "(" [] []
+            1: CSS_DECLARATION@11..27
+              0: CSS_GENERIC_PROPERTY@11..27
+                0: CSS_IDENTIFIER@11..19
+                  0: IDENT@11..19 "variable" [] []
+                1: COLON@19..21 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@21..27
+                  0: SCSS_EXPRESSION_ITEM_LIST@21..27
+                    0: SCSS_VARIABLE@21..27
+                      0: DOLLAR@21..22 "$" [] []
+                      1: CSS_IDENTIFIER@22..27
+                        0: IDENT@22..27 "value" [] []
+              1: (empty)
+            2: R_PAREN@27..29 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@29..47
+          0: L_CURLY@29..30 "{" [] []
+          1: CSS_RULE_LIST@30..45
+            0: CSS_QUALIFIED_RULE@30..45
+              0: CSS_SELECTOR_LIST@30..43
+                0: CSS_COMPOUND_SELECTOR@30..43
+                  0: CSS_NESTED_SELECTOR_LIST@30..30
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@30..43
+                    0: CSS_CLASS_SELECTOR@30..43
+                      0: DOT@30..34 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@34..43
+                        0: IDENT@34..43 "variable" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@43..45
+                0: L_CURLY@43..44 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@44..44
+                2: R_CURLY@44..45 "}" [] []
+          2: R_CURLY@45..47 "}" [Newline("\n")] []
+    1: CSS_AT_RULE@47..133
+      0: AT@47..50 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@50..133
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@50..101
+          0: SUPPORTS_KW@50..59 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@59..101
+            0: L_PAREN@59..60 "(" [] []
+            1: CSS_DECLARATION@60..99
+              0: CSS_GENERIC_PROPERTY@60..99
+                0: CSS_IDENTIFIER@60..82
+                  0: IDENT@60..82 "variable-interpolation" [] []
+                1: COLON@82..84 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@84..99
+                  0: SCSS_EXPRESSION_ITEM_LIST@84..99
+                    0: SCSS_INTERPOLATED_VALUE@84..99
+                      0: SCSS_INTERPOLATED_VALUE_PART_LIST@84..99
+                        0: SCSS_VARIABLE@84..90
+                          0: DOLLAR@84..85 "$" [] []
+                          1: CSS_IDENTIFIER@85..90
+                            0: IDENT@85..90 "value" [] []
+                        1: SCSS_INTERPOLATION@90..99
+                          0: HASH@90..91 "#" [] []
+                          1: L_CURLY@91..92 "{" [] []
+                          2: SCSS_EXPRESSION@92..98
+                            0: SCSS_EXPRESSION_ITEM_LIST@92..98
+                              0: CSS_IDENTIFIER@92..98
+                                0: IDENT@92..98 "suffix" [] []
+                          3: R_CURLY@98..99 "}" [] []
+              1: (empty)
+            2: R_PAREN@99..101 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@101..133
+          0: L_CURLY@101..102 "{" [] []
+          1: CSS_RULE_LIST@102..131
+            0: CSS_QUALIFIED_RULE@102..131
+              0: CSS_SELECTOR_LIST@102..129
+                0: CSS_COMPOUND_SELECTOR@102..129
+                  0: CSS_NESTED_SELECTOR_LIST@102..102
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@102..129
+                    0: CSS_CLASS_SELECTOR@102..129
+                      0: DOT@102..106 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@106..129
+                        0: IDENT@106..129 "variable-interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@129..131
+                0: L_CURLY@129..130 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@130..130
+                2: R_CURLY@130..131 "}" [] []
+          2: R_CURLY@131..133 "}" [Newline("\n")] []
+    2: CSS_AT_RULE@133..199
+      0: AT@133..136 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@136..199
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@136..176
+          0: SUPPORTS_KW@136..145 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@145..176
+            0: L_PAREN@145..146 "(" [] []
+            1: CSS_DECLARATION@146..174
+              0: CSS_GENERIC_PROPERTY@146..174
+                0: CSS_IDENTIFIER@146..159
+                  0: IDENT@146..159 "module-member" [] []
+                1: COLON@159..161 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@161..174
+                  0: SCSS_EXPRESSION_ITEM_LIST@161..174
+                    0: SCSS_MODULE_MEMBER_ACCESS@161..174
+                      0: CSS_IDENTIFIER@161..167
+                        0: IDENT@161..167 "module" [] []
+                      1: DOT@167..168 "." [] []
+                      2: SCSS_VARIABLE@168..174
+                        0: DOLLAR@168..169 "$" [] []
+                        1: CSS_IDENTIFIER@169..174
+                          0: IDENT@169..174 "value" [] []
+              1: (empty)
+            2: R_PAREN@174..176 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@176..199
+          0: L_CURLY@176..177 "{" [] []
+          1: CSS_RULE_LIST@177..197
+            0: CSS_QUALIFIED_RULE@177..197
+              0: CSS_SELECTOR_LIST@177..195
+                0: CSS_COMPOUND_SELECTOR@177..195
+                  0: CSS_NESTED_SELECTOR_LIST@177..177
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@177..195
+                    0: CSS_CLASS_SELECTOR@177..195
+                      0: DOT@177..181 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@181..195
+                        0: IDENT@181..195 "module-member" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@195..197
+                0: L_CURLY@195..196 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@196..196
+                2: R_CURLY@196..197 "}" [] []
+          2: R_CURLY@197..199 "}" [Newline("\n")] []
+    3: CSS_AT_RULE@199..302
+      0: AT@199..202 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@202..302
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@202..265
+          0: SUPPORTS_KW@202..211 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@211..265
+            0: L_PAREN@211..212 "(" [] []
+            1: CSS_DECLARATION@212..263
+              0: CSS_GENERIC_PROPERTY@212..263
+                0: CSS_IDENTIFIER@212..239
+                  0: IDENT@212..239 "module-member-interpolation" [] []
+                1: COLON@239..241 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@241..263
+                  0: SCSS_EXPRESSION_ITEM_LIST@241..263
+                    0: SCSS_INTERPOLATED_VALUE@241..263
+                      0: SCSS_INTERPOLATED_VALUE_PART_LIST@241..263
+                        0: SCSS_NAMESPACED_VARIABLE@241..254
+                          0: CSS_IDENTIFIER@241..247
+                            0: IDENT@241..247 "module" [] []
+                          1: DOT@247..248 "." [] []
+                          2: SCSS_VARIABLE@248..254
+                            0: DOLLAR@248..249 "$" [] []
+                            1: CSS_IDENTIFIER@249..254
+                              0: IDENT@249..254 "value" [] []
+                        1: SCSS_INTERPOLATION@254..263
+                          0: HASH@254..255 "#" [] []
+                          1: L_CURLY@255..256 "{" [] []
+                          2: SCSS_EXPRESSION@256..262
+                            0: SCSS_EXPRESSION_ITEM_LIST@256..262
+                              0: CSS_IDENTIFIER@256..262
+                                0: IDENT@256..262 "suffix" [] []
+                          3: R_CURLY@262..263 "}" [] []
+              1: (empty)
+            2: R_PAREN@263..265 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@265..302
+          0: L_CURLY@265..266 "{" [] []
+          1: CSS_RULE_LIST@266..300
+            0: CSS_QUALIFIED_RULE@266..300
+              0: CSS_SELECTOR_LIST@266..298
+                0: CSS_COMPOUND_SELECTOR@266..298
+                  0: CSS_NESTED_SELECTOR_LIST@266..266
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@266..298
+                    0: CSS_CLASS_SELECTOR@266..298
+                      0: DOT@266..270 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@270..298
+                        0: IDENT@270..298 "module-member-interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@298..300
+                0: L_CURLY@298..299 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@299..299
+                2: R_CURLY@299..300 "}" [] []
+          2: R_CURLY@300..302 "}" [Newline("\n")] []
+    4: CSS_AT_RULE@302..377
+      0: AT@302..305 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@305..377
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@305..349
+          0: SUPPORTS_KW@305..314 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@314..349
+            0: L_PAREN@314..315 "(" [] []
+            1: CSS_DECLARATION@315..347
+              0: CSS_GENERIC_PROPERTY@315..347
+                0: CSS_IDENTIFIER@315..333
+                  0: IDENT@315..333 "qualified-function" [] []
+                1: COLON@333..335 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@335..347
+                  0: SCSS_EXPRESSION_ITEM_LIST@335..347
+                    0: CSS_FUNCTION@335..347
+                      0: SCSS_MODULE_MEMBER_ACCESS@335..344
+                        0: CSS_IDENTIFIER@335..341
+                          0: IDENT@335..341 "module" [] []
+                        1: DOT@341..342 "." [] []
+                        2: CSS_IDENTIFIER@342..344
+                          0: IDENT@342..344 "fn" [] []
+                      1: L_PAREN@344..345 "(" [] []
+                      2: CSS_PARAMETER_LIST@345..346
+                        0: SCSS_EXPRESSION@345..346
+                          0: SCSS_EXPRESSION_ITEM_LIST@345..346
+                            0: CSS_NUMBER@345..346
+                              0: CSS_NUMBER_LITERAL@345..346 "1" [] []
+                      3: R_PAREN@346..347 ")" [] []
+              1: (empty)
+            2: R_PAREN@347..349 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@349..377
+          0: L_CURLY@349..350 "{" [] []
+          1: CSS_RULE_LIST@350..375
+            0: CSS_QUALIFIED_RULE@350..375
+              0: CSS_SELECTOR_LIST@350..373
+                0: CSS_COMPOUND_SELECTOR@350..373
+                  0: CSS_NESTED_SELECTOR_LIST@350..350
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@350..373
+                    0: CSS_CLASS_SELECTOR@350..373
+                      0: DOT@350..354 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@354..373
+                        0: IDENT@354..373 "qualified-function" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@373..375
+                0: L_CURLY@373..374 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@374..374
+                2: R_CURLY@374..375 "}" [] []
+          2: R_CURLY@375..377 "}" [Newline("\n")] []
+    5: CSS_AT_RULE@377..439
+      0: AT@377..380 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@380..439
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@380..416
+          0: SUPPORTS_KW@380..389 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@389..416
+            0: L_PAREN@389..390 "(" [] []
+            1: CSS_DECLARATION@390..414
+              0: CSS_GENERIC_PROPERTY@390..414
+                0: CSS_IDENTIFIER@390..403
+                  0: IDENT@390..403 "interpolation" [] []
+                1: COLON@403..405 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@405..414
+                  0: SCSS_EXPRESSION_ITEM_LIST@405..414
+                    0: SCSS_INTERPOLATION@405..414
+                      0: HASH@405..406 "#" [] []
+                      1: L_CURLY@406..407 "{" [] []
+                      2: SCSS_EXPRESSION@407..413
+                        0: SCSS_EXPRESSION_ITEM_LIST@407..413
+                          0: SCSS_VARIABLE@407..413
+                            0: DOLLAR@407..408 "$" [] []
+                            1: CSS_IDENTIFIER@408..413
+                              0: IDENT@408..413 "value" [] []
+                      3: R_CURLY@413..414 "}" [] []
+              1: (empty)
+            2: R_PAREN@414..416 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@416..439
+          0: L_CURLY@416..417 "{" [] []
+          1: CSS_RULE_LIST@417..437
+            0: CSS_QUALIFIED_RULE@417..437
+              0: CSS_SELECTOR_LIST@417..435
+                0: CSS_COMPOUND_SELECTOR@417..435
+                  0: CSS_NESTED_SELECTOR_LIST@417..417
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@417..435
+                    0: CSS_CLASS_SELECTOR@417..435
+                      0: DOT@417..421 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@421..435
+                        0: IDENT@421..435 "interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@435..437
+                0: L_CURLY@435..436 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@436..436
+                2: R_CURLY@436..437 "}" [] []
+          2: R_CURLY@437..439 "}" [Newline("\n")] []
+    6: CSS_AT_RULE@439..522
+      0: AT@439..442 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@442..522
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@442..489
+          0: SUPPORTS_KW@442..451 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@451..489
+            0: L_PAREN@451..452 "(" [] []
+            1: CSS_DECLARATION@452..487
+              0: CSS_GENERIC_PROPERTY@452..487
+                0: CSS_IDENTIFIER@452..475
+                  0: IDENT@452..475 "adjacent-interpolations" [] []
+                1: COLON@475..477 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@477..487
+                  0: SCSS_EXPRESSION_ITEM_LIST@477..487
+                    0: SCSS_INTERPOLATED_IDENTIFIER@477..487
+                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@477..487
+                        0: SCSS_INTERPOLATION@477..482
+                          0: HASH@477..478 "#" [] []
+                          1: L_CURLY@478..479 "{" [] []
+                          2: SCSS_EXPRESSION@479..481
+                            0: SCSS_EXPRESSION_ITEM_LIST@479..481
+                              0: SCSS_VARIABLE@479..481
+                                0: DOLLAR@479..480 "$" [] []
+                                1: CSS_IDENTIFIER@480..481
+                                  0: IDENT@480..481 "a" [] []
+                          3: R_CURLY@481..482 "}" [] []
+                        1: SCSS_INTERPOLATION@482..487
+                          0: HASH@482..483 "#" [] []
+                          1: L_CURLY@483..484 "{" [] []
+                          2: SCSS_EXPRESSION@484..486
+                            0: SCSS_EXPRESSION_ITEM_LIST@484..486
+                              0: SCSS_VARIABLE@484..486
+                                0: DOLLAR@484..485 "$" [] []
+                                1: CSS_IDENTIFIER@485..486
+                                  0: IDENT@485..486 "b" [] []
+                          3: R_CURLY@486..487 "}" [] []
+              1: (empty)
+            2: R_PAREN@487..489 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@489..522
+          0: L_CURLY@489..490 "{" [] []
+          1: CSS_RULE_LIST@490..520
+            0: CSS_QUALIFIED_RULE@490..520
+              0: CSS_SELECTOR_LIST@490..518
+                0: CSS_COMPOUND_SELECTOR@490..518
+                  0: CSS_NESTED_SELECTOR_LIST@490..490
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@490..518
+                    0: CSS_CLASS_SELECTOR@490..518
+                      0: DOT@490..494 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@494..518
+                        0: IDENT@494..518 "adjacent-interpolations" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@518..520
+                0: L_CURLY@518..519 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@519..519
+                2: R_CURLY@519..520 "}" [] []
+          2: R_CURLY@520..522 "}" [Newline("\n")] []
+    7: CSS_AT_RULE@522..598
+      0: AT@522..525 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@525..598
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@525..568
+          0: SUPPORTS_KW@525..534 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@534..568
+            0: L_PAREN@534..535 "(" [] []
+            1: CSS_DECLARATION@535..566
+              0: CSS_GENERIC_PROPERTY@535..566
+                0: CSS_IDENTIFIER@535..555
+                  0: IDENT@535..555 "number-interpolation" [] []
+                1: COLON@555..557 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@557..566
+                  0: SCSS_EXPRESSION_ITEM_LIST@557..566
+                    0: SCSS_INTERPOLATED_VALUE@557..566
+                      0: SCSS_INTERPOLATED_VALUE_PART_LIST@557..566
+                        0: CSS_NUMBER@557..559
+                          0: CSS_NUMBER_LITERAL@557..559 "10" [] []
+                        1: SCSS_INTERPOLATION@559..566
+                          0: HASH@559..560 "#" [] []
+                          1: L_CURLY@560..561 "{" [] []
+                          2: SCSS_EXPRESSION@561..565
+                            0: SCSS_EXPRESSION_ITEM_LIST@561..565
+                              0: CSS_IDENTIFIER@561..565
+                                0: IDENT@561..565 "unit" [] []
+                          3: R_CURLY@565..566 "}" [] []
+              1: (empty)
+            2: R_PAREN@566..568 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@568..598
+          0: L_CURLY@568..569 "{" [] []
+          1: CSS_RULE_LIST@569..596
+            0: CSS_QUALIFIED_RULE@569..596
+              0: CSS_SELECTOR_LIST@569..594
+                0: CSS_COMPOUND_SELECTOR@569..594
+                  0: CSS_NESTED_SELECTOR_LIST@569..569
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@569..594
+                    0: CSS_CLASS_SELECTOR@569..594
+                      0: DOT@569..573 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@573..594
+                        0: IDENT@573..594 "number-interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@594..596
+                0: L_CURLY@594..595 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@595..595
+                2: R_CURLY@595..596 "}" [] []
+          2: R_CURLY@596..598 "}" [Newline("\n")] []
+    8: CSS_AT_RULE@598..684
+      0: AT@598..601 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@601..684
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@601..651
+          0: SUPPORTS_KW@601..610 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@610..651
+            0: L_PAREN@610..611 "(" [] []
+            1: CSS_DECLARATION@611..649
+              0: CSS_GENERIC_PROPERTY@611..649
+                0: CSS_IDENTIFIER@611..634
+                  0: IDENT@611..634 "dimension-interpolation" [] []
+                1: COLON@634..636 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@636..649
+                  0: SCSS_EXPRESSION_ITEM_LIST@636..649
+                    0: SCSS_INTERPOLATED_VALUE@636..649
+                      0: SCSS_INTERPOLATED_VALUE_PART_LIST@636..649
+                        0: CSS_REGULAR_DIMENSION@636..640
+                          0: CSS_NUMBER_LITERAL@636..638 "10" [] []
+                          1: IDENT@638..640 "px" [] []
+                        1: SCSS_INTERPOLATION@640..649
+                          0: HASH@640..641 "#" [] []
+                          1: L_CURLY@641..642 "{" [] []
+                          2: SCSS_EXPRESSION@642..648
+                            0: SCSS_EXPRESSION_ITEM_LIST@642..648
+                              0: CSS_IDENTIFIER@642..648
+                                0: IDENT@642..648 "suffix" [] []
+                          3: R_CURLY@648..649 "}" [] []
+              1: (empty)
+            2: R_PAREN@649..651 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@651..684
+          0: L_CURLY@651..652 "{" [] []
+          1: CSS_RULE_LIST@652..682
+            0: CSS_QUALIFIED_RULE@652..682
+              0: CSS_SELECTOR_LIST@652..680
+                0: CSS_COMPOUND_SELECTOR@652..680
+                  0: CSS_NESTED_SELECTOR_LIST@652..652
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@652..680
+                    0: CSS_CLASS_SELECTOR@652..680
+                      0: DOT@652..656 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@656..680
+                        0: IDENT@656..680 "dimension-interpolation" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@680..682
+                0: L_CURLY@680..681 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@681..681
+                2: R_CURLY@681..682 "}" [] []
+          2: R_CURLY@682..684 "}" [Newline("\n")] []
+    9: CSS_AT_RULE@684..755
+      0: AT@684..687 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@687..755
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@687..728
+          0: SUPPORTS_KW@687..696 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@696..728
+            0: L_PAREN@696..697 "(" [] []
+            1: CSS_DECLARATION@697..726
+              0: CSS_GENERIC_PROPERTY@697..726
+                0: CSS_IDENTIFIER@697..714
+                  0: IDENT@697..714 "interpolated-name" [] []
+                1: COLON@714..716 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@716..726
+                  0: SCSS_EXPRESSION_ITEM_LIST@716..726
+                    0: SCSS_INTERPOLATED_IDENTIFIER@716..726
+                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@716..726
+                        0: CSS_IDENTIFIER@716..719
+                          0: IDENT@716..719 "foo" [] []
+                        1: SCSS_INTERPOLATION@719..726
+                          0: HASH@719..720 "#" [] []
+                          1: L_CURLY@720..721 "{" [] []
+                          2: SCSS_EXPRESSION@721..725
+                            0: SCSS_EXPRESSION_ITEM_LIST@721..725
+                              0: SCSS_VARIABLE@721..725
+                                0: DOLLAR@721..722 "$" [] []
+                                1: CSS_IDENTIFIER@722..725
+                                  0: IDENT@722..725 "bar" [] []
+                          3: R_CURLY@725..726 "}" [] []
+              1: (empty)
+            2: R_PAREN@726..728 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@728..755
+          0: L_CURLY@728..729 "{" [] []
+          1: CSS_RULE_LIST@729..753
+            0: CSS_QUALIFIED_RULE@729..753
+              0: CSS_SELECTOR_LIST@729..751
+                0: CSS_COMPOUND_SELECTOR@729..751
+                  0: CSS_NESTED_SELECTOR_LIST@729..729
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@729..751
+                    0: CSS_CLASS_SELECTOR@729..751
+                      0: DOT@729..733 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@733..751
+                        0: IDENT@733..751 "interpolated-name" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@751..753
+                0: L_CURLY@751..752 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@752..752
+                2: R_CURLY@752..753 "}" [] []
+          2: R_CURLY@753..755 "}" [Newline("\n")] []
+    10: CSS_AT_RULE@755..831
+      0: AT@755..758 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@758..831
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@758..802
+          0: SUPPORTS_KW@758..767 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@767..802
+            0: L_PAREN@767..768 "(" [] []
+            1: CSS_DECLARATION@768..800
+              0: CSS_GENERIC_PROPERTY@768..800
+                0: CSS_IDENTIFIER@768..787
+                  0: IDENT@768..787 "interpolated-string" [] []
+                1: COLON@787..789 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@789..800
+                  0: SCSS_EXPRESSION_ITEM_LIST@789..800
+                    0: SCSS_INTERPOLATED_STRING@789..800
+                      0: SCSS_STRING_QUOTE@789..790 "\"" [] []
+                      1: SCSS_INTERPOLATED_STRING_PART_LIST@790..799
+                        0: SCSS_INTERPOLATION@790..799
+                          0: HASH@790..791 "#" [] []
+                          1: L_CURLY@791..792 "{" [] []
+                          2: SCSS_EXPRESSION@792..798
+                            0: SCSS_EXPRESSION_ITEM_LIST@792..798
+                              0: SCSS_VARIABLE@792..798
+                                0: DOLLAR@792..793 "$" [] []
+                                1: CSS_IDENTIFIER@793..798
+                                  0: IDENT@793..798 "value" [] []
+                          3: R_CURLY@798..799 "}" [] []
+                      2: SCSS_STRING_QUOTE@799..800 "\"" [] []
+              1: (empty)
+            2: R_PAREN@800..802 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@802..831
+          0: L_CURLY@802..803 "{" [] []
+          1: CSS_RULE_LIST@803..829
+            0: CSS_QUALIFIED_RULE@803..829
+              0: CSS_SELECTOR_LIST@803..827
+                0: CSS_COMPOUND_SELECTOR@803..827
+                  0: CSS_NESTED_SELECTOR_LIST@803..803
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@803..827
+                    0: CSS_CLASS_SELECTOR@803..827
+                      0: DOT@803..807 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@807..827
+                        0: IDENT@807..827 "interpolated-string" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@827..829
+                0: L_CURLY@827..828 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@828..828
+                2: R_CURLY@828..829 "}" [] []
+          2: R_CURLY@829..831 "}" [Newline("\n")] []
+    11: CSS_AT_RULE@831..924
+      0: AT@831..834 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@834..924
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@834..886
+          0: SUPPORTS_KW@834..843 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@843..886
+            0: L_PAREN@843..844 "(" [] []
+            1: CSS_DECLARATION@844..884
+              0: CSS_GENERIC_PROPERTY@844..884
+                0: CSS_IDENTIFIER@844..872
+                  0: IDENT@844..872 "interpolated-custom-property" [] []
+                1: COLON@872..874 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@874..884
+                  0: SCSS_EXPRESSION_ITEM_LIST@874..884
+                    0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@874..884
+                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@874..884
+                        0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@874..875
+                          0: MINUS@874..875 "-" [] []
+                        1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@875..876
+                          0: MINUS@875..876 "-" [] []
+                        2: SCSS_INTERPOLATION@876..884
+                          0: HASH@876..877 "#" [] []
+                          1: L_CURLY@877..878 "{" [] []
+                          2: SCSS_EXPRESSION@878..883
+                            0: SCSS_EXPRESSION_ITEM_LIST@878..883
+                              0: SCSS_VARIABLE@878..883
+                                0: DOLLAR@878..879 "$" [] []
+                                1: CSS_IDENTIFIER@879..883
+                                  0: IDENT@879..883 "name" [] []
+                          3: R_CURLY@883..884 "}" [] []
+              1: (empty)
+            2: R_PAREN@884..886 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@886..924
+          0: L_CURLY@886..887 "{" [] []
+          1: CSS_RULE_LIST@887..922
+            0: CSS_QUALIFIED_RULE@887..922
+              0: CSS_SELECTOR_LIST@887..920
+                0: CSS_COMPOUND_SELECTOR@887..920
+                  0: CSS_NESTED_SELECTOR_LIST@887..887
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@887..920
+                    0: CSS_CLASS_SELECTOR@887..920
+                      0: DOT@887..891 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@891..920
+                        0: IDENT@891..920 "interpolated-custom-property" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@920..922
+                0: L_CURLY@920..921 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@921..921
+                2: R_CURLY@921..922 "}" [] []
+          2: R_CURLY@922..924 "}" [Newline("\n")] []
+    12: CSS_AT_RULE@924..1037
+      0: AT@924..927 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@927..1037
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@927..992
+          0: SUPPORTS_KW@927..936 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@936..992
+            0: L_PAREN@936..937 "(" [] []
+            1: CSS_DECLARATION@937..990
+              0: CSS_GENERIC_PROPERTY@937..990
+                0: CSS_IDENTIFIER@937..972
+                  0: IDENT@937..972 "interpolated-custom-property-suffix" [] []
+                1: COLON@972..974 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@974..990
+                  0: SCSS_EXPRESSION_ITEM_LIST@974..990
+                    0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@974..990
+                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@974..990
+                        0: CSS_IDENTIFIER@974..982
+                          0: IDENT@974..982 "--theme-" [] []
+                        1: SCSS_INTERPOLATION@982..990
+                          0: HASH@982..983 "#" [] []
+                          1: L_CURLY@983..984 "{" [] []
+                          2: SCSS_EXPRESSION@984..989
+                            0: SCSS_EXPRESSION_ITEM_LIST@984..989
+                              0: SCSS_VARIABLE@984..989
+                                0: DOLLAR@984..985 "$" [] []
+                                1: CSS_IDENTIFIER@985..989
+                                  0: IDENT@985..989 "slot" [] []
+                          3: R_CURLY@989..990 "}" [] []
+              1: (empty)
+            2: R_PAREN@990..992 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@992..1037
+          0: L_CURLY@992..993 "{" [] []
+          1: CSS_RULE_LIST@993..1035
+            0: CSS_QUALIFIED_RULE@993..1035
+              0: CSS_SELECTOR_LIST@993..1033
+                0: CSS_COMPOUND_SELECTOR@993..1033
+                  0: CSS_NESTED_SELECTOR_LIST@993..993
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@993..1033
+                    0: CSS_CLASS_SELECTOR@993..1033
+                      0: DOT@993..997 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@997..1033
+                        0: IDENT@997..1033 "interpolated-custom-property-suffix" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1033..1035
+                0: L_CURLY@1033..1034 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1034..1034
+                2: R_CURLY@1034..1035 "}" [] []
+          2: R_CURLY@1035..1037 "}" [Newline("\n")] []
+    13: CSS_AT_RULE@1037..1109
+      0: AT@1037..1040 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@1040..1109
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1040..1075
+          0: MEDIA_KW@1040..1046 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@1046..1075
+            0: CSS_MEDIA_CONDITION_QUERY@1046..1075
+              0: CSS_MEDIA_FEATURE_IN_PARENS@1046..1075
+                0: L_PAREN@1046..1047 "(" [] []
+                1: CSS_QUERY_FEATURE_PLAIN@1047..1073
+                  0: CSS_IDENTIFIER@1047..1059
+                    0: IDENT@1047..1059 "aspect-ratio" [] []
+                  1: COLON@1059..1061 ":" [] [Whitespace(" ")]
+                  2: CSS_FUNCTION@1061..1073
+                    0: SCSS_MODULE_MEMBER_ACCESS@1061..1070
+                      0: CSS_IDENTIFIER@1061..1067
+                        0: IDENT@1061..1067 "module" [] []
+                      1: DOT@1067..1068 "." [] []
+                      2: CSS_IDENTIFIER@1068..1070
+                        0: IDENT@1068..1070 "fn" [] []
+                    1: L_PAREN@1070..1071 "(" [] []
+                    2: CSS_PARAMETER_LIST@1071..1072
+                      0: SCSS_EXPRESSION@1071..1072
+                        0: SCSS_EXPRESSION_ITEM_LIST@1071..1072
+                          0: CSS_NUMBER@1071..1072
+                            0: CSS_NUMBER_LITERAL@1071..1072 "1" [] []
+                    3: R_PAREN@1072..1073 ")" [] []
+                2: R_PAREN@1073..1075 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@1075..1109
+          0: L_CURLY@1075..1076 "{" [] []
+          1: CSS_RULE_LIST@1076..1107
+            0: CSS_QUALIFIED_RULE@1076..1107
+              0: CSS_SELECTOR_LIST@1076..1105
+                0: CSS_COMPOUND_SELECTOR@1076..1105
+                  0: CSS_NESTED_SELECTOR_LIST@1076..1076
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@1076..1105
+                    0: CSS_CLASS_SELECTOR@1076..1105
+                      0: DOT@1076..1080 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@1080..1105
+                        0: IDENT@1080..1105 "media-qualified-function" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1105..1107
+                0: L_CURLY@1105..1106 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1106..1106
+                2: R_CURLY@1106..1107 "}" [] []
+          2: R_CURLY@1107..1109 "}" [Newline("\n")] []
+    14: CSS_AT_RULE@1109..1182
+      0: AT@1109..1112 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@1112..1182
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1112..1143
+          0: MEDIA_KW@1112..1118 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@1118..1143
+            0: CSS_MEDIA_CONDITION_QUERY@1118..1143
+              0: CSS_MEDIA_FEATURE_IN_PARENS@1118..1143
+                0: L_PAREN@1118..1119 "(" [] []
+                1: CSS_QUERY_FEATURE_PLAIN@1119..1141
+                  0: CSS_IDENTIFIER@1119..1129
+                    0: IDENT@1119..1129 "resolution" [] []
+                  1: COLON@1129..1131 ":" [] [Whitespace(" ")]
+                  2: SCSS_INTERPOLATED_IDENTIFIER@1131..1141
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1131..1141
+                      0: SCSS_INTERPOLATION@1131..1136
+                        0: HASH@1131..1132 "#" [] []
+                        1: L_CURLY@1132..1133 "{" [] []
+                        2: SCSS_EXPRESSION@1133..1135
+                          0: SCSS_EXPRESSION_ITEM_LIST@1133..1135
+                            0: SCSS_VARIABLE@1133..1135
+                              0: DOLLAR@1133..1134 "$" [] []
+                              1: CSS_IDENTIFIER@1134..1135
+                                0: IDENT@1134..1135 "a" [] []
+                        3: R_CURLY@1135..1136 "}" [] []
+                      1: SCSS_INTERPOLATION@1136..1141
+                        0: HASH@1136..1137 "#" [] []
+                        1: L_CURLY@1137..1138 "{" [] []
+                        2: SCSS_EXPRESSION@1138..1140
+                          0: SCSS_EXPRESSION_ITEM_LIST@1138..1140
+                            0: SCSS_VARIABLE@1138..1140
+                              0: DOLLAR@1138..1139 "$" [] []
+                              1: CSS_IDENTIFIER@1139..1140
+                                0: IDENT@1139..1140 "b" [] []
+                        3: R_CURLY@1140..1141 "}" [] []
+                2: R_PAREN@1141..1143 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@1143..1182
+          0: L_CURLY@1143..1144 "{" [] []
+          1: CSS_RULE_LIST@1144..1180
+            0: CSS_QUALIFIED_RULE@1144..1180
+              0: CSS_SELECTOR_LIST@1144..1178
+                0: CSS_COMPOUND_SELECTOR@1144..1178
+                  0: CSS_NESTED_SELECTOR_LIST@1144..1144
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@1144..1178
+                    0: CSS_CLASS_SELECTOR@1144..1178
+                      0: DOT@1144..1148 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@1148..1178
+                        0: IDENT@1148..1178 "media-adjacent-interpolations" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@1178..1180
+                0: L_CURLY@1178..1179 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@1179..1179
+                2: R_CURLY@1179..1180 "}" [] []
+          2: R_CURLY@1180..1182 "}" [Newline("\n")] []
+  2: EOF@1182..1183 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/exclusive-value-gates.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/exclusive-value-gates.scss
@@ -1,0 +1,31 @@
+.supported-scss {
+  variable: $value;
+  variable-interpolation: $value#{suffix};
+  module-member: module.$value;
+  module-member-interpolation: module.$value#{suffix};
+  qualified-function: module.fn(1);
+  interpolation: #{$value};
+  adjacent-interpolations: #{$a}#{$b};
+  number-interpolation: 10#{unit};
+  dimension-interpolation: 10px#{suffix};
+  interpolated-name: foo#{$bar};
+  interpolated-string: "#{$value}";
+  interpolated-custom-property: --#{$name};
+  interpolated-custom-property-suffix: --theme-#{$slot};
+}
+
+.function-arguments {
+  variable: fn($value);
+  variable-interpolation: fn($value#{suffix});
+  module-member: fn(module.$value);
+  module-member-interpolation: fn(module.$value#{suffix});
+  qualified-function: fn(module.fn(1));
+  interpolation: fn(#{$value});
+  adjacent-interpolations: fn(#{$a}#{$b});
+  number-interpolation: fn(10#{unit});
+  dimension-interpolation: fn(10px#{suffix});
+  interpolated-name: fn(foo#{$bar});
+  interpolated-string: fn("#{$value}");
+  interpolated-custom-property: fn(--#{$name});
+  interpolated-custom-property-suffix: fn(--theme-#{$slot});
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/exclusive-value-gates.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/exclusive-value-gates.scss.snap
@@ -1,0 +1,1966 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+.supported-scss {
+  variable: $value;
+  variable-interpolation: $value#{suffix};
+  module-member: module.$value;
+  module-member-interpolation: module.$value#{suffix};
+  qualified-function: module.fn(1);
+  interpolation: #{$value};
+  adjacent-interpolations: #{$a}#{$b};
+  number-interpolation: 10#{unit};
+  dimension-interpolation: 10px#{suffix};
+  interpolated-name: foo#{$bar};
+  interpolated-string: "#{$value}";
+  interpolated-custom-property: --#{$name};
+  interpolated-custom-property-suffix: --theme-#{$slot};
+}
+
+.function-arguments {
+  variable: fn($value);
+  variable-interpolation: fn($value#{suffix});
+  module-member: fn(module.$value);
+  module-member-interpolation: fn(module.$value#{suffix});
+  qualified-function: fn(module.fn(1));
+  interpolation: fn(#{$value});
+  adjacent-interpolations: fn(#{$a}#{$b});
+  number-interpolation: fn(10#{unit});
+  dimension-interpolation: fn(10px#{suffix});
+  interpolated-name: fn(foo#{$bar});
+  interpolated-string: fn("#{$value}");
+  interpolated-custom-property: fn(--#{$name});
+  interpolated-custom-property-suffix: fn(--theme-#{$slot});
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@0..1 "." [] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1..16 "supported-scss" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@16..17 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@17..28 "variable" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssVariable {
+                                            dollar_token: DOLLAR@30..31 "$" [] [],
+                                            name: CssIdentifier {
+                                                value_token: IDENT@31..36 "value" [] [],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@36..37 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@37..62 "variable-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@62..64 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedValue {
+                                            items: ScssInterpolatedValuePartList [
+                                                ScssVariable {
+                                                    dollar_token: DOLLAR@64..65 "$" [] [],
+                                                    name: CssIdentifier {
+                                                        value_token: IDENT@65..70 "value" [] [],
+                                                    },
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@70..71 "#" [] [],
+                                                    l_curly_token: L_CURLY@71..72 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssIdentifier {
+                                                                value_token: IDENT@72..78 "suffix" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@78..79 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@79..80 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@80..96 "module-member" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@96..98 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssModuleMemberAccess {
+                                            module: CssIdentifier {
+                                                value_token: IDENT@98..104 "module" [] [],
+                                            },
+                                            dot_token: DOT@104..105 "." [] [],
+                                            member: ScssVariable {
+                                                dollar_token: DOLLAR@105..106 "$" [] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@106..111 "value" [] [],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@111..112 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@112..142 "module-member-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@142..144 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedValue {
+                                            items: ScssInterpolatedValuePartList [
+                                                ScssNamespacedVariable {
+                                                    namespace: CssIdentifier {
+                                                        value_token: IDENT@144..150 "module" [] [],
+                                                    },
+                                                    dot_token: DOT@150..151 "." [] [],
+                                                    name: ScssVariable {
+                                                        dollar_token: DOLLAR@151..152 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@152..157 "value" [] [],
+                                                        },
+                                                    },
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@157..158 "#" [] [],
+                                                    l_curly_token: L_CURLY@158..159 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssIdentifier {
+                                                                value_token: IDENT@159..165 "suffix" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@165..166 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@166..167 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@167..188 "qualified-function" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@188..190 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: ScssModuleMemberAccess {
+                                                module: CssIdentifier {
+                                                    value_token: IDENT@190..196 "module" [] [],
+                                                },
+                                                dot_token: DOT@196..197 "." [] [],
+                                                member: CssIdentifier {
+                                                    value_token: IDENT@197..199 "fn" [] [],
+                                                },
+                                            },
+                                            l_paren_token: L_PAREN@199..200 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssNumber {
+                                                            value_token: CSS_NUMBER_LITERAL@200..201 "1" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@201..202 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@202..203 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@203..219 "interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@219..221 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@221..222 "#" [] [],
+                                            l_curly_token: L_CURLY@222..223 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@223..224 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@224..229 "value" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@229..230 "}" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@230..231 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@231..257 "adjacent-interpolations" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@257..259 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@259..260 "#" [] [],
+                                                    l_curly_token: L_CURLY@260..261 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@261..262 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@262..263 "a" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@263..264 "}" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@264..265 "#" [] [],
+                                                    l_curly_token: L_CURLY@265..266 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@266..267 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@267..268 "b" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@268..269 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@269..270 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@270..293 "number-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@293..295 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedValue {
+                                            items: ScssInterpolatedValuePartList [
+                                                CssNumber {
+                                                    value_token: CSS_NUMBER_LITERAL@295..297 "10" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@297..298 "#" [] [],
+                                                    l_curly_token: L_CURLY@298..299 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssIdentifier {
+                                                                value_token: IDENT@299..303 "unit" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@303..304 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@304..305 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@305..331 "dimension-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@331..333 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedValue {
+                                            items: ScssInterpolatedValuePartList [
+                                                CssRegularDimension {
+                                                    value_token: CSS_NUMBER_LITERAL@333..335 "10" [] [],
+                                                    unit_token: IDENT@335..337 "px" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@337..338 "#" [] [],
+                                                    l_curly_token: L_CURLY@338..339 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssIdentifier {
+                                                                value_token: IDENT@339..345 "suffix" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@345..346 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@346..347 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@347..367 "interpolated-name" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@367..369 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@369..372 "foo" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@372..373 "#" [] [],
+                                                    l_curly_token: L_CURLY@373..374 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@374..375 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@375..378 "bar" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@378..379 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@379..380 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@380..402 "interpolated-string" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@402..404 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedString {
+                                            opening_quote_token: SCSS_STRING_QUOTE@404..405 "\"" [] [],
+                                            parts: ScssInterpolatedStringPartList [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@405..406 "#" [] [],
+                                                    l_curly_token: L_CURLY@406..407 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@407..408 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@408..413 "value" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@413..414 "}" [] [],
+                                                },
+                                            ],
+                                            closing_quote_token: SCSS_STRING_QUOTE@414..415 "\"" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@415..416 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@416..447 "interpolated-custom-property" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@447..449 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedDashedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                ScssInterpolatedIdentifierHyphen {
+                                                    minus_token: MINUS@449..450 "-" [] [],
+                                                },
+                                                ScssInterpolatedIdentifierHyphen {
+                                                    minus_token: MINUS@450..451 "-" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@451..452 "#" [] [],
+                                                    l_curly_token: L_CURLY@452..453 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@453..454 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@454..458 "name" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@458..459 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@459..460 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@460..498 "interpolated-custom-property-suffix" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@498..500 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssInterpolatedDashedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@500..508 "--theme-" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@508..509 "#" [] [],
+                                                    l_curly_token: L_CURLY@509..510 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@510..511 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@511..515 "slot" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@515..516 "}" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@516..517 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@517..519 "}" [Newline("\n")] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@519..522 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@522..541 "function-arguments" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@541..542 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@542..553 "variable" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@553..555 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@555..557 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@557..558 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@558..559 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@559..564 "value" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@564..565 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@565..566 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@566..591 "variable-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@591..593 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@593..595 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@595..596 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolatedValue {
+                                                            items: ScssInterpolatedValuePartList [
+                                                                ScssVariable {
+                                                                    dollar_token: DOLLAR@596..597 "$" [] [],
+                                                                    name: CssIdentifier {
+                                                                        value_token: IDENT@597..602 "value" [] [],
+                                                                    },
+                                                                },
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@602..603 "#" [] [],
+                                                                    l_curly_token: L_CURLY@603..604 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            CssIdentifier {
+                                                                                value_token: IDENT@604..610 "suffix" [] [],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@610..611 "}" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@611..612 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@612..613 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@613..629 "module-member" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@629..631 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@631..633 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@633..634 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssModuleMemberAccess {
+                                                            module: CssIdentifier {
+                                                                value_token: IDENT@634..640 "module" [] [],
+                                                            },
+                                                            dot_token: DOT@640..641 "." [] [],
+                                                            member: ScssVariable {
+                                                                dollar_token: DOLLAR@641..642 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@642..647 "value" [] [],
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@647..648 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@648..649 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@649..679 "module-member-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@679..681 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@681..683 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@683..684 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolatedValue {
+                                                            items: ScssInterpolatedValuePartList [
+                                                                ScssNamespacedVariable {
+                                                                    namespace: CssIdentifier {
+                                                                        value_token: IDENT@684..690 "module" [] [],
+                                                                    },
+                                                                    dot_token: DOT@690..691 "." [] [],
+                                                                    name: ScssVariable {
+                                                                        dollar_token: DOLLAR@691..692 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@692..697 "value" [] [],
+                                                                        },
+                                                                    },
+                                                                },
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@697..698 "#" [] [],
+                                                                    l_curly_token: L_CURLY@698..699 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            CssIdentifier {
+                                                                                value_token: IDENT@699..705 "suffix" [] [],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@705..706 "}" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@706..707 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@707..708 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@708..729 "qualified-function" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@729..731 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@731..733 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@733..734 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssFunction {
+                                                            name: ScssModuleMemberAccess {
+                                                                module: CssIdentifier {
+                                                                    value_token: IDENT@734..740 "module" [] [],
+                                                                },
+                                                                dot_token: DOT@740..741 "." [] [],
+                                                                member: CssIdentifier {
+                                                                    value_token: IDENT@741..743 "fn" [] [],
+                                                                },
+                                                            },
+                                                            l_paren_token: L_PAREN@743..744 "(" [] [],
+                                                            items: CssParameterList [
+                                                                ScssExpression {
+                                                                    items: ScssExpressionItemList [
+                                                                        CssNumber {
+                                                                            value_token: CSS_NUMBER_LITERAL@744..745 "1" [] [],
+                                                                        },
+                                                                    ],
+                                                                },
+                                                            ],
+                                                            r_paren_token: R_PAREN@745..746 ")" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@746..747 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@747..748 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@748..764 "interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@764..766 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@766..768 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@768..769 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@769..770 "#" [] [],
+                                                            l_curly_token: L_CURLY@770..771 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@771..772 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@772..777 "value" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@777..778 "}" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@778..779 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@779..780 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@780..806 "adjacent-interpolations" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@806..808 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@808..810 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@810..811 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolatedIdentifier {
+                                                            items: ScssInterpolatedIdentifierPartList [
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@811..812 "#" [] [],
+                                                                    l_curly_token: L_CURLY@812..813 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            ScssVariable {
+                                                                                dollar_token: DOLLAR@813..814 "$" [] [],
+                                                                                name: CssIdentifier {
+                                                                                    value_token: IDENT@814..815 "a" [] [],
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@815..816 "}" [] [],
+                                                                },
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@816..817 "#" [] [],
+                                                                    l_curly_token: L_CURLY@817..818 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            ScssVariable {
+                                                                                dollar_token: DOLLAR@818..819 "$" [] [],
+                                                                                name: CssIdentifier {
+                                                                                    value_token: IDENT@819..820 "b" [] [],
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@820..821 "}" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@821..822 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@822..823 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@823..846 "number-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@846..848 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@848..850 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@850..851 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolatedValue {
+                                                            items: ScssInterpolatedValuePartList [
+                                                                CssNumber {
+                                                                    value_token: CSS_NUMBER_LITERAL@851..853 "10" [] [],
+                                                                },
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@853..854 "#" [] [],
+                                                                    l_curly_token: L_CURLY@854..855 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            CssIdentifier {
+                                                                                value_token: IDENT@855..859 "unit" [] [],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@859..860 "}" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@860..861 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@861..862 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@862..888 "dimension-interpolation" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@888..890 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@890..892 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@892..893 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolatedValue {
+                                                            items: ScssInterpolatedValuePartList [
+                                                                CssRegularDimension {
+                                                                    value_token: CSS_NUMBER_LITERAL@893..895 "10" [] [],
+                                                                    unit_token: IDENT@895..897 "px" [] [],
+                                                                },
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@897..898 "#" [] [],
+                                                                    l_curly_token: L_CURLY@898..899 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            CssIdentifier {
+                                                                                value_token: IDENT@899..905 "suffix" [] [],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@905..906 "}" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@906..907 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@907..908 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@908..928 "interpolated-name" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@928..930 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@930..932 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@932..933 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolatedIdentifier {
+                                                            items: ScssInterpolatedIdentifierPartList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@933..936 "foo" [] [],
+                                                                },
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@936..937 "#" [] [],
+                                                                    l_curly_token: L_CURLY@937..938 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            ScssVariable {
+                                                                                dollar_token: DOLLAR@938..939 "$" [] [],
+                                                                                name: CssIdentifier {
+                                                                                    value_token: IDENT@939..942 "bar" [] [],
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@942..943 "}" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@943..944 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@944..945 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@945..967 "interpolated-string" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@967..969 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@969..971 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@971..972 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolatedString {
+                                                            opening_quote_token: SCSS_STRING_QUOTE@972..973 "\"" [] [],
+                                                            parts: ScssInterpolatedStringPartList [
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@973..974 "#" [] [],
+                                                                    l_curly_token: L_CURLY@974..975 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            ScssVariable {
+                                                                                dollar_token: DOLLAR@975..976 "$" [] [],
+                                                                                name: CssIdentifier {
+                                                                                    value_token: IDENT@976..981 "value" [] [],
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@981..982 "}" [] [],
+                                                                },
+                                                            ],
+                                                            closing_quote_token: SCSS_STRING_QUOTE@982..983 "\"" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@983..984 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@984..985 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@985..1016 "interpolated-custom-property" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@1016..1018 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@1018..1020 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@1020..1021 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolatedDashedIdentifier {
+                                                            items: ScssInterpolatedIdentifierPartList [
+                                                                ScssInterpolatedIdentifierHyphen {
+                                                                    minus_token: MINUS@1021..1022 "-" [] [],
+                                                                },
+                                                                ScssInterpolatedIdentifierHyphen {
+                                                                    minus_token: MINUS@1022..1023 "-" [] [],
+                                                                },
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@1023..1024 "#" [] [],
+                                                                    l_curly_token: L_CURLY@1024..1025 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            ScssVariable {
+                                                                                dollar_token: DOLLAR@1025..1026 "$" [] [],
+                                                                                name: CssIdentifier {
+                                                                                    value_token: IDENT@1026..1030 "name" [] [],
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@1030..1031 "}" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@1031..1032 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1032..1033 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1033..1071 "interpolated-custom-property-suffix" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@1071..1073 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@1073..1075 "fn" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@1075..1076 "(" [] [],
+                                            items: CssParameterList [
+                                                ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssInterpolatedDashedIdentifier {
+                                                            items: ScssInterpolatedIdentifierPartList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@1076..1084 "--theme-" [] [],
+                                                                },
+                                                                ScssInterpolation {
+                                                                    hash_token: HASH@1084..1085 "#" [] [],
+                                                                    l_curly_token: L_CURLY@1085..1086 "{" [] [],
+                                                                    value: ScssExpression {
+                                                                        items: ScssExpressionItemList [
+                                                                            ScssVariable {
+                                                                                dollar_token: DOLLAR@1086..1087 "$" [] [],
+                                                                                name: CssIdentifier {
+                                                                                    value_token: IDENT@1087..1091 "slot" [] [],
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    r_curly_token: R_CURLY@1091..1092 "}" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@1092..1093 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1093..1094 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@1094..1096 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@1096..1097 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..1097
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..1096
+    0: CSS_QUALIFIED_RULE@0..519
+      0: CSS_SELECTOR_LIST@0..16
+        0: CSS_COMPOUND_SELECTOR@0..16
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@0..16
+            0: CSS_CLASS_SELECTOR@0..16
+              0: DOT@0..1 "." [] []
+              1: CSS_CUSTOM_IDENTIFIER@1..16
+                0: IDENT@1..16 "supported-scss" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@16..519
+        0: L_CURLY@16..17 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@17..517
+          0: CSS_DECLARATION_WITH_SEMICOLON@17..37
+            0: CSS_DECLARATION@17..36
+              0: CSS_GENERIC_PROPERTY@17..36
+                0: CSS_IDENTIFIER@17..28
+                  0: IDENT@17..28 "variable" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@28..30 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@30..36
+                  0: SCSS_EXPRESSION_ITEM_LIST@30..36
+                    0: SCSS_VARIABLE@30..36
+                      0: DOLLAR@30..31 "$" [] []
+                      1: CSS_IDENTIFIER@31..36
+                        0: IDENT@31..36 "value" [] []
+              1: (empty)
+            1: SEMICOLON@36..37 ";" [] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@37..80
+            0: CSS_DECLARATION@37..79
+              0: CSS_GENERIC_PROPERTY@37..79
+                0: CSS_IDENTIFIER@37..62
+                  0: IDENT@37..62 "variable-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@62..64 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@64..79
+                  0: SCSS_EXPRESSION_ITEM_LIST@64..79
+                    0: SCSS_INTERPOLATED_VALUE@64..79
+                      0: SCSS_INTERPOLATED_VALUE_PART_LIST@64..79
+                        0: SCSS_VARIABLE@64..70
+                          0: DOLLAR@64..65 "$" [] []
+                          1: CSS_IDENTIFIER@65..70
+                            0: IDENT@65..70 "value" [] []
+                        1: SCSS_INTERPOLATION@70..79
+                          0: HASH@70..71 "#" [] []
+                          1: L_CURLY@71..72 "{" [] []
+                          2: SCSS_EXPRESSION@72..78
+                            0: SCSS_EXPRESSION_ITEM_LIST@72..78
+                              0: CSS_IDENTIFIER@72..78
+                                0: IDENT@72..78 "suffix" [] []
+                          3: R_CURLY@78..79 "}" [] []
+              1: (empty)
+            1: SEMICOLON@79..80 ";" [] []
+          2: CSS_DECLARATION_WITH_SEMICOLON@80..112
+            0: CSS_DECLARATION@80..111
+              0: CSS_GENERIC_PROPERTY@80..111
+                0: CSS_IDENTIFIER@80..96
+                  0: IDENT@80..96 "module-member" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@96..98 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@98..111
+                  0: SCSS_EXPRESSION_ITEM_LIST@98..111
+                    0: SCSS_MODULE_MEMBER_ACCESS@98..111
+                      0: CSS_IDENTIFIER@98..104
+                        0: IDENT@98..104 "module" [] []
+                      1: DOT@104..105 "." [] []
+                      2: SCSS_VARIABLE@105..111
+                        0: DOLLAR@105..106 "$" [] []
+                        1: CSS_IDENTIFIER@106..111
+                          0: IDENT@106..111 "value" [] []
+              1: (empty)
+            1: SEMICOLON@111..112 ";" [] []
+          3: CSS_DECLARATION_WITH_SEMICOLON@112..167
+            0: CSS_DECLARATION@112..166
+              0: CSS_GENERIC_PROPERTY@112..166
+                0: CSS_IDENTIFIER@112..142
+                  0: IDENT@112..142 "module-member-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@142..144 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@144..166
+                  0: SCSS_EXPRESSION_ITEM_LIST@144..166
+                    0: SCSS_INTERPOLATED_VALUE@144..166
+                      0: SCSS_INTERPOLATED_VALUE_PART_LIST@144..166
+                        0: SCSS_NAMESPACED_VARIABLE@144..157
+                          0: CSS_IDENTIFIER@144..150
+                            0: IDENT@144..150 "module" [] []
+                          1: DOT@150..151 "." [] []
+                          2: SCSS_VARIABLE@151..157
+                            0: DOLLAR@151..152 "$" [] []
+                            1: CSS_IDENTIFIER@152..157
+                              0: IDENT@152..157 "value" [] []
+                        1: SCSS_INTERPOLATION@157..166
+                          0: HASH@157..158 "#" [] []
+                          1: L_CURLY@158..159 "{" [] []
+                          2: SCSS_EXPRESSION@159..165
+                            0: SCSS_EXPRESSION_ITEM_LIST@159..165
+                              0: CSS_IDENTIFIER@159..165
+                                0: IDENT@159..165 "suffix" [] []
+                          3: R_CURLY@165..166 "}" [] []
+              1: (empty)
+            1: SEMICOLON@166..167 ";" [] []
+          4: CSS_DECLARATION_WITH_SEMICOLON@167..203
+            0: CSS_DECLARATION@167..202
+              0: CSS_GENERIC_PROPERTY@167..202
+                0: CSS_IDENTIFIER@167..188
+                  0: IDENT@167..188 "qualified-function" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@188..190 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@190..202
+                  0: SCSS_EXPRESSION_ITEM_LIST@190..202
+                    0: CSS_FUNCTION@190..202
+                      0: SCSS_MODULE_MEMBER_ACCESS@190..199
+                        0: CSS_IDENTIFIER@190..196
+                          0: IDENT@190..196 "module" [] []
+                        1: DOT@196..197 "." [] []
+                        2: CSS_IDENTIFIER@197..199
+                          0: IDENT@197..199 "fn" [] []
+                      1: L_PAREN@199..200 "(" [] []
+                      2: CSS_PARAMETER_LIST@200..201
+                        0: SCSS_EXPRESSION@200..201
+                          0: SCSS_EXPRESSION_ITEM_LIST@200..201
+                            0: CSS_NUMBER@200..201
+                              0: CSS_NUMBER_LITERAL@200..201 "1" [] []
+                      3: R_PAREN@201..202 ")" [] []
+              1: (empty)
+            1: SEMICOLON@202..203 ";" [] []
+          5: CSS_DECLARATION_WITH_SEMICOLON@203..231
+            0: CSS_DECLARATION@203..230
+              0: CSS_GENERIC_PROPERTY@203..230
+                0: CSS_IDENTIFIER@203..219
+                  0: IDENT@203..219 "interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@219..221 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@221..230
+                  0: SCSS_EXPRESSION_ITEM_LIST@221..230
+                    0: SCSS_INTERPOLATION@221..230
+                      0: HASH@221..222 "#" [] []
+                      1: L_CURLY@222..223 "{" [] []
+                      2: SCSS_EXPRESSION@223..229
+                        0: SCSS_EXPRESSION_ITEM_LIST@223..229
+                          0: SCSS_VARIABLE@223..229
+                            0: DOLLAR@223..224 "$" [] []
+                            1: CSS_IDENTIFIER@224..229
+                              0: IDENT@224..229 "value" [] []
+                      3: R_CURLY@229..230 "}" [] []
+              1: (empty)
+            1: SEMICOLON@230..231 ";" [] []
+          6: CSS_DECLARATION_WITH_SEMICOLON@231..270
+            0: CSS_DECLARATION@231..269
+              0: CSS_GENERIC_PROPERTY@231..269
+                0: CSS_IDENTIFIER@231..257
+                  0: IDENT@231..257 "adjacent-interpolations" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@257..259 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@259..269
+                  0: SCSS_EXPRESSION_ITEM_LIST@259..269
+                    0: SCSS_INTERPOLATED_IDENTIFIER@259..269
+                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@259..269
+                        0: SCSS_INTERPOLATION@259..264
+                          0: HASH@259..260 "#" [] []
+                          1: L_CURLY@260..261 "{" [] []
+                          2: SCSS_EXPRESSION@261..263
+                            0: SCSS_EXPRESSION_ITEM_LIST@261..263
+                              0: SCSS_VARIABLE@261..263
+                                0: DOLLAR@261..262 "$" [] []
+                                1: CSS_IDENTIFIER@262..263
+                                  0: IDENT@262..263 "a" [] []
+                          3: R_CURLY@263..264 "}" [] []
+                        1: SCSS_INTERPOLATION@264..269
+                          0: HASH@264..265 "#" [] []
+                          1: L_CURLY@265..266 "{" [] []
+                          2: SCSS_EXPRESSION@266..268
+                            0: SCSS_EXPRESSION_ITEM_LIST@266..268
+                              0: SCSS_VARIABLE@266..268
+                                0: DOLLAR@266..267 "$" [] []
+                                1: CSS_IDENTIFIER@267..268
+                                  0: IDENT@267..268 "b" [] []
+                          3: R_CURLY@268..269 "}" [] []
+              1: (empty)
+            1: SEMICOLON@269..270 ";" [] []
+          7: CSS_DECLARATION_WITH_SEMICOLON@270..305
+            0: CSS_DECLARATION@270..304
+              0: CSS_GENERIC_PROPERTY@270..304
+                0: CSS_IDENTIFIER@270..293
+                  0: IDENT@270..293 "number-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@293..295 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@295..304
+                  0: SCSS_EXPRESSION_ITEM_LIST@295..304
+                    0: SCSS_INTERPOLATED_VALUE@295..304
+                      0: SCSS_INTERPOLATED_VALUE_PART_LIST@295..304
+                        0: CSS_NUMBER@295..297
+                          0: CSS_NUMBER_LITERAL@295..297 "10" [] []
+                        1: SCSS_INTERPOLATION@297..304
+                          0: HASH@297..298 "#" [] []
+                          1: L_CURLY@298..299 "{" [] []
+                          2: SCSS_EXPRESSION@299..303
+                            0: SCSS_EXPRESSION_ITEM_LIST@299..303
+                              0: CSS_IDENTIFIER@299..303
+                                0: IDENT@299..303 "unit" [] []
+                          3: R_CURLY@303..304 "}" [] []
+              1: (empty)
+            1: SEMICOLON@304..305 ";" [] []
+          8: CSS_DECLARATION_WITH_SEMICOLON@305..347
+            0: CSS_DECLARATION@305..346
+              0: CSS_GENERIC_PROPERTY@305..346
+                0: CSS_IDENTIFIER@305..331
+                  0: IDENT@305..331 "dimension-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@331..333 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@333..346
+                  0: SCSS_EXPRESSION_ITEM_LIST@333..346
+                    0: SCSS_INTERPOLATED_VALUE@333..346
+                      0: SCSS_INTERPOLATED_VALUE_PART_LIST@333..346
+                        0: CSS_REGULAR_DIMENSION@333..337
+                          0: CSS_NUMBER_LITERAL@333..335 "10" [] []
+                          1: IDENT@335..337 "px" [] []
+                        1: SCSS_INTERPOLATION@337..346
+                          0: HASH@337..338 "#" [] []
+                          1: L_CURLY@338..339 "{" [] []
+                          2: SCSS_EXPRESSION@339..345
+                            0: SCSS_EXPRESSION_ITEM_LIST@339..345
+                              0: CSS_IDENTIFIER@339..345
+                                0: IDENT@339..345 "suffix" [] []
+                          3: R_CURLY@345..346 "}" [] []
+              1: (empty)
+            1: SEMICOLON@346..347 ";" [] []
+          9: CSS_DECLARATION_WITH_SEMICOLON@347..380
+            0: CSS_DECLARATION@347..379
+              0: CSS_GENERIC_PROPERTY@347..379
+                0: CSS_IDENTIFIER@347..367
+                  0: IDENT@347..367 "interpolated-name" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@367..369 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@369..379
+                  0: SCSS_EXPRESSION_ITEM_LIST@369..379
+                    0: SCSS_INTERPOLATED_IDENTIFIER@369..379
+                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@369..379
+                        0: CSS_IDENTIFIER@369..372
+                          0: IDENT@369..372 "foo" [] []
+                        1: SCSS_INTERPOLATION@372..379
+                          0: HASH@372..373 "#" [] []
+                          1: L_CURLY@373..374 "{" [] []
+                          2: SCSS_EXPRESSION@374..378
+                            0: SCSS_EXPRESSION_ITEM_LIST@374..378
+                              0: SCSS_VARIABLE@374..378
+                                0: DOLLAR@374..375 "$" [] []
+                                1: CSS_IDENTIFIER@375..378
+                                  0: IDENT@375..378 "bar" [] []
+                          3: R_CURLY@378..379 "}" [] []
+              1: (empty)
+            1: SEMICOLON@379..380 ";" [] []
+          10: CSS_DECLARATION_WITH_SEMICOLON@380..416
+            0: CSS_DECLARATION@380..415
+              0: CSS_GENERIC_PROPERTY@380..415
+                0: CSS_IDENTIFIER@380..402
+                  0: IDENT@380..402 "interpolated-string" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@402..404 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@404..415
+                  0: SCSS_EXPRESSION_ITEM_LIST@404..415
+                    0: SCSS_INTERPOLATED_STRING@404..415
+                      0: SCSS_STRING_QUOTE@404..405 "\"" [] []
+                      1: SCSS_INTERPOLATED_STRING_PART_LIST@405..414
+                        0: SCSS_INTERPOLATION@405..414
+                          0: HASH@405..406 "#" [] []
+                          1: L_CURLY@406..407 "{" [] []
+                          2: SCSS_EXPRESSION@407..413
+                            0: SCSS_EXPRESSION_ITEM_LIST@407..413
+                              0: SCSS_VARIABLE@407..413
+                                0: DOLLAR@407..408 "$" [] []
+                                1: CSS_IDENTIFIER@408..413
+                                  0: IDENT@408..413 "value" [] []
+                          3: R_CURLY@413..414 "}" [] []
+                      2: SCSS_STRING_QUOTE@414..415 "\"" [] []
+              1: (empty)
+            1: SEMICOLON@415..416 ";" [] []
+          11: CSS_DECLARATION_WITH_SEMICOLON@416..460
+            0: CSS_DECLARATION@416..459
+              0: CSS_GENERIC_PROPERTY@416..459
+                0: CSS_IDENTIFIER@416..447
+                  0: IDENT@416..447 "interpolated-custom-property" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@447..449 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@449..459
+                  0: SCSS_EXPRESSION_ITEM_LIST@449..459
+                    0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@449..459
+                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@449..459
+                        0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@449..450
+                          0: MINUS@449..450 "-" [] []
+                        1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@450..451
+                          0: MINUS@450..451 "-" [] []
+                        2: SCSS_INTERPOLATION@451..459
+                          0: HASH@451..452 "#" [] []
+                          1: L_CURLY@452..453 "{" [] []
+                          2: SCSS_EXPRESSION@453..458
+                            0: SCSS_EXPRESSION_ITEM_LIST@453..458
+                              0: SCSS_VARIABLE@453..458
+                                0: DOLLAR@453..454 "$" [] []
+                                1: CSS_IDENTIFIER@454..458
+                                  0: IDENT@454..458 "name" [] []
+                          3: R_CURLY@458..459 "}" [] []
+              1: (empty)
+            1: SEMICOLON@459..460 ";" [] []
+          12: CSS_DECLARATION_WITH_SEMICOLON@460..517
+            0: CSS_DECLARATION@460..516
+              0: CSS_GENERIC_PROPERTY@460..516
+                0: CSS_IDENTIFIER@460..498
+                  0: IDENT@460..498 "interpolated-custom-property-suffix" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@498..500 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@500..516
+                  0: SCSS_EXPRESSION_ITEM_LIST@500..516
+                    0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@500..516
+                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@500..516
+                        0: CSS_IDENTIFIER@500..508
+                          0: IDENT@500..508 "--theme-" [] []
+                        1: SCSS_INTERPOLATION@508..516
+                          0: HASH@508..509 "#" [] []
+                          1: L_CURLY@509..510 "{" [] []
+                          2: SCSS_EXPRESSION@510..515
+                            0: SCSS_EXPRESSION_ITEM_LIST@510..515
+                              0: SCSS_VARIABLE@510..515
+                                0: DOLLAR@510..511 "$" [] []
+                                1: CSS_IDENTIFIER@511..515
+                                  0: IDENT@511..515 "slot" [] []
+                          3: R_CURLY@515..516 "}" [] []
+              1: (empty)
+            1: SEMICOLON@516..517 ";" [] []
+        2: R_CURLY@517..519 "}" [Newline("\n")] []
+    1: CSS_QUALIFIED_RULE@519..1096
+      0: CSS_SELECTOR_LIST@519..541
+        0: CSS_COMPOUND_SELECTOR@519..541
+          0: CSS_NESTED_SELECTOR_LIST@519..519
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@519..541
+            0: CSS_CLASS_SELECTOR@519..541
+              0: DOT@519..522 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@522..541
+                0: IDENT@522..541 "function-arguments" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@541..1096
+        0: L_CURLY@541..542 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@542..1094
+          0: CSS_DECLARATION_WITH_SEMICOLON@542..566
+            0: CSS_DECLARATION@542..565
+              0: CSS_GENERIC_PROPERTY@542..565
+                0: CSS_IDENTIFIER@542..553
+                  0: IDENT@542..553 "variable" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@553..555 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@555..565
+                  0: SCSS_EXPRESSION_ITEM_LIST@555..565
+                    0: CSS_FUNCTION@555..565
+                      0: CSS_IDENTIFIER@555..557
+                        0: IDENT@555..557 "fn" [] []
+                      1: L_PAREN@557..558 "(" [] []
+                      2: CSS_PARAMETER_LIST@558..564
+                        0: SCSS_EXPRESSION@558..564
+                          0: SCSS_EXPRESSION_ITEM_LIST@558..564
+                            0: SCSS_VARIABLE@558..564
+                              0: DOLLAR@558..559 "$" [] []
+                              1: CSS_IDENTIFIER@559..564
+                                0: IDENT@559..564 "value" [] []
+                      3: R_PAREN@564..565 ")" [] []
+              1: (empty)
+            1: SEMICOLON@565..566 ";" [] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@566..613
+            0: CSS_DECLARATION@566..612
+              0: CSS_GENERIC_PROPERTY@566..612
+                0: CSS_IDENTIFIER@566..591
+                  0: IDENT@566..591 "variable-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@591..593 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@593..612
+                  0: SCSS_EXPRESSION_ITEM_LIST@593..612
+                    0: CSS_FUNCTION@593..612
+                      0: CSS_IDENTIFIER@593..595
+                        0: IDENT@593..595 "fn" [] []
+                      1: L_PAREN@595..596 "(" [] []
+                      2: CSS_PARAMETER_LIST@596..611
+                        0: SCSS_EXPRESSION@596..611
+                          0: SCSS_EXPRESSION_ITEM_LIST@596..611
+                            0: SCSS_INTERPOLATED_VALUE@596..611
+                              0: SCSS_INTERPOLATED_VALUE_PART_LIST@596..611
+                                0: SCSS_VARIABLE@596..602
+                                  0: DOLLAR@596..597 "$" [] []
+                                  1: CSS_IDENTIFIER@597..602
+                                    0: IDENT@597..602 "value" [] []
+                                1: SCSS_INTERPOLATION@602..611
+                                  0: HASH@602..603 "#" [] []
+                                  1: L_CURLY@603..604 "{" [] []
+                                  2: SCSS_EXPRESSION@604..610
+                                    0: SCSS_EXPRESSION_ITEM_LIST@604..610
+                                      0: CSS_IDENTIFIER@604..610
+                                        0: IDENT@604..610 "suffix" [] []
+                                  3: R_CURLY@610..611 "}" [] []
+                      3: R_PAREN@611..612 ")" [] []
+              1: (empty)
+            1: SEMICOLON@612..613 ";" [] []
+          2: CSS_DECLARATION_WITH_SEMICOLON@613..649
+            0: CSS_DECLARATION@613..648
+              0: CSS_GENERIC_PROPERTY@613..648
+                0: CSS_IDENTIFIER@613..629
+                  0: IDENT@613..629 "module-member" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@629..631 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@631..648
+                  0: SCSS_EXPRESSION_ITEM_LIST@631..648
+                    0: CSS_FUNCTION@631..648
+                      0: CSS_IDENTIFIER@631..633
+                        0: IDENT@631..633 "fn" [] []
+                      1: L_PAREN@633..634 "(" [] []
+                      2: CSS_PARAMETER_LIST@634..647
+                        0: SCSS_EXPRESSION@634..647
+                          0: SCSS_EXPRESSION_ITEM_LIST@634..647
+                            0: SCSS_MODULE_MEMBER_ACCESS@634..647
+                              0: CSS_IDENTIFIER@634..640
+                                0: IDENT@634..640 "module" [] []
+                              1: DOT@640..641 "." [] []
+                              2: SCSS_VARIABLE@641..647
+                                0: DOLLAR@641..642 "$" [] []
+                                1: CSS_IDENTIFIER@642..647
+                                  0: IDENT@642..647 "value" [] []
+                      3: R_PAREN@647..648 ")" [] []
+              1: (empty)
+            1: SEMICOLON@648..649 ";" [] []
+          3: CSS_DECLARATION_WITH_SEMICOLON@649..708
+            0: CSS_DECLARATION@649..707
+              0: CSS_GENERIC_PROPERTY@649..707
+                0: CSS_IDENTIFIER@649..679
+                  0: IDENT@649..679 "module-member-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@679..681 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@681..707
+                  0: SCSS_EXPRESSION_ITEM_LIST@681..707
+                    0: CSS_FUNCTION@681..707
+                      0: CSS_IDENTIFIER@681..683
+                        0: IDENT@681..683 "fn" [] []
+                      1: L_PAREN@683..684 "(" [] []
+                      2: CSS_PARAMETER_LIST@684..706
+                        0: SCSS_EXPRESSION@684..706
+                          0: SCSS_EXPRESSION_ITEM_LIST@684..706
+                            0: SCSS_INTERPOLATED_VALUE@684..706
+                              0: SCSS_INTERPOLATED_VALUE_PART_LIST@684..706
+                                0: SCSS_NAMESPACED_VARIABLE@684..697
+                                  0: CSS_IDENTIFIER@684..690
+                                    0: IDENT@684..690 "module" [] []
+                                  1: DOT@690..691 "." [] []
+                                  2: SCSS_VARIABLE@691..697
+                                    0: DOLLAR@691..692 "$" [] []
+                                    1: CSS_IDENTIFIER@692..697
+                                      0: IDENT@692..697 "value" [] []
+                                1: SCSS_INTERPOLATION@697..706
+                                  0: HASH@697..698 "#" [] []
+                                  1: L_CURLY@698..699 "{" [] []
+                                  2: SCSS_EXPRESSION@699..705
+                                    0: SCSS_EXPRESSION_ITEM_LIST@699..705
+                                      0: CSS_IDENTIFIER@699..705
+                                        0: IDENT@699..705 "suffix" [] []
+                                  3: R_CURLY@705..706 "}" [] []
+                      3: R_PAREN@706..707 ")" [] []
+              1: (empty)
+            1: SEMICOLON@707..708 ";" [] []
+          4: CSS_DECLARATION_WITH_SEMICOLON@708..748
+            0: CSS_DECLARATION@708..747
+              0: CSS_GENERIC_PROPERTY@708..747
+                0: CSS_IDENTIFIER@708..729
+                  0: IDENT@708..729 "qualified-function" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@729..731 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@731..747
+                  0: SCSS_EXPRESSION_ITEM_LIST@731..747
+                    0: CSS_FUNCTION@731..747
+                      0: CSS_IDENTIFIER@731..733
+                        0: IDENT@731..733 "fn" [] []
+                      1: L_PAREN@733..734 "(" [] []
+                      2: CSS_PARAMETER_LIST@734..746
+                        0: SCSS_EXPRESSION@734..746
+                          0: SCSS_EXPRESSION_ITEM_LIST@734..746
+                            0: CSS_FUNCTION@734..746
+                              0: SCSS_MODULE_MEMBER_ACCESS@734..743
+                                0: CSS_IDENTIFIER@734..740
+                                  0: IDENT@734..740 "module" [] []
+                                1: DOT@740..741 "." [] []
+                                2: CSS_IDENTIFIER@741..743
+                                  0: IDENT@741..743 "fn" [] []
+                              1: L_PAREN@743..744 "(" [] []
+                              2: CSS_PARAMETER_LIST@744..745
+                                0: SCSS_EXPRESSION@744..745
+                                  0: SCSS_EXPRESSION_ITEM_LIST@744..745
+                                    0: CSS_NUMBER@744..745
+                                      0: CSS_NUMBER_LITERAL@744..745 "1" [] []
+                              3: R_PAREN@745..746 ")" [] []
+                      3: R_PAREN@746..747 ")" [] []
+              1: (empty)
+            1: SEMICOLON@747..748 ";" [] []
+          5: CSS_DECLARATION_WITH_SEMICOLON@748..780
+            0: CSS_DECLARATION@748..779
+              0: CSS_GENERIC_PROPERTY@748..779
+                0: CSS_IDENTIFIER@748..764
+                  0: IDENT@748..764 "interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@764..766 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@766..779
+                  0: SCSS_EXPRESSION_ITEM_LIST@766..779
+                    0: CSS_FUNCTION@766..779
+                      0: CSS_IDENTIFIER@766..768
+                        0: IDENT@766..768 "fn" [] []
+                      1: L_PAREN@768..769 "(" [] []
+                      2: CSS_PARAMETER_LIST@769..778
+                        0: SCSS_EXPRESSION@769..778
+                          0: SCSS_EXPRESSION_ITEM_LIST@769..778
+                            0: SCSS_INTERPOLATION@769..778
+                              0: HASH@769..770 "#" [] []
+                              1: L_CURLY@770..771 "{" [] []
+                              2: SCSS_EXPRESSION@771..777
+                                0: SCSS_EXPRESSION_ITEM_LIST@771..777
+                                  0: SCSS_VARIABLE@771..777
+                                    0: DOLLAR@771..772 "$" [] []
+                                    1: CSS_IDENTIFIER@772..777
+                                      0: IDENT@772..777 "value" [] []
+                              3: R_CURLY@777..778 "}" [] []
+                      3: R_PAREN@778..779 ")" [] []
+              1: (empty)
+            1: SEMICOLON@779..780 ";" [] []
+          6: CSS_DECLARATION_WITH_SEMICOLON@780..823
+            0: CSS_DECLARATION@780..822
+              0: CSS_GENERIC_PROPERTY@780..822
+                0: CSS_IDENTIFIER@780..806
+                  0: IDENT@780..806 "adjacent-interpolations" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@806..808 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@808..822
+                  0: SCSS_EXPRESSION_ITEM_LIST@808..822
+                    0: CSS_FUNCTION@808..822
+                      0: CSS_IDENTIFIER@808..810
+                        0: IDENT@808..810 "fn" [] []
+                      1: L_PAREN@810..811 "(" [] []
+                      2: CSS_PARAMETER_LIST@811..821
+                        0: SCSS_EXPRESSION@811..821
+                          0: SCSS_EXPRESSION_ITEM_LIST@811..821
+                            0: SCSS_INTERPOLATED_IDENTIFIER@811..821
+                              0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@811..821
+                                0: SCSS_INTERPOLATION@811..816
+                                  0: HASH@811..812 "#" [] []
+                                  1: L_CURLY@812..813 "{" [] []
+                                  2: SCSS_EXPRESSION@813..815
+                                    0: SCSS_EXPRESSION_ITEM_LIST@813..815
+                                      0: SCSS_VARIABLE@813..815
+                                        0: DOLLAR@813..814 "$" [] []
+                                        1: CSS_IDENTIFIER@814..815
+                                          0: IDENT@814..815 "a" [] []
+                                  3: R_CURLY@815..816 "}" [] []
+                                1: SCSS_INTERPOLATION@816..821
+                                  0: HASH@816..817 "#" [] []
+                                  1: L_CURLY@817..818 "{" [] []
+                                  2: SCSS_EXPRESSION@818..820
+                                    0: SCSS_EXPRESSION_ITEM_LIST@818..820
+                                      0: SCSS_VARIABLE@818..820
+                                        0: DOLLAR@818..819 "$" [] []
+                                        1: CSS_IDENTIFIER@819..820
+                                          0: IDENT@819..820 "b" [] []
+                                  3: R_CURLY@820..821 "}" [] []
+                      3: R_PAREN@821..822 ")" [] []
+              1: (empty)
+            1: SEMICOLON@822..823 ";" [] []
+          7: CSS_DECLARATION_WITH_SEMICOLON@823..862
+            0: CSS_DECLARATION@823..861
+              0: CSS_GENERIC_PROPERTY@823..861
+                0: CSS_IDENTIFIER@823..846
+                  0: IDENT@823..846 "number-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@846..848 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@848..861
+                  0: SCSS_EXPRESSION_ITEM_LIST@848..861
+                    0: CSS_FUNCTION@848..861
+                      0: CSS_IDENTIFIER@848..850
+                        0: IDENT@848..850 "fn" [] []
+                      1: L_PAREN@850..851 "(" [] []
+                      2: CSS_PARAMETER_LIST@851..860
+                        0: SCSS_EXPRESSION@851..860
+                          0: SCSS_EXPRESSION_ITEM_LIST@851..860
+                            0: SCSS_INTERPOLATED_VALUE@851..860
+                              0: SCSS_INTERPOLATED_VALUE_PART_LIST@851..860
+                                0: CSS_NUMBER@851..853
+                                  0: CSS_NUMBER_LITERAL@851..853 "10" [] []
+                                1: SCSS_INTERPOLATION@853..860
+                                  0: HASH@853..854 "#" [] []
+                                  1: L_CURLY@854..855 "{" [] []
+                                  2: SCSS_EXPRESSION@855..859
+                                    0: SCSS_EXPRESSION_ITEM_LIST@855..859
+                                      0: CSS_IDENTIFIER@855..859
+                                        0: IDENT@855..859 "unit" [] []
+                                  3: R_CURLY@859..860 "}" [] []
+                      3: R_PAREN@860..861 ")" [] []
+              1: (empty)
+            1: SEMICOLON@861..862 ";" [] []
+          8: CSS_DECLARATION_WITH_SEMICOLON@862..908
+            0: CSS_DECLARATION@862..907
+              0: CSS_GENERIC_PROPERTY@862..907
+                0: CSS_IDENTIFIER@862..888
+                  0: IDENT@862..888 "dimension-interpolation" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@888..890 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@890..907
+                  0: SCSS_EXPRESSION_ITEM_LIST@890..907
+                    0: CSS_FUNCTION@890..907
+                      0: CSS_IDENTIFIER@890..892
+                        0: IDENT@890..892 "fn" [] []
+                      1: L_PAREN@892..893 "(" [] []
+                      2: CSS_PARAMETER_LIST@893..906
+                        0: SCSS_EXPRESSION@893..906
+                          0: SCSS_EXPRESSION_ITEM_LIST@893..906
+                            0: SCSS_INTERPOLATED_VALUE@893..906
+                              0: SCSS_INTERPOLATED_VALUE_PART_LIST@893..906
+                                0: CSS_REGULAR_DIMENSION@893..897
+                                  0: CSS_NUMBER_LITERAL@893..895 "10" [] []
+                                  1: IDENT@895..897 "px" [] []
+                                1: SCSS_INTERPOLATION@897..906
+                                  0: HASH@897..898 "#" [] []
+                                  1: L_CURLY@898..899 "{" [] []
+                                  2: SCSS_EXPRESSION@899..905
+                                    0: SCSS_EXPRESSION_ITEM_LIST@899..905
+                                      0: CSS_IDENTIFIER@899..905
+                                        0: IDENT@899..905 "suffix" [] []
+                                  3: R_CURLY@905..906 "}" [] []
+                      3: R_PAREN@906..907 ")" [] []
+              1: (empty)
+            1: SEMICOLON@907..908 ";" [] []
+          9: CSS_DECLARATION_WITH_SEMICOLON@908..945
+            0: CSS_DECLARATION@908..944
+              0: CSS_GENERIC_PROPERTY@908..944
+                0: CSS_IDENTIFIER@908..928
+                  0: IDENT@908..928 "interpolated-name" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@928..930 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@930..944
+                  0: SCSS_EXPRESSION_ITEM_LIST@930..944
+                    0: CSS_FUNCTION@930..944
+                      0: CSS_IDENTIFIER@930..932
+                        0: IDENT@930..932 "fn" [] []
+                      1: L_PAREN@932..933 "(" [] []
+                      2: CSS_PARAMETER_LIST@933..943
+                        0: SCSS_EXPRESSION@933..943
+                          0: SCSS_EXPRESSION_ITEM_LIST@933..943
+                            0: SCSS_INTERPOLATED_IDENTIFIER@933..943
+                              0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@933..943
+                                0: CSS_IDENTIFIER@933..936
+                                  0: IDENT@933..936 "foo" [] []
+                                1: SCSS_INTERPOLATION@936..943
+                                  0: HASH@936..937 "#" [] []
+                                  1: L_CURLY@937..938 "{" [] []
+                                  2: SCSS_EXPRESSION@938..942
+                                    0: SCSS_EXPRESSION_ITEM_LIST@938..942
+                                      0: SCSS_VARIABLE@938..942
+                                        0: DOLLAR@938..939 "$" [] []
+                                        1: CSS_IDENTIFIER@939..942
+                                          0: IDENT@939..942 "bar" [] []
+                                  3: R_CURLY@942..943 "}" [] []
+                      3: R_PAREN@943..944 ")" [] []
+              1: (empty)
+            1: SEMICOLON@944..945 ";" [] []
+          10: CSS_DECLARATION_WITH_SEMICOLON@945..985
+            0: CSS_DECLARATION@945..984
+              0: CSS_GENERIC_PROPERTY@945..984
+                0: CSS_IDENTIFIER@945..967
+                  0: IDENT@945..967 "interpolated-string" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@967..969 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@969..984
+                  0: SCSS_EXPRESSION_ITEM_LIST@969..984
+                    0: CSS_FUNCTION@969..984
+                      0: CSS_IDENTIFIER@969..971
+                        0: IDENT@969..971 "fn" [] []
+                      1: L_PAREN@971..972 "(" [] []
+                      2: CSS_PARAMETER_LIST@972..983
+                        0: SCSS_EXPRESSION@972..983
+                          0: SCSS_EXPRESSION_ITEM_LIST@972..983
+                            0: SCSS_INTERPOLATED_STRING@972..983
+                              0: SCSS_STRING_QUOTE@972..973 "\"" [] []
+                              1: SCSS_INTERPOLATED_STRING_PART_LIST@973..982
+                                0: SCSS_INTERPOLATION@973..982
+                                  0: HASH@973..974 "#" [] []
+                                  1: L_CURLY@974..975 "{" [] []
+                                  2: SCSS_EXPRESSION@975..981
+                                    0: SCSS_EXPRESSION_ITEM_LIST@975..981
+                                      0: SCSS_VARIABLE@975..981
+                                        0: DOLLAR@975..976 "$" [] []
+                                        1: CSS_IDENTIFIER@976..981
+                                          0: IDENT@976..981 "value" [] []
+                                  3: R_CURLY@981..982 "}" [] []
+                              2: SCSS_STRING_QUOTE@982..983 "\"" [] []
+                      3: R_PAREN@983..984 ")" [] []
+              1: (empty)
+            1: SEMICOLON@984..985 ";" [] []
+          11: CSS_DECLARATION_WITH_SEMICOLON@985..1033
+            0: CSS_DECLARATION@985..1032
+              0: CSS_GENERIC_PROPERTY@985..1032
+                0: CSS_IDENTIFIER@985..1016
+                  0: IDENT@985..1016 "interpolated-custom-property" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@1016..1018 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1018..1032
+                  0: SCSS_EXPRESSION_ITEM_LIST@1018..1032
+                    0: CSS_FUNCTION@1018..1032
+                      0: CSS_IDENTIFIER@1018..1020
+                        0: IDENT@1018..1020 "fn" [] []
+                      1: L_PAREN@1020..1021 "(" [] []
+                      2: CSS_PARAMETER_LIST@1021..1031
+                        0: SCSS_EXPRESSION@1021..1031
+                          0: SCSS_EXPRESSION_ITEM_LIST@1021..1031
+                            0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@1021..1031
+                              0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1021..1031
+                                0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@1021..1022
+                                  0: MINUS@1021..1022 "-" [] []
+                                1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@1022..1023
+                                  0: MINUS@1022..1023 "-" [] []
+                                2: SCSS_INTERPOLATION@1023..1031
+                                  0: HASH@1023..1024 "#" [] []
+                                  1: L_CURLY@1024..1025 "{" [] []
+                                  2: SCSS_EXPRESSION@1025..1030
+                                    0: SCSS_EXPRESSION_ITEM_LIST@1025..1030
+                                      0: SCSS_VARIABLE@1025..1030
+                                        0: DOLLAR@1025..1026 "$" [] []
+                                        1: CSS_IDENTIFIER@1026..1030
+                                          0: IDENT@1026..1030 "name" [] []
+                                  3: R_CURLY@1030..1031 "}" [] []
+                      3: R_PAREN@1031..1032 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1032..1033 ";" [] []
+          12: CSS_DECLARATION_WITH_SEMICOLON@1033..1094
+            0: CSS_DECLARATION@1033..1093
+              0: CSS_GENERIC_PROPERTY@1033..1093
+                0: CSS_IDENTIFIER@1033..1071
+                  0: IDENT@1033..1071 "interpolated-custom-property-suffix" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@1071..1073 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1073..1093
+                  0: SCSS_EXPRESSION_ITEM_LIST@1073..1093
+                    0: CSS_FUNCTION@1073..1093
+                      0: CSS_IDENTIFIER@1073..1075
+                        0: IDENT@1073..1075 "fn" [] []
+                      1: L_PAREN@1075..1076 "(" [] []
+                      2: CSS_PARAMETER_LIST@1076..1092
+                        0: SCSS_EXPRESSION@1076..1092
+                          0: SCSS_EXPRESSION_ITEM_LIST@1076..1092
+                            0: SCSS_INTERPOLATED_DASHED_IDENTIFIER@1076..1092
+                              0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1076..1092
+                                0: CSS_IDENTIFIER@1076..1084
+                                  0: IDENT@1076..1084 "--theme-" [] []
+                                1: SCSS_INTERPOLATION@1084..1092
+                                  0: HASH@1084..1085 "#" [] []
+                                  1: L_CURLY@1085..1086 "{" [] []
+                                  2: SCSS_EXPRESSION@1086..1091
+                                    0: SCSS_EXPRESSION_ITEM_LIST@1086..1091
+                                      0: SCSS_VARIABLE@1086..1091
+                                        0: DOLLAR@1086..1087 "$" [] []
+                                        1: CSS_IDENTIFIER@1087..1091
+                                          0: IDENT@1087..1091 "slot" [] []
+                                  3: R_CURLY@1091..1092 "}" [] []
+                      3: R_PAREN@1092..1093 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1093..1094 ";" [] []
+        2: R_CURLY@1094..1096 "}" [Newline("\n")] []
+  2: EOF@1096..1097 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/scss_exclusive_syntax_feature.rs
+++ b/crates/biome_css_parser/tests/scss_exclusive_syntax_feature.rs
@@ -1,0 +1,107 @@
+use biome_css_parser::{CssParserOptions, parse_css};
+use biome_languages::CssFileSource;
+
+const SCSS_VARIABLE_DECLARATION: &str = "$color: red;";
+const SCSS_VARIABLE_VALUE: &str = ".selector { color: $color; }";
+const SCSS_DIMENSION_INTERPOLATED_VALUE: &str = ".selector { width: 10px#{suffix}; }";
+const SCSS_NUMBER_INTERPOLATED_VALUE: &str = ".selector { width: 10#{unit}; }";
+
+fn diagnostic_text(parse: &biome_css_parser::CssParse) -> String {
+    format!("{:?}", parse.diagnostics())
+}
+
+fn expect_scss_diagnostics(source: &str, expected_message: &str, options: CssParserOptions) {
+    let parse = parse_css(source, CssFileSource::css(), options);
+    let diagnostics = diagnostic_text(&parse);
+
+    assert!(
+        diagnostics.contains(expected_message),
+        "expected an SCSS-specific diagnostic in CSS parser-reporting builds, got: {diagnostics}",
+    );
+}
+
+#[test]
+fn css_files_do_not_report_scss_exclusive_syntax_without_parser_option() {
+    for source in [SCSS_VARIABLE_DECLARATION, SCSS_VARIABLE_VALUE] {
+        let parse = parse_css(source, CssFileSource::css(), CssParserOptions::default());
+        let diagnostics = diagnostic_text(&parse);
+
+        assert!(
+            !diagnostics.contains("SCSS"),
+            "expected no SCSS-specific diagnostics without the parser option, got: {diagnostics}"
+        );
+        assert!(
+            !parse.diagnostics().is_empty(),
+            "expected parsing to keep reporting invalid CSS syntax"
+        );
+    }
+}
+
+#[test]
+fn css_files_report_scss_exclusive_syntax_when_enabled_by_parser_options() {
+    expect_scss_diagnostics(
+        SCSS_VARIABLE_DECLARATION,
+        "SCSS variable declarations",
+        CssParserOptions::default().report_scss_exclusive_syntax(),
+    );
+
+    expect_scss_diagnostics(
+        SCSS_VARIABLE_VALUE,
+        "SCSS variables",
+        CssParserOptions::default().report_scss_exclusive_syntax(),
+    );
+}
+
+#[test]
+fn reporting_scss_exclusive_syntax_only_changes_diagnostic_text() {
+    for source in [
+        SCSS_VARIABLE_VALUE,
+        SCSS_NUMBER_INTERPOLATED_VALUE,
+        SCSS_DIMENSION_INTERPOLATED_VALUE,
+    ] {
+        let default_parse = parse_css(source, CssFileSource::css(), CssParserOptions::default());
+        let reporting_parse = parse_css(
+            source,
+            CssFileSource::css(),
+            CssParserOptions::default().report_scss_exclusive_syntax(),
+        );
+
+        assert_eq!(
+            format!("{:#?}", default_parse.syntax()),
+            format!("{:#?}", reporting_parse.syntax()),
+            "expected parser option to preserve CSS recovery tree for {source}"
+        );
+        assert_eq!(
+            default_parse.diagnostics().len(),
+            reporting_parse.diagnostics().len(),
+            "expected parser option to preserve diagnostic count for {source}"
+        );
+
+        let default_diagnostics = diagnostic_text(&default_parse);
+        let reporting_diagnostics = diagnostic_text(&reporting_parse);
+
+        assert!(
+            !default_diagnostics.contains("SCSS"),
+            "expected default parser option to keep generic diagnostics, got: {default_diagnostics}"
+        );
+        assert!(
+            reporting_diagnostics.contains("SCSS"),
+            "expected reporting parser option to emit SCSS diagnostics, got: {reporting_diagnostics}"
+        );
+    }
+}
+
+#[test]
+fn scss_files_parse_scss_exclusive_syntax_without_reporting_it_as_css_error() {
+    let parse = parse_css(
+        SCSS_VARIABLE_DECLARATION,
+        CssFileSource::scss(),
+        CssParserOptions::default(),
+    );
+    let diagnostics = diagnostic_text(&parse);
+
+    assert!(
+        !diagnostics.contains("SCSS only feature"),
+        "expected SCSS parsing to accept SCSS syntax, got: {diagnostics}"
+    );
+}

--- a/crates/biome_css_parser/tests/spec_test.rs
+++ b/crates/biome_css_parser/tests/spec_test.rs
@@ -50,7 +50,8 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_
     let mut options = CssParserOptions::default()
         // it is an internal option that cannot be configured via options.json
         // TODO: find a way to make it configurable
-        .allow_metavariables();
+        .allow_metavariables()
+        .report_scss_exclusive_syntax();
 
     let mut css_modules_enabled = false;
     let mut css_modules_kind = CssModulesKind::Classic;

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -102,11 +102,11 @@ insta               = { workspace = true }
 
 [features]
 # To parse snippets and embeds inside HTML files
-html_embeds    = ["biome_workspace_db/html_embeds", "lang_css", "lang_html", "lang_js", "lang_json"]
+html_embeds                  = ["biome_workspace_db/html_embeds", "lang_css", "lang_html", "lang_js", "lang_json"]
 # JavaScript embeds
-js_embeds      = ["lang_css", "lang_graphql", "lang_js"]
-js_plugin      = ["biome_plugin_loader/js_plugin", "plugins"]
-lang_css       = [
+js_embeds                    = ["lang_css", "lang_graphql", "lang_js"]
+js_plugin                    = ["biome_plugin_loader/js_plugin", "plugins"]
+lang_css                     = [
   "biome_configuration/lang_css",
   "biome_languages/lang_css",
   "dep:biome_css_analyze",
@@ -115,7 +115,7 @@ lang_css       = [
   "dep:biome_css_semantic",
   "dep:biome_css_syntax"
 ]
-lang_graphql   = [
+lang_graphql                 = [
   "biome_configuration/lang_graphql",
   "biome_languages/lang_graphql",
   "dep:biome_graphql_analyze",
@@ -123,14 +123,14 @@ lang_graphql   = [
   "dep:biome_graphql_parser",
   "dep:biome_graphql_syntax"
 ]
-lang_grit      = [
+lang_grit                    = [
   "biome_languages/lang_grit",
   "dep:biome_grit_formatter",
   "dep:biome_grit_parser",
   "dep:biome_grit_patterns",
   "dep:biome_grit_syntax",
 ]
-lang_html      = [
+lang_html                    = [
   "biome_configuration/lang_html",
   "biome_languages/lang_html",
   "dep:biome_html_analyze",
@@ -139,7 +139,7 @@ lang_html      = [
   "dep:biome_html_parser",
   "dep:biome_html_syntax"
 ]
-lang_js        = [
+lang_js                      = [
   "biome_configuration/lang_js",
   "biome_languages/lang_js",
   "dep:biome_js_analyze",
@@ -149,19 +149,19 @@ lang_js        = [
   "dep:biome_js_semantic",
   "dep:biome_js_syntax",
 ]
-lang_json      = [
+lang_json                    = [
   "biome_configuration/lang_json",
   "biome_languages/lang_json",
 ]
-lang_md        = [
+lang_md                      = [
   "biome_configuration/lang_md",
   "biome_languages/lang_md",
   "dep:biome_markdown_formatter",
   "dep:biome_markdown_parser",
   "dep:biome_markdown_syntax"
 ]
-lang_scss      = ["biome_css_syntax/scss"]
-lang_yaml      = [
+lang_scss                    = ["biome_css_syntax/scss"]
+lang_yaml                    = [
   "biome_configuration/lang_yaml",
   "biome_languages/lang_yaml",
   "dep:biome_yaml_formatter",
@@ -169,9 +169,10 @@ lang_yaml      = [
   "dep:biome_yaml_syntax"
 ]
 # TODO does it need lang_js, lang_html and lang_css? To verify
-module_graph   = ["biome_workspace_db/module_graph", "dep:biome_module_graph"]
-plugins        = ["biome_configuration/plugins", "dep:biome_plugin_loader", "lang_grit"]
-schema         = [
+module_graph                 = ["biome_workspace_db/module_graph", "dep:biome_module_graph"]
+plugins                      = ["biome_configuration/plugins", "dep:biome_plugin_loader", "lang_grit"]
+report_scss_exclusive_syntax = []
+schema                       = [
   "biome_configuration/schema",
   "biome_css_syntax/schema",
   "biome_formatter/schema",
@@ -202,7 +203,7 @@ schema         = [
   "type_inference"
 ]
 # Features that are shipped by CLI, LSP and WASM
-stable         = [
+stable                       = [
   "html_embeds",
   "js_embeds",
   "lang_css",
@@ -212,9 +213,9 @@ stable         = [
   "plugins",
   "type_inference"
 ]
-testing        = []
+testing                      = []
 # TODO does it needs lang_js ? to verify
-type_inference = ["dep:biome_js_type_info", "lang_js", "module_graph"]
+type_inference               = ["dep:biome_js_type_info", "lang_js", "module_graph"]
 
 [lints]
 workspace = true

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -197,6 +197,7 @@ impl ServiceLanguage for CssLanguage {
                 .unwrap_or_default(),
             grit_metavariables: false,
             tailwind_directives: language.tailwind_directives.unwrap_or_default().into(),
+            report_scss_exclusive_syntax: cfg!(feature = "report_scss_exclusive_syntax"),
         };
 
         overrides.apply_override_css_parser_options(path, &mut options);
@@ -1004,6 +1005,21 @@ mod test {
                 .with_indent_width(IndentWidth::default())
                 .with_line_ending(LineEnding::default())
                 .with_line_width(LineWidth::default())
+        );
+    }
+
+    #[test]
+    fn resolve_parse_options_maps_scss_reporting_feature() {
+        let parse_options = CssLanguage::resolve_parse_options(
+            &OverrideSettings::default(),
+            &CssParserSettings::default(),
+            &BiomePath::new("test.css"),
+            &DocumentFileSource::Css(CssFileSource::css()),
+        );
+
+        assert_eq!(
+            parse_options.report_scss_exclusive_syntax,
+            cfg!(feature = "report_scss_exclusive_syntax")
         );
     }
 }

--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -45,11 +45,12 @@ quote              = "1.0.14"
 schemars           = { workspace = true }
 
 [features]
-default   = ["console_error_panic_hook"]
-lang_md   = ["biome_service/lang_md"]
-lang_scss = ["biome_service/lang_scss"]
-lang_yaml = ["biome_service/lang_yaml"]
-unstable  = ["lang_md", "lang_scss", "lang_yaml"]
+default                      = ["console_error_panic_hook"]
+lang_md                      = ["biome_service/lang_md"]
+lang_scss                    = ["biome_service/lang_scss"]
+lang_yaml                    = ["biome_service/lang_yaml"]
+report_scss_exclusive_syntax = ["biome_service/report_scss_exclusive_syntax"]
+unstable                     = ["lang_md", "lang_scss", "lang_yaml", "report_scss_exclusive_syntax"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

  Adds parser coverage and SCSS feature gating for interpolation syntax that was previously parsed too permissively in plain CSS contexts.

  Biome now reports SCSS-only diagnostics for CSS inputs such as:

  ```css
  .foo {
    #{$name}: 1px;
    margin-#{$side}: 1px;
    --#{$prop}: 10px;
  }

  #{$tag} {}

  @media #{$query} {}
  @supports (#{$name}: red) {}
  @#{$rule-name} #{$value};
```

  The SCSS parser path remains supported for the same syntax in .scss files, including value interpolation, query features, selector names, property names, keyframes, and interpolated unknown at-rules.

  > This PR was implemented with assistance from OpenAI Codex.

  ## Test Plan

cargo test -p biome_css_parser