### PR TITLE
chore: run cargo clippy on edited Rust files via Claude hook

### DIFF
--- a/.claude/hooks/clippy-on-edit.sh
+++ b/.claude/hooks/clippy-on-edit.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run cargo clippy on any crate touched by a Write, Edit, or MultiEdit call.
+set -euo pipefail
+
+input=$(cat)
+
+# Extract all edited .rs file paths, resolve to crate roots, deduplicate, run clippy.
+echo "$input" | jq -r '
+  [
+    (.tool_input.file_path // empty),
+    (.tool_input.edits[]?.file_path // empty)
+  ][] | select(endswith(".rs"))
+' | while IFS= read -r file; do
+  dir=$(dirname "$file")
+  while [[ "$dir" != "/" && ! -f "$dir/Cargo.toml" ]]; do
+    dir=$(dirname "$dir")
+  done
+  [[ -f "$dir/Cargo.toml" ]] && echo "$dir"
+done | sort -u | while IFS= read -r dir; do
+  pkg=$(grep -m1 '^name' "$dir/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
+  echo "clippy: $pkg"
+  cargo clippy -p "$pkg" 2>&1 | head -50
+done

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "permissions": {
     "allow": [
       "Bash(cargo insta:*)",
+      "Bash(cargo clippy:*)",
       "Bash(grep:*)",
       "Bash(find:*)",
       "Bash(just:*)",
@@ -15,6 +16,21 @@
     "deny": [
       "Bash(cargo biome-cli-dev:*)",
       "Bash(cargo biome-cli:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/clippy-on-edit.sh",
+            "timeout": 60,
+            "statusMessage": "Running clippy..."
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adds a Claude Code hook that runs `cargo clippy` scoped to the edited crate whenever a `.rs` file is written or edited. This catches lint errors locally before they reach CI.

The hook lives in `.claude/hooks/clippy-on-edit.sh` (checked in, so all contributors get it automatically) and is wired up in `.claude/settings.json` as a `PostToolUse` hook on `Write|Edit`.

**How it works:**
1. Receives the edited file path from Claude's hook stdin
2. Skips non-`.rs` files immediately
3. Walks up the directory tree to find the nearest `Cargo.toml`
4. Extracts the package name and runs `cargo clippy -p <crate>` (scoped, not the full workspace)

## Test Plan

Pipe-tested the script manually — runs clean on the current codebase.

## Docs

N/A