### PR TITLE
feat(css_formatter): improve SCSS variable declaration formatting

### DIFF
--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -314,7 +314,14 @@ fn handle_function_comment(
     }
 }
 
-/// Places `$color/* c */: red;` comments on the variable name/colon boundary.
+/// Attaches comments that belong to SCSS variable boundaries:
+///
+/// ```scss
+/// $color/* c */: red;
+/// $font:
+///   // c
+///   Arial;
+/// ```
 fn handle_scss_variable_declaration_comment(
     comment: DecoratedComment<CssLanguage>,
 ) -> CommentPlacement<CssLanguage> {
@@ -332,6 +339,17 @@ fn handle_scss_variable_declaration_comment(
 
     let comment_piece = comment.piece();
 
+    if comment
+        .preceding_node()
+        .is_some_and(|preceding| preceding == name.syntax())
+        && is_between_variable_colon_and_value(
+            &variable_declaration,
+            comment_piece.text_range().start(),
+        )
+    {
+        return CommentPlacement::dangling(variable_declaration.into_syntax(), comment);
+    }
+
     if let Some(name_token) = name.syntax().last_token() {
         for piece in name_token.trailing_trivia().pieces() {
             if piece.is_comments() && piece.text_range() == comment_piece.text_range() {
@@ -342,6 +360,27 @@ fn handle_scss_variable_declaration_comment(
     }
 
     CommentPlacement::Default(comment)
+}
+
+/// Returns `true` for comments between `:` and the variable value.
+fn is_between_variable_colon_and_value(
+    variable_declaration: &ScssVariableDeclaration,
+    comment_start: TextSize,
+) -> bool {
+    let Ok(colon) = variable_declaration.colon_token() else {
+        return false;
+    };
+
+    let Some(value_start) = variable_declaration
+        .value()
+        .ok()
+        .and_then(|value| value.syntax().first_token())
+        .map(|token| token.text_trimmed_range().start())
+    else {
+        return false;
+    };
+
+    comment_start >= colon.text_trimmed_range().end() && comment_start < value_start
 }
 
 fn handle_generic_property_comment(

--- a/crates/biome_css_formatter/src/scss/auxiliary/binary_expression.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/binary_expression.rs
@@ -21,9 +21,12 @@ impl FormatNodeRule<ScssBinaryExpression> for FormatScssBinaryExpression {
     }
 }
 
-/// Formats the operator and right side of a SCSS binary expression.
+/// Formats the operator and right side, indenting grouped line breaks.
 ///
-/// Broken grouped expressions indent the right operand, as in `$x: "a" +\n  "b";`.
+/// ```scss
+/// $x: "a" +
+///   "b";
+/// ```
 struct FormatScssBinaryRightSide<'a> {
     node: &'a ScssBinaryExpression,
 }

--- a/crates/biome_css_formatter/src/scss/auxiliary/each_header.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/each_header.rs
@@ -78,7 +78,14 @@ impl FormatNodeRule<ScssEachHeader> for FormatScssEachHeader {
 
 /// Detects a single map value whose pairs had blank lines in source.
 ///
-/// Example: `@each $k, $v in (a: b,\n\nc: d)`.
+/// ```scss
+/// @each $k, $v in (
+///   a: b,
+///
+///   c: d
+/// ) {
+/// }
+/// ```
 fn has_single_map_with_blank_lines(values: &ScssEachValueList) -> bool {
     let mut value_elements = values.elements();
     let Some(value) = value_elements.next() else {
@@ -102,7 +109,13 @@ fn has_single_map_with_blank_lines(values: &ScssEachValueList) -> bool {
 
 /// Returns `true` when a map keeps a blank line between pairs.
 ///
-/// Example: `(a: b,\n\nc: d)`.
+/// ```scss
+/// $map: (
+///   a: b,
+///
+///   c: d
+/// );
+/// ```
 fn has_blank_line_between_pairs(node: &ScssMapExpression) -> bool {
     node.pairs().elements().skip(1).any(|element| {
         element
@@ -207,7 +220,11 @@ impl Format<CssFormatContext> for FormatScssEachMultiValueHeader<'_> {
             if index + 1 == binding_count {
                 // The final binding owns `in` and the first value.
                 if has_value_list_line_comment {
-                    // `@each $x in // list\n a, b` keeps the comment after `in`.
+                    // Keep the comment after `in` in:
+                    //
+                    // @each $x in // list
+                    //   a, b {
+                    // }
                     fill.entry(
                         &separator,
                         &group(&indent(&format_args![

--- a/crates/biome_css_formatter/src/scss/auxiliary/interpolation.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/interpolation.rs
@@ -94,7 +94,12 @@ fn should_preserve_identifier_interpolation_spacing(node: &ScssInterpolation) ->
 
 /// Detects spacing after `{`.
 ///
-/// Examples: `#{ $name}` and `#{\n$name}` keep a gap after `{`.
+/// Examples: `$value: #{ $name};` and:
+///
+/// ```scss
+/// $value: #{
+///   $name};
+/// ```
 fn has_source_gap_after_opening_curly(
     l_curly_token: &CssSyntaxToken,
     value: &AnyScssExpression,
@@ -108,7 +113,12 @@ fn has_source_gap_after_opening_curly(
 
 /// Detects spacing before `}`.
 ///
-/// Examples: `#{$name }` and `#{$name\n}` keep a gap before `}`.
+/// Examples: `$value: #{$name };` and:
+///
+/// ```scss
+/// $value: #{$name
+/// };
+/// ```
 fn has_source_gap_before_closing_curly(
     value: &AnyScssExpression,
     r_curly_token: &CssSyntaxToken,

--- a/crates/biome_css_formatter/src/scss/auxiliary/map_expression_pair.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/map_expression_pair.rs
@@ -153,7 +153,14 @@ impl FormatScssMapPairLayout<'_> {
     }
 }
 
-/// Returns `true` for `// comment\nkey: value` and `/* comment */ key: value`.
+/// Returns `true` for comments before a map pair.
+///
+/// ```scss
+/// $map: (
+///   // comment
+///   key: value,
+/// );
+/// ```
 ///
 /// The comment joins the pair group, so long comments break before `key`.
 fn should_group_leading_comments_with_pair(node: &ScssMapExpressionPair, f: &CssFormatter) -> bool {

--- a/crates/biome_css_formatter/src/scss/auxiliary/variable_declaration.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/variable_declaration.rs
@@ -1,4 +1,3 @@
-use crate::comments::FormatCssLeadingComment;
 use crate::prelude::*;
 use crate::utils::comment_trivia::{
     has_block_comment_gap_before_token, has_source_gap_before_token,
@@ -8,7 +7,7 @@ use biome_css_syntax::{
 };
 use biome_formatter::comments::SourceComment;
 use biome_formatter::trivia::format_dangling_comment;
-use biome_formatter::{FormatRefWithRule, format_args, write};
+use biome_formatter::{format_args, write};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssVariableDeclaration;
@@ -17,7 +16,6 @@ impl FormatNodeRule<ScssVariableDeclaration> for FormatScssVariableDeclaration {
     fn fmt_fields(&self, node: &ScssVariableDeclaration, f: &mut CssFormatter) -> FormatResult<()> {
         let ScssVariableDeclarationFields {
             name,
-            value,
             modifiers,
             semicolon_token,
             ..
@@ -29,7 +27,7 @@ impl FormatNodeRule<ScssVariableDeclaration> for FormatScssVariableDeclaration {
 
         write!(f, [name.format()])?;
         variable_comments.fmt_colon_boundary(f)?;
-        write!(f, [space(), value.format()])?;
+        variable_comments.fmt_value_boundary(f)?;
 
         if !modifiers.is_empty() {
             write!(f, [modifiers.format()])?;
@@ -51,8 +49,8 @@ impl FormatNodeRule<ScssVariableDeclaration> for FormatScssVariableDeclaration {
         _node: &ScssVariableDeclaration,
         _f: &mut CssFormatter,
     ) -> FormatResult<()> {
-        // No-op: `fmt_colon_boundary` prints `$color/* c */ : red;` before `:`,
-        // not at the declaration end.
+        // No-op: boundary helpers print `$color/* c */: red;` and
+        // `$font: /* c */ Arial;` around `:`, not at the declaration end.
         Ok(())
     }
 }
@@ -67,33 +65,40 @@ impl<'a> ScssVariableDeclarationComments<'a> {
         Self { node }
     }
 
-    /// Prints `/* note */ $color: red;` as a comment, then the declaration.
+    /// Writes declaration-leading comments on their own lines.
+    ///
+    /// ```scss
+    /// /* note */
+    /// $color: red;
+    /// ```
     fn fmt_leading_comments(&self, f: &mut CssFormatter) -> FormatResult<()> {
         let comments = f.comments().clone();
         let leading_comments = comments.leading_comments(self.node.syntax());
 
         for comment in leading_comments {
-            let format_comment = FormatRefWithRule::new(comment, FormatCssLeadingComment);
-            write!(f, [format_comment])?;
+            write!(f, [format_dangling_comment(comment)])?;
 
             if comment.lines_after() > 1 {
                 write!(f, [empty_line()])?;
             } else {
                 write!(f, [hard_line_break()])?;
             }
-
-            // This override fully prints these leading comments.
-            comment.mark_formatted();
         }
 
         Ok(())
     }
 
-    /// Writes `$color/* c */ : red;` name/colon comments.
+    /// Writes comments between the variable name and `:`.
+    ///
+    /// ```scss
+    /// $color/* c */: red;
+    /// ```
     fn fmt_colon_boundary(&self, f: &mut CssFormatter) -> FormatResult<()> {
         let colon = self.node.colon_token();
         let comments = f.comments().clone();
-        let colon_boundary_comments = comments.dangling_comments(self.node.syntax());
+        let dangling_comments = comments.dangling_comments(self.node.syntax());
+        let value_boundary_start = self.value_boundary_comment_start(dangling_comments);
+        let (colon_boundary_comments, _) = dangling_comments.split_at(value_boundary_start);
 
         if colon_boundary_comments.is_empty() {
             return write!(f, [colon.format()]);
@@ -126,7 +131,7 @@ impl<'a> ScssVariableDeclarationComments<'a> {
         }
     }
 
-    /// Writes one name/colon comment, as in `$color/* c */ : red;`.
+    /// Writes one comment between the variable name and `:`.
     fn fmt_name_boundary_comment(
         &self,
         comment: &SourceComment<CssLanguage>,
@@ -141,7 +146,99 @@ impl<'a> ScssVariableDeclarationComments<'a> {
         }
     }
 
-    /// Writes `;`, preserving `$x: red !default /* c */ ;`.
+    /// Writes comments between `:` and the variable value.
+    ///
+    /// ```scss
+    /// $font:
+    ///   // c
+    ///   Arial;
+    /// ```
+    fn fmt_value_boundary(&self, f: &mut CssFormatter) -> FormatResult<()> {
+        let value = self.node.value();
+        let comments = f.comments().clone();
+        let dangling_comments = comments.dangling_comments(self.node.syntax());
+        let value_boundary_start = self.value_boundary_comment_start(dangling_comments);
+        let (_, value_boundary_comments) = dangling_comments.split_at(value_boundary_start);
+
+        if value_boundary_comments.is_empty() {
+            return write!(f, [space(), value.format()]);
+        }
+
+        let should_break_before_value = value_boundary_comments
+            .iter()
+            .any(|comment| comment.kind().is_line());
+
+        for comment in value_boundary_comments {
+            self.fmt_value_boundary_comment(comment, f)?;
+        }
+
+        if should_break_before_value {
+            write!(f, [hard_line_break(), value.format()])
+        } else {
+            write!(f, [space(), value.format()])
+        }
+    }
+
+    /// Returns `true` for comments between `:` and the value:
+    ///
+    /// ```scss
+    /// $font:
+    ///   // c
+    ///   Arial;
+    /// ```
+    ///
+    /// `$font: Arial; // c` stays a trailing declaration comment.
+    fn is_value_boundary_comment(&self, comment: &SourceComment<CssLanguage>) -> bool {
+        let Ok(colon) = self.node.colon_token() else {
+            return false;
+        };
+
+        let Some(value_start) = self
+            .node
+            .value()
+            .ok()
+            .and_then(|value| value.syntax().first_token())
+            .map(|token| token.text_trimmed_range().start())
+        else {
+            return false;
+        };
+
+        let comment_start = comment.piece().text_range().start();
+
+        comment_start >= colon.text_trimmed_range().end() && comment_start < value_start
+    }
+
+    /// Writes one comment between `:` and the variable value.
+    fn fmt_value_boundary_comment(
+        &self,
+        comment: &SourceComment<CssLanguage>,
+        f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        let formatted = format_dangling_comment(comment);
+
+        if comment.lines_before() > 0 {
+            if comment.kind().is_line() {
+                return write!(f, [indent(&format_args![hard_line_break(), formatted])]);
+            }
+
+            return write!(
+                f,
+                [dedent_to_root(&format_args![hard_line_break(), formatted])]
+            );
+        }
+
+        write!(f, [space(), formatted])
+    }
+
+    /// Finds the first dangling comment between `:` and the value.
+    fn value_boundary_comment_start(&self, comments: &[SourceComment<CssLanguage>]) -> usize {
+        comments
+            .iter()
+            .position(|comment| self.is_value_boundary_comment(comment))
+            .unwrap_or(comments.len())
+    }
+
+    /// Writes the declaration `;`, preserving `$x: red !default /* c */ ;`.
     fn fmt_semicolon_boundary(
         &self,
         semicolon_token: Option<CssSyntaxToken>,
@@ -156,7 +253,7 @@ impl<'a> ScssVariableDeclarationComments<'a> {
 
             write!(f, [semicolon.format()])
         } else {
-            Ok(())
+            write!(f, [token(";")])
         }
     }
 }

--- a/crates/biome_css_formatter/src/scss/lists/map_expression_pair_list.rs
+++ b/crates/biome_css_formatter/src/scss/lists/map_expression_pair_list.rs
@@ -145,7 +145,13 @@ fn has_block_trailing_separator_comments(
 
 /// Returns `true` for a source blank line inside the trailing comment group.
 ///
-/// Example: `(key: value, /* c1 */\n\n/* c2 */)`.
+/// ```scss
+/// $map: (
+///   key: value, /* c1 */
+///
+///   /* c2 */
+/// );
+/// ```
 fn has_blank_line_before_trailing_separator_comments(
     node: &ScssMapExpressionPairList,
     f: &CssFormatter,

--- a/crates/biome_css_formatter/src/utils/component_value_list.rs
+++ b/crates/biome_css_formatter/src/utils/component_value_list.rs
@@ -181,7 +181,11 @@ where
         } else {
             // Prefer breaking at top-level commas in declaration values (Prettier-like)
             // by filling comma-separated groups instead of individual tokens.
-            // This prevents line wraps inside groups like `0px 8px\n16px` for `box-shadow`-like values.
+            // This keeps each box-shadow-like group intact:
+            //
+            // box-shadow:
+            //   0px 8px 16px,
+            //   0px 4px 8px;
             if let Some(result) = try_write_fill_comma_groups(node, layout, f) {
                 return result;
             }

--- a/crates/biome_css_formatter/src/utils/scss_closing_comments.rs
+++ b/crates/biome_css_formatter/src/utils/scss_closing_comments.rs
@@ -59,7 +59,10 @@ pub(crate) fn write_include_closing_comments(
 
 /// Returns `true` for `//` comments before the include-owned closing `)`.
 ///
-/// Example: `@include mix((a, // end\n))` needs a hard break before `)`.
+/// ```scss
+/// @include mix((a, // end
+/// ));
+/// ```
 fn has_line_closing_comment(node: &CssSyntaxNode, f: &CssFormatter) -> bool {
     f.comments()
         .dangling_comments(node)

--- a/crates/biome_css_formatter/src/utils/scss_include_comments.rs
+++ b/crates/biome_css_formatter/src/utils/scss_include_comments.rs
@@ -27,7 +27,10 @@ pub(crate) fn place_map_trailing_separator_comment(
 
 /// Places comments that follow a list separator.
 ///
-/// Example: `$list: a, // next\nb;`.
+/// ```scss
+/// $list: a, // next
+/// b;
+/// ```
 pub(crate) fn place_list_trailing_separator_comment(
     list_expression: &ScssListExpression,
     preceding_element: &ScssListExpressionElement,
@@ -201,7 +204,10 @@ fn place_line_separator_comment(
 
 /// Keeps Prettier-style line comments that were written before the separator.
 ///
-/// Example: `@include mix(1px // note\n, 2px)`.
+/// ```scss
+/// @include mix(1px // note
+/// , 2px);
+/// ```
 fn should_keep_line_comment_trailing(
     comment: &DecoratedComment<CssLanguage>,
     preceding_node: &CssSyntaxNode,

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/comments/between-decl.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/comments/between-decl.scss.snap
@@ -95,17 +95,7 @@ value;
  
    grid-template-areas: "header header header" //
      "sidebar content content" //
-@@ -20,8 +20,7 @@
- }
- 
- // #8052
--$font-family-rich:
--  // custom
-+$font-family-rich: // custom
-   "Noto Sans TC",
-   "Noto Sans SC",
-   "Noto Sans JP",
-@@ -42,8 +41,8 @@
+@@ -42,8 +42,8 @@
  // #7109
  .test {
    background:
@@ -143,7 +133,8 @@ selector {
 }
 
 // #8052
-$font-family-rich: // custom
+$font-family-rich:
+  // custom
   "Noto Sans TC",
   "Noto Sans SC",
   "Noto Sans JP",

--- a/crates/biome_css_formatter/tests/specs/scss/comments/variable-declaration-boundary-comments.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/comments/variable-declaration-boundary-comments.scss
@@ -8,3 +8,4 @@ $tight/* name */:red;
 $gap:red;
 $line:red!default // c
 ;
+$plain-trailing:red;// c

--- a/crates/biome_css_formatter/tests/specs/scss/comments/variable-declaration-boundary-comments.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/comments/variable-declaration-boundary-comments.scss.snap
@@ -16,6 +16,7 @@ $tight/* name */:red;
 $gap:red;
 $line:red!default // c
 ;
+$plain-trailing:red;// c
 
 ```
 
@@ -39,5 +40,6 @@ $tight/* name */: red;
 
 $gap: red;
 $line: red !default; // c
+$plain-trailing: red; // c
 
 ```

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/semicolonless-variable.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/semicolonless-variable.scss
@@ -1,0 +1,11 @@
+@if true {
+  $color: red
+}
+
+@if false {
+  $newKey: ($key: ( $theme-name: $value ))
+}
+
+$map: (
+"a": 1,
+)

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/semicolonless-variable.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/semicolonless-variable.scss.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
+info: scss/declaration/semicolonless-variable.scss
+---
+
+# Input
+
+```scss
+@if true {
+  $color: red
+}
+
+@if false {
+  $newKey: ($key: ( $theme-name: $value ))
+}
+
+$map: (
+"a": 1,
+)
+
+```
+
+
+# Formatted
+
+```scss
+@if true {
+	$color: red;
+}
+
+@if false {
+	$newKey: (
+		$key: (
+				$theme-name: $value,
+			),
+	);
+}
+
+$map: (
+	"a": 1,
+);
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/variable-value-line-comment.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/variable-value-line-comment.scss
@@ -1,0 +1,5 @@
+$font-family-rich:
+  // custom
+  'Noto Sans TC', 'Noto Sans SC', 'Noto Sans JP',
+  // fallback
+  Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif !default;

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/variable-value-line-comment.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/variable-value-line-comment.scss.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
+info: scss/declaration/variable-value-line-comment.scss
+---
+
+# Input
+
+```scss
+$font-family-rich:
+  // custom
+  'Noto Sans TC', 'Noto Sans SC', 'Noto Sans JP',
+  // fallback
+  Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
+
+```
+
+
+# Formatted
+
+```scss
+$font-family-rich:
+	// custom
+	"Noto Sans TC",
+	"Noto Sans SC",
+	"Noto Sans JP",
+	// fallback
+	Roboto,
+	"Helvetica Neue",
+	Helvetica,
+	Arial,
+	sans-serif !default;
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-pair-value-layout.scss.snap
@@ -95,7 +95,7 @@ $icons: (
 		$key: (
 				$theme-name: $value,
 			),
-	)
+	);
 }
 
 @for $i from 1 through 2 {


### PR DESCRIPTION
> This PR was implemented with guidance from Codex AI assistant.

## Summary

Improves SCSS variable declaration formatting around comments and missing semicolons.


  ```scss
  $font-family-rich:
  	// custom
  	"Noto Sans TC",
  	"Noto Sans SC",
  	"Noto Sans JP";

@if true {
  $color: red;
}
```


  ## Test Plan

- cargo test -p biome_css_formatter