### PR TITLE
feat(css_parser): parse interpolated scss media conditions

### DIFF
--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_media_feature_name.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_media_feature_name.rs
@@ -3,10 +3,10 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::{
-    AnyCssMediaAndCombinableCondition, AnyCssMediaCondition, AnyCssMediaInParens,
-    AnyCssMediaOrCombinableCondition, AnyCssMediaQuery, AnyCssMediaTypeCondition,
-    AnyCssMediaTypeQuery, AnyCssQueryFeature, AnyCssQueryFeatureName, CssMediaAndCondition,
-    CssMediaConditionQuery, CssMediaOrCondition, CssMediaQueryList,
+    AnyCssMediaAndCombinableCondition, AnyCssMediaCondition, AnyCssMediaConditionOperand,
+    AnyCssMediaInParens, AnyCssMediaOrCombinableCondition, AnyCssMediaQuery,
+    AnyCssMediaTypeCondition, AnyCssMediaTypeQuery, AnyCssQueryFeature, AnyCssQueryFeatureName,
+    CssMediaAndCondition, CssMediaConditionQuery, CssMediaOrCondition, CssMediaQueryList,
 };
 use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, TokenText};
@@ -131,8 +131,8 @@ fn is_invalid_feature_name_included_in_css_media_condition_query(
     css_media_condition_query: CssMediaConditionQuery,
 ) -> Option<bool> {
     match css_media_condition_query.condition().ok()? {
-        AnyCssMediaCondition::AnyCssMediaInParens(any_css_media_in_parens) => {
-            has_invalid_media_feature_name(any_css_media_in_parens)
+        AnyCssMediaCondition::AnyCssMediaConditionOperand(any_css_media_condition_operand) => {
+            has_invalid_media_condition_operand(any_css_media_condition_operand)
         }
         AnyCssMediaCondition::CssMediaAndCondition(css_media_and_condition) => {
             is_css_media_and_condition_invalid(css_media_and_condition)
@@ -141,7 +141,7 @@ fn is_invalid_feature_name_included_in_css_media_condition_query(
             is_css_media_or_condition_invalid(css_media_or_condition)
         }
         AnyCssMediaCondition::CssMediaNotCondition(css_media_not_condition) => {
-            has_invalid_media_feature_name(css_media_not_condition.condition().ok()?)
+            has_invalid_media_condition_operand(css_media_not_condition.condition().ok()?)
         }
     }
 }
@@ -153,14 +153,16 @@ fn is_invalid_feature_name_included_in_css_media_type_query(
         AnyCssMediaTypeQuery::CssMediaTypeQuery(_) => Some(false),
         AnyCssMediaTypeQuery::CssMediaAndTypeQuery(css_media_and_type_query) => {
             match css_media_and_type_query.right().ok()? {
-                AnyCssMediaTypeCondition::AnyCssMediaInParens(any_css_media_in_parens) => {
-                    has_invalid_media_feature_name(any_css_media_in_parens)
+                AnyCssMediaTypeCondition::AnyCssMediaConditionOperand(
+                    any_css_media_condition_operand,
+                ) => {
+                    has_invalid_media_condition_operand(any_css_media_condition_operand)
                 }
                 AnyCssMediaTypeCondition::CssMediaAndCondition(css_media_and_condition) => {
                     is_css_media_and_condition_invalid(css_media_and_condition)
                 }
                 AnyCssMediaTypeCondition::CssMediaNotCondition(css_media_not_condition) => {
-                    has_invalid_media_feature_name(css_media_not_condition.condition().ok()?)
+                    has_invalid_media_condition_operand(css_media_not_condition.condition().ok()?)
                 }
             }
         }
@@ -170,23 +172,30 @@ fn is_invalid_feature_name_included_in_css_media_type_query(
 fn is_css_media_and_condition_invalid(
     css_media_and_condition: CssMediaAndCondition,
 ) -> Option<bool> {
-    if has_invalid_media_feature_name(css_media_and_condition.left().ok()?)? {
+    if has_invalid_media_condition_operand(css_media_and_condition.left().ok()?)? {
         return Some(true);
     }
     let mut stack = vec![css_media_and_condition.right().ok()?];
     while !stack.is_empty() {
         let element = stack.pop()?;
         match element {
-            AnyCssMediaAndCombinableCondition::AnyCssMediaInParens(any_css_media_in_parens) => {
-                if has_invalid_media_feature_name(any_css_media_in_parens)? {
+            AnyCssMediaAndCombinableCondition::AnyCssMediaConditionOperand(
+                any_css_media_condition_operand,
+            ) => {
+                if has_invalid_media_condition_operand(any_css_media_condition_operand)? {
                     return Some(true);
                 }
             }
             AnyCssMediaAndCombinableCondition::CssMediaAndCondition(css_media_and_condition) => {
-                if has_invalid_media_feature_name(css_media_and_condition.left().ok()?)? {
+                if has_invalid_media_condition_operand(css_media_and_condition.left().ok()?)? {
                     return Some(true);
                 }
                 stack.push(css_media_and_condition.right().ok()?);
+            }
+            AnyCssMediaAndCombinableCondition::CssMediaNotCondition(css_media_not_condition) => {
+                if has_invalid_media_condition_operand(css_media_not_condition.condition().ok()?)? {
+                    return Some(true);
+                }
             }
         }
     }
@@ -194,20 +203,22 @@ fn is_css_media_and_condition_invalid(
 }
 
 fn is_css_media_or_condition_invalid(css_media_or_condition: CssMediaOrCondition) -> Option<bool> {
-    if has_invalid_media_feature_name(css_media_or_condition.left().ok()?)? {
+    if has_invalid_media_condition_operand(css_media_or_condition.left().ok()?)? {
         return Some(true);
     }
     let mut stack = vec![css_media_or_condition.right().ok()?];
     while !stack.is_empty() {
         let element = stack.pop()?;
         match element {
-            AnyCssMediaOrCombinableCondition::AnyCssMediaInParens(any_css_media_in_parens) => {
-                if has_invalid_media_feature_name(any_css_media_in_parens)? {
+            AnyCssMediaOrCombinableCondition::AnyCssMediaConditionOperand(
+                any_css_media_condition_operand,
+            ) => {
+                if has_invalid_media_condition_operand(any_css_media_condition_operand)? {
                     return Some(true);
                 }
             }
             AnyCssMediaOrCombinableCondition::CssMediaOrCondition(css_media_or_condition) => {
-                if has_invalid_media_feature_name(css_media_or_condition.left().ok()?)? {
+                if has_invalid_media_condition_operand(css_media_or_condition.left().ok()?)? {
                     return Some(true);
                 }
                 stack.push(css_media_or_condition.right().ok()?);
@@ -215,6 +226,17 @@ fn is_css_media_or_condition_invalid(css_media_or_condition: CssMediaOrCondition
         }
     }
     Some(false)
+}
+
+fn has_invalid_media_condition_operand(
+    any_css_media_condition_operand: AnyCssMediaConditionOperand,
+) -> Option<bool> {
+    match any_css_media_condition_operand {
+        AnyCssMediaConditionOperand::AnyCssMediaInParens(any_css_media_in_parens) => {
+            has_invalid_media_feature_name(any_css_media_in_parens)
+        }
+        AnyCssMediaConditionOperand::ScssMediaQuery(_) => Some(false),
+    }
 }
 
 fn has_invalid_media_feature_name(any_css_media_in_parens: AnyCssMediaInParens) -> Option<bool> {
@@ -235,49 +257,83 @@ fn has_invalid_media_feature_name(any_css_media_in_parens: AnyCssMediaInParens) 
             }
             AnyCssMediaInParens::CssMediaConditionInParens(css_media_condition_in_parens) => {
                 match css_media_condition_in_parens.condition().ok()? {
-                    AnyCssMediaCondition::AnyCssMediaInParens(any_css_media_in_parens) => {
-                        any_css_media_in_parens_stack.push(any_css_media_in_parens);
+                    AnyCssMediaCondition::AnyCssMediaConditionOperand(
+                        any_css_media_condition_operand,
+                    ) => {
+                        if has_invalid_media_condition_operand(any_css_media_condition_operand)? {
+                            return Some(true);
+                        }
                     }
                     AnyCssMediaCondition::CssMediaAndCondition(css_media_and_condition) => {
-                        any_css_media_in_parens_stack.push(css_media_and_condition.left().ok()?);
+                        if has_invalid_media_condition_operand(
+                            css_media_and_condition.left().ok()?,
+                        )? {
+                            return Some(true);
+                        }
                         let mut css_media_and_condition_stack =
                             vec![css_media_and_condition.right().ok()?];
                         while !css_media_and_condition_stack.is_empty() {
                             let element = css_media_and_condition_stack.pop()?;
                             match element {
-                                AnyCssMediaAndCombinableCondition::AnyCssMediaInParens(
-                                    any_css_media_in_parens,
+                                AnyCssMediaAndCombinableCondition::AnyCssMediaConditionOperand(
+                                    any_css_media_condition_operand,
                                 ) => {
-                                    any_css_media_in_parens_stack.push(any_css_media_in_parens);
+                                    if has_invalid_media_condition_operand(
+                                        any_css_media_condition_operand,
+                                    )? {
+                                        return Some(true);
+                                    }
                                 }
                                 AnyCssMediaAndCombinableCondition::CssMediaAndCondition(
                                     css_media_and_condition,
                                 ) => {
-                                    any_css_media_in_parens_stack
-                                        .push(css_media_and_condition.left().ok()?);
+                                    if has_invalid_media_condition_operand(
+                                        css_media_and_condition.left().ok()?,
+                                    )? {
+                                        return Some(true);
+                                    }
                                     css_media_and_condition_stack
                                         .push(css_media_and_condition.right().ok()?);
+                                }
+                                AnyCssMediaAndCombinableCondition::CssMediaNotCondition(
+                                    css_media_not_condition,
+                                ) => {
+                                    if has_invalid_media_condition_operand(
+                                        css_media_not_condition.condition().ok()?,
+                                    )? {
+                                        return Some(true);
+                                    }
                                 }
                             }
                         }
                     }
                     AnyCssMediaCondition::CssMediaOrCondition(css_media_or_condition) => {
-                        any_css_media_in_parens_stack.push(css_media_or_condition.left().ok()?);
+                        if has_invalid_media_condition_operand(css_media_or_condition.left().ok()?)?
+                        {
+                            return Some(true);
+                        }
                         let mut css_media_or_condition_stack =
                             vec![css_media_or_condition.right().ok()?];
                         while !css_media_or_condition_stack.is_empty() {
                             let element = css_media_or_condition_stack.pop()?;
                             match element {
-                                AnyCssMediaOrCombinableCondition::AnyCssMediaInParens(
-                                    any_css_media_in_parens,
+                                AnyCssMediaOrCombinableCondition::AnyCssMediaConditionOperand(
+                                    any_css_media_condition_operand,
                                 ) => {
-                                    any_css_media_in_parens_stack.push(any_css_media_in_parens);
+                                    if has_invalid_media_condition_operand(
+                                        any_css_media_condition_operand,
+                                    )? {
+                                        return Some(true);
+                                    }
                                 }
                                 AnyCssMediaOrCombinableCondition::CssMediaOrCondition(
                                     css_media_or_condition,
                                 ) => {
-                                    any_css_media_in_parens_stack
-                                        .push(css_media_or_condition.left().ok()?);
+                                    if has_invalid_media_condition_operand(
+                                        css_media_or_condition.left().ok()?,
+                                    )? {
+                                        return Some(true);
+                                    }
                                     css_media_or_condition_stack
                                         .push(css_media_or_condition.right().ok()?);
                                 }
@@ -285,8 +341,11 @@ fn has_invalid_media_feature_name(any_css_media_in_parens: AnyCssMediaInParens) 
                         }
                     }
                     AnyCssMediaCondition::CssMediaNotCondition(css_media_not_condition) => {
-                        any_css_media_in_parens_stack
-                            .push(css_media_not_condition.condition().ok()?);
+                        if has_invalid_media_condition_operand(
+                            css_media_not_condition.condition().ok()?,
+                        )? {
+                            return Some(true);
+                        }
                     }
                 }
             }

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownMediaFeatureName/valid.scss
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownMediaFeatureName/valid.scss
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+@media #{"(unknown-feature)"} {}
+
+@media not #{"(unknown-feature)"} {}
+
+@media (width) and #{"(unknown-feature)"} {}

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownMediaFeatureName/valid.scss.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownMediaFeatureName/valid.scss.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: valid.scss
+---
+# Input
+```css
+/* should not generate diagnostics */
+@media #{"(unknown-feature)"} {}
+
+@media not #{"(unknown-feature)"} {}
+
+@media (width) and #{"(unknown-feature)"} {}
+
+```

--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -1512,7 +1512,7 @@ pub fn css_margin_at_rule(
     ))
 }
 pub fn css_media_and_condition(
-    left: AnyCssMediaInParens,
+    left: AnyCssMediaConditionOperand,
     and_token: SyntaxToken,
     right: AnyCssMediaAndCombinableCondition,
 ) -> CssMediaAndCondition {
@@ -1599,7 +1599,7 @@ pub fn css_media_feature_in_parens(
 }
 pub fn css_media_not_condition(
     not_token: SyntaxToken,
-    condition: AnyCssMediaInParens,
+    condition: AnyCssMediaConditionOperand,
 ) -> CssMediaNotCondition {
     CssMediaNotCondition::unwrap_cast(SyntaxNode::new_detached(
         CssSyntaxKind::CSS_MEDIA_NOT_CONDITION,
@@ -1610,7 +1610,7 @@ pub fn css_media_not_condition(
     ))
 }
 pub fn css_media_or_condition(
-    left: AnyCssMediaInParens,
+    left: AnyCssMediaConditionOperand,
     or_token: SyntaxToken,
     right: AnyCssMediaOrCombinableCondition,
 ) -> CssMediaOrCondition {

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -3092,7 +3092,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
-                    && AnyCssMediaInParens::can_cast(element.kind())
+                    && AnyCssMediaConditionOperand::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();
@@ -3302,7 +3302,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 }
                 slots.next_slot();
                 if let Some(element) = &current_element
-                    && AnyCssMediaInParens::can_cast(element.kind())
+                    && AnyCssMediaConditionOperand::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();
@@ -3321,7 +3321,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
-                    && AnyCssMediaInParens::can_cast(element.kind())
+                    && AnyCssMediaConditionOperand::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_css_formatter/src/css/any/media_and_combinable_condition.rs
+++ b/crates/biome_css_formatter/src/css/any/media_and_combinable_condition.rs
@@ -12,8 +12,11 @@ impl FormatRule<AnyCssMediaAndCombinableCondition> for FormatAnyCssMediaAndCombi
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
         match node {
-            AnyCssMediaAndCombinableCondition::AnyCssMediaInParens(node) => node.format().fmt(f),
+            AnyCssMediaAndCombinableCondition::AnyCssMediaConditionOperand(node) => {
+                node.format().fmt(f)
+            }
             AnyCssMediaAndCombinableCondition::CssMediaAndCondition(node) => node.format().fmt(f),
+            AnyCssMediaAndCombinableCondition::CssMediaNotCondition(node) => node.format().fmt(f),
         }
     }
 }

--- a/crates/biome_css_formatter/src/css/any/media_condition.rs
+++ b/crates/biome_css_formatter/src/css/any/media_condition.rs
@@ -8,7 +8,7 @@ impl FormatRule<AnyCssMediaCondition> for FormatAnyCssMediaCondition {
     type Context = CssFormatContext;
     fn fmt(&self, node: &AnyCssMediaCondition, f: &mut CssFormatter) -> FormatResult<()> {
         match node {
-            AnyCssMediaCondition::AnyCssMediaInParens(node) => node.format().fmt(f),
+            AnyCssMediaCondition::AnyCssMediaConditionOperand(node) => node.format().fmt(f),
             AnyCssMediaCondition::CssMediaAndCondition(node) => node.format().fmt(f),
             AnyCssMediaCondition::CssMediaNotCondition(node) => node.format().fmt(f),
             AnyCssMediaCondition::CssMediaOrCondition(node) => node.format().fmt(f),

--- a/crates/biome_css_formatter/src/css/any/media_condition_operand.rs
+++ b/crates/biome_css_formatter/src/css/any/media_condition_operand.rs
@@ -1,0 +1,15 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
+
+use crate::prelude::*;
+use biome_css_syntax::AnyCssMediaConditionOperand;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatAnyCssMediaConditionOperand;
+impl FormatRule<AnyCssMediaConditionOperand> for FormatAnyCssMediaConditionOperand {
+    type Context = CssFormatContext;
+    fn fmt(&self, node: &AnyCssMediaConditionOperand, f: &mut CssFormatter) -> FormatResult<()> {
+        match node {
+            AnyCssMediaConditionOperand::AnyCssMediaInParens(node) => node.format().fmt(f),
+            AnyCssMediaConditionOperand::ScssMediaQuery(node) => node.format().fmt(f),
+        }
+    }
+}

--- a/crates/biome_css_formatter/src/css/any/media_or_combinable_condition.rs
+++ b/crates/biome_css_formatter/src/css/any/media_or_combinable_condition.rs
@@ -12,7 +12,9 @@ impl FormatRule<AnyCssMediaOrCombinableCondition> for FormatAnyCssMediaOrCombina
         f: &mut CssFormatter,
     ) -> FormatResult<()> {
         match node {
-            AnyCssMediaOrCombinableCondition::AnyCssMediaInParens(node) => node.format().fmt(f),
+            AnyCssMediaOrCombinableCondition::AnyCssMediaConditionOperand(node) => {
+                node.format().fmt(f)
+            }
             AnyCssMediaOrCombinableCondition::CssMediaOrCondition(node) => node.format().fmt(f),
         }
     }

--- a/crates/biome_css_formatter/src/css/any/media_type_condition.rs
+++ b/crates/biome_css_formatter/src/css/any/media_type_condition.rs
@@ -8,7 +8,7 @@ impl FormatRule<AnyCssMediaTypeCondition> for FormatAnyCssMediaTypeCondition {
     type Context = CssFormatContext;
     fn fmt(&self, node: &AnyCssMediaTypeCondition, f: &mut CssFormatter) -> FormatResult<()> {
         match node {
-            AnyCssMediaTypeCondition::AnyCssMediaInParens(node) => node.format().fmt(f),
+            AnyCssMediaTypeCondition::AnyCssMediaConditionOperand(node) => node.format().fmt(f),
             AnyCssMediaTypeCondition::CssMediaAndCondition(node) => node.format().fmt(f),
             AnyCssMediaTypeCondition::CssMediaNotCondition(node) => node.format().fmt(f),
         }

--- a/crates/biome_css_formatter/src/css/any/mod.rs
+++ b/crates/biome_css_formatter/src/css/any/mod.rs
@@ -65,6 +65,7 @@ pub(crate) mod keyframes_selector;
 pub(crate) mod layer;
 pub(crate) mod media_and_combinable_condition;
 pub(crate) mod media_condition;
+pub(crate) mod media_condition_operand;
 pub(crate) mod media_in_parens;
 pub(crate) mod media_or_combinable_condition;
 pub(crate) mod media_query;

--- a/crates/biome_css_formatter/src/generated.rs
+++ b/crates/biome_css_formatter/src/generated.rs
@@ -14160,6 +14160,31 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaCondition {
         )
     }
 }
+impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaConditionOperand {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_css_syntax::AnyCssMediaConditionOperand,
+        crate::css::any::media_condition_operand::FormatAnyCssMediaConditionOperand,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::css::any::media_condition_operand::FormatAnyCssMediaConditionOperand::default(),
+        )
+    }
+}
+impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaConditionOperand {
+    type Format = FormatOwnedWithRule<
+        biome_css_syntax::AnyCssMediaConditionOperand,
+        crate::css::any::media_condition_operand::FormatAnyCssMediaConditionOperand,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::css::any::media_condition_operand::FormatAnyCssMediaConditionOperand::default(),
+        )
+    }
+}
 impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaInParens {
     type Format<'a> = FormatRefWithRule<
         'a,

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/media-interpolated-logic.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/media-interpolated-logic.scss
@@ -1,0 +1,9 @@
+@media   (a)   and   #{"(b) and (c)"}{x{y:z}}
+
+@media   (a)   or   #{"(b) or (c)"}{x{y:z}}
+
+@media   a   and   not   #{"(b)"}{x{y:z}}
+
+@media   #{a}   and   not   (b){x{y:z}}
+
+@media   not   #{"(a)"}{x{y:z}}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/media-interpolated-logic.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/media-interpolated-logic.scss.snap
@@ -1,0 +1,55 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/at-rule/media-interpolated-logic.scss
+---
+
+# Input
+
+```scss
+@media   (a)   and   #{"(b) and (c)"}{x{y:z}}
+
+@media   (a)   or   #{"(b) or (c)"}{x{y:z}}
+
+@media   a   and   not   #{"(b)"}{x{y:z}}
+
+@media   #{a}   and   not   (b){x{y:z}}
+
+@media   not   #{"(a)"}{x{y:z}}
+
+```
+
+
+# Formatted
+
+```scss
+@media (a) and #{"(b) and (c)"} {
+	x {
+		y: z;
+	}
+}
+
+@media (a) or #{"(b) or (c)"} {
+	x {
+		y: z;
+	}
+}
+
+@media a and not #{"(b)"} {
+	x {
+		y: z;
+	}
+}
+
+@media #{a} and not (b) {
+	x {
+		y: z;
+	}
+}
+
+@media not #{"(a)"} {
+	x {
+		y: z;
+	}
+}
+
+```

--- a/crates/biome_css_parser/src/syntax/at_rule/media.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/media.rs
@@ -4,7 +4,8 @@ use crate::syntax::at_rule::error::{AnyInParensChainParseRecovery, AnyInParensPa
 use crate::syntax::at_rule::feature::{expected_any_query_feature, parse_any_query_feature};
 use crate::syntax::block::parse_conditional_block;
 use crate::syntax::scss::{
-    is_at_scss_interpolated_query_feature, is_at_scss_media_query, parse_scss_media_query,
+    is_at_scss_interpolated_media_in_parens, is_at_scss_media_condition, is_at_scss_media_query,
+    parse_scss_interpolated_media_in_parens, parse_scss_media_condition, parse_scss_media_query,
     parse_scss_media_query_or_condition_query,
 };
 use crate::syntax::util::skip_possible_tailwind_syntax;
@@ -162,6 +163,8 @@ pub(crate) fn parse_any_media_condition(p: &mut CssParser) -> ParsedSyntax {
 
     if is_at_media_not_condition(p) {
         parse_media_not_condition(p)
+    } else if is_at_scss_media_condition(p) {
+        parse_scss_media_condition(p)
     } else {
         parse_any_media_condition_operand(p).map(|lhs| match p.cur() {
             T![and] => parse_media_and_condition(p, lhs),
@@ -354,6 +357,10 @@ fn is_at_any_media_in_parens(p: &mut CssParser) -> bool {
 /// `(not (color))` and media features such as `(width <= 500px)`.
 #[inline]
 pub(crate) fn parse_any_media_in_parens(p: &mut CssParser) -> ParsedSyntax {
+    if is_at_scss_interpolated_media_in_parens(p) {
+        return parse_scss_interpolated_media_in_parens(p);
+    }
+
     if !is_at_any_media_in_parens(p) {
         return Absent;
     }
@@ -361,9 +368,7 @@ pub(crate) fn parse_any_media_in_parens(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
     p.bump(T!['(']);
 
-    // Keep interpolated SCSS query features in the feature branch instead of
-    // treating `#{...}` as a nested media condition.
-    let kind = if is_at_any_media_condition(p) && !is_at_scss_interpolated_query_feature(p) {
+    let kind = if is_at_any_media_condition(p) {
         parse_any_media_condition(p)
             .or_recover(p, &AnyInParensParseRecovery, expected_any_media_condition)
             .ok();

--- a/crates/biome_css_parser/src/syntax/at_rule/media.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/media.rs
@@ -3,7 +3,10 @@ use crate::parser::CssParser;
 use crate::syntax::at_rule::error::{AnyInParensChainParseRecovery, AnyInParensParseRecovery};
 use crate::syntax::at_rule::feature::{expected_any_query_feature, parse_any_query_feature};
 use crate::syntax::block::parse_conditional_block;
-use crate::syntax::scss::{is_at_scss_interpolation, parse_scss_regular_interpolation};
+use crate::syntax::scss::{
+    is_at_scss_interpolated_query_feature, is_at_scss_media_query, parse_scss_media_query,
+    parse_scss_media_query_or_condition_query,
+};
 use crate::syntax::util::skip_possible_tailwind_syntax;
 use crate::syntax::{
     is_at_identifier, is_at_metavariable, is_nth_at_identifier, parse_metavariable,
@@ -121,7 +124,7 @@ pub(crate) fn parse_any_media_query(p: &mut CssParser) -> ParsedSyntax {
     if is_at_media_type_query(p) {
         parse_any_media_type_query(p)
     } else if is_at_scss_media_query(p) {
-        parse_scss_media_query(p)
+        parse_scss_media_query_or_condition_query(p)
     } else if is_at_metavariable(p) {
         parse_metavariable(p)
     } else if is_at_any_media_condition(p) {
@@ -144,34 +147,8 @@ fn parse_any_media_condition_query(p: &mut CssParser) -> ParsedSyntax {
 }
 
 #[inline]
-fn is_at_scss_media_query(p: &mut CssParser) -> bool {
-    is_at_scss_interpolation(p)
-}
-
-/// Parses a Sass interpolation as a complete media query.
-///
-/// Example:
-/// ```scss
-/// @media #{$query} {}
-/// ```
-///
-/// Docs: https://sass-lang.com/documentation/at-rules/css/#media
-#[inline]
-fn parse_scss_media_query(p: &mut CssParser) -> ParsedSyntax {
-    if !is_at_scss_media_query(p) {
-        return Absent;
-    }
-
-    let m = p.start();
-    // Guarded by `is_at_scss_media_query` above.
-    parse_scss_regular_interpolation(p).ok();
-
-    Present(m.complete(p, SCSS_MEDIA_QUERY))
-}
-
-#[inline]
 pub(crate) fn is_at_any_media_condition(p: &mut CssParser) -> bool {
-    is_at_media_not_condition(p) || is_at_any_media_in_parens(p)
+    is_at_media_not_condition(p) || is_at_any_media_condition_operand(p)
 }
 
 /// Parses a media condition, including chained `and` / `or` forms.
@@ -186,7 +163,7 @@ pub(crate) fn parse_any_media_condition(p: &mut CssParser) -> ParsedSyntax {
     if is_at_media_not_condition(p) {
         parse_media_not_condition(p)
     } else {
-        parse_any_media_in_parens(p).map(|lhs| match p.cur() {
+        parse_any_media_condition_operand(p).map(|lhs| match p.cur() {
             T![and] => parse_media_and_condition(p, lhs),
             T![or] => parse_media_or_condition(p, lhs),
             _ => lhs,
@@ -249,7 +226,7 @@ fn parse_media_type(p: &mut CssParser) -> ParsedSyntax {
 
 #[inline]
 fn is_at_any_media_type_condition(p: &mut CssParser) -> bool {
-    is_at_media_not_condition(p) || is_at_any_media_in_parens(p)
+    is_at_media_not_condition(p) || is_at_any_media_condition_operand(p)
 }
 #[inline]
 fn parse_any_media_type_condition(p: &mut CssParser) -> ParsedSyntax {
@@ -260,7 +237,7 @@ fn parse_any_media_type_condition(p: &mut CssParser) -> ParsedSyntax {
     if is_at_media_not_condition(p) {
         parse_media_not_condition(p)
     } else {
-        parse_any_media_in_parens(p).map(|lhs| parse_media_and_condition(p, lhs))
+        parse_any_media_condition_operand(p).map(|lhs| parse_media_and_condition(p, lhs))
     }
 }
 
@@ -268,8 +245,13 @@ fn parse_any_media_type_condition(p: &mut CssParser) -> ParsedSyntax {
 fn is_at_media_not_condition(p: &mut CssParser) -> bool {
     p.at(T![not])
 }
+
+/// Parses a media `not` condition starting at the `not` keyword.
+///
+/// In plain CSS media conditions this is only a leading condition. SCSS can
+/// also reuse it after an interpolation-led `and` chain.
 #[inline]
-fn parse_media_not_condition(p: &mut CssParser) -> ParsedSyntax {
+pub fn parse_media_not_condition(p: &mut CssParser) -> ParsedSyntax {
     if !is_at_media_not_condition(p) {
         return Absent;
     }
@@ -277,7 +259,7 @@ fn parse_media_not_condition(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
 
     p.bump(T![not]);
-    parse_any_media_in_parens(p)
+    parse_any_media_condition_operand(p)
         .or_recover(p, &AnyInParensParseRecovery, expected_any_media_in_parens)
         .ok();
 
@@ -285,9 +267,9 @@ fn parse_media_not_condition(p: &mut CssParser) -> ParsedSyntax {
 }
 
 /// Parses a left-associated media `and` condition chain after the first
-/// parenthesized operand has already been parsed.
+/// media condition operand has already been parsed.
 #[inline]
-fn parse_media_and_condition(p: &mut CssParser, lhs: CompletedMarker) -> CompletedMarker {
+pub fn parse_media_and_condition(p: &mut CssParser, lhs: CompletedMarker) -> CompletedMarker {
     if !p.at(T![and]) {
         return lhs;
     }
@@ -295,7 +277,7 @@ fn parse_media_and_condition(p: &mut CssParser, lhs: CompletedMarker) -> Complet
     let m = lhs.precede(p);
     p.bump(T![and]);
 
-    let recovery_result = parse_any_media_in_parens(p)
+    let recovery_result = parse_any_media_condition_operand(p)
         .or_recover(
             p,
             &AnyInParensChainParseRecovery::new(T![and]).with_stop_kind(T![')']),
@@ -303,19 +285,15 @@ fn parse_media_and_condition(p: &mut CssParser, lhs: CompletedMarker) -> Complet
         )
         .map(|rhs| parse_media_and_condition(p, rhs));
 
-    if recovery_result.is_err() && p.at(T![and]) {
-        let m = p.start();
-        let rhs = m.complete(p, CSS_BOGUS);
-        parse_media_and_condition(p, rhs);
-    }
+    recover_missing_and_rhs(p, recovery_result);
 
     m.complete(p, CSS_MEDIA_AND_CONDITION)
 }
 
 /// Parses a left-associated media `or` condition chain after the first
-/// parenthesized operand has already been parsed.
+/// media condition operand has already been parsed.
 #[inline]
-fn parse_media_or_condition(p: &mut CssParser, lhs: CompletedMarker) -> CompletedMarker {
+pub fn parse_media_or_condition(p: &mut CssParser, lhs: CompletedMarker) -> CompletedMarker {
     if !p.at(T![or]) {
         return lhs;
     }
@@ -323,7 +301,7 @@ fn parse_media_or_condition(p: &mut CssParser, lhs: CompletedMarker) -> Complete
     let m = lhs.precede(p);
     p.bump(T![or]);
 
-    let recovery_result = parse_any_media_in_parens(p)
+    let recovery_result = parse_any_media_condition_operand(p)
         .or_recover(
             p,
             &AnyInParensChainParseRecovery::new(T![or]).with_stop_kind(T![')']),
@@ -338,6 +316,31 @@ fn parse_media_or_condition(p: &mut CssParser, lhs: CompletedMarker) -> Complete
     }
 
     m.complete(p, CSS_MEDIA_OR_CONDITION)
+}
+
+/// Continues `and` chain recovery after a missing or invalid RHS.
+#[inline]
+pub fn recover_missing_and_rhs(p: &mut CssParser, recovery_result: RecoveryResult) {
+    if recovery_result.is_err() && p.at(T![and]) {
+        let m = p.start();
+        let rhs = m.complete(p, CSS_BOGUS);
+        parse_media_and_condition(p, rhs);
+    }
+}
+
+#[inline]
+fn is_at_any_media_condition_operand(p: &mut CssParser) -> bool {
+    is_at_scss_media_query(p) || is_at_any_media_in_parens(p)
+}
+
+/// Parses a media condition operand, including Sass interpolation in SCSS files.
+#[inline]
+pub fn parse_any_media_condition_operand(p: &mut CssParser) -> ParsedSyntax {
+    if is_at_scss_media_query(p) {
+        parse_scss_media_query(p)
+    } else {
+        parse_any_media_in_parens(p)
+    }
 }
 
 #[inline]
@@ -358,7 +361,9 @@ pub(crate) fn parse_any_media_in_parens(p: &mut CssParser) -> ParsedSyntax {
     let m = p.start();
     p.bump(T!['(']);
 
-    let kind = if is_at_any_media_condition(p) {
+    // Keep interpolated SCSS query features in the feature branch instead of
+    // treating `#{...}` as a nested media condition.
+    let kind = if is_at_any_media_condition(p) && !is_at_scss_interpolated_query_feature(p) {
         parse_any_media_condition(p)
             .or_recover(p, &AnyInParensParseRecovery, expected_any_media_condition)
             .ok();
@@ -379,6 +384,6 @@ fn expected_any_media_condition(p: &CssParser, range: TextRange) -> ParseDiagnos
     expected_any(&["media condition", "parenthesized media query"], range, p)
 }
 
-fn expected_any_media_in_parens(p: &CssParser, range: TextRange) -> ParseDiagnostic {
+pub fn expected_any_media_in_parens(p: &CssParser, range: TextRange) -> ParseDiagnostic {
     expected_any(&["media condition", "query feature"], range, p)
 }

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/media.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/media.rs
@@ -1,6 +1,11 @@
-use super::super::{is_at_scss_interpolation, parse_scss_regular_interpolation};
+use super::super::{
+    is_at_scss_interpolation, is_nth_at_scss_interpolation, parse_scss_interpolation_or_identifier,
+    parse_scss_regular_interpolation,
+};
+use super::query_feature::parse_scss_interpolated_query_feature_from_head;
 use crate::parser::CssParser;
 use crate::syntax::at_rule::error::AnyInParensChainParseRecovery;
+use crate::syntax::at_rule::feature::expected_any_query_feature;
 use crate::syntax::at_rule::media::{
     expected_any_media_in_parens, parse_any_media_condition_operand, parse_media_and_condition,
     parse_media_not_condition, parse_media_or_condition, recover_missing_and_rhs,
@@ -39,6 +44,77 @@ pub(crate) fn parse_scss_media_query(p: &mut CssParser) -> ParsedSyntax {
     Present(m.complete(p, SCSS_MEDIA_QUERY))
 }
 
+/// Returns true when Sass interpolation starts a parenthesized media branch.
+///
+/// The parser still decides after the shared head whether this is a nested
+/// media condition or a query feature.
+#[inline]
+pub(crate) fn is_at_scss_interpolated_media_in_parens(p: &mut CssParser) -> bool {
+    p.at(T!['(']) && is_nth_at_scss_interpolation(p, 1)
+}
+
+/// Parses an interpolation-led parenthesized media branch.
+///
+/// The shared interpolation head is parsed once, then completed as either a
+/// nested media condition or a query feature after the following token is known.
+///
+/// Examples:
+/// ```scss
+/// @media (#{$query} and not (color)) {}
+/// @media (#{$feature}: #{$value}) {}
+/// ```
+#[inline]
+pub(crate) fn parse_scss_interpolated_media_in_parens(p: &mut CssParser) -> ParsedSyntax {
+    if !is_at_scss_interpolated_media_in_parens(p) {
+        return Absent;
+    }
+
+    let m = p.start();
+    p.bump(T!['(']);
+
+    let Some(head) =
+        parse_scss_interpolation_or_identifier(p).or_add_diagnostic(p, expected_any_query_feature)
+    else {
+        p.expect(T![')']);
+        return Present(m.complete(p, CSS_MEDIA_FEATURE_IN_PARENS));
+    };
+
+    let kind = if head.kind(p) == SCSS_INTERPOLATION && is_at_media_condition_operator(p) {
+        let query = head.precede(p).complete(p, SCSS_MEDIA_QUERY);
+        parse_scss_media_condition_from_query(p, query);
+        CSS_MEDIA_CONDITION_IN_PARENS
+    } else {
+        parse_scss_interpolated_query_feature_from_head(p, head)
+            .or_add_diagnostic(p, expected_any_query_feature);
+        CSS_MEDIA_FEATURE_IN_PARENS
+    };
+
+    p.expect(T![')']);
+
+    Present(m.complete(p, kind))
+}
+
+/// Parses a Sass interpolation-led media condition.
+///
+/// Examples:
+/// ```scss
+/// @media (#{$query} and not (color)) {}
+/// @media (#{$query} or (color)) {}
+/// ```
+#[inline]
+pub(crate) fn parse_scss_media_condition(p: &mut CssParser) -> ParsedSyntax {
+    if !is_at_scss_media_condition(p) {
+        return Absent;
+    }
+
+    parse_scss_media_query(p).map(|query| parse_scss_media_condition_from_query(p, query))
+}
+
+#[inline]
+pub(crate) fn is_at_scss_media_condition(p: &mut CssParser) -> bool {
+    is_at_scss_media_query(p)
+}
+
 /// Parses a media query list item that starts with Sass interpolation.
 ///
 /// Examples:
@@ -49,17 +125,36 @@ pub(crate) fn parse_scss_media_query(p: &mut CssParser) -> ParsedSyntax {
 /// ```
 #[inline]
 pub(crate) fn parse_scss_media_query_or_condition_query(p: &mut CssParser) -> ParsedSyntax {
-    let Present(query) = parse_scss_media_query(p) else {
+    if !is_at_scss_media_query(p) {
         return Absent;
-    };
+    }
 
-    let condition = match p.cur() {
+    parse_scss_media_query(p).map(|query| {
+        if is_at_media_condition_operator(p) {
+            parse_scss_media_condition_from_query(p, query)
+                .precede(p)
+                .complete(p, CSS_MEDIA_CONDITION_QUERY)
+        } else {
+            query
+        }
+    })
+}
+
+#[inline]
+fn parse_scss_media_condition_from_query(
+    p: &mut CssParser,
+    query: CompletedMarker,
+) -> CompletedMarker {
+    match p.cur() {
         T![and] => parse_scss_media_and_condition(p, query),
         T![or] => parse_media_or_condition(p, query),
-        _ => return Present(query),
-    };
+        _ => query,
+    }
+}
 
-    Present(condition.precede(p).complete(p, CSS_MEDIA_CONDITION_QUERY))
+#[inline]
+fn is_at_media_condition_operator(p: &mut CssParser) -> bool {
+    p.at(T![and]) || p.at(T![or])
 }
 
 /// Parses an `and` chain after an interpolation-led media query.

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/media.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/media.rs
@@ -1,0 +1,104 @@
+use super::super::{is_at_scss_interpolation, parse_scss_regular_interpolation};
+use crate::parser::CssParser;
+use crate::syntax::at_rule::error::AnyInParensChainParseRecovery;
+use crate::syntax::at_rule::media::{
+    expected_any_media_in_parens, parse_any_media_condition_operand, parse_media_and_condition,
+    parse_media_not_condition, parse_media_or_condition, recover_missing_and_rhs,
+};
+use biome_css_syntax::CssSyntaxKind::*;
+use biome_css_syntax::T;
+use biome_parser::parsed_syntax::ParsedSyntax::Present;
+use biome_parser::prelude::ParsedSyntax::Absent;
+use biome_parser::prelude::*;
+
+/// Returns true when Sass interpolation can start a media query operand.
+#[inline]
+pub(crate) fn is_at_scss_media_query(p: &mut CssParser) -> bool {
+    is_at_scss_interpolation(p)
+}
+
+/// Parses a Sass interpolation that stands in for a media query operand.
+///
+/// Examples:
+/// ```scss
+/// @media #{$query} {}
+/// @media (color) and #{$query} {}
+/// ```
+///
+/// Docs: https://sass-lang.com/documentation/at-rules/css/#media
+#[inline]
+pub(crate) fn parse_scss_media_query(p: &mut CssParser) -> ParsedSyntax {
+    if !is_at_scss_media_query(p) {
+        return Absent;
+    }
+
+    let m = p.start();
+    // Guarded by `is_at_scss_media_query` above.
+    parse_scss_regular_interpolation(p).ok();
+
+    Present(m.complete(p, SCSS_MEDIA_QUERY))
+}
+
+/// Parses a media query list item that starts with Sass interpolation.
+///
+/// Examples:
+/// ```scss
+/// @media #{$query} {}
+/// @media #{$query} and not (color) {}
+/// @media #{$query} or (color) {}
+/// ```
+#[inline]
+pub(crate) fn parse_scss_media_query_or_condition_query(p: &mut CssParser) -> ParsedSyntax {
+    let Present(query) = parse_scss_media_query(p) else {
+        return Absent;
+    };
+
+    let condition = match p.cur() {
+        T![and] => parse_scss_media_and_condition(p, query),
+        T![or] => parse_media_or_condition(p, query),
+        _ => return Present(query),
+    };
+
+    Present(condition.precede(p).complete(p, CSS_MEDIA_CONDITION_QUERY))
+}
+
+/// Parses an `and` chain after an interpolation-led media query.
+///
+/// Sass accepts `@media #{a} and not (b)`, but plain media conditions such as
+/// `@media (a) and not (b)` must keep recovering as invalid. This helper is the
+/// only place where `not` is accepted as an `and` RHS outside the media-type
+/// query path.
+#[inline]
+fn parse_scss_media_and_condition(p: &mut CssParser, lhs: CompletedMarker) -> CompletedMarker {
+    if !p.at(T![and]) {
+        return lhs;
+    }
+
+    let m = lhs.precede(p);
+    p.bump(T![and]);
+
+    let recovery_result = parse_any_scss_media_and_combinable_condition(p)
+        .or_recover(
+            p,
+            &AnyInParensChainParseRecovery::new(T![and]).with_stop_kind(T![')']),
+            expected_any_media_in_parens,
+        )
+        .map(|rhs| parse_media_and_condition(p, rhs));
+
+    recover_missing_and_rhs(p, recovery_result);
+
+    m.complete(p, CSS_MEDIA_AND_CONDITION)
+}
+
+/// Parses the RHS of an interpolation-led `and` chain.
+///
+/// This is wider than a normal CSS `and` RHS because Sass accepts `not` after
+/// an interpolation-led media query.
+#[inline]
+fn parse_any_scss_media_and_combinable_condition(p: &mut CssParser) -> ParsedSyntax {
+    if p.at(T![not]) {
+        parse_media_not_condition(p)
+    } else {
+        parse_any_media_condition_operand(p).map(|rhs| parse_media_and_condition(p, rhs))
+    }
+}

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/mod.rs
@@ -12,6 +12,7 @@ mod if_at_rule;
 mod import_at_rule;
 mod include_at_rule;
 mod keyframes;
+mod media;
 mod mixin_at_rule;
 mod module_clauses;
 mod parameter;
@@ -43,8 +44,13 @@ pub(crate) use if_at_rule::parse_scss_if_at_rule;
 pub(crate) use import_at_rule::parse_scss_import_at_rule;
 pub(crate) use include_at_rule::parse_scss_include_at_rule;
 pub(crate) use keyframes::{is_at_scss_keyframes_selector, parse_scss_keyframes_selector};
+pub(crate) use media::{
+    is_at_scss_media_query, parse_scss_media_query, parse_scss_media_query_or_condition_query,
+};
 pub(crate) use mixin_at_rule::parse_scss_mixin_at_rule;
-pub(crate) use query_feature::parse_scss_interpolated_query_feature;
+pub(crate) use query_feature::{
+    is_at_scss_interpolated_query_feature, parse_scss_interpolated_query_feature,
+};
 pub(crate) use return_at_rule::parse_scss_return_at_rule;
 pub(crate) use use_at_rule::parse_scss_use_at_rule;
 pub(crate) use warn::parse_scss_warn_at_rule;

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/mod.rs
@@ -45,12 +45,12 @@ pub(crate) use import_at_rule::parse_scss_import_at_rule;
 pub(crate) use include_at_rule::parse_scss_include_at_rule;
 pub(crate) use keyframes::{is_at_scss_keyframes_selector, parse_scss_keyframes_selector};
 pub(crate) use media::{
-    is_at_scss_media_query, parse_scss_media_query, parse_scss_media_query_or_condition_query,
+    is_at_scss_interpolated_media_in_parens, is_at_scss_media_condition, is_at_scss_media_query,
+    parse_scss_interpolated_media_in_parens, parse_scss_media_condition, parse_scss_media_query,
+    parse_scss_media_query_or_condition_query,
 };
 pub(crate) use mixin_at_rule::parse_scss_mixin_at_rule;
-pub(crate) use query_feature::{
-    is_at_scss_interpolated_query_feature, parse_scss_interpolated_query_feature,
-};
+pub(crate) use query_feature::parse_scss_interpolated_query_feature;
 pub(crate) use return_at_rule::parse_scss_return_at_rule;
 pub(crate) use use_at_rule::parse_scss_use_at_rule;
 pub(crate) use warn::parse_scss_warn_at_rule;

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/query_feature.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/query_feature.rs
@@ -9,11 +9,13 @@ use crate::syntax::scss::{
     parse_scss_interpolation_or_identifier,
 };
 use biome_css_syntax::CssSyntaxKind::{
-    SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST, SCSS_INTERPOLATION,
+    CSS_STRING_LITERAL, SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST,
+    SCSS_INTERPOLATION,
 };
-use biome_parser::Parser;
+use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::parsed_syntax::ParsedSyntax;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
+use biome_parser::{Parser, TokenSet, token_set};
 
 /// Parses an interpolation-led query feature.
 ///
@@ -54,6 +56,16 @@ pub(crate) fn parse_scss_interpolated_query_feature(p: &mut CssParser) -> Parsed
 
     parse_query_feature_from_name(p, m)
 }
+
+#[inline]
+pub(crate) fn is_at_scss_interpolated_query_feature(p: &mut CssParser) -> bool {
+    is_at_scss_interpolation(p)
+        && (!p.nth_at(2, CSS_STRING_LITERAL)
+            || p.nth_at_ts(4, SCSS_INTERPOLATED_QUERY_FEATURE_CONTINUATION_SET))
+}
+
+const SCSS_INTERPOLATED_QUERY_FEATURE_CONTINUATION_SET: TokenSet<CssSyntaxKind> =
+    token_set![T![:], T![>], T![<], T![>=], T![<=], T![=]];
 
 #[inline]
 fn is_at_query_feature_name_after_comparison(p: &mut CssParser) -> bool {

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/query_feature.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/query_feature.rs
@@ -9,13 +9,11 @@ use crate::syntax::scss::{
     parse_scss_interpolation_or_identifier,
 };
 use biome_css_syntax::CssSyntaxKind::{
-    CSS_STRING_LITERAL, SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST,
-    SCSS_INTERPOLATION,
+    SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST, SCSS_INTERPOLATION,
 };
-use biome_css_syntax::{CssSyntaxKind, T};
+use biome_parser::CompletedMarker;
 use biome_parser::parsed_syntax::ParsedSyntax;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
-use biome_parser::{Parser, TokenSet, token_set};
 
 /// Parses an interpolation-led query feature.
 ///
@@ -28,17 +26,27 @@ use biome_parser::{Parser, TokenSet, token_set};
 /// Docs: https://sass-lang.com/documentation/interpolation
 #[inline]
 pub(crate) fn parse_scss_interpolated_query_feature(p: &mut CssParser) -> ParsedSyntax {
-    if !is_at_scss_interpolation(p) {
+    if !is_at_scss_interpolated_query_feature_start(p) {
         return Absent;
     }
 
-    let m = p.start();
-
-    let Present(head) = parse_scss_interpolation_or_identifier(p) else {
-        return Absent;
+    let head = match parse_scss_interpolation_or_identifier(p) {
+        Present(head) => head,
+        Absent => return Absent,
     };
 
+    parse_scss_interpolated_query_feature_from_head(p, head)
+}
+
+/// Completes an interpolation-led query feature after the shared head has
+/// already been parsed by an ambiguous caller.
+#[inline]
+pub(crate) fn parse_scss_interpolated_query_feature_from_head(
+    p: &mut CssParser,
+    head: CompletedMarker,
+) -> ParsedSyntax {
     if is_at_query_feature_name_after_comparison(p) {
+        let m = head.precede(p);
         // `#{$min}px <= width`: keep the canonical identifier as the feature name.
         // Safe: `is_at_query_feature_name_after_comparison` checks both tokens.
         parse_query_feature_range_comparison(p).ok();
@@ -47,27 +55,25 @@ pub(crate) fn parse_scss_interpolated_query_feature(p: &mut CssParser) -> Parsed
     }
 
     // `#{$feature}: value` and `#{$feature} <= 10px`: the interpolation is the name.
-    if head.kind(p) == SCSS_INTERPOLATION {
+    let name = if head.kind(p) == SCSS_INTERPOLATION {
         let parts = head
             .precede(p)
             .complete(p, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST);
-        parts.precede(p).complete(p, SCSS_INTERPOLATED_IDENTIFIER);
-    }
+        parts.precede(p).complete(p, SCSS_INTERPOLATED_IDENTIFIER)
+    } else {
+        head
+    };
 
+    let m = name.precede(p);
     parse_query_feature_from_name(p, m)
 }
 
 #[inline]
-pub(crate) fn is_at_scss_interpolated_query_feature(p: &mut CssParser) -> bool {
-    is_at_scss_interpolation(p)
-        && (!p.nth_at(2, CSS_STRING_LITERAL)
-            || p.nth_at_ts(4, SCSS_INTERPOLATED_QUERY_FEATURE_CONTINUATION_SET))
-}
-
-const SCSS_INTERPOLATED_QUERY_FEATURE_CONTINUATION_SET: TokenSet<CssSyntaxKind> =
-    token_set![T![:], T![>], T![<], T![>=], T![<=], T![=]];
-
-#[inline]
 fn is_at_query_feature_name_after_comparison(p: &mut CssParser) -> bool {
     is_at_query_feature_range_comparison(p) && is_nth_at_scss_interpolated_identifier(p, 1)
+}
+
+#[inline]
+fn is_at_scss_interpolated_query_feature_start(p: &mut CssParser) -> bool {
+    is_at_scss_interpolation(p)
 }

--- a/crates/biome_css_parser/src/syntax/scss/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/mod.rs
@@ -10,12 +10,14 @@ mod token_sets;
 mod value;
 
 pub(crate) use at_rule::{
-    is_at_scss_keyframes_selector, parse_bogus_scss_else_at_rule, parse_scss_at_root_at_rule,
-    parse_scss_content_at_rule, parse_scss_debug_at_rule, parse_scss_each_at_rule,
-    parse_scss_error_at_rule, parse_scss_extend_at_rule, parse_scss_for_at_rule,
-    parse_scss_forward_at_rule, parse_scss_function_at_rule, parse_scss_if_at_rule,
-    parse_scss_import_at_rule, parse_scss_include_at_rule, parse_scss_interpolated_query_feature,
-    parse_scss_keyframes_selector, parse_scss_mixin_at_rule, parse_scss_return_at_rule,
+    is_at_scss_interpolated_query_feature, is_at_scss_keyframes_selector, is_at_scss_media_query,
+    parse_bogus_scss_else_at_rule, parse_scss_at_root_at_rule, parse_scss_content_at_rule,
+    parse_scss_debug_at_rule, parse_scss_each_at_rule, parse_scss_error_at_rule,
+    parse_scss_extend_at_rule, parse_scss_for_at_rule, parse_scss_forward_at_rule,
+    parse_scss_function_at_rule, parse_scss_if_at_rule, parse_scss_import_at_rule,
+    parse_scss_include_at_rule, parse_scss_interpolated_query_feature,
+    parse_scss_keyframes_selector, parse_scss_media_query,
+    parse_scss_media_query_or_condition_query, parse_scss_mixin_at_rule, parse_scss_return_at_rule,
     parse_scss_use_at_rule, parse_scss_warn_at_rule, parse_scss_while_at_rule,
 };
 pub(crate) use declaration::{

--- a/crates/biome_css_parser/src/syntax/scss/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/mod.rs
@@ -10,13 +10,14 @@ mod token_sets;
 mod value;
 
 pub(crate) use at_rule::{
-    is_at_scss_interpolated_query_feature, is_at_scss_keyframes_selector, is_at_scss_media_query,
-    parse_bogus_scss_else_at_rule, parse_scss_at_root_at_rule, parse_scss_content_at_rule,
-    parse_scss_debug_at_rule, parse_scss_each_at_rule, parse_scss_error_at_rule,
-    parse_scss_extend_at_rule, parse_scss_for_at_rule, parse_scss_forward_at_rule,
-    parse_scss_function_at_rule, parse_scss_if_at_rule, parse_scss_import_at_rule,
-    parse_scss_include_at_rule, parse_scss_interpolated_query_feature,
-    parse_scss_keyframes_selector, parse_scss_media_query,
+    is_at_scss_interpolated_media_in_parens, is_at_scss_keyframes_selector,
+    is_at_scss_media_condition, is_at_scss_media_query, parse_bogus_scss_else_at_rule,
+    parse_scss_at_root_at_rule, parse_scss_content_at_rule, parse_scss_debug_at_rule,
+    parse_scss_each_at_rule, parse_scss_error_at_rule, parse_scss_extend_at_rule,
+    parse_scss_for_at_rule, parse_scss_forward_at_rule, parse_scss_function_at_rule,
+    parse_scss_if_at_rule, parse_scss_import_at_rule, parse_scss_include_at_rule,
+    parse_scss_interpolated_media_in_parens, parse_scss_interpolated_query_feature,
+    parse_scss_keyframes_selector, parse_scss_media_condition, parse_scss_media_query,
     parse_scss_media_query_or_condition_query, parse_scss_mixin_at_rule, parse_scss_return_at_rule,
     parse_scss_use_at_rule, parse_scss_warn_at_rule, parse_scss_while_at_rule,
 };

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_media_and_not_condition.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_media_and_not_condition.css
@@ -1,0 +1,5 @@
+@media (a) and not (b) {
+  x {
+    y: z;
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_media_and_not_condition.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/at_rule_media_and_not_condition.css.snap
@@ -1,0 +1,203 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@media (a) and not (b) {
+  x {
+    y: z;
+  }
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1..7 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        CssMediaFeatureInParens {
+                                            l_paren_token: L_PAREN@7..8 "(" [] [],
+                                            feature: CssQueryFeatureBoolean {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@8..9 "a" [] [],
+                                                },
+                                            },
+                                            r_paren_token: R_PAREN@9..11 ")" [] [Whitespace(" ")],
+                                        },
+                                        AND_KW@11..15 "and" [] [Whitespace(" ")],
+                                        CssBogus {
+                                            items: [
+                                                NOT_KW@15..19 "not" [] [Whitespace(" ")],
+                                                L_PAREN@19..20 "(" [] [],
+                                                IDENT@20..21 "b" [] [],
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        missing separator,
+                        CssBogusMediaQuery {
+                            items: [
+                                R_PAREN@21..23 ")" [] [Whitespace(" ")],
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@23..24 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@24..29 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@29..30 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@30..36 "y" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@36..38 ":" [] [Whitespace(" ")],
+                                                value: CssGenericComponentValueList [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@38..39 "z" [] [],
+                                                    },
+                                                ],
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@39..40 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@40..44 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@44..46 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..47
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..46
+    0: CSS_AT_RULE@0..46
+      0: AT@0..1 "@" [] []
+      1: CSS_MEDIA_AT_RULE@1..46
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1..23
+          0: MEDIA_KW@1..7 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@7..23
+            0: CSS_BOGUS_MEDIA_QUERY@7..21
+              0: CSS_BOGUS@7..21
+                0: CSS_MEDIA_FEATURE_IN_PARENS@7..11
+                  0: L_PAREN@7..8 "(" [] []
+                  1: CSS_QUERY_FEATURE_BOOLEAN@8..9
+                    0: CSS_IDENTIFIER@8..9
+                      0: IDENT@8..9 "a" [] []
+                  2: R_PAREN@9..11 ")" [] [Whitespace(" ")]
+                1: AND_KW@11..15 "and" [] [Whitespace(" ")]
+                2: CSS_BOGUS@15..21
+                  0: NOT_KW@15..19 "not" [] [Whitespace(" ")]
+                  1: L_PAREN@19..20 "(" [] []
+                  2: IDENT@20..21 "b" [] []
+            1: (empty)
+            2: CSS_BOGUS_MEDIA_QUERY@21..23
+              0: R_PAREN@21..23 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@23..46
+          0: L_CURLY@23..24 "{" [] []
+          1: CSS_RULE_LIST@24..44
+            0: CSS_QUALIFIED_RULE@24..44
+              0: CSS_SELECTOR_LIST@24..29
+                0: CSS_COMPOUND_SELECTOR@24..29
+                  0: CSS_NESTED_SELECTOR_LIST@24..24
+                  1: CSS_TYPE_SELECTOR@24..29
+                    0: (empty)
+                    1: CSS_IDENTIFIER@24..29
+                      0: IDENT@24..29 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@29..29
+              1: CSS_DECLARATION_OR_RULE_BLOCK@29..44
+                0: L_CURLY@29..30 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@30..40
+                  0: CSS_DECLARATION_WITH_SEMICOLON@30..40
+                    0: CSS_DECLARATION@30..39
+                      0: CSS_GENERIC_PROPERTY@30..39
+                        0: CSS_IDENTIFIER@30..36
+                          0: IDENT@30..36 "y" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@36..38 ":" [] [Whitespace(" ")]
+                        2: CSS_GENERIC_COMPONENT_VALUE_LIST@38..39
+                          0: CSS_IDENTIFIER@38..39
+                            0: IDENT@38..39 "z" [] []
+                      1: (empty)
+                    1: SEMICOLON@39..40 ";" [] []
+                2: R_CURLY@40..44 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@44..46 "}" [Newline("\n")] []
+  2: EOF@46..47 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+at_rule_media_and_not_condition.css:1:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a media condition, or a query feature but instead found 'not (b'.
+  
+  > 1 │ @media (a) and not (b) {
+      │                ^^^^^^
+    2 │   x {
+    3 │     y: z;
+  
+  i Expected a media condition, or a query feature here.
+  
+  > 1 │ @media (a) and not (b) {
+      │                ^^^^^^
+    2 │   x {
+    3 │     y: z;
+  
+at_rule_media_and_not_condition.css:1:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `,` but instead found `)`
+  
+  > 1 │ @media (a) and not (b) {
+      │                      ^
+    2 │   x {
+    3 │     y: z;
+  
+  i Remove )
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-and-not-condition.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-and-not-condition.scss
@@ -1,0 +1,5 @@
+@media (a) and not (b) {
+  x {
+    y: z;
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-and-not-condition.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-and-not-condition.scss.snap
@@ -1,0 +1,206 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@media (a) and not (b) {
+  x {
+    y: z;
+  }
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1..7 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        CssMediaFeatureInParens {
+                                            l_paren_token: L_PAREN@7..8 "(" [] [],
+                                            feature: CssQueryFeatureBoolean {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@8..9 "a" [] [],
+                                                },
+                                            },
+                                            r_paren_token: R_PAREN@9..11 ")" [] [Whitespace(" ")],
+                                        },
+                                        AND_KW@11..15 "and" [] [Whitespace(" ")],
+                                        CssBogus {
+                                            items: [
+                                                NOT_KW@15..19 "not" [] [Whitespace(" ")],
+                                                L_PAREN@19..20 "(" [] [],
+                                                IDENT@20..21 "b" [] [],
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        missing separator,
+                        CssBogusMediaQuery {
+                            items: [
+                                R_PAREN@21..23 ")" [] [Whitespace(" ")],
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@23..24 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@24..29 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@29..30 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@30..36 "y" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@36..38 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@38..39 "z" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@39..40 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@40..44 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@44..46 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..47
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..46
+    0: CSS_AT_RULE@0..46
+      0: AT@0..1 "@" [] []
+      1: CSS_MEDIA_AT_RULE@1..46
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1..23
+          0: MEDIA_KW@1..7 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@7..23
+            0: CSS_BOGUS_MEDIA_QUERY@7..21
+              0: CSS_BOGUS@7..21
+                0: CSS_MEDIA_FEATURE_IN_PARENS@7..11
+                  0: L_PAREN@7..8 "(" [] []
+                  1: CSS_QUERY_FEATURE_BOOLEAN@8..9
+                    0: CSS_IDENTIFIER@8..9
+                      0: IDENT@8..9 "a" [] []
+                  2: R_PAREN@9..11 ")" [] [Whitespace(" ")]
+                1: AND_KW@11..15 "and" [] [Whitespace(" ")]
+                2: CSS_BOGUS@15..21
+                  0: NOT_KW@15..19 "not" [] [Whitespace(" ")]
+                  1: L_PAREN@19..20 "(" [] []
+                  2: IDENT@20..21 "b" [] []
+            1: (empty)
+            2: CSS_BOGUS_MEDIA_QUERY@21..23
+              0: R_PAREN@21..23 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@23..46
+          0: L_CURLY@23..24 "{" [] []
+          1: CSS_RULE_LIST@24..44
+            0: CSS_QUALIFIED_RULE@24..44
+              0: CSS_SELECTOR_LIST@24..29
+                0: CSS_COMPOUND_SELECTOR@24..29
+                  0: CSS_NESTED_SELECTOR_LIST@24..24
+                  1: CSS_TYPE_SELECTOR@24..29
+                    0: (empty)
+                    1: CSS_IDENTIFIER@24..29
+                      0: IDENT@24..29 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@29..29
+              1: CSS_DECLARATION_OR_RULE_BLOCK@29..44
+                0: L_CURLY@29..30 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@30..40
+                  0: CSS_DECLARATION_WITH_SEMICOLON@30..40
+                    0: CSS_DECLARATION@30..39
+                      0: CSS_GENERIC_PROPERTY@30..39
+                        0: CSS_IDENTIFIER@30..36
+                          0: IDENT@30..36 "y" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@36..38 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@38..39
+                          0: SCSS_EXPRESSION_ITEM_LIST@38..39
+                            0: CSS_IDENTIFIER@38..39
+                              0: IDENT@38..39 "z" [] []
+                      1: (empty)
+                    1: SEMICOLON@39..40 ";" [] []
+                2: R_CURLY@40..44 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@44..46 "}" [Newline("\n")] []
+  2: EOF@46..47 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+media-and-not-condition.scss:1:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a media condition, or a query feature but instead found 'not (b'.
+  
+  > 1 │ @media (a) and not (b) {
+      │                ^^^^^^
+    2 │   x {
+    3 │     y: z;
+  
+  i Expected a media condition, or a query feature here.
+  
+  > 1 │ @media (a) and not (b) {
+      │                ^^^^^^
+    2 │   x {
+    3 │     y: z;
+  
+media-and-not-condition.scss:1:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `,` but instead found `)`
+  
+  > 1 │ @media (a) and not (b) {
+      │                      ^
+    2 │   x {
+    3 │     y: z;
+  
+  i Remove )
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss
@@ -22,6 +22,12 @@
   }
 }
 
+@media (#{$query} and not (color)) {
+  x {
+    y: z;
+  }
+}
+
 @media not #{"(a)"} {
   x {
     y: z;

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss
@@ -1,0 +1,29 @@
+@media (a) and #{"(b) and (c)"} {
+  x {
+    y: z;
+  }
+}
+
+@media (a) or #{"(b) or (c)"} {
+  x {
+    y: z;
+  }
+}
+
+@media a and not #{"(b)"} {
+  x {
+    y: z;
+  }
+}
+
+@media #{a} and not (b) {
+  x {
+    y: z;
+  }
+}
+
+@media not #{"(a)"} {
+  x {
+    y: z;
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss.snap
@@ -1,0 +1,731 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@media (a) and #{"(b) and (c)"} {
+  x {
+    y: z;
+  }
+}
+
+@media (a) or #{"(b) or (c)"} {
+  x {
+    y: z;
+  }
+}
+
+@media a and not #{"(b)"} {
+  x {
+    y: z;
+  }
+}
+
+@media #{a} and not (b) {
+  x {
+    y: z;
+  }
+}
+
+@media not #{"(a)"} {
+  x {
+    y: z;
+  }
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1..7 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaAndCondition {
+                                left: CssMediaFeatureInParens {
+                                    l_paren_token: L_PAREN@7..8 "(" [] [],
+                                    feature: CssQueryFeatureBoolean {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@8..9 "a" [] [],
+                                        },
+                                    },
+                                    r_paren_token: R_PAREN@9..11 ")" [] [Whitespace(" ")],
+                                },
+                                and_token: AND_KW@11..15 "and" [] [Whitespace(" ")],
+                                right: ScssMediaQuery {
+                                    query: ScssInterpolation {
+                                        hash_token: HASH@15..16 "#" [] [],
+                                        l_curly_token: L_CURLY@16..17 "{" [] [],
+                                        value: ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssString {
+                                                    value_token: CSS_STRING_LITERAL@17..30 "\"(b) and (c)\"" [] [],
+                                                },
+                                            ],
+                                        },
+                                        r_curly_token: R_CURLY@30..32 "}" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@32..33 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@33..38 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@38..39 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@39..45 "y" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@45..47 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@47..48 "z" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@48..49 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@49..53 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@53..55 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@55..58 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@58..64 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaOrCondition {
+                                left: CssMediaFeatureInParens {
+                                    l_paren_token: L_PAREN@64..65 "(" [] [],
+                                    feature: CssQueryFeatureBoolean {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@65..66 "a" [] [],
+                                        },
+                                    },
+                                    r_paren_token: R_PAREN@66..68 ")" [] [Whitespace(" ")],
+                                },
+                                or_token: OR_KW@68..71 "or" [] [Whitespace(" ")],
+                                right: ScssMediaQuery {
+                                    query: ScssInterpolation {
+                                        hash_token: HASH@71..72 "#" [] [],
+                                        l_curly_token: L_CURLY@72..73 "{" [] [],
+                                        value: ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssString {
+                                                    value_token: CSS_STRING_LITERAL@73..85 "\"(b) or (c)\"" [] [],
+                                                },
+                                            ],
+                                        },
+                                        r_curly_token: R_CURLY@85..87 "}" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@87..88 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@88..93 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@93..94 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@94..100 "y" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@100..102 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@102..103 "z" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@103..104 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@104..108 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@108..110 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@110..113 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@113..119 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaAndTypeQuery {
+                            left: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: CssIdentifier {
+                                        value_token: IDENT@119..121 "a" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            and_token: AND_KW@121..125 "and" [] [Whitespace(" ")],
+                            right: CssMediaNotCondition {
+                                not_token: NOT_KW@125..129 "not" [] [Whitespace(" ")],
+                                condition: ScssMediaQuery {
+                                    query: ScssInterpolation {
+                                        hash_token: HASH@129..130 "#" [] [],
+                                        l_curly_token: L_CURLY@130..131 "{" [] [],
+                                        value: ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssString {
+                                                    value_token: CSS_STRING_LITERAL@131..136 "\"(b)\"" [] [],
+                                                },
+                                            ],
+                                        },
+                                        r_curly_token: R_CURLY@136..138 "}" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@138..139 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@139..144 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@144..145 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@145..151 "y" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@151..153 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@153..154 "z" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@154..155 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@155..159 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@159..161 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@161..164 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@164..170 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaAndCondition {
+                                left: ScssMediaQuery {
+                                    query: ScssInterpolation {
+                                        hash_token: HASH@170..171 "#" [] [],
+                                        l_curly_token: L_CURLY@171..172 "{" [] [],
+                                        value: ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@172..173 "a" [] [],
+                                                },
+                                            ],
+                                        },
+                                        r_curly_token: R_CURLY@173..175 "}" [] [Whitespace(" ")],
+                                    },
+                                },
+                                and_token: AND_KW@175..179 "and" [] [Whitespace(" ")],
+                                right: CssMediaNotCondition {
+                                    not_token: NOT_KW@179..183 "not" [] [Whitespace(" ")],
+                                    condition: CssMediaFeatureInParens {
+                                        l_paren_token: L_PAREN@183..184 "(" [] [],
+                                        feature: CssQueryFeatureBoolean {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@184..185 "b" [] [],
+                                            },
+                                        },
+                                        r_paren_token: R_PAREN@185..187 ")" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@187..188 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@188..193 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@193..194 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@194..200 "y" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@200..202 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@202..203 "z" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@203..204 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@204..208 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@208..210 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@210..213 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@213..219 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaNotCondition {
+                                not_token: NOT_KW@219..223 "not" [] [Whitespace(" ")],
+                                condition: ScssMediaQuery {
+                                    query: ScssInterpolation {
+                                        hash_token: HASH@223..224 "#" [] [],
+                                        l_curly_token: L_CURLY@224..225 "{" [] [],
+                                        value: ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssString {
+                                                    value_token: CSS_STRING_LITERAL@225..230 "\"(a)\"" [] [],
+                                                },
+                                            ],
+                                        },
+                                        r_curly_token: R_CURLY@230..232 "}" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@232..233 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@233..238 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@238..239 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@239..245 "y" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@245..247 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@247..248 "z" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@248..249 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@249..253 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@253..255 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@255..256 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..256
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..255
+    0: CSS_AT_RULE@0..55
+      0: AT@0..1 "@" [] []
+      1: CSS_MEDIA_AT_RULE@1..55
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1..32
+          0: MEDIA_KW@1..7 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@7..32
+            0: CSS_MEDIA_CONDITION_QUERY@7..32
+              0: CSS_MEDIA_AND_CONDITION@7..32
+                0: CSS_MEDIA_FEATURE_IN_PARENS@7..11
+                  0: L_PAREN@7..8 "(" [] []
+                  1: CSS_QUERY_FEATURE_BOOLEAN@8..9
+                    0: CSS_IDENTIFIER@8..9
+                      0: IDENT@8..9 "a" [] []
+                  2: R_PAREN@9..11 ")" [] [Whitespace(" ")]
+                1: AND_KW@11..15 "and" [] [Whitespace(" ")]
+                2: SCSS_MEDIA_QUERY@15..32
+                  0: SCSS_INTERPOLATION@15..32
+                    0: HASH@15..16 "#" [] []
+                    1: L_CURLY@16..17 "{" [] []
+                    2: SCSS_EXPRESSION@17..30
+                      0: SCSS_EXPRESSION_ITEM_LIST@17..30
+                        0: CSS_STRING@17..30
+                          0: CSS_STRING_LITERAL@17..30 "\"(b) and (c)\"" [] []
+                    3: R_CURLY@30..32 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@32..55
+          0: L_CURLY@32..33 "{" [] []
+          1: CSS_RULE_LIST@33..53
+            0: CSS_QUALIFIED_RULE@33..53
+              0: CSS_SELECTOR_LIST@33..38
+                0: CSS_COMPOUND_SELECTOR@33..38
+                  0: CSS_NESTED_SELECTOR_LIST@33..33
+                  1: CSS_TYPE_SELECTOR@33..38
+                    0: (empty)
+                    1: CSS_IDENTIFIER@33..38
+                      0: IDENT@33..38 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@38..38
+              1: CSS_DECLARATION_OR_RULE_BLOCK@38..53
+                0: L_CURLY@38..39 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@39..49
+                  0: CSS_DECLARATION_WITH_SEMICOLON@39..49
+                    0: CSS_DECLARATION@39..48
+                      0: CSS_GENERIC_PROPERTY@39..48
+                        0: CSS_IDENTIFIER@39..45
+                          0: IDENT@39..45 "y" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@45..47 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@47..48
+                          0: SCSS_EXPRESSION_ITEM_LIST@47..48
+                            0: CSS_IDENTIFIER@47..48
+                              0: IDENT@47..48 "z" [] []
+                      1: (empty)
+                    1: SEMICOLON@48..49 ";" [] []
+                2: R_CURLY@49..53 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@53..55 "}" [Newline("\n")] []
+    1: CSS_AT_RULE@55..110
+      0: AT@55..58 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@58..110
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@58..87
+          0: MEDIA_KW@58..64 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@64..87
+            0: CSS_MEDIA_CONDITION_QUERY@64..87
+              0: CSS_MEDIA_OR_CONDITION@64..87
+                0: CSS_MEDIA_FEATURE_IN_PARENS@64..68
+                  0: L_PAREN@64..65 "(" [] []
+                  1: CSS_QUERY_FEATURE_BOOLEAN@65..66
+                    0: CSS_IDENTIFIER@65..66
+                      0: IDENT@65..66 "a" [] []
+                  2: R_PAREN@66..68 ")" [] [Whitespace(" ")]
+                1: OR_KW@68..71 "or" [] [Whitespace(" ")]
+                2: SCSS_MEDIA_QUERY@71..87
+                  0: SCSS_INTERPOLATION@71..87
+                    0: HASH@71..72 "#" [] []
+                    1: L_CURLY@72..73 "{" [] []
+                    2: SCSS_EXPRESSION@73..85
+                      0: SCSS_EXPRESSION_ITEM_LIST@73..85
+                        0: CSS_STRING@73..85
+                          0: CSS_STRING_LITERAL@73..85 "\"(b) or (c)\"" [] []
+                    3: R_CURLY@85..87 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@87..110
+          0: L_CURLY@87..88 "{" [] []
+          1: CSS_RULE_LIST@88..108
+            0: CSS_QUALIFIED_RULE@88..108
+              0: CSS_SELECTOR_LIST@88..93
+                0: CSS_COMPOUND_SELECTOR@88..93
+                  0: CSS_NESTED_SELECTOR_LIST@88..88
+                  1: CSS_TYPE_SELECTOR@88..93
+                    0: (empty)
+                    1: CSS_IDENTIFIER@88..93
+                      0: IDENT@88..93 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@93..93
+              1: CSS_DECLARATION_OR_RULE_BLOCK@93..108
+                0: L_CURLY@93..94 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@94..104
+                  0: CSS_DECLARATION_WITH_SEMICOLON@94..104
+                    0: CSS_DECLARATION@94..103
+                      0: CSS_GENERIC_PROPERTY@94..103
+                        0: CSS_IDENTIFIER@94..100
+                          0: IDENT@94..100 "y" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@100..102 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@102..103
+                          0: SCSS_EXPRESSION_ITEM_LIST@102..103
+                            0: CSS_IDENTIFIER@102..103
+                              0: IDENT@102..103 "z" [] []
+                      1: (empty)
+                    1: SEMICOLON@103..104 ";" [] []
+                2: R_CURLY@104..108 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@108..110 "}" [Newline("\n")] []
+    2: CSS_AT_RULE@110..161
+      0: AT@110..113 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@113..161
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@113..138
+          0: MEDIA_KW@113..119 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@119..138
+            0: CSS_MEDIA_AND_TYPE_QUERY@119..138
+              0: CSS_MEDIA_TYPE_QUERY@119..121
+                0: (empty)
+                1: CSS_MEDIA_TYPE@119..121
+                  0: CSS_IDENTIFIER@119..121
+                    0: IDENT@119..121 "a" [] [Whitespace(" ")]
+              1: AND_KW@121..125 "and" [] [Whitespace(" ")]
+              2: CSS_MEDIA_NOT_CONDITION@125..138
+                0: NOT_KW@125..129 "not" [] [Whitespace(" ")]
+                1: SCSS_MEDIA_QUERY@129..138
+                  0: SCSS_INTERPOLATION@129..138
+                    0: HASH@129..130 "#" [] []
+                    1: L_CURLY@130..131 "{" [] []
+                    2: SCSS_EXPRESSION@131..136
+                      0: SCSS_EXPRESSION_ITEM_LIST@131..136
+                        0: CSS_STRING@131..136
+                          0: CSS_STRING_LITERAL@131..136 "\"(b)\"" [] []
+                    3: R_CURLY@136..138 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@138..161
+          0: L_CURLY@138..139 "{" [] []
+          1: CSS_RULE_LIST@139..159
+            0: CSS_QUALIFIED_RULE@139..159
+              0: CSS_SELECTOR_LIST@139..144
+                0: CSS_COMPOUND_SELECTOR@139..144
+                  0: CSS_NESTED_SELECTOR_LIST@139..139
+                  1: CSS_TYPE_SELECTOR@139..144
+                    0: (empty)
+                    1: CSS_IDENTIFIER@139..144
+                      0: IDENT@139..144 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@144..144
+              1: CSS_DECLARATION_OR_RULE_BLOCK@144..159
+                0: L_CURLY@144..145 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@145..155
+                  0: CSS_DECLARATION_WITH_SEMICOLON@145..155
+                    0: CSS_DECLARATION@145..154
+                      0: CSS_GENERIC_PROPERTY@145..154
+                        0: CSS_IDENTIFIER@145..151
+                          0: IDENT@145..151 "y" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@151..153 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@153..154
+                          0: SCSS_EXPRESSION_ITEM_LIST@153..154
+                            0: CSS_IDENTIFIER@153..154
+                              0: IDENT@153..154 "z" [] []
+                      1: (empty)
+                    1: SEMICOLON@154..155 ";" [] []
+                2: R_CURLY@155..159 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@159..161 "}" [Newline("\n")] []
+    3: CSS_AT_RULE@161..210
+      0: AT@161..164 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@164..210
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@164..187
+          0: MEDIA_KW@164..170 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@170..187
+            0: CSS_MEDIA_CONDITION_QUERY@170..187
+              0: CSS_MEDIA_AND_CONDITION@170..187
+                0: SCSS_MEDIA_QUERY@170..175
+                  0: SCSS_INTERPOLATION@170..175
+                    0: HASH@170..171 "#" [] []
+                    1: L_CURLY@171..172 "{" [] []
+                    2: SCSS_EXPRESSION@172..173
+                      0: SCSS_EXPRESSION_ITEM_LIST@172..173
+                        0: CSS_IDENTIFIER@172..173
+                          0: IDENT@172..173 "a" [] []
+                    3: R_CURLY@173..175 "}" [] [Whitespace(" ")]
+                1: AND_KW@175..179 "and" [] [Whitespace(" ")]
+                2: CSS_MEDIA_NOT_CONDITION@179..187
+                  0: NOT_KW@179..183 "not" [] [Whitespace(" ")]
+                  1: CSS_MEDIA_FEATURE_IN_PARENS@183..187
+                    0: L_PAREN@183..184 "(" [] []
+                    1: CSS_QUERY_FEATURE_BOOLEAN@184..185
+                      0: CSS_IDENTIFIER@184..185
+                        0: IDENT@184..185 "b" [] []
+                    2: R_PAREN@185..187 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@187..210
+          0: L_CURLY@187..188 "{" [] []
+          1: CSS_RULE_LIST@188..208
+            0: CSS_QUALIFIED_RULE@188..208
+              0: CSS_SELECTOR_LIST@188..193
+                0: CSS_COMPOUND_SELECTOR@188..193
+                  0: CSS_NESTED_SELECTOR_LIST@188..188
+                  1: CSS_TYPE_SELECTOR@188..193
+                    0: (empty)
+                    1: CSS_IDENTIFIER@188..193
+                      0: IDENT@188..193 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@193..193
+              1: CSS_DECLARATION_OR_RULE_BLOCK@193..208
+                0: L_CURLY@193..194 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@194..204
+                  0: CSS_DECLARATION_WITH_SEMICOLON@194..204
+                    0: CSS_DECLARATION@194..203
+                      0: CSS_GENERIC_PROPERTY@194..203
+                        0: CSS_IDENTIFIER@194..200
+                          0: IDENT@194..200 "y" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@200..202 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@202..203
+                          0: SCSS_EXPRESSION_ITEM_LIST@202..203
+                            0: CSS_IDENTIFIER@202..203
+                              0: IDENT@202..203 "z" [] []
+                      1: (empty)
+                    1: SEMICOLON@203..204 ";" [] []
+                2: R_CURLY@204..208 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@208..210 "}" [Newline("\n")] []
+    4: CSS_AT_RULE@210..255
+      0: AT@210..213 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@213..255
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@213..232
+          0: MEDIA_KW@213..219 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@219..232
+            0: CSS_MEDIA_CONDITION_QUERY@219..232
+              0: CSS_MEDIA_NOT_CONDITION@219..232
+                0: NOT_KW@219..223 "not" [] [Whitespace(" ")]
+                1: SCSS_MEDIA_QUERY@223..232
+                  0: SCSS_INTERPOLATION@223..232
+                    0: HASH@223..224 "#" [] []
+                    1: L_CURLY@224..225 "{" [] []
+                    2: SCSS_EXPRESSION@225..230
+                      0: SCSS_EXPRESSION_ITEM_LIST@225..230
+                        0: CSS_STRING@225..230
+                          0: CSS_STRING_LITERAL@225..230 "\"(a)\"" [] []
+                    3: R_CURLY@230..232 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@232..255
+          0: L_CURLY@232..233 "{" [] []
+          1: CSS_RULE_LIST@233..253
+            0: CSS_QUALIFIED_RULE@233..253
+              0: CSS_SELECTOR_LIST@233..238
+                0: CSS_COMPOUND_SELECTOR@233..238
+                  0: CSS_NESTED_SELECTOR_LIST@233..233
+                  1: CSS_TYPE_SELECTOR@233..238
+                    0: (empty)
+                    1: CSS_IDENTIFIER@233..238
+                      0: IDENT@233..238 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@238..238
+              1: CSS_DECLARATION_OR_RULE_BLOCK@238..253
+                0: L_CURLY@238..239 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@239..249
+                  0: CSS_DECLARATION_WITH_SEMICOLON@239..249
+                    0: CSS_DECLARATION@239..248
+                      0: CSS_GENERIC_PROPERTY@239..248
+                        0: CSS_IDENTIFIER@239..245
+                          0: IDENT@239..245 "y" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@245..247 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@247..248
+                          0: SCSS_EXPRESSION_ITEM_LIST@247..248
+                            0: CSS_IDENTIFIER@247..248
+                              0: IDENT@247..248 "z" [] []
+                      1: (empty)
+                    1: SEMICOLON@248..249 ";" [] []
+                2: R_CURLY@249..253 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@253..255 "}" [Newline("\n")] []
+  2: EOF@255..256 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss.snap
@@ -30,6 +30,12 @@ expression: snapshot
   }
 }
 
+@media (#{$query} and not (color)) {
+  x {
+    y: z;
+  }
+}
+
 @media not #{"(a)"} {
   x {
     y: z;
@@ -387,28 +393,47 @@ CssRoot {
                     media_token: MEDIA_KW@213..219 "media" [] [Whitespace(" ")],
                     queries: CssMediaQueryList [
                         CssMediaConditionQuery {
-                            condition: CssMediaNotCondition {
-                                not_token: NOT_KW@219..223 "not" [] [Whitespace(" ")],
-                                condition: ScssMediaQuery {
-                                    query: ScssInterpolation {
-                                        hash_token: HASH@223..224 "#" [] [],
-                                        l_curly_token: L_CURLY@224..225 "{" [] [],
-                                        value: ScssExpression {
-                                            items: ScssExpressionItemList [
-                                                CssString {
-                                                    value_token: CSS_STRING_LITERAL@225..230 "\"(a)\"" [] [],
-                                                },
-                                            ],
+                            condition: CssMediaConditionInParens {
+                                l_paren_token: L_PAREN@219..220 "(" [] [],
+                                condition: CssMediaAndCondition {
+                                    left: ScssMediaQuery {
+                                        query: ScssInterpolation {
+                                            hash_token: HASH@220..221 "#" [] [],
+                                            l_curly_token: L_CURLY@221..222 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@222..223 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@223..228 "query" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@228..230 "}" [] [Whitespace(" ")],
                                         },
-                                        r_curly_token: R_CURLY@230..232 "}" [] [Whitespace(" ")],
+                                    },
+                                    and_token: AND_KW@230..234 "and" [] [Whitespace(" ")],
+                                    right: CssMediaNotCondition {
+                                        not_token: NOT_KW@234..238 "not" [] [Whitespace(" ")],
+                                        condition: CssMediaFeatureInParens {
+                                            l_paren_token: L_PAREN@238..239 "(" [] [],
+                                            feature: CssQueryFeatureBoolean {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@239..244 "color" [] [],
+                                                },
+                                            },
+                                            r_paren_token: R_PAREN@244..245 ")" [] [],
+                                        },
                                     },
                                 },
+                                r_paren_token: R_PAREN@245..247 ")" [] [Whitespace(" ")],
                             },
                         },
                     ],
                 },
                 block: CssRuleBlock {
-                    l_curly_token: L_CURLY@232..233 "{" [] [],
+                    l_curly_token: L_CURLY@247..248 "{" [] [],
                     rules: CssRuleList [
                         CssQualifiedRule {
                             prelude: CssSelectorList [
@@ -417,54 +442,128 @@ CssRoot {
                                     simple_selector: CssTypeSelector {
                                         namespace: missing (optional),
                                         ident: CssIdentifier {
-                                            value_token: IDENT@233..238 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                            value_token: IDENT@248..253 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                         },
                                     },
                                     sub_selectors: CssSubSelectorList [],
                                 },
                             ],
                             block: CssDeclarationOrRuleBlock {
-                                l_curly_token: L_CURLY@238..239 "{" [] [],
+                                l_curly_token: L_CURLY@253..254 "{" [] [],
                                 items: CssDeclarationOrRuleList [
                                     CssDeclarationWithSemicolon {
                                         declaration: CssDeclaration {
                                             property: CssGenericProperty {
                                                 name: CssIdentifier {
-                                                    value_token: IDENT@239..245 "y" [Newline("\n"), Whitespace("    ")] [],
+                                                    value_token: IDENT@254..260 "y" [Newline("\n"), Whitespace("    ")] [],
                                                 },
-                                                colon_token: COLON@245..247 ":" [] [Whitespace(" ")],
+                                                colon_token: COLON@260..262 ":" [] [Whitespace(" ")],
                                                 value: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         CssIdentifier {
-                                                            value_token: IDENT@247..248 "z" [] [],
+                                                            value_token: IDENT@262..263 "z" [] [],
                                                         },
                                                     ],
                                                 },
                                             },
                                             important: missing (optional),
                                         },
-                                        semicolon_token: SEMICOLON@248..249 ";" [] [],
+                                        semicolon_token: SEMICOLON@263..264 ";" [] [],
                                     },
                                 ],
-                                r_curly_token: R_CURLY@249..253 "}" [Newline("\n"), Whitespace("  ")] [],
+                                r_curly_token: R_CURLY@264..268 "}" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                     ],
-                    r_curly_token: R_CURLY@253..255 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@268..270 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@270..273 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@273..279 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaNotCondition {
+                                not_token: NOT_KW@279..283 "not" [] [Whitespace(" ")],
+                                condition: ScssMediaQuery {
+                                    query: ScssInterpolation {
+                                        hash_token: HASH@283..284 "#" [] [],
+                                        l_curly_token: L_CURLY@284..285 "{" [] [],
+                                        value: ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssString {
+                                                    value_token: CSS_STRING_LITERAL@285..290 "\"(a)\"" [] [],
+                                                },
+                                            ],
+                                        },
+                                        r_curly_token: R_CURLY@290..292 "}" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@292..293 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@293..298 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@298..299 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@299..305 "y" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@305..307 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@307..308 "z" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@308..309 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@309..313 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@313..315 "}" [Newline("\n")] [],
                 },
             },
         },
     ],
-    eof_token: EOF@255..256 "" [Newline("\n")] [],
+    eof_token: EOF@315..316 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..256
+0: CSS_ROOT@0..316
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..255
+  1: CSS_ROOT_ITEM_LIST@0..315
     0: CSS_AT_RULE@0..55
       0: AT@0..1 "@" [] []
       1: CSS_MEDIA_AT_RULE@1..55
@@ -679,53 +778,113 @@ CssRoot {
                     1: SEMICOLON@203..204 ";" [] []
                 2: R_CURLY@204..208 "}" [Newline("\n"), Whitespace("  ")] []
           2: R_CURLY@208..210 "}" [Newline("\n")] []
-    4: CSS_AT_RULE@210..255
+    4: CSS_AT_RULE@210..270
       0: AT@210..213 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_MEDIA_AT_RULE@213..255
-        0: CSS_MEDIA_AT_RULE_DECLARATOR@213..232
+      1: CSS_MEDIA_AT_RULE@213..270
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@213..247
           0: MEDIA_KW@213..219 "media" [] [Whitespace(" ")]
-          1: CSS_MEDIA_QUERY_LIST@219..232
-            0: CSS_MEDIA_CONDITION_QUERY@219..232
-              0: CSS_MEDIA_NOT_CONDITION@219..232
-                0: NOT_KW@219..223 "not" [] [Whitespace(" ")]
-                1: SCSS_MEDIA_QUERY@223..232
-                  0: SCSS_INTERPOLATION@223..232
-                    0: HASH@223..224 "#" [] []
-                    1: L_CURLY@224..225 "{" [] []
-                    2: SCSS_EXPRESSION@225..230
-                      0: SCSS_EXPRESSION_ITEM_LIST@225..230
-                        0: CSS_STRING@225..230
-                          0: CSS_STRING_LITERAL@225..230 "\"(a)\"" [] []
-                    3: R_CURLY@230..232 "}" [] [Whitespace(" ")]
-        1: CSS_RULE_BLOCK@232..255
-          0: L_CURLY@232..233 "{" [] []
-          1: CSS_RULE_LIST@233..253
-            0: CSS_QUALIFIED_RULE@233..253
-              0: CSS_SELECTOR_LIST@233..238
-                0: CSS_COMPOUND_SELECTOR@233..238
-                  0: CSS_NESTED_SELECTOR_LIST@233..233
-                  1: CSS_TYPE_SELECTOR@233..238
+          1: CSS_MEDIA_QUERY_LIST@219..247
+            0: CSS_MEDIA_CONDITION_QUERY@219..247
+              0: CSS_MEDIA_CONDITION_IN_PARENS@219..247
+                0: L_PAREN@219..220 "(" [] []
+                1: CSS_MEDIA_AND_CONDITION@220..245
+                  0: SCSS_MEDIA_QUERY@220..230
+                    0: SCSS_INTERPOLATION@220..230
+                      0: HASH@220..221 "#" [] []
+                      1: L_CURLY@221..222 "{" [] []
+                      2: SCSS_EXPRESSION@222..228
+                        0: SCSS_EXPRESSION_ITEM_LIST@222..228
+                          0: SCSS_VARIABLE@222..228
+                            0: DOLLAR@222..223 "$" [] []
+                            1: CSS_IDENTIFIER@223..228
+                              0: IDENT@223..228 "query" [] []
+                      3: R_CURLY@228..230 "}" [] [Whitespace(" ")]
+                  1: AND_KW@230..234 "and" [] [Whitespace(" ")]
+                  2: CSS_MEDIA_NOT_CONDITION@234..245
+                    0: NOT_KW@234..238 "not" [] [Whitespace(" ")]
+                    1: CSS_MEDIA_FEATURE_IN_PARENS@238..245
+                      0: L_PAREN@238..239 "(" [] []
+                      1: CSS_QUERY_FEATURE_BOOLEAN@239..244
+                        0: CSS_IDENTIFIER@239..244
+                          0: IDENT@239..244 "color" [] []
+                      2: R_PAREN@244..245 ")" [] []
+                2: R_PAREN@245..247 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@247..270
+          0: L_CURLY@247..248 "{" [] []
+          1: CSS_RULE_LIST@248..268
+            0: CSS_QUALIFIED_RULE@248..268
+              0: CSS_SELECTOR_LIST@248..253
+                0: CSS_COMPOUND_SELECTOR@248..253
+                  0: CSS_NESTED_SELECTOR_LIST@248..248
+                  1: CSS_TYPE_SELECTOR@248..253
                     0: (empty)
-                    1: CSS_IDENTIFIER@233..238
-                      0: IDENT@233..238 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-                  2: CSS_SUB_SELECTOR_LIST@238..238
-              1: CSS_DECLARATION_OR_RULE_BLOCK@238..253
-                0: L_CURLY@238..239 "{" [] []
-                1: CSS_DECLARATION_OR_RULE_LIST@239..249
-                  0: CSS_DECLARATION_WITH_SEMICOLON@239..249
-                    0: CSS_DECLARATION@239..248
-                      0: CSS_GENERIC_PROPERTY@239..248
-                        0: CSS_IDENTIFIER@239..245
-                          0: IDENT@239..245 "y" [Newline("\n"), Whitespace("    ")] []
-                        1: COLON@245..247 ":" [] [Whitespace(" ")]
-                        2: SCSS_EXPRESSION@247..248
-                          0: SCSS_EXPRESSION_ITEM_LIST@247..248
-                            0: CSS_IDENTIFIER@247..248
-                              0: IDENT@247..248 "z" [] []
+                    1: CSS_IDENTIFIER@248..253
+                      0: IDENT@248..253 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@253..253
+              1: CSS_DECLARATION_OR_RULE_BLOCK@253..268
+                0: L_CURLY@253..254 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@254..264
+                  0: CSS_DECLARATION_WITH_SEMICOLON@254..264
+                    0: CSS_DECLARATION@254..263
+                      0: CSS_GENERIC_PROPERTY@254..263
+                        0: CSS_IDENTIFIER@254..260
+                          0: IDENT@254..260 "y" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@260..262 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@262..263
+                          0: SCSS_EXPRESSION_ITEM_LIST@262..263
+                            0: CSS_IDENTIFIER@262..263
+                              0: IDENT@262..263 "z" [] []
                       1: (empty)
-                    1: SEMICOLON@248..249 ";" [] []
-                2: R_CURLY@249..253 "}" [Newline("\n"), Whitespace("  ")] []
-          2: R_CURLY@253..255 "}" [Newline("\n")] []
-  2: EOF@255..256 "" [Newline("\n")] []
+                    1: SEMICOLON@263..264 ";" [] []
+                2: R_CURLY@264..268 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@268..270 "}" [Newline("\n")] []
+    5: CSS_AT_RULE@270..315
+      0: AT@270..273 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@273..315
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@273..292
+          0: MEDIA_KW@273..279 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@279..292
+            0: CSS_MEDIA_CONDITION_QUERY@279..292
+              0: CSS_MEDIA_NOT_CONDITION@279..292
+                0: NOT_KW@279..283 "not" [] [Whitespace(" ")]
+                1: SCSS_MEDIA_QUERY@283..292
+                  0: SCSS_INTERPOLATION@283..292
+                    0: HASH@283..284 "#" [] []
+                    1: L_CURLY@284..285 "{" [] []
+                    2: SCSS_EXPRESSION@285..290
+                      0: SCSS_EXPRESSION_ITEM_LIST@285..290
+                        0: CSS_STRING@285..290
+                          0: CSS_STRING_LITERAL@285..290 "\"(a)\"" [] []
+                    3: R_CURLY@290..292 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@292..315
+          0: L_CURLY@292..293 "{" [] []
+          1: CSS_RULE_LIST@293..313
+            0: CSS_QUALIFIED_RULE@293..313
+              0: CSS_SELECTOR_LIST@293..298
+                0: CSS_COMPOUND_SELECTOR@293..298
+                  0: CSS_NESTED_SELECTOR_LIST@293..293
+                  1: CSS_TYPE_SELECTOR@293..298
+                    0: (empty)
+                    1: CSS_IDENTIFIER@293..298
+                      0: IDENT@293..298 "x" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  2: CSS_SUB_SELECTOR_LIST@298..298
+              1: CSS_DECLARATION_OR_RULE_BLOCK@298..313
+                0: L_CURLY@298..299 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@299..309
+                  0: CSS_DECLARATION_WITH_SEMICOLON@299..309
+                    0: CSS_DECLARATION@299..308
+                      0: CSS_GENERIC_PROPERTY@299..308
+                        0: CSS_IDENTIFIER@299..305
+                          0: IDENT@299..305 "y" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@305..307 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@307..308
+                          0: SCSS_EXPRESSION_ITEM_LIST@307..308
+                            0: CSS_IDENTIFIER@307..308
+                              0: IDENT@307..308 "z" [] []
+                      1: (empty)
+                    1: SEMICOLON@308..309 ";" [] []
+                2: R_CURLY@309..313 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@313..315 "}" [Newline("\n")] []
+  2: EOF@315..316 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolation.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolation.scss
@@ -34,6 +34,12 @@
   }
 }
 
+@media (#{$feature}-suffix: 1px) {
+  .box {
+    color: red;
+  }
+}
+
 @media #{$query} {
   .box {
     color: red;

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolation.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolation.scss.snap
@@ -42,6 +42,12 @@ expression: snapshot
   }
 }
 
+@media (#{$feature}-suffix: 1px) {
+  .box {
+    color: red;
+  }
+}
+
 @media #{$query} {
   .box {
     color: red;
@@ -639,27 +645,45 @@ CssRoot {
                 declarator: CssMediaAtRuleDeclarator {
                     media_token: MEDIA_KW@381..387 "media" [] [Whitespace(" ")],
                     queries: CssMediaQueryList [
-                        ScssMediaQuery {
-                            query: ScssInterpolation {
-                                hash_token: HASH@387..388 "#" [] [],
-                                l_curly_token: L_CURLY@388..389 "{" [] [],
-                                value: ScssExpression {
-                                    items: ScssExpressionItemList [
-                                        ScssVariable {
-                                            dollar_token: DOLLAR@389..390 "$" [] [],
-                                            name: CssIdentifier {
-                                                value_token: IDENT@390..395 "query" [] [],
+                        CssMediaConditionQuery {
+                            condition: CssMediaFeatureInParens {
+                                l_paren_token: L_PAREN@387..388 "(" [] [],
+                                feature: CssQueryFeaturePlain {
+                                    name: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@388..389 "#" [] [],
+                                                l_curly_token: L_CURLY@389..390 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@390..391 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@391..398 "feature" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@398..399 "}" [] [],
                                             },
-                                        },
-                                    ],
+                                            CssIdentifier {
+                                                value_token: IDENT@399..406 "-suffix" [] [],
+                                            },
+                                        ],
+                                    },
+                                    colon_token: COLON@406..408 ":" [] [Whitespace(" ")],
+                                    value: CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@408..409 "1" [] [],
+                                        unit_token: IDENT@409..411 "px" [] [],
+                                    },
                                 },
-                                r_curly_token: R_CURLY@395..397 "}" [] [Whitespace(" ")],
+                                r_paren_token: R_PAREN@411..413 ")" [] [Whitespace(" ")],
                             },
                         },
                     ],
                 },
                 block: CssRuleBlock {
-                    l_curly_token: L_CURLY@397..398 "{" [] [],
+                    l_curly_token: L_CURLY@413..414 "{" [] [],
                     rules: CssRuleList [
                         CssQualifiedRule {
                             prelude: CssSelectorList [
@@ -668,81 +692,155 @@ CssRoot {
                                     simple_selector: missing (optional),
                                     sub_selectors: CssSubSelectorList [
                                         CssClassSelector {
-                                            dot_token: DOT@398..402 "." [Newline("\n"), Whitespace("  ")] [],
+                                            dot_token: DOT@414..418 "." [Newline("\n"), Whitespace("  ")] [],
                                             name: CssCustomIdentifier {
-                                                value_token: IDENT@402..406 "box" [] [Whitespace(" ")],
+                                                value_token: IDENT@418..422 "box" [] [Whitespace(" ")],
                                             },
                                         },
                                     ],
                                 },
                             ],
                             block: CssDeclarationOrRuleBlock {
-                                l_curly_token: L_CURLY@406..407 "{" [] [],
+                                l_curly_token: L_CURLY@422..423 "{" [] [],
                                 items: CssDeclarationOrRuleList [
                                     CssDeclarationWithSemicolon {
                                         declaration: CssDeclaration {
                                             property: CssGenericProperty {
                                                 name: CssIdentifier {
-                                                    value_token: IDENT@407..417 "color" [Newline("\n"), Whitespace("    ")] [],
+                                                    value_token: IDENT@423..433 "color" [Newline("\n"), Whitespace("    ")] [],
                                                 },
-                                                colon_token: COLON@417..419 ":" [] [Whitespace(" ")],
+                                                colon_token: COLON@433..435 ":" [] [Whitespace(" ")],
                                                 value: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         CssIdentifier {
-                                                            value_token: IDENT@419..422 "red" [] [],
+                                                            value_token: IDENT@435..438 "red" [] [],
                                                         },
                                                     ],
                                                 },
                                             },
                                             important: missing (optional),
                                         },
-                                        semicolon_token: SEMICOLON@422..423 ";" [] [],
+                                        semicolon_token: SEMICOLON@438..439 ";" [] [],
                                     },
                                 ],
-                                r_curly_token: R_CURLY@423..427 "}" [Newline("\n"), Whitespace("  ")] [],
+                                r_curly_token: R_CURLY@439..443 "}" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                     ],
-                    r_curly_token: R_CURLY@427..429 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@443..445 "}" [Newline("\n")] [],
                 },
             },
         },
         CssAtRule {
-            at_token: AT@429..432 "@" [Newline("\n"), Newline("\n")] [],
+            at_token: AT@445..448 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssMediaAtRule {
                 declarator: CssMediaAtRuleDeclarator {
-                    media_token: MEDIA_KW@432..438 "media" [] [Whitespace(" ")],
+                    media_token: MEDIA_KW@448..454 "media" [] [Whitespace(" ")],
                     queries: CssMediaQueryList [
                         ScssMediaQuery {
                             query: ScssInterpolation {
-                                hash_token: HASH@438..439 "#" [] [],
-                                l_curly_token: L_CURLY@439..440 "{" [] [],
+                                hash_token: HASH@454..455 "#" [] [],
+                                l_curly_token: L_CURLY@455..456 "{" [] [],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssVariable {
-                                            dollar_token: DOLLAR@440..441 "$" [] [],
+                                            dollar_token: DOLLAR@456..457 "$" [] [],
                                             name: CssIdentifier {
-                                                value_token: IDENT@441..446 "query" [] [],
+                                                value_token: IDENT@457..462 "query" [] [],
                                             },
                                         },
                                     ],
                                 },
-                                r_curly_token: R_CURLY@446..447 "}" [] [],
+                                r_curly_token: R_CURLY@462..464 "}" [] [Whitespace(" ")],
                             },
                         },
-                        COMMA@447..449 "," [] [Whitespace(" ")],
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@464..465 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@465..469 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@469..473 "box" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@473..474 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@474..484 "color" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@484..486 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@486..489 "red" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@489..490 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@490..494 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@494..496 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@496..499 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@499..505 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            query: ScssInterpolation {
+                                hash_token: HASH@505..506 "#" [] [],
+                                l_curly_token: L_CURLY@506..507 "{" [] [],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        ScssVariable {
+                                            dollar_token: DOLLAR@507..508 "$" [] [],
+                                            name: CssIdentifier {
+                                                value_token: IDENT@508..513 "query" [] [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                r_curly_token: R_CURLY@513..514 "}" [] [],
+                            },
+                        },
+                        COMMA@514..516 "," [] [Whitespace(" ")],
                         CssMediaTypeQuery {
                             modifier: missing (optional),
                             ty: CssMediaType {
                                 value: CssIdentifier {
-                                    value_token: IDENT@449..456 "screen" [] [Whitespace(" ")],
+                                    value_token: IDENT@516..523 "screen" [] [Whitespace(" ")],
                                 },
                             },
                         },
                     ],
                 },
                 block: CssRuleBlock {
-                    l_curly_token: L_CURLY@456..457 "{" [] [],
+                    l_curly_token: L_CURLY@523..524 "{" [] [],
                     rules: CssRuleList [
                         CssQualifiedRule {
                             prelude: CssSelectorList [
@@ -751,95 +849,95 @@ CssRoot {
                                     simple_selector: missing (optional),
                                     sub_selectors: CssSubSelectorList [
                                         CssClassSelector {
-                                            dot_token: DOT@457..461 "." [Newline("\n"), Whitespace("  ")] [],
+                                            dot_token: DOT@524..528 "." [Newline("\n"), Whitespace("  ")] [],
                                             name: CssCustomIdentifier {
-                                                value_token: IDENT@461..465 "box" [] [Whitespace(" ")],
+                                                value_token: IDENT@528..532 "box" [] [Whitespace(" ")],
                                             },
                                         },
                                     ],
                                 },
                             ],
                             block: CssDeclarationOrRuleBlock {
-                                l_curly_token: L_CURLY@465..466 "{" [] [],
+                                l_curly_token: L_CURLY@532..533 "{" [] [],
                                 items: CssDeclarationOrRuleList [
                                     CssDeclarationWithSemicolon {
                                         declaration: CssDeclaration {
                                             property: CssGenericProperty {
                                                 name: CssIdentifier {
-                                                    value_token: IDENT@466..476 "color" [Newline("\n"), Whitespace("    ")] [],
+                                                    value_token: IDENT@533..543 "color" [Newline("\n"), Whitespace("    ")] [],
                                                 },
-                                                colon_token: COLON@476..478 ":" [] [Whitespace(" ")],
+                                                colon_token: COLON@543..545 ":" [] [Whitespace(" ")],
                                                 value: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         CssIdentifier {
-                                                            value_token: IDENT@478..481 "red" [] [],
+                                                            value_token: IDENT@545..548 "red" [] [],
                                                         },
                                                     ],
                                                 },
                                             },
                                             important: missing (optional),
                                         },
-                                        semicolon_token: SEMICOLON@481..482 ";" [] [],
+                                        semicolon_token: SEMICOLON@548..549 ";" [] [],
                                     },
                                 ],
-                                r_curly_token: R_CURLY@482..486 "}" [Newline("\n"), Whitespace("  ")] [],
+                                r_curly_token: R_CURLY@549..553 "}" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                     ],
-                    r_curly_token: R_CURLY@486..488 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@553..555 "}" [Newline("\n")] [],
                 },
             },
         },
         CssAtRule {
-            at_token: AT@488..491 "@" [Newline("\n"), Newline("\n")] [],
+            at_token: AT@555..558 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssContainerAtRule {
                 declarator: CssContainerAtRuleDeclarator {
-                    container_token: CONTAINER_KW@491..501 "container" [] [Whitespace(" ")],
+                    container_token: CONTAINER_KW@558..568 "container" [] [Whitespace(" ")],
                     name: missing (optional),
                     query: CssContainerSizeFeatureInParens {
-                        l_paren_token: L_PAREN@501..502 "(" [] [],
+                        l_paren_token: L_PAREN@568..569 "(" [] [],
                         feature: CssQueryFeaturePlain {
                             name: ScssInterpolatedIdentifier {
                                 items: ScssInterpolatedIdentifierPartList [
                                     ScssInterpolation {
-                                        hash_token: HASH@502..503 "#" [] [],
-                                        l_curly_token: L_CURLY@503..504 "{" [] [],
+                                        hash_token: HASH@569..570 "#" [] [],
+                                        l_curly_token: L_CURLY@570..571 "{" [] [],
                                         value: ScssExpression {
                                             items: ScssExpressionItemList [
                                                 ScssVariable {
-                                                    dollar_token: DOLLAR@504..505 "$" [] [],
+                                                    dollar_token: DOLLAR@571..572 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@505..512 "feature" [] [],
+                                                        value_token: IDENT@572..579 "feature" [] [],
                                                     },
                                                 },
                                             ],
                                         },
-                                        r_curly_token: R_CURLY@512..513 "}" [] [],
+                                        r_curly_token: R_CURLY@579..580 "}" [] [],
                                     },
                                 ],
                             },
-                            colon_token: COLON@513..515 ":" [] [Whitespace(" ")],
+                            colon_token: COLON@580..582 ":" [] [Whitespace(" ")],
                             value: ScssInterpolation {
-                                hash_token: HASH@515..516 "#" [] [],
-                                l_curly_token: L_CURLY@516..517 "{" [] [],
+                                hash_token: HASH@582..583 "#" [] [],
+                                l_curly_token: L_CURLY@583..584 "{" [] [],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         ScssVariable {
-                                            dollar_token: DOLLAR@517..518 "$" [] [],
+                                            dollar_token: DOLLAR@584..585 "$" [] [],
                                             name: CssIdentifier {
-                                                value_token: IDENT@518..523 "value" [] [],
+                                                value_token: IDENT@585..590 "value" [] [],
                                             },
                                         },
                                     ],
                                 },
-                                r_curly_token: R_CURLY@523..524 "}" [] [],
+                                r_curly_token: R_CURLY@590..591 "}" [] [],
                             },
                         },
-                        r_paren_token: R_PAREN@524..526 ")" [] [Whitespace(" ")],
+                        r_paren_token: R_PAREN@591..593 ")" [] [Whitespace(" ")],
                     },
                 },
                 block: CssRuleBlock {
-                    l_curly_token: L_CURLY@526..527 "{" [] [],
+                    l_curly_token: L_CURLY@593..594 "{" [] [],
                     rules: CssRuleList [
                         CssQualifiedRule {
                             prelude: CssSelectorList [
@@ -848,86 +946,86 @@ CssRoot {
                                     simple_selector: missing (optional),
                                     sub_selectors: CssSubSelectorList [
                                         CssClassSelector {
-                                            dot_token: DOT@527..531 "." [Newline("\n"), Whitespace("  ")] [],
+                                            dot_token: DOT@594..598 "." [Newline("\n"), Whitespace("  ")] [],
                                             name: CssCustomIdentifier {
-                                                value_token: IDENT@531..535 "box" [] [Whitespace(" ")],
+                                                value_token: IDENT@598..602 "box" [] [Whitespace(" ")],
                                             },
                                         },
                                     ],
                                 },
                             ],
                             block: CssDeclarationOrRuleBlock {
-                                l_curly_token: L_CURLY@535..536 "{" [] [],
+                                l_curly_token: L_CURLY@602..603 "{" [] [],
                                 items: CssDeclarationOrRuleList [
                                     CssDeclarationWithSemicolon {
                                         declaration: CssDeclaration {
                                             property: CssGenericProperty {
                                                 name: CssIdentifier {
-                                                    value_token: IDENT@536..546 "color" [Newline("\n"), Whitespace("    ")] [],
+                                                    value_token: IDENT@603..613 "color" [Newline("\n"), Whitespace("    ")] [],
                                                 },
-                                                colon_token: COLON@546..548 ":" [] [Whitespace(" ")],
+                                                colon_token: COLON@613..615 ":" [] [Whitespace(" ")],
                                                 value: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         CssIdentifier {
-                                                            value_token: IDENT@548..551 "red" [] [],
+                                                            value_token: IDENT@615..618 "red" [] [],
                                                         },
                                                     ],
                                                 },
                                             },
                                             important: missing (optional),
                                         },
-                                        semicolon_token: SEMICOLON@551..552 ";" [] [],
+                                        semicolon_token: SEMICOLON@618..619 ";" [] [],
                                     },
                                 ],
-                                r_curly_token: R_CURLY@552..556 "}" [Newline("\n"), Whitespace("  ")] [],
+                                r_curly_token: R_CURLY@619..623 "}" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                     ],
-                    r_curly_token: R_CURLY@556..558 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@623..625 "}" [Newline("\n")] [],
                 },
             },
         },
         CssAtRule {
-            at_token: AT@558..561 "@" [Newline("\n"), Newline("\n")] [],
+            at_token: AT@625..628 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssContainerAtRule {
                 declarator: CssContainerAtRuleDeclarator {
-                    container_token: CONTAINER_KW@561..571 "container" [] [Whitespace(" ")],
+                    container_token: CONTAINER_KW@628..638 "container" [] [Whitespace(" ")],
                     name: missing (optional),
                     query: CssContainerSizeFeatureInParens {
-                        l_paren_token: L_PAREN@571..572 "(" [] [],
+                        l_paren_token: L_PAREN@638..639 "(" [] [],
                         feature: CssQueryFeaturePlain {
                             name: CssIdentifier {
-                                value_token: IDENT@572..581 "min-width" [] [],
+                                value_token: IDENT@639..648 "min-width" [] [],
                             },
-                            colon_token: COLON@581..583 ":" [] [Whitespace(" ")],
+                            colon_token: COLON@648..650 ":" [] [Whitespace(" ")],
                             value: ScssInterpolatedIdentifier {
                                 items: ScssInterpolatedIdentifierPartList [
                                     ScssInterpolation {
-                                        hash_token: HASH@583..584 "#" [] [],
-                                        l_curly_token: L_CURLY@584..585 "{" [] [],
+                                        hash_token: HASH@650..651 "#" [] [],
+                                        l_curly_token: L_CURLY@651..652 "{" [] [],
                                         value: ScssExpression {
                                             items: ScssExpressionItemList [
                                                 ScssVariable {
-                                                    dollar_token: DOLLAR@585..586 "$" [] [],
+                                                    dollar_token: DOLLAR@652..653 "$" [] [],
                                                     name: CssIdentifier {
-                                                        value_token: IDENT@586..591 "value" [] [],
+                                                        value_token: IDENT@653..658 "value" [] [],
                                                     },
                                                 },
                                             ],
                                         },
-                                        r_curly_token: R_CURLY@591..592 "}" [] [],
+                                        r_curly_token: R_CURLY@658..659 "}" [] [],
                                     },
                                     CssIdentifier {
-                                        value_token: IDENT@592..594 "px" [] [],
+                                        value_token: IDENT@659..661 "px" [] [],
                                     },
                                 ],
                             },
                         },
-                        r_paren_token: R_PAREN@594..596 ")" [] [Whitespace(" ")],
+                        r_paren_token: R_PAREN@661..663 ")" [] [Whitespace(" ")],
                     },
                 },
                 block: CssRuleBlock {
-                    l_curly_token: L_CURLY@596..597 "{" [] [],
+                    l_curly_token: L_CURLY@663..664 "{" [] [],
                     rules: CssRuleList [
                         CssQualifiedRule {
                             prelude: CssSelectorList [
@@ -936,56 +1034,56 @@ CssRoot {
                                     simple_selector: missing (optional),
                                     sub_selectors: CssSubSelectorList [
                                         CssClassSelector {
-                                            dot_token: DOT@597..601 "." [Newline("\n"), Whitespace("  ")] [],
+                                            dot_token: DOT@664..668 "." [Newline("\n"), Whitespace("  ")] [],
                                             name: CssCustomIdentifier {
-                                                value_token: IDENT@601..605 "box" [] [Whitespace(" ")],
+                                                value_token: IDENT@668..672 "box" [] [Whitespace(" ")],
                                             },
                                         },
                                     ],
                                 },
                             ],
                             block: CssDeclarationOrRuleBlock {
-                                l_curly_token: L_CURLY@605..606 "{" [] [],
+                                l_curly_token: L_CURLY@672..673 "{" [] [],
                                 items: CssDeclarationOrRuleList [
                                     CssDeclarationWithSemicolon {
                                         declaration: CssDeclaration {
                                             property: CssGenericProperty {
                                                 name: CssIdentifier {
-                                                    value_token: IDENT@606..616 "color" [Newline("\n"), Whitespace("    ")] [],
+                                                    value_token: IDENT@673..683 "color" [Newline("\n"), Whitespace("    ")] [],
                                                 },
-                                                colon_token: COLON@616..618 ":" [] [Whitespace(" ")],
+                                                colon_token: COLON@683..685 ":" [] [Whitespace(" ")],
                                                 value: ScssExpression {
                                                     items: ScssExpressionItemList [
                                                         CssIdentifier {
-                                                            value_token: IDENT@618..621 "red" [] [],
+                                                            value_token: IDENT@685..688 "red" [] [],
                                                         },
                                                     ],
                                                 },
                                             },
                                             important: missing (optional),
                                         },
-                                        semicolon_token: SEMICOLON@621..622 ";" [] [],
+                                        semicolon_token: SEMICOLON@688..689 ";" [] [],
                                     },
                                 ],
-                                r_curly_token: R_CURLY@622..626 "}" [Newline("\n"), Whitespace("  ")] [],
+                                r_curly_token: R_CURLY@689..693 "}" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                     ],
-                    r_curly_token: R_CURLY@626..628 "}" [Newline("\n")] [],
+                    r_curly_token: R_CURLY@693..695 "}" [Newline("\n")] [],
                 },
             },
         },
     ],
-    eof_token: EOF@628..629 "" [Newline("\n")] [],
+    eof_token: EOF@695..696 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..629
+0: CSS_ROOT@0..696
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..628
+  1: CSS_ROOT_ITEM_LIST@0..695
     0: CSS_AT_RULE@0..53
       0: AT@0..1 "@" [] []
       1: CSS_MEDIA_AT_RULE@1..53
@@ -1342,226 +1440,285 @@ CssRoot {
                     1: SEMICOLON@371..372 ";" [] []
                 2: R_CURLY@372..376 "}" [Newline("\n"), Whitespace("  ")] []
           2: R_CURLY@376..378 "}" [Newline("\n")] []
-    6: CSS_AT_RULE@378..429
+    6: CSS_AT_RULE@378..445
       0: AT@378..381 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_MEDIA_AT_RULE@381..429
-        0: CSS_MEDIA_AT_RULE_DECLARATOR@381..397
+      1: CSS_MEDIA_AT_RULE@381..445
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@381..413
           0: MEDIA_KW@381..387 "media" [] [Whitespace(" ")]
-          1: CSS_MEDIA_QUERY_LIST@387..397
-            0: SCSS_MEDIA_QUERY@387..397
-              0: SCSS_INTERPOLATION@387..397
-                0: HASH@387..388 "#" [] []
-                1: L_CURLY@388..389 "{" [] []
-                2: SCSS_EXPRESSION@389..395
-                  0: SCSS_EXPRESSION_ITEM_LIST@389..395
-                    0: SCSS_VARIABLE@389..395
-                      0: DOLLAR@389..390 "$" [] []
-                      1: CSS_IDENTIFIER@390..395
-                        0: IDENT@390..395 "query" [] []
-                3: R_CURLY@395..397 "}" [] [Whitespace(" ")]
-        1: CSS_RULE_BLOCK@397..429
-          0: L_CURLY@397..398 "{" [] []
-          1: CSS_RULE_LIST@398..427
-            0: CSS_QUALIFIED_RULE@398..427
-              0: CSS_SELECTOR_LIST@398..406
-                0: CSS_COMPOUND_SELECTOR@398..406
-                  0: CSS_NESTED_SELECTOR_LIST@398..398
+          1: CSS_MEDIA_QUERY_LIST@387..413
+            0: CSS_MEDIA_CONDITION_QUERY@387..413
+              0: CSS_MEDIA_FEATURE_IN_PARENS@387..413
+                0: L_PAREN@387..388 "(" [] []
+                1: CSS_QUERY_FEATURE_PLAIN@388..411
+                  0: SCSS_INTERPOLATED_IDENTIFIER@388..406
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@388..406
+                      0: SCSS_INTERPOLATION@388..399
+                        0: HASH@388..389 "#" [] []
+                        1: L_CURLY@389..390 "{" [] []
+                        2: SCSS_EXPRESSION@390..398
+                          0: SCSS_EXPRESSION_ITEM_LIST@390..398
+                            0: SCSS_VARIABLE@390..398
+                              0: DOLLAR@390..391 "$" [] []
+                              1: CSS_IDENTIFIER@391..398
+                                0: IDENT@391..398 "feature" [] []
+                        3: R_CURLY@398..399 "}" [] []
+                      1: CSS_IDENTIFIER@399..406
+                        0: IDENT@399..406 "-suffix" [] []
+                  1: COLON@406..408 ":" [] [Whitespace(" ")]
+                  2: CSS_REGULAR_DIMENSION@408..411
+                    0: CSS_NUMBER_LITERAL@408..409 "1" [] []
+                    1: IDENT@409..411 "px" [] []
+                2: R_PAREN@411..413 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@413..445
+          0: L_CURLY@413..414 "{" [] []
+          1: CSS_RULE_LIST@414..443
+            0: CSS_QUALIFIED_RULE@414..443
+              0: CSS_SELECTOR_LIST@414..422
+                0: CSS_COMPOUND_SELECTOR@414..422
+                  0: CSS_NESTED_SELECTOR_LIST@414..414
                   1: (empty)
-                  2: CSS_SUB_SELECTOR_LIST@398..406
-                    0: CSS_CLASS_SELECTOR@398..406
-                      0: DOT@398..402 "." [Newline("\n"), Whitespace("  ")] []
-                      1: CSS_CUSTOM_IDENTIFIER@402..406
-                        0: IDENT@402..406 "box" [] [Whitespace(" ")]
-              1: CSS_DECLARATION_OR_RULE_BLOCK@406..427
-                0: L_CURLY@406..407 "{" [] []
-                1: CSS_DECLARATION_OR_RULE_LIST@407..423
-                  0: CSS_DECLARATION_WITH_SEMICOLON@407..423
-                    0: CSS_DECLARATION@407..422
-                      0: CSS_GENERIC_PROPERTY@407..422
-                        0: CSS_IDENTIFIER@407..417
-                          0: IDENT@407..417 "color" [Newline("\n"), Whitespace("    ")] []
-                        1: COLON@417..419 ":" [] [Whitespace(" ")]
-                        2: SCSS_EXPRESSION@419..422
-                          0: SCSS_EXPRESSION_ITEM_LIST@419..422
-                            0: CSS_IDENTIFIER@419..422
-                              0: IDENT@419..422 "red" [] []
+                  2: CSS_SUB_SELECTOR_LIST@414..422
+                    0: CSS_CLASS_SELECTOR@414..422
+                      0: DOT@414..418 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@418..422
+                        0: IDENT@418..422 "box" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@422..443
+                0: L_CURLY@422..423 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@423..439
+                  0: CSS_DECLARATION_WITH_SEMICOLON@423..439
+                    0: CSS_DECLARATION@423..438
+                      0: CSS_GENERIC_PROPERTY@423..438
+                        0: CSS_IDENTIFIER@423..433
+                          0: IDENT@423..433 "color" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@433..435 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@435..438
+                          0: SCSS_EXPRESSION_ITEM_LIST@435..438
+                            0: CSS_IDENTIFIER@435..438
+                              0: IDENT@435..438 "red" [] []
                       1: (empty)
-                    1: SEMICOLON@422..423 ";" [] []
-                2: R_CURLY@423..427 "}" [Newline("\n"), Whitespace("  ")] []
-          2: R_CURLY@427..429 "}" [Newline("\n")] []
-    7: CSS_AT_RULE@429..488
-      0: AT@429..432 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_MEDIA_AT_RULE@432..488
-        0: CSS_MEDIA_AT_RULE_DECLARATOR@432..456
-          0: MEDIA_KW@432..438 "media" [] [Whitespace(" ")]
-          1: CSS_MEDIA_QUERY_LIST@438..456
-            0: SCSS_MEDIA_QUERY@438..447
-              0: SCSS_INTERPOLATION@438..447
-                0: HASH@438..439 "#" [] []
-                1: L_CURLY@439..440 "{" [] []
-                2: SCSS_EXPRESSION@440..446
-                  0: SCSS_EXPRESSION_ITEM_LIST@440..446
-                    0: SCSS_VARIABLE@440..446
-                      0: DOLLAR@440..441 "$" [] []
-                      1: CSS_IDENTIFIER@441..446
-                        0: IDENT@441..446 "query" [] []
-                3: R_CURLY@446..447 "}" [] []
-            1: COMMA@447..449 "," [] [Whitespace(" ")]
-            2: CSS_MEDIA_TYPE_QUERY@449..456
+                    1: SEMICOLON@438..439 ";" [] []
+                2: R_CURLY@439..443 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@443..445 "}" [Newline("\n")] []
+    7: CSS_AT_RULE@445..496
+      0: AT@445..448 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@448..496
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@448..464
+          0: MEDIA_KW@448..454 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@454..464
+            0: SCSS_MEDIA_QUERY@454..464
+              0: SCSS_INTERPOLATION@454..464
+                0: HASH@454..455 "#" [] []
+                1: L_CURLY@455..456 "{" [] []
+                2: SCSS_EXPRESSION@456..462
+                  0: SCSS_EXPRESSION_ITEM_LIST@456..462
+                    0: SCSS_VARIABLE@456..462
+                      0: DOLLAR@456..457 "$" [] []
+                      1: CSS_IDENTIFIER@457..462
+                        0: IDENT@457..462 "query" [] []
+                3: R_CURLY@462..464 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@464..496
+          0: L_CURLY@464..465 "{" [] []
+          1: CSS_RULE_LIST@465..494
+            0: CSS_QUALIFIED_RULE@465..494
+              0: CSS_SELECTOR_LIST@465..473
+                0: CSS_COMPOUND_SELECTOR@465..473
+                  0: CSS_NESTED_SELECTOR_LIST@465..465
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@465..473
+                    0: CSS_CLASS_SELECTOR@465..473
+                      0: DOT@465..469 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@469..473
+                        0: IDENT@469..473 "box" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@473..494
+                0: L_CURLY@473..474 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@474..490
+                  0: CSS_DECLARATION_WITH_SEMICOLON@474..490
+                    0: CSS_DECLARATION@474..489
+                      0: CSS_GENERIC_PROPERTY@474..489
+                        0: CSS_IDENTIFIER@474..484
+                          0: IDENT@474..484 "color" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@484..486 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@486..489
+                          0: SCSS_EXPRESSION_ITEM_LIST@486..489
+                            0: CSS_IDENTIFIER@486..489
+                              0: IDENT@486..489 "red" [] []
+                      1: (empty)
+                    1: SEMICOLON@489..490 ";" [] []
+                2: R_CURLY@490..494 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@494..496 "}" [Newline("\n")] []
+    8: CSS_AT_RULE@496..555
+      0: AT@496..499 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@499..555
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@499..523
+          0: MEDIA_KW@499..505 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@505..523
+            0: SCSS_MEDIA_QUERY@505..514
+              0: SCSS_INTERPOLATION@505..514
+                0: HASH@505..506 "#" [] []
+                1: L_CURLY@506..507 "{" [] []
+                2: SCSS_EXPRESSION@507..513
+                  0: SCSS_EXPRESSION_ITEM_LIST@507..513
+                    0: SCSS_VARIABLE@507..513
+                      0: DOLLAR@507..508 "$" [] []
+                      1: CSS_IDENTIFIER@508..513
+                        0: IDENT@508..513 "query" [] []
+                3: R_CURLY@513..514 "}" [] []
+            1: COMMA@514..516 "," [] [Whitespace(" ")]
+            2: CSS_MEDIA_TYPE_QUERY@516..523
               0: (empty)
-              1: CSS_MEDIA_TYPE@449..456
-                0: CSS_IDENTIFIER@449..456
-                  0: IDENT@449..456 "screen" [] [Whitespace(" ")]
-        1: CSS_RULE_BLOCK@456..488
-          0: L_CURLY@456..457 "{" [] []
-          1: CSS_RULE_LIST@457..486
-            0: CSS_QUALIFIED_RULE@457..486
-              0: CSS_SELECTOR_LIST@457..465
-                0: CSS_COMPOUND_SELECTOR@457..465
-                  0: CSS_NESTED_SELECTOR_LIST@457..457
+              1: CSS_MEDIA_TYPE@516..523
+                0: CSS_IDENTIFIER@516..523
+                  0: IDENT@516..523 "screen" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@523..555
+          0: L_CURLY@523..524 "{" [] []
+          1: CSS_RULE_LIST@524..553
+            0: CSS_QUALIFIED_RULE@524..553
+              0: CSS_SELECTOR_LIST@524..532
+                0: CSS_COMPOUND_SELECTOR@524..532
+                  0: CSS_NESTED_SELECTOR_LIST@524..524
                   1: (empty)
-                  2: CSS_SUB_SELECTOR_LIST@457..465
-                    0: CSS_CLASS_SELECTOR@457..465
-                      0: DOT@457..461 "." [Newline("\n"), Whitespace("  ")] []
-                      1: CSS_CUSTOM_IDENTIFIER@461..465
-                        0: IDENT@461..465 "box" [] [Whitespace(" ")]
-              1: CSS_DECLARATION_OR_RULE_BLOCK@465..486
-                0: L_CURLY@465..466 "{" [] []
-                1: CSS_DECLARATION_OR_RULE_LIST@466..482
-                  0: CSS_DECLARATION_WITH_SEMICOLON@466..482
-                    0: CSS_DECLARATION@466..481
-                      0: CSS_GENERIC_PROPERTY@466..481
-                        0: CSS_IDENTIFIER@466..476
-                          0: IDENT@466..476 "color" [Newline("\n"), Whitespace("    ")] []
-                        1: COLON@476..478 ":" [] [Whitespace(" ")]
-                        2: SCSS_EXPRESSION@478..481
-                          0: SCSS_EXPRESSION_ITEM_LIST@478..481
-                            0: CSS_IDENTIFIER@478..481
-                              0: IDENT@478..481 "red" [] []
+                  2: CSS_SUB_SELECTOR_LIST@524..532
+                    0: CSS_CLASS_SELECTOR@524..532
+                      0: DOT@524..528 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@528..532
+                        0: IDENT@528..532 "box" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@532..553
+                0: L_CURLY@532..533 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@533..549
+                  0: CSS_DECLARATION_WITH_SEMICOLON@533..549
+                    0: CSS_DECLARATION@533..548
+                      0: CSS_GENERIC_PROPERTY@533..548
+                        0: CSS_IDENTIFIER@533..543
+                          0: IDENT@533..543 "color" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@543..545 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@545..548
+                          0: SCSS_EXPRESSION_ITEM_LIST@545..548
+                            0: CSS_IDENTIFIER@545..548
+                              0: IDENT@545..548 "red" [] []
                       1: (empty)
-                    1: SEMICOLON@481..482 ";" [] []
-                2: R_CURLY@482..486 "}" [Newline("\n"), Whitespace("  ")] []
-          2: R_CURLY@486..488 "}" [Newline("\n")] []
-    8: CSS_AT_RULE@488..558
-      0: AT@488..491 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_CONTAINER_AT_RULE@491..558
-        0: CSS_CONTAINER_AT_RULE_DECLARATOR@491..526
-          0: CONTAINER_KW@491..501 "container" [] [Whitespace(" ")]
+                    1: SEMICOLON@548..549 ";" [] []
+                2: R_CURLY@549..553 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@553..555 "}" [Newline("\n")] []
+    9: CSS_AT_RULE@555..625
+      0: AT@555..558 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_CONTAINER_AT_RULE@558..625
+        0: CSS_CONTAINER_AT_RULE_DECLARATOR@558..593
+          0: CONTAINER_KW@558..568 "container" [] [Whitespace(" ")]
           1: (empty)
-          2: CSS_CONTAINER_SIZE_FEATURE_IN_PARENS@501..526
-            0: L_PAREN@501..502 "(" [] []
-            1: CSS_QUERY_FEATURE_PLAIN@502..524
-              0: SCSS_INTERPOLATED_IDENTIFIER@502..513
-                0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@502..513
-                  0: SCSS_INTERPOLATION@502..513
-                    0: HASH@502..503 "#" [] []
-                    1: L_CURLY@503..504 "{" [] []
-                    2: SCSS_EXPRESSION@504..512
-                      0: SCSS_EXPRESSION_ITEM_LIST@504..512
-                        0: SCSS_VARIABLE@504..512
-                          0: DOLLAR@504..505 "$" [] []
-                          1: CSS_IDENTIFIER@505..512
-                            0: IDENT@505..512 "feature" [] []
-                    3: R_CURLY@512..513 "}" [] []
-              1: COLON@513..515 ":" [] [Whitespace(" ")]
-              2: SCSS_INTERPOLATION@515..524
-                0: HASH@515..516 "#" [] []
-                1: L_CURLY@516..517 "{" [] []
-                2: SCSS_EXPRESSION@517..523
-                  0: SCSS_EXPRESSION_ITEM_LIST@517..523
-                    0: SCSS_VARIABLE@517..523
-                      0: DOLLAR@517..518 "$" [] []
-                      1: CSS_IDENTIFIER@518..523
-                        0: IDENT@518..523 "value" [] []
-                3: R_CURLY@523..524 "}" [] []
-            2: R_PAREN@524..526 ")" [] [Whitespace(" ")]
-        1: CSS_RULE_BLOCK@526..558
-          0: L_CURLY@526..527 "{" [] []
-          1: CSS_RULE_LIST@527..556
-            0: CSS_QUALIFIED_RULE@527..556
-              0: CSS_SELECTOR_LIST@527..535
-                0: CSS_COMPOUND_SELECTOR@527..535
-                  0: CSS_NESTED_SELECTOR_LIST@527..527
+          2: CSS_CONTAINER_SIZE_FEATURE_IN_PARENS@568..593
+            0: L_PAREN@568..569 "(" [] []
+            1: CSS_QUERY_FEATURE_PLAIN@569..591
+              0: SCSS_INTERPOLATED_IDENTIFIER@569..580
+                0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@569..580
+                  0: SCSS_INTERPOLATION@569..580
+                    0: HASH@569..570 "#" [] []
+                    1: L_CURLY@570..571 "{" [] []
+                    2: SCSS_EXPRESSION@571..579
+                      0: SCSS_EXPRESSION_ITEM_LIST@571..579
+                        0: SCSS_VARIABLE@571..579
+                          0: DOLLAR@571..572 "$" [] []
+                          1: CSS_IDENTIFIER@572..579
+                            0: IDENT@572..579 "feature" [] []
+                    3: R_CURLY@579..580 "}" [] []
+              1: COLON@580..582 ":" [] [Whitespace(" ")]
+              2: SCSS_INTERPOLATION@582..591
+                0: HASH@582..583 "#" [] []
+                1: L_CURLY@583..584 "{" [] []
+                2: SCSS_EXPRESSION@584..590
+                  0: SCSS_EXPRESSION_ITEM_LIST@584..590
+                    0: SCSS_VARIABLE@584..590
+                      0: DOLLAR@584..585 "$" [] []
+                      1: CSS_IDENTIFIER@585..590
+                        0: IDENT@585..590 "value" [] []
+                3: R_CURLY@590..591 "}" [] []
+            2: R_PAREN@591..593 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@593..625
+          0: L_CURLY@593..594 "{" [] []
+          1: CSS_RULE_LIST@594..623
+            0: CSS_QUALIFIED_RULE@594..623
+              0: CSS_SELECTOR_LIST@594..602
+                0: CSS_COMPOUND_SELECTOR@594..602
+                  0: CSS_NESTED_SELECTOR_LIST@594..594
                   1: (empty)
-                  2: CSS_SUB_SELECTOR_LIST@527..535
-                    0: CSS_CLASS_SELECTOR@527..535
-                      0: DOT@527..531 "." [Newline("\n"), Whitespace("  ")] []
-                      1: CSS_CUSTOM_IDENTIFIER@531..535
-                        0: IDENT@531..535 "box" [] [Whitespace(" ")]
-              1: CSS_DECLARATION_OR_RULE_BLOCK@535..556
-                0: L_CURLY@535..536 "{" [] []
-                1: CSS_DECLARATION_OR_RULE_LIST@536..552
-                  0: CSS_DECLARATION_WITH_SEMICOLON@536..552
-                    0: CSS_DECLARATION@536..551
-                      0: CSS_GENERIC_PROPERTY@536..551
-                        0: CSS_IDENTIFIER@536..546
-                          0: IDENT@536..546 "color" [Newline("\n"), Whitespace("    ")] []
-                        1: COLON@546..548 ":" [] [Whitespace(" ")]
-                        2: SCSS_EXPRESSION@548..551
-                          0: SCSS_EXPRESSION_ITEM_LIST@548..551
-                            0: CSS_IDENTIFIER@548..551
-                              0: IDENT@548..551 "red" [] []
+                  2: CSS_SUB_SELECTOR_LIST@594..602
+                    0: CSS_CLASS_SELECTOR@594..602
+                      0: DOT@594..598 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@598..602
+                        0: IDENT@598..602 "box" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@602..623
+                0: L_CURLY@602..603 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@603..619
+                  0: CSS_DECLARATION_WITH_SEMICOLON@603..619
+                    0: CSS_DECLARATION@603..618
+                      0: CSS_GENERIC_PROPERTY@603..618
+                        0: CSS_IDENTIFIER@603..613
+                          0: IDENT@603..613 "color" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@613..615 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@615..618
+                          0: SCSS_EXPRESSION_ITEM_LIST@615..618
+                            0: CSS_IDENTIFIER@615..618
+                              0: IDENT@615..618 "red" [] []
                       1: (empty)
-                    1: SEMICOLON@551..552 ";" [] []
-                2: R_CURLY@552..556 "}" [Newline("\n"), Whitespace("  ")] []
-          2: R_CURLY@556..558 "}" [Newline("\n")] []
-    9: CSS_AT_RULE@558..628
-      0: AT@558..561 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_CONTAINER_AT_RULE@561..628
-        0: CSS_CONTAINER_AT_RULE_DECLARATOR@561..596
-          0: CONTAINER_KW@561..571 "container" [] [Whitespace(" ")]
+                    1: SEMICOLON@618..619 ";" [] []
+                2: R_CURLY@619..623 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@623..625 "}" [Newline("\n")] []
+    10: CSS_AT_RULE@625..695
+      0: AT@625..628 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_CONTAINER_AT_RULE@628..695
+        0: CSS_CONTAINER_AT_RULE_DECLARATOR@628..663
+          0: CONTAINER_KW@628..638 "container" [] [Whitespace(" ")]
           1: (empty)
-          2: CSS_CONTAINER_SIZE_FEATURE_IN_PARENS@571..596
-            0: L_PAREN@571..572 "(" [] []
-            1: CSS_QUERY_FEATURE_PLAIN@572..594
-              0: CSS_IDENTIFIER@572..581
-                0: IDENT@572..581 "min-width" [] []
-              1: COLON@581..583 ":" [] [Whitespace(" ")]
-              2: SCSS_INTERPOLATED_IDENTIFIER@583..594
-                0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@583..594
-                  0: SCSS_INTERPOLATION@583..592
-                    0: HASH@583..584 "#" [] []
-                    1: L_CURLY@584..585 "{" [] []
-                    2: SCSS_EXPRESSION@585..591
-                      0: SCSS_EXPRESSION_ITEM_LIST@585..591
-                        0: SCSS_VARIABLE@585..591
-                          0: DOLLAR@585..586 "$" [] []
-                          1: CSS_IDENTIFIER@586..591
-                            0: IDENT@586..591 "value" [] []
-                    3: R_CURLY@591..592 "}" [] []
-                  1: CSS_IDENTIFIER@592..594
-                    0: IDENT@592..594 "px" [] []
-            2: R_PAREN@594..596 ")" [] [Whitespace(" ")]
-        1: CSS_RULE_BLOCK@596..628
-          0: L_CURLY@596..597 "{" [] []
-          1: CSS_RULE_LIST@597..626
-            0: CSS_QUALIFIED_RULE@597..626
-              0: CSS_SELECTOR_LIST@597..605
-                0: CSS_COMPOUND_SELECTOR@597..605
-                  0: CSS_NESTED_SELECTOR_LIST@597..597
+          2: CSS_CONTAINER_SIZE_FEATURE_IN_PARENS@638..663
+            0: L_PAREN@638..639 "(" [] []
+            1: CSS_QUERY_FEATURE_PLAIN@639..661
+              0: CSS_IDENTIFIER@639..648
+                0: IDENT@639..648 "min-width" [] []
+              1: COLON@648..650 ":" [] [Whitespace(" ")]
+              2: SCSS_INTERPOLATED_IDENTIFIER@650..661
+                0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@650..661
+                  0: SCSS_INTERPOLATION@650..659
+                    0: HASH@650..651 "#" [] []
+                    1: L_CURLY@651..652 "{" [] []
+                    2: SCSS_EXPRESSION@652..658
+                      0: SCSS_EXPRESSION_ITEM_LIST@652..658
+                        0: SCSS_VARIABLE@652..658
+                          0: DOLLAR@652..653 "$" [] []
+                          1: CSS_IDENTIFIER@653..658
+                            0: IDENT@653..658 "value" [] []
+                    3: R_CURLY@658..659 "}" [] []
+                  1: CSS_IDENTIFIER@659..661
+                    0: IDENT@659..661 "px" [] []
+            2: R_PAREN@661..663 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@663..695
+          0: L_CURLY@663..664 "{" [] []
+          1: CSS_RULE_LIST@664..693
+            0: CSS_QUALIFIED_RULE@664..693
+              0: CSS_SELECTOR_LIST@664..672
+                0: CSS_COMPOUND_SELECTOR@664..672
+                  0: CSS_NESTED_SELECTOR_LIST@664..664
                   1: (empty)
-                  2: CSS_SUB_SELECTOR_LIST@597..605
-                    0: CSS_CLASS_SELECTOR@597..605
-                      0: DOT@597..601 "." [Newline("\n"), Whitespace("  ")] []
-                      1: CSS_CUSTOM_IDENTIFIER@601..605
-                        0: IDENT@601..605 "box" [] [Whitespace(" ")]
-              1: CSS_DECLARATION_OR_RULE_BLOCK@605..626
-                0: L_CURLY@605..606 "{" [] []
-                1: CSS_DECLARATION_OR_RULE_LIST@606..622
-                  0: CSS_DECLARATION_WITH_SEMICOLON@606..622
-                    0: CSS_DECLARATION@606..621
-                      0: CSS_GENERIC_PROPERTY@606..621
-                        0: CSS_IDENTIFIER@606..616
-                          0: IDENT@606..616 "color" [Newline("\n"), Whitespace("    ")] []
-                        1: COLON@616..618 ":" [] [Whitespace(" ")]
-                        2: SCSS_EXPRESSION@618..621
-                          0: SCSS_EXPRESSION_ITEM_LIST@618..621
-                            0: CSS_IDENTIFIER@618..621
-                              0: IDENT@618..621 "red" [] []
+                  2: CSS_SUB_SELECTOR_LIST@664..672
+                    0: CSS_CLASS_SELECTOR@664..672
+                      0: DOT@664..668 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@668..672
+                        0: IDENT@668..672 "box" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@672..693
+                0: L_CURLY@672..673 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@673..689
+                  0: CSS_DECLARATION_WITH_SEMICOLON@673..689
+                    0: CSS_DECLARATION@673..688
+                      0: CSS_GENERIC_PROPERTY@673..688
+                        0: CSS_IDENTIFIER@673..683
+                          0: IDENT@673..683 "color" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@683..685 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@685..688
+                          0: SCSS_EXPRESSION_ITEM_LIST@685..688
+                            0: CSS_IDENTIFIER@685..688
+                              0: IDENT@685..688 "red" [] []
                       1: (empty)
-                    1: SEMICOLON@621..622 ";" [] []
-                2: R_CURLY@622..626 "}" [Newline("\n"), Whitespace("  ")] []
-          2: R_CURLY@626..628 "}" [Newline("\n")] []
-  2: EOF@628..629 "" [Newline("\n")] []
+                    1: SEMICOLON@688..689 ";" [] []
+                2: R_CURLY@689..693 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@693..695 "}" [Newline("\n")] []
+  2: EOF@695..696 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -4298,7 +4298,7 @@ impl CssMediaAndCondition {
             right: self.right(),
         }
     }
-    pub fn left(&self) -> SyntaxResult<AnyCssMediaInParens> {
+    pub fn left(&self) -> SyntaxResult<AnyCssMediaConditionOperand> {
         support::required_node(&self.syntax, 0usize)
     }
     pub fn and_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -4318,7 +4318,7 @@ impl Serialize for CssMediaAndCondition {
 }
 #[derive(Serialize)]
 pub struct CssMediaAndConditionFields {
-    pub left: SyntaxResult<AnyCssMediaInParens>,
+    pub left: SyntaxResult<AnyCssMediaConditionOperand>,
     pub and_token: SyntaxResult<SyntaxToken>,
     pub right: SyntaxResult<AnyCssMediaAndCombinableCondition>,
 }
@@ -4595,7 +4595,7 @@ impl CssMediaNotCondition {
     pub fn not_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
-    pub fn condition(&self) -> SyntaxResult<AnyCssMediaInParens> {
+    pub fn condition(&self) -> SyntaxResult<AnyCssMediaConditionOperand> {
         support::required_node(&self.syntax, 1usize)
     }
 }
@@ -4610,7 +4610,7 @@ impl Serialize for CssMediaNotCondition {
 #[derive(Serialize)]
 pub struct CssMediaNotConditionFields {
     pub not_token: SyntaxResult<SyntaxToken>,
-    pub condition: SyntaxResult<AnyCssMediaInParens>,
+    pub condition: SyntaxResult<AnyCssMediaConditionOperand>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CssMediaOrCondition {
@@ -4633,7 +4633,7 @@ impl CssMediaOrCondition {
             right: self.right(),
         }
     }
-    pub fn left(&self) -> SyntaxResult<AnyCssMediaInParens> {
+    pub fn left(&self) -> SyntaxResult<AnyCssMediaConditionOperand> {
         support::required_node(&self.syntax, 0usize)
     }
     pub fn or_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -4653,7 +4653,7 @@ impl Serialize for CssMediaOrCondition {
 }
 #[derive(Serialize)]
 pub struct CssMediaOrConditionFields {
-    pub left: SyntaxResult<AnyCssMediaInParens>,
+    pub left: SyntaxResult<AnyCssMediaConditionOperand>,
     pub or_token: SyntaxResult<SyntaxToken>,
     pub right: SyntaxResult<AnyCssMediaOrCombinableCondition>,
 }
@@ -14962,13 +14962,14 @@ impl AnyCssLayer {
 }
 #[derive(Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum AnyCssMediaAndCombinableCondition {
-    AnyCssMediaInParens(AnyCssMediaInParens),
+    AnyCssMediaConditionOperand(AnyCssMediaConditionOperand),
     CssMediaAndCondition(CssMediaAndCondition),
+    CssMediaNotCondition(CssMediaNotCondition),
 }
 impl AnyCssMediaAndCombinableCondition {
-    pub fn as_any_css_media_in_parens(&self) -> Option<&AnyCssMediaInParens> {
+    pub fn as_any_css_media_condition_operand(&self) -> Option<&AnyCssMediaConditionOperand> {
         match &self {
-            Self::AnyCssMediaInParens(item) => Some(item),
+            Self::AnyCssMediaConditionOperand(item) => Some(item),
             _ => None,
         }
     }
@@ -14978,18 +14979,24 @@ impl AnyCssMediaAndCombinableCondition {
             _ => None,
         }
     }
+    pub fn as_css_media_not_condition(&self) -> Option<&CssMediaNotCondition> {
+        match &self {
+            Self::CssMediaNotCondition(item) => Some(item),
+            _ => None,
+        }
+    }
 }
 #[derive(Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum AnyCssMediaCondition {
-    AnyCssMediaInParens(AnyCssMediaInParens),
+    AnyCssMediaConditionOperand(AnyCssMediaConditionOperand),
     CssMediaAndCondition(CssMediaAndCondition),
     CssMediaNotCondition(CssMediaNotCondition),
     CssMediaOrCondition(CssMediaOrCondition),
 }
 impl AnyCssMediaCondition {
-    pub fn as_any_css_media_in_parens(&self) -> Option<&AnyCssMediaInParens> {
+    pub fn as_any_css_media_condition_operand(&self) -> Option<&AnyCssMediaConditionOperand> {
         match &self {
-            Self::AnyCssMediaInParens(item) => Some(item),
+            Self::AnyCssMediaConditionOperand(item) => Some(item),
             _ => None,
         }
     }
@@ -15008,6 +15015,25 @@ impl AnyCssMediaCondition {
     pub fn as_css_media_or_condition(&self) -> Option<&CssMediaOrCondition> {
         match &self {
             Self::CssMediaOrCondition(item) => Some(item),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, Serialize)]
+pub enum AnyCssMediaConditionOperand {
+    AnyCssMediaInParens(AnyCssMediaInParens),
+    ScssMediaQuery(ScssMediaQuery),
+}
+impl AnyCssMediaConditionOperand {
+    pub fn as_any_css_media_in_parens(&self) -> Option<&AnyCssMediaInParens> {
+        match &self {
+            Self::AnyCssMediaInParens(item) => Some(item),
+            _ => None,
+        }
+    }
+    pub fn as_scss_media_query(&self) -> Option<&ScssMediaQuery> {
+        match &self {
+            Self::ScssMediaQuery(item) => Some(item),
             _ => None,
         }
     }
@@ -15033,13 +15059,13 @@ impl AnyCssMediaInParens {
 }
 #[derive(Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum AnyCssMediaOrCombinableCondition {
-    AnyCssMediaInParens(AnyCssMediaInParens),
+    AnyCssMediaConditionOperand(AnyCssMediaConditionOperand),
     CssMediaOrCondition(CssMediaOrCondition),
 }
 impl AnyCssMediaOrCombinableCondition {
-    pub fn as_any_css_media_in_parens(&self) -> Option<&AnyCssMediaInParens> {
+    pub fn as_any_css_media_condition_operand(&self) -> Option<&AnyCssMediaConditionOperand> {
         match &self {
-            Self::AnyCssMediaInParens(item) => Some(item),
+            Self::AnyCssMediaConditionOperand(item) => Some(item),
             _ => None,
         }
     }
@@ -15092,14 +15118,14 @@ impl AnyCssMediaQuery {
 }
 #[derive(Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum AnyCssMediaTypeCondition {
-    AnyCssMediaInParens(AnyCssMediaInParens),
+    AnyCssMediaConditionOperand(AnyCssMediaConditionOperand),
     CssMediaAndCondition(CssMediaAndCondition),
     CssMediaNotCondition(CssMediaNotCondition),
 }
 impl AnyCssMediaTypeCondition {
-    pub fn as_any_css_media_in_parens(&self) -> Option<&AnyCssMediaInParens> {
+    pub fn as_any_css_media_condition_operand(&self) -> Option<&AnyCssMediaConditionOperand> {
         match &self {
-            Self::AnyCssMediaInParens(item) => Some(item),
+            Self::AnyCssMediaConditionOperand(item) => Some(item),
             _ => None,
         }
     }
@@ -38340,23 +38366,34 @@ impl From<CssMediaAndCondition> for AnyCssMediaAndCombinableCondition {
         Self::CssMediaAndCondition(node)
     }
 }
+impl From<CssMediaNotCondition> for AnyCssMediaAndCombinableCondition {
+    fn from(node: CssMediaNotCondition) -> Self {
+        Self::CssMediaNotCondition(node)
+    }
+}
 impl AstNode for AnyCssMediaAndCombinableCondition {
     type Language = Language;
-    const KIND_SET: SyntaxKindSet<Language> =
-        AnyCssMediaInParens::KIND_SET.union(CssMediaAndCondition::KIND_SET);
+    const KIND_SET: SyntaxKindSet<Language> = AnyCssMediaConditionOperand::KIND_SET
+        .union(CssMediaAndCondition::KIND_SET)
+        .union(CssMediaNotCondition::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-            CSS_MEDIA_AND_CONDITION => true,
-            k if AnyCssMediaInParens::can_cast(k) => true,
+            CSS_MEDIA_AND_CONDITION | CSS_MEDIA_NOT_CONDITION => true,
+            k if AnyCssMediaConditionOperand::can_cast(k) => true,
             _ => false,
         }
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
             CSS_MEDIA_AND_CONDITION => Self::CssMediaAndCondition(CssMediaAndCondition { syntax }),
+            CSS_MEDIA_NOT_CONDITION => Self::CssMediaNotCondition(CssMediaNotCondition { syntax }),
             _ => {
-                if let Some(any_css_media_in_parens) = AnyCssMediaInParens::cast(syntax) {
-                    return Some(Self::AnyCssMediaInParens(any_css_media_in_parens));
+                if let Some(any_css_media_condition_operand) =
+                    AnyCssMediaConditionOperand::cast(syntax)
+                {
+                    return Some(Self::AnyCssMediaConditionOperand(
+                        any_css_media_condition_operand,
+                    ));
                 }
                 return None;
             }
@@ -38366,29 +38403,33 @@ impl AstNode for AnyCssMediaAndCombinableCondition {
     fn syntax(&self) -> &SyntaxNode {
         match self {
             Self::CssMediaAndCondition(it) => it.syntax(),
-            Self::AnyCssMediaInParens(it) => it.syntax(),
+            Self::CssMediaNotCondition(it) => it.syntax(),
+            Self::AnyCssMediaConditionOperand(it) => it.syntax(),
         }
     }
     fn into_syntax(self) -> SyntaxNode {
         match self {
             Self::CssMediaAndCondition(it) => it.into_syntax(),
-            Self::AnyCssMediaInParens(it) => it.into_syntax(),
+            Self::CssMediaNotCondition(it) => it.into_syntax(),
+            Self::AnyCssMediaConditionOperand(it) => it.into_syntax(),
         }
     }
 }
 impl std::fmt::Debug for AnyCssMediaAndCombinableCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AnyCssMediaInParens(it) => std::fmt::Debug::fmt(it, f),
+            Self::AnyCssMediaConditionOperand(it) => std::fmt::Debug::fmt(it, f),
             Self::CssMediaAndCondition(it) => std::fmt::Debug::fmt(it, f),
+            Self::CssMediaNotCondition(it) => std::fmt::Debug::fmt(it, f),
         }
     }
 }
 impl From<AnyCssMediaAndCombinableCondition> for SyntaxNode {
     fn from(n: AnyCssMediaAndCombinableCondition) -> Self {
         match n {
-            AnyCssMediaAndCombinableCondition::AnyCssMediaInParens(it) => it.into_syntax(),
+            AnyCssMediaAndCombinableCondition::AnyCssMediaConditionOperand(it) => it.into_syntax(),
             AnyCssMediaAndCombinableCondition::CssMediaAndCondition(it) => it.into_syntax(),
+            AnyCssMediaAndCombinableCondition::CssMediaNotCondition(it) => it.into_syntax(),
         }
     }
 }
@@ -38415,14 +38456,14 @@ impl From<CssMediaOrCondition> for AnyCssMediaCondition {
 }
 impl AstNode for AnyCssMediaCondition {
     type Language = Language;
-    const KIND_SET: SyntaxKindSet<Language> = AnyCssMediaInParens::KIND_SET
+    const KIND_SET: SyntaxKindSet<Language> = AnyCssMediaConditionOperand::KIND_SET
         .union(CssMediaAndCondition::KIND_SET)
         .union(CssMediaNotCondition::KIND_SET)
         .union(CssMediaOrCondition::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             CSS_MEDIA_AND_CONDITION | CSS_MEDIA_NOT_CONDITION | CSS_MEDIA_OR_CONDITION => true,
-            k if AnyCssMediaInParens::can_cast(k) => true,
+            k if AnyCssMediaConditionOperand::can_cast(k) => true,
             _ => false,
         }
     }
@@ -38432,8 +38473,12 @@ impl AstNode for AnyCssMediaCondition {
             CSS_MEDIA_NOT_CONDITION => Self::CssMediaNotCondition(CssMediaNotCondition { syntax }),
             CSS_MEDIA_OR_CONDITION => Self::CssMediaOrCondition(CssMediaOrCondition { syntax }),
             _ => {
-                if let Some(any_css_media_in_parens) = AnyCssMediaInParens::cast(syntax) {
-                    return Some(Self::AnyCssMediaInParens(any_css_media_in_parens));
+                if let Some(any_css_media_condition_operand) =
+                    AnyCssMediaConditionOperand::cast(syntax)
+                {
+                    return Some(Self::AnyCssMediaConditionOperand(
+                        any_css_media_condition_operand,
+                    ));
                 }
                 return None;
             }
@@ -38445,7 +38490,7 @@ impl AstNode for AnyCssMediaCondition {
             Self::CssMediaAndCondition(it) => it.syntax(),
             Self::CssMediaNotCondition(it) => it.syntax(),
             Self::CssMediaOrCondition(it) => it.syntax(),
-            Self::AnyCssMediaInParens(it) => it.syntax(),
+            Self::AnyCssMediaConditionOperand(it) => it.syntax(),
         }
     }
     fn into_syntax(self) -> SyntaxNode {
@@ -38453,14 +38498,14 @@ impl AstNode for AnyCssMediaCondition {
             Self::CssMediaAndCondition(it) => it.into_syntax(),
             Self::CssMediaNotCondition(it) => it.into_syntax(),
             Self::CssMediaOrCondition(it) => it.into_syntax(),
-            Self::AnyCssMediaInParens(it) => it.into_syntax(),
+            Self::AnyCssMediaConditionOperand(it) => it.into_syntax(),
         }
     }
 }
 impl std::fmt::Debug for AnyCssMediaCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AnyCssMediaInParens(it) => std::fmt::Debug::fmt(it, f),
+            Self::AnyCssMediaConditionOperand(it) => std::fmt::Debug::fmt(it, f),
             Self::CssMediaAndCondition(it) => std::fmt::Debug::fmt(it, f),
             Self::CssMediaNotCondition(it) => std::fmt::Debug::fmt(it, f),
             Self::CssMediaOrCondition(it) => std::fmt::Debug::fmt(it, f),
@@ -38470,7 +38515,7 @@ impl std::fmt::Debug for AnyCssMediaCondition {
 impl From<AnyCssMediaCondition> for SyntaxNode {
     fn from(n: AnyCssMediaCondition) -> Self {
         match n {
-            AnyCssMediaCondition::AnyCssMediaInParens(it) => it.into_syntax(),
+            AnyCssMediaCondition::AnyCssMediaConditionOperand(it) => it.into_syntax(),
             AnyCssMediaCondition::CssMediaAndCondition(it) => it.into_syntax(),
             AnyCssMediaCondition::CssMediaNotCondition(it) => it.into_syntax(),
             AnyCssMediaCondition::CssMediaOrCondition(it) => it.into_syntax(),
@@ -38479,6 +38524,69 @@ impl From<AnyCssMediaCondition> for SyntaxNode {
 }
 impl From<AnyCssMediaCondition> for SyntaxElement {
     fn from(n: AnyCssMediaCondition) -> Self {
+        let node: SyntaxNode = n.into();
+        node.into()
+    }
+}
+impl From<ScssMediaQuery> for AnyCssMediaConditionOperand {
+    fn from(node: ScssMediaQuery) -> Self {
+        Self::ScssMediaQuery(node)
+    }
+}
+impl AstNode for AnyCssMediaConditionOperand {
+    type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        AnyCssMediaInParens::KIND_SET.union(ScssMediaQuery::KIND_SET);
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SCSS_MEDIA_QUERY => true,
+            k if AnyCssMediaInParens::can_cast(k) => true,
+            _ => false,
+        }
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        let res = match syntax.kind() {
+            SCSS_MEDIA_QUERY => Self::ScssMediaQuery(ScssMediaQuery { syntax }),
+            _ => {
+                if let Some(any_css_media_in_parens) = AnyCssMediaInParens::cast(syntax) {
+                    return Some(Self::AnyCssMediaInParens(any_css_media_in_parens));
+                }
+                return None;
+            }
+        };
+        Some(res)
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        match self {
+            Self::ScssMediaQuery(it) => it.syntax(),
+            Self::AnyCssMediaInParens(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            Self::ScssMediaQuery(it) => it.into_syntax(),
+            Self::AnyCssMediaInParens(it) => it.into_syntax(),
+        }
+    }
+}
+impl std::fmt::Debug for AnyCssMediaConditionOperand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AnyCssMediaInParens(it) => std::fmt::Debug::fmt(it, f),
+            Self::ScssMediaQuery(it) => std::fmt::Debug::fmt(it, f),
+        }
+    }
+}
+impl From<AnyCssMediaConditionOperand> for SyntaxNode {
+    fn from(n: AnyCssMediaConditionOperand) -> Self {
+        match n {
+            AnyCssMediaConditionOperand::AnyCssMediaInParens(it) => it.into_syntax(),
+            AnyCssMediaConditionOperand::ScssMediaQuery(it) => it.into_syntax(),
+        }
+    }
+}
+impl From<AnyCssMediaConditionOperand> for SyntaxElement {
+    fn from(n: AnyCssMediaConditionOperand) -> Self {
         let node: SyntaxNode = n.into();
         node.into()
     }
@@ -38558,11 +38666,11 @@ impl From<CssMediaOrCondition> for AnyCssMediaOrCombinableCondition {
 impl AstNode for AnyCssMediaOrCombinableCondition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
-        AnyCssMediaInParens::KIND_SET.union(CssMediaOrCondition::KIND_SET);
+        AnyCssMediaConditionOperand::KIND_SET.union(CssMediaOrCondition::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             CSS_MEDIA_OR_CONDITION => true,
-            k if AnyCssMediaInParens::can_cast(k) => true,
+            k if AnyCssMediaConditionOperand::can_cast(k) => true,
             _ => false,
         }
     }
@@ -38570,8 +38678,12 @@ impl AstNode for AnyCssMediaOrCombinableCondition {
         let res = match syntax.kind() {
             CSS_MEDIA_OR_CONDITION => Self::CssMediaOrCondition(CssMediaOrCondition { syntax }),
             _ => {
-                if let Some(any_css_media_in_parens) = AnyCssMediaInParens::cast(syntax) {
-                    return Some(Self::AnyCssMediaInParens(any_css_media_in_parens));
+                if let Some(any_css_media_condition_operand) =
+                    AnyCssMediaConditionOperand::cast(syntax)
+                {
+                    return Some(Self::AnyCssMediaConditionOperand(
+                        any_css_media_condition_operand,
+                    ));
                 }
                 return None;
             }
@@ -38581,20 +38693,20 @@ impl AstNode for AnyCssMediaOrCombinableCondition {
     fn syntax(&self) -> &SyntaxNode {
         match self {
             Self::CssMediaOrCondition(it) => it.syntax(),
-            Self::AnyCssMediaInParens(it) => it.syntax(),
+            Self::AnyCssMediaConditionOperand(it) => it.syntax(),
         }
     }
     fn into_syntax(self) -> SyntaxNode {
         match self {
             Self::CssMediaOrCondition(it) => it.into_syntax(),
-            Self::AnyCssMediaInParens(it) => it.into_syntax(),
+            Self::AnyCssMediaConditionOperand(it) => it.into_syntax(),
         }
     }
 }
 impl std::fmt::Debug for AnyCssMediaOrCombinableCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AnyCssMediaInParens(it) => std::fmt::Debug::fmt(it, f),
+            Self::AnyCssMediaConditionOperand(it) => std::fmt::Debug::fmt(it, f),
             Self::CssMediaOrCondition(it) => std::fmt::Debug::fmt(it, f),
         }
     }
@@ -38602,7 +38714,7 @@ impl std::fmt::Debug for AnyCssMediaOrCombinableCondition {
 impl From<AnyCssMediaOrCombinableCondition> for SyntaxNode {
     fn from(n: AnyCssMediaOrCombinableCondition) -> Self {
         match n {
-            AnyCssMediaOrCombinableCondition::AnyCssMediaInParens(it) => it.into_syntax(),
+            AnyCssMediaOrCombinableCondition::AnyCssMediaConditionOperand(it) => it.into_syntax(),
             AnyCssMediaOrCombinableCondition::CssMediaOrCondition(it) => it.into_syntax(),
         }
     }
@@ -38726,13 +38838,13 @@ impl From<CssMediaNotCondition> for AnyCssMediaTypeCondition {
 }
 impl AstNode for AnyCssMediaTypeCondition {
     type Language = Language;
-    const KIND_SET: SyntaxKindSet<Language> = AnyCssMediaInParens::KIND_SET
+    const KIND_SET: SyntaxKindSet<Language> = AnyCssMediaConditionOperand::KIND_SET
         .union(CssMediaAndCondition::KIND_SET)
         .union(CssMediaNotCondition::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             CSS_MEDIA_AND_CONDITION | CSS_MEDIA_NOT_CONDITION => true,
-            k if AnyCssMediaInParens::can_cast(k) => true,
+            k if AnyCssMediaConditionOperand::can_cast(k) => true,
             _ => false,
         }
     }
@@ -38741,8 +38853,12 @@ impl AstNode for AnyCssMediaTypeCondition {
             CSS_MEDIA_AND_CONDITION => Self::CssMediaAndCondition(CssMediaAndCondition { syntax }),
             CSS_MEDIA_NOT_CONDITION => Self::CssMediaNotCondition(CssMediaNotCondition { syntax }),
             _ => {
-                if let Some(any_css_media_in_parens) = AnyCssMediaInParens::cast(syntax) {
-                    return Some(Self::AnyCssMediaInParens(any_css_media_in_parens));
+                if let Some(any_css_media_condition_operand) =
+                    AnyCssMediaConditionOperand::cast(syntax)
+                {
+                    return Some(Self::AnyCssMediaConditionOperand(
+                        any_css_media_condition_operand,
+                    ));
                 }
                 return None;
             }
@@ -38753,21 +38869,21 @@ impl AstNode for AnyCssMediaTypeCondition {
         match self {
             Self::CssMediaAndCondition(it) => it.syntax(),
             Self::CssMediaNotCondition(it) => it.syntax(),
-            Self::AnyCssMediaInParens(it) => it.syntax(),
+            Self::AnyCssMediaConditionOperand(it) => it.syntax(),
         }
     }
     fn into_syntax(self) -> SyntaxNode {
         match self {
             Self::CssMediaAndCondition(it) => it.into_syntax(),
             Self::CssMediaNotCondition(it) => it.into_syntax(),
-            Self::AnyCssMediaInParens(it) => it.into_syntax(),
+            Self::AnyCssMediaConditionOperand(it) => it.into_syntax(),
         }
     }
 }
 impl std::fmt::Debug for AnyCssMediaTypeCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AnyCssMediaInParens(it) => std::fmt::Debug::fmt(it, f),
+            Self::AnyCssMediaConditionOperand(it) => std::fmt::Debug::fmt(it, f),
             Self::CssMediaAndCondition(it) => std::fmt::Debug::fmt(it, f),
             Self::CssMediaNotCondition(it) => std::fmt::Debug::fmt(it, f),
         }
@@ -38776,7 +38892,7 @@ impl std::fmt::Debug for AnyCssMediaTypeCondition {
 impl From<AnyCssMediaTypeCondition> for SyntaxNode {
     fn from(n: AnyCssMediaTypeCondition) -> Self {
         match n {
-            AnyCssMediaTypeCondition::AnyCssMediaInParens(it) => it.into_syntax(),
+            AnyCssMediaTypeCondition::AnyCssMediaConditionOperand(it) => it.into_syntax(),
             AnyCssMediaTypeCondition::CssMediaAndCondition(it) => it.into_syntax(),
             AnyCssMediaTypeCondition::CssMediaNotCondition(it) => it.into_syntax(),
         }
@@ -44843,6 +44959,11 @@ impl std::fmt::Display for AnyCssMediaAndCombinableCondition {
     }
 }
 impl std::fmt::Display for AnyCssMediaCondition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for AnyCssMediaConditionOperand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -1750,7 +1750,7 @@ impl CssMarginAtRule {
     }
 }
 impl CssMediaAndCondition {
-    pub fn with_left(self, element: AnyCssMediaInParens) -> Self {
+    pub fn with_left(self, element: AnyCssMediaConditionOperand) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
@@ -1872,7 +1872,7 @@ impl CssMediaNotCondition {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_condition(self, element: AnyCssMediaInParens) -> Self {
+    pub fn with_condition(self, element: AnyCssMediaConditionOperand) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
@@ -1880,7 +1880,7 @@ impl CssMediaNotCondition {
     }
 }
 impl CssMediaOrCondition {
-    pub fn with_left(self, element: AnyCssMediaInParens) -> Self {
+    pub fn with_left(self, element: AnyCssMediaConditionOperand) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -1449,42 +1449,49 @@ CssMediaType =
 AnyCssMediaTypeCondition =
 	CssMediaNotCondition
 	| CssMediaAndCondition
-	| AnyCssMediaInParens
+	| AnyCssMediaConditionOperand
 
 // <media-condition> = <media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]
 AnyCssMediaCondition =
 	CssMediaNotCondition
 	| CssMediaAndCondition
 	| CssMediaOrCondition
-	| AnyCssMediaInParens
+	| AnyCssMediaConditionOperand
+
+AnyCssMediaConditionOperand =
+	AnyCssMediaInParens
+	| ScssMediaQuery
 
 // @media not all and not (color)  { }
 //        						^^^^^^^^^^^
 CssMediaNotCondition =
 	'not'
-	condition: AnyCssMediaInParens
+	condition: AnyCssMediaConditionOperand
 
 // @media (width > 400px) or (color) or (inline-width >= 30em)  { }
 //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 CssMediaOrCondition =
-	left: AnyCssMediaInParens
+	left: AnyCssMediaConditionOperand
 	'or'
 	right: AnyCssMediaOrCombinableCondition
 
 AnyCssMediaOrCombinableCondition =
 	CssMediaOrCondition
-	| AnyCssMediaInParens
+	| AnyCssMediaConditionOperand
 
 // @media (width > 400px) and (color) and (inline-width >= 30em)  { }
 //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 CssMediaAndCondition =
-	left: AnyCssMediaInParens
+	left: AnyCssMediaConditionOperand
 	'and'
 	right: AnyCssMediaAndCombinableCondition
 
 AnyCssMediaAndCombinableCondition =
 	CssMediaAndCondition
-	| AnyCssMediaInParens
+	// Sass accepts `@media #{a} and not (b)`, but plain
+	// `@media (a) and not (b)` must stay invalid in the parser.
+	| CssMediaNotCondition
+	| AnyCssMediaConditionOperand
 
 AnyCssMediaInParens =
 	CssMediaConditionInParens


### PR DESCRIPTION
> This PR was created with AI assistance.

## Summary

Adds support for SCSS media conditions where interpolation participates in media logic, for example:

```scss
@media (color) and #{$query} {}
@media #{$query} and not (color) {}
@media #{$query} or (color) {}
```

## Test Plan

- `cargo test -p biome_css_parser`
- `cargo test -p biome_css_formatter`
