### PR TITLE
test(md): cover loose list + mixed space-tab sublist in fuzz corpus

### DIFF
--- a/crates/biome_markdown_parser/tests/fuzz_generate_corpus.cjs
+++ b/crates/biome_markdown_parser/tests/fuzz_generate_corpus.cjs
@@ -293,6 +293,28 @@ function genTabBlankContinuation() {
   return marker + " first\n\t\n\tsecond paragraph\n";
 }
 
+function genLooseTabSublist() {
+  // Loose parent item, a blank line, then a tab-indented sublist whose
+  // marker sits past the parent's content column via a mixed space+tab
+  // indent. Class surfaced by issue #10558: every other tab generator is
+  // *tight* (no blank line) and every blank-separated generator uses
+  // *pure spaces*, so the loose×mixed-tab crossproduct was never produced.
+  // The tab expands to column 4 → ≥ the parent content column 2 (so it
+  // attaches to the item) while the remaining indent is < 4 (so it is a
+  // nested bullet list, not an indented code block).
+  const outer = pick(["-", "*", "+"]);
+  const inner = pick(["-", "*", "+"]);
+  // Mixed space+tab indents that all expand to column 4.
+  const indent = pick([" \t", "  \t", "   \t", "\t"]);
+  return (
+    `${outer} Text\n` +
+    `\n` +
+    `${indent}${inner} foo\n` +
+    `${indent}${inner} lreum\n` +
+    `${indent}${inner} bar\n`
+  );
+}
+
 // #endregion
 
 // #region Content-column-aware nested list combinators — class of
@@ -374,6 +396,7 @@ const blockGenerators = [
   { fn: genTabAfterListMarker, weight: 3 },
   { fn: genDeepTabNesting, weight: 2 },
   { fn: genTabBlankContinuation, weight: 3 },
+  { fn: genLooseTabSublist, weight: 4 },
   // Content-column-aware nested list combinators — class surfaced by
   // PR 10347 (sublist marker at exactly the outer item's content
   // column, pure spaces, no blank-line separator).


### PR DESCRIPTION
> [!NOTE]
> I used Claude to help investigate, reproduce, and patch the fuzz corpus generator.

## Summary

Related to #10558.

Adds `genLooseTabSublist` to cover a missing differential-fuzzer case: a loose list item followed by a mixed space+tab-indented sublist.

The generated cases reproduce #10558, where Biome treats sublist markers as lazy paragraph continuation instead of nested list items. This PR only improves fuzz coverage; it does not fix the parser. `seed.jsonl` is unchanged because it is passing-only and should be updated after the parser fix lands.

## Test Plan

- `just test-crate biome_markdown_parser`
- Generated a targeted corpus and confirmed it surfaces the #10558 mismatch.

## Docs

N/A.
