### PR TITLE
feat(lint): add ignoreBooleanCoercion option to useNullishCoalescing

### DIFF
--- a/.changeset/add-ignore-boolean-coercion.md
+++ b/.changeset/add-ignore-boolean-coercion.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added `ignoreBooleanCoercion` to [useNullishCoalescing](https://biomejs.dev/linter/rules/use-nullish-coalescing/), partially addressing [#9232](https://github.com/biomejs/biome/issues/9232). When enabled, Biome ignores `||` and `||=` used inside a `Boolean()` call, where coalescing on falsy values is intentional.

--- a/.changeset/add-ignore-boolean-coercion.md
+++ b/.changeset/add-ignore-boolean-coercion.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Added `ignoreBooleanCoercion` to [useNullishCoalescing](https://biomejs.dev/linter/rules/use-nullish-coalescing/), partially addressing [#9232](https://github.com/biomejs/biome/issues/9232). When enabled, Biome ignores `||` and `||=` used inside a `Boolean()` call, where coalescing on falsy values is intentional.
+Added the option `ignoreBooleanCoercion` to [useNullishCoalescing](https://biomejs.dev/linter/rules/use-nullish-coalescing/). When enabled, Biome ignores `||` and `||=` used inside a `Boolean()` call, where coalescing on falsy values is intentional.

--- a/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
@@ -7,9 +7,10 @@ use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsAssignmentPattern, AnyJsExpression, JsAssignmentExpression, JsAssignmentOperator,
-    JsBinaryOperator, JsConditionalExpression, JsDoWhileStatement, JsForStatement,
-    JsIfStatement, JsLogicalExpression, JsLogicalOperator, JsParenthesizedExpression,
-    JsSyntaxKind, JsWhileStatement, OperatorPrecedence, T,
+    JsBinaryOperator, JsCallArgumentList, JsCallArguments, JsCallExpression,
+    JsConditionalExpression, JsDoWhileStatement, JsForStatement, JsIfStatement,
+    JsLogicalExpression, JsLogicalOperator, JsParenthesizedExpression, JsSyntaxKind,
+    JsWhileStatement, OperatorPrecedence, T,
 };
 use biome_js_type_info::{ConditionalType, TypeData};
 use biome_rowan::{
@@ -155,6 +156,38 @@ declare_lint_rule! {
     /// declare const b: string;
     /// declare let assigned: string | null;
     /// assigned ||= b && 'fallback';
+    /// ```
+    ///
+    /// ### ignoreBooleanCoercion
+    ///
+    /// Ignore `||` and `||=` used inside a `Boolean()` call, where coalescing on
+    /// falsy values is intentional. Default: `false`.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "ignoreBooleanCoercion": true
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// #### Invalid
+    ///
+    /// `||` and `||=` outside a `Boolean()` call are still reported.
+    ///
+    /// ```ts,expect_diagnostic,use_options,file=invalid-boolean-coercion.ts
+    /// declare const maybeString: string | null;
+    /// const value = maybeString || 'default';
+    /// ```
+    ///
+    /// #### Valid
+    ///
+    /// `||` and `||=` inside a `Boolean()` call are not reported.
+    ///
+    /// ```ts,use_options,file=valid-boolean-coercion.ts
+    /// declare const a: string | null;
+    /// declare const b: string;
+    /// const r = Boolean(a || b);
     /// ```
     ///
     pub UseNullishCoalescing {
@@ -399,6 +432,12 @@ fn run_logical_or(
         return None;
     }
 
+    if options.ignore_boolean_coercion()
+        && is_in_boolean_call_context(&AnyJsLogicalOrLikeExpression::from(logical.clone()))
+    {
+        return None;
+    }
+
     let left = logical.left().ok()?;
     let left_ty = ctx.type_of_expression(&left);
 
@@ -428,6 +467,12 @@ fn run_logical_or_assignment(
     if options.ignore_mixed_logical_expressions()
         && is_in_mixed_logical_tree(AnyJsLogicalOrLikeExpression::from(assignment.clone()))
             .is_some_and(|mixed| mixed)
+    {
+        return None;
+    }
+
+    if options.ignore_boolean_coercion()
+        && is_in_boolean_call_context(&AnyJsLogicalOrLikeExpression::from(assignment.clone()))
     {
         return None;
     }
@@ -604,6 +649,30 @@ fn operand_reaches_logical_and(operand: SyntaxResult<AnyJsExpression>) -> bool {
             _ => false,
         }
     })
+}
+
+/// Returns `true` when the `||`/`||=` expression is boolean-coerced by an
+/// enclosing `Boolean(...)` call, where coalescing on falsy values is the
+/// intended behavior.
+///
+/// It skips parenthesized and logical-expression ancestors (both `||` and `&&`,
+/// since the coerced value still flows into the call) so that
+/// `Boolean(a || b || c)` and `Boolean(x && (a || b))` are both treated as
+/// coerced, then inspects the first ancestor that is neither. That ancestor must
+/// be the argument list of a `Boolean(...)` call for the expression to be
+/// considered coerced.
+fn is_in_boolean_call_context(node: &AnyJsLogicalOrLikeExpression) -> bool {
+    node.syntax()
+        .ancestors()
+        .skip(1)
+        .find(|ancestor| {
+            !(JsParenthesizedExpression::can_cast(ancestor.kind())
+                || JsLogicalExpression::can_cast(ancestor.kind()))
+        })
+        .and_then(JsCallArgumentList::cast)
+        .and_then(|list| list.parent::<JsCallArguments>())
+        .and_then(|args| args.parent::<JsCallExpression>())
+        .is_some_and(|call| call.has_callee("Boolean"))
 }
 
 fn is_in_test_position(logical: &JsLogicalExpression) -> bool {

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionDisabled.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionDisabled.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNullishCoalescing": {
+					"level": "error",
+					"options": {
+						"ignoreBooleanCoercion": false
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionDisabled.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionDisabled.ts
@@ -1,0 +1,16 @@
+// Tests for ignoreBooleanCoercion: false
+// `||` and `||=` inside a Boolean() call SHOULD still generate diagnostics.
+
+declare const a: string | null;
+declare const b: string;
+declare const c: string;
+
+// || directly inside Boolean()
+const r1 = Boolean(a || b);
+
+// chained || inside Boolean()
+const r2 = Boolean(a || b || c);
+
+// ||= inside Boolean()
+declare let assigned: string | null;
+const r3 = Boolean(assigned ||= b);

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionDisabled.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionDisabled.ts.snap
@@ -1,0 +1,85 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignoreBooleanCoercionDisabled.ts
+---
+# Input
+```ts
+// Tests for ignoreBooleanCoercion: false
+// `||` and `||=` inside a Boolean() call SHOULD still generate diagnostics.
+
+declare const a: string | null;
+declare const b: string;
+declare const c: string;
+
+// || directly inside Boolean()
+const r1 = Boolean(a || b);
+
+// chained || inside Boolean()
+const r2 = Boolean(a || b || c);
+
+// ||= inside Boolean()
+declare let assigned: string | null;
+const r3 = Boolean(assigned ||= b);
+
+```
+
+# Diagnostics
+```
+ignoreBooleanCoercionDisabled.ts:9:22 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+     8 │ // || directly inside Boolean()
+   > 9 │ const r1 = Boolean(a || b);
+       │                      ^^
+    10 │ 
+    11 │ // chained || inside Boolean()
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreBooleanCoercionDisabled.ts:12:22 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    11 │ // chained || inside Boolean()
+  > 12 │ const r2 = Boolean(a || b || c);
+       │                      ^^
+    13 │ 
+    14 │ // ||= inside Boolean()
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreBooleanCoercionDisabled.ts:16:29 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    14 │ // ||= inside Boolean()
+    15 │ declare let assigned: string | null;
+  > 16 │ const r3 = Boolean(assigned ||= b);
+       │                             ^^^
+    17 │ 
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionEnabled.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionEnabled.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNullishCoalescing": {
+					"level": "error",
+					"options": {
+						"ignoreBooleanCoercion": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionEnabled.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionEnabled.ts
@@ -1,0 +1,41 @@
+// Tests for ignoreBooleanCoercion: true
+// `||` and `||=` inside a Boolean() call should NOT generate diagnostics.
+
+declare const a: string | null;
+declare const b: string;
+declare const c: string;
+
+// || directly inside Boolean()
+const r1 = Boolean(a || b);
+
+// chained || inside Boolean()
+const r2 = Boolean(a || b || c);
+
+// || inside parenthesized argument
+const r3 = Boolean((a || b));
+
+// ||= inside Boolean()
+declare let assigned: string | null;
+const r4 = Boolean(assigned ||= b);
+
+// || nested inside Boolean() within another call: still suppressed because the
+// value still flows into the Boolean() coercion.
+declare function identity<T>(value: T): T;
+const r4b = identity(Boolean(a || 'default'));
+
+// || mixed with && inside Boolean(): the whole argument is boolean-coerced,
+// so the walk steps through the && parent and suppresses the ||.
+declare const d: string;
+const r4c = Boolean(d && (a || 'default'));
+
+// These SHOULD still generate diagnostics (not inside Boolean()).
+const r5 = a || 'default';
+
+declare const n: number | undefined;
+const r6 = n || 0;
+
+declare let assignPlain: string | null;
+assignPlain ||= 'default';
+
+// Inside a non-Boolean call: SHOULD generate a diagnostic.
+const r7 = identity(a || 'default');

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionEnabled.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreBooleanCoercionEnabled.ts.snap
@@ -1,0 +1,129 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignoreBooleanCoercionEnabled.ts
+---
+# Input
+```ts
+// Tests for ignoreBooleanCoercion: true
+// `||` and `||=` inside a Boolean() call should NOT generate diagnostics.
+
+declare const a: string | null;
+declare const b: string;
+declare const c: string;
+
+// || directly inside Boolean()
+const r1 = Boolean(a || b);
+
+// chained || inside Boolean()
+const r2 = Boolean(a || b || c);
+
+// || inside parenthesized argument
+const r3 = Boolean((a || b));
+
+// ||= inside Boolean()
+declare let assigned: string | null;
+const r4 = Boolean(assigned ||= b);
+
+// || nested inside Boolean() within another call: still suppressed because the
+// value still flows into the Boolean() coercion.
+declare function identity<T>(value: T): T;
+const r4b = identity(Boolean(a || 'default'));
+
+// || mixed with && inside Boolean(): the whole argument is boolean-coerced,
+// so the walk steps through the && parent and suppresses the ||.
+declare const d: string;
+const r4c = Boolean(d && (a || 'default'));
+
+// These SHOULD still generate diagnostics (not inside Boolean()).
+const r5 = a || 'default';
+
+declare const n: number | undefined;
+const r6 = n || 0;
+
+declare let assignPlain: string | null;
+assignPlain ||= 'default';
+
+// Inside a non-Boolean call: SHOULD generate a diagnostic.
+const r7 = identity(a || 'default');
+
+```
+
+# Diagnostics
+```
+ignoreBooleanCoercionEnabled.ts:32:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    31 │ // These SHOULD still generate diagnostics (not inside Boolean()).
+  > 32 │ const r5 = a || 'default';
+       │              ^^
+    33 │ 
+    34 │ declare const n: number | undefined;
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreBooleanCoercionEnabled.ts:35:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    34 │ declare const n: number | undefined;
+  > 35 │ const r6 = n || 0;
+       │              ^^
+    36 │ 
+    37 │ declare let assignPlain: string | null;
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreBooleanCoercionEnabled.ts:38:13 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    37 │ declare let assignPlain: string | null;
+  > 38 │ assignPlain ||= 'default';
+       │             ^^^
+    39 │ 
+    40 │ // Inside a non-Boolean call: SHOULD generate a diagnostic.
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreBooleanCoercionEnabled.ts:41:23 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    40 │ // Inside a non-Boolean call: SHOULD generate a diagnostic.
+  > 41 │ const r7 = identity(a || 'default');
+       │                       ^^
+    42 │ 
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_rule_options/src/use_nullish_coalescing.rs
+++ b/crates/biome_rule_options/src/use_nullish_coalescing.rs
@@ -17,6 +17,10 @@ pub struct UseNullishCoalescingOptions {
     /// Whether to ignore `||` and `||=` binary operations that are part of a mixed logical expression with `&&` (default: `false`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_mixed_logical_expressions: Option<bool>,
+
+    /// Whether to ignore `||` and `||=` binary operations used inside a `Boolean()` call (default: `false`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore_boolean_coercion: Option<bool>,
 }
 
 impl UseNullishCoalescingOptions {
@@ -30,5 +34,9 @@ impl UseNullishCoalescingOptions {
 
     pub fn ignore_mixed_logical_expressions(&self) -> bool {
         self.ignore_mixed_logical_expressions.unwrap_or(false)
+    }
+
+    pub fn ignore_boolean_coercion(&self) -> bool {
+        self.ignore_boolean_coercion.unwrap_or(false)
     }
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8422,6 +8422,10 @@ export type UseNamedCaptureGroupOptions = {};
  */
 export interface UseNullishCoalescingOptions {
 	/**
+	 * Whether to ignore `||` and `||=` binary operations used inside a `Boolean()` call (default: `false`).
+	 */
+	ignoreBooleanCoercion?: boolean;
+	/**
 	 * Ignore `||` expressions in conditional test positions (default: `true`).
 	 */
 	ignoreConditionalTests?: boolean;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -15700,6 +15700,10 @@
 			"description": "Options for the `useNullishCoalescing` rule.",
 			"type": "object",
 			"properties": {
+				"ignoreBooleanCoercion": {
+					"description": "Whether to ignore `||` and `||=` binary operations used inside a `Boolean()` call (default: `false`).",
+					"type": ["boolean", "null"]
+				},
 				"ignoreConditionalTests": {
 					"description": "Ignore `||` expressions in conditional test positions (default: `true`).",
 					"type": ["boolean", "null"]


### PR DESCRIPTION
> This PR was created with AI assistance.

## Summary

adds the `ignoreBooleanCoercion` option to `useNullishCoalescing`, partially addressing #9232. this follows on from #9974 which added `ignoreMixedLogicalExpressions`.

when enabled, `||` and `||=` are not reported if the value is boolean-coerced by an enclosing `Boolean()` call, since coalescing on falsy values is intentional in that spot. i kept the scope to just this one option so it stays easy to review. the remaining options from #9232 (`ignorePrimitives`, `ignoreIfStatements`) can come as separate PRs.

the detection mirrors how the merged mixed-logical code reads: a small typed helper that scans ancestors, skips parens and logical parents (both `||` and `&&`, since the coerced value still flows into the call), and then checks the first other ancestor is the argument of a `Boolean()` call.

## Test Plan

the spec snapshots cover this, but if you want to check it by hand:

1. drop a `biome.json` enabling the rule and option:

```json
{ "linter": { "rules": { "nursery": { "useNullishCoalescing": { "level": "error", "options": { "ignoreBooleanCoercion": true } } } } } }
```

2. make a `test.ts`:

```ts
declare const a: string | null;
declare const b: string;
declare function identity<T>(v: T): T;

const r1 = Boolean(a || b);        // quiet
const r2 = Boolean(a || b || b);   // quiet (chained)
const r3 = Boolean(b && (a || b)); // quiet (&& inside Boolean)
const r4 = a || b;                 // reports
const r5 = identity(a || b);       // reports (not a Boolean call)
```

3. run `biome lint test.ts`. only `r4` and `r5` should report.

4. flip the option to `false` and re-run. now `r1`, `r2`, `r3` should report too.

things worth poking at for coverage:
- `||=` inside `Boolean()` (e.g. `Boolean(x ||= y)`) should be quiet when the option is on
- the non-`Boolean` callee (`identity(...)`) should still report, to confirm it's keyed on the `Boolean` name and not just "any call"
- `new Boolean(a || b)` still reports. i think that's right since it constructs an object rather than coercing, but worth a sanity check

## Docs

the option is documented in the rule's rustdoc with invalid/valid examples and validated by `rules_check`. no website PR needed while the rule is in nursery.

