### PR TITLE
fix(test): leaky CLI tests

### DIFF
--- a/crates/biome_cli/tests/main.rs
+++ b/crates/biome_cli/tests/main.rs
@@ -337,17 +337,17 @@ pub(crate) fn run_cli_with_dyn_fs(
     use biome_cli::SocketTransport;
     use biome_lsp::ServerFactory;
     use biome_service::{WorkspaceRef, workspace};
-    use tokio::{
-        io::{duplex, split},
-        runtime::Runtime,
-    };
+    use tokio::io::{duplex, split};
 
     let factory = ServerFactory::new_with_fs(Arc::new(OsFileSystem::new(
         fs.working_directory().unwrap_or_default(),
     )));
     let connection = factory.create();
 
-    let runtime = Runtime::new().expect("failed to create runtime");
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to create runtime");
 
     let (client, server) = duplex(4096);
     let (stdin, stdout) = split(server);


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

While running the tests with nextest, I discovered that our CLI infra has leaky tests. 

This PR fixes it by using a tokio Runtime created per thread.

Used a coding agent to track down the fix.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Green CI

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
