### PR TITLE
fix(html_formatter): preserve multiline Vue interpolations 🤖🤖🤖

### DIFF
--- a/.changeset/fix-vue-multiline-interpolation.md
+++ b/.changeset/fix-vue-multiline-interpolation.md
@@ -3,3 +3,12 @@
 ---
 
 Fixed [#10330](https://github.com/biomejs/biome/issues/10330): Vue interpolations that contain newline-delimited content now keep a multiline layout instead of being collapsed into whitespace-sensitive tag borrowing.
+
+```diff
+-<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{ $t("nav.my-rooms") }}</v-btn>
++<v-btn v-if="store.state.user" variant="text" to="/my-rooms">
++	{{
++		$t("nav.my-rooms")
++	}}
++</v-btn>
+```

--- a/.changeset/fix-vue-multiline-interpolation.md
+++ b/.changeset/fix-vue-multiline-interpolation.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10330](https://github.com/biomejs/biome/issues/10330): Vue interpolations that contain newline-delimited content now keep a multiline layout instead of being collapsed into whitespace-sensitive tag borrowing.

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -64,16 +64,10 @@ serde                    = { workspace = true, features = ["derive"] }
 serde_json               = { workspace = true }
 smallvec                 = { workspace = true }
 terminal_size            = { workspace = true }
-tokio                    = { workspace = true, features = [
-  "io-std",
-  "io-util",
-  "macros",
-  "net",
-  "rt",
-  "rt-multi-thread",
-  "sync",
-  "time"
-] }
+tokio                    = {
+  workspace = true,
+  features  = ["io-std", "io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"]
+}
 tracing                  = { workspace = true }
 tracing-appender         = "0.2.4"
 tracing-subscriber       = { workspace = true, features = ["env-filter", "json"] }

--- a/crates/biome_html_formatter/src/html/auxiliary/double_text_expression.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/double_text_expression.rs
@@ -16,6 +16,17 @@ impl FormatNodeRule<HtmlDoubleTextExpression> for FormatHtmlDoubleTextExpression
             r_double_curly_token,
         } = node.as_fields();
 
+        if is_multiline_double_text_expression(node) {
+            return write!(
+                f,
+                [
+                    l_double_curly_token.format(),
+                    block_indent(&expression.format()),
+                    r_double_curly_token.format(),
+                ]
+            );
+        }
+
         write!(
             f,
             [
@@ -27,4 +38,15 @@ impl FormatNodeRule<HtmlDoubleTextExpression> for FormatHtmlDoubleTextExpression
             ]
         )
     }
+}
+
+pub(crate) fn is_multiline_double_text_expression(node: &HtmlDoubleTextExpression) -> bool {
+    node.expression()
+        .ok()
+        .and_then(|expression| expression.html_literal_token().ok())
+        .is_some_and(|token| has_boundary_newline(token.text()))
+}
+
+fn has_boundary_newline(text: &str) -> bool {
+    text.starts_with(['\n', '\r']) || text.ends_with(['\n', '\r'])
 }

