### PR TITLE
fix(parser/yaml): lex directives

### DIFF
--- a/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-2-24-global-tags.yml.snap
+++ b/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-2-24-global-tags.yml.snap
@@ -64,17 +64,3 @@ info: yaml/spec/spec-example-2-24-global-tags.yml
   color: 0xFFEEBB
   text: Pretty vector drawing.
 ```
-
-# Errors
-```
-spec-example-2-24-global-tags.yml:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected character `%`
-  
-  > 1 │ %TAG ! tag:clarkevans.com,2002:
-      │ ^
-    2 │ --- !shape
-    3 │   # Use the ! handle for presenting
-  
-
-```

--- a/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-5-9-directive-indicator.yml.snap
+++ b/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-5-9-directive-indicator.yml.snap
@@ -30,17 +30,3 @@ info: yaml/spec/spec-example-5-9-directive-indicator.yml
 %YAML 1.2
 --- text
 ```
-
-# Errors
-```
-spec-example-5-9-directive-indicator.yml:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected character `%`
-  
-  > 1 │ %YAML 1.2
-      │ ^
-    2 │ --- text
-    3 │ 
-  
-
-```

--- a/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-6-13-reserved-directives.yml.snap
+++ b/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-6-13-reserved-directives.yml.snap
@@ -35,17 +35,3 @@ info: yaml/spec/spec-example-6-13-reserved-directives.yml
               # with a warning.
 --- "foo"
 ```
-
-# Errors
-```
-spec-example-6-13-reserved-directives.yml:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected character `%`
-  
-  > 1 │ %FOO  bar baz # Should be ignored
-      │ ^
-    2 │               # with a warning.
-    3 │ --- "foo"
-  
-
-```

--- a/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-6-14-yaml-directive.yml.snap
+++ b/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-6-14-yaml-directive.yml.snap
@@ -35,17 +35,3 @@ info: yaml/spec/spec-example-6-14-yaml-directive.yml
 ---
 "foo"
 ```
-
-# Errors
-```
-spec-example-6-14-yaml-directive.yml:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected character `%`
-  
-  > 1 │ %YAML 1.3 # Attempt parsing
-      │ ^
-    2 │           # with a warning
-    3 │ ---
-  
-
-```

