### PR TITLE
fix(cli): emit rdjson code suggestion replacements

### DIFF
--- a/.changeset/sour-monkeys-love.md
+++ b/.changeset/sour-monkeys-love.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10477](https://github.com/biomejs/biome/issues/10477): The RDJSON reporter now emits code replacement text for fix suggestions instead of the human-readable fix description.

--- a/crates/biome_cli/src/reporter/rdjson.rs
+++ b/crates/biome_cli/src/reporter/rdjson.rs
@@ -1,10 +1,11 @@
 use crate::reporter::{Reporter, ReporterVisitor, ReporterWriter};
 use crate::runner::execution::Execution;
 use crate::{DiagnosticsPayload, TraversalSummary};
-use biome_console::fmt::{Display, Formatter};
-use biome_console::{MarkupBuf, markup};
-use biome_diagnostics::display::{SourceFile, markup_to_string};
-use biome_diagnostics::{Error, Location, LogCategory, PrintDescription, Visit};
+use biome_console::markup;
+use biome_diagnostics::display::SourceFile;
+use biome_diagnostics::{Error, Location, PrintDescription, Visit};
+use biome_rowan::{TextRange, TextSize};
+use biome_text_edit::{CompressedOp, DiffOp, TextEdit};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::Serialize;
 
@@ -138,58 +139,40 @@ fn to_rdjson_location(location: &Location<'_>) -> Option<RdJsonLocation> {
 
 struct SuggestionsVisitor {
     suggestions: Vec<RdJsonSuggestion>,
-    current_message: Option<String>,
-    last_diagnostic_length: usize,
 }
 
 impl Visit for SuggestionsVisitor {
-    fn record_log(&mut self, _category: LogCategory, text: &dyn Display) -> std::io::Result<()> {
-        let message = {
-            let mut message = MarkupBuf::default();
-            let mut fmt = Formatter::new(&mut message);
-            fmt.write_markup(markup!({ { text } }))?;
-            markup_to_string(&message).expect("Invalid markup")
+    fn record_code_suggestion(
+        &mut self,
+        location: Location<'_>,
+        diff: &TextEdit,
+    ) -> std::io::Result<()> {
+        let Some(source_code) = location.source_code else {
+            return Ok(());
         };
-        let current_diagnostic_length = self.suggestions.len();
-
-        if self.last_diagnostic_length != current_diagnostic_length {
-            let last_suggestion = self
-                .suggestions
-                .last_mut()
-                .expect("No suggestions to append to");
-            last_suggestion.text = message;
-        } else if let Some(current_message) = self.current_message.as_mut() {
-            current_message.push_str(&message);
-        } else {
-            self.current_message = Some(message);
-        }
-
-        Ok(())
-    }
-
-    fn record_frame(&mut self, location: Location<'_>) -> std::io::Result<()> {
-        let range = if let (Some(span), Some(source_code)) = (location.span, location.source_code) {
-            let source = SourceFile::new(source_code);
-            let start = source.location(span.start()).expect("Invalid span");
-            let end = source.location(span.end()).expect("Invalid span");
-
-            RdJsonRange {
-                end: RdJsonLineColumn {
-                    line: end.line_number.get(),
-                    column: end.column_number.get(),
-                },
-                start: RdJsonLineColumn {
-                    line: start.line_number.get(),
-                    column: start.column_number.get(),
-                },
-            }
-        } else {
-            RdJsonRange::default()
+        let Some(span) = location
+            .span
+            .or_else(|| changed_input_range(diff, source_code.text))
+        else {
+            return Ok(());
         };
 
-        self.last_diagnostic_length = self.suggestions.len();
+        let source = SourceFile::new(source_code);
+        let start = source.location(span.start()).expect("Invalid span");
+        let end = source.location(span.end()).expect("Invalid span");
+        let range = RdJsonRange {
+            end: RdJsonLineColumn {
+                line: end.line_number.get(),
+                column: end.column_number.get(),
+            },
+            start: RdJsonLineColumn {
+                line: start.line_number.get(),
+                column: start.column_number.get(),
+            },
+        };
+
         self.suggestions.push(RdJsonSuggestion {
-            text: self.current_message.take().unwrap_or_default(),
+            text: suggestion_text(diff, source_code.text, span),
             range,
         });
 
@@ -200,13 +183,91 @@ impl Visit for SuggestionsVisitor {
 fn to_rdjson_suggetions(diagnostic: &Error) -> Vec<RdJsonSuggestion> {
     let mut visitor = SuggestionsVisitor {
         suggestions: vec![],
-        last_diagnostic_length: 0,
-        current_message: None,
     };
 
     diagnostic.advices(&mut visitor).unwrap();
 
     visitor.suggestions
+}
+
+fn suggestion_text(diff: &TextEdit, source: &str, range: TextRange) -> String {
+    let mut output = String::new();
+    let mut input_position = TextSize::from(0);
+
+    for op in diff {
+        match op {
+            CompressedOp::DiffOp(DiffOp::Equal { range: diff_range }) => {
+                let text = diff.get_text(*diff_range);
+                append_overlap(&mut output, text, input_position, range);
+                input_position += diff_range.len();
+            }
+            CompressedOp::DiffOp(DiffOp::Insert { range: diff_range }) => {
+                if range.start() <= input_position && input_position <= range.end() {
+                    output.push_str(diff.get_text(*diff_range));
+                }
+            }
+            CompressedOp::DiffOp(DiffOp::Delete { range: diff_range }) => {
+                input_position += diff_range.len();
+            }
+            CompressedOp::EqualLines { line_count } => {
+                let text = equal_lines_text(source, input_position, line_count.get());
+                append_overlap(&mut output, text, input_position, range);
+                input_position += TextSize::of(text);
+            }
+        }
+    }
+
+    output
+}
+
+fn changed_input_range(diff: &TextEdit, source: &str) -> Option<TextRange> {
+    let mut input_position = TextSize::from(0);
+    let mut start = None;
+    let mut end = TextSize::from(0);
+
+    for op in diff {
+        match op {
+            CompressedOp::DiffOp(DiffOp::Equal { range }) => {
+                input_position += range.len();
+            }
+            CompressedOp::DiffOp(DiffOp::Insert { .. }) => {
+                start.get_or_insert(input_position);
+                end = input_position;
+            }
+            CompressedOp::DiffOp(DiffOp::Delete { range }) => {
+                start.get_or_insert(input_position);
+                input_position += range.len();
+                end = input_position;
+            }
+            CompressedOp::EqualLines { line_count } => {
+                let text = equal_lines_text(source, input_position, line_count.get());
+                input_position += TextSize::of(text);
+            }
+        }
+    }
+
+    start.map(|start| TextRange::new(start, end))
+}
+
+fn append_overlap(output: &mut String, text: &str, text_start: TextSize, range: TextRange) {
+    let text_range = TextRange::at(text_start, TextSize::of(text));
+    let Some(overlap) = text_range.intersect(range) else {
+        return;
+    };
+
+    let relative_range = overlap - text_start;
+    output.push_str(&text[relative_range]);
+}
+
+fn equal_lines_text(source: &str, start: TextSize, line_count: u32) -> &str {
+    let input = &source[usize::from(start)..];
+    let mut length = TextSize::from(0);
+
+    for line in input.split_inclusive('\n').take(line_count as usize + 1) {
+        length += TextSize::of(line);
+    }
+
+    &source[TextRange::at(start, length)]
 }
 
 #[derive(Serialize)]

--- a/crates/biome_cli/src/reporter/rdjson.rs
+++ b/crates/biome_cli/src/reporter/rdjson.rs
@@ -158,8 +158,12 @@ impl Visit for SuggestionsVisitor {
         };
 
         let source = SourceFile::new(source_code);
-        let start = source.location(span.start()).expect("Invalid span");
-        let end = source.location(span.end()).expect("Invalid span");
+        let Ok(start) = source.location(span.start()) else {
+            return Ok(());
+        };
+        let Ok(end) = source.location(span.end()) else {
+            return Ok(());
+        };
         let range = RdJsonRange {
             end: RdJsonLineColumn {
                 line: end.line_number.get(),

--- a/crates/biome_cli/src/reporter/rdjson.rs
+++ b/crates/biome_cli/src/reporter/rdjson.rs
@@ -97,7 +97,7 @@ fn diagnostic_to_rdjson<'a>(diagnostic: &'a Error) -> Option<RdJsonDiagnostic<'a
     let location = diagnostic.location();
     let location = to_rdjson_location(&location);
 
-    let suggestions = to_rdjson_suggetions(diagnostic);
+    let suggestions = to_rdjson_suggestions(diagnostic);
     let category = diagnostic.category()?;
     let code = RdJsonCode {
         url: category.link().map(String::from),
@@ -150,10 +150,10 @@ impl Visit for SuggestionsVisitor {
         let Some(source_code) = location.source_code else {
             return Ok(());
         };
-        let Some(span) = location
-            .span
-            .or_else(|| changed_input_range(diff, source_code.text))
-        else {
+        let Some(span) = changed_input_range(diff, source_code.text).or(location.span) else {
+            return Ok(());
+        };
+        let Some(text) = suggestion_text(diff, source_code.text, span) else {
             return Ok(());
         };
 
@@ -175,16 +175,13 @@ impl Visit for SuggestionsVisitor {
             },
         };
 
-        self.suggestions.push(RdJsonSuggestion {
-            text: suggestion_text(diff, source_code.text, span),
-            range,
-        });
+        self.suggestions.push(RdJsonSuggestion { text, range });
 
         Ok(())
     }
 }
 
-fn to_rdjson_suggetions(diagnostic: &Error) -> Vec<RdJsonSuggestion> {
+fn to_rdjson_suggestions(diagnostic: &Error) -> Vec<RdJsonSuggestion> {
     let mut visitor = SuggestionsVisitor {
         suggestions: vec![],
     };
@@ -194,7 +191,8 @@ fn to_rdjson_suggetions(diagnostic: &Error) -> Vec<RdJsonSuggestion> {
     visitor.suggestions
 }
 
-fn suggestion_text(diff: &TextEdit, source: &str, range: TextRange) -> String {
+/// Computes the replacement text that should be applied to `range`.
+fn suggestion_text(diff: &TextEdit, source: &str, range: TextRange) -> Option<String> {
     let mut output = String::new();
     let mut input_position = TextSize::from(0);
 
@@ -202,7 +200,7 @@ fn suggestion_text(diff: &TextEdit, source: &str, range: TextRange) -> String {
         match op {
             CompressedOp::DiffOp(DiffOp::Equal { range: diff_range }) => {
                 let text = diff.get_text(*diff_range);
-                append_overlap(&mut output, text, input_position, range);
+                append_overlap(&mut output, text, input_position, range)?;
                 input_position += diff_range.len();
             }
             CompressedOp::DiffOp(DiffOp::Insert { range: diff_range }) => {
@@ -214,16 +212,17 @@ fn suggestion_text(diff: &TextEdit, source: &str, range: TextRange) -> String {
                 input_position += diff_range.len();
             }
             CompressedOp::EqualLines { line_count } => {
-                let text = equal_lines_text(source, input_position, line_count.get());
-                append_overlap(&mut output, text, input_position, range);
+                let text = equal_lines_text(source, input_position, line_count.get())?;
+                append_overlap(&mut output, text, input_position, range)?;
                 input_position += TextSize::of(text);
             }
         }
     }
 
-    output
+    Some(output)
 }
 
+/// Returns the input range touched by `diff`.
 fn changed_input_range(diff: &TextEdit, source: &str) -> Option<TextRange> {
     let mut input_position = TextSize::from(0);
     let mut start = None;
@@ -244,7 +243,7 @@ fn changed_input_range(diff: &TextEdit, source: &str) -> Option<TextRange> {
                 end = input_position;
             }
             CompressedOp::EqualLines { line_count } => {
-                let text = equal_lines_text(source, input_position, line_count.get());
+                let text = equal_lines_text(source, input_position, line_count.get())?;
                 input_position += TextSize::of(text);
             }
         }
@@ -253,25 +252,39 @@ fn changed_input_range(diff: &TextEdit, source: &str) -> Option<TextRange> {
     start.map(|start| TextRange::new(start, end))
 }
 
-fn append_overlap(output: &mut String, text: &str, text_start: TextSize, range: TextRange) {
+/// Appends the part of `text` that overlaps with `range`.
+fn append_overlap(
+    output: &mut String,
+    text: &str,
+    text_start: TextSize,
+    range: TextRange,
+) -> Option<()> {
     let text_range = TextRange::at(text_start, TextSize::of(text));
     let Some(overlap) = text_range.intersect(range) else {
-        return;
+        return Some(());
     };
 
     let relative_range = overlap - text_start;
-    output.push_str(&text[relative_range]);
+    let relative_range: std::ops::Range<usize> = relative_range.into();
+    output.push_str(text.get(relative_range)?);
+    Some(())
 }
 
-fn equal_lines_text(source: &str, start: TextSize, line_count: u32) -> &str {
-    let input = &source[usize::from(start)..];
+/// Replays the source text covered by a compressed equal-lines diff operation.
+fn equal_lines_text(source: &str, start: TextSize, line_count: u32) -> Option<&str> {
+    let input = source.get(usize::from(start)..)?;
     let mut length = TextSize::from(0);
 
+    // Keep the same line-count semantics as TextEdit::new_string. Splitting on
+    // '\n' preserves CRLF input because the preceding '\r' remains in each line.
     for line in input.split_inclusive('\n').take(line_count as usize + 1) {
         length += TextSize::of(line);
     }
 
-    &source[TextRange::at(start, length)]
+    let range = TextRange::at(start, length);
+    let range: std::ops::Range<usize> = range.into();
+    debug_assert!(range.end <= source.len());
+    source.get(range)
 }
 
 #[derive(Serialize)]
@@ -325,4 +338,50 @@ pub struct RdJsonSuggestion {
 pub struct RdJsonLineColumn {
     column: usize,
     line: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{changed_input_range, equal_lines_text, suggestion_text};
+    use biome_rowan::{TextRange, TextSize};
+    use biome_text_edit::TextEdit;
+
+    #[test]
+    fn changed_input_range_uses_precise_replacement_range() {
+        let source = "let f;\n";
+        let diff = TextEdit::from_unicode_words(source, "let _f;\n");
+        let range = changed_input_range(&diff, source).unwrap();
+
+        assert_eq!(range, TextRange::new(TextSize::from(4), TextSize::from(5)));
+        assert_eq!(suggestion_text(&diff, source, range), Some("_f".into()));
+    }
+
+    #[test]
+    fn changed_input_range_handles_insertions() {
+        let source = "let f;\n";
+        let mut builder = TextEdit::builder();
+        builder.equal("let ");
+        builder.insert("_");
+        builder.equal("f;\n");
+        let diff = builder.finish();
+        let range = changed_input_range(&diff, source).unwrap();
+
+        assert_eq!(range, TextRange::empty(TextSize::from(4)));
+        assert_eq!(suggestion_text(&diff, source, range), Some("_".into()));
+    }
+
+    #[test]
+    fn equal_lines_text_preserves_crlf() {
+        let source = "a\r\nb\r\nc\r\n";
+
+        assert_eq!(
+            equal_lines_text(source, TextSize::from(0), 2),
+            Some("a\r\nb\r\nc\r\n")
+        );
+    }
+
+    #[test]
+    fn equal_lines_text_rejects_invalid_offsets() {
+        assert_eq!(equal_lines_text("abc", TextSize::from(99), 1), None);
+    }
 }

--- a/crates/biome_cli/tests/cases/reporter_rdjson.rs
+++ b/crates/biome_cli/tests/cases/reporter_rdjson.rs
@@ -25,6 +25,8 @@ debugger
 let f;
 		let f;"#;
 
+const FIXABLE_USE_CONST: &str = "let value = 1;\nconsole.log(value);\n";
+
 #[test]
 fn reports_diagnostics_rdjson_check_command() {
     let fs = MemoryFileSystem::default();
@@ -55,6 +57,40 @@ fn reports_diagnostics_rdjson_check_command() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "reports_diagnostics_rdjson_check_command",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn reports_code_suggestions_rdjson_check_command() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new("main.js");
+    fs.insert(file_path.into(), FIXABLE_USE_CONST.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "check",
+                "--reporter=rdjson",
+                "--only=style/useConst",
+                "--error-on-warnings",
+                file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "reports_code_suggestions_rdjson_check_command",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/first_file_then_reporter_name.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/first_file_then_reporter_name.snap
@@ -29,7 +29,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/one_report_to_console_one_to_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/one_report_to_console_one_to_file.snap
@@ -29,7 +29,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/two_report_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/two_report_files.snap
@@ -29,7 +29,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/two_report_to_console.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/two_report_to_console.snap
@@ -46,7 +46,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_code_suggestions_rdjson_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_code_suggestions_rdjson_check_command.snap
@@ -1,0 +1,70 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `main.js`
+
+```js
+let value = 1;
+console.log(value);
+
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some warnings were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+{
+  "source": {
+    "name": "Biome",
+    "url": "https://biomejs.dev"
+  },
+  "diagnostics": [
+    {
+      "code": {
+        "url": "https://biomejs.dev/linter/rules/use-const",
+        "value": "lint/style/useConst"
+      },
+      "location": {
+        "path": "main.js",
+        "range": {
+          "end": {
+            "column": 4,
+            "line": 1
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        }
+      },
+      "message": "This let declares a variable that is only assigned once.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 4,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": "const"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
@@ -68,7 +68,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This import is unused."
+      "message": "This import is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 21,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -88,7 +103,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Several of these imports are unused."
+      "message": "Several of these imports are unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 13,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 2
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -108,7 +138,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 6,
+              "line": 8
+            },
+            "start": {
+              "column": 5,
+              "line": 8
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -128,7 +173,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 8,
+              "line": 9
+            },
+            "start": {
+              "column": 7,
+              "line": 9
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -148,7 +208,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This import is unused."
+      "message": "This import is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 21,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -168,7 +243,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Several of these imports are unused."
+      "message": "Several of these imports are unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 13,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 2
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -188,7 +278,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 6,
+              "line": 8
+            },
+            "start": {
+              "column": 5,
+              "line": 8
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -208,7 +313,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 8,
+              "line": 9
+            },
+            "start": {
+              "column": 7,
+              "line": 9
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -228,7 +348,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Sort these imports."
+      "message": "Sort these imports.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 32,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 1
+            }
+          },
+          "text": "a, b , z } from \"lodash\"\nimport { z} from \"z"
+        }
+      ]
     },
     {
       "code": {
@@ -248,7 +383,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Using == may be unsafe if you are relying on type coercion."
+      "message": "Using == may be unsafe if you are relying on type coercion.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 5,
+              "line": 4
+            },
+            "start": {
+              "column": 5,
+              "line": 4
+            }
+          },
+          "text": "="
+        }
+      ]
     },
     {
       "code": {
@@ -268,7 +418,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 6
+            },
+            "start": {
+              "column": 6,
+              "line": 4
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -328,22 +493,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'z' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 11,
-              "line": 1
-            },
-            "start": {
-              "column": 10,
-              "line": 1
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'z' is redeclared in the same scope."
     },
     {
       "code": {
@@ -363,22 +513,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'f' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 6,
-              "line": 8
-            },
-            "start": {
-              "column": 5,
-              "line": 8
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'f' is redeclared in the same scope."
     },
     {
       "code": {
@@ -404,7 +539,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Sort these imports."
+      "message": "Sort these imports.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 32,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 1
+            }
+          },
+          "text": "a, b , z } from \"lodash\"\nimport { z} from \"z"
+        }
+      ]
     },
     {
       "code": {
@@ -424,7 +574,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Using == may be unsafe if you are relying on type coercion."
+      "message": "Using == may be unsafe if you are relying on type coercion.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 5,
+              "line": 4
+            },
+            "start": {
+              "column": 5,
+              "line": 4
+            }
+          },
+          "text": "="
+        }
+      ]
     },
     {
       "code": {
@@ -444,7 +609,22 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 6
+            },
+            "start": {
+              "column": 6,
+              "line": 4
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -504,22 +684,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'z' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 11,
-              "line": 1
-            },
-            "start": {
-              "column": 10,
-              "line": 1
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'z' is redeclared in the same scope."
     },
     {
       "code": {
@@ -539,22 +704,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'f' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 6,
-              "line": 8
-            },
-            "start": {
-              "column": 5,
-              "line": 8
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'f' is redeclared in the same scope."
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
@@ -29,7 +29,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This import is unused."
+      "message": "This import is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 21,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -49,7 +64,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "Several of these imports are unused."
+      "message": "Several of these imports are unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 13,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 2
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -69,7 +99,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 6,
+              "line": 8
+            },
+            "start": {
+              "column": 5,
+              "line": 8
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -89,7 +134,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 8,
+              "line": 9
+            },
+            "start": {
+              "column": 7,
+              "line": 9
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -109,7 +169,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This import is unused."
+      "message": "This import is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 21,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -129,7 +204,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "Several of these imports are unused."
+      "message": "Several of these imports are unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 13,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 2
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -149,7 +239,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 6,
+              "line": 8
+            },
+            "start": {
+              "column": 5,
+              "line": 8
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -169,7 +274,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 8,
+              "line": 9
+            },
+            "start": {
+              "column": 7,
+              "line": 9
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -189,7 +309,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "Sort these imports."
+      "message": "Sort these imports.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 32,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 1
+            }
+          },
+          "text": "a, b , z } from \"lodash\"\nimport { z} from \"z"
+        }
+      ]
     },
     {
       "code": {
@@ -209,7 +344,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "Using == may be unsafe if you are relying on type coercion."
+      "message": "Using == may be unsafe if you are relying on type coercion.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 5,
+              "line": 4
+            },
+            "start": {
+              "column": 5,
+              "line": 4
+            }
+          },
+          "text": "="
+        }
+      ]
     },
     {
       "code": {
@@ -229,7 +379,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 6
+            },
+            "start": {
+              "column": 6,
+              "line": 4
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -289,22 +454,7 @@ expression: redactor(content)
           }
         }
       },
-      "message": "'z' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 11,
-              "line": 1
-            },
-            "start": {
-              "column": 10,
-              "line": 1
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'z' is redeclared in the same scope."
     },
     {
       "code": {
@@ -324,22 +474,7 @@ expression: redactor(content)
           }
         }
       },
-      "message": "'f' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 6,
-              "line": 8
-            },
-            "start": {
-              "column": 5,
-              "line": 8
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'f' is redeclared in the same scope."
     },
     {
       "code": {
@@ -365,7 +500,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "Sort these imports."
+      "message": "Sort these imports.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 32,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 1
+            }
+          },
+          "text": "a, b , z } from \"lodash\"\nimport { z} from \"z"
+        }
+      ]
     },
     {
       "code": {
@@ -385,7 +535,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "Using == may be unsafe if you are relying on type coercion."
+      "message": "Using == may be unsafe if you are relying on type coercion.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 5,
+              "line": 4
+            },
+            "start": {
+              "column": 5,
+              "line": 4
+            }
+          },
+          "text": "="
+        }
+      ]
     },
     {
       "code": {
@@ -405,7 +570,22 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 6
+            },
+            "start": {
+              "column": 6,
+              "line": 4
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -465,22 +645,7 @@ expression: redactor(content)
           }
         }
       },
-      "message": "'z' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 11,
-              "line": 1
-            },
-            "start": {
-              "column": 10,
-              "line": 1
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'z' is redeclared in the same scope."
     },
     {
       "code": {
@@ -500,22 +665,7 @@ expression: redactor(content)
           }
         }
       },
-      "message": "'f' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 6,
-              "line": 8
-            },
-            "start": {
-              "column": 5,
-              "line": 8
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'f' is redeclared in the same scope."
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
@@ -68,7 +68,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This import is unused."
+      "message": "This import is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 21,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -88,7 +103,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Several of these imports are unused."
+      "message": "Several of these imports are unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 13,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 2
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -108,7 +138,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 6,
+              "line": 8
+            },
+            "start": {
+              "column": 5,
+              "line": 8
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -128,7 +173,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 8,
+              "line": 9
+            },
+            "start": {
+              "column": 7,
+              "line": 9
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -148,7 +208,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This import is unused."
+      "message": "This import is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 21,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -168,7 +243,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Several of these imports are unused."
+      "message": "Several of these imports are unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 13,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 2
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -188,7 +278,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 6,
+              "line": 8
+            },
+            "start": {
+              "column": 5,
+              "line": 8
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -208,7 +313,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 8,
+              "line": 9
+            },
+            "start": {
+              "column": 7,
+              "line": 9
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -228,7 +348,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Sort these imports."
+      "message": "Sort these imports.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 32,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 1
+            }
+          },
+          "text": "a, b , z } from \"lodash\"\nimport { z} from \"z"
+        }
+      ]
     },
     {
       "code": {
@@ -248,7 +383,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Using == may be unsafe if you are relying on type coercion."
+      "message": "Using == may be unsafe if you are relying on type coercion.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 5,
+              "line": 4
+            },
+            "start": {
+              "column": 5,
+              "line": 4
+            }
+          },
+          "text": "="
+        }
+      ]
     },
     {
       "code": {
@@ -268,7 +418,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 6
+            },
+            "start": {
+              "column": 6,
+              "line": 4
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -328,22 +493,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'z' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 11,
-              "line": 1
-            },
-            "start": {
-              "column": 10,
-              "line": 1
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'z' is redeclared in the same scope."
     },
     {
       "code": {
@@ -363,22 +513,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'f' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 6,
-              "line": 8
-            },
-            "start": {
-              "column": 5,
-              "line": 8
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'f' is redeclared in the same scope."
     },
     {
       "code": {
@@ -404,7 +539,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Sort these imports."
+      "message": "Sort these imports.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 32,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 1
+            }
+          },
+          "text": "a, b , z } from \"lodash\"\nimport { z} from \"z"
+        }
+      ]
     },
     {
       "code": {
@@ -424,7 +574,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "Using == may be unsafe if you are relying on type coercion."
+      "message": "Using == may be unsafe if you are relying on type coercion.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 5,
+              "line": 4
+            },
+            "start": {
+              "column": 5,
+              "line": 4
+            }
+          },
+          "text": "="
+        }
+      ]
     },
     {
       "code": {
@@ -444,7 +609,22 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 6
+            },
+            "start": {
+              "column": 6,
+              "line": 4
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -504,22 +684,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'z' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 11,
-              "line": 1
-            },
-            "start": {
-              "column": 10,
-              "line": 1
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'z' is redeclared in the same scope."
     },
     {
       "code": {
@@ -539,22 +704,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'f' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 6,
-              "line": 8
-            },
-            "start": {
-              "column": 5,
-              "line": 8
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'f' is redeclared in the same scope."
     },
     {
       "code": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_lint_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_lint_command.snap
@@ -68,7 +68,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This import is unused."
+      "message": "This import is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 21,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -88,7 +103,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "Several of these imports are unused."
+      "message": "Several of these imports are unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 13,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 2
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -108,7 +138,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 6,
+              "line": 8
+            },
+            "start": {
+              "column": 5,
+              "line": 8
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -128,7 +173,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 8,
+              "line": 9
+            },
+            "start": {
+              "column": 7,
+              "line": 9
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -148,7 +208,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This import is unused."
+      "message": "This import is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 21,
+              "line": 1
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -168,7 +243,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "Several of these imports are unused."
+      "message": "Several of these imports are unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 13,
+              "line": 2
+            },
+            "start": {
+              "column": 10,
+              "line": 2
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -188,7 +278,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 6,
+              "line": 8
+            },
+            "start": {
+              "column": 5,
+              "line": 8
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -208,7 +313,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This variable f is unused."
+      "message": "This variable f is unused.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 8,
+              "line": 9
+            },
+            "start": {
+              "column": 7,
+              "line": 9
+            }
+          },
+          "text": "_f"
+        }
+      ]
     },
     {
       "code": {
@@ -228,7 +348,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "Using == may be unsafe if you are relying on type coercion."
+      "message": "Using == may be unsafe if you are relying on type coercion.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 5,
+              "line": 4
+            },
+            "start": {
+              "column": 5,
+              "line": 4
+            }
+          },
+          "text": "="
+        }
+      ]
     },
     {
       "code": {
@@ -248,7 +383,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 6
+            },
+            "start": {
+              "column": 6,
+              "line": 4
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -308,22 +458,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "'z' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 11,
-              "line": 1
-            },
-            "start": {
-              "column": 10,
-              "line": 1
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'z' is redeclared in the same scope."
     },
     {
       "code": {
@@ -343,22 +478,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "'f' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 6,
-              "line": 8
-            },
-            "start": {
-              "column": 5,
-              "line": 8
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'f' is redeclared in the same scope."
     },
     {
       "code": {
@@ -378,7 +498,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "Using == may be unsafe if you are relying on type coercion."
+      "message": "Using == may be unsafe if you are relying on type coercion.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 5,
+              "line": 4
+            },
+            "start": {
+              "column": 5,
+              "line": 4
+            }
+          },
+          "text": "="
+        }
+      ]
     },
     {
       "code": {
@@ -398,7 +533,22 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This is an unexpected use of the debugger statement."
+      "message": "This is an unexpected use of the debugger statement.",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 9,
+              "line": 6
+            },
+            "start": {
+              "column": 6,
+              "line": 4
+            }
+          },
+          "text": ""
+        }
+      ]
     },
     {
       "code": {
@@ -458,22 +608,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "'z' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 11,
-              "line": 1
-            },
-            "start": {
-              "column": 10,
-              "line": 1
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'z' is redeclared in the same scope."
     },
     {
       "code": {
@@ -493,22 +628,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "'f' is redeclared in the same scope.",
-      "suggestions": [
-        {
-          "range": {
-            "end": {
-              "column": 6,
-              "line": 8
-            },
-            "start": {
-              "column": 5,
-              "line": 8
-            }
-          },
-          "text": "Remove the duplicate declaration or rename one of the variables."
-        }
-      ]
+      "message": "'f' is redeclared in the same scope."
     }
   ]
 }

--- a/crates/biome_diagnostics/src/advice.rs
+++ b/crates/biome_diagnostics/src/advice.rs
@@ -45,6 +45,16 @@ pub trait Visit {
         Ok(())
     }
 
+    /// Prints an applicable code suggestion at the provided source location.
+    fn record_code_suggestion(
+        &mut self,
+        location: Location<'_>,
+        diff: &TextEdit,
+    ) -> io::Result<()> {
+        let _ = location;
+        self.record_diff(diff)
+    }
+
     /// Prints a Rust backtrace.
     fn record_backtrace(
         &mut self,
@@ -227,6 +237,6 @@ where
             },
         )?;
 
-        visitor.record_diff(&self.suggestion)
+        visitor.record_code_suggestion(Location::builder().build(), &self.suggestion)
     }
 }

--- a/crates/biome_diagnostics/src/context.rs
+++ b/crates/biome_diagnostics/src/context.rs
@@ -634,6 +634,20 @@ mod internal {
             self.visitor.record_diff(diff)
         }
 
+        fn record_code_suggestion(
+            &mut self,
+            location: Location<'_>,
+            diff: &TextEdit,
+        ) -> io::Result<()> {
+            self.visitor.record_code_suggestion(
+                Location {
+                    source_code: Some(location.source_code.unwrap_or(self.source_code)),
+                    ..location
+                },
+                diff,
+            )
+        }
+
         fn record_backtrace(
             &mut self,
             title: &dyn fmt::Display,

--- a/crates/biome_diagnostics/src/serde.rs
+++ b/crates/biome_diagnostics/src/serde.rs
@@ -298,6 +298,7 @@ impl Advice {
             | Self::Command(_)
             | Self::Diff(_) => {}
             Self::Frame(location) | Self::CodeSuggestion(location, _) => {
+                // CodeSuggestion locations are span-less today; offset the TextEdit too if that changes.
                 location.offset_by(offset);
             }
             Self::Group(_, advices) => {
@@ -430,11 +431,12 @@ impl schemars::JsonSchema for DiagnosticTags {
 mod tests {
     use std::io;
 
+    use biome_text_edit::TextEdit;
     use biome_text_size::{TextRange, TextSize};
     use serde_json::{Value, from_value, json, to_value};
 
     use crate::{
-        self as biome_diagnostics, {Advices, LogCategory, Visit},
+        self as biome_diagnostics, {Advices, LogCategory, Resource, Visit},
     };
     use biome_diagnostics_macros::Diagnostic;
 
@@ -552,5 +554,24 @@ mod tests {
         let expected = super::Diagnostic::new(expected);
 
         assert_eq!(diag, expected);
+    }
+
+    #[test]
+    fn test_code_suggestion_advice_round_trip() {
+        let advice = super::Advices {
+            advices: vec![super::Advice::CodeSuggestion(
+                super::Location {
+                    path: Some(Resource::File("path".to_string())),
+                    span: Some(TextRange::new(TextSize::from(0), TextSize::from(3))),
+                    source_code: Some("let".to_string()),
+                },
+                TextEdit::from_unicode_words("let", "const"),
+            )],
+        };
+
+        let json = to_value(&advice).unwrap();
+        let round_trip: super::Advices = from_value(json).unwrap();
+
+        assert_eq!(round_trip, advice);
     }
 }

--- a/crates/biome_diagnostics/src/serde.rs
+++ b/crates/biome_diagnostics/src/serde.rs
@@ -219,6 +219,16 @@ impl Visit for Advices {
         Ok(())
     }
 
+    fn record_code_suggestion(
+        &mut self,
+        location: super::Location<'_>,
+        diff: &TextEdit,
+    ) -> io::Result<()> {
+        self.advices
+            .push(Advice::CodeSuggestion(location.into(), diff.clone()));
+        Ok(())
+    }
+
     fn record_backtrace(
         &mut self,
         title: &dyn fmt::Display,
@@ -273,6 +283,7 @@ enum Advice {
     List(Vec<MarkupBuf>),
     Frame(Location),
     Diff(TextEdit),
+    CodeSuggestion(Location, TextEdit),
     Backtrace(MarkupBuf, Backtrace),
     Command(String),
     Group(MarkupBuf, Advices),
@@ -286,7 +297,7 @@ impl Advice {
             | Self::Backtrace(_, _)
             | Self::Command(_)
             | Self::Diff(_) => {}
-            Self::Frame(location) => {
+            Self::Frame(location) | Self::CodeSuggestion(location, _) => {
                 location.offset_by(offset);
             }
             Self::Group(_, advices) => {
@@ -314,6 +325,17 @@ impl super::Advices for Advice {
                 }),
             }),
             Self::Diff(diff) => visitor.record_diff(diff),
+            Self::CodeSuggestion(location, diff) => visitor.record_code_suggestion(
+                super::Location {
+                    resource: location.path.as_ref().map(super::Resource::as_deref),
+                    span: location.span,
+                    source_code: location.source_code.as_deref().map(|text| SourceCode {
+                        text,
+                        line_starts: None,
+                    }),
+                },
+                diff,
+            ),
             Self::Backtrace(title, backtrace) => visitor.record_backtrace(title, backtrace),
             Self::Command(command) => visitor.record_command(command),
             Self::Group(title, advice) => visitor.record_group(title, advice),

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_are_loaded_and_used_during_analysis.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_are_loaded_and_used_during_analysis.snap
@@ -59,7 +59,12 @@ expression: result.diagnostics
                     Info,
                     "Unsafe fix: If this is intentional, prepend "<Emphasis>"a"</Emphasis>" with an underscore.",
                 ),
-                Diff(
+                CodeSuggestion(
+                    Location {
+                        path: None,
+                        span: None,
+                        source_code: None,
+                    },
                     TextEdit {
                         dictionary: "const a_a = Object.assign({ foo: 'bar' });",
                         ops: [

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_may_use_invalid_span.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_may_use_invalid_span.snap
@@ -89,7 +89,12 @@ expression: result.diagnostics
                     Info,
                     "Unsafe fix: If this is intentional, prepend "<Emphasis>"a"</Emphasis>" with an underscore.",
                 ),
-                Diff(
+                CodeSuggestion(
+                    Location {
+                        path: None,
+                        span: None,
+                        source_code: None,
+                    },
                     TextEdit {
                         dictionary: "const a_a = Object.assign({ foo: 'bar' });",
                         ops: [

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -9638,6 +9638,7 @@ export type Advice =
 	| { list: MarkupBuf[] }
 	| { frame: Location }
 	| { diff: TextEdit }
+	| { codeSuggestion: [Location, TextEdit] }
 	| { backtrace: [MarkupBuf, Backtrace] }
 	| { command: string }
 	| { group: [MarkupBuf, Advices] };


### PR DESCRIPTION
## Summary
- emit RDJSON suggestions from code fix diffs instead of advice text
- keep code suggestions distinct when diagnostics are serialized and replayed
- add a RDJSON regression snapshot for `style/useConst`

Fixes #10477.

## Tests
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=C:\Users\ansha\AppData\Local\Temp\biome-target CARGO_INCREMENTAL=0 cargo test -p biome_cli --test main reporter_rdjson -- --nocapture`
- `CARGO_TARGET_DIR=C:\Users\ansha\AppData\Local\Temp\biome-target CARGO_INCREMENTAL=0 cargo test -p biome_diagnostics -p biome_analyze`

AI assistance: implementation and local verification were assisted by ChatGPT/Codex.