### PR TITLE
fix(linter): recognize contrast-color() as a known CSS function

### DIFF
--- a/.changeset/fuzzy-beans-boil.md
+++ b/.changeset/fuzzy-beans-boil.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the `correctness/noUnknownFunction` rule incorrectly flagging the CSS `contrast-color()` function as unknown. `contrast-color` is Baseline 2026.

--- a/.changeset/fuzzy-beans-boil.md
+++ b/.changeset/fuzzy-beans-boil.md
@@ -2,9 +2,4 @@
 "@biomejs/biome": patch
 ---
 
----
-package: `@biomejs/biome`
-type: patch
----
-
 Fixed [`#10536`](https://github.com/biomejs/biome/issues/10536): [noUnknownFunction](https://biomejs.dev/linter/rules/no-unknown-function/) no longer flagged CSS `contrast-color()` as unknown. `contrast-color()` is Baseline 2026.

--- a/.changeset/fuzzy-beans-boil.md
+++ b/.changeset/fuzzy-beans-boil.md
@@ -2,4 +2,9 @@
 "@biomejs/biome": patch
 ---
 
-Fixed the `correctness/noUnknownFunction` rule incorrectly flagging the CSS `contrast-color()` function as unknown. `contrast-color` is Baseline 2026.
+---
+package: `@biomejs/biome`
+type: patch
+---
+
+Fixed [`#10536`](https://github.com/biomejs/biome/issues/10536): [noUnknownFunction](https://biomejs.dev/linter/rules/no-unknown-function/) no longer flagged CSS `contrast-color()` as unknown. `contrast-color()` is Baseline 2026.

--- a/crates/biome_css_analyze/src/keywords.rs
+++ b/crates/biome_css_analyze/src/keywords.rs
@@ -655,6 +655,7 @@ pub const FUNCTION_KEYWORDS: &[&str] = &[
     "color-stop",
     "conic-gradient",
     "contrast",
+    "contrast-color",
     "cos",
     "counter",
     "counters",

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.css
@@ -21,3 +21,5 @@ a { animation-delay: calc(sibling-count() * 50ms); }
 @font-face {
 	src: url('/fonts/Obviously.woff2?v=1') format('woff2') tech('variations');
 }
+
+a { color: contrast-color(rebeccapurple); }

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.css.snap
@@ -28,6 +28,8 @@ a { animation-delay: calc(sibling-count() * 50ms); }
 	src: url('/fonts/Obviously.woff2?v=1') format('woff2') tech('variations');
 }
 
+a { color: contrast-color(rebeccapurple); }
+
 ```
 
 _Note: The parser emitted 3 diagnostics which are not shown here._


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->
AI assistance notice: I used Claude Sonnet 4.6 to find the places where I needed to make changes. All code changes are done by myself.

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Fixes https://github.com/biomejs/biome/issues/10536. CSS `contrast-color()` is baseline 2026 and should therefore be recognized by biome as a known function. Without this change `correctness/noUnknownFunctions` reports this as an error.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added a test case.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

No new rule or action, nothing documentation worthy IMO.
