### PR TITLE
fix(useImportType): always separate types from default named imports

### DIFF
--- a/.changeset/stale-doors-stay.md
+++ b/.changeset/stale-doors-stay.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10493](https://github.com/biomejs/biome/issues/10493): [`useImportType`](https://biomejs.dev/linter/rules/use-import-type/) now correctly separates types from a default named import when all imports are types and the `style` option is set to `separatedType`.

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -207,16 +207,14 @@ impl Rule for UseImportType {
                             Some(NamedImportTypeFix::UseImportType(specifiers)) => {
                                 if is_default_used_as_type {
                                     Some(ImportTypeFix::UseImportType)
-                                } else if specifiers.is_empty() {
-                                    // Don't group inline type-imports,
-                                    // when the default import is not only used as a type.
-                                    None
                                 } else if style == Style::SeparatedType {
                                     Some(ImportTypeFix::ExtractCombinedImportType(Box::default()))
-                                } else {
+                                } else if !specifiers.is_empty() {
                                     // Prefer adding type keyword instead of
                                     // splitting the import statement into two import statements
                                     Some(ImportTypeFix::AddTypeQualifiers(specifiers))
+                                } else {
+                                    None
                                 }
                             }
                             Some(NamedImportTypeFix::AddInlineTypeQualifiers(specifiers)) => {
@@ -997,10 +995,11 @@ fn extract_combined_specifier_in_new_import(
                                 type_token.leading_trivia().pieces(),
                                 trim_leading_trivia_pieces(type_token.trailing_trivia().pieces()),
                             ))?;
-                        new_specifiers = new_specifiers.replace_child(
-                            specifier.clone().into_syntax().into(),
-                            new_specifier.into_syntax().into(),
-                        )?;
+                        let slot_index = specifier.syntax().index();
+                        new_specifiers = new_specifiers.splice_slots(
+                            slot_index..=slot_index,
+                            [Some(new_specifier.into_syntax().into())],
+                        );
                     }
                 }
                 let new_specifiers = JsNamedImportSpecifierList::unwrap_cast(new_specifiers);

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-separated-type.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-separated-type.ts
@@ -26,3 +26,7 @@ export type { T11, T12 };
 import V6, { type T13 } from "mod";
 export type { T13 };
 export { V6 };
+
+import V7, { type T14, type T15 } from "mod";
+export type { T14, T15 };
+export { V7 };

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-separated-type.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-separated-type.ts.snap
@@ -33,6 +33,10 @@ import V6, { type T13 } from "mod";
 export type { T13 };
 export { V6 };
 
+import V7, { type T14, type T15 } from "mod";
+export type { T14, T15 };
+export { V7 };
+
 ```
 
 # Diagnostics
@@ -218,6 +222,60 @@ invalid-separated-type.ts:23:8 lint/style/useImportType  FIXABLE  ━━━━�
        24 │ + import·type·{·T12·}·from·"mod";
     24 25 │   export type { T11, T12 };
     25 26 │   
+  
+
+```
+
+```
+invalid-separated-type.ts:26:12 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! These named imports are only used as types.
+  
+    24 │ export type { T11, T12 };
+    25 │ 
+  > 26 │ import V6, { type T13 } from "mod";
+       │            ^^^^^^^^^^^^
+    27 │ export type { T13 };
+    28 │ export { V6 };
+  
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
+  
+  i Safe fix: Use import type.
+  
+    24 24 │   export type { T11, T12 };
+    25 25 │   
+    26    │ - import·V6,·{·type·T13·}·from·"mod";
+       26 │ + import·V6·from·"mod";
+       27 │ + import·type·{·T13·}·from·"mod";
+    27 28 │   export type { T13 };
+    28 29 │   export { V6 };
+  
+
+```
+
+```
+invalid-separated-type.ts:30:12 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! These named imports are only used as types.
+  
+    28 │ export { V6 };
+    29 │ 
+  > 30 │ import V7, { type T14, type T15 } from "mod";
+       │            ^^^^^^^^^^^^^^^^^^^^^^
+    31 │ export type { T14, T15 };
+    32 │ export { V7 };
+  
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
+  
+  i Safe fix: Use import type.
+  
+    28 28 │   export { V6 };
+    29 29 │   
+    30    │ - import·V7,·{·type·T14,·type·T15·}·from·"mod";
+       30 │ + import·V7·from·"mod";
+       31 │ + import·type·{·T14,·T15·}·from·"mod";
+    31 32 │   export type { T14, T15 };
+    32 33 │   export { V7 };
   
 
 ```


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/10493

This also fixes a second bug where the code action was omitted when the default named import had more than one named specifier. See my comment about `replace_child`. 

## Test Plan

I added a test

## Docs

I added a changeset.