### PR TITLE
fix(css-parser): allow comma-separated selector lists inside :global() and :local()

### DIFF
--- a/.changeset/seven-schools-shine.md
+++ b/.changeset/seven-schools-shine.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the CSS parser rejecting comma-separated selector lists inside `:global()` and `:local()` pseudo-class functions. Biome now correctly parses `:global(.foo, .bar)`.

--- a/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_selector.rs
+++ b/crates/biome_css_parser/src/syntax/selector/pseudo_class/function_selector.rs
@@ -4,17 +4,14 @@ use crate::syntax::css_modules::{
     slotted_or_deep_not_allowed,
 };
 use crate::syntax::parse_error::expected_selector;
-use crate::syntax::selector::{
-    eat_or_recover_selector_function_close_token, parse_selector,
-    recover_selector_function_parameter,
-};
+use crate::syntax::selector::{SelectorList, eat_or_recover_selector_function_close_token};
 use crate::syntax::{CssSyntaxFeatures, parse_regular_identifier};
-use biome_css_syntax::CssSyntaxKind::CSS_PSEUDO_CLASS_FUNCTION_SELECTOR;
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::T;
+use biome_parser::parse_lists::ParseSeparatedList;
 use biome_parser::parsed_syntax::ParsedSyntax;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
-use biome_parser::{Parser, SyntaxFeature};
+use biome_parser::{Parser, SyntaxFeature, token_set};
 
 /// Checks if the current parser position is at a pseudo-class function selector for CSS Modules and SFC Vue.
 ///
@@ -69,19 +66,23 @@ fn parse_pseudo_selector(p: &mut CssParser) -> ParsedSyntax {
     parse_regular_identifier(p).ok();
     p.bump(T!['(']);
 
-    let kind = match parse_selector(p) {
-        Present(selector) => {
-            if eat_or_recover_selector_function_close_token(p, selector, expected_selector) {
-                CSS_PSEUDO_CLASS_FUNCTION_SELECTOR
-            } else {
-                CSS_BOGUS_PSEUDO_CLASS
-            }
-        }
-        Absent => {
-            recover_selector_function_parameter(p, expected_selector);
-            p.expect(T![')']);
-            CSS_BOGUS_PSEUDO_CLASS
-        }
+    let list = SelectorList::default()
+        .with_end_kind_ts(token_set!(T![')']))
+        .disable_recovery()
+        .parse_list(p);
+    let list_range = list.range(p);
+
+    if list_range.is_empty() && p.at(T![')']) {
+        let diagnostic = expected_selector(p, list_range);
+        p.error(diagnostic);
+    }
+
+    let kind = if eat_or_recover_selector_function_close_token(p, list, expected_selector)
+        && !list_range.is_empty()
+    {
+        CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST
+    } else {
+        CSS_BOGUS_PSEUDO_CLASS
     };
 
     Present(m.complete(p, kind))

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/disabled/pseudo_class_function_selector_disabled.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/disabled/pseudo_class_function_selector_disabled.css
@@ -3,7 +3,6 @@
 :global(.class div) .div {}
 :global( {}
 :global() {}
-:global(.div, .class) {}
 :global(.div, .class {}
 :global(.div .class {}
 :global(.div .class

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/disabled/pseudo_class_function_selector_disabled.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/disabled/pseudo_class_function_selector_disabled.css.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
-assertion_line: 208
+assertion_line: 206
 expression: snapshot
 ---
 
@@ -12,7 +12,6 @@ expression: snapshot
 :global(.class div) .div {}
 :global( {}
 :global() {}
-:global(.div, .class) {}
 :global(.div, .class {}
 :global(.div .class {}
 :global(.div .class
@@ -40,31 +39,33 @@ CssRoot {
                                         value_token: IDENT@1..7 "global" [] [],
                                     },
                                     L_PAREN@7..8 "(" [] [],
-                                    CssComplexSelector {
-                                        left: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@8..9 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@9..14 "class" [] [],
+                                    CssSelectorList [
+                                        CssComplexSelector {
+                                            left: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@8..9 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@9..14 "class" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            combinator: CSS_SPACE_LITERAL@14..15 " " [] [],
+                                            right: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: CssTypeSelector {
+                                                    namespace: missing (optional),
+                                                    ident: CssIdentifier {
+                                                        value_token: IDENT@15..18 "div" [] [],
                                                     },
                                                 },
-                                            ],
-                                        },
-                                        combinator: CSS_SPACE_LITERAL@14..15 " " [] [],
-                                        right: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: CssTypeSelector {
-                                                namespace: missing (optional),
-                                                ident: CssIdentifier {
-                                                    value_token: IDENT@15..18 "div" [] [],
-                                                },
+                                                sub_selectors: CssSubSelectorList [],
                                             },
-                                            sub_selectors: CssSubSelectorList [],
                                         },
-                                    },
+                                    ],
                                     R_PAREN@18..20 ")" [] [Whitespace(" ")],
                                 ],
                             },
@@ -92,46 +93,48 @@ CssRoot {
                                         value_token: IDENT@24..29 "local" [] [],
                                     },
                                     L_PAREN@29..30 "(" [] [],
-                                    CssComplexSelector {
-                                        left: CssComplexSelector {
-                                            left: CssCompoundSelector {
+                                    CssSelectorList [
+                                        CssComplexSelector {
+                                            left: CssComplexSelector {
+                                                left: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: missing (optional),
+                                                    sub_selectors: CssSubSelectorList [
+                                                        CssClassSelector {
+                                                            dot_token: DOT@30..31 "." [] [],
+                                                            name: CssCustomIdentifier {
+                                                                value_token: IDENT@31..36 "class" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                combinator: CSS_SPACE_LITERAL@36..37 " " [] [],
+                                                right: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: CssTypeSelector {
+                                                        namespace: missing (optional),
+                                                        ident: CssIdentifier {
+                                                            value_token: IDENT@37..41 "div" [] [Whitespace(" ")],
+                                                        },
+                                                    },
+                                                    sub_selectors: CssSubSelectorList [],
+                                                },
+                                            },
+                                            combinator: PLUS@41..43 "+" [] [Whitespace(" ")],
+                                            right: CssCompoundSelector {
                                                 nesting_selectors: CssNestedSelectorList [],
                                                 simple_selector: missing (optional),
                                                 sub_selectors: CssSubSelectorList [
-                                                    CssClassSelector {
-                                                        dot_token: DOT@30..31 "." [] [],
+                                                    CssIdSelector {
+                                                        hash_token: HASH@43..44 "#" [] [],
                                                         name: CssCustomIdentifier {
-                                                            value_token: IDENT@31..36 "class" [] [],
+                                                            value_token: IDENT@44..46 "id" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            combinator: CSS_SPACE_LITERAL@36..37 " " [] [],
-                                            right: CssCompoundSelector {
-                                                nesting_selectors: CssNestedSelectorList [],
-                                                simple_selector: CssTypeSelector {
-                                                    namespace: missing (optional),
-                                                    ident: CssIdentifier {
-                                                        value_token: IDENT@37..41 "div" [] [Whitespace(" ")],
-                                                    },
-                                                },
-                                                sub_selectors: CssSubSelectorList [],
-                                            },
                                         },
-                                        combinator: PLUS@41..43 "+" [] [Whitespace(" ")],
-                                        right: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssIdSelector {
-                                                    hash_token: HASH@43..44 "#" [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@44..46 "id" [] [],
-                                                    },
-                                                },
-                                            ],
-                                        },
-                                    },
+                                    ],
                                     R_PAREN@46..48 ")" [] [Whitespace(" ")],
                                 ],
                             },
@@ -160,31 +163,33 @@ CssRoot {
                                             value_token: IDENT@52..58 "global" [] [],
                                         },
                                         L_PAREN@58..59 "(" [] [],
-                                        CssComplexSelector {
-                                            left: CssCompoundSelector {
-                                                nesting_selectors: CssNestedSelectorList [],
-                                                simple_selector: missing (optional),
-                                                sub_selectors: CssSubSelectorList [
-                                                    CssClassSelector {
-                                                        dot_token: DOT@59..60 "." [] [],
-                                                        name: CssCustomIdentifier {
-                                                            value_token: IDENT@60..65 "class" [] [],
+                                        CssSelectorList [
+                                            CssComplexSelector {
+                                                left: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: missing (optional),
+                                                    sub_selectors: CssSubSelectorList [
+                                                        CssClassSelector {
+                                                            dot_token: DOT@59..60 "." [] [],
+                                                            name: CssCustomIdentifier {
+                                                                value_token: IDENT@60..65 "class" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                combinator: CSS_SPACE_LITERAL@65..66 " " [] [],
+                                                right: CssCompoundSelector {
+                                                    nesting_selectors: CssNestedSelectorList [],
+                                                    simple_selector: CssTypeSelector {
+                                                        namespace: missing (optional),
+                                                        ident: CssIdentifier {
+                                                            value_token: IDENT@66..69 "div" [] [],
                                                         },
                                                     },
-                                                ],
-                                            },
-                                            combinator: CSS_SPACE_LITERAL@65..66 " " [] [],
-                                            right: CssCompoundSelector {
-                                                nesting_selectors: CssNestedSelectorList [],
-                                                simple_selector: CssTypeSelector {
-                                                    namespace: missing (optional),
-                                                    ident: CssIdentifier {
-                                                        value_token: IDENT@66..69 "div" [] [],
-                                                    },
+                                                    sub_selectors: CssSubSelectorList [],
                                                 },
-                                                sub_selectors: CssSubSelectorList [],
                                             },
-                                        },
+                                        ],
                                         R_PAREN@69..70 ")" [] [],
                                     ],
                                 },
@@ -226,6 +231,7 @@ CssRoot {
                                         value_token: IDENT@80..86 "global" [] [],
                                     },
                                     L_PAREN@86..88 "(" [] [Whitespace(" ")],
+                                    CssSelectorList [],
                                 ],
                             },
                         },
@@ -252,6 +258,7 @@ CssRoot {
                                         value_token: IDENT@92..98 "global" [] [],
                                     },
                                     L_PAREN@98..99 "(" [] [],
+                                    CssSelectorList [],
                                     R_PAREN@99..101 ")" [] [Whitespace(" ")],
                                 ],
                             },
@@ -279,71 +286,88 @@ CssRoot {
                                         value_token: IDENT@105..111 "global" [] [],
                                     },
                                     L_PAREN@111..112 "(" [] [],
-                                    CssCompoundSelector {
-                                        nesting_selectors: CssNestedSelectorList [],
-                                        simple_selector: missing (optional),
-                                        sub_selectors: CssSubSelectorList [
-                                            CssClassSelector {
-                                                dot_token: DOT@112..113 "." [] [],
-                                                name: CssCustomIdentifier {
-                                                    value_token: IDENT@113..116 "div" [] [],
+                                    CssSelectorList [
+                                        CssCompoundSelector {
+                                            nesting_selectors: CssNestedSelectorList [],
+                                            simple_selector: missing (optional),
+                                            sub_selectors: CssSubSelectorList [
+                                                CssClassSelector {
+                                                    dot_token: DOT@112..113 "." [] [],
+                                                    name: CssCustomIdentifier {
+                                                        value_token: IDENT@113..116 "div" [] [],
+                                                    },
                                                 },
+                                            ],
+                                        },
+                                        COMMA@116..118 "," [] [Whitespace(" ")],
+                                        CssCompoundSelector {
+                                            nesting_selectors: CssNestedSelectorList [],
+                                            simple_selector: missing (optional),
+                                            sub_selectors: CssSubSelectorList [
+                                                CssClassSelector {
+                                                    dot_token: DOT@118..119 "." [] [],
+                                                    name: CssCustomIdentifier {
+                                                        value_token: IDENT@119..125 "class" [] [Whitespace(" ")],
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@125..126 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@126..127 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssPseudoClassSelector {
+                            colon_token: COLON@127..129 ":" [Newline("\n")] [],
+                            class: CssBogusPseudoClass {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@129..135 "global" [] [],
+                                    },
+                                    L_PAREN@135..136 "(" [] [],
+                                    CssSelectorList [
+                                        CssComplexSelector {
+                                            left: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@136..137 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@137..140 "div" [] [],
+                                                        },
+                                                    },
+                                                ],
                                             },
-                                        ],
-                                    },
-                                    CssBogus {
-                                        items: [
-                                            COMMA@116..118 "," [] [Whitespace(" ")],
-                                            DOT@118..119 "." [] [],
-                                            IDENT@119..124 "class" [] [],
-                                        ],
-                                    },
-                                    R_PAREN@124..126 ")" [] [Whitespace(" ")],
-                                ],
-                            },
-                        },
-                    ],
-                },
-            ],
-            block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@126..127 "{" [] [],
-                items: CssDeclarationOrRuleList [],
-                r_curly_token: R_CURLY@127..128 "}" [] [],
-            },
-        },
-        CssQualifiedRule {
-            prelude: CssSelectorList [
-                CssCompoundSelector {
-                    nesting_selectors: CssNestedSelectorList [],
-                    simple_selector: missing (optional),
-                    sub_selectors: CssSubSelectorList [
-                        CssPseudoClassSelector {
-                            colon_token: COLON@128..130 ":" [Newline("\n")] [],
-                            class: CssBogusPseudoClass {
-                                items: [
-                                    CssIdentifier {
-                                        value_token: IDENT@130..136 "global" [] [],
-                                    },
-                                    L_PAREN@136..137 "(" [] [],
-                                    CssCompoundSelector {
-                                        nesting_selectors: CssNestedSelectorList [],
-                                        simple_selector: missing (optional),
-                                        sub_selectors: CssSubSelectorList [
-                                            CssClassSelector {
-                                                dot_token: DOT@137..138 "." [] [],
-                                                name: CssCustomIdentifier {
-                                                    value_token: IDENT@138..141 "div" [] [],
-                                                },
+                                            combinator: CSS_SPACE_LITERAL@140..141 " " [] [],
+                                            right: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@141..142 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@142..148 "class" [] [Whitespace(" ")],
+                                                        },
+                                                    },
+                                                ],
                                             },
-                                        ],
-                                    },
-                                    CssBogus {
-                                        items: [
-                                            COMMA@141..143 "," [] [Whitespace(" ")],
-                                            DOT@143..144 "." [] [],
-                                            IDENT@144..150 "class" [] [Whitespace(" ")],
-                                        ],
-                                    },
+                                        },
+                                    ],
                                 ],
                             },
                         },
@@ -351,9 +375,9 @@ CssRoot {
                 },
             ],
             block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@150..151 "{" [] [],
+                l_curly_token: L_CURLY@148..149 "{" [] [],
                 items: CssDeclarationOrRuleList [],
-                r_curly_token: R_CURLY@151..152 "}" [] [],
+                r_curly_token: R_CURLY@149..150 "}" [] [],
             },
         },
         CssQualifiedRule {
@@ -363,93 +387,42 @@ CssRoot {
                     simple_selector: missing (optional),
                     sub_selectors: CssSubSelectorList [
                         CssPseudoClassSelector {
-                            colon_token: COLON@152..154 ":" [Newline("\n")] [],
+                            colon_token: COLON@150..152 ":" [Newline("\n")] [],
                             class: CssBogusPseudoClass {
                                 items: [
                                     CssIdentifier {
-                                        value_token: IDENT@154..160 "global" [] [],
+                                        value_token: IDENT@152..158 "global" [] [],
                                     },
-                                    L_PAREN@160..161 "(" [] [],
-                                    CssComplexSelector {
-                                        left: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@161..162 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@162..165 "div" [] [],
+                                    L_PAREN@158..159 "(" [] [],
+                                    CssSelectorList [
+                                        CssComplexSelector {
+                                            left: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@159..160 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@160..163 "div" [] [],
+                                                        },
                                                     },
-                                                },
-                                            ],
-                                        },
-                                        combinator: CSS_SPACE_LITERAL@165..166 " " [] [],
-                                        right: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@166..167 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@167..173 "class" [] [Whitespace(" ")],
+                                                ],
+                                            },
+                                            combinator: CSS_SPACE_LITERAL@163..164 " " [] [],
+                                            right: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@164..165 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@165..170 "class" [] [],
+                                                        },
                                                     },
-                                                },
-                                            ],
+                                                ],
+                                            },
                                         },
