### PR TITLE
fix(css_formatter): align grid-template-areas rows after comments

### DIFF
--- a/.changeset/fix-css-grid-template-comment-layout.md
+++ b/.changeset/fix-css-grid-template-comment-layout.md
@@ -1,0 +1,16 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed CSS formatting for `grid-template-areas` declarations with comments before multiline values. Biome now keeps grid area rows aligned instead of adding an extra declaration-boundary indent.
+
+```diff
+ .grid {
+   grid-template-areas:
+ /* row */
+-      "header header"
+-      "footer footer";
++    "header header"
++    "footer footer";
+ }
+```

--- a/crates/biome_css_formatter/src/css/properties/generic_property.rs
+++ b/crates/biome_css_formatter/src/css/properties/generic_property.rs
@@ -159,10 +159,14 @@ impl<'a> CssPropertyColonComments<'a> {
             || value_list_needs_multiline_layout(&value, f);
 
         if should_break_before_value {
-            write!(
-                f,
-                [indent(&format_args![hard_line_break(), &value.format()])]
-            )
+            if should_indent_value_after_colon_comments(&value, f) {
+                write!(
+                    f,
+                    [indent(&format_args![hard_line_break(), &value.format()])]
+                )
+            } else {
+                write!(f, [hard_line_break(), value.format()])
+            }
         } else {
             write!(f, [space(), value.format()])
         }
@@ -233,5 +237,37 @@ fn value_list_needs_multiline_layout(
         ValueListLayout::OnePerLine
             | ValueListLayout::OneGroupPerLine
             | ValueListLayout::OneGroupPerLineWithDanglingComments
+    )
+}
+
+/// Returns `true` when the boundary formatter should indent the value.
+///
+/// For:
+///
+/// ```scss
+/// a {
+///   grid-template-areas: // c
+///     "header";
+/// }
+/// ```
+///
+/// `PreserveInline` indents `"header"`, so the property boundary only writes
+/// the line break after `// c`.
+fn should_indent_value_after_colon_comments(
+    value: &SyntaxResult<AnyCssGenericPropertyValueOrExpression>,
+    f: &CssFormatter,
+) -> bool {
+    !matches!(
+        value.as_ref().ok().and_then(|value| {
+            value
+                .as_css_generic_component_value_list()
+                .map(|list| get_value_list_layout(list, f.comments(), f))
+                .or_else(|| {
+                    value.as_scss_expression().map(|expression| {
+                        get_value_list_layout(&expression.items(), f.comments(), f)
+                    })
+                })
+        }),
+        Some(ValueListLayout::PreserveInline)
     )
 }

--- a/crates/biome_css_formatter/src/utils/component_value_list.rs
+++ b/crates/biome_css_formatter/src/utils/component_value_list.rs
@@ -444,8 +444,13 @@ where
     let has_scss_list_comments =
         scss_parent_property.is_some() && has_list_comments(list, comments);
 
-    // Comment-bearing SCSS grid rows are tracked as a separate layout gap.
-    if is_grid_property && !(has_scss_trailing_comments || has_scss_list_comments) {
+    // In:
+    // .grid {
+    //   grid-template-areas: // row
+    //     "header";
+    // }
+    // PreserveInline owns the string-row indent after the `:` comment.
+    if is_grid_property && (has_scss_trailing_comments || !has_scss_list_comments) {
         ValueListLayout::PreserveInline
     } else if list.len() == 1 {
         ValueListLayout::SingleValue

--- a/crates/biome_css_formatter/tests/specs/css/comments/grid-template-areas-value-comments.css
+++ b/crates/biome_css_formatter/tests/specs/css/comments/grid-template-areas-value-comments.css
@@ -1,0 +1,5 @@
+.grid{grid-template-areas:/* row */"header header" "footer footer";}
+.grid{grid-template-areas:
+/* row */
+"header header"
+"footer footer";}

--- a/crates/biome_css_formatter/tests/specs/css/comments/grid-template-areas-value-comments.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/comments/grid-template-areas-value-comments.css.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/comments/grid-template-areas-value-comments.css
+---
+
+# Input
+
+```css
+.grid{grid-template-areas:/* row */"header header" "footer footer";}
+.grid{grid-template-areas:
+/* row */
+"header header"
+"footer footer";}
+
+```
+
+
+# Formatted
+
+```css
+.grid {
+	grid-template-areas:/* row */ "header header" "footer footer";
+}
+.grid {
+	grid-template-areas:
+/* row */
+		"header header"
+		"footer footer";
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/comments/between-decl.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/comments/between-decl.scss.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
 info: scss/comments/between-decl.scss
 ---
 
@@ -84,17 +85,6 @@ value;
 ```diff
 --- Prettier
 +++ Biome
-@@ -11,8 +11,8 @@
- .grid {
-   grid-template-areas: //
-     "header header header" //
--    "sidebar content content" //
--    "footer footer footer";
-+      "sidebar content content" //
-+      "footer footer footer";
- 
-   grid-template-areas: "header header header" //
-     "sidebar content content" //
 @@ -42,8 +42,8 @@
  // #7109
  .test {
@@ -124,8 +114,8 @@ selector {
 .grid {
   grid-template-areas: //
     "header header header" //
-      "sidebar content content" //
-      "footer footer footer";
+    "sidebar content content" //
+    "footer footer footer";
 
   grid-template-areas: "header header header" //
     "sidebar content content" //

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/grid-template-areas-line-comments.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/grid-template-areas-line-comments.scss
@@ -1,0 +1,4 @@
+.grid{grid-template-areas: //
+"header header header" //
+"sidebar content content" //
+"footer footer footer";}

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/grid-template-areas-line-comments.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/grid-template-areas-line-comments.scss.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
+info: scss/declaration/grid-template-areas-line-comments.scss
+---
+
+# Input
+
+```scss
+.grid{grid-template-areas: //
+"header header header" //
+"sidebar content content" //
+"footer footer footer";}
+
+```
+
+
+# Formatted
+
+```scss
+.grid {
+	grid-template-areas: //
+		"header header header" //
+		"sidebar content content" //
+		"footer footer footer";
+}
+
+```


### PR DESCRIPTION
> This PR was implemented with guidance from Codex.

## Summary

Fixes CSS/SCSS formatting for `grid-template-areas` declarations with comments before multiline values.

  ```diff
   .grid {
     grid-template-areas:
   /* row */
  -      "header header"
  -      "footer footer";
  +    "header header"
  +    "footer footer";
   }
```

  ## Test Plan

  - cargo test -p biome_css_formatter 