--- a/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-9-5-directives-documents.yml.snap
+++ b/crates/biome_yaml_formatter/tests/specs/prettier/yaml/spec/spec-example-9-5-directives-documents.yml.snap
@@ -49,17 +49,3 @@ info: yaml/spec/spec-example-9-5-directives-documents.yml
 # Empty
 ...
 ```
-
-# Errors
-```
-spec-example-9-5-directives-documents.yml:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected character `%`
-  
-  > 1 │ %YAML 1.2
-      │ ^
-    2 │ --- |
-    3 │ %!PS-Adobe-2.0
-  
-
-```

--- a/crates/biome_yaml_parser/src/lexer/mod.rs
+++ b/crates/biome_yaml_parser/src/lexer/mod.rs
@@ -62,6 +62,7 @@ impl<'src> YamlLexer<'src> {
             c if is_break(c) => self.evaluate_block_scope(),
             c if is_space(c) => self.consume_whitespace_token().into(),
             b'#' => self.consume_comment().into(),
+            b'%' if self.is_at_directive() => self.consume_directive().into(),
             b'-' if self.is_at_directive_end() => self.consume_directive_end(),
             b'.' if self.is_at_doc_end() => self.consume_doc_end(),
             b'!' | b'&' => self.consume_block_properties(),
@@ -546,6 +547,39 @@ impl<'src> YamlLexer<'src> {
             }
         };
         LexToken::new(SINGLE_QUOTED_LITERAL, start, token_end)
+    }
+
+    fn is_at_directive(&self) -> bool {
+        self.current_coordinate.column == 0 && self.current_byte().is_some_and(|c| c == b'%')
+    }
+
+    fn consume_directive(&mut self) -> LexToken {
+        self.assert_byte(b'%');
+        let start = self.current_coordinate;
+        while let Some(current) = self.current_byte() {
+            if is_break(current) || self.is_at_directive_trailing_trivia() {
+                break;
+            }
+            self.advance_char_unchecked();
+        }
+
+        LexToken::new(DIRECTIVE_LITERAL, start, self.current_coordinate)
+    }
+
+    fn is_at_directive_trailing_trivia(&self) -> bool {
+        match self.current_byte() {
+            Some(b'#') => self.prev_byte().is_none_or(is_blank),
+            Some(current) if is_space(current) => {
+                let mut offset = 0;
+                while self.byte_at(offset).is_some_and(is_space) {
+                    offset += 1;
+                }
+
+                self.byte_at(offset)
+                    .is_none_or(|c| c == b'#' || is_break(c))
+            }
+            _ => false,
+        }
     }
 
     fn is_at_directive_end(&self) -> bool {

--- a/crates/biome_yaml_parser/tests/yaml_test_suite/ok/document/directives.yaml
+++ b/crates/biome_yaml_parser/tests/yaml_test_suite/ok/document/directives.yaml
@@ -1,0 +1,9 @@
+%YAML 1.2 # comment
+%FOO  bar baz
+---
+...
+%YAML1.2
+---
+...
+%TAG ! tag:clarkevans.com,2002:
+---

--- a/crates/biome_yaml_parser/tests/yaml_test_suite/ok/document/directives.yaml.snap
+++ b/crates/biome_yaml_parser/tests/yaml_test_suite/ok/document/directives.yaml.snap
@@ -1,0 +1,98 @@
+---
+source: crates/biome_yaml_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```yaml
+%YAML 1.2 # comment
+%FOO  bar baz
+---
+...
+%YAML1.2
+---
+...
+%TAG ! tag:clarkevans.com,2002:
+---
+
+```
+
+## AST
+
+```
+YamlRoot {
+    documents: YamlDocumentList [
+        YamlDocument {
+            bom_token: missing (optional),
+            directives: YamlDirectiveList [
+                YamlDirective {
+                    value_token: DIRECTIVE_LITERAL@0..19 "%YAML 1.2" [] [Whitespace(" "), Comments("# comment")],
+                },
+                YamlDirective {
+                    value_token: DIRECTIVE_LITERAL@19..33 "%FOO  bar baz" [Newline("\n")] [],
+                },
+            ],
+            dashdashdash_token: DIRECTIVE_END@33..37 "---" [Newline("\n")] [],
+            node: missing (optional),
+            dotdotdot_token: DOC_END@37..41 "..." [Newline("\n")] [],
+        },
+        YamlDocument {
+            bom_token: missing (optional),
+            directives: YamlDirectiveList [
+                YamlDirective {
+                    value_token: DIRECTIVE_LITERAL@41..50 "%YAML1.2" [Newline("\n")] [],
+                },
+            ],
+            dashdashdash_token: DIRECTIVE_END@50..54 "---" [Newline("\n")] [],
+            node: missing (optional),
+            dotdotdot_token: DOC_END@54..58 "..." [Newline("\n")] [],
+        },
+        YamlDocument {
+            bom_token: missing (optional),
+            directives: YamlDirectiveList [
+                YamlDirective {
+                    value_token: DIRECTIVE_LITERAL@58..90 "%TAG ! tag:clarkevans.com,2002:" [Newline("\n")] [],
+                },
+            ],
+            dashdashdash_token: DIRECTIVE_END@90..94 "---" [Newline("\n")] [],
+            node: missing (optional),
+            dotdotdot_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@94..95 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: YAML_ROOT@0..95
+  0: YAML_DOCUMENT_LIST@0..94
+    0: YAML_DOCUMENT@0..41
+      0: (empty)
+      1: YAML_DIRECTIVE_LIST@0..33
+        0: YAML_DIRECTIVE@0..19
+          0: DIRECTIVE_LITERAL@0..19 "%YAML 1.2" [] [Whitespace(" "), Comments("# comment")]
+        1: YAML_DIRECTIVE@19..33
+          0: DIRECTIVE_LITERAL@19..33 "%FOO  bar baz" [Newline("\n")] []
+      2: DIRECTIVE_END@33..37 "---" [Newline("\n")] []
+      3: (empty)
+      4: DOC_END@37..41 "..." [Newline("\n")] []
+    1: YAML_DOCUMENT@41..58
+      0: (empty)
+      1: YAML_DIRECTIVE_LIST@41..50
+        0: YAML_DIRECTIVE@41..50
+          0: DIRECTIVE_LITERAL@41..50 "%YAML1.2" [Newline("\n")] []
+      2: DIRECTIVE_END@50..54 "---" [Newline("\n")] []
+      3: (empty)
+      4: DOC_END@54..58 "..." [Newline("\n")] []
+    2: YAML_DOCUMENT@58..94
+      0: (empty)
+      1: YAML_DIRECTIVE_LIST@58..90
+        0: YAML_DIRECTIVE@58..90
+          0: DIRECTIVE_LITERAL@58..90 "%TAG ! tag:clarkevans.com,2002:" [Newline("\n")] []
+      2: DIRECTIVE_END@90..94 "---" [Newline("\n")] []
+      3: (empty)
+      4: (empty)
+  1: EOF@94..95 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
## Summary

Implemented the lexer to support YAML directives before the DIRECTIVE_END marker (`---`).

For example:

```yaml
%YAML 1.2
---
```

## Test Plan

Added lexer unit tests.

## Docs

N/A