-                                    },
-                                ],
-                            },
-                        },
-                    ],
-                },
-            ],
-            block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@173..174 "{" [] [],
-                items: CssDeclarationOrRuleList [],
-                r_curly_token: R_CURLY@174..175 "}" [] [],
-            },
-        },
-        CssQualifiedRule {
-            prelude: CssSelectorList [
-                CssCompoundSelector {
-                    nesting_selectors: CssNestedSelectorList [],
-                    simple_selector: missing (optional),
-                    sub_selectors: CssSubSelectorList [
-                        CssPseudoClassSelector {
-                            colon_token: COLON@175..177 ":" [Newline("\n")] [],
-                            class: CssBogusPseudoClass {
-                                items: [
-                                    CssIdentifier {
-                                        value_token: IDENT@177..183 "global" [] [],
-                                    },
-                                    L_PAREN@183..184 "(" [] [],
-                                    CssComplexSelector {
-                                        left: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@184..185 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@185..188 "div" [] [],
-                                                    },
-                                                },
-                                            ],
-                                        },
-                                        combinator: CSS_SPACE_LITERAL@188..189 " " [] [],
-                                        right: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@189..190 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@190..195 "class" [] [],
-                                                    },
-                                                },
-                                            ],
-                                        },
-                                    },
+                                    ],
                                 ],
                             },
                         },
@@ -461,16 +434,16 @@ CssRoot {
             },
         },
     ],
-    eof_token: EOF@195..196 "" [Newline("\n")] [],
+    eof_token: EOF@170..171 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..196
+0: CSS_ROOT@0..171
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..195
+  1: CSS_ROOT_ITEM_LIST@0..170
     0: CSS_QUALIFIED_RULE@0..22
       0: CSS_SELECTOR_LIST@0..20
         0: CSS_COMPOUND_SELECTOR@0..20
