### PR TITLE
feat(linter): expand useIncludes to detect lastIndexOf() patterns

### DIFF
--- a/.changeset/use-includes-last-index-of.md
+++ b/.changeset/use-includes-last-index-of.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Expand `useIncludes` nursery rule to also detect `lastIndexOf()` comparisons against `-1`/`0`, suggesting `.includes()` instead.

--- a/.changeset/use-includes-last-index-of.md
+++ b/.changeset/use-includes-last-index-of.md
@@ -1,5 +1,5 @@
 ---
-"@biomejs/biome": minor
+"@biomejs/biome": patch
 ---
 
-Expand `useIncludes` nursery rule to also detect `lastIndexOf()` comparisons against `-1`/`0`, suggesting `.includes()` instead.
+Partially fixed [#10552](https://github.com/biomejs/biome/issues/10552): [`useIncludes`](https://biomejs.dev/linter/rules/use-includes/) now also detects `lastIndexOf()` comparisons against `-1`/`0`, suggesting `includes()` instead

--- a/crates/biome_js_analyze/src/lint/nursery/use_includes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_includes.rs
@@ -12,11 +12,12 @@ use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
 use crate::services::typed::Typed;
 
 declare_lint_rule! {
-    /// Prefer `Array#includes()` over `Array#indexOf()` checks.
+    /// Prefer `Array#includes()` over `Array#indexOf()` and `Array#lastIndexOf()` checks.
     ///
-    /// `Array#indexOf()` returns a numeric index and is commonly compared against `-1` to check
-    /// for the presence of an element. `Array#includes()` is more readable and expressive for
-    /// this purpose, and avoids off-by-one mistakes with the comparison operator.
+    /// `Array#indexOf()` and `Array#lastIndexOf()` return a numeric index and are commonly
+    /// compared against `-1` to check for the presence of an element. `Array#includes()` is
+    /// more readable and expressive for this purpose, and avoids off-by-one mistakes with the
+    /// comparison operator.
     ///
     /// ## Examples
     ///
@@ -37,6 +38,16 @@ declare_lint_rule! {
     /// arr.indexOf(1) === -1;
     /// ```
     ///
+    /// ```ts,expect_diagnostic,file=invalid4.ts
+    /// const arr = [1, 2, 3];
+    /// arr.lastIndexOf(1) !== -1;
+    /// ```
+    ///
+    /// ```ts,expect_diagnostic,file=invalid5.ts
+    /// const arr = [1, 2, 3];
+    /// arr.lastIndexOf(1) === -1;
+    /// ```
+    ///
     /// ### Valid
     ///
     /// ```ts
@@ -48,6 +59,12 @@ declare_lint_rule! {
     /// const arr = [1, 2, 3];
     /// // Positional use of indexOf is fine
     /// const pos = arr.indexOf(1);
+    /// ```
+    ///
+    /// ```ts
+    /// const arr = [1, 2, 3];
+    /// // Positional use of lastIndexOf is fine
+    /// const pos = arr.lastIndexOf(1);
     /// ```
     ///
     pub UseIncludes {
@@ -97,16 +114,22 @@ impl Rule for UseIncludes {
             CheckKind::NotIncludes => "!...includes()",
         };
 
+        let callee = state.index_of_call.callee().ok()?;
+        let member = callee.as_js_static_member_expression()?;
+        let method_name = member.member().ok()?;
+        let method_text = method_name.as_js_name()?.value_token().ok()?;
+        let method = method_text.text_trimmed();
+
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
                 state.binary.range(),
                 markup! {
-                    "Checking the result of "<Emphasis>"indexOf()"</Emphasis>" against "<Emphasis>"-1"</Emphasis>" to test for presence."
+                    "Checking the result of "<Emphasis>{method}"()"</Emphasis>" against "<Emphasis>"-1"</Emphasis>" to test for presence."
                 },
             )
             .note(markup! {
-                <Emphasis>"indexOf()"</Emphasis>" returns a numeric index, not a boolean. Comparing it against "<Emphasis>"-1"</Emphasis>" is error-prone and harder to read."
+                <Emphasis>{method}"()"</Emphasis>" returns a numeric index, not a boolean. Comparing it against "<Emphasis>"-1"</Emphasis>" is error-prone and harder to read."
             })
             .note(markup! {
                 "Use "<Emphasis>{preferred}</Emphasis>" instead, which directly expresses the intent and returns a boolean."
@@ -202,7 +225,8 @@ fn detect_index_of_pattern(
     None
 }
 
-/// Returns `Some(call)` when `expr` is a call to `something.indexOf(...)`.
+/// Returns `Some(call)` when `expr` is a call to `something.indexOf(...)` or
+/// `something.lastIndexOf(...)`.
 fn as_index_of_call(expr: &AnyJsExpression) -> Option<JsCallExpression> {
     let binding = expr.clone().omit_parentheses();
     let call = binding.as_js_call_expression()?.clone();
@@ -210,7 +234,9 @@ fn as_index_of_call(expr: &AnyJsExpression) -> Option<JsCallExpression> {
     let member = callee.as_js_static_member_expression()?;
     let name = member.member().ok()?;
     let js_name = name.as_js_name()?;
-    if js_name.value_token().ok()?.text_trimmed() != "indexOf" {
+    let method_name = js_name.value_token().ok()?;
+    let text = method_name.text_trimmed();
+    if text != "indexOf" && text != "lastIndexOf" {
         return None;
     }
     // Must have exactly one argument (the search value). If a `fromIndex` is

--- a/crates/biome_js_analyze/tests/specs/nursery/useIncludes/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIncludes/invalid.js
@@ -31,3 +31,22 @@ str.indexOf("world") === -1;
 // parenthesized expressions
 (arr.indexOf(1)) !== -1;
 arr.indexOf(1) !== (-1);
+
+// lastIndexOf — same semantics as indexOf for presence checks
+arr.lastIndexOf(1) !== -1;
+arr.lastIndexOf(1) != -1;
+arr.lastIndexOf(1) >= 0;
+arr.lastIndexOf(1) > -1;
+
+arr.lastIndexOf(1) === -1;
+arr.lastIndexOf(1) == -1;
+arr.lastIndexOf(1) < 0;
+arr.lastIndexOf(1) <= -1;
+
+// reversed operands with lastIndexOf
+-1 !== arr.lastIndexOf(1);
+-1 === arr.lastIndexOf(1);
+
+// lastIndexOf with strings
+str.lastIndexOf("world") !== -1;
+str.lastIndexOf("world") === -1;

--- a/crates/biome_js_analyze/tests/specs/nursery/useIncludes/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIncludes/valid.js
@@ -25,3 +25,20 @@ arr.indexOf(1) + 1;
 
 // not a member call at all
 indexOf(1) !== -1;
+
+// positional use of lastIndexOf — result stored, not compared
+const lastPos = arr.lastIndexOf(1);
+
+// lastIndexOf with fromIndex argument — semantics differ, leave alone
+arr.lastIndexOf(1, 2) !== -1;
+
+// unrelated comparisons that happen to use lastIndexOf result
+arr.lastIndexOf(1) > 0;
+arr.lastIndexOf(1) >= 1;
+arr.lastIndexOf(1) === 0;
+
+// lastIndexOf result used in arithmetic
+arr.lastIndexOf(1) + 1;
+
+// not a member call at all
+lastIndexOf(1) !== -1;

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2652,7 +2652,7 @@ See https://biomejs.dev/linter/rules/use-imports-first
 	 */
 	useImportsFirst?: UseImportsFirstConfiguration;
 	/**
-	* Prefer Array#includes() over Array#indexOf() checks.
+	* Prefer Array#includes() over Array#indexOf() and Array#lastIndexOf() checks.
 See https://biomejs.dev/linter/rules/use-includes 
 	 */
 	useIncludes?: UseIncludesConfiguration;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -6922,7 +6922,7 @@
 					]
 				},
 				"useIncludes": {
-					"description": "Prefer Array#includes() over Array#indexOf() checks.\nSee https://biomejs.dev/linter/rules/use-includes",
+					"description": "Prefer Array#includes() over Array#indexOf() and Array#lastIndexOf() checks.\nSee https://biomejs.dev/linter/rules/use-includes",
 					"anyOf": [
 						{ "$ref": "#/$defs/UseIncludesConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
<!--
  AI Assistance Disclosure: This PR was developed with AI assistance (Cursor IDE with Claude).
  The implementation logic, test cases, and changeset were reviewed and verified by the author.
-->

## Summary

Part of #10552 — expands the `useIncludes` nursery rule to also detect `lastIndexOf()` comparisons against `-1`/`0`, suggesting `.includes()` instead.

`lastIndexOf()` has identical semantics to `indexOf()` for presence checking — both return `-1` when the element is not found. The same readability and correctness arguments apply.

This matches the behavior of [eslint-plugin-unicorn's `prefer-includes`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-includes.md) which covers both methods.

## Test Plan

- Added invalid test cases for `lastIndexOf`: presence checks (`!== -1`, `!= -1`, `>= 0`, `> -1`), absence checks (`=== -1`, `== -1`, `< 0`, `<= -1`), reversed operands, and string variant.
- Added valid test cases: positional use (stored in variable), `fromIndex` argument (different semantics), comparisons against non-standard values, and non-member calls.
- Existing `indexOf` tests remain unchanged and passing.

## Docs

Rule documentation updated inline in `use_includes.rs` with `lastIndexOf` examples for both invalid and valid cases.