--- a/crates/biome_html_formatter/src/html/auxiliary/element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/element.rs
@@ -4,14 +4,15 @@ use crate::verbatim::{format_html_leading_comments, format_html_leading_comments
 use crate::{html::lists::element_list::FormatHtmlElementList, prelude::*};
 use biome_formatter::{CstFormatContext, FormatRefWithRule, FormatRuleWithOptions, write};
 use biome_html_syntax::{
-    AnyHtmlContent, AnyHtmlElement, AnyHtmlTagName, HtmlElement, HtmlElementFields,
-    HtmlElementList, HtmlRoot, HtmlSelfClosingElement, HtmlSyntaxToken,
+    AnyHtmlContent, AnyHtmlElement, AnyHtmlTagName, AnyHtmlTextExpression, HtmlElement,
+    HtmlElementFields, HtmlElementList, HtmlRoot, HtmlSelfClosingElement, HtmlSyntaxToken,
 };
 use biome_rowan::TokenText;
 use biome_string_case::StrLikeExtension;
 
 use super::{
     closing_element::{FormatHtmlClosingElement, FormatHtmlClosingElementOptions},
+    double_text_expression::is_multiline_double_text_expression,
     opening_element::{FormatHtmlOpeningElement, FormatHtmlOpeningElementOptions},
 };
 
@@ -178,7 +179,8 @@ impl FormatHtmlElement {
             || opening_element
                 .r_angle_token()
                 .ok()
-                .is_some_and(|tok| tok.has_trailing_whitespace());
+                .is_some_and(|tok| tok.has_trailing_whitespace())
+            || first_child_is_multiline_interpolation(&children);
         let content_has_trailing_whitespace = children
             .syntax()
             .last_token()
@@ -186,7 +188,8 @@ impl FormatHtmlElement {
             || closing_element
                 .l_angle_token()
                 .ok()
-                .is_some_and(|tok| tok.has_leading_whitespace_or_newline());
+                .is_some_and(|tok| tok.has_leading_whitespace_or_newline())
+            || last_child_is_multiline_interpolation(&children);
 
         // Check if there is a newline between the opening tag and the first child.
         // This is distinct from `content_has_leading_whitespace` which also matches spaces.
@@ -373,4 +376,27 @@ fn has_text_child(node: &HtmlElementList) -> bool {
             .value_token()
             .is_ok_and(|token| !token.text_trimmed().is_empty())
     })
+}
+
+fn first_child_is_multiline_interpolation(node: &HtmlElementList) -> bool {
+    node.iter()
+        .next()
+        .is_some_and(|child| is_multiline_interpolation(&child))
+}
+
+fn last_child_is_multiline_interpolation(node: &HtmlElementList) -> bool {
+    node.iter()
+        .last()
+        .is_some_and(|child| is_multiline_interpolation(&child))
+}
+
+fn is_multiline_interpolation(child: &AnyHtmlElement) -> bool {
+    let AnyHtmlElement::AnyHtmlContent(AnyHtmlContent::AnyHtmlTextExpression(
+        AnyHtmlTextExpression::HtmlDoubleTextExpression(expression),
+    )) = child
+    else {
+        return false;
+    };
+
+    is_multiline_double_text_expression(expression)
 }

--- a/crates/biome_html_formatter/tests/specs/html/vue/issue-10330.vue
+++ b/crates/biome_html_formatter/tests/specs/html/vue/issue-10330.vue
@@ -1,0 +1,11 @@
+<template>
+	<div>
+		<span>
+			<div>
+				<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{
+					$t("nav.my-rooms")
+				}}</v-btn>
+			</div>
+		</span>
+	</div>
+</template>

--- a/crates/biome_html_formatter/tests/specs/html/vue/issue-10330.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/vue/issue-10330.vue.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: vue/issue-10330.vue
+---
+
+# Input
+
+```vue
+<template>
+	<div>
+		<span>
+			<div>
+				<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{
+					$t("nav.my-rooms")
+				}}</v-btn>
+			</div>
+		</span>
+	</div>
+</template>
+
+```
+
+
+# Formatted
+
+```vue
+<template>
+	<div>
+		<span>
+			<div>
+				<v-btn v-if="store.state.user" variant="text" to="/my-rooms">
+					{{
+						$t("nav.my-rooms")
+					}}
+				</v-btn>
+			</div>
+		</span>
+	</div>
+</template>
+
+```


### PR DESCRIPTION
## Summary

Fixes #10330

Vue interpolations whose expression content starts or ends with a newline now keep a block interpolation layout instead of collapsing into whitespace-sensitive tag borrowing.

> This PR was implemented with AI assistance.

## Test Plan

- `just f`
- `just l`
- `cargo test -p biome_html_formatter --test spec_tests issue_10330 -- --nocapture`

## Docs

Not applicable. Formatter bug fix with a changeset.
