### PR TITLE
chore: add SCSS in unstable wasm build

### DIFF
--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -114,6 +114,7 @@ lang_md      = [
   "dep:biome_markdown_parser",
   "dep:biome_markdown_syntax"
 ]
+lang_scss    = ["biome_css_syntax/scss"]
 lang_yaml    = [
   "biome_configuration/lang_yaml",
   "dep:biome_yaml_formatter",

--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -46,8 +46,9 @@ schemars           = { workspace = true }
 [features]
 default   = ["console_error_panic_hook"]
 lang_md   = ["biome_service/lang_md"]
+lang_scss = ["biome_service/lang_scss"]
 lang_yaml = ["biome_service/lang_yaml"]
-unstable  = ["lang_md", "lang_yaml"]
+unstable  = ["lang_md", "lang_scss", "lang_yaml"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Enable SCSS in unstable wasm build to add scss in our playground.

## Test Plan

I emulated the playground wasm path locally and SCSS formatting is available with the unstable wasm build.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SCSS language support to the platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->