### PR TITLE
fix(migrate): avoid trailing comma when a renamed rule is last in its group

### DIFF
--- a/.changeset/fix-migrate-trailing-comma.md
+++ b/.changeset/fix-migrate-trailing-comma.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#ISSUE](https://github.com/biomejs/biome/issues/ISSUE): `biome migrate` no longer emits an invalid trailing comma when a renamed rule (such as `noConsoleLog` → `noConsole`) is the last member of its rule group. Previously this produced malformed output that aborted the migration of a strict-JSON `biome.json` with a parsing error.
+Fixed [#10625](https://github.com/biomejs/biome/issues/10625): `biome migrate` no longer emits an invalid trailing comma when a renamed rule (such as `noConsoleLog` → `noConsole`) is the last member of its rule group. Previously this produced malformed output that aborted the migration of a strict-JSON `biome.json` with a parsing error.

--- a/.changeset/fix-migrate-trailing-comma.md
+++ b/.changeset/fix-migrate-trailing-comma.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#ISSUE](https://github.com/biomejs/biome/issues/ISSUE): `biome migrate` no longer emits an invalid trailing comma when a renamed rule (such as `noConsoleLog` → `noConsole`) is the last member of its rule group. Previously this produced malformed output that aborted the migration of a strict-JSON `biome.json` with a parsing error.

--- a/crates/biome_migrate/src/analyzers/rule_mover.rs
+++ b/crates/biome_migrate/src/analyzers/rule_mover.rs
@@ -253,11 +253,6 @@ impl Rule for RuleMover {
             for elt in old_list.elements() {
                 let node = elt.node.ok()?;
                 let trailing_separator = elt.trailing_separator.ok()?;
-                // Record every original member's separator, including one we are about to
-                // remove below. Otherwise, removing the *last* member (which has no trailing
-                // separator) leaves `last_has_separator` reflecting its predecessor, and
-                // `fix_separators` then appends an illegal trailing comma after the new
-                // last member — which aborts migration of a strict JSON config.
                 last_has_separator = trailing_separator.is_some();
                 if let Some(name) = node.name().ok().and_then(|name| name.inner_string_text()) {
                     if name.text() == new_rule_name {

--- a/crates/biome_migrate/src/analyzers/rule_mover.rs
+++ b/crates/biome_migrate/src/analyzers/rule_mover.rs
@@ -252,6 +252,13 @@ impl Rule for RuleMover {
             let mut is_rule_migrated = false;
             for elt in old_list.elements() {
                 let node = elt.node.ok()?;
+                let trailing_separator = elt.trailing_separator.ok()?;
+                // Record every original member's separator, including one we are about to
+                // remove below. Otherwise, removing the *last* member (which has no trailing
+                // separator) leaves `last_has_separator` reflecting its predecessor, and
+                // `fix_separators` then appends an illegal trailing comma after the new
+                // last member — which aborts migration of a strict JSON config.
+                last_has_separator = trailing_separator.is_some();
                 if let Some(name) = node.name().ok().and_then(|name| name.inner_string_text()) {
                     if name.text() == new_rule_name {
                         // This happens when:
@@ -264,8 +271,6 @@ impl Rule for RuleMover {
                         continue;
                     }
                 }
-                let trailing_separator = elt.trailing_separator.ok()?;
-                last_has_separator = trailing_separator.is_some();
                 new_elements.push((node, trailing_separator));
             }
             if !is_rule_migrated {

--- a/crates/biome_migrate/tests/specs/migrations/ruleMover/renamedRuleLastInGroup.json
+++ b/crates/biome_migrate/tests/specs/migrations/ruleMover/renamedRuleLastInGroup.json
@@ -1,0 +1,10 @@
+{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noConsoleLog": "warn"
+      }
+    }
+  }
+}

--- a/crates/biome_migrate/tests/specs/migrations/ruleMover/renamedRuleLastInGroup.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/ruleMover/renamedRuleLastInGroup.json.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_migrate/tests/spec_tests.rs
+expression: renamedRuleLastInGroup.json
+---
+# Input
+```json
+{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noConsoleLog": "warn"
+      }
+    }
+  }
+}
+
+```
+
+# Diagnostics
+```
+renamedRuleLastInGroup.json:6:9 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This lint rule has been renamed to noConsole.
+  
+    4 │       "suspicious": {
+    5 │         "noExplicitAny": "error",
+  > 6 │         "noConsoleLog": "warn"
+      │         ^^^^^^^^^^^^^^
+    7 │       }
+    8 │     }
+  
+  i Safe fix: Rename the lint rule.
+  
+     4  4 │         "suspicious": {
+     5  5 │           "noExplicitAny": "error",
+     6    │ - ········"noConsoleLog":·"warn"
+        6 │ + ········"noConsole":·{·"level":·"warn",·"options":·{·"allow":·["log"]·}·}
+     7  7 │         }
+     8  8 │       }
+  
+
+```


### PR DESCRIPTION
## Summary

`biome migrate` could break a config file instead of upgrading it.

It happened when a renamed rule was the **last** rule in its group, and there was
another rule before it. Example:

```json
{
  "linter": {
    "rules": {
      "suspicious": {
        "noExplicitAny": "error",
        "noConsoleLog": "warn"
      }
    }
  }
}
```

Running biome migrate on this printed `Code formatting aborted due to parsing errors`
and left the file unchanged.

Why: while removing the old rule, the migration added a comma after the new last rule.
JSON doesn't allow trailing commas, so Biome could not parse its own output. (The same
file saved as .jsonc worked, because .jsonc allows trailing commas.)

The bug: the code set the "trailing comma" flag after skipping the removed rule. When
the removed rule was last, the flag still held the previous rule's state, so a comma was
added by mistake. The fix sets the flag before skipping the rule.

This bug was introduced in #5965 and shipped in 2.0.0 and every release since.

Fixes #10625.

## Test Plan

- Added a test renamedRuleLastInGroup.json for this case. It fails without the fix and
passes with it.
- All biome_migrate tests pass (33 passed, 0 failed).
- Built the CLI and ran biome migrate on the example above: it now upgrades the file
instead of stopping.

## Docs

Not needed. This is a bug fix, not a new rule or option.

## AI assistance

I used Claude Code to help investigate the bug, write the fix and the test, and verify it
locally. I reviewed and checked the change myself.