### PR TITLE
fix(useVueConsistentVBindStyle): don't flag v-bind directives that don't have arguments

### DIFF
--- a/.changeset/cruel-cats-laugh.md
+++ b/.changeset/cruel-cats-laugh.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [`useVueConsistentVBindStyle`](https://biomejs.dev/linter/rules/use-vue-consistent-v-bind-style/): The rule no longer reports argument-less `v-bind` directives because they cannot be converted to shorthand syntax.

--- a/crates/biome_html_analyze/src/lint/style/use_vue_consistent_v_bind_style.rs
+++ b/crates/biome_html_analyze/src/lint/style/use_vue_consistent_v_bind_style.rs
@@ -24,6 +24,7 @@ declare_lint_rule! {
     ///
     /// ```vue
     /// <div :foo="bar" />
+    /// <div v-bind="props" />
     /// ```
     ///
     /// ## Options
@@ -78,8 +79,8 @@ impl Rule for UseVueConsistentVBindStyle {
                 if dir.name_token().ok()?.text_trimmed() != "v-bind" {
                     return None;
                 }
-                // If prefer shorthand, normal form is invalid
-                if style == VueDirectiveStyle::Shorthand {
+                // Argument-less v-bind cannot be represented with shorthand syntax.
+                if style == VueDirectiveStyle::Shorthand && dir.arg().is_some() {
                     return Some(node.clone());
                 }
                 None

--- a/crates/biome_html_analyze/tests/specs/style/useVueConsistentVBindStyle/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/style/useVueConsistentVBindStyle/valid.vue
@@ -1,4 +1,7 @@
 <!-- should not generate diagnostics -->
 <template>
   <div :foo="bar" />
+  <DialogTrigger data-slot="dialog-trigger" v-bind="props">
+    <slot></slot>
+  </DialogTrigger>
 </template>

--- a/crates/biome_html_analyze/tests/specs/style/useVueConsistentVBindStyle/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/style/useVueConsistentVBindStyle/valid.vue.snap
@@ -7,6 +7,9 @@ expression: valid.vue
 <!-- should not generate diagnostics -->
 <template>
   <div :foo="bar" />
+  <DialogTrigger data-slot="dialog-trigger" v-bind="props">
+    <slot></slot>
+  </DialogTrigger>
 </template>
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
A v-bind directive in the form `v-bind="props"` (no argument) is the vue version of spread props eg `<div {...restProps}>`.

Found this while testing on one of my projects.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
updated snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
