### PR TITLE
fix(svelte): share `<script module>`/`<script>` scope for unused-binding rules

### DIFF
--- a/.changeset/fix-svelte-script-module-cross-references.md
+++ b/.changeset/fix-svelte-script-module-cross-references.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed false positives in `noUnusedImports`, `noUnusedVariables`, and `useImportType` for Svelte components that use both a `<script module>` and a `<script>` block. The two blocks compile to a single module and share a top-level scope, so a binding (import, function, or variable) declared in one block and used only in the other is no longer reported as unused.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-svelte-cross-script-imports.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-svelte-cross-script-imports.svelte
@@ -1,0 +1,24 @@
+<!-- should not generate diagnostics -->
+<script module lang="ts">
+import { tick } from "svelte";
+
+// `Snippet` is imported in the instance <script> below, but referenced here.
+export interface Props {
+  row?: Snippet;
+}
+</script>
+
+<script lang="ts">
+import type { Snippet } from "svelte";
+
+const { row }: Props = $props();
+
+// `tick` is imported in the module <script> above, but used only here.
+async function refresh() {
+  await tick();
+}
+
+refresh();
+</script>
+
+<div>{row}</div>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-svelte-cross-script-imports.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-svelte-cross-script-imports.svelte.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-svelte-cross-script-imports.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script module lang="ts">
+import { tick } from "svelte";
+
+// `Snippet` is imported in the instance <script> below, but referenced here.
+export interface Props {
+  row?: Snippet;
+}
+</script>
+
+<script lang="ts">
+import type { Snippet } from "svelte";
+
+const { row }: Props = $props();
+
+// `tick` is imported in the module <script> above, but used only here.
+async function refresh() {
+  await tick();
+}
+
+refresh();
+</script>
+
+<div>{row}</div>
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalid-svelte-unused-module-binding.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalid-svelte-unused-module-binding.svelte
@@ -1,0 +1,13 @@
+<script module lang="ts">
+// Declared in the module script and referenced in neither block nor the
+// template: still reported as unused.
+function unusedHelper(): string {
+  return "unused";
+}
+</script>
+
+<script lang="ts">
+const value = 1;
+</script>
+
+<p>{value}</p>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalid-svelte-unused-module-binding.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalid-svelte-unused-module-binding.svelte.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-svelte-unused-module-binding.svelte
+---
+# Input
+```svelte
+<script module lang="ts">
+// Declared in the module script and referenced in neither block nor the
+// template: still reported as unused.
+function unusedHelper(): string {
+  return "unused";
+}
+</script>
+
+<script lang="ts">
+const value = 1;
+</script>
+
+<p>{value}</p>
+
+```
+
+# Diagnostics
+```
+invalid-svelte-unused-module-binding.svelte:4:10 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━
+
+  ! This function unusedHelper is unused.
+  
+    2 │ // Declared in the module script and referenced in neither block nor the
+    3 │ // template: still reported as unused.
+  > 4 │ function unusedHelper(): string {
+      │          ^^^^^^^^^^^^
+    5 │   return "unused";
+    6 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend unusedHelper with an underscore.
+  
+    2 2 │   // Declared in the module script and referenced in neither block nor the
+    3 3 │   // template: still reported as unused.
+    4   │ - function·unusedHelper():·string·{
+      4 │ + function·_unusedHelper():·string·{
+    5 5 │     return "unused";
+    6 6 │   }
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-svelte-cross-script-references.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-svelte-cross-script-references.svelte
@@ -1,0 +1,18 @@
+<!-- should not generate diagnostics -->
+<script module lang="ts">
+// `<script module>` and `<script>` compile to one module and share a
+// top-level scope. These bindings are declared here but used only in the
+// instance script below, so they must not be reported as unused.
+function formatId(id: number): string {
+  return `row-${id}`;
+}
+
+const PREFIX = "row";
+</script>
+
+<script lang="ts">
+const id = formatId(1);
+const label = `${PREFIX}-${id}`;
+</script>
+
+<div data-id={id}>{label}</div>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-svelte-cross-script-references.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-svelte-cross-script-references.svelte.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-svelte-cross-script-references.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script module lang="ts">
+// `<script module>` and `<script>` compile to one module and share a
+// top-level scope. These bindings are declared here but used only in the
+// instance script below, so they must not be reported as unused.
+function formatId(id: number): string {
+  return `row-${id}`;
+}
+
+const PREFIX = "row";
+</script>
+
+<script lang="ts">
+const id = formatId(1);
+const label = `${PREFIX}-${id}`;
+</script>
+
+<div data-id={id}>{label}</div>
+
+```

--- a/crates/biome_workspace_db/src/embedded/visitor.rs
+++ b/crates/biome_workspace_db/src/embedded/visitor.rs
@@ -151,6 +151,9 @@ fn collect_embedded_references(
     file: ParsedSource,
 ) -> Option<EmbeddedReferencesBuilder> {
     let host_source = db.source_from_index(file.document_source_index(db))?;
+    let is_svelte = host_source
+        .to_html_file_source()
+        .is_some_and(|s| s.is_svelte());
 
     let mut builder = EmbeddedReferencesBuilder::new();
 
@@ -161,7 +164,11 @@ fn collect_embedded_references(
         let Some(js_file_source) = file_source.to_js_file_source() else {
             continue;
         };
-        if !js_file_source.is_embedded_source() {
+        // Templates always; for Svelte also the sibling `<script>` blocks.
+        // A Svelte component's `<script module>` and `<script>` compile to
+        // one module and share a top-level scope, so a binding used only in
+        // the other block must still count as used.
+        if !js_file_source.is_embedded_source() || is_svelte {
             builder.visit_non_source_snippet(&snippet.parsed(db).tree());
         }
     }


### PR DESCRIPTION
> **Depends on #10473** — this PR should not be merged until that one lands. Once it does, the diff here will reduce to the single commit below.

## Summary

A Svelte component's `<script module>` and `<script>` compile to one module and share a top-level scope, but Biome analyzes each block as an isolated embedded snippet. A binding (import, function, or variable) declared in one block and used only in the other was therefore reported as unused by `noUnusedImports`, `noUnusedVariables`, and `useImportType`:

```svelte
<script module lang="ts">
  // declared here, not exported
  function formatId(id: number) { return `row-${id}`; }
</script>

<script lang="ts">
  const id = formatId(1); // used here -> formatId was falsely flagged as unused
</script>
```

Fix: when collecting embedded value/type references, the workspace now also visits Svelte source `<script>` snippets (not just template snippets), so a name referenced in the sibling block counts as used. Gated to Svelte, where the two blocks genuinely share a module scope; Vue and Astro are unchanged.

> This PR was written primarily by Claude Code.

## Test Plan

New fixtures under `noUnusedVariables` and `noUnusedImports`:

- `valid-svelte-cross-script-references.svelte` — a module-declared function/const used only in the instance script.
- `valid-svelte-cross-script-imports.svelte` — an import in each block used only by the other (both directions).
- `invalid-svelte-unused-module-binding.svelte` — a module binding referenced in neither block is still flagged (no over-suppression).

All existing Svelte/Vue/Astro analyzer specs pass.

## Docs

N/A
