### PR TITLE
fix(css_parser): support interpolated dashed identifiers in function at-rules

### DIFF
--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -974,7 +974,7 @@ pub fn css_function_at_rule(
 }
 pub fn css_function_at_rule_declarator(
     function_token: SyntaxToken,
-    name: CssDashedIdentifier,
+    name: AnyCssDashedIdentifier,
     l_paren_token: SyntaxToken,
     parameters: CssFunctionParameterList,
     r_paren_token: SyntaxToken,
@@ -990,7 +990,7 @@ pub fn css_function_at_rule_declarator(
 }
 pub struct CssFunctionAtRuleDeclaratorBuilder {
     function_token: SyntaxToken,
-    name: CssDashedIdentifier,
+    name: AnyCssDashedIdentifier,
     l_paren_token: SyntaxToken,
     parameters: CssFunctionParameterList,
     r_paren_token: SyntaxToken,

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -1941,7 +1941,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 }
                 slots.next_slot();
                 if let Some(element) = &current_element
-                    && CssDashedIdentifier::can_cast(element.kind())
+                    && AnyCssDashedIdentifier::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/function.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/function.scss
@@ -11,3 +11,10 @@ $value * $ratio;
 @function --highlight  ( ) {
 result:var(--highlight,#{$highlight});
 }
+
+$function-name: highlight;
+
+@function
+--#{$function-name}  ( ) {
+result: red;
+}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/function.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/function.scss.snap
@@ -21,6 +21,13 @@ $value * $ratio;
 result:var(--highlight,#{$highlight});
 }
 
+$function-name: highlight;
+
+@function
+--#{$function-name}  ( ) {
+result: red;
+}
+
 ```
 
 
@@ -33,6 +40,12 @@ result:var(--highlight,#{$highlight});
 
 @function --highlight() {
 	result: var(--highlight, #{$highlight});
+}
+
+$function-name: highlight;
+
+@function --#{$function-name}() {
+	result: red;
 }
 
 ```

--- a/crates/biome_css_parser/src/syntax/at_rule/function.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/function.rs
@@ -3,6 +3,9 @@ use crate::syntax::at_rule::parse_error::{
 };
 use crate::syntax::block::parse_declaration_or_at_rule_list_block;
 use crate::syntax::parse_error::expected_dashed_identifier;
+use crate::syntax::scss::{
+    is_at_scss_interpolated_dashed_identifier, parse_scss_interpolated_dashed_identifier,
+};
 use crate::syntax::value::r#type::{
     is_at_syntax_single_component, is_at_syntax_type, is_at_type_function,
     parse_any_syntax_component, parse_type_function,
@@ -60,7 +63,7 @@ pub(crate) fn parse_function_at_rule_declarator(p: &mut CssParser) -> ParsedSynt
     let m = p.start();
     p.bump(T![function]);
 
-    parse_dashed_identifier(p)
+    parse_function_name(p)
         .or_recover_with_token_set(
             p,
             &ParseRecoveryTokenSet::new(CSS_BOGUS, token_set![T!['('], T!['{']]),
@@ -75,6 +78,15 @@ pub(crate) fn parse_function_at_rule_declarator(p: &mut CssParser) -> ParsedSynt
     parse_returns_statement(p).ok();
 
     Present(m.complete(p, CSS_FUNCTION_AT_RULE_DECLARATOR))
+}
+
+#[inline]
+fn parse_function_name(p: &mut CssParser) -> ParsedSyntax {
+    if is_at_scss_interpolated_dashed_identifier(p) {
+        parse_scss_interpolated_dashed_identifier(p)
+    } else {
+        parse_dashed_identifier(p)
+    }
 }
 
 #[inline]

--- a/crates/biome_css_parser/src/syntax/at_rule/mod.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/mod.rs
@@ -73,6 +73,7 @@ use crate::syntax::at_rule::view_transition::{
 };
 
 use crate::syntax::parse_error::{expected_any_at_rule, tailwind_disabled};
