### PR TITLE
feat(cli): add --threads to check command

### DIFF
--- a/.changeset/check-command-threads.md
+++ b/.changeset/check-command-threads.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added `--threads` and `BIOME_THREADS` support to `biome check`. This lets local workflows such as pre-commit hooks limit Biome's worker count while still using `check --write` to apply safe fixes.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -204,6 +204,17 @@ pub enum BiomeCommand {
         #[bpaf(long("since"), argument("REF"))]
         since: Option<String>,
 
+        /// The number of threads to use. This is useful when running the CLI in environments
+        /// with limited resource.
+        #[bpaf(
+            long("threads"),
+            argument("NUMBER"),
+            env("BIOME_THREADS"),
+            optional,
+            hide_usage
+        )]
+        threads: Option<usize>,
+
         /// Run only the given lint rule, assist action, group of rules and actions, or domain.
         /// If the severity level of a rule is `off`,
         /// then the severity level of the rule is set to `error` if it is a recommended rule or `warn` otherwise.
@@ -770,7 +781,7 @@ impl BiomeCommand {
 
     pub const fn get_threads(&self) -> Option<usize> {
         match self {
-            Self::Ci { threads, .. } => *threads,
+            Self::Check { threads, .. } | Self::Ci { threads, .. } => *threads,
             _ => None,
         }
     }

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -103,6 +103,7 @@ impl<'app> CliSession<'app> {
                 skip,
                 watch,
                 profile_rules,
+                threads: _,
             } => run_command(
                 self,
                 &log_options,

--- a/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
@@ -395,6 +395,9 @@ Available options:
         --since=REF           Use this to specify the base branch to compare against when you're
                               using the --changed flag and the `defaultBranch` is not set in your
                               `biome.json`
+        --threads=NUMBER      The number of threads to use. This is useful when running the CLI in
+                              environments with limited resource.
+                              [env:BIOME_THREADS: N/A]
         --only=<GROUP|RULE|DOMAIN|ACTION>  Run only the given lint rule, assist action, group of
                               rules and actions, or domain. If the severity level of a rule is
                               `off`, then the severity level of the rule is set to `error` if it is

--- a/crates/biome_flags/src/lib.rs
+++ b/crates/biome_flags/src/lib.rs
@@ -52,7 +52,7 @@ impl BiomeEnv {
             "What the log should look like. Possible values: pretty, compact, json. Default: pretty.",
         ),
         &BiomeEnvVariable::new("BIOME_CONFIG_PATH", "A path to the configuration file"),
-        &BiomeEnvVariable::new("BIOME_THREADS", "The number of threads to use in CI."),
+        &BiomeEnvVariable::new("BIOME_THREADS", "The number of threads to use in the CLI."),
         &BiomeEnvVariable::new(
             "BIOME_WATCHER_KIND",
             "The kind of watcher to use. Possible values: polling, recommended, none. Default: recommended.",


### PR DESCRIPTION
## Summary

Adds `--threads` and `BIOME_THREADS` support to `biome check`.

Local pre-commit and lint-staged workflows often need `check --write` so Biome can apply safe fixes, but they may still need to bound worker count on large machines. This exposes the same thread control for `check` without requiring users to rely on `RAYON_NUM_THREADS`.

> This PR was implemented with assistance from OpenAI Codex in a local checkout. The solution was reviewed and validated by the contributor.

## Test Plan

- `cargo format`
- `pnpm format`
- `cargo lint`
- `cargo test -p biome_cli check_help --test main`
- `cargo test -p biome_cli ci_help --test main`
- `./target/debug/biome check --threads=1 --reporter=summary crates packages`
- `BIOME_THREADS=1 ./target/debug/biome check --reporter=summary crates packages`

## Docs

CLI help and a changeset are included. No website PR has been opened yet.
