### PR TITLE
fix(markdown): remove unused hard_line slot from MdParagraph

### DIFF
--- a/crates/biome_markdown_factory/src/generated/node_factory.rs
+++ b/crates/biome_markdown_factory/src/generated/node_factory.rs
@@ -455,31 +455,11 @@ pub fn md_ordered_list_item(md_bullet_list: MdBulletList) -> MdOrderedListItem {
         [Some(SyntaxElement::Node(md_bullet_list.into_syntax()))],
     ))
 }
-pub fn md_paragraph(list: MdInlineItemList) -> MdParagraphBuilder {
-    MdParagraphBuilder {
-        list,
-        hard_line: None,
-    }
-}
-pub struct MdParagraphBuilder {
-    list: MdInlineItemList,
-    hard_line: Option<MdHardLine>,
-}
-impl MdParagraphBuilder {
-    pub fn with_hard_line(mut self, hard_line: MdHardLine) -> Self {
-        self.hard_line = Some(hard_line);
-        self
-    }
-    pub fn build(self) -> MdParagraph {
-        MdParagraph::unwrap_cast(SyntaxNode::new_detached(
-            MarkdownSyntaxKind::MD_PARAGRAPH,
-            [
-                Some(SyntaxElement::Node(self.list.into_syntax())),
-                self.hard_line
-                    .map(|token| SyntaxElement::Node(token.into_syntax())),
-            ],
-        ))
-    }
+pub fn md_paragraph(list: MdInlineItemList) -> MdParagraph {
+    MdParagraph::unwrap_cast(SyntaxNode::new_detached(
+        MarkdownSyntaxKind::MD_PARAGRAPH,
+        [Some(SyntaxElement::Node(list.into_syntax()))],
+    ))
 }
 pub fn md_quote(prefix: MdQuotePrefix, content: MdBlockList) -> MdQuote {
     MdQuote::unwrap_cast(SyntaxNode::new_detached(

--- a/crates/biome_markdown_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_markdown_factory/src/generated/syntax_factory.rs
@@ -824,17 +824,10 @@ impl SyntaxFactory for MarkdownSyntaxFactory {
             }
             MD_PARAGRAPH => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<1usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
                     && MdInlineItemList::can_cast(element.kind())
-                {
-                    slots.mark_present();
-                    current_element = elements.next();
-                }
-                slots.next_slot();
-                if let Some(element) = &current_element
-                    && MdHardLine::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/paragraph.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/paragraph.rs
@@ -20,7 +20,7 @@ impl Default for FormatMdParagraph {
 }
 impl FormatNodeRule<MdParagraph> for FormatMdParagraph {
     fn fmt_fields(&self, node: &MdParagraph, f: &mut MarkdownFormatter) -> FormatResult<()> {
-        let MdParagraphFields { list, hard_line } = node.as_fields();
+        let MdParagraphFields { list } = node.as_fields();
         write!(
             f,
             [list
@@ -31,9 +31,6 @@ impl FormatNodeRule<MdParagraph> for FormatMdParagraph {
                     inside_list: self.inside_list,
                 })]
         )?;
-        if let Some(hard_line) = hard_line {
-            write!(f, [hard_line.format()])?;
-        }
         Ok(())
     }
 }

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -662,8 +662,11 @@ fn consume_blank_line(p: &mut MarkdownParser) {
 /// If the paragraph is followed by a setext heading underline (=== or ---),
 /// it becomes a setext heading instead.
 ///
-/// Grammar: MdParagraph = list: MdInlineItemList hard_line: MdHardLine?
+/// Grammar: MdParagraph = list: MdInlineItemList
 /// Grammar: MdSetextHeader = content: MdInlineItemList underline: 'md_setext_underline_literal'
+///
+/// Hard line breaks are inline items inside `list` (`AnyMdInline::MdHardLine`),
+/// not a paragraph-level slot.
 pub(crate) fn parse_paragraph(p: &mut MarkdownParser) -> ParsedSyntax {
     let m = p.start();
 

--- a/crates/biome_markdown_parser/tests/md_test_suite/error/blockquoted_fence_as_bullet_items.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/error/blockquoted_fence_as_bullet_items.md.snap
@@ -72,7 +72,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@13..14 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -159,7 +158,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@12..13 "x" [] []
                     1: MD_TEXTUAL@13..14
                       0: MD_TEXTUAL_LITERAL@13..14 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@14..16
                   0: MD_QUOTE_INDENT_LIST@14..14
                   1: R_ANGLE@14..15 ">" [] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/error/fence_as_bullet_items.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/error/fence_as_bullet_items.md.snap
@@ -60,7 +60,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@9..10 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -130,7 +129,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@8..9 "x" [] []
                 1: MD_TEXTUAL@9..10
                   0: MD_TEXTUAL_LITERAL@9..10 "\n" [] []
-              1: (empty)
         2: MD_BULLET@10..16
           0: MD_LIST_MARKER_PREFIX@10..12
             0: MD_INDENT_TOKEN_LIST@10..10

--- a/crates/biome_markdown_parser/tests/md_test_suite/error/fenced_code_info_backtick.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/error/fenced_code_info_backtick.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 192
 expression: snapshot
 ---
 
@@ -46,7 +45,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@61..62 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@62..62 "" [] [],
@@ -77,7 +75,6 @@ MdDocument {
           2: BACKTICK@60..61 "`" [] []
         5: MD_TEXTUAL@61..62
           0: MD_TEXTUAL_LITERAL@61..62 "\n" [] []
-      1: (empty)
   2: EOF@62..62 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/error/quote_nesting_too_deep.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/error/quote_nesting_too_deep.md.snap
@@ -171,7 +171,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@110..111 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@111..111 "" [] [],
@@ -793,7 +792,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@102..110 "Too deep" [] []
         1: MD_TEXTUAL@110..111
           0: MD_TEXTUAL_LITERAL@110..111 "\n" [] []
-      1: (empty)
   2: EOF@111..111 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/error/too_many_hashes.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/error/too_many_hashes.md.snap
@@ -29,7 +29,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@32..33 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@33..33 "" [] [],
@@ -50,7 +49,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@7..32 " This has too many hashes" [] []
         2: MD_TEXTUAL@32..33
           0: MD_TEXTUAL_LITERAL@32..33 "\n" [] []
-      1: (empty)
   2: EOF@33..33 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/atx_heading_trailing_hash.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/atx_heading_trailing_hash.md.snap
@@ -36,7 +36,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@5..6 "#" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -56,7 +55,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@8..12 " foo" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [
                 MdHash {
@@ -80,7 +78,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@16..22 "   foo" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [
                 MdHash {
@@ -103,7 +100,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@31..32 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@32..32 "" [] [],
@@ -127,7 +123,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@1..5 " foo" [] []
           1: MD_TEXTUAL@5..6
             0: MD_TEXTUAL_LITERAL@5..6 "#" [] []
-        1: (empty)
       3: MD_HASH_LIST@6..6
     1: MD_NEWLINE@6..7
       0: NEWLINE@6..7 "\n" [] []
@@ -140,7 +135,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@8..12
           0: MD_TEXTUAL@8..12
             0: MD_TEXTUAL_LITERAL@8..12 " foo" [] []
-        1: (empty)
       3: MD_HASH_LIST@12..14
         0: MD_HASH@12..14
           0: HASH@12..14 "#" [Whitespace(" ")] []
@@ -155,7 +149,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@16..22
           0: MD_TEXTUAL@16..22
             0: MD_TEXTUAL_LITERAL@16..22 "   foo" [] []
-        1: (empty)
       3: MD_HASH_LIST@22..26
         0: MD_HASH@22..26
           0: HASH@22..26 "#" [Whitespace(" "), Whitespace(" "), Whitespace(" ")] []
@@ -169,7 +162,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@28..31 "foo" [] []
         2: MD_TEXTUAL@31..32
           0: MD_TEXTUAL_LITERAL@31..32 "\n" [] []
-      1: (empty)
   2: EOF@32..32 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/autolinks.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/autolinks.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 131
 expression: snapshot
 ---
 
@@ -50,7 +49,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@35..36 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@36..37 "\n" [] [],
@@ -73,7 +71,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@71..72 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@72..73 "\n" [] [],
@@ -111,7 +108,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@115..116 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@116..117 "\n" [] [],
@@ -143,7 +139,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@167..168 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@168..169 "\n" [] [],
@@ -187,7 +182,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@216..217 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@217..218 "\n" [] [],
@@ -228,7 +222,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@266..267 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@267..268 "\n" [] [],
@@ -266,7 +259,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@314..315 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@315..316 "\n" [] [],
@@ -304,7 +296,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@425..426 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@426..426 "" [] [],
@@ -329,7 +320,6 @@ MdDocument {
           2: R_ANGLE@34..35 ">" [] []
         2: MD_TEXTUAL@35..36
           0: MD_TEXTUAL_LITERAL@35..36 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@36..37
       0: NEWLINE@36..37 "\n" [] []
     2: MD_PARAGRAPH@37..72
@@ -344,7 +334,6 @@ MdDocument {
           2: R_ANGLE@70..71 ">" [] []
         2: MD_TEXTUAL@71..72
           0: MD_TEXTUAL_LITERAL@71..72 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@72..73
       0: NEWLINE@72..73 "\n" [] []
     4: MD_PARAGRAPH@73..116
@@ -369,7 +358,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@114..115 ">" [] []
         9: MD_TEXTUAL@115..116
           0: MD_TEXTUAL_LITERAL@115..116 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@116..117
       0: NEWLINE@116..117 "\n" [] []
     6: MD_PARAGRAPH@117..168
@@ -390,7 +378,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@157..167 " for more." [] []
         3: MD_TEXTUAL@167..168
           0: MD_TEXTUAL_LITERAL@167..168 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@168..169
       0: NEWLINE@168..169 "\n" [] []
     8: MD_PARAGRAPH@169..217
@@ -419,7 +406,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@215..216 ">" [] []
         11: MD_TEXTUAL@216..217
           0: MD_TEXTUAL_LITERAL@216..217 "\n" [] []
-      1: (empty)
     9: MD_NEWLINE@217..218
       0: NEWLINE@217..218 "\n" [] []
     10: MD_PARAGRAPH@218..267
@@ -446,7 +432,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@265..266 ">" [] []
         10: MD_TEXTUAL@266..267
           0: MD_TEXTUAL_LITERAL@266..267 "\n" [] []
-      1: (empty)
     11: MD_NEWLINE@267..268
       0: NEWLINE@267..268 "\n" [] []
     12: MD_PARAGRAPH@268..315
@@ -471,7 +456,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@313..314 ">" [] []
         9: MD_TEXTUAL@314..315
           0: MD_TEXTUAL_LITERAL@314..315 "\n" [] []
-      1: (empty)
     13: MD_NEWLINE@315..316
       0: NEWLINE@315..316 "\n" [] []
     14: MD_PARAGRAPH@316..426
@@ -496,7 +480,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@424..425 ">" [] []
         9: MD_TEXTUAL@425..426
           0: MD_TEXTUAL_LITERAL@425..426 "\n" [] []
-      1: (empty)
   2: EOF@426..426 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote.md.snap
@@ -47,7 +47,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@37..38 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -70,7 +69,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@60..61 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -105,7 +103,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@20..37 "It continues here" [] []
             4: MD_TEXTUAL@37..38
               0: MD_TEXTUAL_LITERAL@37..38 "\n" [] []
-          1: (empty)
     1: MD_NEWLINE@38..39
       0: NEWLINE@38..39 "\n" [] []
     2: MD_QUOTE@39..61
@@ -120,7 +117,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@41..60 "Another quote block" [] []
             1: MD_TEXTUAL@60..61
               0: MD_TEXTUAL_LITERAL@60..61 "\n" [] []
-          1: (empty)
   2: EOF@61..61 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_grouping.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_grouping.md.snap
@@ -50,7 +50,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -84,7 +83,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@17..18 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -114,7 +112,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@29..30 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -151,7 +148,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@6..7 "b" [] []
             4: MD_TEXTUAL@7..8
               0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-          1: (empty)
     1: MD_NEWLINE@8..9
       0: NEWLINE@8..9 "\n" [] []
     2: MD_QUOTE@9..18
@@ -174,7 +170,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@16..17 "b" [] []
             4: MD_TEXTUAL@17..18
               0: MD_TEXTUAL_LITERAL@17..18 "\n" [] []
-          1: (empty)
     3: MD_NEWLINE@18..19
       0: NEWLINE@18..19 "\n" [] []
     4: MD_QUOTE@19..30
@@ -195,7 +190,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@23..29 "nested" [] []
                 1: MD_TEXTUAL@29..30
                   0: MD_TEXTUAL_LITERAL@29..30 "\n" [] []
-              1: (empty)
   2: EOF@30..30 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_list_interrupt.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_list_interrupt.md.snap
@@ -68,7 +68,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@29..30 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -124,7 +123,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@45..46 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -180,7 +178,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@25..29 " baz" [] []
                     5: MD_TEXTUAL@29..30
                       0: MD_TEXTUAL_LITERAL@29..30 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@30..32
                   0: MD_QUOTE_INDENT_LIST@30..30
                   1: R_ANGLE@30..31 ">" [] []
@@ -216,7 +213,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@44..45 ">" [] []
                     3: MD_TEXTUAL@45..46
                       0: MD_TEXTUAL_LITERAL@45..46 "\n" [] []
-                  1: (empty)
   2: EOF@46..46 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_sublist_after_list_item.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_ordered_sublist_after_list_item.md.snap
@@ -44,7 +44,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@10..11 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -77,7 +76,6 @@ MdDocument {
                                                             value_token: MD_TEXTUAL_LITERAL@23..24 "\n" [] [],
                                                         },
                                                     ],
-                                                    hard_line: missing (optional),
                                                 },
                                             ],
                                         },
@@ -121,7 +119,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@4..10 "parent" [] []
                     1: MD_TEXTUAL@10..11
                       0: MD_TEXTUAL_LITERAL@10..11 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@11..13
                   0: MD_QUOTE_INDENT_LIST@11..11
                   1: R_ANGLE@11..12 ">" [] []
@@ -145,7 +142,6 @@ MdDocument {
                               0: MD_TEXTUAL_LITERAL@18..23 "child" [] []
                             1: MD_TEXTUAL@23..24
                               0: MD_TEXTUAL_LITERAL@23..24 "\n" [] []
-                          1: (empty)
   2: EOF@24..24 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_tab_separated.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_tab_separated.md.snap
@@ -40,7 +40,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -75,7 +74,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@4..7 "foo" [] []
                 1: MD_TEXTUAL@7..8
                   0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-              1: (empty)
   2: EOF@8..8 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_thematic_break_after_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/block_quote_thematic_break_after_list.md.snap
@@ -51,7 +51,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@8..9 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -120,7 +119,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -212,7 +210,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@5..8 "foo" [] []
                     1: MD_TEXTUAL@8..9
                       0: MD_TEXTUAL_LITERAL@8..9 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@9..11
                   0: MD_QUOTE_INDENT_LIST@9..9
                   1: R_ANGLE@9..10 ">" [] []
@@ -258,7 +255,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@27..30 "Bar" [] []
                     4: MD_TEXTUAL@30..31
                       0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@31..33
                   0: MD_QUOTE_INDENT_LIST@31..31
                   1: R_ANGLE@31..32 ">" [] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/blockquote_ends_at_unprefixed_ordered_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/blockquote_ends_at_unprefixed_ordered_list.md.snap
@@ -34,7 +34,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@3..4 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -57,7 +56,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@12..13 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -86,7 +84,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@2..3 "a" [] []
             1: MD_TEXTUAL@3..4
               0: MD_TEXTUAL_LITERAL@3..4 "\n" [] []
-          1: (empty)
     1: MD_ORDERED_LIST_ITEM@4..13
       0: MD_BULLET_LIST@4..13
         0: MD_BULLET@4..13
@@ -102,7 +99,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@8..12 "item" [] []
                 1: MD_TEXTUAL@12..13
                   0: MD_TEXTUAL_LITERAL@12..13 "\n" [] []
-              1: (empty)
   2: EOF@13..13 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/blockquote_inside_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/blockquote_inside_list.md.snap
@@ -44,7 +44,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@6..7 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -90,7 +89,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@26..27 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -116,7 +114,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@36..37 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -144,7 +141,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@53..54 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -174,7 +170,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@65..66 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -205,7 +200,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@83..84 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -239,7 +233,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..6 "item" [] []
                 1: MD_TEXTUAL@6..7
                   0: MD_TEXTUAL_LITERAL@6..7 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@7..9
               0: MD_INDENT_TOKEN_LIST@7..9
                 0: MD_INDENT_TOKEN@7..8
@@ -270,7 +263,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@22..26 "more" [] []
                     4: MD_TEXTUAL@26..27
                       0: MD_TEXTUAL_LITERAL@26..27 "\n" [] []
-                  1: (empty)
             3: MD_NEWLINE@27..28
               0: NEWLINE@27..28 "\n" [] []
         1: MD_BULLET@28..54
@@ -286,7 +278,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@30..36 "before" [] []
                 1: MD_TEXTUAL@36..37
                   0: MD_TEXTUAL_LITERAL@36..37 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@37..39
               0: MD_INDENT_TOKEN_LIST@37..39
                 0: MD_INDENT_TOKEN@37..38
@@ -305,7 +296,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@41..53 "single quote" [] []
                     1: MD_TEXTUAL@53..54
                       0: MD_TEXTUAL_LITERAL@53..54 "\n" [] []
-                  1: (empty)
     1: MD_NEWLINE@54..55
       0: NEWLINE@54..55 "\n" [] []
     2: MD_ORDERED_LIST_ITEM@55..84
@@ -323,7 +313,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@58..65 "ordered" [] []
                 1: MD_TEXTUAL@65..66
                   0: MD_TEXTUAL_LITERAL@65..66 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@66..69
               0: MD_INDENT_TOKEN_LIST@66..69
                 0: MD_INDENT_TOKEN@66..67
@@ -344,7 +333,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@71..83 "nested quote" [] []
                     1: MD_TEXTUAL@83..84
                       0: MD_TEXTUAL_LITERAL@83..84 "\n" [] []
-                  1: (empty)
   2: EOF@84..84 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/blockquote_tab_indented_bullet.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/blockquote_tab_indented_bullet.md.snap
@@ -47,7 +47,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@11..12 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -89,7 +88,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@5..11 "nested" [] []
                     1: MD_TEXTUAL@11..12
                       0: MD_TEXTUAL_LITERAL@11..12 "\n" [] []
-                  1: (empty)
   2: EOF@12..12 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/blockquote_tab_indented_bullet_siblings.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/blockquote_tab_indented_bullet_siblings.md.snap
@@ -35,7 +35,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -65,7 +64,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@14..15 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -95,7 +93,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@21..22 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -126,7 +123,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@2..7 "outer" [] []
             1: MD_TEXTUAL@7..8
               0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@8..10
           0: MD_QUOTE_INDENT_LIST@8..8
           1: R_ANGLE@8..9 ">" [] []
@@ -148,7 +144,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@13..14 "a" [] []
                     1: MD_TEXTUAL@14..15
                       0: MD_TEXTUAL_LITERAL@14..15 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@15..17
                   0: MD_QUOTE_INDENT_LIST@15..15
                   1: R_ANGLE@15..16 ">" [] []
@@ -168,7 +163,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@20..21 "b" [] []
                     1: MD_TEXTUAL@21..22
                       0: MD_TEXTUAL_LITERAL@21..22 "\n" [] []
-                  1: (empty)
   2: EOF@22..22 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/bom.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/bom.md.snap
@@ -32,7 +32,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@4..10 " Hello" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -51,7 +50,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@17..18 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@18..18 "" [] [],
@@ -73,7 +71,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@4..10
           0: MD_TEXTUAL@4..10
             0: MD_TEXTUAL_LITERAL@4..10 " Hello" [] []
-        1: (empty)
       3: MD_HASH_LIST@10..10
     1: MD_NEWLINE@10..11
       0: NEWLINE@10..11 "\n" [] []
@@ -85,7 +82,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@12..17 "world" [] []
         1: MD_TEXTUAL@17..18
           0: MD_TEXTUAL_LITERAL@17..18 "\n" [] []
-      1: (empty)
   2: EOF@18..18 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list.md.snap
@@ -44,7 +44,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@10..11 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -65,7 +64,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@21..22 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -86,7 +84,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@34..35 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -114,7 +111,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@56..57 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -135,7 +131,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@71..72 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -163,7 +158,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@86..87 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -184,7 +178,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@106..107 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -216,7 +209,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..10 "Item one" [] []
                 1: MD_TEXTUAL@10..11
                   0: MD_TEXTUAL_LITERAL@10..11 "\n" [] []
-              1: (empty)
         1: MD_BULLET@11..22
           0: MD_LIST_MARKER_PREFIX@11..13
             0: MD_INDENT_TOKEN_LIST@11..11
@@ -230,7 +222,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@13..21 "Item two" [] []
                 1: MD_TEXTUAL@21..22
                   0: MD_TEXTUAL_LITERAL@21..22 "\n" [] []
-              1: (empty)
         2: MD_BULLET@22..35
           0: MD_LIST_MARKER_PREFIX@22..24
             0: MD_INDENT_TOKEN_LIST@22..22
@@ -244,7 +235,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@24..34 "Item three" [] []
                 1: MD_TEXTUAL@34..35
                   0: MD_TEXTUAL_LITERAL@34..35 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@35..36
       0: NEWLINE@35..36 "\n" [] []
     2: MD_BULLET_LIST_ITEM@36..72
@@ -262,7 +252,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@38..56 "Alternative marker" [] []
                 1: MD_TEXTUAL@56..57
                   0: MD_TEXTUAL_LITERAL@56..57 "\n" [] []
-              1: (empty)
         1: MD_BULLET@57..72
           0: MD_LIST_MARKER_PREFIX@57..59
             0: MD_INDENT_TOKEN_LIST@57..57
@@ -276,7 +265,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@59..71 "Another item" [] []
                 1: MD_TEXTUAL@71..72
                   0: MD_TEXTUAL_LITERAL@71..72 "\n" [] []
-              1: (empty)
     3: MD_NEWLINE@72..73
       0: NEWLINE@72..73 "\n" [] []
     4: MD_BULLET_LIST_ITEM@73..107
@@ -294,7 +282,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@75..86 "Plus marker" [] []
                 1: MD_TEXTUAL@86..87
                   0: MD_TEXTUAL_LITERAL@86..87 "\n" [] []
-              1: (empty)
         1: MD_BULLET@87..107
           0: MD_LIST_MARKER_PREFIX@87..89
             0: MD_INDENT_TOKEN_LIST@87..87
@@ -308,7 +295,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@89..106 "Another plus item" [] []
                 1: MD_TEXTUAL@106..107
                   0: MD_TEXTUAL_LITERAL@106..107 "\n" [] []
-              1: (empty)
   2: EOF@107..107 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_loose_after_empty_item.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_loose_after_empty_item.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@3..4 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -76,7 +75,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@10..11 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -108,7 +106,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..3 "a" [] []
                 1: MD_TEXTUAL@3..4
                   0: MD_TEXTUAL_LITERAL@3..4 "\n" [] []
-              1: (empty)
         1: MD_BULLET@4..7
           0: MD_LIST_MARKER_PREFIX@4..5
             0: MD_INDENT_TOKEN_LIST@4..4
@@ -133,7 +130,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@9..10 "c" [] []
                 1: MD_TEXTUAL@10..11
                   0: MD_TEXTUAL_LITERAL@10..11 "\n" [] []
-              1: (empty)
   2: EOF@11..11 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_space_tab_space.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_space_tab_space.md.snap
@@ -43,7 +43,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -79,7 +78,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@4..7 "foo" [] []
                 1: MD_TEXTUAL@7..8
                   0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-              1: (empty)
   2: EOF@8..8 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_split_after_empty_item_marker_change.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_split_after_empty_item_marker_change.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@3..4 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -80,7 +79,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@10..11 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -112,7 +110,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..3 "a" [] []
                 1: MD_TEXTUAL@3..4
                   0: MD_TEXTUAL_LITERAL@3..4 "\n" [] []
-              1: (empty)
         1: MD_BULLET@4..6
           0: MD_LIST_MARKER_PREFIX@4..5
             0: MD_INDENT_TOKEN_LIST@4..4
@@ -139,7 +136,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@9..10 "c" [] []
                 1: MD_TEXTUAL@10..11
                   0: MD_TEXTUAL_LITERAL@10..11 "\n" [] []
-              1: (empty)
   2: EOF@11..11 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_split_after_empty_item_paragraph.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_split_after_empty_item_paragraph.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@3..4 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -70,7 +69,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@10..11 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@11..11 "" [] [],
@@ -98,7 +96,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..3 "a" [] []
                 1: MD_TEXTUAL@3..4
                   0: MD_TEXTUAL_LITERAL@3..4 "\n" [] []
-              1: (empty)
         1: MD_BULLET@4..6
           0: MD_LIST_MARKER_PREFIX@4..5
             0: MD_INDENT_TOKEN_LIST@4..4
@@ -116,7 +113,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@7..10 "foo" [] []
         1: MD_TEXTUAL@10..11
           0: MD_TEXTUAL_LITERAL@10..11 "\n" [] []
-      1: (empty)
   2: EOF@11..11 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_tab_separated.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_list_tab_separated.md.snap
@@ -36,7 +36,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -68,7 +67,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "foo" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
   2: EOF@6..6 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_to_ordered_split.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/bullet_to_ordered_split.md.snap
@@ -38,7 +38,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@8..9 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -66,7 +65,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -98,7 +96,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..8 "bullet" [] []
                 1: MD_TEXTUAL@8..9
                   0: MD_TEXTUAL_LITERAL@8..9 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@9..10
       0: NEWLINE@9..10 "\n" [] []
     2: MD_ORDERED_LIST_ITEM@10..21
@@ -116,7 +113,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@13..20 "ordered" [] []
                 1: MD_TEXTUAL@20..21
                   0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-              1: (empty)
   2: EOF@21..21 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/edge_cases.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/edge_cases.md.snap
@@ -58,7 +58,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@15..16 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@16..17 "\n" [] [],
@@ -75,7 +74,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@31..32 "\n" [] [],
@@ -101,7 +99,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@67..68 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@68..69 "\n" [] [],
@@ -121,7 +118,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@100..101 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@101..102 "\n" [] [],
@@ -206,7 +202,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@163..195 "\tTab after hash is valid heading" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -229,7 +224,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@199..224 "\tMultiple hashes with tab" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -335,7 +329,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@363..364 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@364..365 "\n" [] [],
@@ -349,7 +342,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@377..378 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdHeader {
             indent: MdIndentTokenList [
@@ -383,7 +375,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@415..416 ")" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -441,7 +432,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@504..505 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@505..505 "" [] [],
@@ -462,7 +452,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@1..15 "NoSpaceHeading" [] []
         2: MD_TEXTUAL@15..16
           0: MD_TEXTUAL_LITERAL@15..16 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@16..17
       0: NEWLINE@16..17 "\n" [] []
     2: MD_PARAGRAPH@17..31
@@ -473,7 +462,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@19..30 "AlsoNoSpace" [] []
         2: MD_TEXTUAL@30..31
           0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@31..32
       0: NEWLINE@31..32 "\n" [] []
     4: MD_PARAGRAPH@32..68
@@ -490,7 +478,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@39..67 " bar is not a thematic break" [] []
         5: MD_TEXTUAL@67..68
           0: MD_TEXTUAL_LITERAL@67..68 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@68..69
       0: NEWLINE@68..69 "\n" [] []
     6: MD_PARAGRAPH@69..101
@@ -503,7 +490,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@79..100 " tilde is not a fence" [] []
         3: MD_TEXTUAL@100..101
           0: MD_TEXTUAL_LITERAL@100..101 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@101..102
       0: NEWLINE@101..102 "\n" [] []
     8: MD_INDENT_CODE_BLOCK@102..161
@@ -559,7 +545,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@163..195
           0: MD_TEXTUAL@163..195
             0: MD_TEXTUAL_LITERAL@163..195 "\tTab after hash is valid heading" [] []
-        1: (empty)
       3: MD_HASH_LIST@195..195
     11: MD_NEWLINE@195..196
       0: NEWLINE@195..196 "\n" [] []
@@ -574,7 +559,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@199..224
           0: MD_TEXTUAL@199..224
             0: MD_TEXTUAL_LITERAL@199..224 "\tMultiple hashes with tab" [] []
-        1: (empty)
       3: MD_HASH_LIST@224..224
     14: MD_NEWLINE@224..225
       0: NEWLINE@224..225 "\n" [] []
@@ -644,7 +628,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@341..363 "continues as paragraph" [] []
         30: MD_TEXTUAL@363..364
           0: MD_TEXTUAL_LITERAL@363..364 "\n" [] []
-      1: (empty)
     17: MD_NEWLINE@364..365
       0: NEWLINE@364..365 "\n" [] []
     18: MD_PARAGRAPH@365..378
@@ -653,7 +636,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@365..377 "Another para" [] []
         1: MD_TEXTUAL@377..378
           0: MD_TEXTUAL_LITERAL@377..378 "\n" [] []
-      1: (empty)
     19: MD_HEADER@378..416
       0: MD_INDENT_TOKEN_LIST@378..381
         0: MD_INDENT_TOKEN@378..379
@@ -675,7 +657,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@402..415 "only 3 spaces" [] []
           3: MD_TEXTUAL@415..416
             0: MD_TEXTUAL_LITERAL@415..416 ")" [] []
-        1: (empty)
       3: MD_HASH_LIST@416..416
     20: MD_NEWLINE@416..417
       0: NEWLINE@416..417 "\n" [] []
@@ -713,7 +694,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@480..504 "still the same paragraph" [] []
         9: MD_TEXTUAL@504..505
           0: MD_TEXTUAL_LITERAL@504..505 "\n" [] []
-      1: (empty)
   2: EOF@505..505 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_complex.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_complex.md.snap
@@ -59,7 +59,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@34..35 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@35..36 "\n" [] [],
@@ -94,7 +93,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@64..65 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@65..66 "\n" [] [],
@@ -123,7 +121,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@94..95 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@95..96 "\n" [] [],
@@ -158,7 +155,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@122..123 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@123..124 "\n" [] [],
@@ -187,7 +183,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@156..157 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@157..158 "\n" [] [],
@@ -213,7 +208,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@180..181 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@181..182 "\n" [] [],
@@ -239,7 +233,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@215..216 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@216..216 "" [] [],
@@ -272,7 +265,6 @@ MdDocument {
           2: DOUBLE_STAR@32..34 "**" [] []
         2: MD_TEXTUAL@34..35
           0: MD_TEXTUAL_LITERAL@34..35 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@35..36
       0: NEWLINE@35..36 "\n" [] []
     2: MD_PARAGRAPH@36..65
@@ -295,7 +287,6 @@ MdDocument {
           2: STAR@63..64 "*" [] []
         2: MD_TEXTUAL@64..65
           0: MD_TEXTUAL_LITERAL@64..65 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@65..66
       0: NEWLINE@65..66 "\n" [] []
     4: MD_PARAGRAPH@66..95
@@ -314,7 +305,6 @@ MdDocument {
           2: STAR@93..94 "*" [] []
         2: MD_TEXTUAL@94..95
           0: MD_TEXTUAL_LITERAL@94..95 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@95..96
       0: NEWLINE@95..96 "\n" [] []
     6: MD_PARAGRAPH@96..123
@@ -337,7 +327,6 @@ MdDocument {
           2: STAR@121..122 "*" [] []
         2: MD_TEXTUAL@122..123
           0: MD_TEXTUAL_LITERAL@122..123 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@123..124
       0: NEWLINE@123..124 "\n" [] []
     8: MD_PARAGRAPH@124..157
@@ -356,7 +345,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@155..156 "*" [] []
         6: MD_TEXTUAL@156..157
           0: MD_TEXTUAL_LITERAL@156..157 "\n" [] []
-      1: (empty)
     9: MD_NEWLINE@157..158
       0: NEWLINE@157..158 "\n" [] []
     10: MD_PARAGRAPH@158..181
@@ -373,7 +361,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@177..180 "baz" [] []
         3: MD_TEXTUAL@180..181
           0: MD_TEXTUAL_LITERAL@180..181 "\n" [] []
-      1: (empty)
     11: MD_NEWLINE@181..182
       0: NEWLINE@181..182 "\n" [] []
     12: MD_PARAGRAPH@182..216
@@ -390,7 +377,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@212..215 "baz" [] []
         5: MD_TEXTUAL@215..216
           0: MD_TEXTUAL_LITERAL@215..216 "\n" [] []
-      1: (empty)
   2: EOF@216..216 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_crossing.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_crossing.md.snap
@@ -53,7 +53,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@21..22 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@22..22 "" [] [],
@@ -90,7 +89,6 @@ MdDocument {
           2: STAR@20..21 "*" [] []
         2: MD_TEXTUAL@21..22
           0: MD_TEXTUAL_LITERAL@21..22 "\n" [] []
-      1: (empty)
   2: EOF@22..22 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_edge_cases.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_edge_cases.md.snap
@@ -57,7 +57,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@43..44 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@44..45 "\n" [] [],
@@ -80,7 +79,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@80..81 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@81..82 "\n" [] [],
@@ -129,7 +127,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@130..131 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@131..132 "\n" [] [],
@@ -184,7 +181,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@188..189 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@189..190 "\n" [] [],
@@ -222,7 +218,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@236..237 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@237..238 "\n" [] [],
@@ -259,7 +254,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@282..283 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@283..284 "\n" [] [],
@@ -297,7 +291,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@324..325 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@325..326 "\n" [] [],
@@ -336,7 +329,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@357..358 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@358..359 "\n" [] [],
@@ -395,7 +387,6 @@ MdDocument {
           2: BACKTICK@42..43 "`" [] []
         2: MD_TEXTUAL@43..44
           0: MD_TEXTUAL_LITERAL@43..44 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@44..45
       0: NEWLINE@44..45 "\n" [] []
     2: MD_PARAGRAPH@45..81
@@ -410,7 +401,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@78..80 "\\*" [] []
         4: MD_TEXTUAL@80..81
           0: MD_TEXTUAL_LITERAL@80..81 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@81..82
       0: NEWLINE@81..82 "\n" [] []
     4: MD_PARAGRAPH@82..131
@@ -441,7 +431,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@129..130 ">" [] []
         4: MD_TEXTUAL@130..131
           0: MD_TEXTUAL_LITERAL@130..131 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@131..132
       0: NEWLINE@131..132 "\n" [] []
     6: MD_PARAGRAPH@132..189
@@ -476,7 +465,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@187..188 ">" [] []
         4: MD_TEXTUAL@188..189
           0: MD_TEXTUAL_LITERAL@188..189 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@189..190
       0: NEWLINE@189..190 "\n" [] []
     8: MD_PARAGRAPH@190..237
@@ -501,7 +489,6 @@ MdDocument {
           2: R_ANGLE@235..236 ">" [] []
         2: MD_TEXTUAL@236..237
           0: MD_TEXTUAL_LITERAL@236..237 "\n" [] []
-      1: (empty)
     9: MD_NEWLINE@237..238
       0: NEWLINE@237..238 "\n" [] []
     10: MD_PARAGRAPH@238..283
@@ -526,7 +513,6 @@ MdDocument {
           6: R_PAREN@281..282 ")" [] []
         2: MD_TEXTUAL@282..283
           0: MD_TEXTUAL_LITERAL@282..283 "\n" [] []
-      1: (empty)
     11: MD_NEWLINE@283..284
       0: NEWLINE@283..284 "\n" [] []
     12: MD_PARAGRAPH@284..325
@@ -551,7 +537,6 @@ MdDocument {
             2: R_BRACK@323..324 "]" [] []
         2: MD_TEXTUAL@324..325
           0: MD_TEXTUAL_LITERAL@324..325 "\n" [] []
-      1: (empty)
     13: MD_NEWLINE@325..326
       0: NEWLINE@325..326 "\n" [] []
     14: MD_PARAGRAPH@326..358
@@ -577,7 +562,6 @@ MdDocument {
             2: R_BRACK@356..357 "]" [] []
         2: MD_TEXTUAL@357..358
           0: MD_TEXTUAL_LITERAL@357..358 "\n" [] []
-      1: (empty)
     15: MD_NEWLINE@358..359
       0: NEWLINE@358..359 "\n" [] []
     16: MD_LINK_REFERENCE_DEFINITION@359..387

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_flanking.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_flanking.md.snap
@@ -57,7 +57,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@37..38 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@38..39 "\n" [] [],
@@ -92,7 +91,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@78..79 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@79..80 "\n" [] [],
@@ -118,7 +116,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@135..136 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@136..137 "\n" [] [],
@@ -153,7 +150,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@185..186 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@186..187 "\n" [] [],
@@ -176,7 +172,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@228..229 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@229..230 "\n" [] [],
@@ -202,7 +197,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@250..251 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@251..251 "" [] [],
@@ -235,7 +229,6 @@ MdDocument {
           2: DOUBLE_STAR@35..37 "**" [] []
         4: MD_TEXTUAL@37..38
           0: MD_TEXTUAL_LITERAL@37..38 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@38..39
       0: NEWLINE@38..39 "\n" [] []
     2: MD_PARAGRAPH@39..79
@@ -258,7 +251,6 @@ MdDocument {
           2: DOUBLE_UNDERSCORE@76..78 "__" [] []
         4: MD_TEXTUAL@78..79
           0: MD_TEXTUAL_LITERAL@78..79 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@79..80
       0: NEWLINE@79..80 "\n" [] []
     4: MD_PARAGRAPH@80..136
@@ -275,7 +267,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@112..135 " should not be emphasis" [] []
         5: MD_TEXTUAL@135..136
           0: MD_TEXTUAL_LITERAL@135..136 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@136..137
       0: NEWLINE@136..137 "\n" [] []
     6: MD_PARAGRAPH@137..186
@@ -298,7 +289,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@184..185 ")" [] []
         8: MD_TEXTUAL@185..186
           0: MD_TEXTUAL_LITERAL@185..186 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@186..187
       0: NEWLINE@186..187 "\n" [] []
     8: MD_PARAGRAPH@187..229
@@ -313,7 +303,6 @@ MdDocument {
           2: UNDERSCORE@227..228 "_" [] []
         2: MD_TEXTUAL@228..229
           0: MD_TEXTUAL_LITERAL@228..229 "\n" [] []
-      1: (empty)
     9: MD_NEWLINE@229..230
       0: NEWLINE@229..230 "\n" [] []
     10: MD_PARAGRAPH@230..251
@@ -330,7 +319,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@246..250 " baz" [] []
         3: MD_TEXTUAL@250..251
           0: MD_TEXTUAL_LITERAL@250..251 "\n" [] []
-      1: (empty)
   2: EOF@251..251 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_link_text.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_link_text.md.snap
@@ -55,7 +55,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@32..33 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@33..33 "" [] [],
@@ -94,7 +93,6 @@ MdDocument {
           6: R_PAREN@31..32 ")" [] []
         2: MD_TEXTUAL@32..33
           0: MD_TEXTUAL_LITERAL@32..33 "\n" [] []
-      1: (empty)
   2: EOF@33..33 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_multibyte.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/emphasis_multibyte.md.snap
@@ -59,7 +59,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@167..168 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -104,7 +103,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@113..167 "と同様のアプローチを採用しています。" [] []
             3: MD_TEXTUAL@167..168
               0: MD_TEXTUAL_LITERAL@167..168 "\n" [] []
-          1: (empty)
   2: EOF@168..168 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/entity_references.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/entity_references.md.snap
@@ -51,7 +51,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@35..36 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@36..37 "\n" [] [],
@@ -74,7 +73,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@67..68 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@68..69 "\n" [] [],
@@ -97,7 +95,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@96..97 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@97..98 "\n" [] [],
@@ -123,7 +120,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@130..131 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@131..132 "\n" [] [],
@@ -200,7 +196,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@221..222 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@222..223 "\n" [] [],
@@ -241,7 +236,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@301..302 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@302..302 "" [] [],
@@ -270,7 +264,6 @@ MdDocument {
           0: MD_ENTITY_LITERAL@29..35 "&nbsp;" [] []
         6: MD_TEXTUAL@35..36
           0: MD_TEXTUAL_LITERAL@35..36 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@36..37
       0: NEWLINE@36..37 "\n" [] []
     2: MD_PARAGRAPH@37..68
@@ -285,7 +278,6 @@ MdDocument {
           0: MD_ENTITY_LITERAL@62..67 "&#65;" [] []
         4: MD_TEXTUAL@67..68
           0: MD_TEXTUAL_LITERAL@67..68 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@68..69
       0: NEWLINE@68..69 "\n" [] []
     4: MD_PARAGRAPH@69..97
@@ -300,7 +292,6 @@ MdDocument {
           0: MD_ENTITY_LITERAL@90..96 "&#X2F;" [] []
         4: MD_TEXTUAL@96..97
           0: MD_TEXTUAL_LITERAL@96..97 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@97..98
       0: NEWLINE@97..98 "\n" [] []
     6: MD_PARAGRAPH@98..131
@@ -317,7 +308,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@120..130 " for HTML." [] []
         5: MD_TEXTUAL@130..131
           0: MD_TEXTUAL_LITERAL@130..131 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@131..132
       0: NEWLINE@131..132 "\n" [] []
     8: MD_PARAGRAPH@132..222
@@ -368,7 +358,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@215..221 "& foo;" [] []
         22: MD_TEXTUAL@221..222
           0: MD_TEXTUAL_LITERAL@221..222 "\n" [] []
-      1: (empty)
     9: MD_NEWLINE@222..223
       0: NEWLINE@222..223 "\n" [] []
     10: MD_PARAGRAPH@223..302
@@ -395,7 +384,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@300..301 ")" [] []
         10: MD_TEXTUAL@301..302
           0: MD_TEXTUAL_LITERAL@301..302 "\n" [] []
-      1: (empty)
   2: EOF@302..302 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/fenced_code_advanced.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/fenced_code_advanced.md.snap
@@ -75,7 +75,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdFencedCodeBlock {
             indent: MdIndentTokenList [],
@@ -122,7 +121,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@62..63 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdFencedCodeBlock {
             indent: MdIndentTokenList [],
@@ -163,7 +161,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@104..105 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdFencedCodeBlock {
             indent: MdIndentTokenList [],
@@ -210,7 +207,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@144..145 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdFencedCodeBlock {
             indent: MdIndentTokenList [],
@@ -269,7 +265,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@199..200 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdFencedCodeBlock {
             indent: MdIndentTokenList [],
@@ -332,7 +327,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@262..263 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdFencedCodeBlock {
             indent: MdIndentTokenList [],
@@ -391,7 +385,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@335..336 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdFencedCodeBlock {
             indent: MdIndentTokenList [
@@ -459,7 +452,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@19..20 ":" [] []
         5: MD_TEXTUAL@20..21
           0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-      1: (empty)
     1: MD_FENCED_CODE_BLOCK@21..33
       0: MD_INDENT_TOKEN_LIST@21..21
       1: TRIPLE_BACKTICK@21..24 "```" [] []
@@ -491,7 +483,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@61..62 ":" [] []
         5: MD_TEXTUAL@62..63
           0: MD_TEXTUAL_LITERAL@62..63 "\n" [] []
-      1: (empty)
     5: MD_FENCED_CODE_BLOCK@63..95
       0: MD_INDENT_TOKEN_LIST@63..63
       1: TRIPLE_BACKTICK@63..68 "`````" [] []
@@ -519,7 +510,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@97..104 "Tildes:" [] []
         1: MD_TEXTUAL@104..105
           0: MD_TEXTUAL_LITERAL@104..105 "\n" [] []
-      1: (empty)
     9: MD_FENCED_CODE_BLOCK@105..117
       0: MD_INDENT_TOKEN_LIST@105..105
       1: TRIPLE_TILDE@105..108 "~~~" [] []
@@ -551,7 +541,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@143..144 ":" [] []
         5: MD_TEXTUAL@144..145
           0: MD_TEXTUAL_LITERAL@144..145 "\n" [] []
-      1: (empty)
     13: MD_FENCED_CODE_BLOCK@145..172
       0: MD_INDENT_TOKEN_LIST@145..145
       1: TRIPLE_BACKTICK@145..148 "```" [] []
@@ -591,7 +580,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@198..199 ":" [] []
         5: MD_TEXTUAL@199..200
           0: MD_TEXTUAL_LITERAL@199..200 "\n" [] []
-      1: (empty)
     17: MD_FENCED_CODE_BLOCK@200..215
       0: MD_INDENT_TOKEN_LIST@200..200
       1: TRIPLE_BACKTICK@200..203 "```" [] []
@@ -633,7 +621,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@261..262 ":" [] []
         7: MD_TEXTUAL@262..263
           0: MD_TEXTUAL_LITERAL@262..263 "\n" [] []
-      1: (empty)
     21: MD_FENCED_CODE_BLOCK@263..292
       0: MD_INDENT_TOKEN_LIST@263..263
       1: TRIPLE_BACKTICK@263..267 "````" [] []
@@ -673,7 +660,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@334..335 ":" [] []
         5: MD_TEXTUAL@335..336
           0: MD_TEXTUAL_LITERAL@335..336 "\n" [] []
-      1: (empty)
     25: MD_FENCED_CODE_BLOCK@336..359
       0: MD_INDENT_TOKEN_LIST@336..338
         0: MD_INDENT_TOKEN@336..337

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/fenced_code_after_list_not_absorbed.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/fenced_code_after_list_not_absorbed.md.snap
@@ -40,7 +40,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -61,7 +60,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@11..12 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -114,7 +112,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "one" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
         1: MD_BULLET@6..12
           0: MD_LIST_MARKER_PREFIX@6..8
             0: MD_INDENT_TOKEN_LIST@6..6
@@ -128,7 +125,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@8..11 "two" [] []
                 1: MD_TEXTUAL@11..12
                   0: MD_TEXTUAL_LITERAL@11..12 "\n" [] []
-              1: (empty)
     1: MD_FENCED_CODE_BLOCK@12..29
       0: MD_INDENT_TOKEN_LIST@12..12
       1: TRIPLE_BACKTICK@12..15 "```" [] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/fenced_code_in_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/fenced_code_in_list.md.snap
@@ -40,7 +40,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@6..7 "\n" [] [],
@@ -142,7 +141,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "aaa" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@6..7
               0: NEWLINE@6..7 "\n" [] []
             2: MD_CONTINUATION_INDENT@7..9

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_break_in_blockquote.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_break_in_blockquote.md.snap
@@ -46,7 +46,6 @@ MdDocument {
                             value_token: MD_HARD_LINE_LITERAL@13..16 "  \n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -67,7 +66,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@20..23 "baz" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -102,7 +100,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@10..13 "bar" [] []
             4: MD_HARD_LINE@13..16
               0: MD_HARD_LINE_LITERAL@13..16 "  \n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@16..17
           0: MD_QUOTE_INDENT_LIST@16..16
           1: R_ANGLE@16..17 ">" [] []
@@ -117,7 +114,6 @@ MdDocument {
           0: MD_INLINE_ITEM_LIST@20..23
             0: MD_TEXTUAL@20..23
               0: MD_TEXTUAL_LITERAL@20..23 "baz" [] []
-          1: (empty)
   2: EOF@23..23 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_break_in_list_item.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_break_in_list_item.md.snap
@@ -46,7 +46,6 @@ MdDocument {
                                     value_token: MD_HARD_LINE_LITERAL@13..16 "  \n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@16..17 "\n" [] [],
@@ -70,7 +69,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@22..23 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@23..24 "\n" [] [],
@@ -91,7 +89,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@26..32 "simple" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -127,7 +124,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@8..13 "bar" [Whitespace(" "), Whitespace(" ")] []
                 3: MD_HARD_LINE@13..16
                   0: MD_HARD_LINE_LITERAL@13..16 "  \n" [] []
-              1: (empty)
             1: MD_NEWLINE@16..17
               0: NEWLINE@16..17 "\n" [] []
             2: MD_CONTINUATION_INDENT@17..19
@@ -142,7 +138,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@19..22 "baz" [] []
                 1: MD_TEXTUAL@22..23
                   0: MD_TEXTUAL_LITERAL@22..23 "\n" [] []
-              1: (empty)
             4: MD_NEWLINE@23..24
               0: NEWLINE@23..24 "\n" [] []
         1: MD_BULLET@24..32
@@ -156,7 +151,6 @@ MdDocument {
               0: MD_INLINE_ITEM_LIST@26..32
                 0: MD_TEXTUAL@26..32
                   0: MD_TEXTUAL_LITERAL@26..32 "simple" [] []
-              1: (empty)
   2: EOF@32..32 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_break_nested_quote_in_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_break_nested_quote_in_list.md.snap
@@ -66,7 +66,6 @@ MdDocument {
                                             value_token: MD_HARD_LINE_LITERAL@21..24 "  \n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [
@@ -104,7 +103,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@41..42 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -130,7 +128,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@50..51 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -180,7 +177,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@17..21 "line" [] []
                     4: MD_HARD_LINE@21..24
                       0: MD_HARD_LINE_LITERAL@21..24 "  \n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@24..27
                   0: MD_QUOTE_INDENT_LIST@24..26
                     0: MD_QUOTE_INDENT@24..25
@@ -205,7 +201,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@32..41 "next para" [] []
                     1: MD_TEXTUAL@41..42
                       0: MD_TEXTUAL_LITERAL@41..42 "\n" [] []
-                  1: (empty)
             1: MD_NEWLINE@42..43
               0: NEWLINE@42..43 "\n" [] []
         1: MD_BULLET@43..51
@@ -221,7 +216,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@45..50 "after" [] []
                 1: MD_TEXTUAL@50..51
                   0: MD_TEXTUAL_LITERAL@50..51 "\n" [] []
-              1: (empty)
   2: EOF@51..51 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break.md.snap
@@ -36,7 +36,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@19..20 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@20..21 "\n" [] [],
@@ -56,7 +55,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@42..43 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@43..43 "" [] [],
@@ -79,7 +77,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@11..19 "Line two" [] []
         3: MD_TEXTUAL@19..20
           0: MD_TEXTUAL_LITERAL@19..20 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@20..21
       0: NEWLINE@20..21 "\n" [] []
     2: MD_PARAGRAPH@21..43
@@ -92,7 +89,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@32..42 "line break" [] []
         3: MD_TEXTUAL@42..43
           0: MD_TEXTUAL_LITERAL@42..43 "\n" [] []
-      1: (empty)
   2: EOF@43..43 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break_paragraph_split.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/hard_line_break_paragraph_split.md.snap
@@ -35,7 +35,6 @@ MdDocument {
                     value_token: MD_HARD_LINE_LITERAL@31..34 "  \n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@34..35 "\n" [] [],
@@ -55,7 +54,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@69..71 "  " [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@71..71 "" [] [],
@@ -78,7 +76,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@6..31 "bar with empty line after" [] []
         3: MD_HARD_LINE@31..34
           0: MD_HARD_LINE_LITERAL@31..34 "  \n" [] []
-      1: (empty)
     1: MD_NEWLINE@34..35
       0: NEWLINE@34..35 "\n" [] []
     2: MD_PARAGRAPH@35..71
@@ -91,7 +88,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@41..69 "bar without empty line after" [] []
         3: MD_TEXTUAL@69..71
           0: MD_TEXTUAL_LITERAL@69..71 "  " [] []
-      1: (empty)
   2: EOF@71..71 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/header.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/header.md.snap
@@ -46,7 +46,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@1..11 " Heading 1" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -69,7 +68,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@15..25 " Heading 2" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -92,7 +90,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@30..40 " Heading 3" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -115,7 +112,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@46..56 " Heading 4" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -138,7 +134,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@63..73 " Heading 5" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -161,7 +156,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@81..91 " Heading 6" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -184,7 +178,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@94..108 " Trailing hash" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [
                 MdHash {
@@ -211,7 +204,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@114..132 " Multiple trailing" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [
                 MdHash {
@@ -256,7 +248,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@168..177 " trailing" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [
                 MdHash {
@@ -287,7 +278,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@1..11
           0: MD_TEXTUAL@1..11
             0: MD_TEXTUAL_LITERAL@1..11 " Heading 1" [] []
-        1: (empty)
       3: MD_HASH_LIST@11..11
     1: MD_NEWLINE@11..12
       0: NEWLINE@11..12 "\n" [] []
@@ -302,7 +292,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@15..25
           0: MD_TEXTUAL@15..25
             0: MD_TEXTUAL_LITERAL@15..25 " Heading 2" [] []
-        1: (empty)
       3: MD_HASH_LIST@25..25
     4: MD_NEWLINE@25..26
       0: NEWLINE@25..26 "\n" [] []
@@ -317,7 +306,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@30..40
           0: MD_TEXTUAL@30..40
             0: MD_TEXTUAL_LITERAL@30..40 " Heading 3" [] []
-        1: (empty)
       3: MD_HASH_LIST@40..40
     7: MD_NEWLINE@40..41
       0: NEWLINE@40..41 "\n" [] []
@@ -332,7 +320,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@46..56
           0: MD_TEXTUAL@46..56
             0: MD_TEXTUAL_LITERAL@46..56 " Heading 4" [] []
-        1: (empty)
       3: MD_HASH_LIST@56..56
     10: MD_NEWLINE@56..57
       0: NEWLINE@56..57 "\n" [] []
@@ -347,7 +334,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@63..73
           0: MD_TEXTUAL@63..73
             0: MD_TEXTUAL_LITERAL@63..73 " Heading 5" [] []
-        1: (empty)
       3: MD_HASH_LIST@73..73
     13: MD_NEWLINE@73..74
       0: NEWLINE@73..74 "\n" [] []
@@ -362,7 +348,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@81..91
           0: MD_TEXTUAL@81..91
             0: MD_TEXTUAL_LITERAL@81..91 " Heading 6" [] []
-        1: (empty)
       3: MD_HASH_LIST@91..91
     16: MD_NEWLINE@91..92
       0: NEWLINE@91..92 "\n" [] []
@@ -377,7 +362,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@94..108
           0: MD_TEXTUAL@94..108
             0: MD_TEXTUAL_LITERAL@94..108 " Trailing hash" [] []
-        1: (empty)
       3: MD_HASH_LIST@108..110
         0: MD_HASH@108..110
           0: HASH@108..110 "#" [Whitespace(" ")] []
@@ -394,7 +378,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@114..132
           0: MD_TEXTUAL@114..132
             0: MD_TEXTUAL_LITERAL@114..132 " Multiple trailing" [] []
-        1: (empty)
       3: MD_HASH_LIST@132..135
         0: MD_HASH@132..135
           0: HASH@132..135 "##" [Whitespace(" ")] []
@@ -423,7 +406,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@165..168 "###" [] []
           6: MD_TEXTUAL@168..177
             0: MD_TEXTUAL_LITERAL@168..177 " trailing" [] []
-        1: (empty)
       3: MD_HASH_LIST@177..182
         0: MD_HASH@177..182
           0: HASH@177..182 "####" [Whitespace(" ")] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/header_in_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/header_in_list.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 190
 expression: snapshot
 ---
 
@@ -55,7 +54,6 @@ MdDocument {
                                         value_token: MD_TEXTUAL_LITERAL@3..7 " Foo" [] [],
                                     },
                                 ],
-                                hard_line: missing (optional),
                             },
                             after: MdHashList [],
                         },
@@ -111,7 +109,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@25..26 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@26..27 "\n" [] [],
@@ -139,7 +136,6 @@ MdDocument {
                                         value_token: MD_TEXTUAL_LITERAL@31..39 " Level 2" [] [],
                                     },
                                 ],
-                                hard_line: missing (optional),
                             },
                             after: MdHashList [],
                         },
@@ -176,7 +172,6 @@ MdDocument {
                                         value_token: MD_TEXTUAL_LITERAL@46..54 " Level 3" [] [],
                                     },
                                 ],
-                                hard_line: missing (optional),
                             },
                             after: MdHashList [],
                         },
@@ -213,7 +208,6 @@ MdDocument {
                                         value_token: MD_TEXTUAL_LITERAL@64..72 " Level 6" [] [],
                                     },
                                 ],
-                                hard_line: missing (optional),
                             },
                             after: MdHashList [],
                         },
@@ -246,7 +240,6 @@ MdDocument {
                                         value_token: MD_TEXTUAL_LITERAL@77..91 " Trailing hash" [] [],
                                     },
                                 ],
-                                hard_line: missing (optional),
                             },
                             after: MdHashList [
                                 MdHash {
@@ -287,7 +280,6 @@ MdDocument {
                                         value_token: MD_TEXTUAL_LITERAL@99..115 " Ordered heading" [] [],
                                     },
                                 ],
-                                hard_line: missing (optional),
                             },
                             after: MdHashList [],
                         },
@@ -317,7 +309,6 @@ MdDocument {
                                         value_token: MD_TEXTUAL_LITERAL@121..137 " Ordered level 2" [] [],
                                     },
                                 ],
-                                hard_line: missing (optional),
                             },
                             after: MdHashList [],
                         },
@@ -357,7 +348,6 @@ MdDocument {
                 0: MD_INLINE_ITEM_LIST@3..7
                   0: MD_TEXTUAL@3..7
                     0: MD_TEXTUAL_LITERAL@3..7 " Foo" [] []
-                1: (empty)
               3: MD_HASH_LIST@7..7
             1: MD_NEWLINE@7..8
               0: NEWLINE@7..8 "\n" [] []
@@ -393,7 +383,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@22..25 "baz" [] []
                 1: MD_TEXTUAL@25..26
                   0: MD_TEXTUAL_LITERAL@25..26 "\n" [] []
-              1: (empty)
             4: MD_NEWLINE@26..27
               0: NEWLINE@26..27 "\n" [] []
         2: MD_BULLET@27..39
@@ -412,7 +401,6 @@ MdDocument {
                 0: MD_INLINE_ITEM_LIST@31..39
                   0: MD_TEXTUAL@31..39
                     0: MD_TEXTUAL_LITERAL@31..39 " Level 2" [] []
-                1: (empty)
               3: MD_HASH_LIST@39..39
     1: MD_NEWLINE@39..40
       0: NEWLINE@39..40 "\n" [] []
@@ -436,7 +424,6 @@ MdDocument {
                 0: MD_INLINE_ITEM_LIST@46..54
                   0: MD_TEXTUAL@46..54
                     0: MD_TEXTUAL_LITERAL@46..54 " Level 3" [] []
-                1: (empty)
               3: MD_HASH_LIST@54..54
     4: MD_NEWLINE@54..55
       0: NEWLINE@54..55 "\n" [] []
@@ -460,7 +447,6 @@ MdDocument {
                 0: MD_INLINE_ITEM_LIST@64..72
                   0: MD_TEXTUAL@64..72
                     0: MD_TEXTUAL_LITERAL@64..72 " Level 6" [] []
-                1: (empty)
               3: MD_HASH_LIST@72..72
             1: MD_NEWLINE@72..73
               0: NEWLINE@72..73 "\n" [] []
@@ -482,7 +468,6 @@ MdDocument {
                 0: MD_INLINE_ITEM_LIST@77..91
                   0: MD_TEXTUAL@77..91
                     0: MD_TEXTUAL_LITERAL@77..91 " Trailing hash" [] []
-                1: (empty)
               3: MD_HASH_LIST@91..93
                 0: MD_HASH@91..93
                   0: HASH@91..93 "#" [Whitespace(" ")] []
@@ -508,7 +493,6 @@ MdDocument {
                 0: MD_INLINE_ITEM_LIST@99..115
                   0: MD_TEXTUAL@99..115
                     0: MD_TEXTUAL_LITERAL@99..115 " Ordered heading" [] []
-                1: (empty)
               3: MD_HASH_LIST@115..115
             1: MD_NEWLINE@115..116
               0: NEWLINE@115..116 "\n" [] []
@@ -528,7 +512,6 @@ MdDocument {
                 0: MD_INLINE_ITEM_LIST@121..137
                   0: MD_TEXTUAL@121..137
                     0: MD_TEXTUAL_LITERAL@121..137 " Ordered level 2" [] []
-                1: (empty)
               3: MD_HASH_LIST@137..137
     10: MD_NEWLINE@137..138
       0: NEWLINE@137..138 "\n" [] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/html_block.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/html_block.md.snap
@@ -75,7 +75,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@100..101 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@101..101 "" [] [],
@@ -123,7 +122,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@68..100 "Next paragraph after blank line." [] []
         1: MD_TEXTUAL@100..101
           0: MD_TEXTUAL_LITERAL@100..101 "\n" [] []
-      1: (empty)
   2: EOF@101..101 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/html_block_in_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/html_block_in_list.md.snap
@@ -210,7 +210,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@354..355 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@355..356 "\n" [] [],
@@ -234,7 +233,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@467..468 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@468..469 "\n" [] [],
@@ -2319,7 +2317,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@257..354 ", you can print the same information, but formatted using the same options of your configuration." [] []
                 17: MD_TEXTUAL@354..355
                   0: MD_TEXTUAL_LITERAL@354..355 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@355..356
               0: NEWLINE@355..356 "\n" [] []
             2: MD_CONTINUATION_INDENT@356..358
@@ -2334,7 +2331,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@358..467 "NOTE: the shape of the JSON is considered experimental, and the shape of the JSON might change in the future." [] []
                 1: MD_TEXTUAL@467..468
                   0: MD_TEXTUAL_LITERAL@467..468 "\n" [] []
-              1: (empty)
             4: MD_NEWLINE@468..469
               0: NEWLINE@468..469 "\n" [] []
             5: MD_CONTINUATION_INDENT@469..471

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/html_block_in_list_continuation.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/html_block_in_list_continuation.md.snap
@@ -41,7 +41,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@6..7 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@7..8 "\n" [] [],
@@ -163,7 +162,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..6 "item" [] []
                 1: MD_TEXTUAL@6..7
                   0: MD_TEXTUAL_LITERAL@6..7 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@7..8
               0: NEWLINE@7..8 "\n" [] []
             2: MD_CONTINUATION_INDENT@8..10

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/indent_code_block.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/indent_code_block.md.snap
@@ -127,7 +127,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@86..87 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@87..88 "\n" [] [],
@@ -251,7 +250,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@63..86 "Regular paragraph here." [] []
         1: MD_TEXTUAL@86..87
           0: MD_TEXTUAL_LITERAL@86..87 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@87..88
       0: NEWLINE@87..88 "\n" [] []
     4: MD_INDENT_CODE_BLOCK@88..121

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/indented_code_in_list_vs_continuation.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/indented_code_in_list_vs_continuation.md.snap
@@ -44,7 +44,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@6..7 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@7..8 "\n" [] [],
@@ -99,7 +98,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@40..41 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@41..42 "\n" [] [],
@@ -123,7 +121,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@51..52 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@52..53 "\n" [] [],
@@ -186,7 +183,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..6 "item" [] []
                 1: MD_TEXTUAL@6..7
                   0: MD_TEXTUAL_LITERAL@6..7 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@7..8
               0: NEWLINE@7..8 "\n" [] []
             2: MD_INDENT_CODE_BLOCK@8..25
@@ -221,7 +217,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@28..40 "continuation" [] []
                 1: MD_TEXTUAL@40..41
                   0: MD_TEXTUAL_LITERAL@40..41 "\n" [] []
-              1: (empty)
             6: MD_NEWLINE@41..42
               0: NEWLINE@41..42 "\n" [] []
         1: MD_BULLET@42..69
@@ -237,7 +232,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@44..51 "another" [] []
                 1: MD_TEXTUAL@51..52
                   0: MD_TEXTUAL_LITERAL@51..52 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@52..53
               0: NEWLINE@52..53 "\n" [] []
             2: MD_INDENT_CODE_BLOCK@53..69

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_elements.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_elements.md.snap
@@ -44,7 +44,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@29..30 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@30..31 "\n" [] [],
@@ -82,7 +81,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@69..70 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@70..71 "\n" [] [],
@@ -120,7 +118,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@111..112 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@112..113 "\n" [] [],
@@ -175,7 +172,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@178..179 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@179..179 "" [] [],
@@ -202,7 +198,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@22..29 " in it." [] []
         3: MD_TEXTUAL@29..30
           0: MD_TEXTUAL_LITERAL@29..30 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@30..31
       0: NEWLINE@30..31 "\n" [] []
     2: MD_PARAGRAPH@31..70
@@ -227,7 +222,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@68..69 "." [] []
         5: MD_TEXTUAL@69..70
           0: MD_TEXTUAL_LITERAL@69..70 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@70..71
       0: NEWLINE@70..71 "\n" [] []
     4: MD_PARAGRAPH@71..112
@@ -252,7 +246,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@110..111 "." [] []
         5: MD_TEXTUAL@111..112
           0: MD_TEXTUAL_LITERAL@111..112 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@112..113
       0: NEWLINE@112..113 "\n" [] []
     6: MD_PARAGRAPH@113..179
@@ -290,7 +283,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@177..178 "." [] []
         5: MD_TEXTUAL@178..179
           0: MD_TEXTUAL_LITERAL@178..179 "\n" [] []
-      1: (empty)
   2: EOF@179..179 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_html.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_html.md.snap
@@ -68,7 +68,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@40..41 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@41..42 "\n" [] [],
@@ -114,7 +113,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@82..83 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@83..84 "\n" [] [],
@@ -163,7 +161,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@122..123 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@123..124 "\n" [] [],
@@ -208,7 +205,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@157..158 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@158..159 "\n" [] [],
@@ -238,7 +234,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@190..191 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@191..192 "\n" [] [],
@@ -286,7 +281,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@221..222 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@222..222 "" [] [],
@@ -325,7 +319,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@33..40 " in it." [] []
         5: MD_TEXTUAL@40..41
           0: MD_TEXTUAL_LITERAL@40..41 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@41..42
       0: NEWLINE@41..42 "\n" [] []
     2: MD_PARAGRAPH@42..83
@@ -354,7 +347,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@76..82 " text." [] []
         5: MD_TEXTUAL@82..83
           0: MD_TEXTUAL_LITERAL@82..83 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@83..84
       0: NEWLINE@83..84 "\n" [] []
     4: MD_PARAGRAPH@84..123
@@ -385,7 +377,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@121..122 ">" [] []
         6: MD_TEXTUAL@122..123
           0: MD_TEXTUAL_LITERAL@122..123 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@123..124
       0: NEWLINE@123..124 "\n" [] []
     6: MD_PARAGRAPH@124..158
@@ -414,7 +405,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@149..157 " inline." [] []
         3: MD_TEXTUAL@157..158
           0: MD_TEXTUAL_LITERAL@157..158 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@158..159
       0: NEWLINE@158..159 "\n" [] []
     8: MD_PARAGRAPH@159..191
@@ -433,7 +423,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@184..190 " here." [] []
         3: MD_TEXTUAL@190..191
           0: MD_TEXTUAL_LITERAL@190..191 "\n" [] []
-      1: (empty)
     9: MD_NEWLINE@191..192
       0: NEWLINE@191..192 "\n" [] []
     10: MD_PARAGRAPH@192..222
@@ -464,7 +453,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@215..221 " here." [] []
         3: MD_TEXTUAL@221..222
           0: MD_TEXTUAL_LITERAL@221..222 "\n" [] []
-      1: (empty)
   2: EOF@222..222 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_html_edge_cases.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_html_edge_cases.md.snap
@@ -92,7 +92,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@1..24 " Inline HTML Edge Cases" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -115,7 +114,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@28..44 " Basic Open Tags" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -201,7 +199,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@122..123 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@123..124 "\n" [] [],
@@ -225,7 +222,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@132..144 "Closing Tags" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -301,7 +297,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@230..231 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@231..232 "\n" [] [],
@@ -319,7 +314,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@234..247 " Closing Tags" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -431,7 +425,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@320..321 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@321..322 "\n" [] [],
@@ -449,7 +442,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@324..333 " Comments" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -616,7 +608,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@454..455 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@455..456 "\n" [] [],
@@ -634,7 +625,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@458..482 " Processing Instructions" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -688,7 +678,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@551..552 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@552..553 "\n" [] [],
@@ -706,7 +695,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@555..570 " CDATA Sections" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -802,7 +790,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@637..638 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@638..639 "\n" [] [],
@@ -820,7 +807,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@641..654 " Declarations" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -911,7 +897,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@800..801 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@801..802 "\n" [] [],
@@ -929,7 +914,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@804..827 " Attributes with Quotes" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -1053,7 +1037,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@967..968 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@968..969 "\n" [] [],
@@ -1071,7 +1054,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@971..1001 " Attributes with Special Chars" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -1307,7 +1289,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@1260..1261 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@1261..1262 "\n" [] [],
@@ -1325,7 +1306,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@1264..1278 " Newline Cases" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -1409,7 +1389,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@1390..1391 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdQuote {
             prefix: MdQuotePrefix {
@@ -1443,7 +1422,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@1405..1406 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -1469,7 +1447,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@1420..1441 " Autolinks Should Win" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -1515,7 +1492,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@1509..1510 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@1510..1511 "\n" [] [],
@@ -1533,7 +1509,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@1513..1536 " Tag Names with Hyphens" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -1655,7 +1630,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@1649..1650 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@1650..1651 "\n" [] [],
@@ -1673,7 +1647,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@1653..1664 " Empty Tags" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -1740,7 +1713,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@1719..1720 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@1720..1720 "" [] [],
@@ -1762,7 +1734,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@1..24
           0: MD_TEXTUAL@1..24
             0: MD_TEXTUAL_LITERAL@1..24 " Inline HTML Edge Cases" [] []
-        1: (empty)
       3: MD_HASH_LIST@24..24
     1: MD_NEWLINE@24..25
       0: NEWLINE@24..25 "\n" [] []
@@ -1777,7 +1748,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@28..44
           0: MD_TEXTUAL@28..44
             0: MD_TEXTUAL_LITERAL@28..44 " Basic Open Tags" [] []
-        1: (empty)
       3: MD_HASH_LIST@44..44
     4: MD_NEWLINE@44..45
       0: NEWLINE@44..45 "\n" [] []
@@ -1831,7 +1801,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@117..122 " end." [] []
         11: MD_TEXTUAL@122..123
           0: MD_TEXTUAL_LITERAL@122..123 "\n" [] []
-      1: (empty)
     6: MD_NEWLINE@123..124
       0: NEWLINE@123..124 "\n" [] []
     7: MD_HEADER@124..144
@@ -1847,7 +1816,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@131..132 "-" [] []
           2: MD_TEXTUAL@132..144
             0: MD_TEXTUAL_LITERAL@132..144 "Closing Tags" [] []
-        1: (empty)
       3: MD_HASH_LIST@144..144
     8: MD_NEWLINE@144..145
       0: NEWLINE@144..145 "\n" [] []
@@ -1895,7 +1863,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@223..230 " field." [] []
         11: MD_TEXTUAL@230..231
           0: MD_TEXTUAL_LITERAL@230..231 "\n" [] []
-      1: (empty)
     10: MD_NEWLINE@231..232
       0: NEWLINE@231..232 "\n" [] []
     11: MD_HEADER@232..247
@@ -1907,7 +1874,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@234..247
           0: MD_TEXTUAL@234..247
             0: MD_TEXTUAL_LITERAL@234..247 " Closing Tags" [] []
-        1: (empty)
       3: MD_HASH_LIST@247..247
     12: MD_NEWLINE@247..248
       0: NEWLINE@247..248 "\n" [] []
@@ -1977,7 +1943,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@314..320 " tags." [] []
         13: MD_TEXTUAL@320..321
           0: MD_TEXTUAL_LITERAL@320..321 "\n" [] []
-      1: (empty)
     14: MD_NEWLINE@321..322
       0: NEWLINE@321..322 "\n" [] []
     15: MD_HEADER@322..333
@@ -1989,7 +1954,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@324..333
           0: MD_TEXTUAL@324..333
             0: MD_TEXTUAL_LITERAL@324..333 " Comments" [] []
-        1: (empty)
       3: MD_HASH_LIST@333..333
     16: MD_NEWLINE@333..334
       0: NEWLINE@333..334 "\n" [] []
@@ -2097,7 +2061,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@445..454 " allowed." [] []
         15: MD_TEXTUAL@454..455
           0: MD_TEXTUAL_LITERAL@454..455 "\n" [] []
-      1: (empty)
     18: MD_NEWLINE@455..456
       0: NEWLINE@455..456 "\n" [] []
     19: MD_HEADER@456..482
@@ -2109,7 +2072,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@458..482
           0: MD_TEXTUAL@458..482
             0: MD_TEXTUAL_LITERAL@458..482 " Processing Instructions" [] []
-        1: (empty)
       3: MD_HASH_LIST@482..482
     20: MD_NEWLINE@482..483
       0: NEWLINE@482..483 "\n" [] []
@@ -2143,7 +2105,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@545..551 " code." [] []
         7: MD_TEXTUAL@551..552
           0: MD_TEXTUAL_LITERAL@551..552 "\n" [] []
-      1: (empty)
     22: MD_NEWLINE@552..553
       0: NEWLINE@552..553 "\n" [] []
     23: MD_HEADER@553..570
@@ -2155,7 +2116,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@555..570
           0: MD_TEXTUAL@555..570
             0: MD_TEXTUAL_LITERAL@555..570 " CDATA Sections" [] []
-        1: (empty)
       3: MD_HASH_LIST@570..570
     24: MD_NEWLINE@570..571
       0: NEWLINE@570..571 "\n" [] []
@@ -2217,7 +2177,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@630..637 " chars." [] []
         7: MD_TEXTUAL@637..638
           0: MD_TEXTUAL_LITERAL@637..638 "\n" [] []
-      1: (empty)
     26: MD_NEWLINE@638..639
       0: NEWLINE@638..639 "\n" [] []
     27: MD_HEADER@639..654
@@ -2229,7 +2188,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@641..654
           0: MD_TEXTUAL@641..654
             0: MD_TEXTUAL_LITERAL@641..654 " Declarations" [] []
-        1: (empty)
       3: MD_HASH_LIST@654..654
     28: MD_NEWLINE@654..655
       0: NEWLINE@654..655 "\n" [] []
@@ -2287,7 +2245,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@794..800 " test." [] []
         11: MD_TEXTUAL@800..801
           0: MD_TEXTUAL_LITERAL@800..801 "\n" [] []
-      1: (empty)
     30: MD_NEWLINE@801..802
       0: NEWLINE@801..802 "\n" [] []
     31: MD_HEADER@802..827
@@ -2299,7 +2256,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@804..827
           0: MD_TEXTUAL@804..827
             0: MD_TEXTUAL_LITERAL@804..827 " Attributes with Quotes" [] []
-        1: (empty)
       3: MD_HASH_LIST@827..827
     32: MD_NEWLINE@827..828
       0: NEWLINE@827..828 "\n" [] []
@@ -2377,7 +2333,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@962..967 " end." [] []
         17: MD_TEXTUAL@967..968
           0: MD_TEXTUAL_LITERAL@967..968 "\n" [] []
-      1: (empty)
     34: MD_NEWLINE@968..969
       0: NEWLINE@968..969 "\n" [] []
     35: MD_HEADER@969..1001
@@ -2389,7 +2344,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@971..1001
           0: MD_TEXTUAL@971..1001
             0: MD_TEXTUAL_LITERAL@971..1001 " Attributes with Special Chars" [] []
-        1: (empty)
       3: MD_HASH_LIST@1001..1001
     36: MD_NEWLINE@1001..1002
       0: NEWLINE@1001..1002 "\n" [] []
@@ -2539,7 +2493,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@1255..1260 " end." [] []
         29: MD_TEXTUAL@1260..1261
           0: MD_TEXTUAL_LITERAL@1260..1261 "\n" [] []
-      1: (empty)
     38: MD_NEWLINE@1261..1262
       0: NEWLINE@1261..1262 "\n" [] []
     39: MD_HEADER@1262..1278
@@ -2551,7 +2504,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@1264..1278
           0: MD_TEXTUAL@1264..1278
             0: MD_TEXTUAL_LITERAL@1264..1278 " Newline Cases" [] []
-        1: (empty)
       3: MD_HASH_LIST@1278..1278
     40: MD_NEWLINE@1278..1279
       0: NEWLINE@1278..1279 "\n" [] []
@@ -2605,7 +2557,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@1377..1390 "div class=\"a\"" [] []
         15: MD_TEXTUAL@1390..1391
           0: MD_TEXTUAL_LITERAL@1390..1391 "\n" [] []
-      1: (empty)
     42: MD_QUOTE@1391..1406
       0: MD_QUOTE_PREFIX@1391..1392
         0: MD_QUOTE_INDENT_LIST@1391..1391
@@ -2628,7 +2579,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@1400..1405 " tag." [] []
             3: MD_TEXTUAL@1405..1406
               0: MD_TEXTUAL_LITERAL@1405..1406 "\n" [] []
-          1: (empty)
     43: MD_NEWLINE@1406..1407
       0: NEWLINE@1406..1407 "\n" [] []
     44: MD_HEADER@1407..1441
@@ -2644,7 +2594,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@1419..1420 "-" [] []
           2: MD_TEXTUAL@1420..1441
             0: MD_TEXTUAL_LITERAL@1420..1441 " Autolinks Should Win" [] []
-        1: (empty)
       3: MD_HASH_LIST@1441..1441
     45: MD_NEWLINE@1441..1442
       0: NEWLINE@1441..1442 "\n" [] []
@@ -2674,7 +2623,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@1500..1509 " address." [] []
         7: MD_TEXTUAL@1509..1510
           0: MD_TEXTUAL_LITERAL@1509..1510 "\n" [] []
-      1: (empty)
     47: MD_NEWLINE@1510..1511
       0: NEWLINE@1510..1511 "\n" [] []
     48: MD_HEADER@1511..1536
@@ -2686,7 +2634,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@1513..1536
           0: MD_TEXTUAL@1513..1536
             0: MD_TEXTUAL_LITERAL@1513..1536 " Tag Names with Hyphens" [] []
-        1: (empty)
       3: MD_HASH_LIST@1536..1536
     49: MD_NEWLINE@1536..1537
       0: NEWLINE@1536..1537 "\n" [] []
@@ -2764,7 +2711,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@1644..1649 " tag." [] []
         11: MD_TEXTUAL@1649..1650
           0: MD_TEXTUAL_LITERAL@1649..1650 "\n" [] []
-      1: (empty)
     51: MD_NEWLINE@1650..1651
       0: NEWLINE@1650..1651 "\n" [] []
     52: MD_HEADER@1651..1664
@@ -2776,7 +2722,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@1653..1664
           0: MD_TEXTUAL@1653..1664
             0: MD_TEXTUAL_LITERAL@1653..1664 " Empty Tags" [] []
-        1: (empty)
       3: MD_HASH_LIST@1664..1664
     53: MD_NEWLINE@1664..1665
       0: NEWLINE@1664..1665 "\n" [] []
@@ -2818,7 +2763,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@1712..1719 " break." [] []
         8: MD_TEXTUAL@1719..1720
           0: MD_TEXTUAL_LITERAL@1719..1720 "\n" [] []
-      1: (empty)
   2: EOF@1720..1720 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_html_invalid.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_html_invalid.md.snap
@@ -50,7 +50,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@1..27 " Invalid Inline HTML Cases" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -69,7 +68,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@84..85 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@85..86 "\n" [] [],
@@ -87,7 +85,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@88..107 " Period in Tag Name" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -133,7 +130,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@195..196 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@196..197 "\n" [] [],
@@ -151,7 +147,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@199..213 " Unclosed Tags" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -290,7 +285,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@505..506 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@506..507 "\n" [] [],
@@ -308,7 +302,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@509..526 " Invalid Comments" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -423,7 +416,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@657..658 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@658..658 "" [] [],
@@ -445,7 +437,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@1..27
           0: MD_TEXTUAL@1..27
             0: MD_TEXTUAL_LITERAL@1..27 " Invalid Inline HTML Cases" [] []
-        1: (empty)
       3: MD_HASH_LIST@27..27
     1: MD_NEWLINE@27..28
       0: NEWLINE@27..28 "\n" [] []
@@ -457,7 +448,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@29..84 "These should all be parsed as text, NOT as inline HTML." [] []
         1: MD_TEXTUAL@84..85
           0: MD_TEXTUAL_LITERAL@84..85 "\n" [] []
-      1: (empty)
     4: MD_NEWLINE@85..86
       0: NEWLINE@85..86 "\n" [] []
     5: MD_HEADER@86..107
@@ -469,7 +459,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@88..107
           0: MD_TEXTUAL@88..107
             0: MD_TEXTUAL_LITERAL@88..107 " Period in Tag Name" [] []
-        1: (empty)
       3: MD_HASH_LIST@107..107
     6: MD_NEWLINE@107..108
       0: NEWLINE@107..108 "\n" [] []
@@ -499,7 +488,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@175..195 " should remain text." [] []
         11: MD_TEXTUAL@195..196
           0: MD_TEXTUAL_LITERAL@195..196 "\n" [] []
-      1: (empty)
     8: MD_NEWLINE@196..197
       0: NEWLINE@196..197 "\n" [] []
     9: MD_HEADER@197..213
@@ -511,7 +499,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@199..213
           0: MD_TEXTUAL@199..213
             0: MD_TEXTUAL_LITERAL@199..213 " Unclosed Tags" [] []
-        1: (empty)
       3: MD_HASH_LIST@213..213
     10: MD_NEWLINE@213..214
       0: NEWLINE@213..214 "\n" [] []
@@ -603,7 +590,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@489..505 " should be text." [] []
         40: MD_TEXTUAL@505..506
           0: MD_TEXTUAL_LITERAL@505..506 "\n" [] []
-      1: (empty)
     12: MD_NEWLINE@506..507
       0: NEWLINE@506..507 "\n" [] []
     13: MD_HEADER@507..526
@@ -615,7 +601,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@509..526
           0: MD_TEXTUAL@509..526
             0: MD_TEXTUAL_LITERAL@509..526 " Invalid Comments" [] []
-        1: (empty)
       3: MD_HASH_LIST@526..526
     14: MD_NEWLINE@526..527
       0: NEWLINE@526..527 "\n" [] []
@@ -689,7 +674,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@641..657 " should be text." [] []
         11: MD_TEXTUAL@657..658
           0: MD_TEXTUAL_LITERAL@657..658 "\n" [] []
-      1: (empty)
   2: EOF@658..658 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_link_destination_title.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_link_destination_title.md.snap
@@ -65,7 +65,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@29..30 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@30..31 "\n" [] [],
@@ -114,7 +113,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@62..63 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@63..64 "\n" [] [],
@@ -154,7 +152,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@88..89 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@89..90 "\n" [] [],
@@ -194,7 +191,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@114..115 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@115..116 "\n" [] [],
@@ -240,7 +236,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@139..140 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@140..141 "\n" [] [],
@@ -281,7 +276,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@167..168 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@168..168 "" [] [],
@@ -320,7 +314,6 @@ MdDocument {
           6: R_PAREN@28..29 ")" [] []
         2: MD_TEXTUAL@29..30
           0: MD_TEXTUAL_LITERAL@29..30 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@30..31
       0: NEWLINE@30..31 "\n" [] []
     2: MD_PARAGRAPH@31..63
@@ -353,7 +346,6 @@ MdDocument {
           6: R_PAREN@61..62 ")" [] []
         2: MD_TEXTUAL@62..63
           0: MD_TEXTUAL_LITERAL@62..63 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@63..64
       0: NEWLINE@63..64 "\n" [] []
     4: MD_PARAGRAPH@64..89
@@ -379,7 +371,6 @@ MdDocument {
           6: R_PAREN@87..88 ")" [] []
         2: MD_TEXTUAL@88..89
           0: MD_TEXTUAL_LITERAL@88..89 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@89..90
       0: NEWLINE@89..90 "\n" [] []
     6: MD_PARAGRAPH@90..115
@@ -405,7 +396,6 @@ MdDocument {
           6: R_PAREN@113..114 ")" [] []
         2: MD_TEXTUAL@114..115
           0: MD_TEXTUAL_LITERAL@114..115 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@115..116
       0: NEWLINE@115..116 "\n" [] []
     8: MD_PARAGRAPH@116..140
@@ -435,7 +425,6 @@ MdDocument {
           6: R_PAREN@138..139 ")" [] []
         2: MD_TEXTUAL@139..140
           0: MD_TEXTUAL_LITERAL@139..140 "\n" [] []
-      1: (empty)
     9: MD_NEWLINE@140..141
       0: NEWLINE@140..141 "\n" [] []
     10: MD_PARAGRAPH@141..168
@@ -462,7 +451,6 @@ MdDocument {
           7: R_PAREN@166..167 ")" [] []
         2: MD_TEXTUAL@167..168
           0: MD_TEXTUAL_LITERAL@167..168 "\n" [] []
-      1: (empty)
   2: EOF@168..168 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_link_whitespace.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_link_whitespace.md.snap
@@ -83,7 +83,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@68..69 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@69..70 "\n" [] [],
@@ -132,7 +131,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@122..123 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@123..124 "\n" [] [],
@@ -175,7 +173,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@186..187 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@187..188 "\n" [] [],
@@ -212,7 +209,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@242..243 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@243..244 "\n" [] [],
@@ -249,7 +245,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@299..300 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@300..300 "" [] [],
@@ -295,7 +290,6 @@ MdDocument {
           6: R_PAREN@67..68 ")" [] []
         3: MD_TEXTUAL@68..69
           0: MD_TEXTUAL_LITERAL@68..69 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@69..70
       0: NEWLINE@69..70 "\n" [] []
     2: MD_PARAGRAPH@70..123
@@ -327,7 +321,6 @@ MdDocument {
           6: R_PAREN@121..122 ")" [] []
         3: MD_TEXTUAL@122..123
           0: MD_TEXTUAL_LITERAL@122..123 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@123..124
       0: NEWLINE@123..124 "\n" [] []
     4: MD_PARAGRAPH@124..187
@@ -355,7 +348,6 @@ MdDocument {
           6: R_PAREN@185..186 ")" [] []
         3: MD_TEXTUAL@186..187
           0: MD_TEXTUAL_LITERAL@186..187 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@187..188
       0: NEWLINE@187..188 "\n" [] []
     6: MD_PARAGRAPH@188..243
@@ -380,7 +372,6 @@ MdDocument {
           6: R_PAREN@241..242 ")" [] []
         3: MD_TEXTUAL@242..243
           0: MD_TEXTUAL_LITERAL@242..243 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@243..244
       0: NEWLINE@243..244 "\n" [] []
     8: MD_PARAGRAPH@244..300
@@ -405,7 +396,6 @@ MdDocument {
           6: R_PAREN@298..299 ")" [] []
         3: MD_TEXTUAL@299..300
           0: MD_TEXTUAL_LITERAL@299..300 "\n" [] []
-      1: (empty)
   2: EOF@300..300 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/lazy_continuation.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/lazy_continuation.md.snap
@@ -69,7 +69,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@39..40 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -109,7 +108,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@107..108 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -150,7 +148,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@172..173 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -173,7 +170,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@204..205 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -190,7 +186,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@206..246 " This heading ends the lazy continuation" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -222,7 +217,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@300..301 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -261,7 +255,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@333..334 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -284,7 +277,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@373..374 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -309,7 +301,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@409..410 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -353,7 +344,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@467..468 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -410,7 +400,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@544..545 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -441,7 +430,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@18..39 "that continues lazily" [] []
             3: MD_TEXTUAL@39..40
               0: MD_TEXTUAL_LITERAL@39..40 "\n" [] []
-          1: (empty)
     1: MD_NEWLINE@40..41
       0: NEWLINE@40..41 "\n" [] []
     2: MD_QUOTE@41..108
@@ -468,7 +456,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@82..107 "and explicit continuation" [] []
             6: MD_TEXTUAL@107..108
               0: MD_TEXTUAL_LITERAL@107..108 "\n" [] []
-          1: (empty)
     3: MD_NEWLINE@108..109
       0: NEWLINE@108..109 "\n" [] []
     4: MD_QUOTE@109..173
@@ -495,7 +482,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@151..172 "and even more content" [] []
             7: MD_TEXTUAL@172..173
               0: MD_TEXTUAL_LITERAL@172..173 "\n" [] []
-          1: (empty)
     5: MD_NEWLINE@173..174
       0: NEWLINE@173..174 "\n" [] []
     6: MD_QUOTE@174..205
@@ -510,7 +496,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@176..204 "Quote interrupted by heading" [] []
             1: MD_TEXTUAL@204..205
               0: MD_TEXTUAL_LITERAL@204..205 "\n" [] []
-          1: (empty)
     7: MD_HEADER@205..246
       0: MD_INDENT_TOKEN_LIST@205..205
       1: MD_HASH_LIST@205..206
@@ -520,7 +505,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@206..246
           0: MD_TEXTUAL@206..246
             0: MD_TEXTUAL_LITERAL@206..246 " This heading ends the lazy continuation" [] []
-        1: (empty)
       3: MD_HASH_LIST@246..246
     8: MD_NEWLINE@246..247
       0: NEWLINE@246..247 "\n" [] []
@@ -542,7 +526,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@286..300 "Setext heading" [] []
             3: MD_TEXTUAL@300..301
               0: MD_TEXTUAL_LITERAL@300..301 "\n" [] []
-          1: (empty)
     11: MD_THEMATIC_BREAK_BLOCK@301..304
       0: MD_THEMATIC_BREAK_PART_LIST@301..304
         0: MD_THEMATIC_BREAK_CHAR@301..302
@@ -567,7 +550,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@308..333 "Quote interrupted by list" [] []
             1: MD_TEXTUAL@333..334
               0: MD_TEXTUAL_LITERAL@333..334 "\n" [] []
-          1: (empty)
     15: MD_BULLET_LIST_ITEM@334..374
       0: MD_BULLET_LIST@334..374
         0: MD_BULLET@334..374
@@ -583,7 +565,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@336..373 "This list item ends lazy continuation" [] []
                 1: MD_TEXTUAL@373..374
                   0: MD_TEXTUAL_LITERAL@373..374 "\n" [] []
-              1: (empty)
     16: MD_NEWLINE@374..375
       0: NEWLINE@374..375 "\n" [] []
     17: MD_QUOTE@375..410
@@ -598,7 +579,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@377..409 "Quote interrupted by fenced code" [] []
             1: MD_TEXTUAL@409..410
               0: MD_TEXTUAL_LITERAL@409..410 "\n" [] []
-          1: (empty)
     18: MD_FENCED_CODE_BLOCK@410..428
       0: MD_INDENT_TOKEN_LIST@410..410
       1: TRIPLE_BACKTICK@410..413 "```" [] []
@@ -628,7 +608,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@432..467 "Quote interrupted by thematic break" [] []
             1: MD_TEXTUAL@467..468
               0: MD_TEXTUAL_LITERAL@467..468 "\n" [] []
-          1: (empty)
     22: MD_THEMATIC_BREAK_BLOCK@468..471
       0: MD_THEMATIC_BREAK_PART_LIST@468..471
         0: MD_THEMATIC_BREAK_CHAR@468..469
@@ -665,7 +644,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@514..544 "This is an indented code block" [] []
             7: MD_TEXTUAL@544..545
               0: MD_TEXTUAL_LITERAL@544..545 "\n" [] []
-          1: (empty)
   2: EOF@545..545 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/lazy_continuation_at_marker_indent.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/lazy_continuation_at_marker_indent.md.snap
@@ -43,7 +43,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@3..4 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -86,7 +85,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@16..17 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -114,7 +112,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@25..26 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -175,7 +172,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@73..74 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -211,7 +207,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..3 "a" [] []
                 1: MD_TEXTUAL@3..4
                   0: MD_TEXTUAL_LITERAL@3..4 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@4..6
               0: MD_INDENT_TOKEN_LIST@4..6
                 0: MD_INDENT_TOKEN@4..5
@@ -241,7 +236,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@12..16 "lazy" [] []
                         5: MD_TEXTUAL@16..17
                           0: MD_TEXTUAL_LITERAL@16..17 "\n" [] []
-                      1: (empty)
             3: MD_NEWLINE@17..18
               0: NEWLINE@17..18 "\n" [] []
         1: MD_BULLET@18..74
@@ -257,7 +251,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@20..25 "outer" [] []
                 1: MD_TEXTUAL@25..26
                   0: MD_TEXTUAL_LITERAL@25..26 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@26..28
               0: MD_INDENT_TOKEN_LIST@26..28
                 0: MD_INDENT_TOKEN@26..27
@@ -299,7 +292,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@58..73 "outer continued" [] []
                         11: MD_TEXTUAL@73..74
                           0: MD_TEXTUAL_LITERAL@73..74 "\n" [] []
-                      1: (empty)
   2: EOF@74..74 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/lazy_continuation_emphasis_in_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/lazy_continuation_emphasis_in_list.md.snap
@@ -65,7 +65,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@21..22 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -120,7 +119,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@48..49 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -194,7 +192,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@83..84 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -289,7 +286,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@115..116 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -364,7 +360,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@157..158 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -406,7 +401,6 @@ MdDocument {
                   2: DOUBLE_STAR@19..21 "**" [] []
                 4: MD_TEXTUAL@21..22
                   0: MD_TEXTUAL_LITERAL@21..22 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@22..23
       0: NEWLINE@22..23 "\n" [] []
     2: MD_QUOTE@23..49
@@ -444,7 +438,6 @@ MdDocument {
                       2: DOUBLE_STAR@46..48 "**" [] []
                     5: MD_TEXTUAL@48..49
                       0: MD_TEXTUAL_LITERAL@48..49 "\n" [] []
-                  1: (empty)
     3: MD_NEWLINE@49..50
       0: NEWLINE@49..50 "\n" [] []
     4: MD_QUOTE@50..84
@@ -494,7 +487,6 @@ MdDocument {
                       2: DOUBLE_STAR@81..83 "**" [] []
                     6: MD_TEXTUAL@83..84
                       0: MD_TEXTUAL_LITERAL@83..84 "\n" [] []
-                  1: (empty)
     5: MD_NEWLINE@84..85
       0: NEWLINE@84..85 "\n" [] []
     6: MD_QUOTE@85..116
@@ -558,7 +550,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@111..115 " foo" [] []
                     9: MD_TEXTUAL@115..116
                       0: MD_TEXTUAL_LITERAL@115..116 "\n" [] []
-                  1: (empty)
     7: MD_NEWLINE@116..117
       0: NEWLINE@116..117 "\n" [] []
     8: MD_ORDERED_LIST_ITEM@117..158
@@ -606,7 +597,6 @@ MdDocument {
                   2: DOUBLE_STAR@155..157 "**" [] []
                 12: MD_TEXTUAL@157..158
                   0: MD_TEXTUAL_LITERAL@157..158 "\n" [] []
-              1: (empty)
   2: EOF@158..158 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_edge_cases.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_edge_cases.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 192
 expression: snapshot
 ---
 
@@ -58,7 +57,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@31..32 "\n" [] [],
@@ -115,7 +113,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@75..76 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@76..77 "\n" [] [],
@@ -574,7 +571,6 @@ MdDocument {
                     value_token: MD_HARD_LINE_LITERAL@435..439 "   \n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@439..440 "\n" [] [],
@@ -606,7 +602,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@472..473 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@473..474 "\n" [] [],
@@ -654,7 +649,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@506..507 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@507..507 "" [] [],
@@ -673,7 +667,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@0..30 "Some text with trailing spaces" [] []
         1: MD_TEXTUAL@30..31
           0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@31..32
       0: NEWLINE@31..32 "\n" [] []
     2: MD_LINK_REFERENCE_DEFINITION@32..56
@@ -710,7 +703,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@58..75 "Another paragraph" [] []
         1: MD_TEXTUAL@75..76
           0: MD_TEXTUAL_LITERAL@75..76 "\n" [] []
-      1: (empty)
     6: MD_NEWLINE@76..77
       0: NEWLINE@76..77 "\n" [] []
     7: MD_LINK_REFERENCE_DEFINITION@77..100
@@ -1011,7 +1003,6 @@ MdDocument {
       0: MD_INLINE_ITEM_LIST@435..439
         0: MD_HARD_LINE@435..439
           0: MD_HARD_LINE_LITERAL@435..439 "   \n" [] []
-      1: (empty)
     36: MD_NEWLINE@439..440
       0: NEWLINE@439..440 "\n" [] []
     37: MD_PARAGRAPH@440..473
@@ -1032,7 +1023,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@459..472 " /url invalid" [] []
         7: MD_TEXTUAL@472..473
           0: MD_TEXTUAL_LITERAL@472..473 "\n" [] []
-      1: (empty)
     38: MD_NEWLINE@473..474
       0: NEWLINE@473..474 "\n" [] []
     39: MD_PARAGRAPH@474..507
@@ -1063,7 +1053,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@498..506 " invalid" [] []
         9: MD_TEXTUAL@506..507
           0: MD_TEXTUAL_LITERAL@506..507 "\n" [] []
-      1: (empty)
   2: EOF@507..507 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_indented_continuation.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_indented_continuation.md.snap
@@ -70,7 +70,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@26..27 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@27..28 "\n" [] [],
@@ -94,7 +93,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@35..36 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -137,7 +135,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@58..59 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -190,7 +187,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@18..26 "indented" [] []
         5: MD_TEXTUAL@26..27
           0: MD_TEXTUAL_LITERAL@26..27 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@27..28
       0: NEWLINE@27..28 "\n" [] []
     4: MD_BULLET_LIST_ITEM@28..59
@@ -208,7 +204,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@30..35 "outer" [] []
                 1: MD_TEXTUAL@35..36
                   0: MD_TEXTUAL_LITERAL@35..36 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@36..38
               0: MD_INDENT_TOKEN_LIST@36..38
                 0: MD_INDENT_TOKEN@36..37
@@ -238,7 +233,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@49..58 "lazy line" [] []
                         5: MD_TEXTUAL@58..59
                           0: MD_TEXTUAL_LITERAL@58..59 "\n" [] []
-                      1: (empty)
   2: EOF@59..59 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_invalid.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_invalid.md.snap
@@ -45,7 +45,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@101..102 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@102..103 "\n" [] [],
@@ -89,7 +88,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@184..185 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@185..186 "\n" [] [],
@@ -127,7 +125,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@257..258 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@258..259 "\n" [] [],
@@ -171,7 +168,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@328..329 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@329..330 "\n" [] [],
@@ -200,7 +196,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@362..363 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@363..363 "" [] [],
@@ -223,7 +218,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@58..101 "They should fall back to paragraph parsing." [] []
         3: MD_TEXTUAL@101..102
           0: MD_TEXTUAL_LITERAL@101..102 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@102..103
       0: NEWLINE@102..103 "\n" [] []
     2: MD_PARAGRAPH@103..185
@@ -252,7 +246,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@166..184 "http://example.com" [] []
         11: MD_TEXTUAL@184..185
           0: MD_TEXTUAL_LITERAL@184..185 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@185..186
       0: NEWLINE@185..186 "\n" [] []
     4: MD_PARAGRAPH@186..258
@@ -277,7 +270,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@235..257 " /url trailing garbage" [] []
         9: MD_TEXTUAL@257..258
           0: MD_TEXTUAL_LITERAL@257..258 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@258..259
       0: NEWLINE@258..259 "\n" [] []
     6: MD_PARAGRAPH@259..329
@@ -306,7 +298,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@309..328 " /url \"title\" extra" [] []
         11: MD_TEXTUAL@328..329
           0: MD_TEXTUAL_LITERAL@328..329 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@329..330
       0: NEWLINE@329..330 "\n" [] []
     8: MD_PARAGRAPH@330..363
@@ -326,7 +317,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@357..362 " /url" [] []
         5: MD_TEXTUAL@362..363
           0: MD_TEXTUAL_LITERAL@362..363 "\n" [] []
-      1: (empty)
   2: EOF@363..363 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/link_reference_before_thematic_break.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/link_reference_before_thematic_break.md.snap
@@ -59,7 +59,6 @@ MdDocument {
         },
         MdParagraph {
             list: MdInlineItemList [],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@27..28 "\n" [] [],
@@ -118,7 +117,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@20..27 "\"title\"" [] []
     1: MD_PARAGRAPH@27..27
       0: MD_INLINE_ITEM_LIST@27..27
-      1: (empty)
     2: MD_NEWLINE@27..28
       0: NEWLINE@27..28 "\n" [] []
     3: MD_THEMATIC_BREAK_BLOCK@28..31

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/link_reference_definition_paragraph_continuation.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/link_reference_definition_paragraph_continuation.md.snap
@@ -57,7 +57,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@21..21 "" [] [],
@@ -96,7 +95,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@15..20 " item" [] []
         2: MD_TEXTUAL@20..21
           0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-      1: (empty)
   2: EOF@21..21 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_blank_lines_between_items.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_blank_lines_between_items.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 190
 expression: snapshot
 ---
 
@@ -59,7 +58,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@1..34 " Blank lines between bullet items" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -88,7 +86,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@41..42 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@42..43 "\n" [] [],
@@ -112,7 +109,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@48..49 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@49..50 "\n" [] [],
@@ -136,7 +132,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@55..56 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -158,7 +153,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@58..92 " Blank lines between ordered items" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -187,7 +181,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@102..103 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@103..104 "\n" [] [],
@@ -211,7 +204,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@113..114 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@114..115 "\n" [] [],
@@ -235,7 +227,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@123..124 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -257,7 +248,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@126..161 " Multiple blank lines between items" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -286,7 +276,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@170..171 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@171..172 "\n" [] [],
@@ -313,7 +302,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@179..180 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -335,7 +323,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@182..220 " Mixed: some items separated, some not" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -364,7 +351,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@227..228 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -385,7 +371,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@233..234 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@234..235 "\n" [] [],
@@ -409,7 +394,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@242..243 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -435,7 +419,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@1..34
           0: MD_TEXTUAL@1..34
             0: MD_TEXTUAL_LITERAL@1..34 " Blank lines between bullet items" [] []
-        1: (empty)
       3: MD_HASH_LIST@34..34
     1: MD_NEWLINE@34..35
       0: NEWLINE@34..35 "\n" [] []
@@ -456,7 +439,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@38..41 "foo" [] []
                 1: MD_TEXTUAL@41..42
                   0: MD_TEXTUAL_LITERAL@41..42 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@42..43
               0: NEWLINE@42..43 "\n" [] []
         1: MD_BULLET@43..50
@@ -472,7 +454,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@45..48 "bar" [] []
                 1: MD_TEXTUAL@48..49
                   0: MD_TEXTUAL_LITERAL@48..49 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@49..50
               0: NEWLINE@49..50 "\n" [] []
         2: MD_BULLET@50..56
@@ -488,7 +469,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@52..55 "baz" [] []
                 1: MD_TEXTUAL@55..56
                   0: MD_TEXTUAL_LITERAL@55..56 "\n" [] []
-              1: (empty)
     4: MD_NEWLINE@56..57
       0: NEWLINE@56..57 "\n" [] []
     5: MD_HEADER@57..92
@@ -500,7 +480,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@58..92
           0: MD_TEXTUAL@58..92
             0: MD_TEXTUAL_LITERAL@58..92 " Blank lines between ordered items" [] []
-        1: (empty)
       3: MD_HASH_LIST@92..92
     6: MD_NEWLINE@92..93
       0: NEWLINE@92..93 "\n" [] []
@@ -521,7 +500,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@97..102 "first" [] []
                 1: MD_TEXTUAL@102..103
                   0: MD_TEXTUAL_LITERAL@102..103 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@103..104
               0: NEWLINE@103..104 "\n" [] []
         1: MD_BULLET@104..115
@@ -537,7 +515,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@107..113 "second" [] []
                 1: MD_TEXTUAL@113..114
                   0: MD_TEXTUAL_LITERAL@113..114 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@114..115
               0: NEWLINE@114..115 "\n" [] []
         2: MD_BULLET@115..124
@@ -553,7 +530,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@118..123 "third" [] []
                 1: MD_TEXTUAL@123..124
                   0: MD_TEXTUAL_LITERAL@123..124 "\n" [] []
-              1: (empty)
     9: MD_NEWLINE@124..125
       0: NEWLINE@124..125 "\n" [] []
     10: MD_HEADER@125..161
@@ -565,7 +541,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@126..161
           0: MD_TEXTUAL@126..161
             0: MD_TEXTUAL_LITERAL@126..161 " Multiple blank lines between items" [] []
-        1: (empty)
       3: MD_HASH_LIST@161..161
     11: MD_NEWLINE@161..162
       0: NEWLINE@161..162 "\n" [] []
@@ -586,7 +561,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@165..170 "alpha" [] []
                 1: MD_TEXTUAL@170..171
                   0: MD_TEXTUAL_LITERAL@170..171 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@171..172
               0: NEWLINE@171..172 "\n" [] []
             2: MD_NEWLINE@172..173
@@ -604,7 +578,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@175..179 "beta" [] []
                 1: MD_TEXTUAL@179..180
                   0: MD_TEXTUAL_LITERAL@179..180 "\n" [] []
-              1: (empty)
     14: MD_NEWLINE@180..181
       0: NEWLINE@180..181 "\n" [] []
     15: MD_HEADER@181..220
@@ -616,7 +589,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@182..220
           0: MD_TEXTUAL@182..220
             0: MD_TEXTUAL_LITERAL@182..220 " Mixed: some items separated, some not" [] []
-        1: (empty)
       3: MD_HASH_LIST@220..220
     16: MD_NEWLINE@220..221
       0: NEWLINE@220..221 "\n" [] []
@@ -637,7 +609,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@224..227 "one" [] []
                 1: MD_TEXTUAL@227..228
                   0: MD_TEXTUAL_LITERAL@227..228 "\n" [] []
-              1: (empty)
         1: MD_BULLET@228..235
           0: MD_LIST_MARKER_PREFIX@228..230
             0: MD_INDENT_TOKEN_LIST@228..228
@@ -651,7 +622,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@230..233 "two" [] []
                 1: MD_TEXTUAL@233..234
                   0: MD_TEXTUAL_LITERAL@233..234 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@234..235
               0: NEWLINE@234..235 "\n" [] []
         2: MD_BULLET@235..243
@@ -667,7 +637,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@237..242 "three" [] []
                 1: MD_TEXTUAL@242..243
                   0: MD_TEXTUAL_LITERAL@242..243 "\n" [] []
-              1: (empty)
   2: EOF@243..243 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_continuation_edge_cases.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_continuation_edge_cases.md.snap
@@ -69,7 +69,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@11..43 "only blank line inside list item" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -105,7 +104,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@60..61 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [
@@ -143,7 +141,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@89..90 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -169,7 +166,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@105..106 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -203,7 +199,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@119..151 "only item followed by blank line" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -248,7 +243,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@203..204 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@204..205 "\n" [] [],
@@ -272,7 +266,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@209..270 " Nested list with continuation requiring virtual line restore" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -301,7 +294,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@284..285 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -362,7 +354,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@365..366 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -390,7 +381,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@384..385 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -418,7 +408,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@390..449 " Lazy continuation with insufficient indent after paragraph" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -453,7 +442,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@494..495 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -474,7 +462,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@506..507 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -508,7 +495,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@10..11 "-" [] []
           4: MD_TEXTUAL@11..43
             0: MD_TEXTUAL_LITERAL@11..43 "only blank line inside list item" [] []
-        1: (empty)
       3: MD_HASH_LIST@43..43
     1: MD_NEWLINE@43..44
       0: NEWLINE@43..44 "\n" [] []
@@ -535,7 +521,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@48..60 " quoted line" [] []
                     1: MD_TEXTUAL@60..61
                       0: MD_TEXTUAL_LITERAL@60..61 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@61..64
                   0: MD_QUOTE_INDENT_LIST@61..63
                     0: MD_QUOTE_INDENT@61..62
@@ -560,7 +545,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@69..89 "continued quote line" [] []
                     1: MD_TEXTUAL@89..90
                       0: MD_TEXTUAL_LITERAL@89..90 "\n" [] []
-                  1: (empty)
             1: MD_NEWLINE@90..91
               0: NEWLINE@90..91 "\n" [] []
         1: MD_BULLET@91..106
@@ -576,7 +560,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@93..105 "sibling item" [] []
                 1: MD_TEXTUAL@105..106
                   0: MD_TEXTUAL_LITERAL@105..106 "\n" [] []
-              1: (empty)
     4: MD_NEWLINE@106..107
       0: NEWLINE@106..107 "\n" [] []
     5: MD_HEADER@107..151
@@ -596,7 +579,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@118..119 "-" [] []
           4: MD_TEXTUAL@119..151
             0: MD_TEXTUAL_LITERAL@119..151 "only item followed by blank line" [] []
-        1: (empty)
       3: MD_HASH_LIST@151..151
     6: MD_NEWLINE@151..152
       0: NEWLINE@151..152 "\n" [] []
@@ -625,7 +607,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@188..203 "only list item." [] []
         3: MD_TEXTUAL@203..204
           0: MD_TEXTUAL_LITERAL@203..204 "\n" [] []
-      1: (empty)
     11: MD_NEWLINE@204..205
       0: NEWLINE@204..205 "\n" [] []
     12: MD_HEADER@205..270
@@ -641,7 +622,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@208..209 ")" [] []
           2: MD_TEXTUAL@209..270
             0: MD_TEXTUAL_LITERAL@209..270 " Nested list with continuation requiring virtual line restore" [] []
-        1: (empty)
       3: MD_HASH_LIST@270..270
     13: MD_NEWLINE@270..271
       0: NEWLINE@270..271 "\n" [] []
@@ -662,7 +642,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@274..284 "outer item" [] []
                 1: MD_TEXTUAL@284..285
                   0: MD_TEXTUAL_LITERAL@284..285 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@285..287
               0: MD_INDENT_TOKEN_LIST@285..287
                 0: MD_INDENT_TOKEN@285..286
@@ -704,7 +683,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@325..365 "outer continuation at parent indentation" [] []
                         11: MD_TEXTUAL@365..366
                           0: MD_TEXTUAL_LITERAL@365..366 "\n" [] []
-                      1: (empty)
             3: MD_NEWLINE@366..367
               0: NEWLINE@366..367 "\n" [] []
         1: MD_BULLET@367..385
@@ -720,7 +698,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@369..384 "next outer item" [] []
                 1: MD_TEXTUAL@384..385
                   0: MD_TEXTUAL_LITERAL@384..385 "\n" [] []
-              1: (empty)
     16: MD_NEWLINE@385..386
       0: NEWLINE@385..386 "\n" [] []
     17: MD_HEADER@386..449
@@ -736,7 +713,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@389..390 ")" [] []
           2: MD_TEXTUAL@390..449
             0: MD_TEXTUAL_LITERAL@390..449 " Lazy continuation with insufficient indent after paragraph" [] []
-        1: (empty)
       3: MD_HASH_LIST@449..449
     18: MD_NEWLINE@449..450
       0: NEWLINE@449..450 "\n" [] []
@@ -761,7 +737,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@472..494 "lazy continuation line" [] []
                 3: MD_TEXTUAL@494..495
                   0: MD_TEXTUAL_LITERAL@494..495 "\n" [] []
-              1: (empty)
         1: MD_BULLET@495..507
           0: MD_LIST_MARKER_PREFIX@495..497
             0: MD_INDENT_TOKEN_LIST@495..495
@@ -775,7 +750,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@497..506 "next item" [] []
                 1: MD_TEXTUAL@506..507
                   0: MD_TEXTUAL_LITERAL@506..507 "\n" [] []
-              1: (empty)
   2: EOF@507..507 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_in_blockquote.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_in_blockquote.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 192
 expression: snapshot
 ---
 
@@ -61,7 +60,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -95,7 +93,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@13..14 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -132,7 +129,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@21..22 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -166,7 +162,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -203,7 +198,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@37..38 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -229,7 +223,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@43..44 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -266,7 +259,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@50..51 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -304,7 +296,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@58..59 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -341,7 +332,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@65..66 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -379,7 +369,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@74..75 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -419,7 +408,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@4..5 "a" [] []
                     1: MD_TEXTUAL@5..6
                       0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@6..7
                   0: MD_QUOTE_INDENT_LIST@6..6
                   1: R_ANGLE@6..7 ">" [] []
@@ -443,7 +431,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@12..13 "b" [] []
                     1: MD_TEXTUAL@13..14
                       0: MD_TEXTUAL_LITERAL@13..14 "\n" [] []
-                  1: (empty)
     1: MD_NEWLINE@14..15
       0: NEWLINE@14..15 "\n" [] []
     2: MD_QUOTE@15..31
@@ -467,7 +454,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@20..21 "a" [] []
                     1: MD_TEXTUAL@21..22
                       0: MD_TEXTUAL_LITERAL@21..22 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@22..23
                   0: MD_QUOTE_INDENT_LIST@22..22
                   1: R_ANGLE@22..23 ">" [] []
@@ -491,7 +477,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@29..30 "b" [] []
                     1: MD_TEXTUAL@30..31
                       0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
-                  1: (empty)
     3: MD_NEWLINE@31..32
       0: NEWLINE@31..32 "\n" [] []
     4: MD_QUOTE@32..44
@@ -515,7 +500,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@36..37 "a" [] []
                     1: MD_TEXTUAL@37..38
                       0: MD_TEXTUAL_LITERAL@37..38 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@38..40
                   0: MD_QUOTE_INDENT_LIST@38..38
                   1: R_ANGLE@38..39 ">" [] []
@@ -533,7 +517,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@42..43 "b" [] []
                     1: MD_TEXTUAL@43..44
                       0: MD_TEXTUAL_LITERAL@43..44 "\n" [] []
-                  1: (empty)
     5: MD_NEWLINE@44..45
       0: NEWLINE@44..45 "\n" [] []
     6: MD_QUOTE@45..59
@@ -557,7 +540,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@49..50 "a" [] []
                     1: MD_TEXTUAL@50..51
                       0: MD_TEXTUAL_LITERAL@50..51 "\n" [] []
-                  1: (empty)
         1: MD_QUOTE_PREFIX@51..52
           0: MD_QUOTE_INDENT_LIST@51..51
           1: R_ANGLE@51..52 ">" [] []
@@ -583,7 +565,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@57..58 "b" [] []
                     1: MD_TEXTUAL@58..59
                       0: MD_TEXTUAL_LITERAL@58..59 "\n" [] []
-                  1: (empty)
     7: MD_NEWLINE@59..60
       0: NEWLINE@59..60 "\n" [] []
     8: MD_QUOTE@60..75
@@ -607,7 +588,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@64..65 "a" [] []
                     1: MD_TEXTUAL@65..66
                       0: MD_TEXTUAL_LITERAL@65..66 "\n" [] []
-                  1: (empty)
         1: MD_QUOTE_PREFIX@66..67
           0: MD_QUOTE_INDENT_LIST@66..66
           1: R_ANGLE@66..67 ">" [] []
@@ -633,7 +613,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@73..74 "b" [] []
                     1: MD_TEXTUAL@74..75
                       0: MD_TEXTUAL_LITERAL@74..75 "\n" [] []
-                  1: (empty)
   2: EOF@75..75 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_indentation.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_indentation.md.snap
@@ -103,7 +103,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@50..51 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@51..52 "\n" [] [],
@@ -139,7 +138,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@70..71 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -175,7 +173,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@133..134 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@134..135 "\n" [] [],
@@ -208,7 +205,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@156..157 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -244,7 +240,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@221..222 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@222..223 "\n" [] [],
@@ -286,7 +281,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@245..246 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -322,7 +316,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@310..311 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@311..312 "\n" [] [],
@@ -361,7 +354,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@337..338 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -391,7 +383,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@391..392 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@392..393 "\n" [] [],
@@ -430,7 +421,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@413..414 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -466,7 +456,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@473..474 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@474..475 "\n" [] [],
@@ -502,7 +491,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@498..499 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -538,7 +526,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@556..557 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@557..558 "\n" [] [],
@@ -577,7 +564,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@607..608 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -595,7 +581,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@621..622 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@622..623 "\n" [] [],
@@ -631,7 +616,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@641..642 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -649,7 +633,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@655..656 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@656..657 "\n" [] [],
@@ -685,7 +668,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@675..676 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -703,7 +685,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@702..703 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@703..704 "\n" [] [],
@@ -727,7 +708,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@711..712 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -788,7 +768,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@759..760 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -810,7 +789,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@788..789 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@789..790 "\n" [] [],
@@ -824,7 +802,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@807..808 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@808..809 "\n" [] [],
@@ -860,7 +837,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@840..841 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -878,7 +854,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@858..859 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@859..859 "" [] [],
@@ -909,7 +884,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@49..50 ":" [] []
         7: MD_TEXTUAL@50..51
           0: MD_TEXTUAL_LITERAL@50..51 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@51..52
       0: NEWLINE@51..52 "\n" [] []
     2: MD_BULLET_LIST_ITEM@52..71
@@ -935,7 +909,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@61..70 "continued" [] []
                 5: MD_TEXTUAL@70..71
                   0: MD_TEXTUAL_LITERAL@70..71 "\n" [] []
-              1: (empty)
     3: MD_NEWLINE@71..72
       0: NEWLINE@71..72 "\n" [] []
     4: MD_PARAGRAPH@72..134
@@ -956,7 +929,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@132..133 ":" [] []
         7: MD_TEXTUAL@133..134
           0: MD_TEXTUAL_LITERAL@133..134 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@134..135
       0: NEWLINE@134..135 "\n" [] []
     6: MD_BULLET_LIST_ITEM@135..157
@@ -980,7 +952,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@143..156 "not continued" [] []
                 4: MD_TEXTUAL@156..157
                   0: MD_TEXTUAL_LITERAL@156..157 "\n" [] []
-              1: (empty)
     7: MD_NEWLINE@157..158
       0: NEWLINE@157..158 "\n" [] []
     8: MD_PARAGRAPH@158..222
@@ -1001,7 +972,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@220..221 ":" [] []
         7: MD_TEXTUAL@221..222
           0: MD_TEXTUAL_LITERAL@221..222 "\n" [] []
-      1: (empty)
     9: MD_NEWLINE@222..223
       0: NEWLINE@222..223 "\n" [] []
     10: MD_ORDERED_LIST_ITEM@223..246
@@ -1031,7 +1001,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@236..245 "continued" [] []
                 7: MD_TEXTUAL@245..246
                   0: MD_TEXTUAL_LITERAL@245..246 "\n" [] []
-              1: (empty)
     11: MD_NEWLINE@246..247
       0: NEWLINE@246..247 "\n" [] []
     12: MD_PARAGRAPH@247..311
@@ -1052,7 +1021,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@309..310 ":" [] []
         7: MD_TEXTUAL@310..311
           0: MD_TEXTUAL_LITERAL@310..311 "\n" [] []
-      1: (empty)
     13: MD_NEWLINE@311..312
       0: NEWLINE@311..312 "\n" [] []
     14: MD_ORDERED_LIST_ITEM@312..338
@@ -1080,7 +1048,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@324..337 "not continued" [] []
                 6: MD_TEXTUAL@337..338
                   0: MD_TEXTUAL_LITERAL@337..338 "\n" [] []
-              1: (empty)
     15: MD_NEWLINE@338..339
       0: NEWLINE@338..339 "\n" [] []
     16: MD_PARAGRAPH@339..392
@@ -1097,7 +1064,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@390..391 ":" [] []
         5: MD_TEXTUAL@391..392
           0: MD_TEXTUAL_LITERAL@391..392 "\n" [] []
-      1: (empty)
     17: MD_NEWLINE@392..393
       0: NEWLINE@392..393 "\n" [] []
     18: MD_ORDERED_LIST_ITEM@393..414
@@ -1125,7 +1091,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@404..413 "continued" [] []
                 6: MD_TEXTUAL@413..414
                   0: MD_TEXTUAL_LITERAL@413..414 "\n" [] []
-              1: (empty)
     19: MD_NEWLINE@414..415
       0: NEWLINE@414..415 "\n" [] []
     20: MD_PARAGRAPH@415..474
@@ -1146,7 +1111,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@472..473 ":" [] []
         7: MD_TEXTUAL@473..474
           0: MD_TEXTUAL_LITERAL@473..474 "\n" [] []
-      1: (empty)
     21: MD_NEWLINE@474..475
       0: NEWLINE@474..475 "\n" [] []
     22: MD_ORDERED_LIST_ITEM@475..499
@@ -1172,7 +1136,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@485..498 "not continued" [] []
                 5: MD_TEXTUAL@498..499
                   0: MD_TEXTUAL_LITERAL@498..499 "\n" [] []
-              1: (empty)
     23: MD_NEWLINE@499..500
       0: NEWLINE@499..500 "\n" [] []
     24: MD_PARAGRAPH@500..557
@@ -1193,7 +1156,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@555..556 ":" [] []
         7: MD_TEXTUAL@556..557
           0: MD_TEXTUAL_LITERAL@556..557 "\n" [] []
-      1: (empty)
     25: MD_NEWLINE@557..558
       0: NEWLINE@557..558 "\n" [] []
     26: MD_BULLET_LIST_ITEM@558..608
@@ -1221,7 +1183,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@586..607 "continued at 3 spaces" [] []
                 6: MD_TEXTUAL@607..608
                   0: MD_TEXTUAL_LITERAL@607..608 "\n" [] []
-              1: (empty)
     27: MD_NEWLINE@608..609
       0: NEWLINE@608..609 "\n" [] []
     28: MD_PARAGRAPH@609..622
@@ -1230,7 +1191,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@609..621 "Plus marker:" [] []
         1: MD_TEXTUAL@621..622
           0: MD_TEXTUAL_LITERAL@621..622 "\n" [] []
-      1: (empty)
     29: MD_NEWLINE@622..623
       0: NEWLINE@622..623 "\n" [] []
     30: MD_BULLET_LIST_ITEM@623..642
@@ -1256,7 +1216,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@632..641 "continued" [] []
                 5: MD_TEXTUAL@641..642
                   0: MD_TEXTUAL_LITERAL@641..642 "\n" [] []
-              1: (empty)
     31: MD_NEWLINE@642..643
       0: NEWLINE@642..643 "\n" [] []
     32: MD_PARAGRAPH@643..656
@@ -1265,7 +1224,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@643..655 "Star marker:" [] []
         1: MD_TEXTUAL@655..656
           0: MD_TEXTUAL_LITERAL@655..656 "\n" [] []
-      1: (empty)
     33: MD_NEWLINE@656..657
       0: NEWLINE@656..657 "\n" [] []
     34: MD_BULLET_LIST_ITEM@657..676
@@ -1291,7 +1249,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@666..675 "continued" [] []
                 5: MD_TEXTUAL@675..676
                   0: MD_TEXTUAL_LITERAL@675..676 "\n" [] []
-              1: (empty)
     35: MD_NEWLINE@676..677
       0: NEWLINE@676..677 "\n" [] []
     36: MD_PARAGRAPH@677..703
@@ -1300,7 +1257,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@677..702 "Nested list continuation:" [] []
         1: MD_TEXTUAL@702..703
           0: MD_TEXTUAL_LITERAL@702..703 "\n" [] []
-      1: (empty)
     37: MD_NEWLINE@703..704
       0: NEWLINE@703..704 "\n" [] []
     38: MD_BULLET_LIST_ITEM@704..760
@@ -1318,7 +1274,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@706..711 "outer" [] []
                 1: MD_TEXTUAL@711..712
                   0: MD_TEXTUAL_LITERAL@711..712 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@712..714
               0: MD_INDENT_TOKEN_LIST@712..714
                 0: MD_INDENT_TOKEN@712..713
@@ -1360,7 +1315,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@744..759 "outer continued" [] []
                         11: MD_TEXTUAL@759..760
                           0: MD_TEXTUAL_LITERAL@759..760 "\n" [] []
-                      1: (empty)
     39: MD_NEWLINE@760..761
       0: NEWLINE@760..761 "\n" [] []
     40: MD_PARAGRAPH@761..789
@@ -1369,7 +1323,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@761..788 "Mixed paragraphs and lists:" [] []
         1: MD_TEXTUAL@788..789
           0: MD_TEXTUAL_LITERAL@788..789 "\n" [] []
-      1: (empty)
     41: MD_NEWLINE@789..790
       0: NEWLINE@789..790 "\n" [] []
     42: MD_PARAGRAPH@790..808
@@ -1378,7 +1331,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@790..807 "Some text before." [] []
         1: MD_TEXTUAL@807..808
           0: MD_TEXTUAL_LITERAL@807..808 "\n" [] []
-      1: (empty)
     43: MD_NEWLINE@808..809
       0: NEWLINE@808..809 "\n" [] []
     44: MD_BULLET_LIST_ITEM@809..841
@@ -1404,7 +1356,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@823..840 "with continuation" [] []
                 5: MD_TEXTUAL@840..841
                   0: MD_TEXTUAL_LITERAL@840..841 "\n" [] []
-              1: (empty)
     45: MD_NEWLINE@841..842
       0: NEWLINE@841..842 "\n" [] []
     46: MD_PARAGRAPH@842..859
@@ -1413,7 +1364,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@842..858 "Some text after." [] []
         1: MD_TEXTUAL@858..859
           0: MD_TEXTUAL_LITERAL@858..859 "\n" [] []
-      1: (empty)
   2: EOF@859..859 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_interrupt_bullet.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_interrupt_bullet.md.snap
@@ -27,7 +27,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@34..35 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdBulletListItem {
             md_bullet_list: MdBulletList [
@@ -48,7 +47,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@45..46 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -71,7 +69,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@0..34 "Paragraph followed by bullet list." [] []
         1: MD_TEXTUAL@34..35
           0: MD_TEXTUAL_LITERAL@34..35 "\n" [] []
-      1: (empty)
     1: MD_BULLET_LIST_ITEM@35..46
       0: MD_BULLET_LIST@35..46
         0: MD_BULLET@35..46
@@ -87,7 +84,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@37..45 "item one" [] []
                 1: MD_TEXTUAL@45..46
                   0: MD_TEXTUAL_LITERAL@45..46 "\n" [] []
-              1: (empty)
   2: EOF@46..46 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_interrupt_empty_bullet.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_interrupt_empty_bullet.md.snap
@@ -34,7 +34,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@42..43 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@43..44 "\n" [] [],
@@ -60,7 +59,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@41..42 "+" [] []
         3: MD_TEXTUAL@42..43
           0: MD_TEXTUAL_LITERAL@42..43 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@43..44
       0: NEWLINE@43..44 "\n" [] []
   2: EOF@44..44 "" [] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_interrupt_ordered.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_interrupt_ordered.md.snap
@@ -27,7 +27,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@35..36 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdOrderedListItem {
             md_bullet_list: MdBulletList [
@@ -48,7 +47,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@49..50 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -71,7 +69,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@0..35 "Paragraph followed by ordered list." [] []
         1: MD_TEXTUAL@35..36
           0: MD_TEXTUAL_LITERAL@35..36 "\n" [] []
-      1: (empty)
     1: MD_ORDERED_LIST_ITEM@36..50
       0: MD_BULLET_LIST@36..50
         0: MD_BULLET@36..50
@@ -87,7 +84,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@39..49 "first item" [] []
                 1: MD_TEXTUAL@49..50
                   0: MD_TEXTUAL_LITERAL@49..50 "\n" [] []
-              1: (empty)
   2: EOF@50..50 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_item_tab_indented_fenced_code.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_item_tab_indented_fenced_code.md.snap
@@ -40,7 +40,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@6..7 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@7..8 "\n" [] [],
@@ -110,7 +109,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..6 "item" [] []
                 1: MD_TEXTUAL@6..7
                   0: MD_TEXTUAL_LITERAL@6..7 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@7..8
               0: NEWLINE@7..8 "\n" [] []
             2: MD_CONTINUATION_INDENT@8..9

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_lazy_link_reference_continuation.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_lazy_link_reference_continuation.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 192
 expression: snapshot
 ---
 
@@ -67,7 +66,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@21..22 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -131,7 +129,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@64..65 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@65..65 "" [] [],
@@ -176,7 +173,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@15..21 " /path" [] []
                 7: MD_TEXTUAL@21..22
                   0: MD_TEXTUAL_LITERAL@21..22 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@22..23
       0: NEWLINE@22..23 "\n" [] []
     2: MD_LINK_REFERENCE_DEFINITION@23..57
@@ -215,7 +211,6 @@ MdDocument {
           3: (empty)
         1: MD_TEXTUAL@64..65
           0: MD_TEXTUAL_LITERAL@64..65 "\n" [] []
-      1: (empty)
   2: EOF@65..65 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_link_reference_tab_non_thematic_break.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_link_reference_tab_non_thematic_break.md.snap
@@ -77,7 +77,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@16..17 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -135,7 +134,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@15..16 "x" [] []
                 3: MD_TEXTUAL@16..17
                   0: MD_TEXTUAL_LITERAL@16..17 "\n" [] []
-              1: (empty)
   2: EOF@17..17 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_link_reference_tab_thematic_break.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_link_reference_tab_thematic_break.md.snap
@@ -54,7 +54,6 @@ MdDocument {
                         },
                         MdParagraph {
                             list: MdInlineItemList [],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@11..12 "\n" [] [],
@@ -124,7 +123,6 @@ MdDocument {
               6: (empty)
             1: MD_PARAGRAPH@11..11
               0: MD_INLINE_ITEM_LIST@11..11
-              1: (empty)
             2: MD_NEWLINE@11..12
               0: NEWLINE@11..12 "\n" [] []
             3: MD_CONTINUATION_INDENT@12..13

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_marker_trailing_spaces.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_marker_trailing_spaces.md.snap
@@ -59,7 +59,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@9..10 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@10..11 "\n" [] [],
@@ -96,7 +95,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@21..22 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -137,7 +135,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@31..32 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@32..33 "\n" [] [],
@@ -174,7 +171,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@38..39 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -215,7 +211,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@8..9 "a" [] []
                 1: MD_TEXTUAL@9..10
                   0: MD_TEXTUAL_LITERAL@9..10 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@10..11
               0: NEWLINE@10..11 "\n" [] []
         2: MD_BULLET@11..17
@@ -240,7 +235,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@20..21 "b" [] []
                 1: MD_TEXTUAL@21..22
                   0: MD_TEXTUAL_LITERAL@21..22 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@22..23
       0: NEWLINE@22..23 "\n" [] []
     2: MD_BULLET_LIST_ITEM@23..39
@@ -267,7 +261,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@30..31 "c" [] []
                 1: MD_TEXTUAL@31..32
                   0: MD_TEXTUAL_LITERAL@31..32 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@32..33
               0: NEWLINE@32..33 "\n" [] []
         2: MD_BULLET@33..35
@@ -292,7 +285,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@37..38 "d" [] []
                 1: MD_TEXTUAL@38..39
                   0: MD_TEXTUAL_LITERAL@38..39 "\n" [] []
-              1: (empty)
   2: EOF@39..39 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_no_interrupt_empty_bullet.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_no_interrupt_empty_bullet.md.snap
@@ -40,7 +40,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@100..101 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@101..101 "" [] [],
@@ -67,7 +66,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@43..100 "Still paragraph because no blank line after empty bullet." [] []
         5: MD_TEXTUAL@100..101
           0: MD_TEXTUAL_LITERAL@100..101 "\n" [] []
-      1: (empty)
   2: EOF@101..101 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_no_interrupt_ordered_2.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_no_interrupt_ordered_2.md.snap
@@ -36,7 +36,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@96..97 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@97..97 "" [] [],
@@ -61,7 +60,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@44..96 " This stays in paragraph because 2 cannot interrupt." [] []
         4: MD_TEXTUAL@96..97
           0: MD_TEXTUAL_LITERAL@96..97 "\n" [] []
-      1: (empty)
   2: EOF@97..97 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_tightness.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_tightness.md.snap
@@ -87,7 +87,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@1..13 " Tight Lists" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -106,7 +105,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@61..62 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@62..63 "\n" [] [],
@@ -130,7 +128,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@71..72 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -151,7 +148,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@80..81 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -172,7 +168,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@89..90 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -190,7 +185,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@110..111 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@111..112 "\n" [] [],
@@ -214,7 +208,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@120..121 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -235,7 +228,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@130..131 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -256,7 +248,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@139..140 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -278,7 +269,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@142..154 " Loose Lists" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -297,7 +287,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@199..200 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@200..201 "\n" [] [],
@@ -321,7 +310,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@215..216 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@216..217 "\n" [] [],
@@ -345,7 +333,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@231..232 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@232..233 "\n" [] [],
@@ -369,7 +356,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@247..248 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -387,7 +373,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@268..269 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@269..270 "\n" [] [],
@@ -411,7 +396,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@284..285 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@285..286 "\n" [] [],
@@ -435,7 +419,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@301..302 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@302..303 "\n" [] [],
@@ -459,7 +442,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@317..318 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -493,7 +475,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@346..358 "line Content" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -524,7 +505,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@417..418 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@418..419 "\n" [] [],
@@ -560,7 +540,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@446..447 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -593,7 +572,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@474..475 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -621,7 +599,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@492..508 " Mixed Tightness" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -640,7 +617,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@535..536 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@536..537 "\n" [] [],
@@ -664,7 +640,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@546..547 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -695,7 +670,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@558..559 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                         MdNewline {
                                             value_token: NEWLINE@559..560 "\n" [] [],
@@ -726,7 +700,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@571..572 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -751,7 +724,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@581..582 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -769,7 +741,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@608..609 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@609..610 "\n" [] [],
@@ -793,7 +764,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@619..620 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@620..621 "\n" [] [],
@@ -817,7 +787,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@630..631 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -848,7 +817,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@642..643 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -876,7 +844,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@654..655 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -906,7 +873,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@1..13
           0: MD_TEXTUAL@1..13
             0: MD_TEXTUAL_LITERAL@1..13 " Tight Lists" [] []
-        1: (empty)
       3: MD_HASH_LIST@13..13
     1: MD_NEWLINE@13..14
       0: NEWLINE@13..14 "\n" [] []
@@ -918,7 +884,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@15..61 "A tight list has no blank lines between items:" [] []
         1: MD_TEXTUAL@61..62
           0: MD_TEXTUAL_LITERAL@61..62 "\n" [] []
-      1: (empty)
     4: MD_NEWLINE@62..63
       0: NEWLINE@62..63 "\n" [] []
     5: MD_BULLET_LIST_ITEM@63..90
@@ -936,7 +901,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@65..71 "Item 1" [] []
                 1: MD_TEXTUAL@71..72
                   0: MD_TEXTUAL_LITERAL@71..72 "\n" [] []
-              1: (empty)
         1: MD_BULLET@72..81
           0: MD_LIST_MARKER_PREFIX@72..74
             0: MD_INDENT_TOKEN_LIST@72..72
@@ -950,7 +914,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@74..80 "Item 2" [] []
                 1: MD_TEXTUAL@80..81
                   0: MD_TEXTUAL_LITERAL@80..81 "\n" [] []
-              1: (empty)
         2: MD_BULLET@81..90
           0: MD_LIST_MARKER_PREFIX@81..83
             0: MD_INDENT_TOKEN_LIST@81..81
@@ -964,7 +927,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@83..89 "Item 3" [] []
                 1: MD_TEXTUAL@89..90
                   0: MD_TEXTUAL_LITERAL@89..90 "\n" [] []
-              1: (empty)
     6: MD_NEWLINE@90..91
       0: NEWLINE@90..91 "\n" [] []
     7: MD_PARAGRAPH@91..111
@@ -973,7 +935,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@91..110 "Ordered tight list:" [] []
         1: MD_TEXTUAL@110..111
           0: MD_TEXTUAL_LITERAL@110..111 "\n" [] []
-      1: (empty)
     8: MD_NEWLINE@111..112
       0: NEWLINE@111..112 "\n" [] []
     9: MD_ORDERED_LIST_ITEM@112..140
@@ -991,7 +952,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@115..120 "First" [] []
                 1: MD_TEXTUAL@120..121
                   0: MD_TEXTUAL_LITERAL@120..121 "\n" [] []
-              1: (empty)
         1: MD_BULLET@121..131
           0: MD_LIST_MARKER_PREFIX@121..124
             0: MD_INDENT_TOKEN_LIST@121..121
@@ -1005,7 +965,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@124..130 "Second" [] []
                 1: MD_TEXTUAL@130..131
                   0: MD_TEXTUAL_LITERAL@130..131 "\n" [] []
-              1: (empty)
         2: MD_BULLET@131..140
           0: MD_LIST_MARKER_PREFIX@131..134
             0: MD_INDENT_TOKEN_LIST@131..131
@@ -1019,7 +978,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@134..139 "Third" [] []
                 1: MD_TEXTUAL@139..140
                   0: MD_TEXTUAL_LITERAL@139..140 "\n" [] []
-              1: (empty)
     10: MD_NEWLINE@140..141
       0: NEWLINE@140..141 "\n" [] []
     11: MD_HEADER@141..154
@@ -1031,7 +989,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@142..154
           0: MD_TEXTUAL@142..154
             0: MD_TEXTUAL_LITERAL@142..154 " Loose Lists" [] []
-        1: (empty)
       3: MD_HASH_LIST@154..154
     12: MD_NEWLINE@154..155
       0: NEWLINE@154..155 "\n" [] []
@@ -1043,7 +1000,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@156..199 "A loose list has blank lines between items:" [] []
         1: MD_TEXTUAL@199..200
           0: MD_TEXTUAL_LITERAL@199..200 "\n" [] []
-      1: (empty)
     15: MD_NEWLINE@200..201
       0: NEWLINE@200..201 "\n" [] []
     16: MD_BULLET_LIST_ITEM@201..248
@@ -1061,7 +1017,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@203..215 "Loose item 1" [] []
                 1: MD_TEXTUAL@215..216
                   0: MD_TEXTUAL_LITERAL@215..216 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@216..217
               0: NEWLINE@216..217 "\n" [] []
         1: MD_BULLET@217..233
@@ -1077,7 +1032,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@219..231 "Loose item 2" [] []
                 1: MD_TEXTUAL@231..232
                   0: MD_TEXTUAL_LITERAL@231..232 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@232..233
               0: NEWLINE@232..233 "\n" [] []
         2: MD_BULLET@233..248
@@ -1093,7 +1047,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@235..247 "Loose item 3" [] []
                 1: MD_TEXTUAL@247..248
                   0: MD_TEXTUAL_LITERAL@247..248 "\n" [] []
-              1: (empty)
     17: MD_NEWLINE@248..249
       0: NEWLINE@248..249 "\n" [] []
     18: MD_PARAGRAPH@249..269
@@ -1102,7 +1055,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@249..268 "Ordered loose list:" [] []
         1: MD_TEXTUAL@268..269
           0: MD_TEXTUAL_LITERAL@268..269 "\n" [] []
-      1: (empty)
     19: MD_NEWLINE@269..270
       0: NEWLINE@269..270 "\n" [] []
     20: MD_ORDERED_LIST_ITEM@270..318
@@ -1120,7 +1072,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@273..284 "First loose" [] []
                 1: MD_TEXTUAL@284..285
                   0: MD_TEXTUAL_LITERAL@284..285 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@285..286
               0: NEWLINE@285..286 "\n" [] []
         1: MD_BULLET@286..303
@@ -1136,7 +1087,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@289..301 "Second loose" [] []
                 1: MD_TEXTUAL@301..302
                   0: MD_TEXTUAL_LITERAL@301..302 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@302..303
               0: NEWLINE@302..303 "\n" [] []
         2: MD_BULLET@303..318
@@ -1152,7 +1102,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@306..317 "Third loose" [] []
                 1: MD_TEXTUAL@317..318
                   0: MD_TEXTUAL_LITERAL@317..318 "\n" [] []
-              1: (empty)
     21: MD_NEWLINE@318..319
       0: NEWLINE@318..319 "\n" [] []
     22: MD_HEADER@319..358
@@ -1172,7 +1121,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@345..346 "-" [] []
           4: MD_TEXTUAL@346..358
             0: MD_TEXTUAL_LITERAL@346..358 "line Content" [] []
-        1: (empty)
       3: MD_HASH_LIST@358..358
     23: MD_NEWLINE@358..359
       0: NEWLINE@358..359 "\n" [] []
@@ -1192,7 +1140,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@416..417 ":" [] []
         5: MD_TEXTUAL@417..418
           0: MD_TEXTUAL_LITERAL@417..418 "\n" [] []
-      1: (empty)
     26: MD_NEWLINE@418..419
       0: NEWLINE@418..419 "\n" [] []
     27: MD_BULLET_LIST_ITEM@419..475
@@ -1218,7 +1165,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@432..446 "continues here" [] []
                 5: MD_TEXTUAL@446..447
                   0: MD_TEXTUAL_LITERAL@446..447 "\n" [] []
-              1: (empty)
         1: MD_BULLET@447..475
           0: MD_LIST_MARKER_PREFIX@447..449
             0: MD_INDENT_TOKEN_LIST@447..447
@@ -1240,7 +1186,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@460..474 "also continues" [] []
                 5: MD_TEXTUAL@474..475
                   0: MD_TEXTUAL_LITERAL@474..475 "\n" [] []
-              1: (empty)
     28: MD_NEWLINE@475..476
       0: NEWLINE@475..476 "\n" [] []
     29: MD_HEADER@476..508
@@ -1256,7 +1201,6 @@ MdDocument {
             0: MD_TEXTUAL_LITERAL@491..492 "-" [] []
           2: MD_TEXTUAL@492..508
             0: MD_TEXTUAL_LITERAL@492..508 " Mixed Tightness" [] []
-        1: (empty)
       3: MD_HASH_LIST@508..508
     30: MD_NEWLINE@508..509
       0: NEWLINE@508..509 "\n" [] []
@@ -1268,7 +1212,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@510..535 "Outer tight, inner loose:" [] []
         1: MD_TEXTUAL@535..536
           0: MD_TEXTUAL_LITERAL@535..536 "\n" [] []
-      1: (empty)
     33: MD_NEWLINE@536..537
       0: NEWLINE@536..537 "\n" [] []
     34: MD_BULLET_LIST_ITEM@537..582
@@ -1286,7 +1229,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@539..546 "Outer 1" [] []
                 1: MD_TEXTUAL@546..547
                   0: MD_TEXTUAL_LITERAL@546..547 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@547..549
               0: MD_INDENT_TOKEN_LIST@547..549
                 0: MD_INDENT_TOKEN@547..548
@@ -1308,7 +1250,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@551..558 "Inner 1" [] []
                         1: MD_TEXTUAL@558..559
                           0: MD_TEXTUAL_LITERAL@558..559 "\n" [] []
-                      1: (empty)
                     1: MD_NEWLINE@559..560
                       0: NEWLINE@559..560 "\n" [] []
                 1: MD_BULLET@560..572
@@ -1328,7 +1269,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@564..571 "Inner 2" [] []
                         1: MD_TEXTUAL@571..572
                           0: MD_TEXTUAL_LITERAL@571..572 "\n" [] []
-                      1: (empty)
         1: MD_BULLET@572..582
           0: MD_LIST_MARKER_PREFIX@572..574
             0: MD_INDENT_TOKEN_LIST@572..572
@@ -1342,7 +1282,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@574..581 "Outer 2" [] []
                 1: MD_TEXTUAL@581..582
                   0: MD_TEXTUAL_LITERAL@581..582 "\n" [] []
-              1: (empty)
     35: MD_NEWLINE@582..583
       0: NEWLINE@582..583 "\n" [] []
     36: MD_PARAGRAPH@583..609
@@ -1351,7 +1290,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@583..608 "Outer loose, inner tight:" [] []
         1: MD_TEXTUAL@608..609
           0: MD_TEXTUAL_LITERAL@608..609 "\n" [] []
-      1: (empty)
     37: MD_NEWLINE@609..610
       0: NEWLINE@609..610 "\n" [] []
     38: MD_BULLET_LIST_ITEM@610..655
@@ -1369,7 +1307,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@612..619 "Outer A" [] []
                 1: MD_TEXTUAL@619..620
                   0: MD_TEXTUAL_LITERAL@619..620 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@620..621
               0: NEWLINE@620..621 "\n" [] []
         1: MD_BULLET@621..655
@@ -1385,7 +1322,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@623..630 "Outer B" [] []
                 1: MD_TEXTUAL@630..631
                   0: MD_TEXTUAL_LITERAL@630..631 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@631..633
               0: MD_INDENT_TOKEN_LIST@631..633
                 0: MD_INDENT_TOKEN@631..632
@@ -1407,7 +1343,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@635..642 "Inner A" [] []
                         1: MD_TEXTUAL@642..643
                           0: MD_TEXTUAL_LITERAL@642..643 "\n" [] []
-                      1: (empty)
                 1: MD_BULLET@643..655
                   0: MD_LIST_MARKER_PREFIX@643..647
                     0: MD_INDENT_TOKEN_LIST@643..645
@@ -1425,7 +1360,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@647..654 "Inner B" [] []
                         1: MD_TEXTUAL@654..655
                           0: MD_TEXTUAL_LITERAL@654..655 "\n" [] []
-                      1: (empty)
   2: EOF@655..655 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_bullet_markers_split.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_bullet_markers_split.md.snap
@@ -38,7 +38,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -66,7 +65,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@12..13 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -98,7 +96,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "one" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@6..7
       0: NEWLINE@6..7 "\n" [] []
     2: MD_BULLET_LIST_ITEM@7..13
@@ -116,7 +113,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@9..12 "two" [] []
                 1: MD_TEXTUAL@12..13
                   0: MD_TEXTUAL_LITERAL@12..13 "\n" [] []
-              1: (empty)
   2: EOF@13..13 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_after_fenced_code.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_after_fenced_code.md.snap
@@ -42,7 +42,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@6..7 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@7..8 "\n" [] [],
@@ -117,7 +116,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@35..36 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -149,7 +147,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..6 "item" [] []
                 1: MD_TEXTUAL@6..7
                   0: MD_TEXTUAL_LITERAL@6..7 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@7..8
               0: NEWLINE@7..8 "\n" [] []
             2: MD_CONTINUATION_INDENT@8..10
@@ -198,7 +195,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@30..35 "other" [] []
                 1: MD_TEXTUAL@35..36
                   0: MD_TEXTUAL_LITERAL@35..36 "\n" [] []
-              1: (empty)
   2: EOF@36..36 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_heading_in_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_heading_in_list.md.snap
@@ -42,7 +42,6 @@ MdDocument {
                                         value_token: MD_TEXTUAL_LITERAL@3..7 " Bar" [] [],
                                     },
                                 ],
-                                hard_line: missing (optional),
                             },
                             after: MdHashList [],
                         },
@@ -75,7 +74,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@15..16 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -110,7 +108,6 @@ MdDocument {
                 0: MD_INLINE_ITEM_LIST@3..7
                   0: MD_TEXTUAL@3..7
                     0: MD_TEXTUAL_LITERAL@3..7 " Bar" [] []
-                1: (empty)
               3: MD_HASH_LIST@7..7
     1: MD_NEWLINE@7..8
       0: NEWLINE@7..8 "\n" [] []
@@ -131,7 +128,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@11..15 "item" [] []
                 1: MD_TEXTUAL@15..16
                   0: MD_TEXTUAL_LITERAL@15..16 "\n" [] []
-              1: (empty)
   2: EOF@16..16 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_paragraph.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_paragraph.md.snap
@@ -38,7 +38,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -66,7 +65,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@13..14 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -98,7 +96,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "bar" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@6..7
       0: NEWLINE@6..7 "\n" [] []
     2: MD_BULLET_LIST_ITEM@7..14
@@ -116,7 +113,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@9..13 "item" [] []
                 1: MD_TEXTUAL@13..14
                   0: MD_TEXTUAL_LITERAL@13..14 "\n" [] []
-              1: (empty)
   2: EOF@14..14 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_setext.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_setext.md.snap
@@ -76,7 +76,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@19..20 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -132,7 +131,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@15..19 "item" [] []
                 1: MD_TEXTUAL@19..20
                   0: MD_TEXTUAL_LITERAL@19..20 "\n" [] []
-              1: (empty)
   2: EOF@20..20 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_thematic_break.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_thematic_break.md.snap
@@ -63,7 +63,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@13..14 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -111,7 +110,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@9..13 "item" [] []
                 1: MD_TEXTUAL@13..14
                   0: MD_TEXTUAL_LITERAL@13..14 "\n" [] []
-              1: (empty)
   2: EOF@14..14 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_three_after_heading_in_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_markers_three_after_heading_in_list.md.snap
@@ -44,7 +44,6 @@ MdDocument {
                                         value_token: MD_TEXTUAL_LITERAL@3..7 " Bar" [] [],
                                     },
                                 ],
-                                hard_line: missing (optional),
                             },
                             after: MdHashList [],
                         },
@@ -77,7 +76,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@19..20 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -105,7 +103,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@31..32 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -140,7 +137,6 @@ MdDocument {
                 0: MD_INLINE_ITEM_LIST@3..7
                   0: MD_TEXTUAL@3..7
                     0: MD_TEXTUAL_LITERAL@3..7 " Bar" [] []
-                1: (empty)
               3: MD_HASH_LIST@7..7
     1: MD_NEWLINE@7..8
       0: NEWLINE@7..8 "\n" [] []
@@ -161,7 +157,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@11..19 "item one" [] []
                 1: MD_TEXTUAL@19..20
                   0: MD_TEXTUAL_LITERAL@19..20 "\n" [] []
-              1: (empty)
     4: MD_NEWLINE@20..21
       0: NEWLINE@20..21 "\n" [] []
     5: MD_BULLET_LIST_ITEM@21..32
@@ -179,7 +174,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@23..31 "item two" [] []
                 1: MD_TEXTUAL@31..32
                   0: MD_TEXTUAL_LITERAL@31..32 "\n" [] []
-              1: (empty)
   2: EOF@32..32 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_ordered_delimiters_split.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/mixed_ordered_delimiters_split.md.snap
@@ -38,7 +38,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@6..7 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -66,7 +65,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@14..15 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -98,7 +96,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@3..6 "one" [] []
                 1: MD_TEXTUAL@6..7
                   0: MD_TEXTUAL_LITERAL@6..7 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@7..8
       0: NEWLINE@7..8 "\n" [] []
     2: MD_ORDERED_LIST_ITEM@8..15
@@ -116,7 +113,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@11..14 "two" [] []
                 1: MD_TEXTUAL@14..15
                   0: MD_TEXTUAL_LITERAL@14..15 "\n" [] []
-              1: (empty)
   2: EOF@15..15 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/multi_backtick_code.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/multi_backtick_code.md.snap
@@ -41,7 +41,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@23..24 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@24..25 "\n" [] [],
@@ -76,7 +75,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@76..77 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@77..78 "\n" [] [],
@@ -111,7 +109,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@118..119 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@119..120 "\n" [] [],
@@ -140,7 +137,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@151..152 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@152..152 "" [] [],
@@ -165,7 +161,6 @@ MdDocument {
           2: BACKTICK@22..23 "`" [] []
         2: MD_TEXTUAL@23..24
           0: MD_TEXTUAL_LITERAL@23..24 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@24..25
       0: NEWLINE@24..25 "\n" [] []
     2: MD_PARAGRAPH@25..77
@@ -188,7 +183,6 @@ MdDocument {
           2: BACKTICK@74..76 "``" [] []
         2: MD_TEXTUAL@76..77
           0: MD_TEXTUAL_LITERAL@76..77 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@77..78
       0: NEWLINE@77..78 "\n" [] []
     4: MD_PARAGRAPH@78..119
@@ -211,7 +205,6 @@ MdDocument {
           2: BACKTICK@115..118 "```" [] []
         2: MD_TEXTUAL@118..119
           0: MD_TEXTUAL_LITERAL@118..119 "\n" [] []
-      1: (empty)
     5: MD_NEWLINE@119..120
       0: NEWLINE@119..120 "\n" [] []
     6: MD_PARAGRAPH@120..152
@@ -230,7 +223,6 @@ MdDocument {
           2: BACKTICK@149..151 "``" [] []
         2: MD_TEXTUAL@151..152
           0: MD_TEXTUAL_LITERAL@151..152 "\n" [] []
-      1: (empty)
   2: EOF@152..152 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/multibyte_emphasis_in_blockquote.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/multibyte_emphasis_in_blockquote.md.snap
@@ -59,7 +59,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@167..168 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -104,7 +103,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@113..167 "と同様のアプローチを採用しています。" [] []
             3: MD_TEXTUAL@167..168
               0: MD_TEXTUAL_LITERAL@167..168 "\n" [] []
-          1: (empty)
   2: EOF@168..168 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/multiline_label_reference.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/multiline_label_reference.md.snap
@@ -40,7 +40,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@9..10 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@10..10 "" [] [],
@@ -68,7 +67,6 @@ MdDocument {
           3: (empty)
         1: MD_TEXTUAL@9..10
           0: MD_TEXTUAL_LITERAL@9..10 "\n" [] []
-      1: (empty)
   2: EOF@10..10 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/multiline_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/multiline_list.md.snap
@@ -59,7 +59,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@32..33 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -80,7 +79,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@46..47 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -123,7 +121,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@81..82 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -144,7 +141,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@97..98 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -172,7 +168,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@114..115 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -203,7 +198,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@129..130 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -231,7 +225,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@147..148 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -256,7 +249,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@164..165 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -296,7 +288,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@15..32 "with continuation" [] []
                 5: MD_TEXTUAL@32..33
                   0: MD_TEXTUAL_LITERAL@32..33 "\n" [] []
-              1: (empty)
         1: MD_BULLET@33..47
           0: MD_LIST_MARKER_PREFIX@33..35
             0: MD_INDENT_TOKEN_LIST@33..33
@@ -310,7 +301,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@35..46 "Second item" [] []
                 1: MD_TEXTUAL@46..47
                   0: MD_TEXTUAL_LITERAL@46..47 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@47..48
       0: NEWLINE@47..48 "\n" [] []
     2: MD_ORDERED_LIST_ITEM@48..98
@@ -338,7 +328,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@67..81 "continues here" [] []
                 6: MD_TEXTUAL@81..82
                   0: MD_TEXTUAL_LITERAL@81..82 "\n" [] []
-              1: (empty)
         1: MD_BULLET@82..98
           0: MD_LIST_MARKER_PREFIX@82..85
             0: MD_INDENT_TOKEN_LIST@82..82
@@ -352,7 +341,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@85..97 "Next ordered" [] []
                 1: MD_TEXTUAL@97..98
                   0: MD_TEXTUAL_LITERAL@97..98 "\n" [] []
-              1: (empty)
     3: MD_NEWLINE@98..99
       0: NEWLINE@98..99 "\n" [] []
     4: MD_BULLET_LIST_ITEM@99..165
@@ -370,7 +358,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@101..114 "Nested lists:" [] []
                 1: MD_TEXTUAL@114..115
                   0: MD_TEXTUAL_LITERAL@114..115 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@115..117
               0: MD_INDENT_TOKEN_LIST@115..117
                 0: MD_INDENT_TOKEN@115..116
@@ -392,7 +379,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@119..129 "Child item" [] []
                         1: MD_TEXTUAL@129..130
                           0: MD_TEXTUAL_LITERAL@129..130 "\n" [] []
-                      1: (empty)
                 1: MD_BULLET@130..148
                   0: MD_LIST_MARKER_PREFIX@130..134
                     0: MD_INDENT_TOKEN_LIST@130..132
@@ -410,7 +396,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@134..147 "Another child" [] []
                         1: MD_TEXTUAL@147..148
                           0: MD_TEXTUAL_LITERAL@147..148 "\n" [] []
-                      1: (empty)
         1: MD_BULLET@148..165
           0: MD_LIST_MARKER_PREFIX@148..150
             0: MD_INDENT_TOKEN_LIST@148..148
@@ -424,7 +409,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@150..164 "Back to parent" [] []
                 1: MD_TEXTUAL@164..165
                   0: MD_TEXTUAL_LITERAL@164..165 "\n" [] []
-              1: (empty)
   2: EOF@165..165 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/multiline_open_tag_blockquote_marker.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/multiline_open_tag_blockquote_marker.md.snap
@@ -33,7 +33,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@23..24 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdQuote {
             prefix: MdQuotePrefix {
@@ -67,7 +66,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@38..39 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -92,7 +90,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@10..23 "div class=\"a\"" [] []
         3: MD_TEXTUAL@23..24
           0: MD_TEXTUAL_LITERAL@23..24 "\n" [] []
-      1: (empty)
     1: MD_QUOTE@24..39
       0: MD_QUOTE_PREFIX@24..25
         0: MD_QUOTE_INDENT_LIST@24..24
@@ -115,7 +112,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@33..38 " tag." [] []
             3: MD_TEXTUAL@38..39
               0: MD_TEXTUAL_LITERAL@38..39 "\n" [] []
-          1: (empty)
   2: EOF@39..39 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_bullet_indent_tokens.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_bullet_indent_tokens.md.snap
@@ -37,7 +37,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@4..5 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -68,7 +67,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@11..12 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -104,7 +102,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..4 "ff" [] []
                 1: MD_TEXTUAL@4..5
                   0: MD_TEXTUAL_LITERAL@4..5 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@5..7
               0: MD_INDENT_TOKEN_LIST@5..7
                 0: MD_INDENT_TOKEN@5..6
@@ -126,7 +123,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@9..11 "ff" [] []
                         1: MD_TEXTUAL@11..12
                           0: MD_TEXTUAL_LITERAL@11..12 "\n" [] []
-                      1: (empty)
   2: EOF@12..12 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_lazy_continuation_loose_item.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_lazy_continuation_loose_item.md.snap
@@ -40,7 +40,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -83,7 +82,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                         MdNewline {
                                             value_token: NEWLINE@31..32 "\n" [] [],
@@ -113,7 +111,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@44..45 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -149,7 +146,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..7 "outer" [] []
                 1: MD_TEXTUAL@7..8
                   0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@8..10
               0: MD_INDENT_TOKEN_LIST@8..10
                 0: MD_INDENT_TOKEN@8..9
@@ -179,7 +175,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] []
                         5: MD_TEXTUAL@30..31
                           0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
-                      1: (empty)
                     1: MD_NEWLINE@31..32
                       0: NEWLINE@31..32 "\n" [] []
                     2: MD_CONTINUATION_INDENT@32..36
@@ -198,7 +193,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@36..44 "indented" [] []
                         1: MD_TEXTUAL@44..45
                           0: MD_TEXTUAL_LITERAL@44..45 "\n" [] []
-                      1: (empty)
   2: EOF@45..45 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_lazy_continuation_same_marker_trailing.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_lazy_continuation_same_marker_trailing.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -88,7 +87,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@36..37 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -124,7 +122,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..7 "outer" [] []
                 1: MD_TEXTUAL@7..8
                   0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@8..10
               0: MD_INDENT_TOKEN_LIST@8..10
                 0: MD_INDENT_TOKEN@8..9
@@ -158,7 +155,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@31..36 "hello" [] []
                         7: MD_TEXTUAL@36..37
                           0: MD_TEXTUAL_LITERAL@36..37 "\n" [] []
-                      1: (empty)
   2: EOF@37..37 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_lazy_continuation_trailing_paragraph.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_lazy_continuation_trailing_paragraph.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -88,7 +87,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@36..37 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -124,7 +122,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..7 "outer" [] []
                 1: MD_TEXTUAL@7..8
                   0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@8..10
               0: MD_INDENT_TOKEN_LIST@8..10
                 0: MD_INDENT_TOKEN@8..9
@@ -158,7 +155,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@31..36 "hello" [] []
                         7: MD_TEXTUAL@36..37
                           0: MD_TEXTUAL_LITERAL@36..37 "\n" [] []
-                      1: (empty)
   2: EOF@37..37 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_blank_line_siblings.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_blank_line_siblings.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -70,7 +69,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@15..16 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                         MdNewline {
                                             value_token: NEWLINE@16..17 "\n" [] [],
@@ -101,7 +99,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@26..27 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -137,7 +134,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "top" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@6..8
               0: MD_INDENT_TOKEN_LIST@6..8
                 0: MD_INDENT_TOKEN@6..7
@@ -159,7 +155,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@10..15 "sub a" [] []
                         1: MD_TEXTUAL@15..16
                           0: MD_TEXTUAL_LITERAL@15..16 "\n" [] []
-                      1: (empty)
                     1: MD_NEWLINE@16..17
                       0: NEWLINE@16..17 "\n" [] []
                 1: MD_BULLET@17..27
@@ -179,7 +174,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@21..26 "sub b" [] []
                         1: MD_TEXTUAL@26..27
                           0: MD_TEXTUAL_LITERAL@26..27 "\n" [] []
-                      1: (empty)
   2: EOF@27..27 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_double_blank.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_double_blank.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 190
 expression: snapshot
 ---
 
@@ -41,7 +40,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -72,7 +70,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@15..16 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                         MdNewline {
                                             value_token: NEWLINE@16..17 "\n" [] [],
@@ -106,7 +103,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@27..28 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -142,7 +138,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "top" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@6..8
               0: MD_INDENT_TOKEN_LIST@6..8
                 0: MD_INDENT_TOKEN@6..7
@@ -164,7 +159,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@10..15 "sub a" [] []
                         1: MD_TEXTUAL@15..16
                           0: MD_TEXTUAL_LITERAL@15..16 "\n" [] []
-                      1: (empty)
                     1: MD_NEWLINE@16..17
                       0: NEWLINE@16..17 "\n" [] []
                     2: MD_NEWLINE@17..18
@@ -186,7 +180,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@22..27 "sub b" [] []
                         1: MD_TEXTUAL@27..28
                           0: MD_TEXTUAL_LITERAL@27..28 "\n" [] []
-                      1: (empty)
   2: EOF@28..28 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_double_blank_siblings.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_double_blank_siblings.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 190
 expression: snapshot
 ---
 
@@ -41,7 +40,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -72,7 +70,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@15..16 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                         MdNewline {
                                             value_token: NEWLINE@16..17 "\n" [] [],
@@ -106,7 +103,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@27..28 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -142,7 +138,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "top" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@6..8
               0: MD_INDENT_TOKEN_LIST@6..8
                 0: MD_INDENT_TOKEN@6..7
@@ -164,7 +159,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@10..15 "sub a" [] []
                         1: MD_TEXTUAL@15..16
                           0: MD_TEXTUAL_LITERAL@15..16 "\n" [] []
-                      1: (empty)
                     1: MD_NEWLINE@16..17
                       0: NEWLINE@16..17 "\n" [] []
                     2: MD_NEWLINE@17..18
@@ -186,7 +180,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@22..27 "sub b" [] []
                         1: MD_TEXTUAL@27..28
                           0: MD_TEXTUAL_LITERAL@27..28 "\n" [] []
-                      1: (empty)
   2: EOF@28..28 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_interrupt_after_newline.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_interrupt_after_newline.md.snap
@@ -37,7 +37,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -68,7 +67,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@13..14 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -104,7 +102,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "foo" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@6..8
               0: MD_INDENT_TOKEN_LIST@6..8
                 0: MD_INDENT_TOKEN@6..7
@@ -126,7 +123,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@10..13 "bar" [] []
                         1: MD_TEXTUAL@13..14
                           0: MD_TEXTUAL_LITERAL@13..14 "\n" [] []
-                      1: (empty)
   2: EOF@14..14 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_fence.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_fence.md.snap
@@ -41,7 +41,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -84,7 +83,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -141,7 +139,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..7 "outer" [] []
                 1: MD_TEXTUAL@7..8
                   0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@8..10
               0: MD_INDENT_TOKEN_LIST@8..10
                 0: MD_INDENT_TOKEN@8..9
@@ -171,7 +168,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@21..30 "lazy line" [] []
                         5: MD_TEXTUAL@30..31
                           0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
-                      1: (empty)
     1: MD_FENCED_CODE_BLOCK@31..48
       0: MD_INDENT_TOKEN_LIST@31..31
       1: TRIPLE_BACKTICK@31..34 "```" [] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_link_reference.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_lazy_continuation_before_link_reference.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -100,7 +99,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@44..45 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -136,7 +134,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..7 "outer" [] []
                 1: MD_TEXTUAL@7..8
                   0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@8..10
               0: MD_INDENT_TOKEN_LIST@8..10
                 0: MD_INDENT_TOKEN@8..9
@@ -178,7 +175,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@39..44 " /url" [] []
                         11: MD_TEXTUAL@44..45
                           0: MD_TEXTUAL_LITERAL@44..45 "\n" [] []
-                      1: (empty)
   2: EOF@45..45 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_tab_indented_siblings.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_tab_indented_siblings.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -67,7 +66,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@17..18 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -92,7 +90,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@29..30 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                         MdContinuationIndent {
                                             indent: MdIndentTokenList [
@@ -129,7 +126,6 @@ MdDocument {
                                                                     value_token: MD_TEXTUAL_LITERAL@44..45 "\n" [] [],
                                                                 },
                                                             ],
-                                                            hard_line: missing (optional),
                                                         },
                                                     ],
                                                 },
@@ -169,7 +165,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "Top" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@6..7
               0: MD_INDENT_TOKEN_LIST@6..7
                 0: MD_INDENT_TOKEN@6..7
@@ -189,7 +184,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@9..17 "Nested 1" [] []
                         1: MD_TEXTUAL@17..18
                           0: MD_TEXTUAL_LITERAL@17..18 "\n" [] []
-                      1: (empty)
                 1: MD_BULLET@18..45
                   0: MD_LIST_MARKER_PREFIX@18..21
                     0: MD_INDENT_TOKEN_LIST@18..19
@@ -205,7 +199,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@21..29 "Nested 2" [] []
                         1: MD_TEXTUAL@29..30
                           0: MD_TEXTUAL_LITERAL@29..30 "\n" [] []
-                      1: (empty)
                     1: MD_CONTINUATION_INDENT@30..32
                       0: MD_INDENT_TOKEN_LIST@30..32
                         0: MD_INDENT_TOKEN@30..31
@@ -231,7 +224,6 @@ MdDocument {
                                   0: MD_TEXTUAL_LITERAL@38..44 "Nested" [] []
                                 3: MD_TEXTUAL@44..45
                                   0: MD_TEXTUAL_LITERAL@44..45 "\n" [] []
-                              1: (empty)
   2: EOF@45..45 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_triple_blank_siblings.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_list_triple_blank_siblings.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 190
 expression: snapshot
 ---
 
@@ -42,7 +41,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@5..6 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -73,7 +71,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@15..16 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                         MdNewline {
                                             value_token: NEWLINE@16..17 "\n" [] [],
@@ -110,7 +107,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@28..29 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -146,7 +142,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..5 "top" [] []
                 1: MD_TEXTUAL@5..6
                   0: MD_TEXTUAL_LITERAL@5..6 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@6..8
               0: MD_INDENT_TOKEN_LIST@6..8
                 0: MD_INDENT_TOKEN@6..7
@@ -168,7 +163,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@10..15 "sub a" [] []
                         1: MD_TEXTUAL@15..16
                           0: MD_TEXTUAL_LITERAL@15..16 "\n" [] []
-                      1: (empty)
                     1: MD_NEWLINE@16..17
                       0: NEWLINE@16..17 "\n" [] []
                     2: MD_NEWLINE@17..18
@@ -192,7 +186,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@23..28 "sub b" [] []
                         1: MD_TEXTUAL@28..29
                           0: MD_TEXTUAL_LITERAL@28..29 "\n" [] []
-                      1: (empty)
   2: EOF@29..29 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_quote.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/nested_quote.md.snap
@@ -37,7 +37,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@13..14 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -60,7 +59,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@29..30 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdQuotePrefix {
                             pre_marker_indent: MdQuoteIndentList [],
@@ -88,7 +86,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@47..48 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -115,7 +112,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@64..65 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -142,7 +138,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@2..13 "Outer quote" [] []
             1: MD_TEXTUAL@13..14
               0: MD_TEXTUAL_LITERAL@13..14 "\n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@14..15
           0: MD_QUOTE_INDENT_LIST@14..14
           1: R_ANGLE@14..15 ">" [] []
@@ -159,7 +154,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@17..29 "Nested quote" [] []
                 1: MD_TEXTUAL@29..30
                   0: MD_TEXTUAL_LITERAL@29..30 "\n" [] []
-              1: (empty)
             1: MD_QUOTE_PREFIX@30..31
               0: MD_QUOTE_INDENT_LIST@30..30
               1: R_ANGLE@30..31 ">" [] []
@@ -180,7 +174,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@34..47 "Deeply nested" [] []
                     1: MD_TEXTUAL@47..48
                       0: MD_TEXTUAL_LITERAL@47..48 "\n" [] []
-                  1: (empty)
     1: MD_NEWLINE@48..49
       0: NEWLINE@48..49 "\n" [] []
     2: MD_QUOTE@49..65
@@ -195,7 +188,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@51..64 "Back to outer" [] []
             1: MD_TEXTUAL@64..65
               0: MD_TEXTUAL_LITERAL@64..65 "\n" [] []
-          1: (empty)
   2: EOF@65..65 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_list.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_list.md.snap
@@ -41,7 +41,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@13..14 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -62,7 +61,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@28..29 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -83,7 +81,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@42..43 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -111,7 +108,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@64..65 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -132,7 +128,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@80..81 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -164,7 +159,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@3..13 "First item" [] []
                 1: MD_TEXTUAL@13..14
                   0: MD_TEXTUAL_LITERAL@13..14 "\n" [] []
-              1: (empty)
         1: MD_BULLET@14..29
           0: MD_LIST_MARKER_PREFIX@14..17
             0: MD_INDENT_TOKEN_LIST@14..14
@@ -178,7 +172,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@17..28 "Second item" [] []
                 1: MD_TEXTUAL@28..29
                   0: MD_TEXTUAL_LITERAL@28..29 "\n" [] []
-              1: (empty)
         2: MD_BULLET@29..43
           0: MD_LIST_MARKER_PREFIX@29..32
             0: MD_INDENT_TOKEN_LIST@29..29
@@ -192,7 +185,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@32..42 "Third item" [] []
                 1: MD_TEXTUAL@42..43
                   0: MD_TEXTUAL_LITERAL@42..43 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@43..44
       0: NEWLINE@43..44 "\n" [] []
     2: MD_ORDERED_LIST_ITEM@44..81
@@ -210,7 +202,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@47..64 "Using parenthesis" [] []
                 1: MD_TEXTUAL@64..65
                   0: MD_TEXTUAL_LITERAL@64..65 "\n" [] []
-              1: (empty)
         1: MD_BULLET@65..81
           0: MD_LIST_MARKER_PREFIX@65..68
             0: MD_INDENT_TOKEN_LIST@65..65
@@ -224,7 +215,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@68..80 "Another item" [] []
                 1: MD_TEXTUAL@80..81
                   0: MD_TEXTUAL_LITERAL@80..81 "\n" [] []
-              1: (empty)
   2: EOF@81..81 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_list_link_reference_tab_thematic_break.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_list_link_reference_tab_thematic_break.md.snap
@@ -54,7 +54,6 @@ MdDocument {
                         },
                         MdParagraph {
                             list: MdInlineItemList [],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@13..14 "\n" [] [],
@@ -127,7 +126,6 @@ MdDocument {
               6: (empty)
             1: MD_PARAGRAPH@13..13
               0: MD_INLINE_ITEM_LIST@13..13
-              1: (empty)
             2: MD_NEWLINE@13..14
               0: NEWLINE@13..14 "\n" [] []
             3: MD_CONTINUATION_INDENT@14..16

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_list_loose_after_empty_item.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_list_loose_after_empty_item.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@4..5 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -76,7 +75,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@13..14 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -108,7 +106,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@3..4 "a" [] []
                 1: MD_TEXTUAL@4..5
                   0: MD_TEXTUAL_LITERAL@4..5 "\n" [] []
-              1: (empty)
         1: MD_BULLET@5..9
           0: MD_LIST_MARKER_PREFIX@5..7
             0: MD_INDENT_TOKEN_LIST@5..5
@@ -133,7 +130,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@12..13 "c" [] []
                 1: MD_TEXTUAL@13..14
                   0: MD_TEXTUAL_LITERAL@13..14 "\n" [] []
-              1: (empty)
   2: EOF@14..14 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_list_split_after_empty_item_delimiter_change.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_list_split_after_empty_item_delimiter_change.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 190
 expression: snapshot
 ---
 
@@ -40,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@4..5 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -81,7 +79,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@13..14 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -113,7 +110,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@3..4 "a" [] []
                 1: MD_TEXTUAL@4..5
                   0: MD_TEXTUAL_LITERAL@4..5 "\n" [] []
-              1: (empty)
         1: MD_BULLET@5..8
           0: MD_LIST_MARKER_PREFIX@5..7
             0: MD_INDENT_TOKEN_LIST@5..5
@@ -140,7 +136,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@12..13 "c" [] []
                 1: MD_TEXTUAL@13..14
                   0: MD_TEXTUAL_LITERAL@13..14 "\n" [] []
-              1: (empty)
   2: EOF@14..14 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_marker_non_one_in_bullet_item.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_marker_non_one_in_bullet_item.md.snap
@@ -55,7 +55,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -99,7 +98,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@13..20 " nested" [] []
                 7: MD_TEXTUAL@20..21
                   0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-              1: (empty)
   2: EOF@21..21 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_marker_non_one_top_level.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_marker_non_one_top_level.md.snap
@@ -55,7 +55,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@19..20 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -99,7 +98,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@14..19 " lazy" [] []
                 7: MD_TEXTUAL@19..20
                   0: MD_TEXTUAL_LITERAL@19..20 "\n" [] []
-              1: (empty)
   2: EOF@20..20 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_marker_one_starts_sublist_in_bullet.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_marker_one_starts_sublist_in_bullet.md.snap
@@ -37,7 +37,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -71,7 +70,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -107,7 +105,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..7 "outer" [] []
                 1: MD_TEXTUAL@7..8
                   0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@8..11
               0: MD_INDENT_TOKEN_LIST@8..11
                 0: MD_INDENT_TOKEN@8..9
@@ -131,7 +128,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@14..20 "nested" [] []
                         1: MD_TEXTUAL@20..21
                           0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-                      1: (empty)
   2: EOF@21..21 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_at_content_column.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_at_content_column.md.snap
@@ -50,7 +50,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@6..7 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -84,7 +83,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@15..16 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -112,7 +110,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@24..25 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdNewline {
                             value_token: NEWLINE@25..26 "\n" [] [],
@@ -152,7 +149,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@35..36 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -180,7 +176,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@46..47 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -217,7 +212,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@58..59 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -256,7 +250,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@71..72 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -289,7 +282,6 @@ MdDocument {
                                                             value_token: MD_TEXTUAL_LITERAL@82..83 "\n" [] [],
                                                         },
                                                     ],
-                                                    hard_line: missing (optional),
                                                 },
                                             ],
                                         },
@@ -330,7 +322,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@95..96 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                                 MdQuotePrefix {
                                     pre_marker_indent: MdQuoteIndentList [],
@@ -363,7 +354,6 @@ MdDocument {
                                                             value_token: MD_TEXTUAL_LITERAL@107..108 "\n" [] [],
                                                         },
                                                     ],
-                                                    hard_line: missing (optional),
                                                 },
                                             ],
                                         },
@@ -401,7 +391,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@3..6 "foo" [] []
                 1: MD_TEXTUAL@6..7
                   0: MD_TEXTUAL_LITERAL@6..7 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@7..10
               0: MD_INDENT_TOKEN_LIST@7..10
                 0: MD_INDENT_TOKEN@7..8
@@ -425,7 +414,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@12..15 "bar" [] []
                         1: MD_TEXTUAL@15..16
                           0: MD_TEXTUAL_LITERAL@15..16 "\n" [] []
-                      1: (empty)
             3: MD_NEWLINE@16..17
               0: NEWLINE@16..17 "\n" [] []
         1: MD_BULLET@17..37
@@ -441,7 +429,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@21..24 "foo" [] []
                 1: MD_TEXTUAL@24..25
                   0: MD_TEXTUAL_LITERAL@24..25 "\n" [] []
-              1: (empty)
             1: MD_NEWLINE@25..26
               0: NEWLINE@25..26 "\n" [] []
             2: MD_CONTINUATION_INDENT@26..30
@@ -469,7 +456,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@32..35 "bar" [] []
                         1: MD_TEXTUAL@35..36
                           0: MD_TEXTUAL_LITERAL@35..36 "\n" [] []
-                      1: (empty)
             4: MD_NEWLINE@36..37
               0: NEWLINE@36..37 "\n" [] []
         2: MD_BULLET@37..59
@@ -485,7 +471,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@41..46 "outer" [] []
                 1: MD_TEXTUAL@46..47
                   0: MD_TEXTUAL_LITERAL@46..47 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@47..51
               0: MD_INDENT_TOKEN_LIST@47..51
                 0: MD_INDENT_TOKEN@47..48
@@ -511,7 +496,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@53..58 "inner" [] []
                         1: MD_TEXTUAL@58..59
                           0: MD_TEXTUAL_LITERAL@58..59 "\n" [] []
-                      1: (empty)
     1: MD_NEWLINE@59..60
       0: NEWLINE@59..60 "\n" [] []
     2: MD_QUOTE@60..83
@@ -535,7 +519,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@65..71 "quoted" [] []
                     1: MD_TEXTUAL@71..72
                       0: MD_TEXTUAL_LITERAL@71..72 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@72..74
                   0: MD_QUOTE_INDENT_LIST@72..72
                   1: R_ANGLE@72..73 ">" [] []
@@ -559,7 +542,6 @@ MdDocument {
                               0: MD_TEXTUAL_LITERAL@79..82 "sub" [] []
                             1: MD_TEXTUAL@82..83
                               0: MD_TEXTUAL_LITERAL@82..83 "\n" [] []
-                          1: (empty)
     3: MD_NEWLINE@83..84
       0: NEWLINE@83..84 "\n" [] []
     4: MD_QUOTE@84..108
@@ -583,7 +565,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@89..95 "quoted" [] []
                     1: MD_TEXTUAL@95..96
                       0: MD_TEXTUAL_LITERAL@95..96 "\n" [] []
-                  1: (empty)
                 1: MD_QUOTE_PREFIX@96..98
                   0: MD_QUOTE_INDENT_LIST@96..96
                   1: R_ANGLE@96..97 ">" [] []
@@ -607,7 +588,6 @@ MdDocument {
                               0: MD_TEXTUAL_LITERAL@104..107 "sub" [] []
                             1: MD_TEXTUAL@107..108
                               0: MD_TEXTUAL_LITERAL@107..108 "\n" [] []
-                          1: (empty)
   2: EOF@108..108 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@9..10 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -60,7 +59,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -97,7 +95,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@35..36 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -131,7 +128,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@51..52 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -167,7 +163,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@4..9 "first" [] []
                 1: MD_TEXTUAL@9..10
                   0: MD_TEXTUAL_LITERAL@9..10 "\n" [] []
-              1: (empty)
         1: MD_BULLET@10..52
           0: MD_LIST_MARKER_PREFIX@10..14
             0: MD_INDENT_TOKEN_LIST@10..10
@@ -181,7 +176,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@14..20 "second" [] []
                 1: MD_TEXTUAL@20..21
                   0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@21..25
               0: MD_INDENT_TOKEN_LIST@21..25
                 0: MD_INDENT_TOKEN@21..22
@@ -207,7 +201,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@30..35 "third" [] []
                         1: MD_TEXTUAL@35..36
                           0: MD_TEXTUAL_LITERAL@35..36 "\n" [] []
-                      1: (empty)
                 1: MD_BULLET@36..52
                   0: MD_LIST_MARKER_PREFIX@36..45
                     0: MD_INDENT_TOKEN_LIST@36..40
@@ -229,7 +222,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@45..51 "fourth" [] []
                         1: MD_TEXTUAL@51..52
                           0: MD_TEXTUAL_LITERAL@51..52 "\n" [] []
-                      1: (empty)
   2: EOF@52..52 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space_delimiter_cross.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_sublist_post_marker_wide_space_delimiter_cross.md.snap
@@ -39,7 +39,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@9..10 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -60,7 +59,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                         MdContinuationIndent {
                             indent: MdIndentTokenList [
@@ -100,7 +98,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@36..37 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -137,7 +134,6 @@ MdDocument {
                                                     value_token: MD_TEXTUAL_LITERAL@53..54 "\n" [] [],
                                                 },
                                             ],
-                                            hard_line: missing (optional),
                                         },
                                     ],
                                 },
@@ -173,7 +169,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@4..9 "first" [] []
                 1: MD_TEXTUAL@9..10
                   0: MD_TEXTUAL_LITERAL@9..10 "\n" [] []
-              1: (empty)
         1: MD_BULLET@10..54
           0: MD_LIST_MARKER_PREFIX@10..14
             0: MD_INDENT_TOKEN_LIST@10..10
@@ -187,7 +182,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@14..20 "second" [] []
                 1: MD_TEXTUAL@20..21
                   0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-              1: (empty)
             1: MD_CONTINUATION_INDENT@21..25
               0: MD_INDENT_TOKEN_LIST@21..25
                 0: MD_INDENT_TOKEN@21..22
@@ -215,7 +209,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@31..36 "third" [] []
                         2: MD_TEXTUAL@36..37
                           0: MD_TEXTUAL_LITERAL@36..37 "\n" [] []
-                      1: (empty)
                 1: MD_BULLET@37..54
                   0: MD_LIST_MARKER_PREFIX@37..46
                     0: MD_INDENT_TOKEN_LIST@37..41
@@ -239,7 +232,6 @@ MdDocument {
                           0: MD_TEXTUAL_LITERAL@52..53 "*" [] []
                         2: MD_TEXTUAL@53..54
                           0: MD_TEXTUAL_LITERAL@53..54 "\n" [] []
-                      1: (empty)
   2: EOF@54..54 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_to_bullet_split.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/ordered_to_bullet_split.md.snap
@@ -38,7 +38,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@10..11 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -66,7 +65,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -98,7 +96,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@3..10 "ordered" [] []
                 1: MD_TEXTUAL@10..11
                   0: MD_TEXTUAL_LITERAL@10..11 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@11..12
       0: NEWLINE@11..12 "\n" [] []
     2: MD_BULLET_LIST_ITEM@12..21
@@ -116,7 +113,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@14..20 "bullet" [] []
                 1: MD_TEXTUAL@20..21
                   0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-              1: (empty)
   2: EOF@21..21 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/paragraph.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/paragraph.md.snap
@@ -27,7 +27,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@27..28 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@28..29 "\n" [] [],
@@ -38,7 +37,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@29..55 "This is another paragraph." [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@55..55 "" [] [],
@@ -57,14 +55,12 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@0..27 "This is a simple paragraph." [] []
         1: MD_TEXTUAL@27..28
           0: MD_TEXTUAL_LITERAL@27..28 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@28..29
       0: NEWLINE@28..29 "\n" [] []
     2: MD_PARAGRAPH@29..55
       0: MD_INLINE_ITEM_LIST@29..55
         0: MD_TEXTUAL@29..55
           0: MD_TEXTUAL_LITERAL@29..55 "This is another paragraph." [] []
-      1: (empty)
   2: EOF@55..55 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/paragraph_interruption.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/paragraph_interruption.md.snap
@@ -41,7 +41,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@14..15 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdHeader {
             indent: MdIndentTokenList [],
@@ -56,7 +55,6 @@ MdDocument {
                         value_token: MD_TEXTUAL_LITERAL@16..35 " Heading interrupts" [] [],
                     },
                 ],
-                hard_line: missing (optional),
             },
             after: MdHashList [],
         },
@@ -75,7 +73,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@51..52 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdBulletListItem {
             md_bullet_list: MdBulletList [
@@ -96,7 +93,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@69..70 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -114,7 +110,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@83..84 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdQuote {
             prefix: MdQuotePrefix {
@@ -132,7 +127,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@102..103 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -148,7 +142,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@113..114 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdFencedCodeBlock {
             indent: MdIndentTokenList [],
@@ -183,7 +176,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@150..151 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdThematicBreakBlock {
             parts: MdThematicBreakPartList [
@@ -218,7 +210,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@0..14 "Paragraph text" [] []
         1: MD_TEXTUAL@14..15
           0: MD_TEXTUAL_LITERAL@14..15 "\n" [] []
-      1: (empty)
     1: MD_HEADER@15..35
       0: MD_INDENT_TOKEN_LIST@15..15
       1: MD_HASH_LIST@15..16
@@ -228,7 +219,6 @@ MdDocument {
         0: MD_INLINE_ITEM_LIST@16..35
           0: MD_TEXTUAL@16..35
             0: MD_TEXTUAL_LITERAL@16..35 " Heading interrupts" [] []
-        1: (empty)
       3: MD_HASH_LIST@35..35
     2: MD_NEWLINE@35..36
       0: NEWLINE@35..36 "\n" [] []
@@ -240,7 +230,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@37..51 "More text here" [] []
         1: MD_TEXTUAL@51..52
           0: MD_TEXTUAL_LITERAL@51..52 "\n" [] []
-      1: (empty)
     5: MD_BULLET_LIST_ITEM@52..70
       0: MD_BULLET_LIST@52..70
         0: MD_BULLET@52..70
@@ -256,7 +245,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@54..69 "List interrupts" [] []
                 1: MD_TEXTUAL@69..70
                   0: MD_TEXTUAL_LITERAL@69..70 "\n" [] []
-              1: (empty)
     6: MD_NEWLINE@70..71
       0: NEWLINE@70..71 "\n" [] []
     7: MD_PARAGRAPH@71..84
@@ -265,7 +253,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@71..83 "Another para" [] []
         1: MD_TEXTUAL@83..84
           0: MD_TEXTUAL_LITERAL@83..84 "\n" [] []
-      1: (empty)
     8: MD_QUOTE@84..103
       0: MD_QUOTE_PREFIX@84..86
         0: MD_QUOTE_INDENT_LIST@84..84
@@ -278,7 +265,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@86..102 "Quote interrupts" [] []
             1: MD_TEXTUAL@102..103
               0: MD_TEXTUAL_LITERAL@102..103 "\n" [] []
-          1: (empty)
     9: MD_NEWLINE@103..104
       0: NEWLINE@103..104 "\n" [] []
     10: MD_PARAGRAPH@104..114
@@ -287,7 +273,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@104..113 "Some text" [] []
         1: MD_TEXTUAL@113..114
           0: MD_TEXTUAL_LITERAL@113..114 "\n" [] []
-      1: (empty)
     11: MD_FENCED_CODE_BLOCK@114..138
       0: MD_INDENT_TOKEN_LIST@114..114
       1: TRIPLE_BACKTICK@114..117 "```" [] []
@@ -311,7 +296,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@140..150 "Final text" [] []
         1: MD_TEXTUAL@150..151
           0: MD_TEXTUAL_LITERAL@150..151 "\n" [] []
-      1: (empty)
     15: MD_THEMATIC_BREAK_BLOCK@151..154
       0: MD_THEMATIC_BREAK_PART_LIST@151..154
         0: MD_THEMATIC_BREAK_CHAR@151..152

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/paren_depth_limit.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/paren_depth_limit.md.snap
@@ -235,7 +235,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@71..72 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@72..72 "" [] [],
@@ -394,7 +393,6 @@ MdDocument {
           6: R_PAREN@70..71 ")" [] []
         1: MD_TEXTUAL@71..72
           0: MD_TEXTUAL_LITERAL@71..72 "\n" [] []
-      1: (empty)
   2: EOF@72..72 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/quote_list_link_reference_before_thematic_break.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/quote_list_link_reference_before_thematic_break.md.snap
@@ -61,7 +61,6 @@ MdDocument {
                                 },
                                 MdParagraph {
                                     list: MdInlineItemList [],
-                                    hard_line: missing (optional),
                                 },
                                 MdNewline {
                                     value_token: NEWLINE@13..14 "\n" [] [],
@@ -144,7 +143,6 @@ MdDocument {
                   6: (empty)
                 1: MD_PARAGRAPH@13..13
                   0: MD_INLINE_ITEM_LIST@13..13
-                  1: (empty)
                 2: MD_NEWLINE@13..14
                   0: NEWLINE@13..14 "\n" [] []
                 3: MD_QUOTE_PREFIX@14..16

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/quote_list_link_reference_tab_non_thematic_break.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/quote_list_link_reference_tab_non_thematic_break.md.snap
@@ -89,7 +89,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -159,7 +158,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@19..20 "x" [] []
                     3: MD_TEXTUAL@20..21
                       0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-                  1: (empty)
   2: EOF@21..21 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/quote_pre_marker_indent.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/quote_pre_marker_indent.md.snap
@@ -44,7 +44,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@19..20 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -74,7 +73,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@41..42 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -107,7 +105,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@66..67 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -145,7 +142,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@98..99 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -192,7 +188,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@3..19 "one space indent" [] []
             1: MD_TEXTUAL@19..20
               0: MD_TEXTUAL_LITERAL@19..20 "\n" [] []
-          1: (empty)
     1: MD_NEWLINE@20..21
       0: NEWLINE@20..21 "\n" [] []
     2: MD_QUOTE@21..42
@@ -211,7 +206,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@25..41 "two space indent" [] []
             1: MD_TEXTUAL@41..42
               0: MD_TEXTUAL_LITERAL@41..42 "\n" [] []
-          1: (empty)
     3: MD_NEWLINE@42..43
       0: NEWLINE@42..43 "\n" [] []
     4: MD_QUOTE@43..67
@@ -232,7 +226,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@48..66 "three space indent" [] []
             1: MD_TEXTUAL@66..67
               0: MD_TEXTUAL_LITERAL@66..67 "\n" [] []
-          1: (empty)
     5: MD_NEWLINE@67..68
       0: NEWLINE@67..68 "\n" [] []
     6: MD_QUOTE@68..99
@@ -257,7 +250,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@73..98 " nested with outer indent" [] []
                 1: MD_TEXTUAL@98..99
                   0: MD_TEXTUAL_LITERAL@98..99 "\n" [] []
-              1: (empty)
     7: MD_NEWLINE@99..100
       0: NEWLINE@99..100 "\n" [] []
     8: MD_INDENT_CODE_BLOCK@100..120

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/quote_textual_marker_parity.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/quote_textual_marker_parity.md.snap
@@ -40,7 +40,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@16..17 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -66,7 +65,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@34..35 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -93,7 +91,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@52..53 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -119,7 +116,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@72..73 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -157,7 +153,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@108..109 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -184,7 +179,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@2..16 "paragraph line" [] []
             1: MD_TEXTUAL@16..17
               0: MD_TEXTUAL_LITERAL@16..17 "\n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@17..19
           0: MD_QUOTE_INDENT_LIST@17..17
           1: R_ANGLE@17..18 ">" [] []
@@ -204,7 +198,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@21..34 "nested bullet" [] []
                     1: MD_TEXTUAL@34..35
                       0: MD_TEXTUAL_LITERAL@34..35 "\n" [] []
-                  1: (empty)
     1: MD_NEWLINE@35..36
       0: NEWLINE@35..36 "\n" [] []
     2: MD_QUOTE@36..73
@@ -219,7 +212,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@38..52 "paragraph line" [] []
             1: MD_TEXTUAL@52..53
               0: MD_TEXTUAL_LITERAL@52..53 "\n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@53..55
           0: MD_QUOTE_INDENT_LIST@53..53
           1: R_ANGLE@53..54 ">" [] []
@@ -239,7 +231,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@58..72 "nested ordered" [] []
                     1: MD_TEXTUAL@72..73
                       0: MD_TEXTUAL_LITERAL@72..73 "\n" [] []
-                  1: (empty)
     3: MD_NEWLINE@73..74
       0: NEWLINE@73..74 "\n" [] []
     4: MD_QUOTE@74..109
@@ -262,7 +253,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@93..108 "still paragraph" [] []
             4: MD_TEXTUAL@108..109
               0: MD_TEXTUAL_LITERAL@108..109 "\n" [] []
-          1: (empty)
   2: EOF@109..109 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/quoted_ordered_marker_non_one_no_interrupt.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/quoted_ordered_marker_non_one_no_interrupt.md.snap
@@ -61,7 +61,6 @@ MdDocument {
                                             value_token: MD_TEXTUAL_LITERAL@26..27 "\n" [] [],
                                         },
                                     ],
-                                    hard_line: missing (optional),
                                 },
                             ],
                         },
@@ -113,7 +112,6 @@ MdDocument {
                       0: MD_TEXTUAL_LITERAL@20..26 " inner" [] []
                     6: MD_TEXTUAL@26..27
                       0: MD_TEXTUAL_LITERAL@26..27 "\n" [] []
-                  1: (empty)
   2: EOF@27..27 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/reference_link_not_implemented.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/reference_link_not_implemented.md.snap
@@ -47,7 +47,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@76..77 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@77..77 "" [] [],
@@ -80,7 +79,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@75..76 "." [] []
         8: MD_TEXTUAL@76..77
           0: MD_TEXTUAL_LITERAL@76..77 "\n" [] []
-      1: (empty)
   2: EOF@77..77 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/reference_links.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/reference_links.md.snap
@@ -119,7 +119,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@85..86 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@86..87 "\n" [] [],
@@ -147,7 +146,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@119..120 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@120..121 "\n" [] [],
@@ -171,7 +169,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@150..151 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@151..152 "\n" [] [],
@@ -234,7 +231,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@204..205 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@205..206 "\n" [] [],
@@ -263,7 +259,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@231..232 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@232..233 "\n" [] [],
@@ -288,7 +283,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@255..256 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@256..257 "\n" [] [],
@@ -320,7 +314,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@316..317 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@317..318 "\n" [] [],
@@ -363,7 +356,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@351..352 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@352..353 "\n" [] [],
@@ -416,7 +408,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@421..422 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@422..423 "\n" [] [],
@@ -468,7 +459,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@489..490 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@490..491 "\n" [] [],
@@ -503,7 +493,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@570..571 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@571..572 "\n" [] [],
@@ -563,7 +552,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@638..639 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@639..640 "\n" [] [],
@@ -587,7 +575,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@677..678 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@678..679 "\n" [] [],
@@ -655,7 +642,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@756..757 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@757..757 "" [] [],
@@ -711,7 +697,6 @@ MdDocument {
             2: R_BRACK@84..85 "]" [] []
         2: MD_TEXTUAL@85..86
           0: MD_TEXTUAL_LITERAL@85..86 "\n" [] []
-      1: (empty)
     4: MD_NEWLINE@86..87
       0: NEWLINE@86..87 "\n" [] []
     5: MD_PARAGRAPH@87..120
@@ -730,7 +715,6 @@ MdDocument {
             2: R_BRACK@118..119 "]" [] []
         2: MD_TEXTUAL@119..120
           0: MD_TEXTUAL_LITERAL@119..120 "\n" [] []
-      1: (empty)
     6: MD_NEWLINE@120..121
       0: NEWLINE@120..121 "\n" [] []
     7: MD_PARAGRAPH@121..151
@@ -746,7 +730,6 @@ MdDocument {
           3: (empty)
         2: MD_TEXTUAL@150..151
           0: MD_TEXTUAL_LITERAL@150..151 "\n" [] []
-      1: (empty)
     8: MD_NEWLINE@151..152
       0: NEWLINE@151..152 "\n" [] []
     9: MD_LINK_REFERENCE_DEFINITION@152..174
@@ -788,7 +771,6 @@ MdDocument {
             2: R_BRACK@203..204 "]" [] []
         2: MD_TEXTUAL@204..205
           0: MD_TEXTUAL_LITERAL@204..205 "\n" [] []
-      1: (empty)
     13: MD_NEWLINE@205..206
       0: NEWLINE@205..206 "\n" [] []
     14: MD_PARAGRAPH@206..232
@@ -808,7 +790,6 @@ MdDocument {
             2: R_BRACK@230..231 "]" [] []
         2: MD_TEXTUAL@231..232
           0: MD_TEXTUAL_LITERAL@231..232 "\n" [] []
-      1: (empty)
     15: MD_NEWLINE@232..233
       0: NEWLINE@232..233 "\n" [] []
     16: MD_PARAGRAPH@233..256
@@ -825,7 +806,6 @@ MdDocument {
           4: (empty)
         2: MD_TEXTUAL@255..256
           0: MD_TEXTUAL_LITERAL@255..256 "\n" [] []
-      1: (empty)
     17: MD_NEWLINE@256..257
       0: NEWLINE@256..257 "\n" [] []
     18: MD_PARAGRAPH@257..317
@@ -846,7 +826,6 @@ MdDocument {
             2: R_BRACK@315..316 "]" [] []
         2: MD_TEXTUAL@316..317
           0: MD_TEXTUAL_LITERAL@316..317 "\n" [] []
-      1: (empty)
     19: MD_NEWLINE@317..318
       0: NEWLINE@317..318 "\n" [] []
     20: MD_PARAGRAPH@318..352
@@ -875,7 +854,6 @@ MdDocument {
             2: R_BRACK@350..351 "]" [] []
         7: MD_TEXTUAL@351..352
           0: MD_TEXTUAL_LITERAL@351..352 "\n" [] []
-      1: (empty)
     21: MD_NEWLINE@352..353
       0: NEWLINE@352..353 "\n" [] []
     22: MD_LINK_REFERENCE_DEFINITION@353..377
@@ -910,7 +888,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@420..421 "]" [] []
         4: MD_TEXTUAL@421..422
           0: MD_TEXTUAL_LITERAL@421..422 "\n" [] []
-      1: (empty)
     26: MD_NEWLINE@422..423
       0: NEWLINE@422..423 "\n" [] []
     27: MD_PARAGRAPH@423..490
@@ -945,7 +922,6 @@ MdDocument {
             2: R_BRACK@488..489 "]" [] []
         4: MD_TEXTUAL@489..490
           0: MD_TEXTUAL_LITERAL@489..490 "\n" [] []
-      1: (empty)
     28: MD_NEWLINE@490..491
       0: NEWLINE@490..491 "\n" [] []
     29: MD_PARAGRAPH@491..571
@@ -968,7 +944,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@555..570 " in the middle." [] []
         3: MD_TEXTUAL@570..571
           0: MD_TEXTUAL_LITERAL@570..571 "\n" [] []
-      1: (empty)
     30: MD_NEWLINE@571..572
       0: NEWLINE@571..572 "\n" [] []
     31: MD_LINK_REFERENCE_DEFINITION@572..606
@@ -1008,7 +983,6 @@ MdDocument {
           3: (empty)
         4: MD_TEXTUAL@638..639
           0: MD_TEXTUAL_LITERAL@638..639 "\n" [] []
-      1: (empty)
     35: MD_NEWLINE@639..640
       0: NEWLINE@639..640 "\n" [] []
     36: MD_PARAGRAPH@640..678
@@ -1024,7 +998,6 @@ MdDocument {
           3: (empty)
         2: MD_TEXTUAL@677..678
           0: MD_TEXTUAL_LITERAL@677..678 "\n" [] []
-      1: (empty)
     37: MD_NEWLINE@678..679
       0: NEWLINE@678..679 "\n" [] []
     38: MD_LINK_REFERENCE_DEFINITION@679..713
@@ -1069,7 +1042,6 @@ MdDocument {
             2: R_BRACK@755..756 "]" [] []
         2: MD_TEXTUAL@756..757
           0: MD_TEXTUAL_LITERAL@756..757 "\n" [] []
-      1: (empty)
   2: EOF@757..757 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/setext_heading_edge_cases.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/setext_heading_edge_cases.md.snap
@@ -171,7 +171,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@65..66 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -282,7 +281,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@62..65 "baz" [] []
                 1: MD_TEXTUAL@65..66
                   0: MD_TEXTUAL_LITERAL@65..66 "\n" [] []
-              1: (empty)
   2: EOF@66..66 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/setext_heading_in_blockquote.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/setext_heading_in_blockquote.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
-assertion_line: 192
 expression: snapshot
 ---
 
@@ -167,7 +166,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@66..67 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -217,7 +215,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@83..84 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -261,7 +258,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@110..111 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -311,7 +307,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@133..134 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -355,7 +350,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@166..167 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
                 MdQuotePrefix {
                     pre_marker_indent: MdQuoteIndentList [],
@@ -445,7 +439,6 @@ MdDocument {
                             value_token: MD_TEXTUAL_LITERAL@304..305 "\n" [] [],
                         },
                     ],
-                    hard_line: missing (optional),
                 },
             ],
         },
@@ -545,7 +538,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@48..66 "Dashes with spaces" [] []
             1: MD_TEXTUAL@66..67
               0: MD_TEXTUAL_LITERAL@66..67 "\n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@67..69
           0: MD_QUOTE_INDENT_LIST@67..67
           1: R_ANGLE@67..68 ">" [] []
@@ -578,7 +570,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@78..83 "Stars" [] []
             1: MD_TEXTUAL@83..84
               0: MD_TEXTUAL_LITERAL@83..84 "\n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@84..86
           0: MD_QUOTE_INDENT_LIST@84..84
           1: R_ANGLE@84..85 ">" [] []
@@ -607,7 +598,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@93..110 "Stars with spaces" [] []
             1: MD_TEXTUAL@110..111
               0: MD_TEXTUAL_LITERAL@110..111 "\n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@111..113
           0: MD_QUOTE_INDENT_LIST@111..111
           1: R_ANGLE@111..112 ">" [] []
@@ -640,7 +630,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@122..133 "Underscores" [] []
             1: MD_TEXTUAL@133..134
               0: MD_TEXTUAL_LITERAL@133..134 "\n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@134..136
           0: MD_QUOTE_INDENT_LIST@134..134
           1: R_ANGLE@134..135 ">" [] []
@@ -669,7 +658,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@143..166 "Underscores with spaces" [] []
             1: MD_TEXTUAL@166..167
               0: MD_TEXTUAL_LITERAL@166..167 "\n" [] []
-          1: (empty)
         1: MD_QUOTE_PREFIX@167..169
           0: MD_QUOTE_INDENT_LIST@167..167
           1: R_ANGLE@167..168 ">" [] []
@@ -730,7 +718,6 @@ MdDocument {
               0: MD_TEXTUAL_LITERAL@303..304 "_" [] []
             13: MD_TEXTUAL@304..305
               0: MD_TEXTUAL_LITERAL@304..305 "\n" [] []
-          1: (empty)
   2: EOF@305..305 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/setext_heading_negative.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/setext_heading_negative.md.snap
@@ -44,7 +44,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@7..8 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@8..9 "\n" [] [],
@@ -76,7 +75,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@20..21 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@21..22 "\n" [] [],
@@ -107,7 +105,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@33..34 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
         MdNewline {
             value_token: NEWLINE@34..35 "\n" [] [],
@@ -141,7 +138,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@67..68 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@68..68 "" [] [],
@@ -164,7 +160,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@4..7 "= =" [] []
         3: MD_TEXTUAL@7..8
           0: MD_TEXTUAL_LITERAL@7..8 "\n" [] []
-      1: (empty)
     1: MD_NEWLINE@8..9
       0: NEWLINE@8..9 "\n" [] []
     2: MD_PARAGRAPH@9..21
@@ -185,7 +180,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@17..20 "---" [] []
         7: MD_TEXTUAL@20..21
           0: MD_TEXTUAL_LITERAL@20..21 "\n" [] []
-      1: (empty)
     3: MD_NEWLINE@21..22
       0: NEWLINE@21..22 "\n" [] []
     4: MD_SETEXT_HEADER@22..31
@@ -205,7 +199,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@32..33 "`" [] []
         1: MD_TEXTUAL@33..34
           0: MD_TEXTUAL_LITERAL@33..34 "\n" [] []
-      1: (empty)
     7: MD_NEWLINE@34..35
       0: NEWLINE@34..35 "\n" [] []
     8: MD_SETEXT_HEADER@35..54
@@ -227,7 +220,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@66..67 ">" [] []
         2: MD_TEXTUAL@67..68
           0: MD_TEXTUAL_LITERAL@67..68 "\n" [] []
-      1: (empty)
   2: EOF@68..68 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/single_item_lists_marker_split.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/single_item_lists_marker_split.md.snap
@@ -38,7 +38,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@10..11 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -66,7 +65,6 @@ MdDocument {
                                     value_token: MD_TEXTUAL_LITERAL@22..23 "\n" [] [],
                                 },
                             ],
-                            hard_line: missing (optional),
                         },
                     ],
                 },
@@ -98,7 +96,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@2..10 "item one" [] []
                 1: MD_TEXTUAL@10..11
                   0: MD_TEXTUAL_LITERAL@10..11 "\n" [] []
-              1: (empty)
     1: MD_NEWLINE@11..12
       0: NEWLINE@11..12 "\n" [] []
     2: MD_BULLET_LIST_ITEM@12..23
@@ -116,7 +113,6 @@ MdDocument {
                   0: MD_TEXTUAL_LITERAL@14..22 "item two" [] []
                 1: MD_TEXTUAL@22..23
                   0: MD_TEXTUAL_LITERAL@22..23 "\n" [] []
-              1: (empty)
   2: EOF@23..23 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_bold.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_bold.md.snap
@@ -35,7 +35,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@24..25 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@25..25 "" [] [],
@@ -60,7 +59,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@11..24 "unclosed bold" [] []
         4: MD_TEXTUAL@24..25
           0: MD_TEXTUAL_LITERAL@24..25 "\n" [] []
-      1: (empty)
   2: EOF@25..25 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_code_span.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_code_span.md.snap
@@ -32,7 +32,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@23..24 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@24..24 "" [] [],
@@ -55,7 +54,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@10..23 "unclosed code" [] []
         3: MD_TEXTUAL@23..24
           0: MD_TEXTUAL_LITERAL@23..24 "\n" [] []
-      1: (empty)
   2: EOF@24..24 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_emphasis.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_emphasis.md.snap
@@ -32,7 +32,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@27..28 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@28..28 "" [] [],
@@ -55,7 +54,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@10..27 "unclosed emphasis" [] []
         3: MD_TEXTUAL@27..28
           0: MD_TEXTUAL_LITERAL@27..28 "\n" [] []
-      1: (empty)
   2: EOF@28..28 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_image.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_image.md.snap
@@ -35,7 +35,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@25..26 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@26..26 "" [] [],
@@ -60,7 +59,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@11..25 "unclosed image" [] []
         4: MD_TEXTUAL@25..26
           0: MD_TEXTUAL_LITERAL@25..26 "\n" [] []
-      1: (empty)
   2: EOF@26..26 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_link.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_link.md.snap
@@ -32,7 +32,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@23..24 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@24..24 "" [] [],
@@ -55,7 +54,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@10..23 "unclosed link" [] []
         3: MD_TEXTUAL@23..24
           0: MD_TEXTUAL_LITERAL@23..24 "\n" [] []
-      1: (empty)
   2: EOF@24..24 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_reference_image_label.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_reference_image_label.md.snap
@@ -44,7 +44,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@31..31 "" [] [],
@@ -75,7 +74,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@16..30 "unclosed label" [] []
         7: MD_TEXTUAL@30..31
           0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
-      1: (empty)
   2: EOF@31..31 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_reference_link_label.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/unclosed_reference_link_label.md.snap
@@ -41,7 +41,6 @@ MdDocument {
                     value_token: MD_TEXTUAL_LITERAL@30..31 "\n" [] [],
                 },
             ],
-            hard_line: missing (optional),
         },
     ],
     eof_token: EOF@31..31 "" [] [],
@@ -70,7 +69,6 @@ MdDocument {
           0: MD_TEXTUAL_LITERAL@16..30 "unclosed label" [] []
         6: MD_TEXTUAL@30..31
           0: MD_TEXTUAL_LITERAL@30..31 "\n" [] []
-      1: (empty)
   2: EOF@31..31 "" [] []
 
 ```

--- a/crates/biome_markdown_syntax/src/generated/nodes.rs
+++ b/crates/biome_markdown_syntax/src/generated/nodes.rs
@@ -1190,16 +1190,10 @@ impl MdParagraph {
         Self { syntax }
     }
     pub fn as_fields(&self) -> MdParagraphFields {
-        MdParagraphFields {
-            list: self.list(),
-            hard_line: self.hard_line(),
-        }
+        MdParagraphFields { list: self.list() }
     }
     pub fn list(&self) -> MdInlineItemList {
         support::list(&self.syntax, 0usize)
-    }
-    pub fn hard_line(&self) -> Option<MdHardLine> {
-        support::node(&self.syntax, 1usize)
     }
 }
 impl Serialize for MdParagraph {
@@ -1213,7 +1207,6 @@ impl Serialize for MdParagraph {
 #[derive(Serialize)]
 pub struct MdParagraphFields {
     pub list: MdInlineItemList,
-    pub hard_line: Option<MdHardLine>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct MdQuote {
@@ -3356,10 +3349,6 @@ impl std::fmt::Debug for MdParagraph {
             DEPTH.set(current_depth + 1);
             f.debug_struct("MdParagraph")
                 .field("list", &self.list())
-                .field(
-                    "hard_line",
-                    &support::DebugOptionalElement(self.hard_line()),
-                )
                 .finish()
         } else {
             f.debug_struct("MdParagraph").finish()

--- a/crates/biome_markdown_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_markdown_syntax/src/generated/nodes_mut.rs
@@ -478,12 +478,6 @@ impl MdParagraph {
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
         )
     }
-    pub fn with_hard_line(self, element: Option<MdHardLine>) -> Self {
-        Self::unwrap_cast(self.syntax.splice_slots(
-            1usize..=1usize,
-            once(element.map(|element| element.into_syntax().into())),
-        ))
-    }
 }
 impl MdQuote {
     pub fn with_prefix(self, element: MdQuotePrefix) -> Self {

--- a/xtask/codegen/markdown.ungram
+++ b/xtask/codegen/markdown.ungram
@@ -238,7 +238,6 @@ MdListMarkerPrefix =
 // Another block paragraph
 MdParagraph =
 	list: MdInlineItemList
-	hard_line: MdHardLine?
 
 MdInlineItemList = AnyMdInline*
 


### PR DESCRIPTION
> [!NOTE]
> I used Claude to help investigate, implement, and validate this fix.

## Summary

Closes #10557.

Removed the unused `hard_line` slot from `MdParagraph`; hard line breaks already live in `MdInlineItemList` as `MdHardLine` items. Formatting output is unchanged.

## Test Plan

- Updated CST snapshots.
- `just test-crate biome_markdown_parser`
- `just test-crate biome_markdown_formatter`
- `just test-markdown-conformance` (652/652)
- `just fuzz-markdown-differential`

## Docs

N/A.