@@ -483,23 +456,24 @@ CssRoot {
                 0: CSS_IDENTIFIER@1..7
                   0: IDENT@1..7 "global" [] []
                 1: L_PAREN@7..8 "(" [] []
-                2: CSS_COMPLEX_SELECTOR@8..18
-                  0: CSS_COMPOUND_SELECTOR@8..14
-                    0: CSS_NESTED_SELECTOR_LIST@8..8
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@8..14
-                      0: CSS_CLASS_SELECTOR@8..14
-                        0: DOT@8..9 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@9..14
-                          0: IDENT@9..14 "class" [] []
-                  1: CSS_SPACE_LITERAL@14..15 " " [] []
-                  2: CSS_COMPOUND_SELECTOR@15..18
-                    0: CSS_NESTED_SELECTOR_LIST@15..15
-                    1: CSS_TYPE_SELECTOR@15..18
-                      0: (empty)
-                      1: CSS_IDENTIFIER@15..18
-                        0: IDENT@15..18 "div" [] []
-                    2: CSS_SUB_SELECTOR_LIST@18..18
+                2: CSS_SELECTOR_LIST@8..18
+                  0: CSS_COMPLEX_SELECTOR@8..18
+                    0: CSS_COMPOUND_SELECTOR@8..14
+                      0: CSS_NESTED_SELECTOR_LIST@8..8
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@8..14
+                        0: CSS_CLASS_SELECTOR@8..14
+                          0: DOT@8..9 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@9..14
+                            0: IDENT@9..14 "class" [] []
+                    1: CSS_SPACE_LITERAL@14..15 " " [] []
+                    2: CSS_COMPOUND_SELECTOR@15..18
+                      0: CSS_NESTED_SELECTOR_LIST@15..15
+                      1: CSS_TYPE_SELECTOR@15..18
+                        0: (empty)
+                        1: CSS_IDENTIFIER@15..18
+                          0: IDENT@15..18 "div" [] []
+                      2: CSS_SUB_SELECTOR_LIST@18..18
                 3: R_PAREN@18..20 ")" [] [Whitespace(" ")]
       1: CSS_DECLARATION_OR_RULE_BLOCK@20..22
         0: L_CURLY@20..21 "{" [] []
@@ -517,33 +491,34 @@ CssRoot {
                 0: CSS_IDENTIFIER@24..29
                   0: IDENT@24..29 "local" [] []
                 1: L_PAREN@29..30 "(" [] []
-                2: CSS_COMPLEX_SELECTOR@30..46
-                  0: CSS_COMPLEX_SELECTOR@30..41
-                    0: CSS_COMPOUND_SELECTOR@30..36
-                      0: CSS_NESTED_SELECTOR_LIST@30..30
+                2: CSS_SELECTOR_LIST@30..46
+                  0: CSS_COMPLEX_SELECTOR@30..46
+                    0: CSS_COMPLEX_SELECTOR@30..41
+                      0: CSS_COMPOUND_SELECTOR@30..36
+                        0: CSS_NESTED_SELECTOR_LIST@30..30
+                        1: (empty)
+                        2: CSS_SUB_SELECTOR_LIST@30..36
+                          0: CSS_CLASS_SELECTOR@30..36
+                            0: DOT@30..31 "." [] []
+                            1: CSS_CUSTOM_IDENTIFIER@31..36
+                              0: IDENT@31..36 "class" [] []
+                      1: CSS_SPACE_LITERAL@36..37 " " [] []
+                      2: CSS_COMPOUND_SELECTOR@37..41
+                        0: CSS_NESTED_SELECTOR_LIST@37..37
+                        1: CSS_TYPE_SELECTOR@37..41
+                          0: (empty)
+                          1: CSS_IDENTIFIER@37..41
+                            0: IDENT@37..41 "div" [] [Whitespace(" ")]
+                        2: CSS_SUB_SELECTOR_LIST@41..41
+                    1: PLUS@41..43 "+" [] [Whitespace(" ")]
+                    2: CSS_COMPOUND_SELECTOR@43..46
+                      0: CSS_NESTED_SELECTOR_LIST@43..43
                       1: (empty)
-                      2: CSS_SUB_SELECTOR_LIST@30..36
-                        0: CSS_CLASS_SELECTOR@30..36
-                          0: DOT@30..31 "." [] []
-                          1: CSS_CUSTOM_IDENTIFIER@31..36
-                            0: IDENT@31..36 "class" [] []
-                    1: CSS_SPACE_LITERAL@36..37 " " [] []
-                    2: CSS_COMPOUND_SELECTOR@37..41
-                      0: CSS_NESTED_SELECTOR_LIST@37..37
-                      1: CSS_TYPE_SELECTOR@37..41
-                        0: (empty)
-                        1: CSS_IDENTIFIER@37..41
-                          0: IDENT@37..41 "div" [] [Whitespace(" ")]
-                      2: CSS_SUB_SELECTOR_LIST@41..41
-                  1: PLUS@41..43 "+" [] [Whitespace(" ")]
-                  2: CSS_COMPOUND_SELECTOR@43..46
-                    0: CSS_NESTED_SELECTOR_LIST@43..43
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@43..46
-                      0: CSS_ID_SELECTOR@43..46
-                        0: HASH@43..44 "#" [] []
-                        1: CSS_CUSTOM_IDENTIFIER@44..46
-                          0: IDENT@44..46 "id" [] []
+                      2: CSS_SUB_SELECTOR_LIST@43..46
+                        0: CSS_ID_SELECTOR@43..46
+                          0: HASH@43..44 "#" [] []
+                          1: CSS_CUSTOM_IDENTIFIER@44..46
+                            0: IDENT@44..46 "id" [] []
                 3: R_PAREN@46..48 ")" [] [Whitespace(" ")]
       1: CSS_DECLARATION_OR_RULE_BLOCK@48..50
         0: L_CURLY@48..49 "{" [] []
@@ -562,23 +537,24 @@ CssRoot {
                   0: CSS_IDENTIFIER@52..58
                     0: IDENT@52..58 "global" [] []
                   1: L_PAREN@58..59 "(" [] []
-                  2: CSS_COMPLEX_SELECTOR@59..69
-                    0: CSS_COMPOUND_SELECTOR@59..65
-                      0: CSS_NESTED_SELECTOR_LIST@59..59
-                      1: (empty)
-                      2: CSS_SUB_SELECTOR_LIST@59..65
-                        0: CSS_CLASS_SELECTOR@59..65
-                          0: DOT@59..60 "." [] []
-                          1: CSS_CUSTOM_IDENTIFIER@60..65
-                            0: IDENT@60..65 "class" [] []
-                    1: CSS_SPACE_LITERAL@65..66 " " [] []
-                    2: CSS_COMPOUND_SELECTOR@66..69
-                      0: CSS_NESTED_SELECTOR_LIST@66..66
-                      1: CSS_TYPE_SELECTOR@66..69
-                        0: (empty)
-                        1: CSS_IDENTIFIER@66..69
-                          0: IDENT@66..69 "div" [] []
-                      2: CSS_SUB_SELECTOR_LIST@69..69
+                  2: CSS_SELECTOR_LIST@59..69
+                    0: CSS_COMPLEX_SELECTOR@59..69
+                      0: CSS_COMPOUND_SELECTOR@59..65
+                        0: CSS_NESTED_SELECTOR_LIST@59..59
+                        1: (empty)
+                        2: CSS_SUB_SELECTOR_LIST@59..65
+                          0: CSS_CLASS_SELECTOR@59..65
+                            0: DOT@59..60 "." [] []
+                            1: CSS_CUSTOM_IDENTIFIER@60..65
+                              0: IDENT@60..65 "class" [] []
+                      1: CSS_SPACE_LITERAL@65..66 " " [] []
+                      2: CSS_COMPOUND_SELECTOR@66..69
+                        0: CSS_NESTED_SELECTOR_LIST@66..66
+                        1: CSS_TYPE_SELECTOR@66..69
+                          0: (empty)
+                          1: CSS_IDENTIFIER@66..69
+                            0: IDENT@66..69 "div" [] []
+                        2: CSS_SUB_SELECTOR_LIST@69..69
                   3: R_PAREN@69..70 ")" [] []
           1: CSS_SPACE_LITERAL@70..71 " " [] []
           2: CSS_COMPOUND_SELECTOR@71..76
@@ -605,6 +581,7 @@ CssRoot {
                 0: CSS_IDENTIFIER@80..86
                   0: IDENT@80..86 "global" [] []
                 1: L_PAREN@86..88 "(" [] [Whitespace(" ")]
+                2: CSS_SELECTOR_LIST@88..88
       1: CSS_DECLARATION_OR_RULE_BLOCK@88..90
         0: L_CURLY@88..89 "{" [] []
         1: CSS_DECLARATION_OR_RULE_LIST@89..89
@@ -621,134 +598,114 @@ CssRoot {
                 0: CSS_IDENTIFIER@92..98
                   0: IDENT@92..98 "global" [] []
                 1: L_PAREN@98..99 "(" [] []
-                2: R_PAREN@99..101 ")" [] [Whitespace(" ")]
+                2: CSS_SELECTOR_LIST@99..99
+                3: R_PAREN@99..101 ")" [] [Whitespace(" ")]
       1: CSS_DECLARATION_OR_RULE_BLOCK@101..103
         0: L_CURLY@101..102 "{" [] []
         1: CSS_DECLARATION_OR_RULE_LIST@102..102
         2: R_CURLY@102..103 "}" [] []
-    5: CSS_QUALIFIED_RULE@103..128
-      0: CSS_SELECTOR_LIST@103..126
-        0: CSS_COMPOUND_SELECTOR@103..126
+    5: CSS_QUALIFIED_RULE@103..127
+      0: CSS_SELECTOR_LIST@103..125
+        0: CSS_COMPOUND_SELECTOR@103..125
           0: CSS_NESTED_SELECTOR_LIST@103..103
           1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@103..126
-            0: CSS_PSEUDO_CLASS_SELECTOR@103..126
+          2: CSS_SUB_SELECTOR_LIST@103..125
+            0: CSS_PSEUDO_CLASS_SELECTOR@103..125
               0: COLON@103..105 ":" [Newline("\n")] []
-              1: CSS_BOGUS_PSEUDO_CLASS@105..126
+              1: CSS_BOGUS_PSEUDO_CLASS@105..125
                 0: CSS_IDENTIFIER@105..111
                   0: IDENT@105..111 "global" [] []
                 1: L_PAREN@111..112 "(" [] []
-                2: CSS_COMPOUND_SELECTOR@112..116
-                  0: CSS_NESTED_SELECTOR_LIST@112..112
-                  1: (empty)
-                  2: CSS_SUB_SELECTOR_LIST@112..116
-                    0: CSS_CLASS_SELECTOR@112..116
-                      0: DOT@112..113 "." [] []
-                      1: CSS_CUSTOM_IDENTIFIER@113..116
-                        0: IDENT@113..116 "div" [] []
-                3: CSS_BOGUS@116..124
-                  0: COMMA@116..118 "," [] [Whitespace(" ")]
-                  1: DOT@118..119 "." [] []
-                  2: IDENT@119..124 "class" [] []
-                4: R_PAREN@124..126 ")" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@126..128
-        0: L_CURLY@126..127 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@127..127
-        2: R_CURLY@127..128 "}" [] []
-    6: CSS_QUALIFIED_RULE@128..152
-      0: CSS_SELECTOR_LIST@128..150
-        0: CSS_COMPOUND_SELECTOR@128..150
-          0: CSS_NESTED_SELECTOR_LIST@128..128
+                2: CSS_SELECTOR_LIST@112..125
+                  0: CSS_COMPOUND_SELECTOR@112..116
+                    0: CSS_NESTED_SELECTOR_LIST@112..112
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@112..116
+                      0: CSS_CLASS_SELECTOR@112..116
+                        0: DOT@112..113 "." [] []
+                        1: CSS_CUSTOM_IDENTIFIER@113..116
+                          0: IDENT@113..116 "div" [] []
+                  1: COMMA@116..118 "," [] [Whitespace(" ")]
+                  2: CSS_COMPOUND_SELECTOR@118..125
+                    0: CSS_NESTED_SELECTOR_LIST@118..118
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@118..125
+                      0: CSS_CLASS_SELECTOR@118..125
+                        0: DOT@118..119 "." [] []
+                        1: CSS_CUSTOM_IDENTIFIER@119..125
+                          0: IDENT@119..125 "class" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@125..127
+        0: L_CURLY@125..126 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@126..126
+        2: R_CURLY@126..127 "}" [] []
+    6: CSS_QUALIFIED_RULE@127..150
+      0: CSS_SELECTOR_LIST@127..148
+        0: CSS_COMPOUND_SELECTOR@127..148
+          0: CSS_NESTED_SELECTOR_LIST@127..127
           1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@128..150
-            0: CSS_PSEUDO_CLASS_SELECTOR@128..150
-              0: COLON@128..130 ":" [Newline("\n")] []
-              1: CSS_BOGUS_PSEUDO_CLASS@130..150
-                0: CSS_IDENTIFIER@130..136
-                  0: IDENT@130..136 "global" [] []
-                1: L_PAREN@136..137 "(" [] []
-                2: CSS_COMPOUND_SELECTOR@137..141
-                  0: CSS_NESTED_SELECTOR_LIST@137..137
-                  1: (empty)
-                  2: CSS_SUB_SELECTOR_LIST@137..141
-                    0: CSS_CLASS_SELECTOR@137..141
-                      0: DOT@137..138 "." [] []
-                      1: CSS_CUSTOM_IDENTIFIER@138..141
-                        0: IDENT@138..141 "div" [] []
-                3: CSS_BOGUS@141..150
-                  0: COMMA@141..143 "," [] [Whitespace(" ")]
-                  1: DOT@143..144 "." [] []
-                  2: IDENT@144..150 "class" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@150..152
-        0: L_CURLY@150..151 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@151..151
-        2: R_CURLY@151..152 "}" [] []
-    7: CSS_QUALIFIED_RULE@152..175
-      0: CSS_SELECTOR_LIST@152..173
-        0: CSS_COMPOUND_SELECTOR@152..173
-          0: CSS_NESTED_SELECTOR_LIST@152..152
+          2: CSS_SUB_SELECTOR_LIST@127..148
+            0: CSS_PSEUDO_CLASS_SELECTOR@127..148
+              0: COLON@127..129 ":" [Newline("\n")] []
+              1: CSS_BOGUS_PSEUDO_CLASS@129..148
+                0: CSS_IDENTIFIER@129..135
+                  0: IDENT@129..135 "global" [] []
+                1: L_PAREN@135..136 "(" [] []
+                2: CSS_SELECTOR_LIST@136..148
+                  0: CSS_COMPLEX_SELECTOR@136..148
+                    0: CSS_COMPOUND_SELECTOR@136..140
+                      0: CSS_NESTED_SELECTOR_LIST@136..136
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@136..140
+                        0: CSS_CLASS_SELECTOR@136..140
+                          0: DOT@136..137 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@137..140
+                            0: IDENT@137..140 "div" [] []
+                    1: CSS_SPACE_LITERAL@140..141 " " [] []
+                    2: CSS_COMPOUND_SELECTOR@141..148
+                      0: CSS_NESTED_SELECTOR_LIST@141..141
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@141..148
+                        0: CSS_CLASS_SELECTOR@141..148
+                          0: DOT@141..142 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@142..148
+                            0: IDENT@142..148 "class" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@148..150
+        0: L_CURLY@148..149 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@149..149
+        2: R_CURLY@149..150 "}" [] []
+    7: CSS_QUALIFIED_RULE@150..170
+      0: CSS_SELECTOR_LIST@150..170
+        0: CSS_COMPOUND_SELECTOR@150..170
+          0: CSS_NESTED_SELECTOR_LIST@150..150
           1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@152..173
-            0: CSS_PSEUDO_CLASS_SELECTOR@152..173
-              0: COLON@152..154 ":" [Newline("\n")] []
-              1: CSS_BOGUS_PSEUDO_CLASS@154..173
-                0: CSS_IDENTIFIER@154..160
-                  0: IDENT@154..160 "global" [] []
-                1: L_PAREN@160..161 "(" [] []
-                2: CSS_COMPLEX_SELECTOR@161..173
-                  0: CSS_COMPOUND_SELECTOR@161..165
-                    0: CSS_NESTED_SELECTOR_LIST@161..161
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@161..165
-                      0: CSS_CLASS_SELECTOR@161..165
-                        0: DOT@161..162 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@162..165
-                          0: IDENT@162..165 "div" [] []
-                  1: CSS_SPACE_LITERAL@165..166 " " [] []
-                  2: CSS_COMPOUND_SELECTOR@166..173
-                    0: CSS_NESTED_SELECTOR_LIST@166..166
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@166..173
-                      0: CSS_CLASS_SELECTOR@166..173
-                        0: DOT@166..167 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@167..173
-                          0: IDENT@167..173 "class" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@173..175
-        0: L_CURLY@173..174 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@174..174
-        2: R_CURLY@174..175 "}" [] []
-    8: CSS_QUALIFIED_RULE@175..195
-      0: CSS_SELECTOR_LIST@175..195
-        0: CSS_COMPOUND_SELECTOR@175..195
-          0: CSS_NESTED_SELECTOR_LIST@175..175
-          1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@175..195
-            0: CSS_PSEUDO_CLASS_SELECTOR@175..195
-              0: COLON@175..177 ":" [Newline("\n")] []
-              1: CSS_BOGUS_PSEUDO_CLASS@177..195
-                0: CSS_IDENTIFIER@177..183
-                  0: IDENT@177..183 "global" [] []
-                1: L_PAREN@183..184 "(" [] []
-                2: CSS_COMPLEX_SELECTOR@184..195
-                  0: CSS_COMPOUND_SELECTOR@184..188
-                    0: CSS_NESTED_SELECTOR_LIST@184..184
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@184..188
-                      0: CSS_CLASS_SELECTOR@184..188
-                        0: DOT@184..185 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@185..188
-                          0: IDENT@185..188 "div" [] []
-                  1: CSS_SPACE_LITERAL@188..189 " " [] []
-                  2: CSS_COMPOUND_SELECTOR@189..195
-                    0: CSS_NESTED_SELECTOR_LIST@189..189
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@189..195
-                      0: CSS_CLASS_SELECTOR@189..195
-                        0: DOT@189..190 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@190..195
-                          0: IDENT@190..195 "class" [] []
-      1: CSS_BOGUS_BLOCK@195..195
-  2: EOF@195..196 "" [Newline("\n")] []
+          2: CSS_SUB_SELECTOR_LIST@150..170
+            0: CSS_PSEUDO_CLASS_SELECTOR@150..170
+              0: COLON@150..152 ":" [Newline("\n")] []
+              1: CSS_BOGUS_PSEUDO_CLASS@152..170
+                0: CSS_IDENTIFIER@152..158
+                  0: IDENT@152..158 "global" [] []
+                1: L_PAREN@158..159 "(" [] []
+                2: CSS_SELECTOR_LIST@159..170
+                  0: CSS_COMPLEX_SELECTOR@159..170
+                    0: CSS_COMPOUND_SELECTOR@159..163
+                      0: CSS_NESTED_SELECTOR_LIST@159..159
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@159..163
+                        0: CSS_CLASS_SELECTOR@159..163
+                          0: DOT@159..160 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@160..163
+                            0: IDENT@160..163 "div" [] []
+                    1: CSS_SPACE_LITERAL@163..164 " " [] []
+                    2: CSS_COMPOUND_SELECTOR@164..170
+                      0: CSS_NESTED_SELECTOR_LIST@164..164
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@164..170
+                        0: CSS_CLASS_SELECTOR@164..170
+                          0: DOT@164..165 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@165..170
+                            0: IDENT@165..170 "class" [] []
+      1: CSS_BOGUS_BLOCK@170..170
+  2: EOF@170..171 "" [Newline("\n")] []
 
 ```
 
@@ -800,7 +757,7 @@ pseudo_class_function_selector_disabled.css:4:2 parse ━━━━━━━━�
   > 4 │ :global( {}
       │  ^^^^^^^
     5 │ :global() {}
-    6 │ :global(.div, .class) {}
+    6 │ :global(.div, .class {}
   
   i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
@@ -812,8 +769,8 @@ pseudo_class_function_selector_disabled.css:5:2 parse ━━━━━━━━�
     4 │ :global( {}
   > 5 │ :global() {}
       │  ^^^^^^^^
-    6 │ :global(.div, .class) {}
-    7 │ :global(.div, .class {}
+    6 │ :global(.div, .class {}
+    7 │ :global(.div .class {}
   
   i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
@@ -823,10 +780,10 @@ pseudo_class_function_selector_disabled.css:6:2 parse ━━━━━━━━�
   
     4 │ :global( {}
     5 │ :global() {}
-  > 6 │ :global(.div, .class) {}
-      │  ^^^^^^^^^^^^^^^^^^^^
-    7 │ :global(.div, .class {}
-    8 │ :global(.div .class {}
+  > 6 │ :global(.div, .class {}
+      │  ^^^^^^^^^^^^^^^^^^^
+    7 │ :global(.div .class {}
+    8 │ :global(.div .class
   
   i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
@@ -835,11 +792,11 @@ pseudo_class_function_selector_disabled.css:7:2 parse ━━━━━━━━�
   × `:local` and `:global` pseudo-classes are not standard CSS features.
   
     5 │ :global() {}
-    6 │ :global(.div, .class) {}
-  > 7 │ :global(.div, .class {}
-      │  ^^^^^^^^^^^^^^^^^^^
-    8 │ :global(.div .class {}
-    9 │ :global(.div .class
+    6 │ :global(.div, .class {}
+  > 7 │ :global(.div .class {}
+      │  ^^^^^^^^^^^^^^^^^^
+    8 │ :global(.div .class
+    9 │ 
   
   i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
@@ -847,41 +804,28 @@ pseudo_class_function_selector_disabled.css:8:2 parse ━━━━━━━━�
 
   × `:local` and `:global` pseudo-classes are not standard CSS features.
   
-     6 │ :global(.div, .class) {}
-     7 │ :global(.div, .class {}
-   > 8 │ :global(.div .class {}
-       │  ^^^^^^^^^^^^^^^^^^
-     9 │ :global(.div .class
-    10 │ 
+    6 │ :global(.div, .class {}
+    7 │ :global(.div .class {}
+  > 8 │ :global(.div .class
+      │  ^^^^^^^^^^^^^^^^^^
+    9 │ 
   
   i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
   
-pseudo_class_function_selector_disabled.css:9:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × `:local` and `:global` pseudo-classes are not standard CSS features.
-  
-     7 │ :global(.div, .class {}
-     8 │ :global(.div .class {}
-   > 9 │ :global(.div .class
-       │  ^^^^^^^^^^^^^^^^^^
-    10 │ 
-  
-  i You can enable `:local` and `:global` pseudo-class parsing by setting the `css.parser.cssModules` option to `true` in your configuration file.
-  
-pseudo_class_function_selector_disabled.css:10:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+pseudo_class_function_selector_disabled.css:9:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `{` but instead the file ends
   
-     8 │ :global(.div .class {}
-     9 │ :global(.div .class
-  > 10 │ 
-       │ 
+    7 │ :global(.div .class {}
+    8 │ :global(.div .class
+  > 9 │ 
+      │ 
   
   i the file ends here
   
-     8 │ :global(.div .class {}
-     9 │ :global(.div .class
-  > 10 │ 
-       │ 
+    7 │ :global(.div .class {}
+    8 │ :global(.div .class
+  > 9 │ 
+      │ 
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/enabled/pseudo_class_function_selector_enabled.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/enabled/pseudo_class_function_selector_enabled.css
@@ -1,6 +1,5 @@
 :global( {}
 :global() {}
-:global(.div, .class) {}
 :global(.div, .class {}
 :global(.div .class {}
 :global(.div .class

--- a/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/enabled/pseudo_class_function_selector_enabled.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/selector/pseudo_class/pseudo_class_function_selector/enabled/pseudo_class_function_selector_enabled.css.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
-assertion_line: 208
+assertion_line: 206
 expression: snapshot
 ---
 
@@ -9,7 +9,6 @@ expression: snapshot
 ```css
 :global( {}
 :global() {}
-:global(.div, .class) {}
 :global(.div, .class {}
 :global(.div .class {}
 :global(.div .class
@@ -37,6 +36,7 @@ CssRoot {
                                         value_token: IDENT@1..7 "global" [] [],
                                     },
                                     L_PAREN@7..9 "(" [] [Whitespace(" ")],
+                                    CssSelectorList [],
                                 ],
                             },
                         },
@@ -63,6 +63,7 @@ CssRoot {
                                         value_token: IDENT@13..19 "global" [] [],
                                     },
                                     L_PAREN@19..20 "(" [] [],
+                                    CssSelectorList [],
                                     R_PAREN@20..22 ")" [] [Whitespace(" ")],
                                 ],
                             },
@@ -90,71 +91,88 @@ CssRoot {
                                         value_token: IDENT@26..32 "global" [] [],
                                     },
                                     L_PAREN@32..33 "(" [] [],
-                                    CssCompoundSelector {
-                                        nesting_selectors: CssNestedSelectorList [],
-                                        simple_selector: missing (optional),
-                                        sub_selectors: CssSubSelectorList [
-                                            CssClassSelector {
-                                                dot_token: DOT@33..34 "." [] [],
-                                                name: CssCustomIdentifier {
-                                                    value_token: IDENT@34..37 "div" [] [],
+                                    CssSelectorList [
+                                        CssCompoundSelector {
+                                            nesting_selectors: CssNestedSelectorList [],
+                                            simple_selector: missing (optional),
+                                            sub_selectors: CssSubSelectorList [
+                                                CssClassSelector {
+                                                    dot_token: DOT@33..34 "." [] [],
+                                                    name: CssCustomIdentifier {
+                                                        value_token: IDENT@34..37 "div" [] [],
+                                                    },
                                                 },
+                                            ],
+                                        },
+                                        COMMA@37..39 "," [] [Whitespace(" ")],
+                                        CssCompoundSelector {
+                                            nesting_selectors: CssNestedSelectorList [],
+                                            simple_selector: missing (optional),
+                                            sub_selectors: CssSubSelectorList [
+                                                CssClassSelector {
+                                                    dot_token: DOT@39..40 "." [] [],
+                                                    name: CssCustomIdentifier {
+                                                        value_token: IDENT@40..46 "class" [] [Whitespace(" ")],
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@46..47 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@47..48 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssPseudoClassSelector {
+                            colon_token: COLON@48..50 ":" [Newline("\n")] [],
+                            class: CssBogusPseudoClass {
+                                items: [
+                                    CssIdentifier {
+                                        value_token: IDENT@50..56 "global" [] [],
+                                    },
+                                    L_PAREN@56..57 "(" [] [],
+                                    CssSelectorList [
+                                        CssComplexSelector {
+                                            left: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@57..58 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@58..61 "div" [] [],
+                                                        },
+                                                    },
+                                                ],
                                             },
-                                        ],
-                                    },
-                                    CssBogus {
-                                        items: [
-                                            COMMA@37..39 "," [] [Whitespace(" ")],
-                                            DOT@39..40 "." [] [],
-                                            IDENT@40..45 "class" [] [],
-                                        ],
-                                    },
-                                    R_PAREN@45..47 ")" [] [Whitespace(" ")],
-                                ],
-                            },
-                        },
-                    ],
-                },
-            ],
-            block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@47..48 "{" [] [],
-                items: CssDeclarationOrRuleList [],
-                r_curly_token: R_CURLY@48..49 "}" [] [],
-            },
-        },
-        CssQualifiedRule {
-            prelude: CssSelectorList [
-                CssCompoundSelector {
-                    nesting_selectors: CssNestedSelectorList [],
-                    simple_selector: missing (optional),
-                    sub_selectors: CssSubSelectorList [
-                        CssPseudoClassSelector {
-                            colon_token: COLON@49..51 ":" [Newline("\n")] [],
-                            class: CssBogusPseudoClass {
-                                items: [
-                                    CssIdentifier {
-                                        value_token: IDENT@51..57 "global" [] [],
-                                    },
-                                    L_PAREN@57..58 "(" [] [],
-                                    CssCompoundSelector {
-                                        nesting_selectors: CssNestedSelectorList [],
-                                        simple_selector: missing (optional),
-                                        sub_selectors: CssSubSelectorList [
-                                            CssClassSelector {
-                                                dot_token: DOT@58..59 "." [] [],
-                                                name: CssCustomIdentifier {
-                                                    value_token: IDENT@59..62 "div" [] [],
-                                                },
+                                            combinator: CSS_SPACE_LITERAL@61..62 " " [] [],
+                                            right: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@62..63 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@63..69 "class" [] [Whitespace(" ")],
+                                                        },
+                                                    },
+                                                ],
                                             },
-                                        ],
-                                    },
-                                    CssBogus {
-                                        items: [
-                                            COMMA@62..64 "," [] [Whitespace(" ")],
-                                            DOT@64..65 "." [] [],
-                                            IDENT@65..71 "class" [] [Whitespace(" ")],
-                                        ],
-                                    },
+                                        },
+                                    ],
                                 ],
                             },
                         },
@@ -162,9 +180,9 @@ CssRoot {
                 },
             ],
             block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@71..72 "{" [] [],
+                l_curly_token: L_CURLY@69..70 "{" [] [],
                 items: CssDeclarationOrRuleList [],
-                r_curly_token: R_CURLY@72..73 "}" [] [],
+                r_curly_token: R_CURLY@70..71 "}" [] [],
             },
         },
         CssQualifiedRule {
@@ -174,93 +192,42 @@ CssRoot {
                     simple_selector: missing (optional),
                     sub_selectors: CssSubSelectorList [
                         CssPseudoClassSelector {
-                            colon_token: COLON@73..75 ":" [Newline("\n")] [],
+                            colon_token: COLON@71..73 ":" [Newline("\n")] [],
                             class: CssBogusPseudoClass {
                                 items: [
                                     CssIdentifier {
-                                        value_token: IDENT@75..81 "global" [] [],
+                                        value_token: IDENT@73..79 "global" [] [],
                                     },
-                                    L_PAREN@81..82 "(" [] [],
-                                    CssComplexSelector {
-                                        left: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@82..83 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@83..86 "div" [] [],
+                                    L_PAREN@79..80 "(" [] [],
+                                    CssSelectorList [
+                                        CssComplexSelector {
+                                            left: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@80..81 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@81..84 "div" [] [],
+                                                        },
                                                     },
-                                                },
-                                            ],
-                                        },
-                                        combinator: CSS_SPACE_LITERAL@86..87 " " [] [],
-                                        right: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@87..88 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@88..94 "class" [] [Whitespace(" ")],
+                                                ],
+                                            },
+                                            combinator: CSS_SPACE_LITERAL@84..85 " " [] [],
+                                            right: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@85..86 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@86..91 "class" [] [],
+                                                        },
                                                     },
-                                                },
-                                            ],
+                                                ],
+                                            },
                                         },
