### PR TITLE
docs(useValidAnchor): enhance lint rule explainer

### DIFF
--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -21,7 +21,7 @@ declare_lint_rule! {
     /// This rule is designed to prevent invalid anchor usage when the `href` is missing or not navigable,
     /// including the empty fragment `#` both with and without attached logic. With logic attached, an anchor
     /// with an invalid `href` usually behaves like an action and should be a `button`, because that's likely
-    /// what the user wants. Without logic, `href="#"`still points to no real target and can cause scroll
+    /// what the user wants. Without logic, `href="#"` still points to no real target and can cause scroll
     /// position and keyboard focus to fall out of sync. Prefer linking to an actual destination, such as 
     /// `href="#top"`.
     ///

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -18,10 +18,12 @@ declare_lint_rule! {
     /// While before it was possible to attach logic to an anchor element, with the advent of JSX libraries,
     /// it's now easier to attach logic to any HTML element, anchors included.
     ///
-    /// This rule is designed to prevent users from attaching logic at the click of anchors when the `href`
-    /// provided to the anchor element is not valid. Avoid using `#` symbol inside the `href` when you are
-    /// attaching the logic to the anchor element. If the anchor has logic attached to it with an incorrect `href`
-    /// the rules suggests to turn it to a `button`, because that's likely what the user wants.
+    /// This rule is designed to prevent invalid anchor usage when the `href` is missing or not navigable,
+    /// including the empty fragment `#` both with and without attached logic. With logic attached, an anchor
+    /// with an invalid `href` usually behaves like an action and should be a `button`, because that's likely
+    /// what the user wants. Without logic, `href="#"`still points to no real target and can cause scroll
+    /// position and keyboard focus to fall out of sync. Prefer linking to an actual destination, such as 
+    /// `href="#top"`.
     ///
     /// Anchor `<a></a>` elements should be used for navigation, while `<button></button>` should be
     /// used for user interaction.
@@ -35,11 +37,6 @@ declare_lint_rule! {
     ///
     /// For a detailed explanation, check out [this article by Marcy Sutton](https://marcysutton.com/links-vs-buttons-in-modern-web-applications)
     ///
-    /// Even without attached logic, a link that uses the empty fragment `#` for in-page navigation does not
-    /// point to a real target, so some browsers may scroll the page while leaving keyboard focus on the link.
-    /// This can make visual position and focus order fall out of sync; prefer linking to a real element such
-    /// as `href="#top"`.
-    /// 
     /// ## Examples
     ///
     /// ### Invalid

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -35,6 +35,11 @@ declare_lint_rule! {
     ///
     /// For a detailed explanation, check out [this article by Marcy Sutton](https://marcysutton.com/links-vs-buttons-in-modern-web-applications)
     ///
+    /// Even without attached logic, a link that uses the empty fragment `#` for in-page navigation does not
+    /// point to a real target, so some browsers may scroll the page while leaving keyboard focus on the link.
+    /// This can make visual position and focus order fall out of sync; prefer linking to a real element such
+    /// as `href="#top"`.
+    /// 
     /// ## Examples
     ///
     /// ### Invalid

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -29,9 +29,14 @@ declare_lint_rule! {
     /// - it can source of invalid links, and crawlers can't navigate the website, risking to penalize
     /// SEO ranking
     ///
-    ///
+    /// 
     /// For a detailed explanation, check out https://marcysutton.com/links-vs-buttons-in-modern-web-applications
     ///
+    /// Even without attached logic, a link that uses the empty fragment `#` for in-page navigation does not
+    /// point to a real target, so some browsers may scroll the page while leaving keyboard focus on the link.
+    /// This can make visual position and focus order fall out of sync; prefer linking to a real element such
+    /// as `href="#top"`.
+    /// 
     /// ## Examples
     ///
     /// ### Invalid

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -18,7 +18,7 @@ declare_lint_rule! {
     /// This rule is designed to prevent invalid anchor usage when the `href` is missing or not navigable,
     /// including the empty fragment `#` both with and without attached logic. With logic attached, an anchor
     /// with an invalid `href` usually behaves like an action and should be a `button`, because that's likely
-    /// what the user wants. Without logic, `href="#"`still points to no real target and can cause scroll
+    /// what the user wants. Without logic, `href="#"` still points to no real target and can cause scroll
     /// position and keyboard focus to fall out of sync. Prefer linking to an actual destination, such as 
     /// `href="#top"`.
     ///

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -15,10 +15,12 @@ declare_lint_rule! {
     /// While before it was possible to attach logic to an anchor element, with the advent of JSX libraries,
     /// it's now  easier to attach logic to any HTML element, anchors included.
     ///
-    /// This rule is designed to prevent users from attaching logic at the click of anchors when the `href`
-    /// provided to the anchor element is not valid. Avoid using `#` symbol inside the `href` when you are
-    /// attaching the logic to the anchor element. If the anchor has logic attached to it with an incorrect `href`
-    /// the rules suggests to turn it to a `button`, because that's likely what the user wants.
+    /// This rule is designed to prevent invalid anchor usage when the `href` is missing or not navigable,
+    /// including the empty fragment `#` both with and without attached logic. With logic attached, an anchor
+    /// with an invalid `href` usually behaves like an action and should be a `button`, because that's likely
+    /// what the user wants. Without logic, `href="#"`still points to no real target and can cause scroll
+    /// position and keyboard focus to fall out of sync. Prefer linking to an actual destination, such as 
+    /// `href="#top"`.
     ///
     /// Anchor `<a></a>` elements should be used for navigation, while `<button></button>` should be
     /// used for user interaction.
@@ -31,11 +33,6 @@ declare_lint_rule! {
     ///
     /// 
     /// For a detailed explanation, check out https://marcysutton.com/links-vs-buttons-in-modern-web-applications
-    ///
-    /// Even without attached logic, a link that uses the empty fragment `#` for in-page navigation does not
-    /// point to a real target, so some browsers may scroll the page while leaving keyboard focus on the link.
-    /// This can make visual position and focus order fall out of sync; prefer linking to a real element such
-    /// as `href="#top"`.
     /// 
     /// ## Examples
     ///


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

`useValidAnchor` is throwing an error for anchor links with `href="#"`.

The docs currently explain, why this should not be used when attaching logic, e.g. though the `click` event, but entirely leaves out why it should not be used without JavaScript either.

This PR adds an explainer on why it shouldn't be used at all and the accessibility/usability issue that using it without JavaScript creates as discussed in https://github.com/biomejs/biome/issues/10656

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

I've also written a post about it that can be referenced for more details if you'd like: [href=”#” and the Focus Trap](https://th3s4mur41.me/blog/href-hash-focus-desync-accessibility/)


<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

