### PR TITLE
refactor: removes mutex from salsa db

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: tombi-toml/setup-tombi@74c3f4f31e7915e27c3397831e4c628463e3e0da # v1.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Format TOML files
         run: tombi format

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -54,9 +54,7 @@ jobs:
 
       - uses: tombi-toml/setup-tombi@74c3f4f31e7915e27c3397831e4c628463e3e0da # v1.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          version: '0.7.32'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
 
       - name: Format TOML files
         run: tombi format

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -68,16 +68,10 @@ serde                    = { workspace = true, features = ["derive"] }
 serde_json               = { workspace = true }
 smallvec                 = { workspace = true }
 terminal_size            = { workspace = true }
-tokio                    = { workspace = true, features = [
-  "io-std",
-  "io-util",
-  "macros",
-  "net",
-  "rt",
-  "rt-multi-thread",
-  "sync",
-  "time"
-] }
+tokio                    = {
+  workspace = true,
+  features  = ["io-std", "io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"]
+}
 tracing                  = { workspace = true }
 tracing-appender         = "0.2.4"
 tracing-subscriber       = { workspace = true, features = ["env-filter", "json"] }

--- a/crates/biome_css_analyze/src/lint/nursery/no_unused_classes.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unused_classes.rs
@@ -3,7 +3,7 @@ use biome_analyze::{Rule, RuleDiagnostic, RuleDomain, context::RuleContext, decl
 use biome_console::markup;
 use biome_css_syntax::CssClassSelector;
 use biome_css_syntax::selector_ext::AnyCssPseudoClassFunctionSelector;
-use biome_module_graph::{ModuleDb, SymbolName, is_class_referenced_by_importers};
+use biome_module_graph::{ModuleDb, SymbolFromModuleInfo, is_class_referenced_by_importers};
 use biome_rowan::AstNode;
 use biome_rule_options::no_unused_classes::NoUnusedClassesOptions;
 
@@ -81,8 +81,7 @@ impl Rule for NoUnusedClasses {
 
         if is_class_referenced_by_importers(
             db,
-            module,
-            SymbolName::new(db, class_name.token_text_trimmed().text()),
+            SymbolFromModuleInfo::new(db, class_name.token_text_trimmed().text(), module),
         ) {
             return None;
         }

--- a/crates/biome_html_analyze/src/lint/nursery/no_undeclared_classes.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/no_undeclared_classes.rs
@@ -112,7 +112,7 @@ impl Rule for NoUndeclaredClasses {
         // stylesheets, and CSS imported by parent files via upward traversal).
         // If no CSS is reachable at all, skip to avoid false positives on
         // completely unstyled files.
-        let css_steps: Vec<_> = traverse_import_tree_for_html_classes(db, module);
+        let css_steps = traverse_import_tree_for_html_classes(db, module);
 
         if css_steps.is_empty() {
             return Vec::new();
@@ -130,7 +130,7 @@ impl Rule for NoUndeclaredClasses {
 
             // Check if this class exists in any of the collected CSS steps.
             let mut found_class = false;
-            for step in &css_steps {
+            for step in css_steps {
                 if step
                     .css_classes
                     .values()

--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -8,7 +8,7 @@ use biome_fs::BiomePath;
 use biome_js_syntax::{AnyJsImportClause, AnyJsImportLike, JsModuleSource};
 use biome_jsdoc_comment::JsdocComment;
 use biome_module_graph::{
-    JsImportPath, ModuleDb, ModuleInfo, SymbolName, find_jsdoc_for_exported_symbol,
+    JsImportPath, ModuleDb, ModuleInfo, SymbolFromModuleInfo, find_jsdoc_for_exported_symbol,
 };
 use biome_rowan::{AstNode, Text, TextRange};
 use biome_rule_options::no_private_imports::{NoPrivateImportsOptions, Visibility};
@@ -292,8 +292,7 @@ fn get_restricted_import_visibility(
 ) -> Option<Visibility> {
     let visibility = find_jsdoc_for_exported_symbol(
         options.module_db,
-        options.target_info,
-        SymbolName::new(options.module_db, import_name.text()),
+        SymbolFromModuleInfo::new(options.module_db, import_name.text(), options.target_info),
     )
     .as_ref()
     .and_then(parse_visibility)

--- a/crates/biome_js_analyze/src/lint/correctness/no_unresolved_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unresolved_imports.rs
@@ -6,7 +6,8 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsImportClause, AnyJsImportLike, JsModuleSource};
 use biome_module_graph::{
-    JsImportPath, ModuleDb, ModuleInfo, SUPPORTED_EXTENSIONS, SymbolName, find_js_exported_symbol,
+    JsImportPath, ModuleDb, ModuleInfo, SUPPORTED_EXTENSIONS, SymbolFromModuleInfo,
+    find_js_exported_symbol,
 };
 use biome_resolver::ResolveError;
 use biome_rowan::{AstNode, Text, TextRange, TokenText};
@@ -269,8 +270,7 @@ fn get_unresolved_imports_from_module_source(
 fn has_exported_symbol(import_name: &Text, options: &GetUnresolvedImportsOptions) -> bool {
     find_js_exported_symbol(
         options.module_db,
-        options.target_info,
-        SymbolName::new(options.module_db, import_name.text()),
+        SymbolFromModuleInfo::new(options.module_db, import_name.text(), options.target_info),
     )
     .is_some()
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_undeclared_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_undeclared_classes.rs
@@ -112,7 +112,7 @@ impl Rule for NoUndeclaredClasses {
         };
         // Collect all reachable CSS steps. If no CSS is reachable at all,
         // skip to avoid false positives on files without any stylesheets.
-        let css_steps: Vec<_> = if is_html_like {
+        let css_steps = if is_html_like {
             traverse_import_tree_for_html_classes(db, module)
         } else {
             traverse_import_tree_for_classes(db, module)
@@ -291,7 +291,7 @@ fn run_without_semantic(
 
     // Collect all reachable CSS steps. If no CSS is reachable at all,
     // skip to avoid false positives on files without any stylesheets.
-    let css_steps: Vec<_> = traverse_import_tree_for_html_classes(db, module);
+    let css_steps = traverse_import_tree_for_html_classes(db, module);
 
     if css_steps.is_empty() {
         return Vec::new();

--- a/crates/biome_js_analyze/src/lint/suspicious/no_deprecated_imports.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_deprecated_imports.rs
@@ -5,7 +5,7 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsImportClause, AnyJsImportLike, JsModuleSource};
 use biome_module_graph::{
-    JsImportPath, ModuleDb, ModuleInfo, SymbolName, find_jsdoc_for_exported_symbol,
+    JsImportPath, ModuleDb, ModuleInfo, SymbolFromModuleInfo, find_jsdoc_for_exported_symbol,
 };
 use biome_rowan::{AstNode, Text, TextRange};
 use biome_rule_options::no_deprecated_imports::NoDeprecatedImportsOptions;
@@ -153,36 +153,34 @@ fn find_deprecation(
     module_db: &dyn ModuleDb,
     name: &Text,
 ) -> Option<Option<String>> {
-    find_jsdoc_for_exported_symbol(
-        module_db,
-        module_info,
-        SymbolName::new(module_db, name.text()),
-    )
-    .and_then(|jsdoc| {
-        let mut is_deprecated = false;
-        let mut message = String::new();
-        for line in jsdoc.lines() {
-            let line = line.trim();
-            if is_deprecated {
-                if line.is_empty() {
-                    break;
-                }
+    let symbol = SymbolFromModuleInfo::new(module_db, name.text(), module_info);
+    find_jsdoc_for_exported_symbol(module_db, symbol)
+        .as_ref()
+        .and_then(|jsdoc| {
+            let mut is_deprecated = false;
+            let mut message = String::new();
+            for line in jsdoc.lines() {
+                let line = line.trim();
+                if is_deprecated {
+                    if line.is_empty() {
+                        break;
+                    }
 
-                if !message.is_empty() {
-                    message.push(' ');
-                }
+                    if !message.is_empty() {
+                        message.push(' ');
+                    }
 
-                message.push_str(line);
-            } else if let Some((_before, after)) = line.split_once("@deprecated") {
-                is_deprecated = true;
-                message.push_str(after.trim_start());
+                    message.push_str(line);
+                } else if let Some((_before, after)) = line.split_once("@deprecated") {
+                    is_deprecated = true;
+                    message.push_str(after.trim_start());
+                }
             }
-        }
 
-        is_deprecated.then_some(if message.is_empty() {
-            None
-        } else {
-            Some(message)
+            is_deprecated.then_some(if message.is_empty() {
+                None
+            } else {
+                Some(message)
+            })
         })
-    })
 }

--- a/crates/biome_module_graph/src/db/project_database.rs
+++ b/crates/biome_module_graph/src/db/project_database.rs
@@ -22,6 +22,35 @@ impl ProjectDatabase {
     pub fn remove_module(&self, path: &Utf8Path) {
         self.modules.pin().remove(path);
     }
+
+    pub fn unload_path(&self, path: &Utf8Path) {
+        let modules = self.modules.pin();
+        let to_remove: Vec<Utf8PathBuf> = modules
+            .keys()
+            .filter(|p| p.starts_with(path))
+            .cloned()
+            .collect();
+        for p in to_remove {
+            modules.remove(&p);
+        }
+    }
+}
+
+/// This handler is exclusively used for cloning operations (reading operations).
+/// Writing operations still go through [ProjectDatabase].
+#[derive(Clone, Default)]
+pub struct ProjectDatabaseHandle {
+    modules: Arc<HashMap<Utf8PathBuf, ModuleInfo>>,
+    storage: salsa::StorageHandle<ProjectDatabase>,
+}
+
+impl ProjectDatabaseHandle {
+    pub fn to_db(&self) -> ProjectDatabase {
+        ProjectDatabase {
+            modules: self.modules.clone(),
+            storage: self.storage.clone().into_storage(),
+        }
+    }
 }
 
 #[salsa::db]

--- a/crates/biome_module_graph/src/db/queries.rs
+++ b/crates/biome_module_graph/src/db/queries.rs
@@ -10,7 +10,7 @@
 
 use crate::css_module_info::traverse::{CssClassStep, ImportTreeTraversal};
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
-use crate::{CssTraversalStep, ImportTreeNode, JsExport, JsOwnExport, ModuleDb};
+use crate::{ImportTreeNode, JsExport, JsOwnExport, ModuleDb};
 use biome_css_syntax::{TextRange, TextSize};
 use biome_js_type_info::ImportSymbol;
 use biome_jsdoc_comment::JsdocComment;
@@ -23,7 +23,7 @@ use std::collections::VecDeque;
 ///
 /// Tracked: depends on `js_module_info(db, module)` and on the CSS modules it
 /// imports. If any of those change, this recomputes.
-#[salsa::tracked(no_eq)]
+#[salsa::tracked(no_eq, returns(deref))]
 pub fn css_classes_for_module(db: &dyn ModuleDb, module: ModuleInfo) -> Vec<CssClassStep> {
     let module_kind = module.kind(db);
     let Some(js_info) = module_kind.as_js_module_info() else {
@@ -51,7 +51,7 @@ pub fn css_classes_for_module(db: &dyn ModuleDb, module: ModuleInfo) -> Vec<CssC
 ///
 /// The returned set includes only JS/HTML files (potential class consumers),
 /// not intermediate CSS files.
-#[salsa::tracked]
+#[salsa::tracked(returns(deref))]
 pub fn transitive_importers_of(db: &dyn ModuleDb, module: ModuleInfo) -> Vec<Utf8PathBuf> {
     let mut result = Vec::new();
     let mut visited: FxHashSet<Utf8PathBuf> = FxHashSet::default();
@@ -110,7 +110,7 @@ pub fn transitive_importers_of(db: &dyn ModuleDb, module: ModuleInfo) -> Vec<Utf
 }
 
 /// Returns CSS class steps for the given JS file by traversing its imports.
-#[salsa::tracked]
+#[salsa::tracked(returns(deref))]
 pub fn traverse_import_tree_for_classes(
     db: &dyn ModuleDb,
     module: ModuleInfo,
@@ -145,7 +145,7 @@ pub fn traverse_import_tree_for_classes(
 }
 
 /// Returns CSS class steps for the given HTML file.
-#[salsa::tracked]
+#[salsa::tracked(returns(deref))]
 pub fn traverse_import_tree_for_html_classes(
     db: &dyn ModuleDb,
     module: ModuleInfo,
@@ -209,158 +209,30 @@ pub fn traverse_import_tree_for_html_classes(
         .collect()
 }
 
-/// Collects all CSS classes available through the import tree of the given JS file.
-#[salsa::tracked]
-pub fn collect_available_classes_for_js_file(
-    db: &dyn ModuleDb,
-    module: ModuleInfo,
-) -> (FxHashSet<String>, Vec<CssTraversalStep>) {
-    let mut available_classes = FxHashSet::default();
-    let mut traversal_path = Vec::new();
-    let mut visited = FxHashSet::default();
-    let all_modules = db.all_modules();
-
-    if let Some(js_info) = db.js_module_info_for_path(module.path(db)) {
-        for import_path in js_info
-            .static_import_paths
-            .values()
-            .chain(js_info.dynamic_import_paths.values())
-        {
-            if let Some(path) = import_path.as_path()
-                && let Some(css_info) = db.css_module_info_for_path(path)
-            {
-                for class in css_info.classes.values() {
-                    let class_name = class.text().to_string();
-                    available_classes.insert(class_name);
-                }
-                traversal_path.push(CssTraversalStep {
-                    css_path: path.to_path_buf(),
-                    importer_path: module.path(db).to_path_buf(),
-                    component_chain: vec![module.path(db).to_path_buf()],
-                    is_direct: true,
-                });
-            }
-        }
-    }
-
-    let mut queue: VecDeque<_> = VecDeque::new();
-    queue.push_back((
-        module.path(db).to_path_buf(),
-        vec![module.path(db).to_path_buf()],
-    ));
-    visited.insert(module.path(db).to_path_buf());
-
-    while let Some((current_path, current_chain)) = queue.pop_front() {
-        for (file_path, module_info) in &all_modules {
-            if visited.contains(file_path.as_path()) {
-                continue;
-            }
-
-            let imports_current = match module_info {
-                ModuleInfoKind::Js(js_info) => js_info
-                    .static_import_paths
-                    .values()
-                    .chain(js_info.dynamic_import_paths.values())
-                    .any(|p| p.as_path() == Some(current_path.as_path())),
-                ModuleInfoKind::Html(html_info) => html_info
-                    .imported_stylesheets
-                    .iter()
-                    .chain(html_info.static_import_paths.values())
-                    .chain(html_info.dynamic_import_paths.values())
-                    .any(|p| p.as_path() == Some(current_path.as_path())),
-                ModuleInfoKind::Css(_) => false,
-            };
-
-            if imports_current {
-                visited.insert(file_path.clone());
-
-                match module_info {
-                    ModuleInfoKind::Js(js_info) => {
-                        let mut new_chain = current_chain.clone();
-                        new_chain.push(file_path.clone());
-
-                        for import_path in js_info
-                            .static_import_paths
-                            .values()
-                            .chain(js_info.dynamic_import_paths.values())
-                        {
-                            if let Some(path) = import_path.as_path()
-                                && let Some(css_info) = db.css_module_info_for_path(path)
-                            {
-                                for class in css_info.classes.values() {
-                                    let class_name = class.text().to_string();
-                                    available_classes.insert(class_name);
-                                }
-
-                                traversal_path.push(CssTraversalStep {
-                                    css_path: path.to_path_buf(),
-                                    importer_path: file_path.clone(),
-                                    component_chain: new_chain.clone(),
-                                    is_direct: false,
-                                });
-                            }
-                        }
-                        queue.push_back((file_path.clone(), new_chain));
-                    }
-                    ModuleInfoKind::Html(html_info) => {
-                        let mut new_chain = current_chain.clone();
-                        new_chain.push(file_path.clone());
-
-                        for stylesheet_path in html_info
-                            .imported_stylesheets
-                            .iter()
-                            .chain(html_info.static_import_paths.values())
-                            .chain(html_info.dynamic_import_paths.values())
-                        {
-                            if let Some(path) = stylesheet_path.as_path()
-                                && let Some(css_info) = db.css_module_info_for_path(path)
-                            {
-                                for class in css_info.classes.values() {
-                                    let class_name = class.text().to_string();
-                                    available_classes.insert(class_name);
-                                }
-                                traversal_path.push(CssTraversalStep {
-                                    css_path: path.to_path_buf(),
-                                    importer_path: file_path.clone(),
-                                    component_chain: new_chain.clone(),
-                                    is_direct: false,
-                                });
-                            }
-                        }
-                        queue.push_back((file_path.clone(), new_chain));
-                    }
-                    ModuleInfoKind::Css(_) => {}
-                }
-            }
-        }
-    }
-
-    (available_classes, traversal_path)
-}
-
 #[salsa::interned]
 /// Generic symbol used by queries to track a generic "symbol", which can represent everything (variable name, class name, etc.)
-pub struct SymbolName {
-    #[returns(ref)]
+pub struct SymbolFromModuleInfo {
+    #[returns(clone)]
     name: String,
+
+    #[returns(ref)]
+    module: ModuleInfo,
 }
 
 /// Finds the default exported symbol.
 #[salsa::tracked]
 pub fn find_js_exported_symbol<'db>(
     db: &'db dyn ModuleDb,
-    module: ModuleInfo,
-    symbol_name: SymbolName<'db>,
+    symbol: SymbolFromModuleInfo<'db>,
 ) -> Option<JsOwnExport> {
-    let ModuleInfoKind::Js(module) = module.kind(db) else {
-        return None;
-    };
-
     let mut seen_paths = std::collections::BTreeSet::new();
-    let mut stack = vec![(module.clone(), symbol_name)];
+    let mut stack = vec![symbol];
 
-    while let Some((module, symbol_name)) = stack.pop() {
-        match &module.exports.get(symbol_name.name(db).as_str()) {
+    while let Some(symbol) = stack.pop() {
+        let ModuleInfoKind::Js(module) = symbol.module(db).kind(db) else {
+            continue;
+        };
+        match &module.exports.get(symbol.name(db).as_str()) {
             Some(JsExport::Own(own_export) | JsExport::OwnType(own_export)) => {
                 return Some(own_export.clone());
             }
@@ -371,8 +243,12 @@ pub fn find_js_exported_symbol<'db>(
                         let lookup = source_name.text().to_string();
                         match reexport.import.resolved_path.as_deref() {
                             Ok(path) if seen_paths.insert(path.to_path_buf()) => {
-                                if let Some(module) = db.js_module_info_for_path(path) {
-                                    stack.push((module, SymbolName::new(db, lookup.clone())));
+                                if let Some(module) = db.module_for_path(path) {
+                                    stack.push(SymbolFromModuleInfo::new(
+                                        db,
+                                        lookup.clone(),
+                                        module,
+                                    ));
                                 }
                             }
                             _ => break,
@@ -381,9 +257,9 @@ pub fn find_js_exported_symbol<'db>(
                     ImportSymbol::Default => {
                         if let Ok(path) = reexport.import.resolved_path.as_deref()
                             && seen_paths.insert(path.to_path_buf())
-                            && let Some(module) = db.js_module_info_for_path(path)
+                            && let Some(module) = db.module_for_path(path)
                         {
-                            stack.push((module, symbol_name));
+                            stack.push(SymbolFromModuleInfo::new(db, symbol.name(db), module));
                         }
                     }
                 }
@@ -392,9 +268,9 @@ pub fn find_js_exported_symbol<'db>(
                 for reexport in module.blanket_reexports.iter() {
                     if let Ok(path) = reexport.import.resolved_path.as_deref()
                         && seen_paths.insert(path.to_path_buf())
-                        && let Some(module) = db.js_module_info_for_path(path)
+                        && let Some(module) = db.module_for_path(path)
                     {
-                        stack.push((module, symbol_name));
+                        stack.push(SymbolFromModuleInfo::new(db, symbol.name(db), module));
                     }
                 }
             }
@@ -409,12 +285,11 @@ pub fn find_js_exported_symbol<'db>(
 #[salsa::tracked]
 pub fn is_class_referenced_by_importers<'db>(
     db: &'db dyn ModuleDb,
-    module: ModuleInfo,
-    class_name: SymbolName<'db>,
+    class_name: SymbolFromModuleInfo<'db>,
 ) -> bool {
-    let importers = transitive_importers_of(db, module);
+    let importers = transitive_importers_of(db, *class_name.module(db));
 
-    for importer_path in &importers {
+    for importer_path in importers {
         let Some(module) = db.module_for_path(importer_path) else {
             continue;
         };
@@ -430,7 +305,7 @@ pub fn is_class_referenced_by_importers<'db>(
 fn is_class_used_in_component_tree<'db>(
     db: &'db dyn ModuleDb,
     module: ModuleInfo,
-    class_name: SymbolName<'db>,
+    class_name: SymbolFromModuleInfo<'db>,
 ) -> bool {
     let mut visited = FxHashSet::default();
     let mut queue = VecDeque::new();
@@ -479,20 +354,19 @@ fn is_class_used_in_component_tree<'db>(
 }
 
 /// Finds JSDoc for an exported symbol by `name`, following re-exports through the db.
-#[salsa::tracked]
+#[salsa::tracked(returns(ref))]
 pub fn find_jsdoc_for_exported_symbol<'db>(
     db: &'db dyn ModuleDb,
-    module: ModuleInfo,
-    symbol_name: SymbolName<'db>,
+    symbol: SymbolFromModuleInfo<'db>,
 ) -> Option<JsdocComment> {
-    let ModuleInfoKind::Js(module) = module.kind(db) else {
-        return None;
-    };
     let mut seen_paths = std::collections::BTreeSet::new();
-    let mut stack = vec![(module, symbol_name)];
+    let mut stack = vec![symbol];
 
-    while let Some((module, symbol_name)) = stack.pop() {
-        match &module.exports.get(symbol_name.name(db).as_str()) {
+    while let Some(symbol) = stack.pop() {
+        let ModuleInfoKind::Js(module) = symbol.module(db).kind(db) else {
+            continue;
+        };
+        match &module.exports.get(symbol.name(db).as_str()) {
             Some(JsExport::Own(own_export) | JsExport::OwnType(own_export)) => {
                 return match own_export {
                     JsOwnExport::Binding(binding_range) => module
@@ -512,8 +386,12 @@ pub fn find_jsdoc_for_exported_symbol<'db>(
                         let lookup = source_name.text().to_string();
                         match reexport.import.resolved_path.as_deref() {
                             Ok(path) if seen_paths.insert(path.to_path_buf()) => {
-                                if let Some(module) = db.js_module_info_for_path(path) {
-                                    stack.push((module, SymbolName::new(db, lookup.clone())));
+                                if let Some(module) = db.module_for_path(path) {
+                                    stack.push(SymbolFromModuleInfo::new(
+                                        db,
+                                        lookup.clone(),
+                                        module,
+                                    ));
                                 }
                             }
                             _ => break,
@@ -521,9 +399,9 @@ pub fn find_jsdoc_for_exported_symbol<'db>(
                     }
                     ImportSymbol::Default => {
                         if let Ok(path) = reexport.import.resolved_path.as_deref()
-                            && let Some(module) = db.js_module_info_for_path(path)
+                            && let Some(module) = db.module_for_path(path)
                         {
-                            stack.push((module, symbol_name));
+                            stack.push(SymbolFromModuleInfo::new(db, symbol.name(db), module));
                         }
                     }
                 }
@@ -532,9 +410,9 @@ pub fn find_jsdoc_for_exported_symbol<'db>(
                 for reexport in module.blanket_reexports.iter() {
                     if let Ok(path) = reexport.import.resolved_path.as_deref()
                         && seen_paths.insert(path.to_path_buf())
-                        && let Some(module) = db.js_module_info_for_path(path)
+                        && let Some(module) = db.module_for_path(path)
                     {
-                        stack.push((module, symbol_name));
+                        stack.push(SymbolFromModuleInfo::new(db, symbol.name(db), module));
                     }
                 }
             }
@@ -548,17 +426,17 @@ pub fn find_jsdoc_for_exported_symbol<'db>(
 #[salsa::tracked]
 pub fn find_css_class_definition<'db>(
     db: &'db dyn ModuleDb,
-    module: ModuleInfo,
-    class_name: SymbolName<'db>,
+    symbol: SymbolFromModuleInfo<'db>,
 ) -> Vec<(Utf8PathBuf, TextRange, Option<TextSize>)> {
     let mut result = Vec::new();
+    let module = symbol.module(db);
     let mut visited_css = FxHashSet::default();
     // 1. Check inline style classes in HTML-like files (carry content_offset)
     if let ModuleInfoKind::Html(html_info) = module.kind(db) {
         for class_def in &html_info.style_classes {
-            if class_def.name.text() == class_name.name(db) {
+            if class_def.name.text() == symbol.name(db) {
                 result.push((
-                    module.path(db).to_path_buf(),
+                    symbol.module(db).path(db).to_path_buf(),
                     class_def.range,
                     class_def.content_offset,
                 ));
@@ -567,7 +445,7 @@ pub fn find_css_class_definition<'db>(
     }
 
     // 2. Check CSS files reachable from HTML (linked stylesheets + script imports)
-    for step in traverse_import_tree_for_html_classes(db, module) {
+    for step in traverse_import_tree_for_html_classes(db, *module) {
         if &step.css_path == module.path(db) {
             continue; // Already checked inline styles above
         }
@@ -575,16 +453,24 @@ pub fn find_css_class_definition<'db>(
             continue;
         };
 
-        let this_result = search_css_class_transitive(db, module, class_name, &mut visited_css);
+        let this_result = search_css_class_transitive(
+            db,
+            SymbolFromModuleInfo::new(db, symbol.name(db), module),
+            &mut visited_css,
+        );
         result.extend(this_result);
     }
 
     // 3. Check CSS files imported by JS (e.g., `import './styles.css'` in JSX)
-    for step in traverse_import_tree_for_classes(db, module) {
+    for step in traverse_import_tree_for_classes(db, *module) {
         let Some(module) = db.module_for_path(&step.css_path) else {
             continue;
         };
-        let this_result = search_css_class_transitive(db, module, class_name, &mut visited_css);
+        let this_result = search_css_class_transitive(
+            db,
+            SymbolFromModuleInfo::new(db, symbol.name(db), module),
+            &mut visited_css,
+        );
 
         result.extend(this_result);
     }
@@ -594,13 +480,12 @@ pub fn find_css_class_definition<'db>(
 
 fn search_css_class_transitive<'db>(
     db: &'db dyn ModuleDb,
-    css_module: ModuleInfo,
-    class_name: SymbolName<'db>,
+    symbol: SymbolFromModuleInfo<'db>,
     visited: &mut FxHashSet<Utf8PathBuf>,
 ) -> Vec<(Utf8PathBuf, TextRange, Option<TextSize>)> {
     let mut result = vec![];
     let mut queue = VecDeque::new();
-    queue.push_back(css_module);
+    queue.push_back(*symbol.module(db));
 
     while let Some(current) = queue.pop_front() {
         if !visited.insert(current.path(db).to_path_buf()) {
@@ -612,7 +497,7 @@ fn search_css_class_transitive<'db>(
         };
 
         for (range, token) in css_info.classes.iter() {
-            if token.text() == class_name.name(db) {
+            if token.text() == symbol.name(db) {
                 result.push((current.path(db).to_path_buf(), *range, None));
             }
         }

--- a/crates/biome_module_graph/src/lib.rs
+++ b/crates/biome_module_graph/src/lib.rs
@@ -17,7 +17,7 @@ pub use css_module_info::{
     ImportTreeDisplay, ImportTreeNode,
 };
 pub use db::ModuleDb;
-pub use db::project_database::ProjectDatabase;
+pub use db::project_database::{ProjectDatabase, ProjectDatabaseHandle};
 pub use db::queries::*;
 pub use diagnostics::ModuleDiagnostic;
 pub use html_module_info::{HtmlEmbeddedContent, HtmlModuleInfo, SerializedHtmlModuleInfo};

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -26,10 +26,10 @@ use biome_json_value::{JsonObject, JsonString};
 use biome_module_graph::{
     HtmlEmbeddedContent, ImportSymbol, JsExport, JsImport, JsImportPath, JsImportPhase,
     JsModuleInfoDiagnostic, JsOwnExport, JsReexport, ModuleDb, ModuleDiagnostic, ModuleInfo,
-    ModuleInfoKind, ModuleResolver, PathInfoCache, ProjectDatabase, ResolvedPath, SymbolName,
-    collect_available_classes_for_js_file, find_js_exported_symbol,
-    is_class_referenced_by_importers, resolve_css_module, resolve_html_module, resolve_js_module,
-    transitive_importers_of, traverse_import_tree_for_html_classes,
+    ModuleInfoKind, ModuleResolver, PathInfoCache, ProjectDatabase, ResolvedPath,
+    SymbolFromModuleInfo, find_js_exported_symbol, is_class_referenced_by_importers,
+    resolve_css_module, resolve_html_module, resolve_js_module, transitive_importers_of,
+    traverse_import_tree_for_classes, traverse_import_tree_for_html_classes,
 };
 use biome_package::{Dependencies, PackageJson};
 use biome_project_layout::ProjectLayout;
@@ -41,6 +41,7 @@ use biome_service::test_utils::setup_workspace_and_open_project;
 use biome_service::workspace::UpdateSettingsParams;
 use biome_test_utils::{get_added_js_paths, get_css_added_paths};
 use camino::{Utf8Path, Utf8PathBuf};
+use rustc_hash::FxHashSet;
 use walkdir::WalkDir;
 
 fn build_js_db(
@@ -2544,14 +2545,16 @@ fn test_aliased_named_reexport_is_found_by_alias() {
     // the re-export chain to a binding in `source.ts`).
     let barrel = db.module_for_path(Utf8Path::new("/src/barrel.ts")).unwrap();
 
-    let found = find_js_exported_symbol(&db, barrel, SymbolName::new(&db, "renamedSymbol"));
+    let found =
+        find_js_exported_symbol(&db, SymbolFromModuleInfo::new(&db, "renamedSymbol", barrel));
     assert!(
         found.is_some(),
         "`renamedSymbol` must be found via the aliased re-export chain; got None"
     );
 
     // `originalName` must NOT be visible under the barrel's public API.
-    let not_found = find_js_exported_symbol(&db, barrel, SymbolName::new(&db, "originalName"));
+    let not_found =
+        find_js_exported_symbol(&db, SymbolFromModuleInfo::new(&db, "originalName", barrel));
     assert!(
         not_found.is_none(),
         "`originalName` must not be directly exported from the barrel"
@@ -2616,7 +2619,7 @@ fn test_namespace_reexport_is_own_export() {
     );
 
     // Confirm `find_js_exported_symbol` returns `Some` as the lint rule sees it.
-    let found = find_js_exported_symbol(&db, barrel, SymbolName::new(&db, "MyNs"));
+    let found = find_js_exported_symbol(&db, SymbolFromModuleInfo::new(&db, "MyNs", barrel));
     assert!(
         found.is_some(),
         "`MyNs` must be found by find_js_exported_symbol"
@@ -2811,11 +2814,14 @@ export function Component() {
         .unwrap();
 
     assert!(
-        is_class_referenced_by_importers(&db, styles_css, SymbolName::new(&db, "used")),
+        is_class_referenced_by_importers(&db, SymbolFromModuleInfo::new(&db, "used", styles_css)),
         "'used' class should be referenced by Component.jsx"
     );
     assert!(
-        !is_class_referenced_by_importers(&db, styles_css, SymbolName::new(&db, "unused")),
+        !is_class_referenced_by_importers(
+            &db,
+            SymbolFromModuleInfo::new(&db, "unused", styles_css)
+        ),
         "'unused' class should not be referenced by any importer"
     );
 }
@@ -2877,13 +2883,13 @@ export function App() {
 
     // The 'base' class is used by App.jsx, so it should be considered referenced.
     assert!(
-        is_class_referenced_by_importers(&db, module, SymbolName::new(&db, "base")),
+        is_class_referenced_by_importers(&db, SymbolFromModuleInfo::new(&db, "base", module)),
         "'base' class must be referenced transitively"
     );
 
     // The 'orphan' class is never used anywhere.
     assert!(
-        !is_class_referenced_by_importers(&db, module, SymbolName::new(&db, "orphan")),
+        !is_class_referenced_by_importers(&db, SymbolFromModuleInfo::new(&db, "orphan", module)),
         "'orphan' class must not be referenced"
     );
 }
@@ -2977,12 +2983,18 @@ export function App() {
 
     // Classes used in App.tsx should be detected even from nested CSS
     assert!(
-        is_class_referenced_by_importers(&db, components_css, SymbolName::new(&db, "button"),),
+        is_class_referenced_by_importers(
+            &db,
+            SymbolFromModuleInfo::new(&db, "button", components_css)
+        ),
         "'button' class from components.css should be detected as used"
     );
 
     assert!(
-        is_class_referenced_by_importers(&db, components_css, SymbolName::new(&db, "card")),
+        is_class_referenced_by_importers(
+            &db,
+            SymbolFromModuleInfo::new(&db, "card", components_css)
+        ),
         "'card' class from components.css should be detected as used"
     );
 
@@ -2990,20 +3002,19 @@ export function App() {
     assert!(
         !is_class_referenced_by_importers(
             &db,
-            components_css,
-            SymbolName::new(&db, "unused-component-class"),
+            SymbolFromModuleInfo::new(&db, "unused-component-class", components_css)
         ),
         "'unused-component-class' should be detected as unused"
     );
 
     // Utils classes should also work
     assert!(
-        is_class_referenced_by_importers(&db, utils_css, SymbolName::new(&db, "flex")),
+        is_class_referenced_by_importers(&db, SymbolFromModuleInfo::new(&db, "flex", utils_css)),
         "'flex' class from utils.css should be detected as used"
     );
 
     assert!(
-        !is_class_referenced_by_importers(&db, utils_css, SymbolName::new(&db, "grid")),
+        !is_class_referenced_by_importers(&db, SymbolFromModuleInfo::new(&db, "grid", utils_css)),
         "'grid' class from utils.css should be detected as unused"
     );
 }
@@ -3096,100 +3107,33 @@ export function Dashboard() {
 
     // button used in App.tsx
     assert!(
-        is_class_referenced_by_importers(&db, components_css, SymbolName::new(&db, "button")),
+        is_class_referenced_by_importers(
+            &db,
+            SymbolFromModuleInfo::new(&db, "button", components_css)
+        ),
         "'button' should be detected as used"
     );
 
     // card used in Dashboard.tsx
     assert!(
-        is_class_referenced_by_importers(&db, components_css, SymbolName::new(&db, "card")),
+        is_class_referenced_by_importers(
+            &db,
+            SymbolFromModuleInfo::new(&db, "card", components_css)
+        ),
         "'card' should be detected as used"
     );
 
     // modal not used anywhere
     assert!(
-        !is_class_referenced_by_importers(&db, components_css, SymbolName::new(&db, "modal")),
+        !is_class_referenced_by_importers(
+            &db,
+            SymbolFromModuleInfo::new(&db, "modal", components_css)
+        ),
         "'modal' should be detected as unused"
     );
 }
 
-/// Verifies deep nesting: 3 levels of CSS imports.
-///
-/// App.tsx → main.css → theme.css → base.css (defines .primary)
-#[test]
-fn test_deeply_nested_css_import_chain() {
-    let fs = MemoryFileSystem::default();
-
-    fs.insert(
-        "/src/base.css".into(),
-        r#"
-.primary { color: blue; }
-.secondary { color: gray; }
-"#,
-    );
-
-    fs.insert(
-        "/src/theme.css".into(),
-        r#"
-@import "./base.css";
-"#,
-    );
-
-    fs.insert(
-        "/src/main.css".into(),
-        r#"
-@import "./theme.css";
-"#,
-    );
-
-    fs.insert(
-        "/src/App.tsx".into(),
-        r#"
-import "./main.css";
-
-export function App() {
-    return <button className="primary">Primary Button</button>;
-}
-"#,
-    );
-
-    let css_paths = [
-        BiomePath::new("/src/base.css"),
-        BiomePath::new("/src/theme.css"),
-        BiomePath::new("/src/main.css"),
-    ];
-    let css_roots = get_css_added_paths(&fs, &css_paths);
-    let js_paths = [BiomePath::new("/src/App.tsx")];
-    let js_roots = get_added_js_paths(&fs, &js_paths);
-
-    let db = ProjectDatabase::default();
-    add_css_modules(&db, &fs, &ProjectLayout::default(), &css_roots);
-    add_js_modules(&db, &fs, &ProjectLayout::default(), &js_roots, false);
-
-    // App.tsx should be found even for deeply nested base.css
-    let base_css = db.module_for_path(Utf8Path::new("/src/base.css")).unwrap();
-    let consumers = transitive_importers_of(&db, base_css);
-    assert!(
-        consumers
-            .iter()
-            .any(|p| p.as_path() == Utf8Path::new("/src/App.tsx")),
-        "App.tsx should be a consumer of base.css through 3-level import chain; got: {consumers:?}"
-    );
-
-    // primary used in App.tsx
-    assert!(
-        is_class_referenced_by_importers(&db, base_css, SymbolName::new(&db, "primary")),
-        "'primary' from deeply nested base.css should be detected as used"
-    );
-
-    // secondary not used
-    assert!(
-        !is_class_referenced_by_importers(&db, base_css, SymbolName::new(&db, "secondary")),
-        "'secondary' should be detected as unused"
-    );
-}
-
-/// Tests `collect_available_classes_for_js_file` for a JSX file that directly
+/// Tests `traverse_import_tree_for_classes` for a JSX file that directly
 /// imports CSS.
 #[test]
 fn test_collect_available_classes_for_js_file() {
@@ -3221,10 +3165,15 @@ export function App() {
     add_css_modules(&db, &fs, &ProjectLayout::default(), &css_roots);
     add_js_modules(&db, &fs, &ProjectLayout::default(), &js_roots, false);
 
-    let (classes, traversal) = collect_available_classes_for_js_file(
+    let traversal = traverse_import_tree_for_classes(
         &db,
         db.module_for_path(Utf8Path::new("/src/App.jsx")).unwrap(),
     );
+    let classes: FxHashSet<String> = traversal
+        .iter()
+        .flat_map(|step| step.css_classes.values())
+        .map(|class| class.text().to_string())
+        .collect();
 
     // Should find both CSS classes
     assert!(classes.contains("button"), "Should find .button class");
@@ -3239,7 +3188,7 @@ export function App() {
     );
 }
 
-/// Tests `collect_available_classes_for_js_file` with multiple CSS imports.
+/// Tests `traverse_import_tree_for_classes` with multiple CSS imports.
 #[test]
 fn test_collect_available_classes_for_js_file_multiple_css() {
     let fs = MemoryFileSystem::default();
@@ -3281,10 +3230,15 @@ export function App() {
     add_css_modules(&db, &fs, &ProjectLayout::default(), &css_roots);
     add_js_modules(&db, &fs, &ProjectLayout::default(), &js_roots, false);
 
-    let (classes, traversal) = collect_available_classes_for_js_file(
+    let traversal = traverse_import_tree_for_classes(
         &db,
         db.module_for_path(Utf8Path::new("/src/App.jsx")).unwrap(),
     );
+    let classes: FxHashSet<String> = traversal
+        .iter()
+        .flat_map(|step| step.css_classes.values())
+        .map(|class| class.text().to_string())
+        .collect();
 
     // Should find all CSS classes from both imports
     assert!(classes.contains("btn"), "Should find .btn class");
@@ -3332,14 +3286,19 @@ fn test_export_equals_namespace_without_type_inference() {
         .module_for_path(Utf8Path::new("/node_modules/@types/react/index.d.ts"))
         .expect("react module must exist");
 
-    let use_state = find_js_exported_symbol(&db, react_module, SymbolName::new(&db, "useState"));
+    let use_state = find_js_exported_symbol(
+        &db,
+        SymbolFromModuleInfo::new(&db, "useState", react_module),
+    );
     assert!(
         use_state.is_some(),
         "`useState` must be visible as a named export from `@types/react` even without type inference"
     );
 
-    let use_callback =
-        find_js_exported_symbol(&db, react_module, SymbolName::new(&db, "useCallback"));
+    let use_callback = find_js_exported_symbol(
+        &db,
+        SymbolFromModuleInfo::new(&db, "useCallback", react_module),
+    );
     assert!(
         use_callback.is_some(),
         "`useCallback` must be visible as a named export from `@types/react` even without type inference"
@@ -3604,7 +3563,7 @@ fn test_vue_mixed_scoped_and_unscoped() {
     // Only Global class appears in the traversal.
     let module = db.module_for_path(Utf8Path::new("/src/Mixed.vue")).unwrap();
     let traversal_classes: Vec<_> = traverse_import_tree_for_html_classes(&db, module)
-        .into_iter()
+        .iter()
         .flat_map(|step| {
             step.css_classes
                 .values()
@@ -3878,8 +3837,8 @@ fn test_vue_upward_traversal() {
         .module_for_path(Utf8Path::new("/src/Button.vue"))
         .unwrap();
     let available_classes: Vec<_> = traverse_import_tree_for_html_classes(&db, module)
-        .into_iter()
-        .flat_map(|step| step.css_classes.into_values())
+        .iter()
+        .flat_map(|step| step.css_classes.values())
         .collect();
 
     assert!(

--- a/crates/biome_service/src/file_handlers/css/go_to.rs
+++ b/crates/biome_service/src/file_handlers/css/go_to.rs
@@ -2,7 +2,7 @@ use crate::file_handlers::ResolveDefinitionParams;
 use crate::workspace::{DefinitionReference, GoToDefinitionResult};
 use biome_css_syntax::CssClassSelector;
 use biome_fs::BiomePath;
-use biome_module_graph::{SymbolName, find_css_class_definition};
+use biome_module_graph::{SymbolFromModuleInfo, find_css_class_definition};
 use biome_rowan::AstNode;
 use std::ops::Add;
 
@@ -15,8 +15,7 @@ pub(crate) fn resolve_definition(params: ResolveDefinitionParams) -> Option<GoTo
         if let Some(module) = params.module_db.module_for_path(path) {
             for (css_path, mut range, content_offset) in find_css_class_definition(
                 params.module_db,
-                module,
-                SymbolName::new(params.module_db, class_name),
+                SymbolFromModuleInfo::new(params.module_db, class_name, module),
             ) {
                 // For inline `<style>` blocks, the range is snippet-local.
                 // Apply the content_offset to get parent document coordinates.

--- a/crates/biome_service/src/file_handlers/javascript/go_to.rs
+++ b/crates/biome_service/src/file_handlers/javascript/go_to.rs
@@ -8,7 +8,7 @@ use biome_js_syntax::{
     JsVariableDeclarator, JsxAttribute, JsxReferenceIdentifier, JsxString,
 };
 use biome_module_graph::{
-    JsOwnExport, ModuleDb, ModuleInfoKind, SymbolName, find_js_exported_symbol,
+    JsOwnExport, ModuleDb, ModuleInfoKind, SymbolFromModuleInfo, find_js_exported_symbol,
 };
 use biome_rowan::{AstNode, AstSeparatedList, TokenAtOffset, TokenText};
 use camino::Utf8Path;
@@ -220,13 +220,11 @@ fn resolve_import_definition(
 
             match find_js_exported_symbol(
                 module_db,
-                target_module,
-                SymbolName::new(module_db, local_name),
+                SymbolFromModuleInfo::new(module_db, local_name, target_module),
             )
             .or(find_js_exported_symbol(
                 module_db,
-                target_module,
-                SymbolName::new(module_db, "default"),
+                SymbolFromModuleInfo::new(module_db, "default", target_module),
             )) {
                 None => {
                     result.store(
@@ -258,8 +256,7 @@ fn resolve_import_definition(
             if let Some(module) = module_db.module_for_path(target_path) {
                 match find_js_exported_symbol(
                     module_db,
-                    module,
-                    SymbolName::new(module_db, local_name),
+                    SymbolFromModuleInfo::new(module_db, local_name, module),
                 ) {
                     None => {
                         result.store(

--- a/crates/biome_service/src/workspace/db.rs
+++ b/crates/biome_service/src/workspace/db.rs
@@ -1,19 +1,9 @@
-use crate::WorkspaceError;
-use biome_module_graph::PathInfoCache;
 pub use biome_module_graph::ProjectDatabase;
-use std::sync::{Mutex, MutexGuard};
+use biome_module_graph::{PathInfoCache, ProjectDatabaseHandle};
 
 /// Represents the state of the database in the workspace.
 #[derive(Default)]
 pub(crate) struct DbState {
-    pub(crate) db: Mutex<ProjectDatabase>,
+    pub(crate) handle: ProjectDatabaseHandle,
     pub(crate) path_info_cache: PathInfoCache,
-}
-
-impl DbState {
-    pub(crate) fn lock_db(&self) -> Result<MutexGuard<'_, ProjectDatabase>, WorkspaceError> {
-        self.db
-            .lock()
-            .map_err(|_| WorkspaceError::db_lock_poisoned())
-    }
 }

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -75,7 +75,7 @@ use papaya::HashMap;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::fmt::Debug;
 use std::panic::RefUnwindSafe;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::watch;
 use tracing::{info, instrument, warn};
@@ -237,8 +237,7 @@ impl WorkspaceServer {
 
     /// Returns a clone of the project database for passing to analyzers.
     fn module_db(&self) -> ProjectDatabase {
-        let db = self.db_state.db.lock().expect("db lock poisoned");
-        db.clone()
+        self.db_state.handle.to_db()
     }
 
     /// Returns the module db for use in tests.
@@ -1491,8 +1490,9 @@ impl WorkspaceServer {
         }
     }
 
-    fn lock_db(&self) -> Result<MutexGuard<'_, ProjectDatabase>, WorkspaceError> {
-        self.db_state.lock_db()
+    /// Returns a clone of the database. This is usually used to **read** data from it.
+    fn get_db(&self) -> ProjectDatabase {
+        self.db_state.handle.to_db()
     }
 
     /// Stores a [ModuleInfo] in the database
@@ -1501,23 +1501,16 @@ impl WorkspaceServer {
         path: &Utf8Path,
         kind: ModuleInfoKind,
     ) -> Result<(), WorkspaceError> {
-        let mut db = self.lock_db()?;
-        let path_buf = path.to_path_buf();
-
-        let existing = db.modules.pin().get(&path_buf).copied();
-        if let Some(module_info) = existing {
-            salsa::Setter::to(module_info.set_kind(&mut *db), kind);
-        } else {
-            let module_info = ModuleInfo::new(&*db, path_buf.clone(), kind);
-            db.insert_module(path_buf, module_info);
-        }
+        let db = self.db_state.handle.to_db();
+        let module_info = ModuleInfo::new(&db, path.to_path_buf(), kind);
+        db.insert_module(path.to_path_buf(), module_info);
         Ok(())
     }
 
     /// Removes a [ModuleInfo] from the database
     fn db_remove_module(&self, path: &Utf8Path) -> Result<(), WorkspaceError> {
         self.db_state.path_info_cache.remove(path);
-        let db = self.lock_db()?;
+        let db = self.db_state.handle.to_db();
         db.remove_module(path);
         Ok(())
     }
@@ -1525,18 +1518,7 @@ impl WorkspaceServer {
     /// Purges the path from the database
     fn db_unload_path(&self, path: &Utf8Path) {
         self.db_state.path_info_cache.remove(path);
-        let Ok(db) = self.lock_db() else {
-            return;
-        };
-        let modules = db.modules.pin();
-        let to_remove: Vec<Utf8PathBuf> = modules
-            .keys()
-            .filter(|p| p.starts_with(path))
-            .cloned()
-            .collect();
-        for p in to_remove {
-            modules.remove(&p);
-        }
+        self.db_state.handle.to_db().unload_path(path);
     }
 
     /// Updates the state of any services relevant to the given `path`.
@@ -3148,7 +3130,7 @@ impl Workspace for WorkspaceServer {
         &self,
         _params: GetModuleGraphParams,
     ) -> Result<GetModuleGraphResult, WorkspaceError> {
-        let db = self.lock_db()?;
+        let db = self.get_db();
         let mut data = FxHashMap::default();
         db.for_each_module(&mut |path, kind| {
             data.insert(path.as_str().to_string(), kind.dump());
@@ -3197,7 +3179,7 @@ impl WorkspaceScannerBridge for WorkspaceServer {
                     .into_iter()
                     .any(|package_path| package_path.starts_with(workspace_root))
             }),
-            _ => self.lock_db().is_ok_and(|db| db.contains(path)),
+            _ => self.module_db().contains(path),
         }
     }
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR addresses feedback from @MichaReiser and improves how the database is read from the threads. It creates a handler, so that we're able to bypass the `Sync` constraint without using a `Mutex`

It also changes some queries to return references instead of closed data. Also, the queries now take only two arguments, and `ModuleInfo` and `name` belong to a new interned type.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Tests updated

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