-                                    },
-                                ],
-                            },
-                        },
-                    ],
-                },
-            ],
-            block: CssDeclarationOrRuleBlock {
-                l_curly_token: L_CURLY@94..95 "{" [] [],
-                items: CssDeclarationOrRuleList [],
-                r_curly_token: R_CURLY@95..96 "}" [] [],
-            },
-        },
-        CssQualifiedRule {
-            prelude: CssSelectorList [
-                CssCompoundSelector {
-                    nesting_selectors: CssNestedSelectorList [],
-                    simple_selector: missing (optional),
-                    sub_selectors: CssSubSelectorList [
-                        CssPseudoClassSelector {
-                            colon_token: COLON@96..98 ":" [Newline("\n")] [],
-                            class: CssBogusPseudoClass {
-                                items: [
-                                    CssIdentifier {
-                                        value_token: IDENT@98..104 "global" [] [],
-                                    },
-                                    L_PAREN@104..105 "(" [] [],
-                                    CssComplexSelector {
-                                        left: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@105..106 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@106..109 "div" [] [],
-                                                    },
-                                                },
-                                            ],
-                                        },
-                                        combinator: CSS_SPACE_LITERAL@109..110 " " [] [],
-                                        right: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@110..111 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@111..116 "class" [] [],
-                                                    },
-                                                },
-                                            ],
-                                        },
-                                    },
+                                    ],
                                 ],
                             },
                         },
