### PR TITLE
fix(html_analyze): ignore dynamic ARIA bindings in useValidAriaValues

### DIFF
--- a/.changeset/wet-buckets-poke.md
+++ b/.changeset/wet-buckets-poke.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10637](https://github.com/biomejs/biome/issues/10637): [`useValidAriaValues`](https://biomejs.dev/linter/rules/use-valid-aria-values/) no longer reports a false positive for dynamic ARIA bindings in Svelte and Astro, such as `aria-rowcount={count}`, `aria-rowcount="{count}"`, and `aria-rowcount="row-{count}"`.

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_values.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_values.rs
@@ -6,7 +6,7 @@ use biome_analyze::{
 use biome_aria_metadata::{AriaAttribute, AriaValueType};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlAttribute, HtmlAttribute};
+use biome_html_syntax::{AnyHtmlAttribute, AnyHtmlAttributeInitializer, HtmlAttribute};
 use biome_languages::HtmlFileSource;
 use biome_rowan::{AstNode, TokenText};
 use biome_rule_options::use_valid_aria_values::UseValidAriaValuesOptions;
@@ -77,6 +77,24 @@ impl Rule for UseValidAriaValues {
             AnyHtmlAttribute::AnyVueDirective(_) => return None,
             _ => return None,
         };
+
+        // Svelte/Astro dynamic bindings carry a runtime value, not a static one,
+        // so skip them. This covers both aria-x={expr} and interpolated values
+        // such as aria-x="row-{expr}".
+        let is_dynamic_binding = html_attr
+            .initializer()
+            .and_then(|init| init.value().ok())
+            .is_some_and(|value| match &value {
+                AnyHtmlAttributeInitializer::HtmlAttributeSingleTextExpression(_) => true,
+                // Interpolated values have no statically-known string.
+                AnyHtmlAttributeInitializer::SvelteTemplateAttributeValue(_) => {
+                    value.string_value().is_none()
+                }
+                _ => false,
+            });
+        if is_dynamic_binding {
+            return None;
+        }
 
         let name = extract_html_attribute_name(html_attr)?;
         let is_html_file = ctx.source_type::<HtmlFileSource>().is_html();

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAriaValues/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAriaValues/astro/valid.astro
@@ -7,3 +7,6 @@
 
 <!-- valid tristate -->
 <span aria-checked="mixed">some text</span>
+
+<!-- dynamic binding should be ignored -->
+<div role="grid" aria-rowcount={count}></div>

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAriaValues/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAriaValues/astro/valid.astro.snap
@@ -14,4 +14,7 @@ expression: valid.astro
 <!-- valid tristate -->
 <span aria-checked="mixed">some text</span>
 
+<!-- dynamic binding should be ignored -->
+<div role="grid" aria-rowcount={count}></div>
+
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAriaValues/svelte/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAriaValues/svelte/valid.svelte
@@ -5,3 +5,15 @@
 
 <!-- valid tristate -->
 <span aria-checked="mixed">some text</span>
+
+<!-- dynamic binding should be ignored -->
+<div role="grid" aria-rowcount={count}></div>
+
+<!-- dynamic binding on a non-integer attribute should be ignored -->
+<span aria-checked={isChecked}>some text</span>
+
+<!-- quoted dynamic binding should be ignored -->
+<div role="grid" aria-rowcount="{count}"></div>
+
+<!-- interpolated value should be ignored -->
+<div role="grid" aria-rowcount="row-{count}"></div>

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAriaValues/svelte/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAriaValues/svelte/valid.svelte.snap
@@ -12,4 +12,16 @@ expression: valid.svelte
 <!-- valid tristate -->
 <span aria-checked="mixed">some text</span>
 
+<!-- dynamic binding should be ignored -->
+<div role="grid" aria-rowcount={count}></div>
+
+<!-- dynamic binding on a non-integer attribute should be ignored -->
+<span aria-checked={isChecked}>some text</span>
+
+<!-- quoted dynamic binding should be ignored -->
+<div role="grid" aria-rowcount="{count}"></div>
+
+<!-- interpolated value should be ignored -->
+<div role="grid" aria-rowcount="row-{count}"></div>
+
 ```


### PR DESCRIPTION
## Summary
Fixes #10637. `useValidAriaValues` flagged dynamic ARIA bindings in Svelte/Astro as invalid because their runtime value isn't a valid static value. They're now skipped, like Vue `:aria-*` directives.

## Test Plan
`cargo test -p biome_html_analyze`. Added valid Svelte/Astro cases; invalid static values still report.

## Docs
No documentation changes needed, bug fix.