### PR TITLE
chore(biome_configuration): add allowTrailingCommas to json-schema to make VSCode happy

### DIFF
--- a/.changeset/shy-cougars-raise.md
+++ b/.changeset/shy-cougars-raise.md
@@ -1,5 +1,5 @@
 ---
-"@biomejs/biome": minor
+"@biomejs/biome": patch
 ---
 
 Add allowTrailingCommas to json-schema to make VSCode happy.

--- a/.changeset/shy-cougars-raise.md
+++ b/.changeset/shy-cougars-raise.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Add allowTrailingCommas to json-schema to make VSCode happy.
+Improved the DX the JSON schema when it's used by certain code editors like VSCode.

--- a/.changeset/shy-cougars-raise.md
+++ b/.changeset/shy-cougars-raise.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Add allowTrailingCommas to json-schema to make VSCode happy.

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -126,7 +126,7 @@ pub type RootEnabled = Bool<true>;
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Deserializable, Merge)]
 #[cfg_attr(feature = "cli", derive(Bpaf))]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "schema", schemars(extend("allowTrailingCommas" = true)))] // mute VSCode warns
+#[cfg_attr(feature = "schema", schemars(extend("allowTrailingCommas" = true)))] // mute VSCode warning
 #[serde(deny_unknown_fields, default, rename_all = "camelCase")]
 #[deserializable(with_validator)]
 pub struct Configuration {

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -126,6 +126,7 @@ pub type RootEnabled = Bool<true>;
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Deserializable, Merge)]
 #[cfg_attr(feature = "cli", derive(Bpaf))]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(extend("allowTrailingCommas" = true)))]
 #[serde(deny_unknown_fields, default, rename_all = "camelCase")]
 #[deserializable(with_validator)]
 pub struct Configuration {

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -126,7 +126,7 @@ pub type RootEnabled = Bool<true>;
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Deserializable, Merge)]
 #[cfg_attr(feature = "cli", derive(Bpaf))]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "schema", schemars(extend("allowTrailingCommas" = true)))]
+#[cfg_attr(feature = "schema", schemars(extend("allowTrailingCommas" = true)))] // mute VSCode warns
 #[serde(deny_unknown_fields, default, rename_all = "camelCase")]
 #[deserializable(with_validator)]
 pub struct Configuration {

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -73,6 +73,7 @@
 		}
 	},
 	"additionalProperties": false,
+	"allowTrailingCommas": true,
 	"$defs": {
 		"A11y": {
 			"description": "A list of rules that belong to this group",


### PR DESCRIPTION
## Summary

Resolve: <https://github.com/biomejs/biome/discussions/5755>

The `extend` API of schemars is now stable. It is time to comfort VSCode.

## Test Plan

Running `cargo codegen-schema`, the schema is generated correctly with `"allowTrailingCommas" = true`.

## Docs

No need.
