### PR TITLE
fix(parse/js/vue): allow v-on directives with multiple inline statements

### DIFF
--- a/.changeset/forty-corners-move.md
+++ b/.changeset/forty-corners-move.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10519](https://github.com/biomejs/biome/issues/10519): Vue `v-on` event handlers with multiple inline statements are now parsed consistently with Vue.

--- a/crates/biome_js_parser/src/syntax/program.rs
+++ b/crates/biome_js_parser/src/syntax/program.rs
@@ -12,14 +12,31 @@ use crate::syntax::js_parse_error;
 use crate::syntax::stmt::parse_directives;
 use crate::syntax::typescript::TypeContext;
 use biome_js_syntax::JsSyntaxKind::*;
-use biome_js_syntax::ModuleKind;
+use biome_js_syntax::{JsSyntaxKind, ModuleKind};
 // test_err js unterminated_unicode_codepoint
 // let s = "\u{200";
+
+const VUE_EXPRESSION_HANDLER_SET: TokenSet<JsSyntaxKind> = token_set![
+    JS_IDENTIFIER_EXPRESSION,
+    JS_STATIC_MEMBER_EXPRESSION,
+    JS_COMPUTED_MEMBER_EXPRESSION,
+    JS_ARROW_FUNCTION_EXPRESSION,
+    JS_FUNCTION_EXPRESSION
+];
+
+const VUE_FUNCTION_EXPRESSION_HANDLER_SET: TokenSet<JsSyntaxKind> =
+    token_set![JS_ARROW_FUNCTION_EXPRESSION, JS_FUNCTION_EXPRESSION];
 
 pub(crate) fn parse(p: &mut JsParser) -> CompletedMarker {
     let m = p.start();
     p.eat(UNICODE_BOM);
     p.eat(JS_SHEBANG);
+
+    // Vue event handlers use Vue's own heuristic: member/function expressions
+    // are handlers, and all other expressions are inline statements.
+    if p.source_type().is_vue_event_handler() {
+        return parse_vue_event_handler(p, m);
+    }
 
     // Handle template expressions (Vue {{ }}, Svelte { }, Astro { })
     // These should be parsed as expressions, not as modules with statements
@@ -106,6 +123,55 @@ fn parse_template_expression(p: &mut JsParser, m: Marker) -> CompletedMarker {
     // Always complete as JS_EXPRESSION_TEMPLATE_ROOT
     // The expression child might be bogus, but the root should always be this type
     m.complete(p, JS_EXPRESSION_TEMPLATE_ROOT)
+}
+
+fn parse_vue_event_handler(p: &mut JsParser, m: Marker) -> CompletedMarker {
+    let checkpoint = p.checkpoint();
+    let expr_marker = p.start();
+    let expr_result = parse_expression(p, ExpressionContext::default());
+    let has_expression = !expr_result.is_absent();
+
+    if !has_expression {
+        p.error(js_parse_error::template_expression_expected_expression(
+            p,
+            p.cur_range(),
+        ));
+        expr_marker.complete(p, JS_BOGUS_EXPRESSION);
+        return m.complete(p, JS_EXPRESSION_TEMPLATE_ROOT);
+    }
+
+    let expression = expr_result.unwrap();
+    let expression_kind = expression.kind(p);
+
+    if p.at(EOF) && VUE_EXPRESSION_HANDLER_SET.contains(expression_kind) {
+        expr_marker.abandon(p);
+        return m.complete(p, JS_EXPRESSION_TEMPLATE_ROOT);
+    }
+
+    if VUE_FUNCTION_EXPRESSION_HANDLER_SET.contains(expression_kind) {
+        p.error(js_parse_error::template_expression_trailing_code(
+            p,
+            p.cur_range(),
+        ));
+
+        while !p.at(EOF) {
+            p.bump_any();
+        }
+
+        expr_marker.complete(p, JS_BOGUS_EXPRESSION);
+        return m.complete(p, JS_EXPRESSION_TEMPLATE_ROOT);
+    }
+
+    expr_marker.abandon(p);
+    p.rewind(checkpoint);
+    let (statement_list, strict_snapshot) = parse_directives(p);
+    parse_statements(p, false, statement_list);
+
+    if let Some(strict_snapshot) = strict_snapshot {
+        EnableStrictMode::restore(p.state_mut(), strict_snapshot);
+    }
+
+    m.complete(p, JS_SCRIPT)
 }
 
 /// Parses a Svelte snippet declaration: `add(a: any, b: float)`.

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.tests.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.tests.rs
@@ -127,3 +127,90 @@ fn svelte_each_with_incorrect_method_call_key() {
 
     assert_diagnostics(FILE_PATH, FILE_CONTENT);
 }
+
+#[test]
+fn vue_v_on_accepts_inline_statements_and_expression_handlers() {
+    // Mirrors Vue's v-on handler cases:
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L148-L161
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L163-L179
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L181-L197
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L260-L273
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L305-L320
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L347-L370
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L372-L385
+    const FILE_PATH: &str = "/project/file.vue";
+    const FILE_CONTENT: &str = r#"<script setup>
+let counter = 0;
+function foo() {}
+function bar() {}
+const a = { b: foo };
+const c = "b";
+</script>
+<template>
+  <button @click="counter++; counter++;"></button>
+  <button @click="foo();bar()"></button>
+  <button @click="
+    counter++;
+    counter++;
+  "></button>
+  <button @click="foo"></button>
+  <button @click="a['b' + c]"></button>
+  <button @click="$event => foo($event)"></button>
+  <button @click="async $event => foo($event)"></button>
+  <button @click="function($event) { foo($event) }"></button>
+  <button v-on:click="counter++; counter++;"></button>
+</template>
+"#;
+
+    assert_no_diagnostics(FILE_PATH, FILE_CONTENT);
+}
+
+#[test]
+fn vue_v_on_accepts_typescript_function_handler() {
+    // Mirrors Vue's TypeScript function-expression v-on handler case:
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L275-L303
+    const FILE_PATH: &str = "/project/file.vue";
+    const FILE_CONTENT: &str = r#"<script lang="ts">
+let counter = 0;
+</script>
+<template>
+  <button @click="($event: MouseEvent) => counter++"></button>
+</template>
+"#;
+
+    assert_no_diagnostics(FILE_PATH, FILE_CONTENT);
+}
+
+#[test]
+fn vue_v_on_rejects_function_handler_with_trailing_statement() {
+    // Enforces Vue's split between function-expression handlers and inline
+    // statement handlers by combining these upstream cases:
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L260-L273
+    // https://github.com/vuejs/core/blob/86ad0764fd9f7b01cef75b4fc941b03419306bf8/packages/compiler-core/__tests__/transforms/vOn.spec.ts#L163-L179
+    const FILE_PATH: &str = "/project/file.vue";
+    const FILE_CONTENT: &str = r#"<template>
+  <button @click="() => {counter++}; counter++;"></button>
+</template>
+"#;
+
+    assert_diagnostics(FILE_PATH, FILE_CONTENT);
+}
+
+#[test]
+fn vue_non_event_directives_stay_expression_only() {
+    const FILE_PATH: &str = "/project/file.vue";
+    const FILE_CONTENT: &str = r#"<script setup>
+const isActive = true;
+const foo = "foo";
+const bar = "bar";
+const duration = 100;
+</script>
+<template>
+  <div :class="{ active: isActive }"></div>
+  <div v-bind="{ id: foo, class: bar }"></div>
+  <div>{{ { duration } }}</div>
+</template>
+"#;
+
+    assert_no_diagnostics(FILE_PATH, FILE_CONTENT);
+}


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Vue's handling of v-on turns out to be a little more complicated than expected. A major thing we didn't previously handle is multiple inline statements in a v-on `@click="foo++; foo++;"`. See #10519 for full context.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
closes #10519

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added new tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
