### PR TITLE
fix: avoid infinite recursion by passing depth to resolve_callee_to_function

### DIFF
--- a/.changeset/old-birds-pick.md
+++ b/.changeset/old-birds-pick.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10492](https://github.com/biomejs/biome/issues/10492): Biome no longer crashes with a stack overflow on certain code when a type-aware rule such as [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-floating-promises/), [`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/), or [`noUnnecessaryConditions`](https://biomejs.dev/linter/rules/no-unnecessary-conditions/) is enabled. For example, the following code used to crash Biome:
+
+```js
+function f(visitor) {
+	let ctrl = visitor();
+	for (const x of [0]) ctrl = ctrl();
+}
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue_10492.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue_10492.ts
@@ -1,0 +1,6 @@
+// should not generate diagnostics
+
+function f(visitor) {
+	let ctrl = visitor();
+	for (const x of [0]) ctrl = ctrl();
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue_10492.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue_10492.ts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_10492.ts
+---
+# Input
+```ts
+// should not generate diagnostics
+
+function f(visitor) {
+	let ctrl = visitor();
+	for (const x of [0]) ctrl = ctrl();
+}
+
+```

--- a/crates/biome_js_type_info/src/flattening.rs
+++ b/crates/biome_js_type_info/src/flattening.rs
@@ -84,7 +84,7 @@ impl TypeData {
                 },
                 None => None,
             },
-            Self::TypeofExpression(expr) => flattened_expression(expr, resolver),
+            Self::TypeofExpression(expr) => flattened_expression(expr, resolver, 0),
             Self::TypeofType(reference) => resolver
                 .resolve_reference(reference.as_ref())
                 .map(Self::reference),

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -26,6 +26,7 @@ use crate::{
 pub(super) fn flattened_expression(
     expr: &TypeofExpression,
     resolver: &mut dyn TypeResolver,
+    depth: usize,
 ) -> Option<TypeData> {
     match expr {
         TypeofExpression::Addition(expr) => {
@@ -101,7 +102,7 @@ pub(super) fn flattened_expression(
                 })
         }
         TypeofExpression::Call(expr) => match resolver.resolve_and_get(&expr.callee) {
-            Some(callee) => flattened_call(expr, callee.to_data(), resolver),
+            Some(callee) => flattened_call(expr, callee.to_data(), resolver, depth),
             None => None,
         },
         TypeofExpression::Conditional(expr) => {
@@ -350,14 +351,25 @@ pub(super) fn flattened_expression(
 }
 
 /// Resolves a callee type through layers of indirection (`TypeofExpression`,
-/// `InstanceOf`, `Interface`, `Object`) until a `Function` is found, bounded
-/// by [`MAX_FLATTEN_DEPTH`] iterations.
+/// `InstanceOf`, `Interface`, `Object`) until a `Function` is found.
+///
+/// Each invocation unwraps at most [`MAX_FLATTEN_DEPTH`] non-recursive layers.
+/// Flattening a `TypeofExpression` callee re-enters [`flattened_expression`],
+/// which can cycle back here for self-calling values (e.g. `ctrl = ctrl()`), so
+/// `depth` bounds that recursion and the function bails once it exceeds
+/// [`MAX_FLATTEN_DEPTH`].
 ///
 /// Returns `None` if no function can be reached.
 fn resolve_callee_to_function(
     callee: TypeData,
     resolver: &mut dyn TypeResolver,
+    mut depth: usize,
 ) -> Option<Box<Function>> {
+    depth += 1;
+    if depth > MAX_FLATTEN_DEPTH {
+        return None;
+    }
+
     let mut callee = callee;
     for _ in 0..MAX_FLATTEN_DEPTH {
         match callee {
@@ -366,7 +378,7 @@ fn resolve_callee_to_function(
             // are represented as unflattened `TypeofExpression` nodes when imported.
             // Eagerly flatten them so the underlying function type is reachable.
             TypeData::TypeofExpression(expr) => {
-                callee = flattened_expression(&expr, resolver)?;
+                callee = flattened_expression(&expr, resolver, depth)?;
             }
             TypeData::InstanceOf(instance) => {
                 let instance_callee = resolver.resolve_and_get(&instance.ty)?;
@@ -398,6 +410,7 @@ fn flattened_call(
     expr: &TypeofCallExpression,
     callee: TypeData,
     resolver: &mut dyn TypeResolver,
+    depth: usize,
 ) -> Option<TypeData> {
     match callee {
         TypeData::Union(union) => {
@@ -421,7 +434,8 @@ fn flattened_call(
                     }
                     _ => {}
                 }
-                if let Some(function) = resolve_callee_to_function(resolved.to_data(), resolver)
+                if let Some(function) =
+                    resolve_callee_to_function(resolved.to_data(), resolver, depth)
                     && let Some(result) = flattened_function_call(expr, &function, resolver)
                 {
                     return_types.push(result);
@@ -443,7 +457,7 @@ fn flattened_call(
             }
         }
         callee => {
-            let function = resolve_callee_to_function(callee, resolver)?;
+            let function = resolve_callee_to_function(callee, resolver, depth)?;
             flattened_function_call(expr, &function, resolver)
         }
     }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #10492 

Added a `depth` parameter to bind the max depth size. 

Implemented via AI coding agent.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a new test 

<!-- What demonstrates that your implementation is correct? -->

## Docs


N/A
<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
