### PR TITLE
refactor(noTsIgnore): avoid one alloc, improve range reporting

### DIFF
--- a/.changeset/flat-wombats-pick.md
+++ b/.changeset/flat-wombats-pick.md
@@ -2,6 +2,5 @@
 "@biomejs/biome": patch
 ---
 
-[`noTsIgnore`](https://biomejs.dev/linter/rules/no-ts-ignore/) now reports more
-precisely the range of the `@ts-ignore` comment.
-
+Improved [`noTsIgnore`](https://biomejs.dev/linter/rules/no-ts-ignore/).
+The rule now reports more precisely the range of the `@ts-ignore` comment.

--- a/.changeset/flat-wombats-pick.md
+++ b/.changeset/flat-wombats-pick.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+[`noTsIgnore`](https://biomejs.dev/linter/rules/no-ts-ignore/) now reports more
+precisely the range of the `@ts-ignore` comment.
+

--- a/crates/biome_js_analyze/src/lint/suspicious/no_ts_ignore.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_ts_ignore.rs
@@ -59,22 +59,14 @@ impl Rule for NoTsIgnore {
 
         let mut tokens = vec![];
         for token in module.syntax().descendants_tokens(Direction::Next) {
-            let leading_trivia = token.leading_trivia();
-            let comments: Vec<_> = leading_trivia
-                .pieces()
-                .filter_map(|trivia| {
-                    if let Some(comment) = trivia.as_comments()
-                        && let Some((index, _)) = comment.text().match_indices("@ts-ignore").next()
-                    {
-                        return Some((
-                            token.clone(),
-                            comment.text_range().add_start(TextSize::from(index as u32)),
-                        ));
-                    }
-                    None
-                })
-                .collect();
-
+            let comments = token.leading_trivia().pieces().filter_map(|trivia| {
+                const TS_IGNORE_DIRECTIVE: &str = "@ts-ignore";
+                let comment = trivia.as_comments()?;
+                let (index, _) = comment.text().match_indices(TS_IGNORE_DIRECTIVE).next()?;
+                let start = comment.text_range().start() + TextSize::from(index as u32);
+                let len = TextSize::from(TS_IGNORE_DIRECTIVE.len() as u32);
+                Some((token.clone(), TextRange::new(start, start + len)))
+            });
             tokens.extend(comments);
         }
 

--- a/crates/biome_js_analyze/tests/specs/suspicious/noTsIgnore/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noTsIgnore/invalid.ts.snap
@@ -64,14 +64,11 @@ invalid.ts:6:4 lint/suspicious/noTsIgnore  FIXABLE  ━━━━━━━━━�
 
   ! Unsafe use of the @ts-ignore directive found in this comment.
   
-     5 │ /**
-   > 6 │  * @ts-ignore
-       │    ^^^^^^^^^^
-   > 7 │  * more comments
-   > 8 │  */
-       │  ^^
-     9 │ let foo;
-    10 │ 
+    5 │ /**
+  > 6 │  * @ts-ignore
+      │    ^^^^^^^^^^
+    7 │  * more comments
+    8 │  */
   
   i The directive is applied to this line.
   
@@ -135,7 +132,7 @@ invalid.ts:19:4 lint/suspicious/noTsIgnore  FIXABLE  ━━━━━━━━━
   
     18 │ // Some comment
   > 19 │ // @ts-ignore Some other comment
-       │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       │    ^^^^^^^^^^
     20 │ let someTextAfter;
     21 │ 
   


### PR DESCRIPTION
## Summary

This PR avoids one allocation in the implementation of `noTsIgnore`.
Note that this should not change the overall perf because the allocation was done only when a `@ts-ignore` directive was found.
I also took the opportunity of improving the reported range (See the affected snapshot). 

## Test Plan
I updated the affected snapshot

## Docs

I added a changeset.