@@ -272,16 +239,16 @@ CssRoot {
             },
         },
     ],
-    eof_token: EOF@116..117 "" [Newline("\n")] [],
+    eof_token: EOF@91..92 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..117
+0: CSS_ROOT@0..92
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..116
+  1: CSS_ROOT_ITEM_LIST@0..91
     0: CSS_QUALIFIED_RULE@0..11
       0: CSS_SELECTOR_LIST@0..9
         0: CSS_COMPOUND_SELECTOR@0..9
@@ -294,6 +261,7 @@ CssRoot {
                 0: CSS_IDENTIFIER@1..7
                   0: IDENT@1..7 "global" [] []
                 1: L_PAREN@7..9 "(" [] [Whitespace(" ")]
+                2: CSS_SELECTOR_LIST@9..9
       1: CSS_DECLARATION_OR_RULE_BLOCK@9..11
         0: L_CURLY@9..10 "{" [] []
         1: CSS_DECLARATION_OR_RULE_LIST@10..10
@@ -310,134 +278,114 @@ CssRoot {
                 0: CSS_IDENTIFIER@13..19
                   0: IDENT@13..19 "global" [] []
                 1: L_PAREN@19..20 "(" [] []
-                2: R_PAREN@20..22 ")" [] [Whitespace(" ")]
+                2: CSS_SELECTOR_LIST@20..20
+                3: R_PAREN@20..22 ")" [] [Whitespace(" ")]
       1: CSS_DECLARATION_OR_RULE_BLOCK@22..24
         0: L_CURLY@22..23 "{" [] []
         1: CSS_DECLARATION_OR_RULE_LIST@23..23
         2: R_CURLY@23..24 "}" [] []
-    2: CSS_QUALIFIED_RULE@24..49
-      0: CSS_SELECTOR_LIST@24..47
-        0: CSS_COMPOUND_SELECTOR@24..47
+    2: CSS_QUALIFIED_RULE@24..48
+      0: CSS_SELECTOR_LIST@24..46
+        0: CSS_COMPOUND_SELECTOR@24..46
           0: CSS_NESTED_SELECTOR_LIST@24..24
           1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@24..47
-            0: CSS_PSEUDO_CLASS_SELECTOR@24..47
+          2: CSS_SUB_SELECTOR_LIST@24..46
+            0: CSS_PSEUDO_CLASS_SELECTOR@24..46
               0: COLON@24..26 ":" [Newline("\n")] []
-              1: CSS_BOGUS_PSEUDO_CLASS@26..47
+              1: CSS_BOGUS_PSEUDO_CLASS@26..46
                 0: CSS_IDENTIFIER@26..32
                   0: IDENT@26..32 "global" [] []
                 1: L_PAREN@32..33 "(" [] []
-                2: CSS_COMPOUND_SELECTOR@33..37
-                  0: CSS_NESTED_SELECTOR_LIST@33..33
-                  1: (empty)
-                  2: CSS_SUB_SELECTOR_LIST@33..37
-                    0: CSS_CLASS_SELECTOR@33..37
-                      0: DOT@33..34 "." [] []
-                      1: CSS_CUSTOM_IDENTIFIER@34..37
-                        0: IDENT@34..37 "div" [] []
-                3: CSS_BOGUS@37..45
-                  0: COMMA@37..39 "," [] [Whitespace(" ")]
-                  1: DOT@39..40 "." [] []
-                  2: IDENT@40..45 "class" [] []
-                4: R_PAREN@45..47 ")" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@47..49
-        0: L_CURLY@47..48 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@48..48
-        2: R_CURLY@48..49 "}" [] []
-    3: CSS_QUALIFIED_RULE@49..73
-      0: CSS_SELECTOR_LIST@49..71
-        0: CSS_COMPOUND_SELECTOR@49..71
-          0: CSS_NESTED_SELECTOR_LIST@49..49
+                2: CSS_SELECTOR_LIST@33..46
+                  0: CSS_COMPOUND_SELECTOR@33..37
+                    0: CSS_NESTED_SELECTOR_LIST@33..33
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@33..37
+                      0: CSS_CLASS_SELECTOR@33..37
+                        0: DOT@33..34 "." [] []
+                        1: CSS_CUSTOM_IDENTIFIER@34..37
+                          0: IDENT@34..37 "div" [] []
+                  1: COMMA@37..39 "," [] [Whitespace(" ")]
+                  2: CSS_COMPOUND_SELECTOR@39..46
+                    0: CSS_NESTED_SELECTOR_LIST@39..39
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@39..46
+                      0: CSS_CLASS_SELECTOR@39..46
+                        0: DOT@39..40 "." [] []
+                        1: CSS_CUSTOM_IDENTIFIER@40..46
+                          0: IDENT@40..46 "class" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@46..48
+        0: L_CURLY@46..47 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@47..47
+        2: R_CURLY@47..48 "}" [] []
+    3: CSS_QUALIFIED_RULE@48..71
+      0: CSS_SELECTOR_LIST@48..69
+        0: CSS_COMPOUND_SELECTOR@48..69
+          0: CSS_NESTED_SELECTOR_LIST@48..48
           1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@49..71
-            0: CSS_PSEUDO_CLASS_SELECTOR@49..71
-              0: COLON@49..51 ":" [Newline("\n")] []
-              1: CSS_BOGUS_PSEUDO_CLASS@51..71
-                0: CSS_IDENTIFIER@51..57
-                  0: IDENT@51..57 "global" [] []
-                1: L_PAREN@57..58 "(" [] []
-                2: CSS_COMPOUND_SELECTOR@58..62
-                  0: CSS_NESTED_SELECTOR_LIST@58..58
-                  1: (empty)
-                  2: CSS_SUB_SELECTOR_LIST@58..62
-                    0: CSS_CLASS_SELECTOR@58..62
-                      0: DOT@58..59 "." [] []
-                      1: CSS_CUSTOM_IDENTIFIER@59..62
-                        0: IDENT@59..62 "div" [] []
-                3: CSS_BOGUS@62..71
-                  0: COMMA@62..64 "," [] [Whitespace(" ")]
-                  1: DOT@64..65 "." [] []
-                  2: IDENT@65..71 "class" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@71..73
-        0: L_CURLY@71..72 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@72..72
-        2: R_CURLY@72..73 "}" [] []
-    4: CSS_QUALIFIED_RULE@73..96
-      0: CSS_SELECTOR_LIST@73..94
-        0: CSS_COMPOUND_SELECTOR@73..94
-          0: CSS_NESTED_SELECTOR_LIST@73..73
+          2: CSS_SUB_SELECTOR_LIST@48..69
+            0: CSS_PSEUDO_CLASS_SELECTOR@48..69
+              0: COLON@48..50 ":" [Newline("\n")] []
+              1: CSS_BOGUS_PSEUDO_CLASS@50..69
+                0: CSS_IDENTIFIER@50..56
+                  0: IDENT@50..56 "global" [] []
+                1: L_PAREN@56..57 "(" [] []
+                2: CSS_SELECTOR_LIST@57..69
+                  0: CSS_COMPLEX_SELECTOR@57..69
+                    0: CSS_COMPOUND_SELECTOR@57..61
+                      0: CSS_NESTED_SELECTOR_LIST@57..57
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@57..61
+                        0: CSS_CLASS_SELECTOR@57..61
+                          0: DOT@57..58 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@58..61
+                            0: IDENT@58..61 "div" [] []
+                    1: CSS_SPACE_LITERAL@61..62 " " [] []
+                    2: CSS_COMPOUND_SELECTOR@62..69
+                      0: CSS_NESTED_SELECTOR_LIST@62..62
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@62..69
+                        0: CSS_CLASS_SELECTOR@62..69
+                          0: DOT@62..63 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@63..69
+                            0: IDENT@63..69 "class" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@69..71
+        0: L_CURLY@69..70 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@70..70
+        2: R_CURLY@70..71 "}" [] []
+    4: CSS_QUALIFIED_RULE@71..91
+      0: CSS_SELECTOR_LIST@71..91
+        0: CSS_COMPOUND_SELECTOR@71..91
+          0: CSS_NESTED_SELECTOR_LIST@71..71
           1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@73..94
-            0: CSS_PSEUDO_CLASS_SELECTOR@73..94
-              0: COLON@73..75 ":" [Newline("\n")] []
-              1: CSS_BOGUS_PSEUDO_CLASS@75..94
-                0: CSS_IDENTIFIER@75..81
-                  0: IDENT@75..81 "global" [] []
-                1: L_PAREN@81..82 "(" [] []
-                2: CSS_COMPLEX_SELECTOR@82..94
-                  0: CSS_COMPOUND_SELECTOR@82..86
-                    0: CSS_NESTED_SELECTOR_LIST@82..82
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@82..86
-                      0: CSS_CLASS_SELECTOR@82..86
-                        0: DOT@82..83 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@83..86
-                          0: IDENT@83..86 "div" [] []
-                  1: CSS_SPACE_LITERAL@86..87 " " [] []
-                  2: CSS_COMPOUND_SELECTOR@87..94
-                    0: CSS_NESTED_SELECTOR_LIST@87..87
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@87..94
-                      0: CSS_CLASS_SELECTOR@87..94
-                        0: DOT@87..88 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@88..94
-                          0: IDENT@88..94 "class" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@94..96
-        0: L_CURLY@94..95 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@95..95
-        2: R_CURLY@95..96 "}" [] []
-    5: CSS_QUALIFIED_RULE@96..116
-      0: CSS_SELECTOR_LIST@96..116
-        0: CSS_COMPOUND_SELECTOR@96..116
-          0: CSS_NESTED_SELECTOR_LIST@96..96
-          1: (empty)
-          2: CSS_SUB_SELECTOR_LIST@96..116
-            0: CSS_PSEUDO_CLASS_SELECTOR@96..116
-              0: COLON@96..98 ":" [Newline("\n")] []
-              1: CSS_BOGUS_PSEUDO_CLASS@98..116
-                0: CSS_IDENTIFIER@98..104
-                  0: IDENT@98..104 "global" [] []
-                1: L_PAREN@104..105 "(" [] []
-                2: CSS_COMPLEX_SELECTOR@105..116
-                  0: CSS_COMPOUND_SELECTOR@105..109
-                    0: CSS_NESTED_SELECTOR_LIST@105..105
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@105..109
-                      0: CSS_CLASS_SELECTOR@105..109
-                        0: DOT@105..106 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@106..109
-                          0: IDENT@106..109 "div" [] []
-                  1: CSS_SPACE_LITERAL@109..110 " " [] []
-                  2: CSS_COMPOUND_SELECTOR@110..116
-                    0: CSS_NESTED_SELECTOR_LIST@110..110
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@110..116
-                      0: CSS_CLASS_SELECTOR@110..116
-                        0: DOT@110..111 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@111..116
-                          0: IDENT@111..116 "class" [] []
-      1: CSS_BOGUS_BLOCK@116..116
-  2: EOF@116..117 "" [Newline("\n")] []
+          2: CSS_SUB_SELECTOR_LIST@71..91
+            0: CSS_PSEUDO_CLASS_SELECTOR@71..91
+              0: COLON@71..73 ":" [Newline("\n")] []
+              1: CSS_BOGUS_PSEUDO_CLASS@73..91
+                0: CSS_IDENTIFIER@73..79
+                  0: IDENT@73..79 "global" [] []
+                1: L_PAREN@79..80 "(" [] []
+                2: CSS_SELECTOR_LIST@80..91
+                  0: CSS_COMPLEX_SELECTOR@80..91
+                    0: CSS_COMPOUND_SELECTOR@80..84
+                      0: CSS_NESTED_SELECTOR_LIST@80..80
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@80..84
+                        0: CSS_CLASS_SELECTOR@80..84
+                          0: DOT@80..81 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@81..84
+                            0: IDENT@81..84 "div" [] []
+                    1: CSS_SPACE_LITERAL@84..85 " " [] []
+                    2: CSS_COMPOUND_SELECTOR@85..91
+                      0: CSS_NESTED_SELECTOR_LIST@85..85
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@85..91
+                        0: CSS_CLASS_SELECTOR@85..91
+                          0: DOT@85..86 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@86..91
+                            0: IDENT@86..91 "class" [] []
+      1: CSS_BOGUS_BLOCK@91..91
+  2: EOF@91..92 "" [Newline("\n")] []
 
 ```
 
@@ -451,113 +399,73 @@ pseudo_class_function_selector_enabled.css:1:10 parse ━━━━━━━━�
   > 1 │ :global( {}
       │          ^
     2 │ :global() {}
-    3 │ :global(.div, .class) {}
+    3 │ :global(.div, .class {}
   
   i Expected a selector here.
   
   > 1 │ :global( {}
       │          ^
     2 │ :global() {}
-    3 │ :global(.div, .class) {}
+    3 │ :global(.div, .class {}
   
 pseudo_class_function_selector_enabled.css:2:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a selector but instead found ')'.
+  × Expected a selector but instead found ''.
   
     1 │ :global( {}
   > 2 │ :global() {}
-      │         ^
-    3 │ :global(.div, .class) {}
-    4 │ :global(.div, .class {}
+      │         
+    3 │ :global(.div, .class {}
+    4 │ :global(.div .class {}
   
   i Expected a selector here.
   
     1 │ :global( {}
   > 2 │ :global() {}
-      │         ^
-    3 │ :global(.div, .class) {}
-    4 │ :global(.div, .class {}
+      │         
+    3 │ :global(.div, .class {}
+    4 │ :global(.div .class {}
   
-pseudo_class_function_selector_enabled.css:3:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+pseudo_class_function_selector_enabled.css:3:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a selector but instead found '.div, .class'.
+  × expected `,` but instead found `{`
   
     1 │ :global( {}
     2 │ :global() {}
-  > 3 │ :global(.div, .class) {}
-      │         ^^^^^^^^^^^^
-    4 │ :global(.div, .class {}
-    5 │ :global(.div .class {}
-  
-  i Expected a selector here.
-  
-    1 │ :global( {}
-    2 │ :global() {}
-  > 3 │ :global(.div, .class) {}
-      │         ^^^^^^^^^^^^
-    4 │ :global(.div, .class {}
-    5 │ :global(.div .class {}
-  
-pseudo_class_function_selector_enabled.css:4:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a selector but instead found '.div, .class'.
-  
-    2 │ :global() {}
-    3 │ :global(.div, .class) {}
-  > 4 │ :global(.div, .class {}
-      │         ^^^^^^^^^^^^
-    5 │ :global(.div .class {}
-    6 │ :global(.div .class
-  
-  i Expected a selector here.
-  
-    2 │ :global() {}
-    3 │ :global(.div, .class) {}
-  > 4 │ :global(.div, .class {}
-      │         ^^^^^^^^^^^^
-    5 │ :global(.div .class {}
-    6 │ :global(.div .class
-  
-pseudo_class_function_selector_enabled.css:4:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `)` but instead found `{`
-  
-    2 │ :global() {}
-    3 │ :global(.div, .class) {}
-  > 4 │ :global(.div, .class {}
+  > 3 │ :global(.div, .class {}
       │                      ^
-    5 │ :global(.div .class {}
-    6 │ :global(.div .class
+    4 │ :global(.div .class {}
+    5 │ :global(.div .class
   
   i Remove {
   
-pseudo_class_function_selector_enabled.css:5:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+pseudo_class_function_selector_enabled.css:4:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `)` but instead found `{`
+  × expected `,` but instead found `{`
   
-    3 │ :global(.div, .class) {}
-    4 │ :global(.div, .class {}
-  > 5 │ :global(.div .class {}
+    2 │ :global() {}
+    3 │ :global(.div, .class {}
+  > 4 │ :global(.div .class {}
       │                     ^
-    6 │ :global(.div .class
-    7 │ 
+    5 │ :global(.div .class
+    6 │ 
   
   i Remove {
   
-pseudo_class_function_selector_enabled.css:7:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+pseudo_class_function_selector_enabled.css:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `)` but instead the file ends
   
-    5 │ :global(.div .class {}
-    6 │ :global(.div .class
-  > 7 │ 
+    4 │ :global(.div .class {}
+    5 │ :global(.div .class
+  > 6 │ 
       │ 
   
   i the file ends here
   
-    5 │ :global(.div .class {}
-    6 │ :global(.div .class
-  > 7 │ 
+    4 │ :global(.div .class {}
+    5 │ :global(.div .class
+  > 6 │ 
       │ 
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_module/pseudo_class_module.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_module/pseudo_class_module.css
@@ -1,3 +1,5 @@
 :global(.class div) {}
 :local(.class div + #id) {}
 :global(.class div) .div {}
+:global(.foo, .bar) {}
+:local(.a, .b, .c) {}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_module/pseudo_class_module.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/selector/pseudo_class/pseudo_class_module/pseudo_class_module.css.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_css_parser/tests/spec_test.rs
+assertion_line: 206
 expression: snapshot
 ---
 
@@ -9,6 +10,8 @@ expression: snapshot
 :global(.class div) {}
 :local(.class div + #id) {}
 :global(.class div) .div {}
+:global(.foo, .bar) {}
+:local(.a, .b, .c) {}
 
 ```
 
@@ -27,36 +30,38 @@ CssRoot {
                     sub_selectors: CssSubSelectorList [
                         CssPseudoClassSelector {
                             colon_token: COLON@0..1 ":" [] [],
-                            class: CssPseudoClassFunctionSelector {
+                            class: CssPseudoClassFunctionSelectorList {
                                 name: CssIdentifier {
                                     value_token: IDENT@1..7 "global" [] [],
                                 },
                                 l_paren_token: L_PAREN@7..8 "(" [] [],
-                                selector: CssComplexSelector {
-                                    left: CssCompoundSelector {
-                                        nesting_selectors: CssNestedSelectorList [],
-                                        simple_selector: missing (optional),
-                                        sub_selectors: CssSubSelectorList [
-                                            CssClassSelector {
-                                                dot_token: DOT@8..9 "." [] [],
-                                                name: CssCustomIdentifier {
-                                                    value_token: IDENT@9..14 "class" [] [],
+                                selectors: CssSelectorList [
+                                    CssComplexSelector {
+                                        left: CssCompoundSelector {
+                                            nesting_selectors: CssNestedSelectorList [],
+                                            simple_selector: missing (optional),
+                                            sub_selectors: CssSubSelectorList [
+                                                CssClassSelector {
+                                                    dot_token: DOT@8..9 "." [] [],
+                                                    name: CssCustomIdentifier {
+                                                        value_token: IDENT@9..14 "class" [] [],
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                        combinator: CSS_SPACE_LITERAL@14..15 " " [] [],
+                                        right: CssCompoundSelector {
+                                            nesting_selectors: CssNestedSelectorList [],
+                                            simple_selector: CssTypeSelector {
+                                                namespace: missing (optional),
+                                                ident: CssIdentifier {
+                                                    value_token: IDENT@15..18 "div" [] [],
                                                 },
                                             },
-                                        ],
-                                    },
-                                    combinator: CSS_SPACE_LITERAL@14..15 " " [] [],
-                                    right: CssCompoundSelector {
-                                        nesting_selectors: CssNestedSelectorList [],
-                                        simple_selector: CssTypeSelector {
-                                            namespace: missing (optional),
-                                            ident: CssIdentifier {
-                                                value_token: IDENT@15..18 "div" [] [],
-                                            },
+                                            sub_selectors: CssSubSelectorList [],
                                         },
-                                        sub_selectors: CssSubSelectorList [],
                                     },
-                                },
+                                ],
                                 r_paren_token: R_PAREN@18..20 ")" [] [Whitespace(" ")],
                             },
                         },
@@ -77,51 +82,53 @@ CssRoot {
                     sub_selectors: CssSubSelectorList [
                         CssPseudoClassSelector {
                             colon_token: COLON@22..24 ":" [Newline("\n")] [],
-                            class: CssPseudoClassFunctionSelector {
+                            class: CssPseudoClassFunctionSelectorList {
                                 name: CssIdentifier {
                                     value_token: IDENT@24..29 "local" [] [],
                                 },
                                 l_paren_token: L_PAREN@29..30 "(" [] [],
-                                selector: CssComplexSelector {
-                                    left: CssComplexSelector {
-                                        left: CssCompoundSelector {
+                                selectors: CssSelectorList [
+                                    CssComplexSelector {
+                                        left: CssComplexSelector {
+                                            left: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@30..31 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@31..36 "class" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            combinator: CSS_SPACE_LITERAL@36..37 " " [] [],
+                                            right: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: CssTypeSelector {
+                                                    namespace: missing (optional),
+                                                    ident: CssIdentifier {
+                                                        value_token: IDENT@37..41 "div" [] [Whitespace(" ")],
+                                                    },
+                                                },
+                                                sub_selectors: CssSubSelectorList [],
+                                            },
+                                        },
+                                        combinator: PLUS@41..43 "+" [] [Whitespace(" ")],
+                                        right: CssCompoundSelector {
                                             nesting_selectors: CssNestedSelectorList [],
                                             simple_selector: missing (optional),
                                             sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@30..31 "." [] [],
+                                                CssIdSelector {
+                                                    hash_token: HASH@43..44 "#" [] [],
                                                     name: CssCustomIdentifier {
-                                                        value_token: IDENT@31..36 "class" [] [],
+                                                        value_token: IDENT@44..46 "id" [] [],
                                                     },
                                                 },
                                             ],
                                         },
-                                        combinator: CSS_SPACE_LITERAL@36..37 " " [] [],
-                                        right: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: CssTypeSelector {
-                                                namespace: missing (optional),
-                                                ident: CssIdentifier {
-                                                    value_token: IDENT@37..41 "div" [] [Whitespace(" ")],
-                                                },
-                                            },
-                                            sub_selectors: CssSubSelectorList [],
-                                        },
                                     },
-                                    combinator: PLUS@41..43 "+" [] [Whitespace(" ")],
-                                    right: CssCompoundSelector {
-                                        nesting_selectors: CssNestedSelectorList [],
-                                        simple_selector: missing (optional),
-                                        sub_selectors: CssSubSelectorList [
-                                            CssIdSelector {
-                                                hash_token: HASH@43..44 "#" [] [],
-                                                name: CssCustomIdentifier {
-                                                    value_token: IDENT@44..46 "id" [] [],
-                                                },
-                                            },
-                                        ],
-                                    },
-                                },
+                                ],
                                 r_paren_token: R_PAREN@46..48 ")" [] [Whitespace(" ")],
                             },
                         },
@@ -143,36 +150,38 @@ CssRoot {
                         sub_selectors: CssSubSelectorList [
                             CssPseudoClassSelector {
                                 colon_token: COLON@50..52 ":" [Newline("\n")] [],
-                                class: CssPseudoClassFunctionSelector {
+                                class: CssPseudoClassFunctionSelectorList {
                                     name: CssIdentifier {
                                         value_token: IDENT@52..58 "global" [] [],
                                     },
                                     l_paren_token: L_PAREN@58..59 "(" [] [],
-                                    selector: CssComplexSelector {
-                                        left: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: missing (optional),
-                                            sub_selectors: CssSubSelectorList [
-                                                CssClassSelector {
-                                                    dot_token: DOT@59..60 "." [] [],
-                                                    name: CssCustomIdentifier {
-                                                        value_token: IDENT@60..65 "class" [] [],
+                                    selectors: CssSelectorList [
+                                        CssComplexSelector {
+                                            left: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: missing (optional),
+                                                sub_selectors: CssSubSelectorList [
+                                                    CssClassSelector {
+                                                        dot_token: DOT@59..60 "." [] [],
+                                                        name: CssCustomIdentifier {
+                                                            value_token: IDENT@60..65 "class" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            combinator: CSS_SPACE_LITERAL@65..66 " " [] [],
+                                            right: CssCompoundSelector {
+                                                nesting_selectors: CssNestedSelectorList [],
+                                                simple_selector: CssTypeSelector {
+                                                    namespace: missing (optional),
+                                                    ident: CssIdentifier {
+                                                        value_token: IDENT@66..69 "div" [] [],
                                                     },
                                                 },
-                                            ],
-                                        },
-                                        combinator: CSS_SPACE_LITERAL@65..66 " " [] [],
-                                        right: CssCompoundSelector {
-                                            nesting_selectors: CssNestedSelectorList [],
-                                            simple_selector: CssTypeSelector {
-                                                namespace: missing (optional),
-                                                ident: CssIdentifier {
-                                                    value_token: IDENT@66..69 "div" [] [],
-                                                },
+                                                sub_selectors: CssSubSelectorList [],
                                             },
-                                            sub_selectors: CssSubSelectorList [],
                                         },
-                                    },
+                                    ],
                                     r_paren_token: R_PAREN@69..70 ")" [] [],
                                 },
                             },
@@ -199,17 +208,134 @@ CssRoot {
                 r_curly_token: R_CURLY@77..78 "}" [] [],
             },
         },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssPseudoClassSelector {
+                            colon_token: COLON@78..80 ":" [Newline("\n")] [],
+                            class: CssPseudoClassFunctionSelectorList {
+                                name: CssIdentifier {
+                                    value_token: IDENT@80..86 "global" [] [],
+                                },
+                                l_paren_token: L_PAREN@86..87 "(" [] [],
+                                selectors: CssSelectorList [
+                                    CssCompoundSelector {
+                                        nesting_selectors: CssNestedSelectorList [],
+                                        simple_selector: missing (optional),
+                                        sub_selectors: CssSubSelectorList [
+                                            CssClassSelector {
+                                                dot_token: DOT@87..88 "." [] [],
+                                                name: CssCustomIdentifier {
+                                                    value_token: IDENT@88..91 "foo" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    COMMA@91..93 "," [] [Whitespace(" ")],
+                                    CssCompoundSelector {
+                                        nesting_selectors: CssNestedSelectorList [],
+                                        simple_selector: missing (optional),
+                                        sub_selectors: CssSubSelectorList [
+                                            CssClassSelector {
+                                                dot_token: DOT@93..94 "." [] [],
+                                                name: CssCustomIdentifier {
+                                                    value_token: IDENT@94..97 "bar" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@97..99 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@99..100 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@100..101 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssPseudoClassSelector {
+                            colon_token: COLON@101..103 ":" [Newline("\n")] [],
+                            class: CssPseudoClassFunctionSelectorList {
+                                name: CssIdentifier {
+                                    value_token: IDENT@103..108 "local" [] [],
+                                },
+                                l_paren_token: L_PAREN@108..109 "(" [] [],
+                                selectors: CssSelectorList [
+                                    CssCompoundSelector {
+                                        nesting_selectors: CssNestedSelectorList [],
+                                        simple_selector: missing (optional),
+                                        sub_selectors: CssSubSelectorList [
+                                            CssClassSelector {
+                                                dot_token: DOT@109..110 "." [] [],
+                                                name: CssCustomIdentifier {
+                                                    value_token: IDENT@110..111 "a" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    COMMA@111..113 "," [] [Whitespace(" ")],
+                                    CssCompoundSelector {
+                                        nesting_selectors: CssNestedSelectorList [],
+                                        simple_selector: missing (optional),
+                                        sub_selectors: CssSubSelectorList [
+                                            CssClassSelector {
+                                                dot_token: DOT@113..114 "." [] [],
+                                                name: CssCustomIdentifier {
+                                                    value_token: IDENT@114..115 "b" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    COMMA@115..117 "," [] [Whitespace(" ")],
+                                    CssCompoundSelector {
+                                        nesting_selectors: CssNestedSelectorList [],
+                                        simple_selector: missing (optional),
+                                        sub_selectors: CssSubSelectorList [
+                                            CssClassSelector {
+                                                dot_token: DOT@117..118 "." [] [],
+                                                name: CssCustomIdentifier {
+                                                    value_token: IDENT@118..119 "c" [] [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@119..121 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@121..122 "{" [] [],
+                items: CssDeclarationOrRuleList [],
+                r_curly_token: R_CURLY@122..123 "}" [] [],
+            },
+        },
     ],
-    eof_token: EOF@78..79 "" [Newline("\n")] [],
+    eof_token: EOF@123..124 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..79
+0: CSS_ROOT@0..124
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..78
+  1: CSS_ROOT_ITEM_LIST@0..123
     0: CSS_QUALIFIED_RULE@0..22
       0: CSS_SELECTOR_LIST@0..20
         0: CSS_COMPOUND_SELECTOR@0..20
@@ -218,27 +344,28 @@ CssRoot {
           2: CSS_SUB_SELECTOR_LIST@0..20
             0: CSS_PSEUDO_CLASS_SELECTOR@0..20
               0: COLON@0..1 ":" [] []
-              1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR@1..20
+              1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@1..20
                 0: CSS_IDENTIFIER@1..7
                   0: IDENT@1..7 "global" [] []
                 1: L_PAREN@7..8 "(" [] []
-                2: CSS_COMPLEX_SELECTOR@8..18
-                  0: CSS_COMPOUND_SELECTOR@8..14
-                    0: CSS_NESTED_SELECTOR_LIST@8..8
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@8..14
-                      0: CSS_CLASS_SELECTOR@8..14
-                        0: DOT@8..9 "." [] []
-                        1: CSS_CUSTOM_IDENTIFIER@9..14
-                          0: IDENT@9..14 "class" [] []
-                  1: CSS_SPACE_LITERAL@14..15 " " [] []
-                  2: CSS_COMPOUND_SELECTOR@15..18
-                    0: CSS_NESTED_SELECTOR_LIST@15..15
-                    1: CSS_TYPE_SELECTOR@15..18
-                      0: (empty)
-                      1: CSS_IDENTIFIER@15..18
-                        0: IDENT@15..18 "div" [] []
-                    2: CSS_SUB_SELECTOR_LIST@18..18
+                2: CSS_SELECTOR_LIST@8..18
+                  0: CSS_COMPLEX_SELECTOR@8..18
+                    0: CSS_COMPOUND_SELECTOR@8..14
+                      0: CSS_NESTED_SELECTOR_LIST@8..8
+                      1: (empty)
+                      2: CSS_SUB_SELECTOR_LIST@8..14
+                        0: CSS_CLASS_SELECTOR@8..14
+                          0: DOT@8..9 "." [] []
+                          1: CSS_CUSTOM_IDENTIFIER@9..14
+                            0: IDENT@9..14 "class" [] []
+                    1: CSS_SPACE_LITERAL@14..15 " " [] []
+                    2: CSS_COMPOUND_SELECTOR@15..18
+                      0: CSS_NESTED_SELECTOR_LIST@15..15
+                      1: CSS_TYPE_SELECTOR@15..18
+                        0: (empty)
+                        1: CSS_IDENTIFIER@15..18
+                          0: IDENT@15..18 "div" [] []
+                      2: CSS_SUB_SELECTOR_LIST@18..18
                 3: R_PAREN@18..20 ")" [] [Whitespace(" ")]
       1: CSS_DECLARATION_OR_RULE_BLOCK@20..22
         0: L_CURLY@20..21 "{" [] []
@@ -252,37 +379,38 @@ CssRoot {
           2: CSS_SUB_SELECTOR_LIST@22..48
             0: CSS_PSEUDO_CLASS_SELECTOR@22..48
               0: COLON@22..24 ":" [Newline("\n")] []
-              1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR@24..48
+              1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@24..48
                 0: CSS_IDENTIFIER@24..29
                   0: IDENT@24..29 "local" [] []
                 1: L_PAREN@29..30 "(" [] []
-                2: CSS_COMPLEX_SELECTOR@30..46
-                  0: CSS_COMPLEX_SELECTOR@30..41
-                    0: CSS_COMPOUND_SELECTOR@30..36
-                      0: CSS_NESTED_SELECTOR_LIST@30..30
+                2: CSS_SELECTOR_LIST@30..46
+                  0: CSS_COMPLEX_SELECTOR@30..46
+                    0: CSS_COMPLEX_SELECTOR@30..41
+                      0: CSS_COMPOUND_SELECTOR@30..36
+                        0: CSS_NESTED_SELECTOR_LIST@30..30
+                        1: (empty)
+                        2: CSS_SUB_SELECTOR_LIST@30..36
+                          0: CSS_CLASS_SELECTOR@30..36
+                            0: DOT@30..31 "." [] []
+                            1: CSS_CUSTOM_IDENTIFIER@31..36
+                              0: IDENT@31..36 "class" [] []
+                      1: CSS_SPACE_LITERAL@36..37 " " [] []
+                      2: CSS_COMPOUND_SELECTOR@37..41
+                        0: CSS_NESTED_SELECTOR_LIST@37..37
+                        1: CSS_TYPE_SELECTOR@37..41
+                          0: (empty)
+                          1: CSS_IDENTIFIER@37..41
+                            0: IDENT@37..41 "div" [] [Whitespace(" ")]
+                        2: CSS_SUB_SELECTOR_LIST@41..41
+                    1: PLUS@41..43 "+" [] [Whitespace(" ")]
+                    2: CSS_COMPOUND_SELECTOR@43..46
+                      0: CSS_NESTED_SELECTOR_LIST@43..43
                       1: (empty)
-                      2: CSS_SUB_SELECTOR_LIST@30..36
-                        0: CSS_CLASS_SELECTOR@30..36
-                          0: DOT@30..31 "." [] []
-                          1: CSS_CUSTOM_IDENTIFIER@31..36
-                            0: IDENT@31..36 "class" [] []
-                    1: CSS_SPACE_LITERAL@36..37 " " [] []
-                    2: CSS_COMPOUND_SELECTOR@37..41
-                      0: CSS_NESTED_SELECTOR_LIST@37..37
-                      1: CSS_TYPE_SELECTOR@37..41
-                        0: (empty)
-                        1: CSS_IDENTIFIER@37..41
-                          0: IDENT@37..41 "div" [] [Whitespace(" ")]
-                      2: CSS_SUB_SELECTOR_LIST@41..41
-                  1: PLUS@41..43 "+" [] [Whitespace(" ")]
-                  2: CSS_COMPOUND_SELECTOR@43..46
-                    0: CSS_NESTED_SELECTOR_LIST@43..43
-                    1: (empty)
-                    2: CSS_SUB_SELECTOR_LIST@43..46
-                      0: CSS_ID_SELECTOR@43..46
-                        0: HASH@43..44 "#" [] []
-                        1: CSS_CUSTOM_IDENTIFIER@44..46
-                          0: IDENT@44..46 "id" [] []
+                      2: CSS_SUB_SELECTOR_LIST@43..46
+                        0: CSS_ID_SELECTOR@43..46
+                          0: HASH@43..44 "#" [] []
+                          1: CSS_CUSTOM_IDENTIFIER@44..46
+                            0: IDENT@44..46 "id" [] []
                 3: R_PAREN@46..48 ")" [] [Whitespace(" ")]
       1: CSS_DECLARATION_OR_RULE_BLOCK@48..50
         0: L_CURLY@48..49 "{" [] []
@@ -297,27 +425,28 @@ CssRoot {
             2: CSS_SUB_SELECTOR_LIST@50..70
               0: CSS_PSEUDO_CLASS_SELECTOR@50..70
                 0: COLON@50..52 ":" [Newline("\n")] []
-                1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR@52..70
+                1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@52..70
                   0: CSS_IDENTIFIER@52..58
                     0: IDENT@52..58 "global" [] []
                   1: L_PAREN@58..59 "(" [] []
-                  2: CSS_COMPLEX_SELECTOR@59..69
-                    0: CSS_COMPOUND_SELECTOR@59..65
-                      0: CSS_NESTED_SELECTOR_LIST@59..59
-                      1: (empty)
-                      2: CSS_SUB_SELECTOR_LIST@59..65
-                        0: CSS_CLASS_SELECTOR@59..65
-                          0: DOT@59..60 "." [] []
-                          1: CSS_CUSTOM_IDENTIFIER@60..65
-                            0: IDENT@60..65 "class" [] []
-                    1: CSS_SPACE_LITERAL@65..66 " " [] []
-                    2: CSS_COMPOUND_SELECTOR@66..69
-                      0: CSS_NESTED_SELECTOR_LIST@66..66
-                      1: CSS_TYPE_SELECTOR@66..69
-                        0: (empty)
-                        1: CSS_IDENTIFIER@66..69
-                          0: IDENT@66..69 "div" [] []
-                      2: CSS_SUB_SELECTOR_LIST@69..69
+                  2: CSS_SELECTOR_LIST@59..69
+                    0: CSS_COMPLEX_SELECTOR@59..69
+                      0: CSS_COMPOUND_SELECTOR@59..65
+                        0: CSS_NESTED_SELECTOR_LIST@59..59
+                        1: (empty)
+                        2: CSS_SUB_SELECTOR_LIST@59..65
+                          0: CSS_CLASS_SELECTOR@59..65
+                            0: DOT@59..60 "." [] []
+                            1: CSS_CUSTOM_IDENTIFIER@60..65
+                              0: IDENT@60..65 "class" [] []
+                      1: CSS_SPACE_LITERAL@65..66 " " [] []
+                      2: CSS_COMPOUND_SELECTOR@66..69
+                        0: CSS_NESTED_SELECTOR_LIST@66..66
+                        1: CSS_TYPE_SELECTOR@66..69
+                          0: (empty)
+                          1: CSS_IDENTIFIER@66..69
+                            0: IDENT@66..69 "div" [] []
+                        2: CSS_SUB_SELECTOR_LIST@69..69
                   3: R_PAREN@69..70 ")" [] []
           1: CSS_SPACE_LITERAL@70..71 " " [] []
           2: CSS_COMPOUND_SELECTOR@71..76
@@ -332,6 +461,85 @@ CssRoot {
         0: L_CURLY@76..77 "{" [] []
         1: CSS_DECLARATION_OR_RULE_LIST@77..77
         2: R_CURLY@77..78 "}" [] []
-  2: EOF@78..79 "" [Newline("\n")] []
+    3: CSS_QUALIFIED_RULE@78..101
+      0: CSS_SELECTOR_LIST@78..99
+        0: CSS_COMPOUND_SELECTOR@78..99
+          0: CSS_NESTED_SELECTOR_LIST@78..78
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@78..99
+            0: CSS_PSEUDO_CLASS_SELECTOR@78..99
+              0: COLON@78..80 ":" [Newline("\n")] []
+              1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@80..99
+                0: CSS_IDENTIFIER@80..86
+                  0: IDENT@80..86 "global" [] []
+                1: L_PAREN@86..87 "(" [] []
+                2: CSS_SELECTOR_LIST@87..97
+                  0: CSS_COMPOUND_SELECTOR@87..91
+                    0: CSS_NESTED_SELECTOR_LIST@87..87
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@87..91
+                      0: CSS_CLASS_SELECTOR@87..91
+                        0: DOT@87..88 "." [] []
+                        1: CSS_CUSTOM_IDENTIFIER@88..91
+                          0: IDENT@88..91 "foo" [] []
+                  1: COMMA@91..93 "," [] [Whitespace(" ")]
+                  2: CSS_COMPOUND_SELECTOR@93..97
+                    0: CSS_NESTED_SELECTOR_LIST@93..93
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@93..97
+                      0: CSS_CLASS_SELECTOR@93..97
+                        0: DOT@93..94 "." [] []
+                        1: CSS_CUSTOM_IDENTIFIER@94..97
+                          0: IDENT@94..97 "bar" [] []
+                3: R_PAREN@97..99 ")" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@99..101
+        0: L_CURLY@99..100 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@100..100
+        2: R_CURLY@100..101 "}" [] []
+    4: CSS_QUALIFIED_RULE@101..123
+      0: CSS_SELECTOR_LIST@101..121
+        0: CSS_COMPOUND_SELECTOR@101..121
+          0: CSS_NESTED_SELECTOR_LIST@101..101
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@101..121
+            0: CSS_PSEUDO_CLASS_SELECTOR@101..121
+              0: COLON@101..103 ":" [Newline("\n")] []
+              1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@103..121
+                0: CSS_IDENTIFIER@103..108
+                  0: IDENT@103..108 "local" [] []
+                1: L_PAREN@108..109 "(" [] []
+                2: CSS_SELECTOR_LIST@109..119
+                  0: CSS_COMPOUND_SELECTOR@109..111
+                    0: CSS_NESTED_SELECTOR_LIST@109..109
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@109..111
+                      0: CSS_CLASS_SELECTOR@109..111
+                        0: DOT@109..110 "." [] []
+                        1: CSS_CUSTOM_IDENTIFIER@110..111
+                          0: IDENT@110..111 "a" [] []
+                  1: COMMA@111..113 "," [] [Whitespace(" ")]
+                  2: CSS_COMPOUND_SELECTOR@113..115
+                    0: CSS_NESTED_SELECTOR_LIST@113..113
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@113..115
+                      0: CSS_CLASS_SELECTOR@113..115
+                        0: DOT@113..114 "." [] []
+                        1: CSS_CUSTOM_IDENTIFIER@114..115
+                          0: IDENT@114..115 "b" [] []
+                  3: COMMA@115..117 "," [] [Whitespace(" ")]
+                  4: CSS_COMPOUND_SELECTOR@117..119
+                    0: CSS_NESTED_SELECTOR_LIST@117..117
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@117..119
+                      0: CSS_CLASS_SELECTOR@117..119
+                        0: DOT@117..118 "." [] []
+                        1: CSS_CUSTOM_IDENTIFIER@118..119
+                          0: IDENT@118..119 "c" [] []
+                3: R_PAREN@119..121 ")" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@121..123
+        0: L_CURLY@121..122 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@122..122
+        2: R_CURLY@122..123 "}" [] []
+  2: EOF@123..124 "" [Newline("\n")] []
 
 ```


### PR DESCRIPTION
## Summary

Biome should support `:global(.div, .class) {}`, it's valid. 

## Test Plan

Make sure that `:global(.div, .class) {}` is not triggering a failure when doing biome check

[Playground](https://biomejs.dev/playground/?tab=formatter&pane=Diagnostics&code=OgBnAGwAbwBiAGEAbAAoAC4AZABpAHYALAAgAC4AYwBsAGEAcwBzACkAIAB7AH0A&language=css)


### Note

A lot of help from Claude code