### PR TITLE
fix(lint): detect imported process env usage

### DIFF
--- a/.changeset/no-process-env-named-import.md
+++ b/.changeset/no-process-env-named-import.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed `noProcessEnv` missing diagnostics for imported `env` bindings from `process` and `node:process`.

--- a/.changeset/no-process-env-named-import.md
+++ b/.changeset/no-process-env-named-import.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed `noProcessEnv` missing diagnostics for imported `env` bindings from `process` and `node:process`.
+Fixed [#10447](https://github.com/biomejs/biome/issues/10447): now the rule [`noProcessEnv`](https://biomejs.dev/linter/rules/no-process-env) detects the use of `env` when it's imported from `process` and `node:process`.

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -2,7 +2,9 @@ use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, decl
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
-    AnyJsNamedImportSpecifier, JsImport, JsStaticMemberExpression, global_identifier,
+    AnyJsExpression, AnyJsImportLike, AnyJsNamedImportSpecifier, JsImport,
+    JsObjectBindingPatternShorthandProperty, JsStaticMemberExpression, JsVariableDeclarator,
+    global_identifier,
 };
 use biome_rowan::AstNode;
 use biome_rule_options::no_process_env::NoProcessEnvOptions;
@@ -104,13 +106,58 @@ fn is_process_module_import(binding: &biome_js_semantic::Binding) -> bool {
 
 const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
 
+/// Returns `true` when `binding` is the `env` binding of the `process` (or
+/// `node:process`) module, regardless of whether it is imported or required.
 fn is_env_from_process(binding: &biome_js_semantic::Binding) -> bool {
+    is_env_named_binding(binding) && is_from_process_module(binding)
+}
+
+/// Whether `binding` refers to the `env` export, e.g. `import { env }` (with an
+/// optional alias) or `const { env } = ...`.
+fn is_env_named_binding(binding: &biome_js_semantic::Binding) -> bool {
     binding.syntax().ancestors().skip(1).any(|n| {
-        AnyJsNamedImportSpecifier::cast(n.clone())
-            .and_then(|s| s.imported_name())
+        if let Some(specifier) = AnyJsNamedImportSpecifier::cast(n.clone()) {
+            return specifier
+                .imported_name()
+                .is_some_and(|name| name.text_trimmed() == "env");
+        }
+        JsObjectBindingPatternShorthandProperty::cast(n)
+            .and_then(|property| property.identifier().ok())
+            .and_then(|id| id.as_js_identifier_binding()?.name_token().ok())
             .is_some_and(|name| name.text_trimmed() == "env")
-            || JsImport::cast(n.clone())
-                .and_then(|i| i.source_text().ok())
-                .is_some_and(|src| PROCESS_MODULE_NAMES.contains(&src.text()))
     })
+}
+
+/// Whether `binding` originates from the `process`/`node:process` module,
+/// either through an `import` statement, a `require(...)` call, or a dynamic
+/// `import(...)` call.
+fn is_from_process_module(binding: &biome_js_semantic::Binding) -> bool {
+    binding.syntax().ancestors().skip(1).any(|n| {
+        if let Some(import) = JsImport::cast(n.clone()) {
+            return import
+                .source_text()
+                .ok()
+                .is_some_and(|source| PROCESS_MODULE_NAMES.contains(&source.text()));
+        }
+        JsVariableDeclarator::cast(n)
+            .and_then(|declarator| process_module_specifier(&declarator))
+            .is_some_and(|source| PROCESS_MODULE_NAMES.contains(&source.text()))
+    })
+}
+
+/// Returns the module specifier of a `require(...)` or dynamic `import(...)`
+/// call used to initialize `declarator`, if any.
+fn process_module_specifier(declarator: &JsVariableDeclarator) -> Option<biome_rowan::TokenText> {
+    let expression = match declarator.initializer()?.expression().ok()? {
+        AnyJsExpression::JsAwaitExpression(await_expression) => await_expression.argument().ok()?,
+        expression => expression,
+    };
+    let import_like = match expression {
+        AnyJsExpression::JsCallExpression(call) => AnyJsImportLike::JsCallExpression(call),
+        AnyJsExpression::JsImportCallExpression(call) => {
+            AnyJsImportLike::JsImportCallExpression(call)
+        }
+        _ => return None,
+    };
+    import_like.inner_string_text()
 }

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -61,8 +61,7 @@ impl Rule for NoProcessEnv {
         let object = node.object().ok()?;
         let member = node.member().ok()?.as_js_name()?.to_trimmed_text();
 
-        let (reference, name) =
-            global_identifier(&object.as_any_global_identifier_expression()?)?;
+        let (reference, name) = global_identifier(&object.as_any_global_identifier_expression()?)?;
 
         if member.text() == "env" && name.text() == "process" {
             return match model.binding(&reference) {
@@ -71,7 +70,10 @@ impl Rule for NoProcessEnv {
             };
         }
 
-        model.binding(&reference).filter(is_env_from_process).map(|_| ())
+        model
+            .binding(&reference)
+            .filter(is_env_from_process)
+            .map(|_| ())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
@@ -103,15 +105,13 @@ fn is_process_module_import(binding: &biome_js_semantic::Binding) -> bool {
 const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
 
 fn is_env_from_process(binding: &biome_js_semantic::Binding) -> bool {
-
-    binding
-    	.syntax()
-    	.ancestors()
-    	.skip(1)
-        .find_map(|n| AnyJsNamedImportSpecifier::cast(n.clone())?.imported_name())
-        .is_some_and(|name| name.text_trimmed() == "env")
-        && ancestors
-            .iter()
-            .find_map(|n| JsImport::cast(n.clone())?.source_text().ok())
-            .is_some_and(|src| PROCESS_MODULE_NAMES.contains(&src.text()))
+    binding.syntax().ancestors().skip(1).any(|n| {
+        AnyJsNamedImportSpecifier::cast(n.clone())?
+            .imported_name()
+            .is_some_and(|name| name.text_trimmed() == "env")
+            || JsImport::cast(n.clone())?
+                .source_text()
+                .ok()
+                .is_some_and(|src| PROCESS_MODULE_NAMES.contains(&src.text()))
+    })
 }

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -95,16 +95,17 @@ impl Rule for NoProcessEnv {
     }
 }
 
+const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
+
+/// Whether the `process` `binding` is imported from the `process`/`node:process`
+/// module through an `import` statement.
 fn is_process_module_import(binding: &biome_js_semantic::Binding) -> bool {
-    const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
     binding
         .syntax()
         .ancestors()
         .find_map(|ancestor| JsImport::cast(ancestor)?.source_text().ok())
         .is_some_and(|source| PROCESS_MODULE_NAMES.contains(&source.text()))
 }
-
-const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
 
 /// Returns `true` when `binding` is the `env` binding of the `process` (or
 /// `node:process`) module, regardless of whether it is imported or required.
@@ -132,32 +133,39 @@ fn is_env_named_binding(binding: &biome_js_semantic::Binding) -> bool {
 /// either through an `import` statement, a `require(...)` call, or a dynamic
 /// `import(...)` call.
 fn is_from_process_module(binding: &biome_js_semantic::Binding) -> bool {
-    binding.syntax().ancestors().skip(1).any(|n| {
-        if let Some(import) = JsImport::cast(n.clone()) {
-            return import
-                .source_text()
-                .ok()
-                .is_some_and(|source| PROCESS_MODULE_NAMES.contains(&source.text()));
-        }
-        JsVariableDeclarator::cast(n)
-            .and_then(|declarator| process_module_specifier(&declarator))
-            .is_some_and(|source| PROCESS_MODULE_NAMES.contains(&source.text()))
-    })
-}
-
-/// Returns the module specifier of a `require(...)` or dynamic `import(...)`
-/// call used to initialize `declarator`, if any.
-fn process_module_specifier(declarator: &JsVariableDeclarator) -> Option<biome_rowan::TokenText> {
-    let expression = match declarator.initializer()?.expression().ok()? {
-        AnyJsExpression::JsAwaitExpression(await_expression) => await_expression.argument().ok()?,
-        expression => expression,
-    };
-    let import_like = match expression {
-        AnyJsExpression::JsCallExpression(call) => AnyJsImportLike::JsCallExpression(call),
-        AnyJsExpression::JsImportCallExpression(call) => {
-            AnyJsImportLike::JsImportCallExpression(call)
-        }
-        _ => return None,
-    };
-    import_like.inner_string_text()
+    binding
+        .syntax()
+        .ancestors()
+        .skip(1)
+        .find_map(|node| {
+            if let Some(import) = JsImport::cast(node.clone()) {
+                return import
+                    .import_clause()
+                    .ok()?
+                    .source()
+                    .ok()
+                    .map(AnyJsImportLike::JsModuleSource);
+            }
+            let expression = match JsVariableDeclarator::cast(node)?
+                .initializer()?
+                .expression()
+                .ok()?
+            {
+                AnyJsExpression::JsAwaitExpression(await_expression) => {
+                    await_expression.argument().ok()?
+                }
+                expression => expression,
+            };
+            match expression {
+                AnyJsExpression::JsCallExpression(call) => {
+                    Some(AnyJsImportLike::JsCallExpression(call))
+                }
+                AnyJsExpression::JsImportCallExpression(call) => {
+                    Some(AnyJsImportLike::JsImportCallExpression(call))
+                }
+                _ => None,
+            }
+        })
+        .and_then(|import_like| import_like.inner_string_text())
+        .is_some_and(|source| PROCESS_MODULE_NAMES.contains(&source.text()))
 }

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -1,7 +1,9 @@
 use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{JsImport, JsStaticMemberExpression, global_identifier};
+use biome_js_syntax::{
+    AnyJsNamedImportSpecifier, JsImport, JsStaticMemberExpression, global_identifier,
+};
 use biome_rowan::AstNode;
 use biome_rule_options::no_process_env::NoProcessEnvOptions;
 
@@ -54,23 +56,22 @@ impl Rule for NoProcessEnv {
     type Options = NoProcessEnvOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let static_member_expr = ctx.query();
+        let node = ctx.query();
         let model = ctx.model();
-        let object = static_member_expr.object().ok()?;
-        let member_expr = static_member_expr.member().ok()?;
-        if member_expr.as_js_name()?.to_trimmed_text().text() != "env" {
-            return None;
-        }
+        let object = node.object().ok()?;
+        let member = node.member().ok()?.as_js_name()?.to_trimmed_text();
 
         let (reference, name) =
             global_identifier(&object.as_any_global_identifier_expression()?)?;
-        if name.text() != "process" {
-            return None;
+
+        if member.text() == "env" && name.text() == "process" {
+            return match model.binding(&reference) {
+                None => Some(()),
+                Some(binding) => is_process_module_import(&binding).then_some(()),
+            };
         }
-        match model.binding(&reference) {
-            None => Some(()),
-            Some(binding) => is_process_module_import(&binding).then_some(()),
-        }
+
+        model.binding(&reference).filter(is_env_from_process).map(|_| ())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
@@ -97,4 +98,17 @@ fn is_process_module_import(binding: &biome_js_semantic::Binding) -> bool {
         .ancestors()
         .find_map(|ancestor| JsImport::cast(ancestor)?.source_text().ok())
         .is_some_and(|source| PROCESS_MODULE_NAMES.contains(&source.text()))
+}
+
+fn is_env_from_process(binding: &biome_js_semantic::Binding) -> bool {
+    const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
+    let ancestors: Vec<_> = binding.syntax().ancestors().collect();
+    ancestors
+        .iter()
+        .find_map(|n| AnyJsNamedImportSpecifier::cast(n.clone())?.imported_name())
+        .is_some_and(|name| name.text_trimmed() == "env")
+        && ancestors
+            .iter()
+            .find_map(|n| JsImport::cast(n.clone())?.source_text().ok())
+            .is_some_and(|src| PROCESS_MODULE_NAMES.contains(&src.text()))
 }

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -100,10 +100,14 @@ fn is_process_module_import(binding: &biome_js_semantic::Binding) -> bool {
         .is_some_and(|source| PROCESS_MODULE_NAMES.contains(&source.text()))
 }
 
+const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
+
 fn is_env_from_process(binding: &biome_js_semantic::Binding) -> bool {
-    const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
-    let ancestors: Vec<_> = binding.syntax().ancestors().collect();
-    ancestors
+
+    binding
+    	.syntax()
+    	.ancestors()
+    	.skip(1)
         .iter()
         .find_map(|n| AnyJsNamedImportSpecifier::cast(n.clone())?.imported_name())
         .is_some_and(|name| name.text_trimmed() == "env")

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -108,7 +108,6 @@ fn is_env_from_process(binding: &biome_js_semantic::Binding) -> bool {
     	.syntax()
     	.ancestors()
     	.skip(1)
-        .iter()
         .find_map(|n| AnyJsNamedImportSpecifier::cast(n.clone())?.imported_name())
         .is_some_and(|name| name.text_trimmed() == "env")
         && ancestors

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -106,12 +106,11 @@ const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
 
 fn is_env_from_process(binding: &biome_js_semantic::Binding) -> bool {
     binding.syntax().ancestors().skip(1).any(|n| {
-        AnyJsNamedImportSpecifier::cast(n.clone())?
-            .imported_name()
+        AnyJsNamedImportSpecifier::cast(n.clone())
+            .and_then(|s| s.imported_name())
             .is_some_and(|name| name.text_trimmed() == "env")
-            || JsImport::cast(n.clone())?
-                .source_text()
-                .ok()
+            || JsImport::cast(n.clone())
+                .and_then(|i| i.source_text().ok())
                 .is_some_and(|src| PROCESS_MODULE_NAMES.contains(&src.text()))
     })
 }

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidDynamicImportEnv.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidDynamicImportEnv.js
@@ -1,0 +1,9 @@
+async function fromProcess() {
+	const { env } = await import("process");
+	env.NODE_ENV;
+}
+
+async function fromNodeProcess() {
+	const { env } = await import("node:process");
+	env.HOME;
+}

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidDynamicImportEnv.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidDynamicImportEnv.js.snap
@@ -1,0 +1,52 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidDynamicImportEnv.js
+---
+# Input
+```js
+async function fromProcess() {
+	const { env } = await import("process");
+	env.NODE_ENV;
+}
+
+async function fromNodeProcess() {
+	const { env } = await import("node:process");
+	env.HOME;
+}
+
+```
+
+# Diagnostics
+```
+invalidDynamicImportEnv.js:3:2 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    1 │ async function fromProcess() {
+    2 │ 	const { env } = await import("process");
+  > 3 │ 	env.NODE_ENV;
+      │ 	^^^^^^^^^^^^
+    4 │ }
+    5 │ 
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```
+
+```
+invalidDynamicImportEnv.js:8:2 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+     6 │ async function fromNodeProcess() {
+     7 │ 	const { env } = await import("node:process");
+   > 8 │ 	env.HOME;
+       │ 	^^^^^^^^
+     9 │ }
+    10 │ 
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnv.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnv.js
@@ -1,0 +1,3 @@
+import { env } from 'process';
+env.NODE_ENV;
+env.HOME;

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnv.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnv.js.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidImportedEnv.js
+---
+# Input
+```js
+import { env } from 'process';
+env.NODE_ENV;
+env.HOME;
+
+```
+
+# Diagnostics
+```
+invalidImportedEnv.js:2:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    1 │ import { env } from 'process';
+  > 2 │ env.NODE_ENV;
+      │ ^^^^^^^^^^^^
+    3 │ env.HOME;
+    4 │ 
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```
+
+```
+invalidImportedEnv.js:3:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    1 │ import { env } from 'process';
+    2 │ env.NODE_ENV;
+  > 3 │ env.HOME;
+      │ ^^^^^^^^
+    4 │ 
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnvAlias.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnvAlias.js
@@ -1,0 +1,5 @@
+import { env as processEnv } from 'process';
+processEnv.PATH;
+
+import { env as nodeEnv } from 'node:process';
+nodeEnv.HOME;

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnvAlias.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidImportedEnvAlias.js.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidImportedEnvAlias.js
+---
+# Input
+```js
+import { env as processEnv } from 'process';
+processEnv.PATH;
+
+import { env as nodeEnv } from 'node:process';
+nodeEnv.HOME;
+
+```
+
+# Diagnostics
+```
+invalidImportedEnvAlias.js:2:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    1 │ import { env as processEnv } from 'process';
+  > 2 │ processEnv.PATH;
+      │ ^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ import { env as nodeEnv } from 'node:process';
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```
+
+```
+invalidImportedEnvAlias.js:5:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    4 │ import { env as nodeEnv } from 'node:process';
+  > 5 │ nodeEnv.HOME;
+      │ ^^^^^^^^^^^^
+    6 │ 
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidRequiredEnv.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidRequiredEnv.js
@@ -1,0 +1,8 @@
+{
+	const { env } = require("process");
+	env.NODE_ENV;
+}
+{
+	const { env } = require("node:process");
+	env.HOME;
+}

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidRequiredEnv.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidRequiredEnv.js.snap
@@ -1,0 +1,51 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidRequiredEnv.js
+---
+# Input
+```js
+{
+	const { env } = require("process");
+	env.NODE_ENV;
+}
+{
+	const { env } = require("node:process");
+	env.HOME;
+}
+
+```
+
+# Diagnostics
+```
+invalidRequiredEnv.js:3:2 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    1 │ {
+    2 │ 	const { env } = require("process");
+  > 3 │ 	env.NODE_ENV;
+      │ 	^^^^^^^^^^^^
+    4 │ }
+    5 │ {
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```
+
+```
+invalidRequiredEnv.js:7:2 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    5 │ {
+    6 │ 	const { env } = require("node:process");
+  > 7 │ 	env.HOME;
+      │ 	^^^^^^^^
+    8 │ }
+    9 │ 
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validImportedEnv.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validImportedEnv.js
@@ -1,0 +1,3 @@
+/* should not generate diagnostics */
+import { env } from './config';
+env.FOO;

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validImportedEnv.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validImportedEnv.js.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validImportedEnv.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+import { env } from './config';
+env.FOO;
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validRequiredOtherModule.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validRequiredOtherModule.js
@@ -1,0 +1,3 @@
+/* should not generate diagnostics */
+const { env } = require("./config");
+env.FOO;

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validRequiredOtherModule.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/validRequiredOtherModule.js.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validRequiredOtherModule.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+const { env } = require("./config");
+env.FOO;
+
+```


### PR DESCRIPTION
## Summary

Fixes #10447.

noProcessEnv already reports direct process.env usage, but it was missing cases where env is imported from process or node:process.

This updates the rule to also catch cases like:
- import { env } from "process"
- import { env as processEnv } from "node:process"

while still ignoring unrelated local imports with the same name.

I used AI tools while investigating the issue and tracing the relevant code paths, but reviewed and cleaned up the final implementation and tests manually before submitting.

## Test Plan

Added fixtures/snapshots covering:
- direct env imports from process
- aliased env imports
- valid local env imports

Ran the relevant noProcessEnv analyzer tests and regenerated snapshots with the normal test workflow.

## Docs

No documentation changes needed.