### PR TITLE
fix(css/parser): allow & as a trailing sub-selector in compound selectors

### DIFF
--- a/.changeset/fix-css-nesting-trailing-amp.md
+++ b/.changeset/fix-css-nesting-trailing-amp.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7718](https://github.com/biomejs/biome/issues/7718): Biome now correctly parses CSS nesting selectors when `&` appears as a trailing sub-selector after a type selector, e.g. `h1& { color: red; }`.

--- a/crates/biome_css_formatter/src/css/any/sub_selector.rs
+++ b/crates/biome_css_formatter/src/css/any/sub_selector.rs
@@ -12,6 +12,7 @@ impl FormatRule<AnyCssSubSelector> for FormatAnyCssSubSelector {
             AnyCssSubSelector::CssBogusSubSelector(node) => node.format().fmt(f),
             AnyCssSubSelector::CssClassSelector(node) => node.format().fmt(f),
             AnyCssSubSelector::CssIdSelector(node) => node.format().fmt(f),
+            AnyCssSubSelector::CssNestedSelector(node) => node.format().fmt(f),
             AnyCssSubSelector::CssPseudoClassSelector(node) => node.format().fmt(f),
             AnyCssSubSelector::CssPseudoElementSelector(node) => node.format().fmt(f),
         }

--- a/crates/biome_css_parser/src/syntax/selector/mod.rs
+++ b/crates/biome_css_parser/src/syntax/selector/mod.rs
@@ -16,7 +16,9 @@ use crate::syntax::scss::{
     parse_scss_selector_custom_identifier, parse_scss_selector_identifier,
 };
 use crate::syntax::selector::attribute::parse_attribute_selector;
-use crate::syntax::selector::nested_selector::NestedSelectorList;
+use crate::syntax::selector::nested_selector::{
+    NestedSelectorList, parse_nested_selector_as_sub_selector,
+};
 use crate::syntax::selector::pseudo_class::parse_pseudo_class_selector;
 pub(crate) use crate::syntax::selector::pseudo_class::{
     PSEUDO_CLASS_NTH_SIGN_SET, PseudoValueList, is_at_pseudo_class_nth_argument,
@@ -413,7 +415,7 @@ fn parse_namespace_prefix(p: &mut CssParser) -> ParsedSyntax {
 pub(crate) struct SubSelectorList;
 impl SubSelectorList {
     pub(crate) const START_SET: TokenSet<CssSyntaxKind> =
-        token_set![T![#], T![.], T![:], T![::], T!['[']];
+        token_set![T![#], T![.], T![:], T![::], T!['['], T![&]];
 }
 impl ParseNodeList for SubSelectorList {
     type Kind = CssSyntaxKind;
@@ -442,7 +444,8 @@ impl ParseNodeList for SubSelectorList {
 ///
 /// This function is responsible for identifying and parsing different types of sub-selectors
 /// based on the current token in the CSS parser. It dispatches to specific parsing functions
-/// for class selectors, ID selectors, attribute selectors, pseudo-classes, and pseudo-elements.
+/// for class selectors, ID selectors, attribute selectors, pseudo-classes, pseudo-elements,
+/// and the nesting selector (`&`), e.g. the trailing `&` in `h1&`.
 #[inline]
 fn parse_sub_selector(p: &mut CssParser) -> ParsedSyntax {
     match p.cur() {
@@ -451,6 +454,7 @@ fn parse_sub_selector(p: &mut CssParser) -> ParsedSyntax {
         T!['['] => parse_attribute_selector(p),
         T![:] => parse_pseudo_class_selector(p),
         T![::] => parse_pseudo_element_selector(p),
+        T![&] => parse_nested_selector_as_sub_selector(p),
         _ => Absent,
     }
 }

--- a/crates/biome_css_parser/src/syntax/selector/nested_selector.rs
+++ b/crates/biome_css_parser/src/syntax/selector/nested_selector.rs
@@ -64,3 +64,21 @@ fn parse_nested_selector(p: &mut CssParser) -> ParsedSyntax {
 
     Present(m.complete(p, CSS_NESTED_SELECTOR))
 }
+
+/// Parses a `&` (nesting selector) appearing as a sub-selector, e.g. the
+/// trailing `&` in `h1&`. Unlike [parse_nested_selector], this never produces
+/// a `ScssParentSelector`, since `AnyCssSubSelector` only allows
+/// `CssNestedSelector`; the SCSS parent-selector suffix syntax (`&-100`,
+/// `&#{$state}`) is only meaningful when `&` opens a compound selector.
+#[inline]
+pub(crate) fn parse_nested_selector_as_sub_selector(p: &mut CssParser) -> ParsedSyntax {
+    if !is_at_nested_selector(p) {
+        return Absent;
+    }
+
+    let m = p.start();
+    let context = selector_lex_context(p);
+    p.bump_with_context(T![&], context);
+
+    Present(m.complete(p, CSS_NESTED_SELECTOR))
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/nesting/trailing_amp.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/nesting/trailing_amp.css
@@ -1,0 +1,5 @@
+[data-smth="true"] {
+	h1& {
+		color: red;
+	}
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/nesting/trailing_amp.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/nesting/trailing_amp.css.snap
@@ -1,0 +1,167 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+[data-smth="true"] {
+	h1& {
+		color: red;
+	}
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssAttributeSelector {
+                            l_brack_token: L_BRACK@0..1 "[" [] [],
+                            name: CssAttributeName {
+                                namespace: missing (optional),
+                                name: CssIdentifier {
+                                    value_token: IDENT@1..10 "data-smth" [] [],
+                                },
+                            },
+                            matcher: CssAttributeMatcher {
+                                operator: EQ@10..11 "=" [] [],
+                                value: CssAttributeMatcherValue {
+                                    name: CssString {
+                                        value_token: CSS_STRING_LITERAL@11..17 "\"true\"" [] [],
+                                    },
+                                },
+                                modifier: missing (optional),
+                            },
+                            r_brack_token: R_BRACK@17..19 "]" [] [Whitespace(" ")],
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@19..20 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssNestedQualifiedRule {
+                        prelude: CssRelativeSelectorList [
+                            CssRelativeSelector {
+                                combinator: missing (optional),
+                                selector: CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@20..24 "h1" [Newline("\n"), Whitespace("\t")] [],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [
+                                        CssNestedSelector {
+                                            amp_token: AMP@24..26 "&" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                        block: CssDeclarationOrRuleBlock {
+                            l_curly_token: L_CURLY@26..27 "{" [] [],
+                            items: CssDeclarationOrRuleList [
+                                CssDeclarationWithSemicolon {
+                                    declaration: CssDeclaration {
+                                        property: CssGenericProperty {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@27..35 "color" [Newline("\n"), Whitespace("\t\t")] [],
+                                            },
+                                            colon_token: COLON@35..37 ":" [] [Whitespace(" ")],
+                                            value: CssGenericComponentValueList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@37..40 "red" [] [],
+                                                },
+                                            ],
+                                        },
+                                        important: missing (optional),
+                                    },
+                                    semicolon_token: SEMICOLON@40..41 ";" [] [],
+                                },
+                            ],
+                            r_curly_token: R_CURLY@41..44 "}" [Newline("\n"), Whitespace("\t")] [],
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@44..46 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..47
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..46
+    0: CSS_QUALIFIED_RULE@0..46
+      0: CSS_SELECTOR_LIST@0..19
+        0: CSS_COMPOUND_SELECTOR@0..19
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@0..19
+            0: CSS_ATTRIBUTE_SELECTOR@0..19
+              0: L_BRACK@0..1 "[" [] []
+              1: CSS_ATTRIBUTE_NAME@1..10
+                0: (empty)
+                1: CSS_IDENTIFIER@1..10
+                  0: IDENT@1..10 "data-smth" [] []
+              2: CSS_ATTRIBUTE_MATCHER@10..17
+                0: EQ@10..11 "=" [] []
+                1: CSS_ATTRIBUTE_MATCHER_VALUE@11..17
+                  0: CSS_STRING@11..17
+                    0: CSS_STRING_LITERAL@11..17 "\"true\"" [] []
+                2: (empty)
+              3: R_BRACK@17..19 "]" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@19..46
+        0: L_CURLY@19..20 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@20..44
+          0: CSS_NESTED_QUALIFIED_RULE@20..44
+            0: CSS_RELATIVE_SELECTOR_LIST@20..26
+              0: CSS_RELATIVE_SELECTOR@20..26
+                0: (empty)
+                1: CSS_COMPOUND_SELECTOR@20..26
+                  0: CSS_NESTED_SELECTOR_LIST@20..20
+                  1: CSS_TYPE_SELECTOR@20..24
+                    0: (empty)
+                    1: CSS_IDENTIFIER@20..24
+                      0: IDENT@20..24 "h1" [Newline("\n"), Whitespace("\t")] []
+                  2: CSS_SUB_SELECTOR_LIST@24..26
+                    0: CSS_NESTED_SELECTOR@24..26
+                      0: AMP@24..26 "&" [] [Whitespace(" ")]
+            1: CSS_DECLARATION_OR_RULE_BLOCK@26..44
+              0: L_CURLY@26..27 "{" [] []
+              1: CSS_DECLARATION_OR_RULE_LIST@27..41
+                0: CSS_DECLARATION_WITH_SEMICOLON@27..41
+                  0: CSS_DECLARATION@27..40
+                    0: CSS_GENERIC_PROPERTY@27..40
+                      0: CSS_IDENTIFIER@27..35
+                        0: IDENT@27..35 "color" [Newline("\n"), Whitespace("\t\t")] []
+                      1: COLON@35..37 ":" [] [Whitespace(" ")]
+                      2: CSS_GENERIC_COMPONENT_VALUE_LIST@37..40
+                        0: CSS_IDENTIFIER@37..40
+                          0: IDENT@37..40 "red" [] []
+                    1: (empty)
+                  1: SEMICOLON@40..41 ";" [] []
+              2: R_CURLY@41..44 "}" [Newline("\n"), Whitespace("\t")] []
+        2: R_CURLY@44..46 "}" [Newline("\n")] []
+  2: EOF@46..47 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_semantic/src/semantic_model/specificity.rs
+++ b/crates/biome_css_semantic/src/semantic_model/specificity.rs
@@ -130,6 +130,10 @@ fn evaluate_any_subselector(selector: &AnyCssSubSelector) -> Specificity {
         AnyCssSubSelector::CssAttributeSelector(_) => CLASS_SPECIFICITY,
         AnyCssSubSelector::CssPseudoClassSelector(s) => evaluate_pseudo_selector(s),
         AnyCssSubSelector::CssPseudoElementSelector(_) => TYPE_SPECIFICITY,
+        // The nesting selector's specificity is the specificity of the parent
+        // selector it's substituted with, which isn't known here. As with the
+        // leading `&` in `nesting_selectors`, treat it as contributing nothing.
+        AnyCssSubSelector::CssNestedSelector(_) => ZERO_SPECIFICITY,
         AnyCssSubSelector::CssBogusSubSelector(_) => ZERO_SPECIFICITY,
     }
 }

--- a/crates/biome_css_semantic/src/semantic_model/specificity.rs
+++ b/crates/biome_css_semantic/src/semantic_model/specificity.rs
@@ -130,9 +130,6 @@ fn evaluate_any_subselector(selector: &AnyCssSubSelector) -> Specificity {
         AnyCssSubSelector::CssAttributeSelector(_) => CLASS_SPECIFICITY,
         AnyCssSubSelector::CssPseudoClassSelector(s) => evaluate_pseudo_selector(s),
         AnyCssSubSelector::CssPseudoElementSelector(_) => TYPE_SPECIFICITY,
-        // The nesting selector's specificity is the specificity of the parent
-        // selector it's substituted with, which isn't known here. As with the
-        // leading `&` in `nesting_selectors`, treat it as contributing nothing.
         AnyCssSubSelector::CssNestedSelector(_) => ZERO_SPECIFICITY,
         AnyCssSubSelector::CssBogusSubSelector(_) => ZERO_SPECIFICITY,
     }

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -16117,6 +16117,7 @@ pub enum AnyCssSubSelector {
     CssBogusSubSelector(CssBogusSubSelector),
     CssClassSelector(CssClassSelector),
     CssIdSelector(CssIdSelector),
+    CssNestedSelector(CssNestedSelector),
     CssPseudoClassSelector(CssPseudoClassSelector),
     CssPseudoElementSelector(CssPseudoElementSelector),
 }
@@ -16142,6 +16143,12 @@ impl AnyCssSubSelector {
     pub fn as_css_id_selector(&self) -> Option<&CssIdSelector> {
         match &self {
             Self::CssIdSelector(item) => Some(item),
+            _ => None,
+        }
+    }
+    pub fn as_css_nested_selector(&self) -> Option<&CssNestedSelector> {
+        match &self {
+            Self::CssNestedSelector(item) => Some(item),
             _ => None,
         }
     }
@@ -41570,6 +41577,11 @@ impl From<CssIdSelector> for AnyCssSubSelector {
         Self::CssIdSelector(node)
     }
 }
+impl From<CssNestedSelector> for AnyCssSubSelector {
+    fn from(node: CssNestedSelector) -> Self {
+        Self::CssNestedSelector(node)
+    }
+}
 impl From<CssPseudoClassSelector> for AnyCssSubSelector {
     fn from(node: CssPseudoClassSelector) -> Self {
         Self::CssPseudoClassSelector(node)
@@ -41586,6 +41598,7 @@ impl AstNode for AnyCssSubSelector {
         .union(CssBogusSubSelector::KIND_SET)
         .union(CssClassSelector::KIND_SET)
         .union(CssIdSelector::KIND_SET)
+        .union(CssNestedSelector::KIND_SET)
         .union(CssPseudoClassSelector::KIND_SET)
         .union(CssPseudoElementSelector::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
@@ -41595,6 +41608,7 @@ impl AstNode for AnyCssSubSelector {
                 | CSS_BOGUS_SUB_SELECTOR
                 | CSS_CLASS_SELECTOR
                 | CSS_ID_SELECTOR
+                | CSS_NESTED_SELECTOR
                 | CSS_PSEUDO_CLASS_SELECTOR
                 | CSS_PSEUDO_ELEMENT_SELECTOR
         )
@@ -41605,6 +41619,7 @@ impl AstNode for AnyCssSubSelector {
             CSS_BOGUS_SUB_SELECTOR => Self::CssBogusSubSelector(CssBogusSubSelector { syntax }),
             CSS_CLASS_SELECTOR => Self::CssClassSelector(CssClassSelector { syntax }),
             CSS_ID_SELECTOR => Self::CssIdSelector(CssIdSelector { syntax }),
+            CSS_NESTED_SELECTOR => Self::CssNestedSelector(CssNestedSelector { syntax }),
             CSS_PSEUDO_CLASS_SELECTOR => {
                 Self::CssPseudoClassSelector(CssPseudoClassSelector { syntax })
             }
@@ -41621,6 +41636,7 @@ impl AstNode for AnyCssSubSelector {
             Self::CssBogusSubSelector(it) => it.syntax(),
             Self::CssClassSelector(it) => it.syntax(),
             Self::CssIdSelector(it) => it.syntax(),
+            Self::CssNestedSelector(it) => it.syntax(),
             Self::CssPseudoClassSelector(it) => it.syntax(),
             Self::CssPseudoElementSelector(it) => it.syntax(),
         }
@@ -41631,6 +41647,7 @@ impl AstNode for AnyCssSubSelector {
             Self::CssBogusSubSelector(it) => it.into_syntax(),
             Self::CssClassSelector(it) => it.into_syntax(),
             Self::CssIdSelector(it) => it.into_syntax(),
+            Self::CssNestedSelector(it) => it.into_syntax(),
             Self::CssPseudoClassSelector(it) => it.into_syntax(),
             Self::CssPseudoElementSelector(it) => it.into_syntax(),
         }
@@ -41643,6 +41660,7 @@ impl std::fmt::Debug for AnyCssSubSelector {
             Self::CssBogusSubSelector(it) => std::fmt::Debug::fmt(it, f),
             Self::CssClassSelector(it) => std::fmt::Debug::fmt(it, f),
             Self::CssIdSelector(it) => std::fmt::Debug::fmt(it, f),
+            Self::CssNestedSelector(it) => std::fmt::Debug::fmt(it, f),
             Self::CssPseudoClassSelector(it) => std::fmt::Debug::fmt(it, f),
             Self::CssPseudoElementSelector(it) => std::fmt::Debug::fmt(it, f),
         }
@@ -41655,6 +41673,7 @@ impl From<AnyCssSubSelector> for SyntaxNode {
             AnyCssSubSelector::CssBogusSubSelector(it) => it.into_syntax(),
             AnyCssSubSelector::CssClassSelector(it) => it.into_syntax(),
             AnyCssSubSelector::CssIdSelector(it) => it.into_syntax(),
+            AnyCssSubSelector::CssNestedSelector(it) => it.into_syntax(),
             AnyCssSubSelector::CssPseudoClassSelector(it) => it.into_syntax(),
             AnyCssSubSelector::CssPseudoElementSelector(it) => it.into_syntax(),
         }

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -190,6 +190,7 @@ AnyCssSubSelector =
 	| CssAttributeSelector
 	| CssPseudoClassSelector
 	| CssPseudoElementSelector
+	| CssNestedSelector
 	| CssBogusSubSelector
 
 // * {}


### PR DESCRIPTION
Fixes #7718.

## AI assistance disclosure

This PR was written primarily by Claude Code.

## Summary

CSS Nesting Module Level 1 permits `&` as a `<subclass-selector>`, meaning it can appear after a type selector (e.g. `h1& { color: red; }`). Previously `SubSelectorList::START_SET` did not include `T![&]`, causing a parse error.

## Changes

- `css.ungram`: added `CssNestedSelector` to `AnyCssSubSelector`
- `nodes.rs`: regenerated via `cargo run -p xtask_codegen -- grammar css`
- `nested_selector.rs`: added `parse_nested_selector_as_sub_selector` (bare `&` only, no SCSS suffix)
- `mod.rs`: added `T![&]` to `SubSelectorList::START_SET`; dispatch in `parse_sub_selector`
- `specificity.rs`: `CssNestedSelector` → `ZERO_SPECIFICITY` (consistent with leading `&`)
- `sub_selector.rs`: new match arm (regenerated via `cargo run -p xtask_codegen -- formatter`)
- Test: `ok/nesting/trailing_amp.css` + accepted snapshot