### PR TITLE
refactor(useExportType): improve docs and code

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -11,9 +11,9 @@ use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsExportNamedSpecifier, AnyJsModuleSource, JsExport, JsExportNamedClause,
-    JsExportNamedFromClause, JsExportNamedFromSpecifier, JsExportNamedFromSpecifierList,
-    JsExportNamedSpecifierList, JsFileSource, JsSyntaxToken, T,
+    AnyJsExportNamedSpecifier, JsExport, JsExportNamedClause, JsExportNamedFromClause,
+    JsExportNamedFromSpecifier, JsExportNamedFromSpecifierList, JsExportNamedSpecifierList,
+    JsFileSource, JsSyntaxToken, T,
 };
 use biome_rowan::{
     AstNode, AstSeparatedList, BatchMutationExt, TriviaPieceKind, chain_trivia_pieces,
@@ -24,11 +24,17 @@ use biome_rule_options::use_export_type::{Style, UseExportTypeOptions};
 declare_lint_rule! {
     /// Promotes the use of `export type` for types.
     ///
-    /// _TypeScript_ allows adding the `type` keyword on an `export` to indicate that the `export` doesn't exist at runtime.
+    /// _TypeScript_ allows specifying a `type` keyword on an `export` to indicate that the `export` doesn't exist at runtime.
     /// This allows compilers to safely drop exports of types without looking for their definition.
     ///
-    /// The rule ensures that types are exported using a type-only `export`.
+    /// The rule ensures that all exports used only as a type use a type-only `export`.
     /// It also groups inline type exports into a grouped `export type`.
+    ///
+    /// If you use the TypeScript Compiler (TSC) to compile your code into JavaScript,
+    /// then you can disable this rule, as TSC can remove exports only used as types.
+    /// However, for consistency and compatibility with other compilers, you may want to enable this rule.
+    /// In that case we recommend to enable TSC's [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax).
+    /// This configuration ensures that TSC preserves exports not marked with the `type` keyword.
     ///
     /// ## Examples
     ///
@@ -77,7 +83,7 @@ declare_lint_rule! {
     ///
     /// - `inlineType`: always use `export { type T }` instead of `export type { T }`
     /// - `separatedType`: always use `export type { T }` instead of `export { type T }`
-    /// - `auto`: use both `export type { T }` and `export { type T }` (default)
+    /// - `auto`: use `export type { T }` or `export { type T, V }` when values are exported alongside types (default)
     ///
     /// ```jsonc,options
     /// {
@@ -487,14 +493,8 @@ impl Rule for UseExportType {
                             &specifiers,
                             specifiers_requiring_type_marker,
                         )?;
-                        let (export_named_type, export_named_value) = new_named_exports(
-                            export_token,
-                            named_type,
-                            named_value,
-                            clause.l_curly_token().ok()?,
-                            clause.r_curly_token().ok()?,
-                            clause.semicolon_token(),
-                        );
+                        let (export_named_type, export_named_value) =
+                            new_named_exports(export_token, clause, named_type, named_value)?;
                         add_module_items(
                             &mut mutation,
                             export.syntax(),
@@ -525,16 +525,8 @@ impl Rule for UseExportType {
                             &specifiers,
                             specifiers_requiring_type_marker,
                         )?;
-                        let (export_named_type, export_named_value) = new_named_from_exports(
-                            export_token,
-                            named_type,
-                            named_value,
-                            clause.l_curly_token().ok()?,
-                            clause.r_curly_token().ok()?,
-                            clause.from_token().ok()?,
-                            clause.source().ok()?,
-                            clause.semicolon_token(),
-                        );
+                        let (export_named_type, export_named_value) =
+                            new_named_from_exports(export_token, clause, named_type, named_value)?;
                         add_module_items(
                             &mut mutation,
                             export.syntax(),
@@ -658,6 +650,8 @@ fn split_export_named_specifiers(
     specifiers: &JsExportNamedSpecifierList,
     specifiers_requiring_type_keyword: &[AnyJsExportNamedSpecifier],
 ) -> Option<(JsExportNamedSpecifierList, JsExportNamedSpecifierList)> {
+    // There is at least one expprt that is not a type.
+    // Thus there is at most `len - 1` type-only exports.
     let mut type_specifiers = Vec::with_capacity(specifiers.len() - 1);
     let mut type_specifier_separators = Vec::with_capacity(specifiers.len() - 1);
     let mut value_specifiers =
@@ -708,6 +702,8 @@ fn split_export_named_from_specifiers(
     JsExportNamedFromSpecifierList,
     JsExportNamedFromSpecifierList,
 )> {
+    // There is at least one expprt that is not a type.
+    // Thus there is at most `len - 1` type-only exports.
     let mut type_specifiers = Vec::with_capacity(specifiers.len() - 1);
     let mut type_specifier_separators = Vec::with_capacity(specifiers.len() - 1);
     let mut value_specifiers =
@@ -753,12 +749,13 @@ fn split_export_named_from_specifiers(
 
 fn new_named_exports(
     export_token: JsSyntaxToken,
+    export_clause: &JsExportNamedClause,
     named_type_specifiers: JsExportNamedSpecifierList,
     named_value_specifiers: JsExportNamedSpecifierList,
-    l_curly_token: JsSyntaxToken,
-    r_curly_token: JsSyntaxToken,
-    semicolon_token: Option<JsSyntaxToken>,
-) -> (JsExport, JsExport) {
+) -> Option<(JsExport, JsExport)> {
+    let l_curly_token = export_clause.l_curly_token().ok()?;
+    let r_curly_token = export_clause.r_curly_token().ok()?;
+    let semicolon_token = export_clause.semicolon_token();
     let type_export_clause = make::js_export_named_clause(
         l_curly_token.clone(),
         named_type_specifiers,
@@ -786,20 +783,20 @@ fn new_named_exports(
         new_export_token,
         value_export_clause.into(),
     );
-    (export_type, export_value)
+    Some((export_type, export_value))
 }
 
-#[expect(clippy::too_many_arguments)]
 fn new_named_from_exports(
     export_token: JsSyntaxToken,
+    export_clause: &JsExportNamedFromClause,
     named_type_specifiers: JsExportNamedFromSpecifierList,
     named_value_specifiers: JsExportNamedFromSpecifierList,
-    l_curly_token: JsSyntaxToken,
-    r_curly_token: JsSyntaxToken,
-    from_token: JsSyntaxToken,
-    source: AnyJsModuleSource,
-    semicolon_token: Option<JsSyntaxToken>,
-) -> (JsExport, JsExport) {
+) -> Option<(JsExport, JsExport)> {
+    let l_curly_token = export_clause.l_curly_token().ok()?;
+    let r_curly_token = export_clause.r_curly_token().ok()?;
+    let from_token = export_clause.from_token().ok()?;
+    let source = export_clause.source().ok()?;
+    let semicolon_token = export_clause.semicolon_token();
     let type_export_clause = make::js_export_named_from_clause(
         l_curly_token.clone(),
         named_type_specifiers,
@@ -834,5 +831,5 @@ fn new_named_from_exports(
         new_export_token,
         value_export_clause.into(),
     );
-    (export_type, export_value)
+    Some((export_type, export_value))
 }

--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -33,7 +33,7 @@ declare_lint_rule! {
     /// If you use the TypeScript Compiler (TSC) to compile your code into JavaScript,
     /// then you can disable this rule, as TSC can remove exports only used as types.
     /// However, for consistency and compatibility with other compilers, you may want to enable this rule.
-    /// In that case we recommend to enable TSC's [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax).
+    /// In that case, it's recommended to enable TSC's [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax).
     /// This configuration ensures that TSC preserves exports not marked with the `type` keyword.
     ///
     /// ## Examples

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -39,7 +39,7 @@ declare_lint_rule! {
     /// If you use the TypeScript Compiler (TSC) to compile your code into JavaScript,
     /// then you can disable this rule, as TSC can remove imports only used as types.
     /// However, for consistency and compatibility with other compilers, you may want to enable this rule.
-    /// In that case we recommend to enable TSC's [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax).
+    /// In that case, it's recommended to enable TSC's [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax).
     /// This configuration ensures that TSC preserves imports not marked with the `type` keyword.
     ///
     /// You may also want to enable the editor setting [`typescript.preferences.preferTypeOnlyAutoImports`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-3-rc/#settings-to-prefer-type-auto-imports) from the TypeScript LSP.

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -120,7 +120,7 @@ declare_lint_rule! {
     ///
     /// - `inlineType`: always use `import { type T }` instead of `import type { T }`
     /// - `separatedType`: always use `import type { T }` instead of `import { type T }`
-    /// - `auto`: use both `import type { T }` and `import { type T }` (default)
+    /// - `auto`: use `import type { T }` or `import { type T, V }` when values are imported alongside types (default)
     ///
     /// ```jsonc,options
     /// {
@@ -1067,6 +1067,8 @@ fn split_named_import_specifiers(
     specifiers_requiring_type_marker: &[AnyJsNamedImportSpecifier],
 ) -> Option<(JsNamedImportSpecifiers, JsNamedImportSpecifiers)> {
     let specifiers = named_specifiers.specifiers();
+    // There is at least one import that is not a type.
+    // Thus there is at most `len - 1` type-only imports.
     let mut type_specifiers = Vec::with_capacity(specifiers.len() - 1);
     let mut type_specifier_separators = Vec::with_capacity(specifiers.len() - 1);
     let mut value_specifiers =

--- a/crates/biome_rule_options/src/use_export_type.rs
+++ b/crates/biome_rule_options/src/use_export_type.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct UseExportTypeOptions {
-    /// The style to apply when exporting types. Default to "auto"
+    /// The style to apply when exporting types. Default to "auto".
     #[serde(skip_serializing_if = "Option::<_>::is_none")]
     pub style: Option<Style>,
 }
@@ -24,12 +24,12 @@ pub struct UseExportTypeOptions {
 )]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum Style {
-    /// Use the best fitting style according to the situation
+    /// Use the best fitting style according to the situation.
     #[default]
     Auto,
-    /// Always use inline type keywords
+    /// Always use inline type keywords.
     InlineType,
-    /// Always separate types in a dedicated `export type`
+    /// Always separate types in a dedicated `export type`.
     SeparatedType,
 }
 

--- a/crates/biome_rule_options/src/use_import_type.rs
+++ b/crates/biome_rule_options/src/use_import_type.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct UseImportTypeOptions {
-    /// The style to apply when import types. Default to "auto"
+    /// The style to apply when importing types. Default to "auto".
     #[serde(skip_serializing_if = "Option::<_>::is_none")]
     pub style: Option<Style>,
 }
@@ -24,12 +24,12 @@ pub struct UseImportTypeOptions {
 )]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum Style {
-    /// Use the best fitting style according to the situation
+    /// Use the best fitting style according to the situation.
     #[default]
     Auto,
-    /// Always use inline type keywords
+    /// Always use inline type keywords.
     InlineType,
-    /// Always separate types in a dedicated `import type`
+    /// Always separate types in a dedicated `import type`.
     SeparatedType,
 }
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8722,7 +8722,7 @@ export type UseExplicitLengthCheckOptions = {};
 export type UseExponentiationOperatorOptions = {};
 export interface UseExportTypeOptions {
 	/**
-	 * The style to apply when exporting types. Default to "auto"
+	 * The style to apply when exporting types. Default to "auto".
 	 */
 	style?: UseExportTypeStyle;
 }
@@ -8753,7 +8753,7 @@ export type UseGraphqlNamingConventionOptions = {};
 export type UseGroupedAccessorPairsOptions = {};
 export interface UseImportTypeOptions {
 	/**
-	 * The style to apply when import types. Default to "auto"
+	 * The style to apply when importing types. Default to "auto".
 	 */
 	style?: UseImportTypeStyle;
 }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -15154,7 +15154,7 @@
 			"type": "object",
 			"properties": {
 				"style": {
-					"description": "The style to apply when exporting types. Default to \"auto\"",
+					"description": "The style to apply when exporting types. Default to \"auto\".",
 					"anyOf": [
 						{ "$ref": "#/$defs/UseExportTypeStyle" },
 						{ "type": "null" }
@@ -15417,7 +15417,7 @@
 			"type": "object",
 			"properties": {
 				"style": {
-					"description": "The style to apply when import types. Default to \"auto\"",
+					"description": "The style to apply when importing types. Default to \"auto\".",
 					"anyOf": [
 						{ "$ref": "#/$defs/UseImportTypeStyle" },
 						{ "type": "null" }


### PR DESCRIPTION
## Summary

Address most of the @ematipico reviews in https://github.com/biomejs/biome/pull/10561

This doesn't address comments related to duplicated code because this not so easy that creating a union type: the split and node builder creates distinct node types.
Anyway as I said in the PR, I plan to explore alternative way of implementing it.
The logic of these function is basically copied from `useImportType`.