### PR TITLE
fix(lint): ignore non-defineProps calls in Vue props rule 🤖🤖🤖

### DIFF
--- a/.changeset/fix-vue-define-props-push.md
+++ b/.changeset/fix-vue-define-props-push.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8682](https://github.com/biomejs/biome/issues/8682): [`useVueConsistentDefinePropsDeclaration`](https://biomejs.dev/linter/rules/use-vue-consistent-define-props-declaration/) no longer reports ordinary chained function calls, such as `array.push()`, as `defineProps()` declarations.

--- a/crates/biome_js_analyze/src/lint/nursery/use_vue_consistent_define_props_declaration.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_vue_consistent_define_props_declaration.rs
@@ -64,9 +64,7 @@ impl Rule for UseVueConsistentDefinePropsDeclaration {
         }
 
         let node = ctx.query();
-        if let Some(callee_name) = get_callee_name(node)
-            && callee_name != "defineProps"
-        {
+        if get_callee_name(node).is_none_or(|callee_name| callee_name != "defineProps") {
             return None;
         }
 

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueConsistentDefinePropsDeclaration/valid-push.vue
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueConsistentDefinePropsDeclaration/valid-push.vue
@@ -1,0 +1,13 @@
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import { ref } from "vue";
+
+const myArray = ref<string[]>([]);
+
+const selectModel = (x: string) => {
+	myArray.value.push(x);
+};
+</script>
+
+<template>
+</template>

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueConsistentDefinePropsDeclaration/valid-push.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueConsistentDefinePropsDeclaration/valid-push.vue.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-push.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import { ref } from "vue";
+
+const myArray = ref<string[]>([]);
+
+const selectModel = (x: string) => {
+	myArray.value.push(x);
+};
+</script>
+
+<template>
+</template>
+
+```


### PR DESCRIPTION
## Summary

Fixes #8682

Restricts `useVueConsistentDefinePropsDeclaration` to `defineProps` calls so ordinary chained calls are ignored.

> This PR was implemented with AI assistance from Codex.

## Test Plan

- `CARGO_TARGET_DIR=/tmp/biome-8682-target cargo test -p biome_js_analyze --test spec_tests use_vue_consistent_define_props_declaration`
- `CARGO_TARGET_DIR=/tmp/biome-8682-target cargo biome-cli-dev lint --config-path=/tmp/biome-8682-repro/biome.json --only=nursery/useVueConsistentDefinePropsDeclaration /tmp/biome-8682-repro/repro.vue`
- `CARGO_TARGET_DIR=/tmp/biome-8682-target cargo run -p xtask_codegen -- analyzer`
- `CARGO_TARGET_DIR=/tmp/biome-8682-target cargo run -p xtask_codegen --features configuration -- configuration`
- `cargo format`
- `CARGO_TARGET_DIR=/tmp/biome-8682-target cargo clippy -p biome_js_analyze --all-targets -- --deny warnings`
- `CARGO_TARGET_DIR=/tmp/biome-8682-target cargo run -p rules_check`

## Docs

Not applicable; this fixes existing rule behavior.
