### PR TITLE
fix(parse/html): don't bother tracking unicode escape sequences

### DIFF
--- a/.changeset/fix-html-unicode-escape.md
+++ b/.changeset/fix-html-unicode-escape.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10513](https://github.com/biomejs/biome/issues/10513): Biome no longer rejects literal `\u` sequences in quoted HTML attribute values.

--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -10,7 +10,6 @@ use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{Lexer, LexerCheckpoint, LexerWithCheckpoint, ReLexer, TokenFlags};
 use biome_rowan::SyntaxKind;
 use biome_unicode_table::{Dispatch::*, lookup_byte};
-use std::ops::Add;
 
 pub(crate) struct HtmlLexer<'src> {
     /// Source text
@@ -962,8 +961,8 @@ impl<'src> HtmlLexer<'src> {
         HTML_LITERAL
     }
 
-    /// Consumes a quoted string literal token, handling escaped characters and unicode sequences.
-    /// Returns ERROR_TOKEN if the string is not properly terminated or contains invalid escapes.
+    /// Consumes a quoted string literal token.
+    /// Returns ERROR_TOKEN if the string is not properly terminated.
     fn consume_string_literal(&mut self, quote: u8) -> HtmlSyntaxKind {
         self.assert_current_char_boundary();
         let start = self.text_position();
@@ -982,39 +981,6 @@ impl<'src> HtmlLexer<'src> {
                         state => state,
                     };
                     break;
-                }
-                // '\t' etc
-                BSL => {
-                    self.advance(1);
-
-                    match self.current_byte() {
-                        Some(b'\n' | b'\r') => self.advance(1),
-
-                        // Handle escaped `'` but only if this is a end quote string.
-                        Some(b'\'') if quote == b'\'' => {
-                            self.advance(1);
-                        }
-
-                        // Handle escaped `'` but only if this is a end quote string.
-                        Some(b'"') if quote == b'"' => {
-                            self.advance(1);
-                        }
-
-                        Some(b'u') => match (self.consume_unicode_escape(), state) {
-                            (Ok(_), _) => {}
-                            (Err(err), LexStringState::InString) => {
-                                self.diagnostics.push(err);
-                                state = LexStringState::InvalidEscapeSequence;
-                            }
-                            (Err(_), _) => {}
-                        },
-
-                        Some(chr) => {
-                            self.advance_byte_or_char(chr);
-                        }
-
-                        None => {}
-                    }
                 }
                 // we don't need to handle IDT because it's always len 1.
                 UNI => self.advance_char_unchecked(),
@@ -1036,7 +1002,6 @@ impl<'src> HtmlLexer<'src> {
 
                 ERROR_TOKEN
             }
-            LexStringState::InvalidEscapeSequence => ERROR_TOKEN,
         }
     }
 
@@ -1268,54 +1233,6 @@ impl<'src> HtmlLexer<'src> {
 
         self.advance(3);
         T!["]]>"]
-    }
-
-    /// Lexes a `\u0000` escape sequence. Assumes that the lexer is positioned at the `u` token.
-    ///
-    /// A unicode escape sequence must consist of 4 hex characters.
-    fn consume_unicode_escape(&mut self) -> Result<(), ParseDiagnostic> {
-        self.assert_byte(b'u');
-        self.assert_current_char_boundary();
-
-        let start = self.text_position();
-
-        let start = start
-            // Subtract 1 to get position of `\`
-            .checked_sub(TextSize::from(1))
-            .unwrap_or(start);
-
-        self.advance(1); // Advance over `u`
-
-        for _ in 0..4 {
-            match self.current_byte() {
-                Some(byte) if byte.is_ascii_hexdigit() => self.advance(1),
-                Some(_) => {
-                    let char = self.current_char_unchecked();
-                    // Reached a non-hex digit which is invalid
-                    return Err(ParseDiagnostic::new(
-
-                        "Invalid unicode sequence",
-                        start..self.text_position(),
-                    )
-                        .with_detail(self.text_position()..self.text_position().add(char.text_len()), "Non hexadecimal number")
-                        .with_hint("A unicode escape sequence must consist of 4 hexadecimal numbers: `\\uXXXX`, e.g. `\\u002F' for '/'."));
-                }
-                None => {
-                    // Reached the end of the file before processing 4 hex digits
-                    return Err(ParseDiagnostic::new(
-                        "Unicode escape sequence with two few hexadecimal numbers.",
-                        start..self.text_position(),
-                    )
-                        .with_detail(
-                            self.text_position()..self.text_position(),
-                            "reached the end of the file",
-                        )
-                        .with_hint("A unicode escape sequence must consist of 4 hexadecimal numbers: `\\uXXXX`, e.g. `\\u002F' for '/'."));
-                }
-            }
-        }
-
-        Ok(())
     }
 
     /// Consume a single block of HTML text outside of tags.
@@ -1664,9 +1581,6 @@ fn is_at_start_identifier(byte: u8) -> bool {
 
 #[derive(Copy, Clone, Debug)]
 enum LexStringState {
-    /// String that contains an invalid escape sequence
-    InvalidEscapeSequence,
-
     /// Between the opening `"` and closing `"` quotes.
     InString,
 

--- a/crates/biome_html_parser/tests/html_specs/ok/unicode-escape-attribute.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/unicode-escape-attribute.html
@@ -1,0 +1,2 @@
+<!-- valid because we don't care about unicode escape sequences in html strings -->
+<div data-test="\u"></div>

--- a/crates/biome_html_parser/tests/html_specs/ok/unicode-escape-attribute.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/unicode-escape-attribute.html.snap
@@ -1,0 +1,90 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+<!-- valid because we don't care about unicode escape sequences in html strings -->
+<div data-test="\u"></div>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..85 "<" [Comments("<!-- valid because we ..."), Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@85..89 "div" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@89..98 "data-test" [] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@98..99 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@99..103 "\"\\u\"" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@103..104 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@104..105 "<" [] [],
+                slash_token: SLASH@105..106 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@106..109 "div" [] [],
+                },
+                r_angle_token: R_ANGLE@109..110 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@110..111 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..111
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..110
+    0: HTML_ELEMENT@0..110
+      0: HTML_OPENING_ELEMENT@0..104
+        0: L_ANGLE@0..85 "<" [Comments("<!-- valid because we ..."), Newline("\n")] []
+        1: HTML_TAG_NAME@85..89
+          0: HTML_LITERAL@85..89 "div" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@89..103
+          0: HTML_ATTRIBUTE@89..103
+            0: HTML_ATTRIBUTE_NAME@89..98
+              0: HTML_LITERAL@89..98 "data-test" [] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@98..103
+              0: EQ@98..99 "=" [] []
+              1: HTML_STRING@99..103
+                0: HTML_STRING_LITERAL@99..103 "\"\\u\"" [] []
+        3: R_ANGLE@103..104 ">" [] []
+      1: HTML_ELEMENT_LIST@104..104
+      2: HTML_CLOSING_ELEMENT@104..110
+        0: L_ANGLE@104..105 "<" [] []
+        1: SLASH@105..106 "/" [] []
+        2: HTML_TAG_NAME@106..109
+          0: HTML_LITERAL@106..109 "div" [] []
+        3: R_ANGLE@109..110 ">" [] []
+  4: EOF@110..111 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This fixes a bug that was likely the result of me copying string parsing from one of the other formatters. Now the lexer no longer cares about unicode escape sequences.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
fixes #10513

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
