### PR TITLE
docs: fix duplicate "being" in symlink test comments

### DIFF
--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -910,7 +910,7 @@ fn no_lint_if_files_are_listed_in_ignore_option() {
 /// Creating a symbolic link will fail on Windows if the current process is
 /// unprivileged. Since running tests as administrator is uncommon and
 /// constraining, this error gets silently ignored if we're not running on CI
-/// (the workflows are being being run with the correct permissions on CI)
+/// (the workflows are being run with the correct permissions on CI)
 #[cfg(target_os = "windows")]
 macro_rules! check_windows_symlink {
     ($result:expr) => {

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -750,7 +750,7 @@ fn no_lint_if_files_are_listed_in_ignore_option() {
 /// Creating a symbolic link will fail on Windows if the current process is
 /// unprivileged. Since running tests as administrator is uncommon and
 /// constraining, this error gets silently ignored if we're not running on CI
-/// (the workflows are being being run with the correct permissions on CI)
+/// (the workflows are being run with the correct permissions on CI)
 #[cfg(target_os = "windows")]
 macro_rules! check_windows_symlink {
     ($result:expr) => {


### PR DESCRIPTION
Duplicate word in the doc comment on the `check_windows_symlink` test macro: `are being being run` -> `are being run`. The same comment appears in `check.rs` and `lint.rs`.
