### PR TITLE
fix(a11y): useAriaPropsForRole no longer false-positives on Vue v-bind shorthand 🤖🤖🤖

### DIFF
--- a/.changeset/fix-use-aria-props-for-role-vue-bindings.md
+++ b/.changeset/fix-use-aria-props-for-role-vue-bindings.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10564](https://github.com/biomejs/biome/issues/10564): `useAriaPropsForRole` no longer reports false positives for Vue v-bind shorthand bindings (`:aria-checked`, `:aria-level`, etc.).

--- a/crates/biome_html_analyze/src/lint/a11y/use_aria_props_for_role.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_aria_props_for_role.rs
@@ -78,7 +78,7 @@ impl Rule for UseAriaPropsForRole {
             .flat_map(|role| role.required_attributes().iter())
             .filter_map(|attribute| {
                 let attribute_name = attribute.as_str();
-                node.find_attribute_by_name(attribute_name)
+                node.find_attribute_or_vue_binding(attribute_name)
                     .is_none()
                     .then_some(attribute_name)
             })

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/valid.html
@@ -37,3 +37,4 @@
 	aria-valuemin="0"
 	aria-valuenow="50"
 ></span>
+

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/valid.html.snap
@@ -44,4 +44,5 @@ expression: valid.html
 	aria-valuenow="50"
 ></span>
 
+
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/valid.vue
@@ -1,0 +1,15 @@
+<!-- should not generate diagnostics: Vue v-bind shorthand (:aria-*) bindings satisfy required aria props -->
+<template>
+	<span role="checkbox" :aria-checked="isChecked"></span>
+	<span role="radio" :aria-checked="true"></span>
+	<span role="switch" :aria-checked="dynamicValue"></span>
+	<span role="heading" :aria-level="level"></span>
+	<span role="option" :aria-selected="selected"></span>
+	<span
+		role="slider"
+		:aria-valuemax="max"
+		:aria-valuemin="min"
+		:aria-valuenow="current"
+	></span>
+	<span role="meter" :aria-valuenow="progress"></span>
+</template>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/valid.vue.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics: Vue v-bind shorthand (:aria-*) bindings satisfy required aria props -->
+<template>
+	<span role="checkbox" :aria-checked="isChecked"></span>
+	<span role="radio" :aria-checked="true"></span>
+	<span role="switch" :aria-checked="dynamicValue"></span>
+	<span role="heading" :aria-level="level"></span>
+	<span role="option" :aria-selected="selected"></span>
+	<span
+		role="slider"
+		:aria-valuemax="max"
+		:aria-valuemin="min"
+		:aria-valuenow="current"
+	></span>
+	<span role="meter" :aria-valuenow="progress"></span>
+</template>
+
+```


### PR DESCRIPTION
Fixes #10564

## Summary

`useAriaPropsForRole` was reporting false positives when required aria attributes were supplied via Vue v-bind shorthand syntax (`:aria-checked="value"`, `:aria-level="n"`, etc.).

The rule checks for missing required aria props by calling `find_attribute_by_name`, which only inspects `HtmlAttribute` nodes. Vue v-bind shorthands are parsed as `VueVBindShorthandDirective` nodes with a structured `arg()` field — not as `HtmlAttribute` nodes — so `find_attribute_by_name` always returned `None` for them, triggering a spurious diagnostic.

Fix: replace `find_attribute_by_name` with `find_attribute_or_vue_binding`, which already handles both plain html attributes and Vue v-bind directives. This is the same pattern used in `use_alt_text.rs`.

## Test Plan

Added `valid.vue` snapshot test covering `:aria-checked`, `:aria-level`, `:aria-selected`, `:aria-valuenow/min/max`, and `:aria-valuenow` for several roles (`checkbox`, `radio`, `switch`, `heading`, `option`, `slider`, `meter`). All 3 spec tests pass (invalid.html, valid.html, valid.vue).

```
cargo test -p biome_html_analyze use_aria_props_for_role
# test result: ok. 3 passed; 0 failed
```

## Docs

No documentation changes needed — rule behavior is unchanged for static attributes; this only removes a false positive for dynamic Vue bindings.

> This PR was created with AI assistance (Claude Code).
