### PR TITLE
chore: enable unstable features on preview builds for playground

### DIFF
--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build WASM module for the web
-        run: just build-wasm-web
+        run: just build-wasm-web --features=unstable
 
       # https://github.com/actions/cache/issues/342
       - name: Clear old wasm cache

--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -45,6 +45,9 @@ schemars           = { workspace = true }
 
 [features]
 default = ["console_error_panic_hook"]
+unstable = ["lang_md", "lang_yaml"]
+lang_md = ["biome_service/lang_md"]
+lang_yaml = ["biome_service/lang_yaml"]
 
 [lints]
 workspace = true

--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -44,10 +44,10 @@ quote              = "1.0.14"
 schemars           = { workspace = true }
 
 [features]
-default = ["console_error_panic_hook"]
-unstable = ["lang_md", "lang_yaml"]
-lang_md = ["biome_service/lang_md"]
+default   = ["console_error_panic_hook"]
+lang_md   = ["biome_service/lang_md"]
 lang_yaml = ["biome_service/lang_yaml"]
+unstable  = ["lang_md", "lang_yaml"]
 
 [lints]
 workspace = true

--- a/justfile
+++ b/justfile
@@ -128,8 +128,8 @@ build-wasm-web-dev:
     --typescript
 
 # Build WASM for web target (release)
-build-wasm-web:
-  cargo build --lib --target wasm32-unknown-unknown --release -p biome_wasm
+build-wasm-web *args='':
+  cargo build --lib --target wasm32-unknown-unknown --release -p biome_wasm {{args}}
   wasm-bindgen target/wasm32-unknown-unknown/release/biome_wasm.wasm \
     --out-dir packages/@biomejs/wasm-web \
     --no-demangle \


### PR DESCRIPTION
## Summary

The wasm-web preview builds, made by the repository dispatch job, now enables the unstable features (lang_md, lang_yaml) to use them in our playground.

## Test Plan

Dispatched the job manually (https://github.com/biomejs/biome/actions/runs/26531258176) and confirmed the published build now contains Markdown and YAML features.

## Docs

N/A
