### PR TITLE
fix(lint/noFloatingPromises): select the matching overload

### DIFF
--- a/.changeset/fix-no-floating-promises-overloads.md
+++ b/.changeset/fix-no-floating-promises-overloads.md
@@ -1,0 +1,17 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9568](https://github.com/biomejs/biome/issues/9568): [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-floating-promises/) no longer reports a false positive when calling an overloaded function and the selected overload does not return a promise.
+
+```ts
+function bestEffort(cb: () => Promise<number>): Promise<number>;
+function bestEffort(cb: () => number): number;
+function bestEffort(cb: () => number | Promise<number>): Promise<number> | number {
+	return cb() as Promise<number> | number;
+}
+
+// This resolves to the second overload, which returns `number`, so it is no
+// longer flagged as a floating promise.
+bestEffort(() => 42);
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_generic.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_generic.ts
@@ -1,0 +1,15 @@
+/* should not generate diagnostics */
+
+function bestEffort<T>(cb: () => Promise<T>): Promise<T | undefined>;
+function bestEffort<T>(cb: () => T): T | undefined;
+function bestEffort<T>(cb: (() => T) | (() => Promise<T>)): Promise<T | undefined> | T | undefined {
+	return undefined;
+}
+
+function syncWork(): number {
+	return 42;
+}
+
+// Generic overload exactly like the reported issue: selects the second
+// overload (sync), so it must NOT be flagged.
+bestEffort(syncWork);

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_generic.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_generic.ts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue9568_generic.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+function bestEffort<T>(cb: () => Promise<T>): Promise<T | undefined>;
+function bestEffort<T>(cb: () => T): T | undefined;
+function bestEffort<T>(cb: (() => T) | (() => Promise<T>)): Promise<T | undefined> | T | undefined {
+	return undefined;
+}
+
+function syncWork(): number {
+	return 42;
+}
+
+// Generic overload exactly like the reported issue: selects the second
+// overload (sync), so it must NOT be flagged.
+bestEffort(syncWork);
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_invalid.ts
@@ -1,0 +1,13 @@
+function bestEffort(cb: () => Promise<number>): Promise<number>;
+function bestEffort(cb: () => number): number;
+function bestEffort(cb: () => number | Promise<number>): Promise<number> | number {
+	return cb() as Promise<number> | number;
+}
+
+async function asyncWork(): Promise<number> {
+	return 42;
+}
+
+// Resolves to the first overload (async callback) -> returns a promise,
+// so this floating call must still be flagged.
+bestEffort(asyncWork);

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_invalid.ts.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue9568_invalid.ts
+---
+# Input
+```ts
+function bestEffort(cb: () => Promise<number>): Promise<number>;
+function bestEffort(cb: () => number): number;
+function bestEffort(cb: () => number | Promise<number>): Promise<number> | number {
+	return cb() as Promise<number> | number;
+}
+
+async function asyncWork(): Promise<number> {
+	return 42;
+}
+
+// Resolves to the first overload (async callback) -> returns a promise,
+// so this floating call must still be flagged.
+bestEffort(asyncWork);
+
+```
+
+# Diagnostics
+```
+issue9568_invalid.ts:13:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    11 │ // Resolves to the first overload (async callback) -> returns a promise,
+    12 │ // so this floating call must still be flagged.
+  > 13 │ bestEffort(asyncWork);
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_valid.ts
@@ -1,0 +1,15 @@
+/* should not generate diagnostics */
+
+function bestEffort(cb: () => Promise<number>): Promise<number>;
+function bestEffort(cb: () => number): number;
+function bestEffort(cb: () => number | Promise<number>): Promise<number> | number {
+	return cb() as Promise<number> | number;
+}
+
+function syncWork(): number {
+	return 42;
+}
+
+// Resolves to the second overload (sync callback) -> returns `number`,
+// which is not a promise, so this must NOT be flagged.
+bestEffort(syncWork);

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue9568_valid.ts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue9568_valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+function bestEffort(cb: () => Promise<number>): Promise<number>;
+function bestEffort(cb: () => number): number;
+function bestEffort(cb: () => number | Promise<number>): Promise<number> | number {
+	return cb() as Promise<number> | number;
+}
+
+function syncWork(): number {
+	return 42;
+}
+
+// Resolves to the second overload (sync callback) -> returns `number`,
+// which is not a promise, so this must NOT be flagged.
+bestEffort(syncWork);
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadCallableInterface.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadCallableInterface.ts
@@ -1,0 +1,16 @@
+/* should not generate diagnostics */
+
+interface SyncCb { (): void }
+interface AsyncCb { (): Promise<void> }
+
+function run(cb: AsyncCb): Promise<void>;
+function run(cb: SyncCb): void;
+function run(cb: SyncCb | AsyncCb): Promise<void> | void {
+	const result = cb();
+	return result instanceof Promise ? result : undefined;
+}
+
+const sync: SyncCb = () => {};
+
+// SyncCb argument selects the second overload (returns `void`), must NOT be flagged.
+run(sync);

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadCallableInterface.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadCallableInterface.ts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 149
+expression: overloadCallableInterface.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+interface SyncCb { (): void }
+interface AsyncCb { (): Promise<void> }
+
+function run(cb: AsyncCb): Promise<void>;
+function run(cb: SyncCb): void;
+function run(cb: SyncCb | AsyncCb): Promise<void> | void {
+	const result = cb();
+	return result instanceof Promise ? result : undefined;
+}
+
+const sync: SyncCb = () => {};
+
+// SyncCb argument selects the second overload (returns `void`), must NOT be flagged.
+run(sync);
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadNoMatchIsUnknown.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadNoMatchIsUnknown.ts
@@ -1,0 +1,14 @@
+/* should not generate diagnostics */
+
+function onlyAsync(cb: () => Promise<void>): Promise<void>;
+function onlyAsync(cb: () => Promise<void>, retries: number): Promise<void>;
+function onlyAsync(cb: () => Promise<void>, retries?: number): Promise<void> {
+	return cb();
+}
+
+function syncCb(): void {}
+
+// Neither overload accepts a synchronous callback, so the call resolves to no
+// signature. Its type is unknown rather than the first overload's
+// `Promise<void>`, so it must NOT be flagged as a floating promise.
+onlyAsync(syncCb);

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadNoMatchIsUnknown.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadNoMatchIsUnknown.ts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: overloadNoMatchIsUnknown.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+function onlyAsync(cb: () => Promise<void>): Promise<void>;
+function onlyAsync(cb: () => Promise<void>, retries: number): Promise<void>;
+function onlyAsync(cb: () => Promise<void>, retries?: number): Promise<void> {
+	return cb();
+}
+
+function syncCb(): void {}
+
+// Neither overload accepts a synchronous callback, so the call resolves to no
+// signature. Its type is unknown rather than the first overload's
+// `Promise<void>`, so it must NOT be flagged as a floating promise.
+onlyAsync(syncCb);
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadSelectedByArity.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadSelectedByArity.ts
@@ -1,0 +1,13 @@
+/* should not generate diagnostics */
+
+function run(cb: () => void): Promise<void>;
+function run(cb: () => void, immediate: boolean): void;
+function run(cb: () => void, immediate?: boolean): Promise<void> | void {
+	return immediate ? cb() : Promise.resolve();
+}
+
+function task(): void {}
+
+// Two arguments select the second overload (returns `void`, not a promise),
+// so this must NOT be flagged.
+run(task, true);

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadSelectedByArity.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadSelectedByArity.ts.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: overloadSelectedByArity.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+function run(cb: () => void): Promise<void>;
+function run(cb: () => void, immediate: boolean): void;
+function run(cb: () => void, immediate?: boolean): Promise<void> | void {
+	return immediate ? cb() : Promise.resolve();
+}
+
+function task(): void {}
+
+// Two arguments select the second overload (returns `void`, not a promise),
+// so this must NOT be flagged.
+run(task, true);
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadSelectedByArityInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadSelectedByArityInvalid.ts
@@ -1,0 +1,12 @@
+function run(cb: () => void): void;
+function run(cb: () => void, immediate: boolean): Promise<void>;
+function run(cb: () => void, immediate?: boolean): void | Promise<void> {
+	return immediate ? Promise.resolve() : cb();
+}
+
+function task(): void {}
+
+// Two arguments select the second overload, which returns `Promise<void>` (not
+// the first, `void`-returning one). That promise floats here, so it must still
+// be flagged.
+run(task, true);

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadSelectedByArityInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/overloadSelectedByArityInvalid.ts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: overloadSelectedByArityInvalid.ts
+---
+# Input
+```ts
+function run(cb: () => void): void;
+function run(cb: () => void, immediate: boolean): Promise<void>;
+function run(cb: () => void, immediate?: boolean): void | Promise<void> {
+	return immediate ? Promise.resolve() : cb();
+}
+
+function task(): void {}
+
+// Two arguments select the second overload, which returns `Promise<void>` (not
+// the first, `void`-returning one). That promise floats here, so it must still
+// be flagged.
+run(task, true);
+
+```
+
+# Diagnostics
+```
+overloadSelectedByArityInvalid.ts:12:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    10 │ // the first, `void`-returning one). That promise floats here, so it must still
+    11 │ // be flagged.
+  > 12 │ run(task, true);
+       │ ^^^^^^^^^^^^^^^^
+    13 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -457,10 +457,138 @@ fn flattened_call(
             }
         }
         callee => {
-            let function = resolve_callee_to_function(callee, resolver, depth)?;
+            let function = match select_overload(&callee, &expr.arguments, resolver) {
+                OverloadSelection::Selected(function) => function,
+                // The callee is an overload set, but no signature accepts the
+                // arguments. Its result type is unknown, so we must *not* fall
+                // back to silently picking the first call signature.
+                OverloadSelection::NoMatch => return None,
+                OverloadSelection::NotOverloaded => {
+                    resolve_callee_to_function(callee, resolver, depth)?
+                }
+            };
             flattened_function_call(expr, &function, resolver)
         }
     }
+}
+
+/// Outcome of [`select_overload`].
+enum OverloadSelection {
+    /// The callee is not an overload set (it carries fewer than two call
+    /// signatures); resolve it through the regular single-signature path.
+    NotOverloaded,
+    /// The callee is an overload set, but no signature accepts the arguments,
+    /// so the call's result type is unknown — notably *not* the first
+    /// signature's return type.
+    NoMatch,
+    /// A signature was selected for the given arguments.
+    Selected(Box<Function>),
+}
+
+/// Selects an overload when the callee is an object or interface carrying more
+/// than one call signature. This is the shape produced for a set of same-name
+/// function declarations, but it also applies to a hand-written interface with
+/// multiple call signatures.
+///
+/// Mirroring TypeScript, the first signature whose parameters accept the
+/// arguments wins, in declaration order. The three-way result lets the caller
+/// tell a non-overloaded callee (fall back to single-signature resolution)
+/// apart from an overloaded callee with no matching signature (the result is
+/// unknown, so the caller must *not* fall back to the first signature).
+fn select_overload(
+    callee: &TypeData,
+    arguments: &[CallArgumentType],
+    resolver: &dyn TypeResolver,
+) -> OverloadSelection {
+    let resolved = ResolvedTypeData::from((ResolverId::from_level(resolver.level()), callee));
+    let signatures: Vec<TypeReference> = resolved
+        .all_members(resolver)
+        .filter(|member| member.kind().is_call_signature())
+        .map(|member| member.to_member().deref_ty(resolver).into_owned())
+        .collect();
+    if signatures.len() < 2 {
+        return OverloadSelection::NotOverloaded;
+    }
+
+    signatures
+        .iter()
+        .find_map(|signature| {
+            match resolver
+                .resolve_and_get(signature)
+                .map(ResolvedTypeData::to_data)
+            {
+                Some(TypeData::Function(function))
+                    if signature_accepts_arguments(&function, arguments, resolver) =>
+                {
+                    Some(function)
+                }
+                _ => None,
+            }
+        })
+        .map_or(OverloadSelection::NoMatch, OverloadSelection::Selected)
+}
+
+/// Narrow applicability heuristic used for overload selection.
+///
+/// This is deliberately **not** a general assignability check: beyond an arity
+/// check, it only disambiguates overloads that differ by whether a callback
+/// argument returns a promise, which is the case that matters for
+/// promise-related rules. Any argument whose shape it does not understand (e.g.
+/// a non-function parameter/argument pair) places no constraint, so the first
+/// arity-compatible signature in declaration order wins.
+///
+/// Callers must therefore treat a `true` result as "this signature is *not
+/// ruled out*", not as "the arguments are assignable". When real assignability
+/// infrastructure exists, replace this body with `is_assignable_to` per
+/// parameter; the [`select_overload`] seam around it does not need to change.
+// TODO: generalize to a real assignability check once available.
+fn signature_accepts_arguments(
+    function: &Function,
+    arguments: &[CallArgumentType],
+    resolver: &dyn TypeResolver,
+) -> bool {
+    let parameters = &function.parameters;
+    let accepts_rest = parameters.last().is_some_and(FunctionParameter::is_rest);
+    let required = parameters
+        .iter()
+        .filter(|parameter| !parameter.is_optional() && !parameter.is_rest())
+        .count();
+    if arguments.len() < required || (!accepts_rest && arguments.len() > parameters.len()) {
+        return false;
+    }
+
+    parameters
+        .iter()
+        .zip(arguments)
+        .all(|(parameter, argument)| {
+            let (CallArgumentType::Argument(argument) | CallArgumentType::Spread(argument)) =
+                argument;
+            match (
+                resolve_function(parameter.ty(), resolver),
+                resolve_function(argument, resolver),
+            ) {
+                (Some(parameter_fn), Some(argument_fn)) => {
+                    function_returns_promise(&parameter_fn, resolver)
+                        == function_returns_promise(&argument_fn, resolver)
+                }
+                _ => true,
+            }
+        })
+}
+
+fn resolve_function(ty: &TypeReference, resolver: &dyn TypeResolver) -> Option<Box<Function>> {
+    match resolver.resolve_and_get(ty)?.to_data() {
+        TypeData::Function(function) => Some(function),
+        _ => None,
+    }
+}
+
+fn function_returns_promise(function: &Function, resolver: &dyn TypeResolver) -> bool {
+    function
+        .return_type
+        .as_type()
+        .and_then(|return_ty| resolver.resolve_and_get(return_ty))
+        .is_some_and(|resolved| resolved.is_promise_instance(resolver))
 }
 
 fn flattened_destructure(

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -579,6 +579,17 @@ fn signature_accepts_arguments(
 fn resolve_function(ty: &TypeReference, resolver: &dyn TypeResolver) -> Option<Box<Function>> {
     match resolver.resolve_and_get(ty)?.to_data() {
         TypeData::Function(function) => Some(function),
+        // Callable interfaces/objects: `interface Cb { (): Promise<void> }`
+        TypeData::Interface(interface) => interface
+            .members
+            .iter()
+            .find(|m| m.kind.is_call_signature())
+            .and_then(|m| resolve_function(&m.ty, resolver)),
+        TypeData::Object(object) => object
+            .members
+            .iter()
+            .find(|m| m.kind.is_call_signature())
+            .and_then(|m| resolve_function(&m.ty, resolver)),
         _ => None,
     }
 }

--- a/crates/biome_js_type_info/src/type_data.rs
+++ b/crates/biome_js_type_info/src/type_data.rs
@@ -573,6 +573,20 @@ impl FunctionParameter {
             Self::Pattern(pattern) => &pattern.ty,
         }
     }
+
+    pub fn is_optional(&self) -> bool {
+        match self {
+            Self::Named(named) => named.is_optional,
+            Self::Pattern(pattern) => pattern.is_optional,
+        }
+    }
+
+    pub fn is_rest(&self) -> bool {
+        match self {
+            Self::Named(named) => named.is_rest,
+            Self::Pattern(pattern) => pattern.is_rest,
+        }
+    }
 }
 
 /// A plain function parameter where the name of the parameter is also the name


### PR DESCRIPTION
## Summary

Fixes #9568 (part 2 of 2). Stacked on #10585 — that should be reviewed and merged first.

Calling an overloaded function resolved to a single, arbitrary signature, so `noFloatingPromises` judged the call by the first overload's return type. When that overload returned a promise but the selected one did not, the call was flagged incorrectly.

A set of same-name function declarations (preserved by #10585) now resolves to an object carrying one call signature per declaration — the way TypeScript models an overloaded function internally. At a call site, the first signature whose parameters accept the arguments wins, in declaration order, using a narrow promise-aware check plus an arity check (no general assignability). The call's return type is then taken from the selected signature, so a non-promise overload is no longer flagged while a promise-returning one still is.

```ts
function bestEffort(cb: () => Promise<number>): Promise<number>;
function bestEffort(cb: () => number): number;
function bestEffort(cb: () => number | Promise<number>): Promise<number> | number {
	return cb() as Promise<number> | number;
}

bestEffort(() => 42);          // selected overload returns `number` -> no longer flagged
bestEffort(async () => 42);    // selected overload returns a promise -> still flagged
```

### How to review

- This PR is **stacked on #10585**; until that merges, the diff includes its commit. This PR's own change is the `fix(noFloatingPromises): ...` commit.
- `collector.rs` — overload sets become an object of call signatures (the carrier surfaced to name resolution).
- `expressions.rs` — `select_overload` and the narrow applicability check, wired into `flattened_call`.
- `type_data.rs` — two small `FunctionParameter` accessors (`is_optional` / `is_rest`) for the arity check.

## Test Plan

- `issue9568_valid` / `issue9568_generic` — the sync overload (including the exact generic case from the report) is no longer flagged.
- `issue9568_invalid` — the async overload is still flagged (guards against a false negative).
- `overloadSelectedByArity` — an overload distinguished only by arity selects the non-promise signature.
- The full analyzer spec suite passes, no regressions.

## Scope and future work

The selection here is deliberately narrow: it disambiguates by whether a callback argument returns a promise (plus arity), which is what this rule needs — not general overload resolution.

A fuller direction would give the type system first-class overload support: keep all signatures and a selection step (arity + structural parameter matching) usable by any type-aware rule, which would also let this rule drop the promise-specific check. Happy to open a separate design discussion if the team wants to pursue that.

## Docs

Changeset included (patch).