+use crate::syntax::scss::is_nth_at_scss_interpolated_dashed_identifier;
 use crate::syntax::scss::{
     parse_bogus_scss_else_at_rule, parse_scss_at_root_at_rule, parse_scss_content_at_rule,
     parse_scss_debug_at_rule, parse_scss_each_at_rule, parse_scss_error_at_rule,
@@ -132,14 +133,9 @@ pub(crate) fn parse_any_at_rule(p: &mut CssParser) -> ParsedSyntax {
         T![font_face] => parse_font_face_at_rule(p),
         T![font_feature_values] => parse_font_feature_values_at_rule(p),
         T![font_palette_values] => parse_font_palette_values_at_rule(p),
-        T![function]
-            if CssSyntaxFeatures::Scss.is_supported(p) && is_nth_at_dashed_identifier(p, 1) =>
-        {
-            // `@function --highlight()` is plain CSS in SCSS; `double()` stays Sass.
-            parse_function_at_rule(p)
-        }
         T![function] => {
-            if CssSyntaxFeatures::Scss.is_supported(p) {
+            // `@function --highlight()` is plain CSS in SCSS; `double()` stays Sass.
+            if CssSyntaxFeatures::Scss.is_supported(p) && !is_at_css_function_at_rule_name(p) {
                 parse_scss_function_at_rule(p)
             } else {
                 parse_function_at_rule(p)
@@ -265,6 +261,11 @@ pub(crate) fn parse_any_at_rule(p: &mut CssParser) -> ParsedSyntax {
         _ if is_at_unknown_at_rule(p) => parse_unknown_at_rule(p),
         _ => Absent,
     }
+}
+
+#[inline]
+fn is_at_css_function_at_rule_name(p: &mut CssParser) -> bool {
+    is_nth_at_dashed_identifier(p, 1) || is_nth_at_scss_interpolated_dashed_identifier(p, 1)
 }
 
 #[inline]

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/function-interpolated-dashed-name.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/function-interpolated-dashed-name.scss
@@ -1,0 +1,3 @@
+@function --#{name}() {
+  result: red;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/function-interpolated-dashed-name.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/function-interpolated-dashed-name.scss.snap
@@ -1,0 +1,133 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@function --#{name}() {
+  result: red;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssFunctionAtRule {
+                declarator: CssFunctionAtRuleDeclarator {
+                    function_token: FUNCTION_KW@1..10 "function" [] [Whitespace(" ")],
+                    name: ScssInterpolatedDashedIdentifier {
+                        items: ScssInterpolatedIdentifierPartList [
+                            ScssInterpolatedIdentifierHyphen {
+                                minus_token: MINUS@10..11 "-" [] [],
+                            },
+                            ScssInterpolatedIdentifierHyphen {
+                                minus_token: MINUS@11..12 "-" [] [],
+                            },
+                            ScssInterpolation {
+                                hash_token: HASH@12..13 "#" [] [],
+                                l_curly_token: L_CURLY@13..14 "{" [] [],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssIdentifier {
+                                            value_token: IDENT@14..18 "name" [] [],
+                                        },
+                                    ],
+                                },
+                                r_curly_token: R_CURLY@18..19 "}" [] [],
+                            },
+                        ],
+                    },
+                    l_paren_token: L_PAREN@19..20 "(" [] [],
+                    parameters: CssFunctionParameterList [],
+                    r_paren_token: R_PAREN@20..22 ")" [] [Whitespace(" ")],
+                    returns: missing (optional),
+                },
+                block: CssDeclarationOrAtRuleBlock {
+                    l_curly_token: L_CURLY@22..23 "{" [] [],
+                    items: CssDeclarationOrAtRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@23..32 "result" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                    colon_token: COLON@32..34 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@34..37 "red" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@37..38 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@38..40 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@40..41 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..41
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..40
+    0: CSS_AT_RULE@0..40
+      0: AT@0..1 "@" [] []
+      1: CSS_FUNCTION_AT_RULE@1..40
+        0: CSS_FUNCTION_AT_RULE_DECLARATOR@1..22
+          0: FUNCTION_KW@1..10 "function" [] [Whitespace(" ")]
+          1: SCSS_INTERPOLATED_DASHED_IDENTIFIER@10..19
+            0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@10..19
+              0: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@10..11
+                0: MINUS@10..11 "-" [] []
+              1: SCSS_INTERPOLATED_IDENTIFIER_HYPHEN@11..12
+                0: MINUS@11..12 "-" [] []
+              2: SCSS_INTERPOLATION@12..19
+                0: HASH@12..13 "#" [] []
+                1: L_CURLY@13..14 "{" [] []
+                2: SCSS_EXPRESSION@14..18
+                  0: SCSS_EXPRESSION_ITEM_LIST@14..18
+                    0: CSS_IDENTIFIER@14..18
+                      0: IDENT@14..18 "name" [] []
+                3: R_CURLY@18..19 "}" [] []
+          2: L_PAREN@19..20 "(" [] []
+          3: CSS_FUNCTION_PARAMETER_LIST@20..20
+          4: R_PAREN@20..22 ")" [] [Whitespace(" ")]
+          5: (empty)
+        1: CSS_DECLARATION_OR_AT_RULE_BLOCK@22..40
+          0: L_CURLY@22..23 "{" [] []
+          1: CSS_DECLARATION_OR_AT_RULE_LIST@23..38
+            0: CSS_DECLARATION_WITH_SEMICOLON@23..38
+              0: CSS_DECLARATION@23..37
+                0: CSS_GENERIC_PROPERTY@23..37
+                  0: CSS_IDENTIFIER@23..32
+                    0: IDENT@23..32 "result" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@32..34 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@34..37
+                    0: SCSS_EXPRESSION_ITEM_LIST@34..37
+                      0: CSS_IDENTIFIER@34..37
+                        0: IDENT@34..37 "red" [] []
+                1: (empty)
+              1: SEMICOLON@37..38 ";" [] []
+          2: R_CURLY@38..40 "}" [Newline("\n")] []
+  2: EOF@40..41 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -2724,7 +2724,7 @@ impl CssFunctionAtRuleDeclarator {
     pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
-    pub fn name(&self) -> SyntaxResult<CssDashedIdentifier> {
+    pub fn name(&self) -> SyntaxResult<AnyCssDashedIdentifier> {
         support::required_node(&self.syntax, 1usize)
     }
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -2751,7 +2751,7 @@ impl Serialize for CssFunctionAtRuleDeclarator {
 #[derive(Serialize)]
 pub struct CssFunctionAtRuleDeclaratorFields {
     pub function_token: SyntaxResult<SyntaxToken>,
-    pub name: SyntaxResult<CssDashedIdentifier>,
+    pub name: SyntaxResult<AnyCssDashedIdentifier>,
     pub l_paren_token: SyntaxResult<SyntaxToken>,
     pub parameters: CssFunctionParameterList,
     pub r_paren_token: SyntaxResult<SyntaxToken>,

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -1084,7 +1084,7 @@ impl CssFunctionAtRuleDeclarator {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_name(self, element: CssDashedIdentifier) -> Self {
+    pub fn with_name(self, element: AnyCssDashedIdentifier) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -931,7 +931,7 @@ CssViewTransitionAtRuleDeclarator =
 
 CssFunctionAtRuleDeclarator =
 	'function'
-	name: CssDashedIdentifier
+	name: AnyCssDashedIdentifier
 	'('
 	parameters: CssFunctionParameterList
 	')'


### PR DESCRIPTION

> This PR was created with AI assistance (Codex).

## Summary

Adds SCSS parsing and formatting support for interpolated CSS custom `@function` names.

```scss
@function --#{name}() {
  result: red;
}
```

## Test Plan

- `cargo test -p biome_css_parser`
- `cargo test -p biome_css_formatter`