### PR TITLE
fix(cli): detect musl without ldd

### DIFF
--- a/.changeset/empty-areas-repair.md
+++ b/.changeset/empty-areas-repair.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10501](https://github.com/biomejs/biome/issues/10501): Biome now uses Node.js runtime metadata to select the musl Linux binary when `ldd` is unavailable.

--- a/packages/@biomejs/biome/bin/biome
+++ b/packages/@biomejs/biome/bin/biome
@@ -3,18 +3,27 @@ const { platform, arch, env, version, release } = process;
 const { execSync } = require("child_process");
 
 function isMusl() {
-	let stderr;
+	let nodeReportHeader;
 	try {
-		stderr = execSync("ldd --version", {
-			stdio: ['pipe', 'pipe', 'pipe']
+		nodeReportHeader = process.report?.getReport?.()?.header;
+	} catch {
+		nodeReportHeader = undefined;
+	}
+
+	if (nodeReportHeader != null) {
+		return nodeReportHeader.glibcVersionRuntime == null;
+	}
+
+	let lddOutput;
+	try {
+		lddOutput = execSync("ldd --version", {
+			stdio: ["pipe", "pipe", "pipe"],
 		});
 	} catch (err) {
-		stderr = err.stderr;
+		lddOutput = err.stderr;
 	}
-	if (stderr.indexOf("musl") > -1) {
-		return true;
-	}
-	return false;
+
+	return lddOutput?.includes("musl") ?? false;
 }
 
 const PLATFORMS = {


### PR DESCRIPTION
## Summary

Fixes #10501

Biome now uses Node.js runtime metadata to select the musl Linux binary when `ldd` is unavailable.

> This PR was created with AI assistance (Codex).

## Test Plan

Verified the wrapper in `dhi.io/node:24.16.0-alpine3.23-dev` on `linux/amd64`: `ldd` is absent, `glibcVersionRuntime` is unavailable, and Biome selects `@biomejs/cli-linux-x64-musl/biome`.

Verified the wrapper in `dhi.io/node:24.16.0-alpine3.23-dev` on `linux/arm64`: Biome selects `@biomejs/cli-linux-arm64-musl/biome`.

Verified `node --check packages/@biomejs/biome/bin/biome`.

## Docs

Not applicable.
