### PR TITLE
docs: fix duplicate "from" in noUntrustedLicenses diagnostic

### DIFF
--- a/.changeset/fix-no-untrusted-licenses-diagnostic.md
+++ b/.changeset/fix-no-untrusted-licenses-diagnostic.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed diagnostics emitted by the `noUntrustedLicenses` rule.

--- a/crates/biome_json_analyze/src/lint/nursery/no_untrusted_licenses.rs
+++ b/crates/biome_json_analyze/src/lint/nursery/no_untrusted_licenses.rs
@@ -308,7 +308,7 @@ impl Rule for NoUntrustedLicenses {
                     },
                 )
                 .note(markup! {
-                    "Add the license to the allow list or remove it from from the project."
+                    "Add the license to the allow list or remove it from the project."
                 }),
                 RejectReason::NotFsfLibre => RuleDiagnostic::new(
                     rule_category!(),
@@ -318,7 +318,7 @@ impl Rule for NoUntrustedLicenses {
                     },
                 )
                 .note(markup! {
-                    "Add the license to the allow list or remove it from from the project."
+                    "Add the license to the allow list or remove it from the project."
                 }),
                 RejectReason::Deprecated => RuleDiagnostic::new(
                     rule_category!(),

--- a/crates/biome_json_analyze/tests/specs/nursery/noUntrustedLicenses/fsf_required/package.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noUntrustedLicenses/fsf_required/package.json.snap
@@ -26,7 +26,7 @@ package.json:4:9 lint/nursery/noUntrustedLicenses ━━━━━━━━━━
     5 │     }
     6 │ }
   
-  i Add the license to the allow list or remove it from from the project.
+  i Add the license to the allow list or remove it from the project.
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   

--- a/crates/biome_json_analyze/tests/specs/nursery/noUntrustedLicenses/osi_required/package.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noUntrustedLicenses/osi_required/package.json.snap
@@ -26,7 +26,7 @@ package.json:4:9 lint/nursery/noUntrustedLicenses ━━━━━━━━━━
     5 │     }
     6 │ }
   
-  i Add the license to the allow list or remove it from from the project.
+  i Add the license to the allow list or remove it from the project.
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   


### PR DESCRIPTION
Removes a duplicate "from" in two diagnostic notes of `noUntrustedLicenses` (NotOsiApproved and NotFsfLibre branches).

The text "remove it from from the project" is shown to users when the lint rule rejects a license; both branches share the same note.
