### PR TITLE
refactor(organizeImports): require `sortBareImports` for bare matchers

### DIFF
--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-matchers-without-enabling-sort-bare-imports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-matchers-without-enabling-sort-bare-imports.js.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: bare-matchers-without-enabling-sort-bare-imports.js
+---
+# Input
+```js
+
+```
+
+# Diagnostics
+```
+bare-matchers-without-enabling-sort-bare-imports.options:8:22 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The groups option contains kind matchers set to bare or !bare. They have no effect because the sortBareImports option is not set to true. Set sortBareImports to true or remove the bare kind matchers.
+  
+     6 │         "organizeImports": {
+     7 │           "level": "on",
+   > 8 │           "options": {
+       │                      ^
+   > 9 │             "groups": [
+  > 10 │               { "kind": "bare", "source": ":STYLE:" }
+  > 11 │             ]
+  > 12 │           }
+       │           ^
+    13 │         }
+    14 │       }
+  
+  i We are assessing an approach to sort a subset of bare imports, using bare kind matchers without setting sortBareImports to true. See the Pull Request for more details.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-matchers-without-enabling-sort-bare-imports.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-matchers-without-enabling-sort-bare-imports.js.snap
@@ -25,7 +25,7 @@ bare-matchers-without-enabling-sort-bare-imports.options:8:22 deserialize ━━
     13 │         }
     14 │       }
   
-  i We are assessing an approach to sort a subset of bare imports, using bare kind matchers without setting sortBareImports to true. See the Pull Request for more details.
+  i This might change in a future versions of Biome. See the Pull Request for more details.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-matchers-without-enabling-sort-bare-imports.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/bare-matchers-without-enabling-sort-bare-imports.options.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              { "kind": "bare", "source": ":STYLE:" }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_rule_options/src/organize_imports.rs
+++ b/crates/biome_rule_options/src/organize_imports.rs
@@ -3,12 +3,16 @@ pub mod import_source;
 
 use crate::organize_imports::import_groups::ImportGroups;
 pub use crate::shared::sort_order::SortOrder;
+use biome_console::markup;
+use biome_deserialize::{DeserializableValidator, DeserializationDiagnostic};
 use biome_deserialize_macros::{Deserializable, Merge};
+use biome_diagnostics::Severity;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+#[deserializable(with_validator)]
 pub struct OrganizeImportsOptions {
     /// Groups to change how imports and exports are sorted.
     #[serde(skip_serializing_if = "Option::<_>::is_none")]
@@ -21,4 +25,39 @@ pub struct OrganizeImportsOptions {
     /// If `true`, bare imports such as `import "module"` are sorted with other imports.
     #[serde(skip_serializing_if = "Option::<_>::is_none")]
     pub sort_bare_imports: Option<bool>,
+}
+
+impl DeserializableValidator for OrganizeImportsOptions {
+    fn validate(
+        &mut self,
+        ctx: &mut impl biome_deserialize::DeserializationContext,
+        _name: &str,
+        range: biome_rowan::TextRange,
+    ) -> bool {
+        if self
+            .sort_bare_imports
+            .is_none_or(|sort_bare_imports| !sort_bare_imports)
+            && let Some(groups) = self.groups.as_ref()
+            && groups.has_bare_matchers()
+        {
+            ctx.report(
+                DeserializationDiagnostic::new(
+                    markup!(
+                        "The "<Emphasis>"groups"</Emphasis>" option contains kind matchers set to "<Emphasis>"bare"</Emphasis>" or "<Emphasis>"!bare"</Emphasis>". "
+                        "They have no effect because the "<Emphasis>"sortBareImports"</Emphasis>" option is not set to "<Emphasis>"true"</Emphasis>". "
+                        "Set "<Emphasis>"sortBareImports"</Emphasis>" to "<Emphasis>"true"</Emphasis>" or remove the bare kind matchers."
+                    ),
+                )
+                .with_range(range)
+                .with_custom_severity(Severity::Error)
+                .with_note(markup!(
+                        "We are assessing an approach to sort a subset of bare imports, using bare kind matchers without setting "<Emphasis>"sortBareImports"</Emphasis>" to "<Emphasis>"true"</Emphasis>". "
+                        "See the "<Hyperlink href="https://github.com/biomejs/biome/pull/10190">"Pull Request"</Hyperlink>" for more details."
+                    ))
+            );
+            false
+        } else {
+            true
+        }
+    }
 }

--- a/crates/biome_rule_options/src/organize_imports.rs
+++ b/crates/biome_rule_options/src/organize_imports.rs
@@ -51,7 +51,7 @@ impl DeserializableValidator for OrganizeImportsOptions {
                 .with_range(range)
                 .with_custom_severity(Severity::Error)
                 .with_note(markup!(
-                        "We are assessing an approach to sort a subset of bare imports, using bare kind matchers without setting "<Emphasis>"sortBareImports"</Emphasis>" to "<Emphasis>"true"</Emphasis>". "
+                        "This might change in a future versions of Biome. "
                         "See the "<Hyperlink href="https://github.com/biomejs/biome/pull/10190">"Pull Request"</Hyperlink>" for more details."
                     ))
             );

--- a/crates/biome_rule_options/src/organize_imports/import_groups.rs
+++ b/crates/biome_rule_options/src/organize_imports/import_groups.rs
@@ -28,6 +28,11 @@ impl ImportGroups {
             .unwrap_or(self.0.len()) as u16
     }
 
+    /// Is there a group that match or unmatch explicitly bare imports?
+    pub fn has_bare_matchers(&self) -> bool {
+        self.0.iter().any(|group| group.has_bare_matchers())
+    }
+
     /// Returns how many blank lines must separate `first_group` and `second_group`.
     pub fn separated_by_blank_line(&self, first_group: u16, second_group: u16) -> bool {
         self.0
@@ -86,6 +91,16 @@ impl ImportGroup {
             Self::MatcherList(matchers) => candidate.matches_with_exceptions(matchers.iter()),
         }
     }
+
+    fn has_bare_matchers(&self) -> bool {
+        match self {
+            Self::BlankLine => false,
+            Self::Matcher(group_matcher) => group_matcher.has_bare_matchers(),
+            Self::MatcherList(group_matchers) => group_matchers
+                .iter()
+                .any(|group_matcher| group_matcher.has_bare_matchers()),
+        }
+    }
 }
 impl Deserializable for ImportGroup {
     fn deserialize(
@@ -128,6 +143,15 @@ impl GroupMatcher {
         match self {
             Self::Import(_) => false,
             Self::Source(matcher) => matcher.is_negated(),
+        }
+    }
+
+    pub fn has_bare_matchers(&self) -> bool {
+        match self {
+            Self::Import(import_matcher) => import_matcher
+                .kind
+                .is_some_and(|kind_matcher| kind_matcher.kind.is_bare()),
+            Self::Source(_source_matcher) => false,
         }
     }
 
@@ -197,14 +221,14 @@ impl ImportMatcher {
 /// Kind matcher for [`ImportMatcher::kind`].
 ///
 /// Accepts a plain kind (e.g. `"bare"`) or a negated kind (e.g. `"!bare"`).
-#[derive(Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct NegatableImportKindMatcher {
     is_negated: bool,
     kind: ImportKindMatcher,
 }
 impl NegatableImportKindMatcher {
-    pub fn is_match(&self, candidate: &ImportCandidate<'_>) -> bool {
+    pub fn is_match(self, candidate: &ImportCandidate<'_>) -> bool {
         self.kind.is_match(candidate) != self.is_negated
     }
 }
@@ -286,17 +310,23 @@ impl schemars::JsonSchema for NegatableImportKindMatcher {
     }
 }
 
-#[derive(Clone, Debug, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize,
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum ImportKindMatcher {
     #[serde(rename = "bare")]
     Bare,
 }
 impl ImportKindMatcher {
-    fn is_match(&self, candidate: &ImportCandidate<'_>) -> bool {
+    fn is_match(self, candidate: &ImportCandidate<'_>) -> bool {
         match self {
             Self::Bare => candidate.is_bare,
         }
+    }
+
+    pub const fn is_bare(self) -> bool {
+        matches!(self, Self::Bare)
     }
 }
 impl std::fmt::Display for ImportKindMatcher {

--- a/crates/biome_rule_options/src/organize_imports/import_groups.rs
+++ b/crates/biome_rule_options/src/organize_imports/import_groups.rs
@@ -228,7 +228,7 @@ pub struct NegatableImportKindMatcher {
     kind: ImportKindMatcher,
 }
 impl NegatableImportKindMatcher {
-    pub fn is_match(self, candidate: &ImportCandidate<'_>) -> bool {
+    pub fn is_match(&self, candidate: &ImportCandidate<'_>) -> bool {
         self.kind.is_match(candidate) != self.is_negated
     }
 }
@@ -319,13 +319,13 @@ pub enum ImportKindMatcher {
     Bare,
 }
 impl ImportKindMatcher {
-    fn is_match(self, candidate: &ImportCandidate<'_>) -> bool {
+    fn is_match(&self, candidate: &ImportCandidate<'_>) -> bool {
         match self {
             Self::Bare => candidate.is_bare,
         }
     }
 
-    pub const fn is_bare(self) -> bool {
+    pub const fn is_bare(&self) -> bool {
         matches!(self, Self::Bare)
     }
 }


### PR DESCRIPTION
## Summary

I think that https://github.com/biomejs/biome/pull/10190 is not ready for v2.5
To avoid any blocking, I submitted this PR.

This PR errors on configurations that use bare kind matchers without settings `sortBareImports` to `true`.
The diagnostic points to https://github.com/biomejs/biome/pull/10190.

## Test Plan

I added a test.

## Docs

No change. The docs and changesets already speak about that.
