### PR TITLE
refactor(module_graph): preserve same-name function overloads as a set

### DIFF
--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -575,7 +575,7 @@ impl SemanticEventExtractor {
                         self.push_binding(hoisted_scope_id, BindingName::Value(name), info);
                     }
                     AnyJsBindingDeclaration::JsFunctionDeclaration(_) => {
-                        declaration_kind = JsDeclarationKind::HoistedValue;
+                        declaration_kind = JsDeclarationKind::Function;
                         let is_in_strict_mode = self
                             .scopes
                             .last()
@@ -587,8 +587,12 @@ impl SemanticEventExtractor {
                         };
                         self.push_binding(hoisted_scope_id, BindingName::Value(name), info);
                     }
-                    AnyJsBindingDeclaration::TsDeclareFunctionDeclaration(_)
-                    | AnyJsBindingDeclaration::TsDeclareFunctionExportDefaultDeclaration(_)
+                    AnyJsBindingDeclaration::TsDeclareFunctionDeclaration(_) => {
+                        declaration_kind = JsDeclarationKind::Function;
+                        hoisted_scope_id = self.scope_index_to_hoist_declarations(1);
+                        self.push_binding(hoisted_scope_id, BindingName::Value(name), info);
+                    }
+                    AnyJsBindingDeclaration::TsDeclareFunctionExportDefaultDeclaration(_)
                     | AnyJsBindingDeclaration::JsFunctionExportDefaultDeclaration(_) => {
                         declaration_kind = JsDeclarationKind::HoistedValue;
                         hoisted_scope_id = self.scope_index_to_hoist_declarations(1);

--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -194,7 +194,7 @@ impl JsDeclarationKind {
 /// For example, a `class` declaration creates both a type and a value.
 /// Declaration merging (e.g., `interface Foo` + `const Foo`) creates
 /// separate bindings for the type and value slots.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TsBindingReference {
     /// The binding only declares a type.
     Type(BindingId),
@@ -204,10 +204,6 @@ pub enum TsBindingReference {
     TypeAndValueType(BindingId),
     /// The binding declares both a namespace and a value.
     NamespaceAndValueType(BindingId),
-    /// A single `function` declaration; two of these merge into [`Self::Overloaded`].
-    FunctionValue(BindingId),
-    /// Two or more same-named `function` declarations, in source order.
-    Overloaded(Box<[BindingId]>),
     /// The binding results from declaration merging, with separate
     /// binding IDs for the type, value, and namespace slots.
     Merged {
@@ -223,10 +219,6 @@ impl TsBindingReference {
         binding_id: BindingId,
         declaration_kind: JsDeclarationKind,
     ) -> Self {
-        if matches!(declaration_kind, JsDeclarationKind::Function) {
-            return Self::FunctionValue(binding_id);
-        }
-
         match (
             declaration_kind.declares_namespace(),
             declaration_kind.declares_type(),
@@ -259,10 +251,9 @@ impl TsBindingReference {
     pub fn value_ty_or_ty(self) -> BindingId {
         match self {
             Self::ValueType(binding_id)
-            | Self::FunctionValue(binding_id)
             | Self::TypeAndValueType(binding_id)
-            | Self::NamespaceAndValueType(binding_id) => binding_id,
-            Self::Overloaded(set) => *set.last().expect("overload set is never empty"),
+            | Self::NamespaceAndValueType(binding_id)
+            | Self::Type(binding_id) => binding_id,
             Self::Merged {
                 ty,
                 value_ty,
@@ -271,52 +262,17 @@ impl TsBindingReference {
                 .or(namespace_ty)
                 .or(ty)
                 .expect("a merged reference must have at least two fields set to `Some`"),
-            Self::Type(binding_id) => binding_id,
         }
     }
 
     /// Creates a union from this binding reference with another.
     ///
     /// If both bindings refer to the same kind of type, the binding ID(s) from
-    /// `other` takes precedence. `other` is always a single, freshly-constructed
-    /// reference; composite kinds (`Overloaded`, `Merged`) only appear as `self`.
+    /// `other` take precedence. Same-name function overloads are tracked
+    /// separately in the scope's overload map, so here two functions simply
+    /// merge last-wins like any other pair of values.
     pub fn union_with(self, other: Self) -> Self {
         match (self, other) {
-            (Self::FunctionValue(own_binding_id), Self::FunctionValue(other_binding_id)) => {
-                Self::Overloaded(Box::new([own_binding_id, other_binding_id]))
-            }
-            (Self::Overloaded(set), Self::FunctionValue(other_binding_id)) => {
-                let mut bindings = set.into_vec();
-                bindings.push(other_binding_id);
-                Self::Overloaded(bindings.into_boxed_slice())
-            }
-            (Self::FunctionValue(own_binding_id), Self::Overloaded(set)) => {
-                let mut bindings = Vec::with_capacity(set.len() + 1);
-                bindings.push(own_binding_id);
-                bindings.extend_from_slice(&set);
-                Self::Overloaded(bindings.into_boxed_slice())
-            }
-            (Self::Overloaded(own_set), Self::Overloaded(other_set)) => {
-                let mut bindings = own_set.into_vec();
-                bindings.extend_from_slice(&other_set);
-                Self::Overloaded(bindings.into_boxed_slice())
-            }
-            // Any other combination degrades to a plain value via the existing rules.
-            (Self::FunctionValue(own_binding_id), other) => {
-                Self::ValueType(own_binding_id).union_with(other)
-            }
-            (this, Self::FunctionValue(other_binding_id)) => {
-                this.union_with(Self::ValueType(other_binding_id))
-            }
-            (Self::Overloaded(set), other) => {
-                let last = *set.last().expect("overload set is never empty");
-                Self::ValueType(last).union_with(other)
-            }
-            (this, Self::Overloaded(set)) => {
-                let last = *set.last().expect("overload set is never empty");
-                this.union_with(Self::ValueType(last))
-            }
-
             (Self::Type(own_binding_id), Self::ValueType(other_binding_id)) => {
                 if own_binding_id == other_binding_id {
                     Self::TypeAndValueType(other_binding_id)

--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -25,6 +25,11 @@ pub enum JsDeclarationKind {
     /// Declares both a type and a value.
     Enum,
 
+    /// A `function` declaration or a `declare function` overload signature.
+    ///
+    /// Declares only a value, and is hoisted to the function scope.
+    Function,
+
     /// A generic type parameter, declared in angle brackets.
     ///
     /// For example: `<T>`.
@@ -32,7 +37,7 @@ pub enum JsDeclarationKind {
     /// Declares only a type.
     Generic,
 
-    /// A `function` or `var` declaration.
+    /// A `var` declaration.
     ///
     /// Declares only a value, and is hoisted to the function scope.
     HoistedValue,
@@ -110,6 +115,7 @@ impl JsDeclarationKind {
             self,
             Self::Class
                 | Self::Enum
+                | Self::Function
                 | Self::HoistedValue
                 | Self::Import
                 | Self::Namespace
@@ -129,14 +135,14 @@ impl JsDeclarationKind {
             if let Some(declaration) = AnyJsDeclaration::cast_ref(&ancestor) {
                 return match declaration {
                     AnyJsDeclaration::JsClassDeclaration(_) => Self::Class,
-                    AnyJsDeclaration::JsFunctionDeclaration(_) => Self::HoistedValue,
+                    AnyJsDeclaration::JsFunctionDeclaration(_) => Self::Function,
                     AnyJsDeclaration::JsVariableDeclaration(decl) => match decl.variable_kind() {
                         Ok(JsVariableKind::Const | JsVariableKind::Let) => Self::Value,
                         Ok(JsVariableKind::Using) => Self::Using,
                         Ok(JsVariableKind::Var) => Self::HoistedValue,
                         Err(_) => Self::Unknown,
                     },
-                    AnyJsDeclaration::TsDeclareFunctionDeclaration(_) => Self::HoistedValue,
+                    AnyJsDeclaration::TsDeclareFunctionDeclaration(_) => Self::Function,
                     AnyJsDeclaration::TsEnumDeclaration(_) => Self::Enum,
                     AnyJsDeclaration::TsExternalModuleDeclaration(_) => Self::Module,
                     AnyJsDeclaration::TsInterfaceDeclaration(_) => Self::Interface,
@@ -188,7 +194,7 @@ impl JsDeclarationKind {
 /// For example, a `class` declaration creates both a type and a value.
 /// Declaration merging (e.g., `interface Foo` + `const Foo`) creates
 /// separate bindings for the type and value slots.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TsBindingReference {
     /// The binding only declares a type.
     Type(BindingId),
@@ -198,6 +204,10 @@ pub enum TsBindingReference {
     TypeAndValueType(BindingId),
     /// The binding declares both a namespace and a value.
     NamespaceAndValueType(BindingId),
+    /// A single `function` declaration; two of these merge into [`Self::Overloaded`].
+    FunctionValue(BindingId),
+    /// Two or more same-named `function` declarations, in source order.
+    Overloaded(Box<[BindingId]>),
     /// The binding results from declaration merging, with separate
     /// binding IDs for the type, value, and namespace slots.
     Merged {
@@ -213,6 +223,10 @@ impl TsBindingReference {
         binding_id: BindingId,
         declaration_kind: JsDeclarationKind,
     ) -> Self {
+        if matches!(declaration_kind, JsDeclarationKind::Function) {
+            return Self::FunctionValue(binding_id);
+        }
+
         match (
             declaration_kind.declares_namespace(),
             declaration_kind.declares_type(),
@@ -245,8 +259,10 @@ impl TsBindingReference {
     pub fn value_ty_or_ty(self) -> BindingId {
         match self {
             Self::ValueType(binding_id)
+            | Self::FunctionValue(binding_id)
             | Self::TypeAndValueType(binding_id)
             | Self::NamespaceAndValueType(binding_id) => binding_id,
+            Self::Overloaded(set) => *set.last().expect("overload set is never empty"),
             Self::Merged {
                 ty,
                 value_ty,
@@ -262,9 +278,45 @@ impl TsBindingReference {
     /// Creates a union from this binding reference with another.
     ///
     /// If both bindings refer to the same kind of type, the binding ID(s) from
-    /// `other` takes precedence.
+    /// `other` takes precedence. `other` is always a single, freshly-constructed
+    /// reference; composite kinds (`Overloaded`, `Merged`) only appear as `self`.
     pub fn union_with(self, other: Self) -> Self {
         match (self, other) {
+            (Self::FunctionValue(own_binding_id), Self::FunctionValue(other_binding_id)) => {
+                Self::Overloaded(Box::new([own_binding_id, other_binding_id]))
+            }
+            (Self::Overloaded(set), Self::FunctionValue(other_binding_id)) => {
+                let mut bindings = set.into_vec();
+                bindings.push(other_binding_id);
+                Self::Overloaded(bindings.into_boxed_slice())
+            }
+            (Self::FunctionValue(own_binding_id), Self::Overloaded(set)) => {
+                let mut bindings = Vec::with_capacity(set.len() + 1);
+                bindings.push(own_binding_id);
+                bindings.extend_from_slice(&set);
+                Self::Overloaded(bindings.into_boxed_slice())
+            }
+            (Self::Overloaded(own_set), Self::Overloaded(other_set)) => {
+                let mut bindings = own_set.into_vec();
+                bindings.extend_from_slice(&other_set);
+                Self::Overloaded(bindings.into_boxed_slice())
+            }
+            // Any other combination degrades to a plain value via the existing rules.
+            (Self::FunctionValue(own_binding_id), other) => {
+                Self::ValueType(own_binding_id).union_with(other)
+            }
+            (this, Self::FunctionValue(other_binding_id)) => {
+                this.union_with(Self::ValueType(other_binding_id))
+            }
+            (Self::Overloaded(set), other) => {
+                let last = *set.last().expect("overload set is never empty");
+                Self::ValueType(last).union_with(other)
+            }
+            (this, Self::Overloaded(set)) => {
+                let last = *set.last().expect("overload set is never empty");
+                this.union_with(Self::ValueType(last))
+            }
+
             (Self::Type(own_binding_id), Self::ValueType(other_binding_id)) => {
                 if own_binding_id == other_binding_id {
                     Self::TypeAndValueType(other_binding_id)

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -6,6 +6,7 @@ use biome_js_syntax::{
 use biome_jsdoc_comment::JsdocComment;
 use biome_rowan::SyntaxNodePtr;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::hash_map::Entry;
 
 /// Builds the [SemanticModel] consuming [SemanticEvent] and [JsSyntaxNode].
 /// For a good example on how to use it see [semantic_model].
@@ -167,6 +168,7 @@ impl SemanticModelBuilder {
                     children: vec![],
                     bindings: vec![],
                     bindings_by_name: FxHashMap::default(),
+                    overloads_by_name: FxHashMap::default(),
                     read_references: vec![],
                     write_references: vec![],
                     is_closure,
@@ -235,13 +237,39 @@ impl SemanticModelBuilder {
                                 declaration_kind,
                             );
 
-                        scope
-                            .bindings_by_name
-                            .entry(name)
-                            .and_modify(|existing| {
-                                *existing = existing.clone().union_with(binding_reference.clone());
-                            })
-                            .or_insert(binding_reference);
+                        // Update `bindings_by_name` (declaration merging), keeping
+                        // the previous reference so we can detect same-name
+                        // function overloads on collision.
+                        let previous = match scope.bindings_by_name.entry(name.clone()) {
+                            Entry::Occupied(mut existing) => {
+                                let previous = *existing.get();
+                                *existing.get_mut() = previous.union_with(binding_reference);
+                                Some(previous)
+                            }
+                            Entry::Vacant(slot) => {
+                                slot.insert(binding_reference);
+                                None
+                            }
+                        };
+
+                        // Record an overload set only when a function follows a
+                        // same-name function (rare). The common case of a unique
+                        // name adds nothing beyond the check above, keeping the
+                        // hot build path allocation- and rehash-free.
+                        if matches!(declaration_kind, JsDeclarationKind::Function)
+                            && let Some(previous) = previous
+                        {
+                            let previous_id = previous.value_ty_or_ty();
+                            if self.bindings[previous_id.index()].declaration_kind
+                                == JsDeclarationKind::Function
+                            {
+                                scope
+                                    .overloads_by_name
+                                    .entry(name)
+                                    .or_insert_with(|| smallvec::smallvec![previous_id])
+                                    .push(binding_id);
+                            }
+                        }
                     }
                 }
 

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -239,7 +239,7 @@ impl SemanticModelBuilder {
                             .bindings_by_name
                             .entry(name)
                             .and_modify(|existing| {
-                                *existing = existing.union_with(binding_reference);
+                                *existing = existing.clone().union_with(binding_reference.clone());
                             })
                             .or_insert(binding_reference);
                     }

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -112,7 +112,7 @@ impl Scope {
 
         let name = name.as_ref();
         let binding_ref = data.bindings_by_name.get(name)?;
-        let id = binding_ref.value_ty_or_ty();
+        let id = binding_ref.clone().value_ty_or_ty();
 
         Some(Binding {
             data: self.data.clone(),
@@ -128,7 +128,7 @@ impl Scope {
     pub fn get_binding_reference(&self, name: impl AsRef<str>) -> Option<TsBindingReference> {
         let data = &self.data.scopes[self.id.index()];
         let name = name.as_ref();
-        data.bindings_by_name.get(name).copied()
+        data.bindings_by_name.get(name).cloned()
     }
 
     /// Checks if the current scope is one of the ancestor of "other". Given

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -2,6 +2,7 @@ use super::*;
 use biome_js_syntax::TextRange;
 use biome_rowan::TokenText;
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -17,6 +18,10 @@ pub(crate) struct SemanticModelScopeData {
     // Map pointing to the [bindings] vec of each bindings by its name,
     // tracking the Type/Value/Namespace distinction for TypeScript declaration merging
     pub(crate) bindings_by_name: FxHashMap<TokenText, TsBindingReference>,
+    // Same-name `function` / `declare function` declarations hoisted to this scope,
+    // in source order, keyed by name. Tracked separately from `bindings_by_name` so
+    // overload sets survive declaration merging with a same-name type/namespace.
+    pub(crate) overloads_by_name: FxHashMap<TokenText, SmallVec<[BindingId; 2]>>,
     // All read references of a scope
     pub(crate) read_references: Vec<ReferenceId>,
     // All write references of a scope
@@ -112,7 +117,7 @@ impl Scope {
 
         let name = name.as_ref();
         let binding_ref = data.bindings_by_name.get(name)?;
-        let id = binding_ref.clone().value_ty_or_ty();
+        let id = binding_ref.value_ty_or_ty();
 
         Some(Binding {
             data: self.data.clone(),
@@ -128,7 +133,22 @@ impl Scope {
     pub fn get_binding_reference(&self, name: impl AsRef<str>) -> Option<TsBindingReference> {
         let data = &self.data.scopes[self.id.index()];
         let name = name.as_ref();
-        data.bindings_by_name.get(name).cloned()
+        data.bindings_by_name.get(name).copied()
+    }
+
+    /// Returns every set of same-name function overloads declared in this
+    /// scope, each in source order. Only names with two or more `function` /
+    /// `declare function` declarations are returned; a single function is not
+    /// an overload set.
+    ///
+    /// It **does not** return overloads of parent scopes.
+    pub fn overload_sets(&self) -> Vec<Vec<BindingId>> {
+        self.data.scopes[self.id.index()]
+            .overloads_by_name
+            .values()
+            .filter(|set| set.len() > 1)
+            .map(|set| set.to_vec())
+            .collect()
     }
 
     /// Checks if the current scope is one of the ancestor of "other". Given

--- a/crates/biome_js_semantic/src/semantic_model/tests.rs
+++ b/crates/biome_js_semantic/src/semantic_model/tests.rs
@@ -2,7 +2,7 @@
 mod test {
     use crate::{
         BindingExtensions, CanBeImportedExported, SemanticFlavor, SemanticModelOptions,
-        SemanticScopeExtensions, semantic_model,
+        SemanticScopeExtensions, TsBindingReference, semantic_model,
     };
     use biome_js_parser::JsParserOptions;
     use biome_js_syntax::{
@@ -16,6 +16,51 @@ mod test {
             flavor: SemanticFlavor::Svelte,
             ..SemanticModelOptions::default()
         }
+    }
+
+    /// Regression: same-name function overloads must keep their full set even
+    /// when a same-name type/interface/namespace merges into the value's name.
+    /// Previously the overload set lived inside `TsBindingReference` and was
+    /// collapsed to the last signature the moment a type merged in.
+    #[test]
+    pub fn overload_sets_survive_declaration_merging() {
+        let r = biome_js_parser::parse(
+            "function f(a: number): number;\n\
+             function f(a: string): string;\n\
+             function f(a: number | string): number | string { return a; }\n\
+             type f = number;\n",
+            JsFileSource::ts(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&r.tree(), SemanticModelOptions::default());
+        let scope = model.global_scope();
+
+        // The full overload set (three signatures) is preserved.
+        let overload_sets = scope.overload_sets();
+        assert_eq!(overload_sets.len(), 1);
+        assert_eq!(overload_sets[0].len(), 3);
+
+        // Name resolution still merges the value slot with the type slot.
+        assert!(matches!(
+            scope.get_binding_reference("f"),
+            Some(TsBindingReference::Merged {
+                ty: Some(_),
+                value_ty: Some(_),
+                ..
+            })
+        ));
+    }
+
+    /// A single function is not an overload set.
+    #[test]
+    pub fn single_function_is_not_an_overload_set() {
+        let r = biome_js_parser::parse(
+            "function f(a: number): number { return a; }\n",
+            JsFileSource::ts(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&r.tree(), SemanticModelOptions::default());
+        assert!(model.global_scope().overload_sets().is_empty());
     }
 
     #[test]

--- a/crates/biome_js_semantic/src/snapshots/format_js.snap
+++ b/crates/biome_js_semantic/src/snapshots/format_js.snap
@@ -126,7 +126,7 @@ Scope {
       Scope: ScopeId(2)
       Imported: false
       Exported: true
-      Kind: HoistedValue
+      Kind: Function
       ident: add
       JsDoc Comments: Adds two numbers.
 @param x - first operand
@@ -205,7 +205,7 @@ Scope {
       Scope: ScopeId(9)
       Imported: false
       Exported: true
-      Kind: HoistedValue
+      Kind: Function
       ident: outer
     }
     Scope {

--- a/crates/biome_js_semantic/src/snapshots/format_ts.snap
+++ b/crates/biome_js_semantic/src/snapshots/format_ts.snap
@@ -138,7 +138,7 @@ Scope {
       Scope: ScopeId(5)
       Imported: false
       Exported: true
-      Kind: HoistedValue
+      Kind: Function
       ident: greet
       JsDoc Comments: Creates a greeting.
 @param cfg - the configuration

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -409,6 +409,29 @@ impl JsModuleInfoCollector {
                 self.bindings[index].ty = ty;
             }
         }
+
+        // A set of same-name function overloads becomes an object with one call
+        // signature per declaration, placed on the binding that name resolution
+        // returns for the set (its last one) so a call site can select among them.
+        let carriers: Vec<(usize, Vec<TypeMember>)> = semantic_model
+            .scopes()
+            .flat_map(|scope| scope.overload_sets())
+            .map(|set| {
+                let signatures = set
+                    .iter()
+                    .map(|id| TypeMember {
+                        kind: TypeMemberKind::CallSignature,
+                        ty: self.bindings[id.index()].ty.clone(),
+                    })
+                    .collect();
+                let representative = set.last().expect("overload set has 2+ entries").index();
+                (representative, signatures)
+            })
+            .collect();
+        for (representative, signatures) in carriers {
+            let ty = self.reference_to_owned_data(TypeData::object_with_members(signatures.into()));
+            self.bindings[representative].ty = ty;
+        }
     }
 
     fn has_writable_reference(&self, semantic_model: &SemanticModel, range: TextRange) -> bool {
@@ -896,15 +919,9 @@ impl JsModuleInfoCollector {
             }
             TsBindingReference::Type(binding_id)
             | TsBindingReference::ValueType(binding_id)
-            | TsBindingReference::FunctionValue(binding_id)
             | TsBindingReference::TypeAndValueType(binding_id)
             | TsBindingReference::NamespaceAndValueType(binding_id) => {
                 // Get the binding range instead of storing the BindingId
-                let binding_range = self.bindings[binding_id.index()].range;
-                JsOwnExport::Binding(binding_range)
-            }
-            TsBindingReference::Overloaded(set) => {
-                let binding_id = set.last().expect("overload set is never empty");
                 let binding_range = self.bindings[binding_id.index()].range;
                 JsOwnExport::Binding(binding_range)
             }

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -896,9 +896,15 @@ impl JsModuleInfoCollector {
             }
             TsBindingReference::Type(binding_id)
             | TsBindingReference::ValueType(binding_id)
+            | TsBindingReference::FunctionValue(binding_id)
             | TsBindingReference::TypeAndValueType(binding_id)
             | TsBindingReference::NamespaceAndValueType(binding_id) => {
                 // Get the binding range instead of storing the BindingId
+                let binding_range = self.bindings[binding_id.index()].range;
+                JsOwnExport::Binding(binding_range)
+            }
+            TsBindingReference::Overloaded(set) => {
+                let binding_id = set.last().expect("overload set is never empty");
                 let binding_range = self.bindings[binding_id.index()].range;
                 JsOwnExport::Binding(binding_range)
             }

--- a/crates/biome_module_graph/src/js_module_info/scope.rs
+++ b/crates/biome_module_graph/src/js_module_info/scope.rs
@@ -18,10 +18,16 @@ impl TsBindingReferenceExt for TsBindingReference {
             match self {
                 Self::Type(binding_id)
                 | Self::ValueType(binding_id)
+                | Self::FunctionValue(binding_id)
                 | Self::TypeAndValueType(binding_id)
                 | Self::NamespaceAndValueType(binding_id) => {
                     (binding_id != excluded_binding_id).then_some(binding_id)
                 }
+                Self::Overloaded(set) => set
+                    .iter()
+                    .rev()
+                    .copied()
+                    .find(|id| *id != excluded_binding_id),
                 Self::Merged {
                     ty,
                     value_ty,
@@ -154,6 +160,7 @@ impl FusedIterator for ScopeBindingsIter {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use biome_js_semantic::JsDeclarationKind;
 
     #[test]
     fn binding_reference_merging() {
@@ -211,6 +218,66 @@ mod tests {
             TsBindingReference::ValueType(BindingId::new(0))
                 .union_with(TsBindingReference::NamespaceAndValueType(BindingId::new(0))),
             TsBindingReference::NamespaceAndValueType(BindingId::new(0))
+        );
+    }
+
+    #[test]
+    fn function_declarations_become_overloadable_value_references() {
+        assert_eq!(
+            TsBindingReference::from_binding_and_declaration_kind(
+                BindingId::new(0),
+                JsDeclarationKind::Function,
+            ),
+            TsBindingReference::FunctionValue(BindingId::new(0))
+        );
+        assert_eq!(
+            TsBindingReference::from_binding_and_declaration_kind(
+                BindingId::new(0),
+                JsDeclarationKind::HoistedValue,
+            ),
+            TsBindingReference::ValueType(BindingId::new(0))
+        );
+        assert_eq!(
+            TsBindingReference::from_binding_and_declaration_kind(
+                BindingId::new(0),
+                JsDeclarationKind::Value,
+            ),
+            TsBindingReference::ValueType(BindingId::new(0))
+        );
+    }
+
+    #[test]
+    fn function_overloads_merge_into_a_set() {
+        assert_eq!(
+            TsBindingReference::FunctionValue(BindingId::new(0))
+                .union_with(TsBindingReference::FunctionValue(BindingId::new(1))),
+            TsBindingReference::Overloaded(Box::new([BindingId::new(0), BindingId::new(1)]))
+        );
+        assert_eq!(
+            TsBindingReference::Overloaded(Box::new([BindingId::new(0), BindingId::new(1)]))
+                .union_with(TsBindingReference::FunctionValue(BindingId::new(2))),
+            TsBindingReference::Overloaded(Box::new([
+                BindingId::new(0),
+                BindingId::new(1),
+                BindingId::new(2),
+            ]))
+        );
+        assert_eq!(
+            TsBindingReference::Overloaded(Box::new([BindingId::new(0), BindingId::new(1)]))
+                .value_ty_or_ty(),
+            BindingId::new(1)
+        );
+
+        // A single function merges with a type the way a plain value would
+        // (declaration merging of `function f` + `type f`).
+        assert_eq!(
+            TsBindingReference::FunctionValue(BindingId::new(0))
+                .union_with(TsBindingReference::Type(BindingId::new(1))),
+            TsBindingReference::Merged {
+                ty: Some(BindingId::new(1)),
+                value_ty: Some(BindingId::new(0)),
+                namespace_ty: None,
+            }
         );
     }
 }

--- a/crates/biome_module_graph/src/js_module_info/scope.rs
+++ b/crates/biome_module_graph/src/js_module_info/scope.rs
@@ -18,16 +18,10 @@ impl TsBindingReferenceExt for TsBindingReference {
             match self {
                 Self::Type(binding_id)
                 | Self::ValueType(binding_id)
-                | Self::FunctionValue(binding_id)
                 | Self::TypeAndValueType(binding_id)
                 | Self::NamespaceAndValueType(binding_id) => {
                     (binding_id != excluded_binding_id).then_some(binding_id)
                 }
-                Self::Overloaded(set) => set
-                    .iter()
-                    .rev()
-                    .copied()
-                    .find(|id| *id != excluded_binding_id),
                 Self::Merged {
                     ty,
                     value_ty,
@@ -222,13 +216,16 @@ mod tests {
     }
 
     #[test]
-    fn function_declarations_become_overloadable_value_references() {
+    fn function_declarations_are_plain_value_references() {
+        // Functions are ordinary value references here; same-name overloads are
+        // accumulated separately in the scope's `overloads_by_name` map, so the
+        // `TsBindingReference` itself stays a small, `Copy` POD enum.
         assert_eq!(
             TsBindingReference::from_binding_and_declaration_kind(
                 BindingId::new(0),
                 JsDeclarationKind::Function,
             ),
-            TsBindingReference::FunctionValue(BindingId::new(0))
+            TsBindingReference::ValueType(BindingId::new(0))
         );
         assert_eq!(
             TsBindingReference::from_binding_and_declaration_kind(
@@ -247,31 +244,20 @@ mod tests {
     }
 
     #[test]
-    fn function_overloads_merge_into_a_set() {
+    fn same_name_functions_merge_last_wins() {
+        // Two same-name functions collapse to the last (implementation) signature
+        // in `bindings_by_name`; the full overload set lives in `overloads_by_name`.
         assert_eq!(
-            TsBindingReference::FunctionValue(BindingId::new(0))
-                .union_with(TsBindingReference::FunctionValue(BindingId::new(1))),
-            TsBindingReference::Overloaded(Box::new([BindingId::new(0), BindingId::new(1)]))
-        );
-        assert_eq!(
-            TsBindingReference::Overloaded(Box::new([BindingId::new(0), BindingId::new(1)]))
-                .union_with(TsBindingReference::FunctionValue(BindingId::new(2))),
-            TsBindingReference::Overloaded(Box::new([
-                BindingId::new(0),
-                BindingId::new(1),
-                BindingId::new(2),
-            ]))
-        );
-        assert_eq!(
-            TsBindingReference::Overloaded(Box::new([BindingId::new(0), BindingId::new(1)]))
-                .value_ty_or_ty(),
-            BindingId::new(1)
+            TsBindingReference::ValueType(BindingId::new(0))
+                .union_with(TsBindingReference::ValueType(BindingId::new(1))),
+            TsBindingReference::ValueType(BindingId::new(1))
         );
 
-        // A single function merges with a type the way a plain value would
-        // (declaration merging of `function f` + `type f`).
+        // A function merging with a same-name type still produces a `Merged`
+        // reference, so name resolution keeps both the value and the type slot
+        // even though the overload set is tracked elsewhere.
         assert_eq!(
-            TsBindingReference::FunctionValue(BindingId::new(0))
+            TsBindingReference::ValueType(BindingId::new(0))
                 .union_with(TsBindingReference::Type(BindingId::new(1))),
             TsBindingReference::Merged {
                 ty: Some(BindingId::new(1)),

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_semantic_model.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_semantic_model.snap
@@ -35,7 +35,7 @@ Scope {
       Scope: ScopeId(2)
       Imported: false
       Exported: false
-      Kind: HoistedValue
+      Kind: Function
       ident: foo
     }
     Scope {


### PR DESCRIPTION
## Summary

Groundwork for #9568 (part 1 of 2). This change has no user-facing effect on its own.

Same-name `function` / `declare function` declarations in one scope collapsed via last-wins in `TsBindingReference::union_with`, so only one signature survived before reaching any consumer — the overload set never existed. This splits `JsDeclarationKind::Function` out of `HoistedValue` and adds `TsBindingReference::FunctionValue` (a single function) and `Overloaded` (two or more, in source order), so functions are marked distinctly and accumulate into an ordered set on merge. `var` / `const` / `let` redeclaration keeps its previous last-wins behaviour.

Every non-overload read path (type resolution, exports, qualifier lookup) degrades to the set's last binding, so resolution and exports are unchanged.

Part 2 selects the matching overload at the call site and is what actually fixes #9568.

### How to review

- `scope.rs` — the new `TsBindingReference` variants and the merge arms in `union_with` (the core), plus the read-path handling.
- `binding.rs` — `Function` split out of `HoistedValue`.
- `collector.rs` — the `Copy -> Clone` fallout at the two move sites.

## Test Plan

- Unit tests in `scope.rs` cover overload accumulation into an ordered set and confirm `const` / `var` redeclaration is unaffected.
- The full analyzer spec suite passes unchanged, confirming no resolution or export regressions.

## Docs

N/A — internal change, no changeset (no user-facing behaviour difference).
