### PR TITLE
feat(assist): add groups, ignoreCase, sortScope, and multiline options to useSortedAttributes

### DIFF
--- a/.changeset/add-use-sorted-attributes-groups-options.md
+++ b/.changeset/add-use-sorted-attributes-groups-options.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": minor
+---
+
+Added `groups`, `ignoreCase`, `sortScope`, and `multiline` options to [`useSortedAttributes`](https://biomejs.dev/assist/actions/use-sorted-attributes/).
+
+- `groups` accepts an ordered list of predefined group tokens (`:CALLBACK:`, `:IMPLICIT:`, `:RESERVED:`, `:DOM_RESERVED:`, `:REST:`) that control where special prop categories appear relative to each other. `:REST:` is a catch-all for props matching no other group and, unlike the implicit fallback used when it's omitted, is sorted like a regular group.
+- `ignoreCase` makes prop name comparisons case-insensitive.
+- `sortScope: "group"` enables group-aware sorting: props are partitioned into groups, sorted within each group, then concatenated in group order. Props not matching any named group (and not covered by a `:REST:` group) preserve their original relative order.
+- `multiline` controls how props with multiline values are ordered relative to single-line props. Accepted values are `"group"` (default, no special treatment), `"groupFirst"` and `"groupLast"` (multiline props first or last within each group), and `"first"` and `"last"` (all multiline props before or after all single-line props across groups).
+
+When `sortScope` is `"global"` (the default), all existing behavior is preserved.

--- a/crates/biome_js_analyze/src/assist/source/use_sorted_attributes.rs
+++ b/crates/biome_js_analyze/src/assist/source/use_sorted_attributes.rs
@@ -12,8 +12,12 @@ use biome_js_syntax::{
     AnyJsxAttribute, JsLanguage, JsxAttribute, JsxAttributeList, JsxOpeningElement,
     JsxSelfClosingElement,
 };
-use biome_rowan::{AstNode, AstNodeExt, BatchMutationExt, SyntaxToken};
-use biome_rule_options::use_sorted_attributes::{SortOrder, UseSortedAttributesOptions};
+use biome_rowan::{AstNode, AstNodeExt, BatchMutationExt, SyntaxToken, TriviaPieceKind};
+use biome_rule_options::use_sorted_attributes::{
+    AttributeGroups, MultilineOrder, SortOrder, SortScope, UseSortedAttributesOptions,
+    default_attribute_groups, is_multiline_prop,
+};
+use biome_string_case::StrLikeExtension;
 
 use crate::JsRuleAction;
 
@@ -71,6 +75,65 @@ declare_source_rule! {
     /// <Hello tel={5555555} {...this.props} opt1="John" opt2="" opt12="" opt11="" />;
     /// ```
     ///
+    /// ### `groups`
+    ///
+    /// Controls the ordering of special prop categories. Only active when
+    /// `sortScope` is `"group"`. Accepts an ordered array of predefined group
+    /// tokens. Props not matching any group are placed after all named groups.
+    ///
+    /// Available group tokens:
+    /// - `":CALLBACK:"` — Callback props: names starting with `on` + uppercase (e.g. `onClick`).
+    /// - `":IMPLICIT:"` — Implicit (boolean shorthand) props: no value (e.g. `<Foo disabled />`).
+    /// - `":RESERVED:"` — React reserved props: `key` and `ref`.
+    /// - `":DOM_RESERVED:"` — DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.
+    /// - `":REST:"` — Catch-all for props that don't match any other configured group.
+    ///   Sorted like a regular group, using `sortOrder` and `ignoreCase`. If omitted from
+    ///   `groups`, unmatched props are instead placed after all named groups, in their
+    ///   original relative order (unsorted).
+    ///
+    /// When not configured, the default ordering is:
+    /// `[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]`.
+    ///
+    /// ### `multiline`
+    ///
+    /// Controls where multiline props land relative to single-line props.
+    /// Only meaningful when `sortScope` is `"group"`. Defaults to `"group"`.
+    ///
+    /// - `"group"` (default): multiline props are sorted together with single-line props in their group.
+    /// - `"groupFirst"`: within each group, multiline props are placed before single-line props.
+    /// - `"groupLast"`: within each group, multiline props are placed after single-line props.
+    /// - `"first"`: all multiline props are collected, sorted by group order, and placed before all non-multiline groups.
+    /// - `"last"`: all multiline props are collected, sorted by group order, and placed after all non-multiline groups.
+    ///
+    /// ### `ignoreCase`
+    ///
+    /// When `true`, prop names are compared case-insensitively. Defaults to `false`.
+    ///
+    /// When `sortScope` is `"global"`, applies to the flat sort.
+    /// When `sortScope` is `"group"`, applies within each group independently.
+    ///
+    /// ### `sortScope`
+    ///
+    /// Controls how `sortOrder` and `ignoreCase` interact with `groups`.
+    ///
+    /// - `"global"` (default): flat sort across all props, groups are ignored.
+    ///   Preserves existing behavior.
+    /// - `"group"`: props are first partitioned into groups (defined by `groups`),
+    ///   sorted within each group using `sortOrder` and `ignoreCase`, then
+    ///   concatenated in group order.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "sortScope": "group",
+    ///         "groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"]
+    ///     }
+    /// }
+    /// ```
+    /// ```jsx,use_options,expect_diagnostic
+    /// <Hello onClick={fn} disabled key="1" name="John" />;
+    /// ```
+    ///
     pub UseSortedAttributes {
         version: "2.0.0",
         name: "useSortedAttributes",
@@ -89,48 +152,47 @@ impl Rule for UseSortedAttributes {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let props = ctx.query();
-        let mut current_prop_group = AttributeGroup::default();
-        let mut prop_groups = Vec::new();
         let options = ctx.options();
-        let sort_by = options.sort_order.unwrap_or_default();
+        let comparator = select_comparator(options);
+        let sort_scope = options.sort_scope.unwrap_or_default();
+        let multiline = options.multiline.unwrap_or_default();
+        let groups = resolve_groups(options, sort_scope);
 
-        let comparator = match sort_by {
-            SortOrder::Natural => SortableJsxAttribute::ascii_nat_cmp,
-            SortOrder::Lexicographic => SortableJsxAttribute::lexicographic_cmp,
-        };
-
-        // Convert to boolean-based comparator for is_sorted_by
-        let boolean_comparator = |a: &SortableJsxAttribute, b: &SortableJsxAttribute| {
-            comparator(a, b) != Ordering::Greater
-        };
+        let mut current_bucket: Vec<SortableJsxAttribute> = Vec::new();
+        let mut prop_groups: Vec<AttributeGroup<SortableJsxAttribute>> = Vec::new();
 
         for prop in props {
             match prop {
                 AnyJsxAttribute::JsxAttribute(attr) => {
-                    current_prop_group.attrs.push(SortableJsxAttribute(attr));
+                    current_bucket.push(SortableJsxAttribute(attr));
                 }
-                // spread or shorthand attribute resets sort order: it carries
+                // Spread or shorthand attribute resets sort order: it carries
                 // an opaque expression that may have side effects on the
                 // resulting prop set, so attributes on either side cannot be
                 // freely reordered across it.
                 AnyJsxAttribute::JsxSpreadAttribute(_)
                 | AnyJsxAttribute::JsxShorthandAttribute(_) => {
-                    if !current_prop_group.is_empty()
-                        && !current_prop_group.is_sorted(boolean_comparator)
-                    {
-                        prop_groups.push(current_prop_group);
-                        current_prop_group = AttributeGroup::default();
-                    } else {
-                        // Reuse the same buffer
-                        current_prop_group.clear();
-                    }
+                    flush_bucket(
+                        &mut current_bucket,
+                        &mut prop_groups,
+                        groups.as_ref(),
+                        sort_scope,
+                        multiline,
+                        comparator,
+                    );
                 }
                 AnyJsxAttribute::JsMetavariable(_) => {}
             }
         }
-        if !current_prop_group.is_empty() && !current_prop_group.is_sorted(boolean_comparator) {
-            prop_groups.push(current_prop_group);
-        }
+        flush_bucket(
+            &mut current_bucket,
+            &mut prop_groups,
+            groups.as_ref(),
+            sort_scope,
+            multiline,
+            comparator,
+        );
+
         prop_groups.into_boxed_slice()
     }
 
@@ -155,15 +217,20 @@ impl Rule for UseSortedAttributes {
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
         let mut mutation = ctx.root().begin();
         let options = ctx.options();
-        let sort_by = options.sort_order.unwrap_or_default();
+        let comparator = select_comparator(options);
+        let sort_scope = options.sort_scope.unwrap_or_default();
+        let multiline = options.multiline.unwrap_or_default();
+        let groups = resolve_groups(options, sort_scope);
 
-        let comparator = match sort_by {
-            SortOrder::Natural => SortableJsxAttribute::ascii_nat_cmp,
-            SortOrder::Lexicographic => SortableJsxAttribute::lexicographic_cmp,
+        let sorted = match sort_scope {
+            SortScope::Global => state.get_sorted_attributes(comparator)?,
+            SortScope::Group => {
+                get_sorted_by_groups(&state.attrs, groups.as_ref(), multiline, comparator)?
+            }
         };
 
         for (SortableJsxAttribute(attr), SortableJsxAttribute(sorted_attr)) in
-            zip(state.attrs.iter(), state.get_sorted_attributes(comparator)?)
+            zip(state.attrs.iter(), sorted)
         {
             mutation.replace_node_discard_trivia(attr.clone(), sorted_attr);
         }
@@ -176,6 +243,283 @@ impl Rule for UseSortedAttributes {
         ))
     }
 }
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Returns the effective `AttributeGroups` when `sort_scope` is `Group`.
+fn resolve_groups(
+    options: &UseSortedAttributesOptions,
+    sort_scope: SortScope,
+) -> Option<AttributeGroups> {
+    if sort_scope == SortScope::Global {
+        return None;
+    }
+    Some(
+        options
+            .groups
+            .clone()
+            .unwrap_or_else(default_attribute_groups),
+    )
+}
+
+type ComparatorFn = fn(&SortableJsxAttribute, &SortableJsxAttribute) -> Ordering;
+
+/// Selects the comparator based on `sortOrder` × `ignoreCase`.
+fn select_comparator(options: &UseSortedAttributesOptions) -> ComparatorFn {
+    let sort_order = options.sort_order.unwrap_or_default();
+    let ignore_case = options.ignore_case.unwrap_or(false);
+    match (sort_order, ignore_case) {
+        (SortOrder::Natural, false) => SortableJsxAttribute::ascii_nat_cmp,
+        (SortOrder::Natural, true) => SortableJsxAttribute::ascii_nat_cmp_ignore_case,
+        (SortOrder::Lexicographic, false) => SortableJsxAttribute::lexicographic_cmp,
+        (SortOrder::Lexicographic, true) => SortableJsxAttribute::lexicographic_cmp_ignore_case,
+    }
+}
+
+/// Checks a bucket of props and, if unsorted, pushes an `AttributeGroup` to `out`.
+fn flush_bucket(
+    bucket: &mut Vec<SortableJsxAttribute>,
+    out: &mut Vec<AttributeGroup<SortableJsxAttribute>>,
+    groups: Option<&AttributeGroups>,
+    sort_scope: SortScope,
+    multiline: MultilineOrder,
+    comparator: ComparatorFn,
+) {
+    if bucket.is_empty() {
+        return;
+    }
+
+    let is_already_sorted = match sort_scope {
+        SortScope::Global => {
+            let bc = |a: &SortableJsxAttribute, b: &SortableJsxAttribute| {
+                comparator(a, b) != Ordering::Greater
+            };
+            bucket.is_sorted_by(bc)
+        }
+        SortScope::Group => {
+            let sorted = get_sorted_by_groups(bucket, groups, multiline, comparator);
+            sorted.is_some_and(|sorted| bucket.iter().zip(sorted.iter()).all(|(a, b)| a.0 == b.0))
+        }
+    };
+
+    if is_already_sorted {
+        bucket.clear();
+    } else {
+        out.push(AttributeGroup {
+            attrs: std::mem::take(bucket),
+        });
+    }
+}
+
+/// Returns props sorted with group-aware logic, dispatching to the right
+/// multiline mode.
+///
+/// Each mode sorts independently-bucketed groups and concatenates them. The
+/// separating-whitespace fixup is applied **once** over the fully concatenated
+/// result (see [`ensure_separating_whitespace`]); doing it per-bucket would
+/// miss the seams between buckets and could emit mashed-together, invalid JSX.
+fn get_sorted_by_groups(
+    attrs: &[SortableJsxAttribute],
+    groups: Option<&AttributeGroups>,
+    multiline: MultilineOrder,
+    comparator: ComparatorFn,
+) -> Option<Vec<SortableJsxAttribute>> {
+    let mut result = match multiline {
+        MultilineOrder::Group => sort_into_buckets(attrs, groups, comparator),
+        MultilineOrder::GroupFirst => sort_into_buckets_subgroup(attrs, groups, comparator, true),
+        MultilineOrder::GroupLast => sort_into_buckets_subgroup(attrs, groups, comparator, false),
+        MultilineOrder::First => sort_split_multiline(attrs, groups, comparator, true),
+        MultilineOrder::Last => sort_split_multiline(attrs, groups, comparator, false),
+    }?;
+    ensure_separating_whitespace(&mut result)?;
+    Some(result)
+}
+
+/// Ensures every attribute except the last carries separating trailing
+/// whitespace.
+///
+/// Group sorting concatenates independently-sorted buckets. A bucket's last
+/// attribute may be the source's final prop (e.g. the one right before `/>` or
+/// `>`), which carries no trailing whitespace. Once reordered next to another
+/// bucket, the two attributes would render mashed together
+/// (`onClick={fn}key="1"`), producing invalid JSX. This pass runs once over the
+/// fully concatenated result, mirroring what
+/// `AttributeGroup::get_sorted_attributes` does for the global (flat) path.
+fn ensure_separating_whitespace(attrs: &mut [SortableJsxAttribute]) -> Option<()> {
+    let mut iter = attrs.iter_mut().peekable();
+    while let Some(attr) = iter.next() {
+        if iter.peek().is_some() {
+            let ends_in_whitespace = attr
+                .node()
+                .syntax()
+                .last_trailing_trivia()
+                .and_then(|last_trivia| last_trivia.last())
+                .is_some_and(|last| last.is_whitespace() || last.is_newline());
+
+            let next_starts_with_whitespace = iter
+                .peek()
+                .and_then(|next_attr| next_attr.node().syntax().first_leading_trivia())
+                .and_then(|first_trivia| first_trivia.first())
+                .is_some_and(|first| first.is_whitespace() || first.is_newline());
+
+            if !ends_in_whitespace && !next_starts_with_whitespace {
+                let old_last_token = attr.node().syntax().last_token()?;
+                let new_last_token =
+                    old_last_token.with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")]);
+                *attr = attr.clone().replace_token(old_last_token, new_last_token)?;
+            }
+        }
+    }
+    Some(())
+}
+
+/// Assigns each prop to a group bucket, sorts named buckets, and concatenates.
+/// The implicit rest bucket (when `:REST:` is not configured) is left unsorted.
+fn sort_into_buckets(
+    attrs: &[SortableJsxAttribute],
+    groups: Option<&AttributeGroups>,
+    comparator: ComparatorFn,
+) -> Option<Vec<SortableJsxAttribute>> {
+    if attrs.is_empty() {
+        return Some(Vec::new());
+    }
+
+    // The implicit-fallback-bucket index is `groups.len()` (one past the
+    // last named group). `AttributeGroups::group_index` only ever returns
+    // this index for props that match neither a named group nor a
+    // configured `:REST:` group, so this bucket is only ever non-empty when
+    // `:REST:` isn't configured. Such props are NOT sorted — their original
+    // relative order is preserved. An explicit `:REST:` group, by contrast,
+    // occupies its own (sorted) bucket at its configured position.
+    let rest_index = groups.map_or(0, |g| g.len());
+
+    let annotated: Vec<(usize, SortableJsxAttribute)> = attrs
+        .iter()
+        .map(|attr| {
+            let idx = match groups {
+                Some(g) => g.group_index(&attr.0),
+                None => 0,
+            };
+            (idx, attr.clone())
+        })
+        .collect();
+
+    let max_bucket = annotated.iter().map(|(idx, _)| *idx).max().unwrap_or(0);
+    let mut buckets: Vec<Vec<SortableJsxAttribute>> = vec![Vec::new(); max_bucket + 1];
+    for (idx, attr) in annotated {
+        buckets[idx].push(attr);
+    }
+
+    let mut result: Vec<SortableJsxAttribute> = Vec::with_capacity(attrs.len());
+    for (idx, mut bucket) in buckets.into_iter().enumerate() {
+        // The rest bucket preserves source order; named buckets are sorted.
+        // Separating whitespace is fixed up once by the caller.
+        if idx != rest_index {
+            bucket.sort_by(comparator);
+        }
+        result.extend(bucket);
+    }
+
+    Some(result)
+}
+
+/// `GroupFirst`/`GroupLast`: within each group bucket, multiline props are
+/// sorted into a sub-group placed before (`multiline_first = true`) or after
+/// single-line props in that same bucket.
+fn sort_into_buckets_subgroup(
+    attrs: &[SortableJsxAttribute],
+    groups: Option<&AttributeGroups>,
+    comparator: ComparatorFn,
+    multiline_first: bool,
+) -> Option<Vec<SortableJsxAttribute>> {
+    if attrs.is_empty() {
+        return Some(Vec::new());
+    }
+
+    let rest_index = groups.map_or(0, |g| g.len());
+
+    let annotated: Vec<(usize, SortableJsxAttribute)> = attrs
+        .iter()
+        .map(|attr| {
+            let idx = match groups {
+                Some(g) => g.group_index(&attr.0),
+                None => 0,
+            };
+            (idx, attr.clone())
+        })
+        .collect();
+
+    let max_bucket = annotated.iter().map(|(idx, _)| *idx).max().unwrap_or(0);
+    let mut buckets: Vec<Vec<SortableJsxAttribute>> = vec![Vec::new(); max_bucket + 1];
+    for (idx, attr) in annotated {
+        buckets[idx].push(attr);
+    }
+
+    let mut result: Vec<SortableJsxAttribute> = Vec::with_capacity(attrs.len());
+    for (idx, bucket) in buckets.into_iter().enumerate() {
+        if idx == rest_index {
+            // Unsorted rest bucket: split by multiline, preserve insertion order within each part.
+            let (ml, sl): (Vec<_>, Vec<_>) =
+                bucket.into_iter().partition(|a| is_multiline_prop(&a.0));
+            if multiline_first {
+                result.extend(ml);
+                result.extend(sl);
+            } else {
+                result.extend(sl);
+                result.extend(ml);
+            }
+        } else {
+            let (mut ml_bucket, mut sl_bucket): (Vec<_>, Vec<_>) =
+                bucket.into_iter().partition(|a| is_multiline_prop(&a.0));
+            ml_bucket.sort_by(comparator);
+            sl_bucket.sort_by(comparator);
+            if multiline_first {
+                result.extend(ml_bucket);
+                result.extend(sl_bucket);
+            } else {
+                result.extend(sl_bucket);
+                result.extend(ml_bucket);
+            }
+        }
+    }
+
+    Some(result)
+}
+
+/// `First`/`Last`: separate all props into multiline and non-multiline sets,
+/// sort each set by groups independently, then concatenate with multilines
+/// first (`multiline_first = true`) or last.
+fn sort_split_multiline(
+    attrs: &[SortableJsxAttribute],
+    groups: Option<&AttributeGroups>,
+    comparator: ComparatorFn,
+    multiline_first: bool,
+) -> Option<Vec<SortableJsxAttribute>> {
+    let mut ml_attrs: Vec<SortableJsxAttribute> = Vec::new();
+    let mut sl_attrs: Vec<SortableJsxAttribute> = Vec::new();
+    for attr in attrs {
+        if is_multiline_prop(&attr.0) {
+            ml_attrs.push(attr.clone());
+        } else {
+            sl_attrs.push(attr.clone());
+        }
+    }
+
+    let ml_sorted = sort_into_buckets(&ml_attrs, groups, comparator)?;
+    let sl_sorted = sort_into_buckets(&sl_attrs, groups, comparator)?;
+
+    let mut result = Vec::with_capacity(attrs.len());
+    if multiline_first {
+        result.extend(ml_sorted);
+        result.extend(sl_sorted);
+    } else {
+        result.extend(sl_sorted);
+        result.extend(ml_sorted);
+    }
+    Some(result)
+}
+
+// ── SortableJsxAttribute ──────────────────────────────────────────────────────
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct SortableJsxAttribute(JsxAttribute);
@@ -203,5 +547,35 @@ impl SortableAttribute for SortableJsxAttribute {
             self.0
                 .replace_token_discard_trivia(prev_token, next_token)?,
         ))
+    }
+}
+
+impl SortableJsxAttribute {
+    /// Case-insensitive natural sort, used when `ignoreCase: true`.
+    fn ascii_nat_cmp_ignore_case(&self, other: &Self) -> Ordering {
+        match (self.name(), other.name()) {
+            (Some(a), Some(b)) => {
+                let a_lower = a.text_trimmed().to_ascii_lowercase_cow();
+                let b_lower = b.text_trimmed().to_ascii_lowercase_cow();
+                a_lower.ascii_nat_cmp(&b_lower)
+            }
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        }
+    }
+
+    /// Case-insensitive lexicographic sort, used when `ignoreCase: true`.
+    fn lexicographic_cmp_ignore_case(&self, other: &Self) -> Ordering {
+        match (self.name(), other.name()) {
+            (Some(a), Some(b)) => {
+                let a_lower = a.text_trimmed().to_ascii_lowercase_cow();
+                let b_lower = b.text_trimmed().to_ascii_lowercase_cow();
+                a_lower.lexicographic_cmp(&b_lower)
+            }
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        }
     }
 }

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.jsx
@@ -1,0 +1,55 @@
+// sortScope: "group" with default groups [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+// Complex components exercising all five group types.
+
+// Unsorted: all five group types mixed
+<Hello
+  onFocus={handleFocus}
+  name="John"
+  children={<Avatar />}
+  active
+  ref={myRef}
+  onChange={handleChange}
+  lastName="Smith"
+  dangerouslySetInnerHTML={{ __html: html }}
+  disabled
+  key="user-1"
+/>;
+
+// Correctly sorted: [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+// within each group sorted alphabetically
+<Hello
+  active
+  disabled
+  key="user-1"
+  ref={myRef}
+  children={<Avatar />}
+  dangerouslySetInnerHTML={{ __html: html }}
+  lastName="Smith"
+  name="John"
+  onChange={handleChange}
+  onFocus={handleFocus}
+/>;
+
+// Unsorted: RESERVED group — key after REST prop
+<Hello name="John" key="1" />;
+
+// Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+<Hello name="John" key="1" children={<Foo />} />;
+
+// Unsorted: multiple callbacks out of alphabetical order, after implicit props
+<Hello onFocus={fn} onClick={fn} active name="John" />;
+
+// Unsorted with spread fence: each segment covers all group types
+<Hello
+  onClick={handleClick}
+  name="John"
+  disabled
+  key="user-1"
+  children={<Avatar />}
+  {...defaults}
+  onFocus={handleFocus}
+  lastName="Smith"
+  active
+  ref={myRef}
+  dangerouslySetInnerHTML={{ __html: html }}
+/>;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.jsx.snap
@@ -1,0 +1,251 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 150
+expression: groups-all-types.jsx
+---
+# Input
+```jsx
+// sortScope: "group" with default groups [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+// Complex components exercising all five group types.
+
+// Unsorted: all five group types mixed
+<Hello
+  onFocus={handleFocus}
+  name="John"
+  children={<Avatar />}
+  active
+  ref={myRef}
+  onChange={handleChange}
+  lastName="Smith"
+  dangerouslySetInnerHTML={{ __html: html }}
+  disabled
+  key="user-1"
+/>;
+
+// Correctly sorted: [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+// within each group sorted alphabetically
+<Hello
+  active
+  disabled
+  key="user-1"
+  ref={myRef}
+  children={<Avatar />}
+  dangerouslySetInnerHTML={{ __html: html }}
+  lastName="Smith"
+  name="John"
+  onChange={handleChange}
+  onFocus={handleFocus}
+/>;
+
+// Unsorted: RESERVED group — key after REST prop
+<Hello name="John" key="1" />;
+
+// Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+<Hello name="John" key="1" children={<Foo />} />;
+
+// Unsorted: multiple callbacks out of alphabetical order, after implicit props
+<Hello onFocus={fn} onClick={fn} active name="John" />;
+
+// Unsorted with spread fence: each segment covers all group types
+<Hello
+  onClick={handleClick}
+  name="John"
+  disabled
+  key="user-1"
+  children={<Avatar />}
+  {...defaults}
+  onFocus={handleFocus}
+  lastName="Smith"
+  active
+  ref={myRef}
+  dangerouslySetInnerHTML={{ __html: html }}
+/>;
+
+```
+
+# Diagnostics
+```
+groups-all-types.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     4 │ // Unsorted: all five group types mixed
+   > 5 │ <Hello
+       │ ^^^^^^
+   > 6 │   onFocus={handleFocus}
+        ...
+  > 15 │   key="user-1"
+  > 16 │ />;
+       │ ^^
+    17 │ 
+    18 │ // Correctly sorted: [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+  
+  i Safe fix: Sort the JSX props.
+  
+     4  4 │   // Unsorted: all five group types mixed
+     5  5 │   <Hello
+     6    │ - ··onFocus={handleFocus}
+     7    │ - ··name="John"
+     8    │ - ··children={<Avatar·/>}
+     9    │ - ··active
+    10    │ - ··ref={myRef}
+    11    │ - ··onChange={handleChange}
+        6 │ + ··active
+        7 │ + ··disabled
+        8 │ + ··key="user-1"
+        9 │ + ··ref={myRef}
+       10 │ + ··children={<Avatar·/>}
+       11 │ + ··dangerouslySetInnerHTML={{·__html:·html·}}
+    12 12 │     lastName="Smith"
+    13    │ - ··dangerouslySetInnerHTML={{·__html:·html·}}
+    14    │ - ··disabled
+    15    │ - ··key="user-1"
+       13 │ + ··name="John"
+       14 │ + ··onChange={handleChange}
+       15 │ + ··onFocus={handleFocus}
+    16 16 │   />;
+    17 17 │   
+  
+
+```
+
+```
+groups-all-types.jsx:34:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    33 │ // Unsorted: RESERVED group — key after REST prop
+  > 34 │ <Hello name="John" key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    35 │ 
+    36 │ // Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+  
+  i Safe fix: Sort the JSX props.
+  
+    32 32 │   
+    33 33 │   // Unsorted: RESERVED group — key after REST prop
+    34    │ - <Hello·name="John"·key="1"·/>;
+       34 │ + <Hello·key="1"·name="John"·/>;
+    35 35 │   
+    36 36 │   // Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+  
+
+```
+
+```
+groups-all-types.jsx:37:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    36 │ // Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+  > 37 │ <Hello name="John" key="1" children={<Foo />} />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    38 │ 
+    39 │ // Unsorted: multiple callbacks out of alphabetical order, after implicit props
+  
+  i Safe fix: Sort the JSX props.
+  
+    35 35 │   
+    36 36 │   // Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+    37    │ - <Hello·name="John"·key="1"·children={<Foo·/>}·/>;
+       37 │ + <Hello·key="1"·children={<Foo·/>}·name="John"·/>;
+    38 38 │   
+    39 39 │   // Unsorted: multiple callbacks out of alphabetical order, after implicit props
+  
+
+```
+
+```
+groups-all-types.jsx:40:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    39 │ // Unsorted: multiple callbacks out of alphabetical order, after implicit props
+  > 40 │ <Hello onFocus={fn} onClick={fn} active name="John" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    41 │ 
+    42 │ // Unsorted with spread fence: each segment covers all group types
+  
+  i Safe fix: Sort the JSX props.
+  
+    38 38 │   
+    39 39 │   // Unsorted: multiple callbacks out of alphabetical order, after implicit props
+    40    │ - <Hello·onFocus={fn}·onClick={fn}·active·name="John"·/>;
+       40 │ + <Hello·active·name="John"·onClick={fn}·onFocus={fn}·/>;
+    41 41 │   
+    42 42 │   // Unsorted with spread fence: each segment covers all group types
+  
+
+```
+
+```
+groups-all-types.jsx:43:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    42 │ // Unsorted with spread fence: each segment covers all group types
+  > 43 │ <Hello
+       │ ^^^^^^
+  > 44 │   onClick={handleClick}
+        ...
+  > 53 │   ref={myRef}
+  > 54 │   dangerouslySetInnerHTML={{ __html: html }}
+  > 55 │ />;
+       │ ^^
+    56 │ 
+  
+  i Safe fix: Sort the JSX props.
+  
+    48 48 │     children={<Avatar />}
+    49 49 │     {...defaults}
+    50    │ - ··onFocus={handleFocus}
+    51    │ - ··lastName="Smith"
+    52    │ - ··active
+    53    │ - ··ref={myRef}
+    54    │ - ··dangerouslySetInnerHTML={{·__html:·html·}}
+       50 │ + ··active
+       51 │ + ··ref={myRef}
+       52 │ + ··dangerouslySetInnerHTML={{·__html:·html·}}
+       53 │ + ··lastName="Smith"
+       54 │ + ··onFocus={handleFocus}
+    55 55 │   />;
+    56 56 │   
+  
+
+```
+
+```
+groups-all-types.jsx:43:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    42 │ // Unsorted with spread fence: each segment covers all group types
+  > 43 │ <Hello
+       │ ^^^^^^
+  > 44 │   onClick={handleClick}
+        ...
+  > 53 │   ref={myRef}
+  > 54 │   dangerouslySetInnerHTML={{ __html: html }}
+  > 55 │ />;
+       │ ^^
+    56 │ 
+  
+  i Safe fix: Sort the JSX props.
+  
+    42 42 │   // Unsorted with spread fence: each segment covers all group types
+    43 43 │   <Hello
+    44    │ - ··onClick={handleClick}
+    45    │ - ··name="John"
+    46    │ - ··disabled
+    47    │ - ··key="user-1"
+    48    │ - ··children={<Avatar·/>}
+       44 │ + ··disabled
+       45 │ + ··key="user-1"
+       46 │ + ··children={<Avatar·/>}
+       47 │ + ··name="John"
+       48 │ + ··onClick={handleClick}
+    49 49 │     {...defaults}
+    50 50 │     onFocus={handleFocus}
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group"
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.jsx
@@ -1,0 +1,11 @@
+// Custom groups order: [:CALLBACK:, :RESERVED:, :IMPLICIT:]
+// Callbacks first, then reserved (key/ref), then implicit (shorthand), then rest
+
+// Unsorted: implicit before callback
+<Hello disabled key="1" onChange={fn} name="John" />;
+
+// Unsorted: reserved (key) after callback but implicit in wrong position
+<Hello name="John" onChange={fn} disabled key="1" />;
+
+// Correctly ordered: callback, reserved, implicit, rest
+<Hello onChange={fn} key="1" disabled name="John" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.jsx.snap
@@ -1,0 +1,67 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 154
+expression: groups-custom-order.jsx
+---
+# Input
+```jsx
+// Custom groups order: [:CALLBACK:, :RESERVED:, :IMPLICIT:]
+// Callbacks first, then reserved (key/ref), then implicit (shorthand), then rest
+
+// Unsorted: implicit before callback
+<Hello disabled key="1" onChange={fn} name="John" />;
+
+// Unsorted: reserved (key) after callback but implicit in wrong position
+<Hello name="John" onChange={fn} disabled key="1" />;
+
+// Correctly ordered: callback, reserved, implicit, rest
+<Hello onChange={fn} key="1" disabled name="John" />;
+
+```
+
+# Diagnostics
+```
+groups-custom-order.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    4 │ // Unsorted: implicit before callback
+  > 5 │ <Hello disabled key="1" onChange={fn} name="John" />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ // Unsorted: reserved (key) after callback but implicit in wrong position
+  
+  i Safe fix: Sort the JSX props.
+  
+     3  3 │   
+     4  4 │   // Unsorted: implicit before callback
+     5    │ - <Hello·disabled·key="1"·onChange={fn}·name="John"·/>;
+        5 │ + <Hello·onChange={fn}·key="1"·disabled·name="John"·/>;
+     6  6 │   
+     7  7 │   // Unsorted: reserved (key) after callback but implicit in wrong position
+  
+
+```
+
+```
+groups-custom-order.jsx:8:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     7 │ // Unsorted: reserved (key) after callback but implicit in wrong position
+   > 8 │ <Hello name="John" onChange={fn} disabled key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Correctly ordered: callback, reserved, implicit, rest
+  
+  i Safe fix: Sort the JSX props.
+  
+     6  6 │   
+     7  7 │   // Unsorted: reserved (key) after callback but implicit in wrong position
+     8    │ - <Hello·name="John"·onChange={fn}·disabled·key="1"·/>;
+        8 │ + <Hello·onChange={fn}·key="1"·disabled·name="John"·/>;
+     9  9 │   
+    10 10 │   // Correctly ordered: callback, reserved, implicit, rest
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":CALLBACK:", ":RESERVED:", ":IMPLICIT:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.jsx
@@ -1,0 +1,7 @@
+// sortScope: "group", groups: []
+// An empty groups list disables group sorting: every prop falls into the
+// implicit (unsorted) rest bucket, so source order is always preserved and the
+// rule never reports. This pins that behavior.
+
+// Clearly unsorted by name, but no diagnostic is emitted (no-op)
+<Hello zebra="z" apple="a" key="1" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.jsx.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-empty.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: []
+// An empty groups list disables group sorting: every prop falls into the
+// implicit (unsorted) rest bucket, so source order is always preserved and the
+// rule never reports. This pins that behavior.
+
+// Clearly unsorted by name, but no diagnostic is emitted (no-op)
+<Hello zebra="z" apple="a" key="1" />;
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": []
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-ignore-case-group.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-ignore-case-group.jsx
@@ -1,0 +1,16 @@
+// ignoreCase: true, sortScope: "group" with default groups
+// Case-insensitive comparison applies within each group independently.
+// ASCII case-sensitive: uppercase letters sort before lowercase ('Z' < 'a').
+// Case-insensitive: 'Z'/'z' > 'a', so "Zebra" comes after "ant".
+
+// Unsorted: REST group has Bbb before aaa
+// (case-sensitive 'B' < 'a', but case-insensitive 'b' > 'a')
+<Hello Bbb="" aaa="" disabled key="1" onChange={fn} />;
+
+// Unsorted: IMPLICIT group has Zebra before active
+// (case-sensitive 'Z' < 'a', but case-insensitive 'z' > 'a')
+<Hello Zebra active key="1" />;
+
+// Correctly sorted (case-insensitive):
+// IMPLICIT [active, Zebra], RESERVED [key], REST [aaa, Bbb], CALLBACK [onChange]
+<Hello active Zebra key="1" aaa="" Bbb="" onChange={fn} />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-ignore-case-group.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-ignore-case-group.jsx.snap
@@ -1,0 +1,73 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-ignore-case-group.jsx
+---
+# Input
+```jsx
+// ignoreCase: true, sortScope: "group" with default groups
+// Case-insensitive comparison applies within each group independently.
+// ASCII case-sensitive: uppercase letters sort before lowercase ('Z' < 'a').
+// Case-insensitive: 'Z'/'z' > 'a', so "Zebra" comes after "ant".
+
+// Unsorted: REST group has Bbb before aaa
+// (case-sensitive 'B' < 'a', but case-insensitive 'b' > 'a')
+<Hello Bbb="" aaa="" disabled key="1" onChange={fn} />;
+
+// Unsorted: IMPLICIT group has Zebra before active
+// (case-sensitive 'Z' < 'a', but case-insensitive 'z' > 'a')
+<Hello Zebra active key="1" />;
+
+// Correctly sorted (case-insensitive):
+// IMPLICIT [active, Zebra], RESERVED [key], REST [aaa, Bbb], CALLBACK [onChange]
+<Hello active Zebra key="1" aaa="" Bbb="" onChange={fn} />;
+
+```
+
+# Diagnostics
+```
+groups-ignore-case-group.jsx:8:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     6 │ // Unsorted: REST group has Bbb before aaa
+     7 │ // (case-sensitive 'B' < 'a', but case-insensitive 'b' > 'a')
+   > 8 │ <Hello Bbb="" aaa="" disabled key="1" onChange={fn} />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Unsorted: IMPLICIT group has Zebra before active
+  
+  i Safe fix: Sort the JSX props.
+  
+     6  6 │   // Unsorted: REST group has Bbb before aaa
+     7  7 │   // (case-sensitive 'B' < 'a', but case-insensitive 'b' > 'a')
+     8    │ - <Hello·Bbb=""·aaa=""·disabled·key="1"·onChange={fn}·/>;
+        8 │ + <Hello·disabled·key="1"·aaa=""·Bbb=""·onChange={fn}·/>;
+     9  9 │   
+    10 10 │   // Unsorted: IMPLICIT group has Zebra before active
+  
+
+```
+
+```
+groups-ignore-case-group.jsx:12:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Unsorted: IMPLICIT group has Zebra before active
+    11 │ // (case-sensitive 'Z' < 'a', but case-insensitive 'z' > 'a')
+  > 12 │ <Hello Zebra active key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ 
+    14 │ // Correctly sorted (case-insensitive):
+  
+  i Safe fix: Sort the JSX props.
+  
+    10 10 │   // Unsorted: IMPLICIT group has Zebra before active
+    11 11 │   // (case-sensitive 'Z' < 'a', but case-insensitive 'z' > 'a')
+    12    │ - <Hello·Zebra·active·key="1"·/>;
+       12 │ + <Hello·active·Zebra·key="1"·/>;
+    13 13 │   
+    14 14 │   // Correctly sorted (case-insensitive):
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-ignore-case-group.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-ignore-case-group.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"ignoreCase": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.jsx
@@ -1,0 +1,9 @@
+// sortScope: "group", sortOrder: "lexicographic", groups: [:RESERVED:, :REST:]
+// Lexicographic (byte) order applies within each group: "item10" sorts before
+// "item2" (unlike natural order), and uppercase sorts before lowercase.
+
+// Unsorted REST: lexicographic puts Zebra before apple, and item10 before item2
+<Hello item2="a" key="1" item10="b" apple="c" Zebra="d" />;
+
+// Correctly ordered: reserved key, then REST in lexicographic order
+<Hello key="1" Zebra="d" apple="c" item10="b" item2="a" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.jsx.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-lexicographic.jsx
+---
+# Input
+```jsx
+// sortScope: "group", sortOrder: "lexicographic", groups: [:RESERVED:, :REST:]
+// Lexicographic (byte) order applies within each group: "item10" sorts before
+// "item2" (unlike natural order), and uppercase sorts before lowercase.
+
+// Unsorted REST: lexicographic puts Zebra before apple, and item10 before item2
+<Hello item2="a" key="1" item10="b" apple="c" Zebra="d" />;
+
+// Correctly ordered: reserved key, then REST in lexicographic order
+<Hello key="1" Zebra="d" apple="c" item10="b" item2="a" />;
+
+```
+
+# Diagnostics
+```
+groups-lexicographic.jsx:6:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    5 │ // Unsorted REST: lexicographic puts Zebra before apple, and item10 before item2
+  > 6 │ <Hello item2="a" key="1" item10="b" apple="c" Zebra="d" />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
+    8 │ // Correctly ordered: reserved key, then REST in lexicographic order
+  
+  i Safe fix: Sort the JSX props.
+  
+     4  4 │   
+     5  5 │   // Unsorted REST: lexicographic puts Zebra before apple, and item10 before item2
+     6    │ - <Hello·item2="a"·key="1"·item10="b"·apple="c"·Zebra="d"·/>;
+        6 │ + <Hello·key="1"·Zebra="d"·apple="c"·item10="b"·item2="a"·/>;
+     7  7 │   
+     8  8 │   // Correctly ordered: reserved key, then REST in lexicographic order
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.options.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"sortOrder": "lexicographic",
+						"groups": [":RESERVED:", ":REST:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.jsx
@@ -1,0 +1,14 @@
+// sortScope: "group", groups: [:CALLBACK:, :RESERVED:]
+// Regression: the source-final prop carries no trailing whitespace (it sits
+// right before `/>` or `>`). When a group moves it off the end, the result must
+// still keep a separating space, otherwise the props mash into invalid JSX
+// (e.g. `onClick={fn}key="1"`).
+
+// Self-closing, no space before `/>`: reserved key moved after callback
+<Hello key="1" onClick={fn}/>;
+
+// Opening element, no space before `>`
+<Hello key="1" onClick={fn}>x</Hello>;
+
+// Already in group order (callback, then reserved): no diagnostic
+<Hello onClick={fn} key="1"/>;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.jsx.snap
@@ -1,0 +1,69 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-no-trailing-space.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:CALLBACK:, :RESERVED:]
+// Regression: the source-final prop carries no trailing whitespace (it sits
+// right before `/>` or `>`). When a group moves it off the end, the result must
+// still keep a separating space, otherwise the props mash into invalid JSX
+// (e.g. `onClick={fn}key="1"`).
+
+// Self-closing, no space before `/>`: reserved key moved after callback
+<Hello key="1" onClick={fn}/>;
+
+// Opening element, no space before `>`
+<Hello key="1" onClick={fn}>x</Hello>;
+
+// Already in group order (callback, then reserved): no diagnostic
+<Hello onClick={fn} key="1"/>;
+
+```
+
+# Diagnostics
+```
+groups-no-trailing-space.jsx:8:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     7 │ // Self-closing, no space before `/>`: reserved key moved after callback
+   > 8 │ <Hello key="1" onClick={fn}/>;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Opening element, no space before `>`
+  
+  i Safe fix: Sort the JSX props.
+  
+     6  6 │   
+     7  7 │   // Self-closing, no space before `/>`: reserved key moved after callback
+     8    │ - <Hello·key="1"·onClick={fn}/>;
+        8 │ + <Hello·onClick={fn}·key="1"·/>;
+     9  9 │   
+    10 10 │   // Opening element, no space before `>`
+  
+
+```
+
+```
+groups-no-trailing-space.jsx:11:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Opening element, no space before `>`
+  > 11 │ <Hello key="1" onClick={fn}>x</Hello>;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // Already in group order (callback, then reserved): no diagnostic
+  
+  i Safe fix: Sort the JSX props.
+  
+     9  9 │   
+    10 10 │   // Opening element, no space before `>`
+    11    │ - <Hello·key="1"·onClick={fn}>x</Hello>;
+       11 │ + <Hello·onClick={fn}·key="1"·>x</Hello>;
+    12 12 │   
+    13 13 │   // Already in group order (callback, then reserved): no diagnostic
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":CALLBACK:", ":RESERVED:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.jsx
@@ -1,0 +1,10 @@
+// Custom groups with an explicit :REST: placement: [:RESERVED:, :REST:, :CALLBACK:]
+// :REST: catches everything not explicitly listed (including implicit/dom-reserved
+// props, since :IMPLICIT: and :DOM_RESERVED: aren't configured here) and sorts
+// them like a regular group, instead of leaving them unsorted at the end.
+
+// Unsorted: reserved not first, rest props out of order
+<Hello zebra="z" key="1" apple="a" onClick={fn} disabled />;
+
+// Correctly ordered: reserved, then rest (sorted, including "disabled"), then callback
+<Hello key="1" apple="a" disabled zebra="z" onClick={fn} />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.jsx.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-rest-explicit.jsx
+---
+# Input
+```jsx
+// Custom groups with an explicit :REST: placement: [:RESERVED:, :REST:, :CALLBACK:]
+// :REST: catches everything not explicitly listed (including implicit/dom-reserved
+// props, since :IMPLICIT: and :DOM_RESERVED: aren't configured here) and sorts
+// them like a regular group, instead of leaving them unsorted at the end.
+
+// Unsorted: reserved not first, rest props out of order
+<Hello zebra="z" key="1" apple="a" onClick={fn} disabled />;
+
+// Correctly ordered: reserved, then rest (sorted, including "disabled"), then callback
+<Hello key="1" apple="a" disabled zebra="z" onClick={fn} />;
+
+```
+
+# Diagnostics
+```
+groups-rest-explicit.jsx:7:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    6 │ // Unsorted: reserved not first, rest props out of order
+  > 7 │ <Hello zebra="z" key="1" apple="a" onClick={fn} disabled />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ // Correctly ordered: reserved, then rest (sorted, including "disabled"), then callback
+  
+  i Safe fix: Sort the JSX props.
+  
+     5  5 │   
+     6  6 │   // Unsorted: reserved not first, rest props out of order
+     7    │ - <Hello·zebra="z"·key="1"·apple="a"·onClick={fn}·disabled·/>;
+        7 │ + <Hello·key="1"·apple="a"·disabled·zebra="z"·onClick={fn}·/>;
+     8  8 │   
+     9  9 │   // Correctly ordered: reserved, then rest (sorted, including "disabled"), then callback
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":REST:", ":CALLBACK:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.jsx
@@ -1,0 +1,20 @@
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:]
+// Spread props act as fences: each batch between spreads is sorted independently.
+
+// Unsorted batch before a spread
+<Hello onChange={fn} disabled key="1" {...this.props} />;
+
+// Unsorted batch after a spread
+<Hello {...this.props} onChange={fn} disabled key="1" />;
+
+// Both batches unsorted
+<Hello onChange={fn} disabled key="1" {...this.props} onChange={fn} disabled key="2" />;
+
+// First batch sorted, second unsorted
+<Hello key="1" disabled onChange={fn} {...this.props} onChange={fn} disabled key="2" />;
+
+// Correctly sorted: all batches already in group order — no diagnostic
+<Hello key="1" disabled onChange={fn} {...this.props} key="2" disabled onChange={fn} />;
+
+// Multiple spreads: each segment sorted independently
+<Hello onChange={fn} disabled {...props1} lastName="Smith" firstName="John" {...props2} onChange={fn} key="1" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.jsx.snap
@@ -1,0 +1,186 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-spread.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:]
+// Spread props act as fences: each batch between spreads is sorted independently.
+
+// Unsorted batch before a spread
+<Hello onChange={fn} disabled key="1" {...this.props} />;
+
+// Unsorted batch after a spread
+<Hello {...this.props} onChange={fn} disabled key="1" />;
+
+// Both batches unsorted
+<Hello onChange={fn} disabled key="1" {...this.props} onChange={fn} disabled key="2" />;
+
+// First batch sorted, second unsorted
+<Hello key="1" disabled onChange={fn} {...this.props} onChange={fn} disabled key="2" />;
+
+// Correctly sorted: all batches already in group order — no diagnostic
+<Hello key="1" disabled onChange={fn} {...this.props} key="2" disabled onChange={fn} />;
+
+// Multiple spreads: each segment sorted independently
+<Hello onChange={fn} disabled {...props1} lastName="Smith" firstName="John" {...props2} onChange={fn} key="1" />;
+
+```
+
+# Diagnostics
+```
+groups-spread.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    4 │ // Unsorted batch before a spread
+  > 5 │ <Hello onChange={fn} disabled key="1" {...this.props} />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ // Unsorted batch after a spread
+  
+  i Safe fix: Sort the JSX props.
+  
+     3  3 │   
+     4  4 │   // Unsorted batch before a spread
+     5    │ - <Hello·onChange={fn}·disabled·key="1"·{...this.props}·/>;
+        5 │ + <Hello·key="1"·disabled·onChange={fn}·{...this.props}·/>;
+     6  6 │   
+     7  7 │   // Unsorted batch after a spread
+  
+
+```
+
+```
+groups-spread.jsx:8:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     7 │ // Unsorted batch after a spread
+   > 8 │ <Hello {...this.props} onChange={fn} disabled key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Both batches unsorted
+  
+  i Safe fix: Sort the JSX props.
+  
+     6  6 │   
+     7  7 │   // Unsorted batch after a spread
+     8    │ - <Hello·{...this.props}·onChange={fn}·disabled·key="1"·/>;
+        8 │ + <Hello·{...this.props}·key="1"·disabled·onChange={fn}·/>;
+     9  9 │   
+    10 10 │   // Both batches unsorted
+  
+
+```
+
+```
+groups-spread.jsx:11:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Both batches unsorted
+  > 11 │ <Hello onChange={fn} disabled key="1" {...this.props} onChange={fn} disabled key="2" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // First batch sorted, second unsorted
+  
+  i Safe fix: Sort the JSX props.
+  
+     9  9 │   
+    10 10 │   // Both batches unsorted
+    11    │ - <Hello·onChange={fn}·disabled·key="1"·{...this.props}·onChange={fn}·disabled·key="2"·/>;
+       11 │ + <Hello·key="1"·disabled·onChange={fn}·{...this.props}·onChange={fn}·disabled·key="2"·/>;
+    12 12 │   
+    13 13 │   // First batch sorted, second unsorted
+  
+
+```
+
+```
+groups-spread.jsx:11:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Both batches unsorted
+  > 11 │ <Hello onChange={fn} disabled key="1" {...this.props} onChange={fn} disabled key="2" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // First batch sorted, second unsorted
+  
+  i Safe fix: Sort the JSX props.
+  
+     9  9 │   
+    10 10 │   // Both batches unsorted
+    11    │ - <Hello·onChange={fn}·disabled·key="1"·{...this.props}·onChange={fn}·disabled·key="2"·/>;
+       11 │ + <Hello·onChange={fn}·disabled·key="1"·{...this.props}·key="2"·disabled·onChange={fn}·/>;
+    12 12 │   
+    13 13 │   // First batch sorted, second unsorted
+  
+
+```
+
+```
+groups-spread.jsx:14:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    13 │ // First batch sorted, second unsorted
+  > 14 │ <Hello key="1" disabled onChange={fn} {...this.props} onChange={fn} disabled key="2" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ 
+    16 │ // Correctly sorted: all batches already in group order — no diagnostic
+  
+  i Safe fix: Sort the JSX props.
+  
+    12 12 │   
+    13 13 │   // First batch sorted, second unsorted
+    14    │ - <Hello·key="1"·disabled·onChange={fn}·{...this.props}·onChange={fn}·disabled·key="2"·/>;
+       14 │ + <Hello·key="1"·disabled·onChange={fn}·{...this.props}·key="2"·disabled·onChange={fn}·/>;
+    15 15 │   
+    16 16 │   // Correctly sorted: all batches already in group order — no diagnostic
+  
+
+```
+
+```
+groups-spread.jsx:20:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    19 │ // Multiple spreads: each segment sorted independently
+  > 20 │ <Hello onChange={fn} disabled {...props1} lastName="Smith" firstName="John" {...props2} onChange={fn} key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
+  
+  i Safe fix: Sort the JSX props.
+  
+    18 18 │   
+    19 19 │   // Multiple spreads: each segment sorted independently
+    20    │ - <Hello·onChange={fn}·disabled·{...props1}·lastName="Smith"·firstName="John"·{...props2}·onChange={fn}·key="1"·/>;
+       20 │ + <Hello·onChange={fn}·disabled·{...props1}·lastName="Smith"·firstName="John"·{...props2}·key="1"·onChange={fn}·/>;
+    21 21 │   
+  
+
+```
+
+```
+groups-spread.jsx:20:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    19 │ // Multiple spreads: each segment sorted independently
+  > 20 │ <Hello onChange={fn} disabled {...props1} lastName="Smith" firstName="John" {...props2} onChange={fn} key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
+  
+  i Safe fix: Sort the JSX props.
+  
+    18 18 │   
+    19 19 │   // Multiple spreads: each segment sorted independently
+    20    │ - <Hello·onChange={fn}·disabled·{...props1}·lastName="Smith"·firstName="John"·{...props2}·onChange={fn}·key="1"·/>;
+       20 │ + <Hello·disabled·onChange={fn}·{...props1}·lastName="Smith"·firstName="John"·{...props2}·onChange={fn}·key="1"·/>;
+    21 21 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/ignore-case.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/ignore-case.jsx
@@ -1,0 +1,11 @@
+// ignoreCase: true, sortScope: "global" (flat sort, case-insensitive)
+
+// Unsorted: uppercase Z before lowercase a without ignoreCase would be fine,
+// but with ignoreCase "Zip" should sort after "name"
+<Hello Zip="NY" name="John" tel={5555555} />;
+
+// Correctly sorted case-insensitively: "age", "Name", "zip"
+<Hello age={30} Name="John" zip="NY" />;
+
+// Unsorted: "Bbb" should come before "ccc" case-insensitively
+<Hello ccc="" Bbb="" aaa="" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/ignore-case.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/ignore-case.jsx.snap
@@ -1,0 +1,65 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignore-case.jsx
+---
+# Input
+```jsx
+// ignoreCase: true, sortScope: "global" (flat sort, case-insensitive)
+
+// Unsorted: uppercase Z before lowercase a without ignoreCase would be fine,
+// but with ignoreCase "Zip" should sort after "name"
+<Hello Zip="NY" name="John" tel={5555555} />;
+
+// Correctly sorted case-insensitively: "age", "Name", "zip"
+<Hello age={30} Name="John" zip="NY" />;
+
+// Unsorted: "Bbb" should come before "ccc" case-insensitively
+<Hello ccc="" Bbb="" aaa="" />;
+
+```
+
+# Diagnostics
+```
+ignore-case.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    3 │ // Unsorted: uppercase Z before lowercase a without ignoreCase would be fine,
+    4 │ // but with ignoreCase "Zip" should sort after "name"
+  > 5 │ <Hello Zip="NY" name="John" tel={5555555} />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ // Correctly sorted case-insensitively: "age", "Name", "zip"
+  
+  i Safe fix: Sort the JSX props.
+  
+     3  3 │   // Unsorted: uppercase Z before lowercase a without ignoreCase would be fine,
+     4  4 │   // but with ignoreCase "Zip" should sort after "name"
+     5    │ - <Hello·Zip="NY"·name="John"·tel={5555555}·/>;
+        5 │ + <Hello·name="John"·tel={5555555}·Zip="NY"·/>;
+     6  6 │   
+     7  7 │   // Correctly sorted case-insensitively: "age", "Name", "zip"
+  
+
+```
+
+```
+ignore-case.jsx:11:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Unsorted: "Bbb" should come before "ccc" case-insensitively
+  > 11 │ <Hello ccc="" Bbb="" aaa="" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+  
+  i Safe fix: Sort the JSX props.
+  
+     9  9 │   
+    10 10 │   // Unsorted: "Bbb" should come before "ccc" case-insensitively
+    11    │ - <Hello·ccc=""·Bbb=""·aaa=""·/>;
+       11 │ + <Hello·aaa=""·Bbb=""·ccc=""·/>;
+    12 12 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/ignore-case.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/ignore-case.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"ignoreCase": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-first.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-first.jsx
@@ -1,0 +1,28 @@
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "first"
+// All multiline-value props come before all single-line props.
+// Within each part, props are sorted by group order.
+
+// Unsorted: single-line props before multiline onChange
+<Hello disabled key="1" onClick={fn} name="John" onChange={(e) => {
+  fn(e);
+}} />;
+
+// Unsorted: single-line props interleaved with multilines from different groups
+<Hello disabled key="1" onClick={fn} ref={(el) => {
+  domRef.current = el;
+}} name="John" onChange={(e) => {
+  fn(e);
+}} />;
+
+// Correctly ordered: multiline onChange first, then single-line props by group order
+<Hello onChange={(e) => {
+  fn(e);
+}} key="1" disabled onClick={fn} name="John" />;
+
+// Correctly ordered: multilines from RESERVED then CALLBACK first (group order),
+// then single-line props
+<Hello ref={(el) => {
+  domRef.current = el;
+}} onChange={(e) => {
+  fn(e);
+}} key="1" disabled onClick={fn} name="John" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-first.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-first.jsx.snap
@@ -1,0 +1,103 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: multiline-first.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "first"
+// All multiline-value props come before all single-line props.
+// Within each part, props are sorted by group order.
+
+// Unsorted: single-line props before multiline onChange
+<Hello disabled key="1" onClick={fn} name="John" onChange={(e) => {
+  fn(e);
+}} />;
+
+// Unsorted: single-line props interleaved with multilines from different groups
+<Hello disabled key="1" onClick={fn} ref={(el) => {
+  domRef.current = el;
+}} name="John" onChange={(e) => {
+  fn(e);
+}} />;
+
+// Correctly ordered: multiline onChange first, then single-line props by group order
+<Hello onChange={(e) => {
+  fn(e);
+}} key="1" disabled onClick={fn} name="John" />;
+
+// Correctly ordered: multilines from RESERVED then CALLBACK first (group order),
+// then single-line props
+<Hello ref={(el) => {
+  domRef.current = el;
+}} onChange={(e) => {
+  fn(e);
+}} key="1" disabled onClick={fn} name="John" />;
+
+```
+
+# Diagnostics
+```
+multiline-first.jsx:6:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     5 │ // Unsorted: single-line props before multiline onChange
+   > 6 │ <Hello disabled key="1" onClick={fn} name="John" onChange={(e) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 7 │   fn(e);
+   > 8 │ }} />;
+       │ ^^^^^
+     9 │ 
+    10 │ // Unsorted: single-line props interleaved with multilines from different groups
+  
+  i Safe fix: Sort the JSX props.
+  
+     4  4 │   
+     5  5 │   // Unsorted: single-line props before multiline onChange
+     6    │ - <Hello·disabled·key="1"·onClick={fn}·name="John"·onChange={(e)·=>·{
+     7    │ - ··fn(e);
+     8    │ - }}·/>;
+        6 │ + <Hello·onChange={(e)·=>·{
+        7 │ + ··fn(e);
+        8 │ + }}·key="1"·disabled·onClick={fn}·name="John"·/>;
+     9  9 │   
+    10 10 │   // Unsorted: single-line props interleaved with multilines from different groups
+  
+
+```
+
+```
+multiline-first.jsx:11:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Unsorted: single-line props interleaved with multilines from different groups
+  > 11 │ <Hello disabled key="1" onClick={fn} ref={(el) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 12 │   domRef.current = el;
+  > 13 │ }} name="John" onChange={(e) => {
+  > 14 │   fn(e);
+  > 15 │ }} />;
+       │ ^^^^^
+    16 │ 
+    17 │ // Correctly ordered: multiline onChange first, then single-line props by group order
+  
+  i Safe fix: Sort the JSX props.
+  
+     9  9 │   
+    10 10 │   // Unsorted: single-line props interleaved with multilines from different groups
+    11    │ - <Hello·disabled·key="1"·onClick={fn}·ref={(el)·=>·{
+    12    │ - ··domRef.current·=·el;
+    13    │ - }}·name="John"·onChange={(e)·=>·{
+    14    │ - ··fn(e);
+    15    │ - }}·/>;
+       11 │ + <Hello·ref={(el)·=>·{
+       12 │ + ··domRef.current·=·el;
+       13 │ + }}·onChange={(e)·=>·{
+       14 │ + ··fn(e);
+       15 │ + }}·key="1"·disabled·onClick={fn}·name="John"·/>;
+    16 16 │   
+    17 17 │   // Correctly ordered: multiline onChange first, then single-line props by group order
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-first.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-first.options.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"],
+						"multiline": "first"
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-formatted.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-formatted.jsx
@@ -1,0 +1,23 @@
+// sortScope: "group", groups: [:REST:, :CALLBACK:], multiline: "first"
+// Normally-formatted JSX (one prop per line). Only `data` has a multiline
+// VALUE; the other props are single-line even though each sits on its own
+// source line. `multiline: "first"` must pull only `data` to the front, not
+// treat every own-line prop as multiline.
+
+// Unsorted: multiline-value `data` should move before the single-line props
+<Hello
+  name="John"
+  data={{
+    a: 1,
+  }}
+  onClick={fn}
+/>;
+
+// Correctly ordered: multiline `data` first, then REST (name), then CALLBACK (onClick)
+<Hello
+  data={{
+    a: 1,
+  }}
+  name="John"
+  onClick={fn}
+/>;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-formatted.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-formatted.jsx.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: multiline-formatted.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:REST:, :CALLBACK:], multiline: "first"
+// Normally-formatted JSX (one prop per line). Only `data` has a multiline
+// VALUE; the other props are single-line even though each sits on its own
+// source line. `multiline: "first"` must pull only `data` to the front, not
+// treat every own-line prop as multiline.
+
+// Unsorted: multiline-value `data` should move before the single-line props
+<Hello
+  name="John"
+  data={{
+    a: 1,
+  }}
+  onClick={fn}
+/>;
+
+// Correctly ordered: multiline `data` first, then REST (name), then CALLBACK (onClick)
+<Hello
+  data={{
+    a: 1,
+  }}
+  name="John"
+  onClick={fn}
+/>;
+
+```
+
+# Diagnostics
+```
+multiline-formatted.jsx:8:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     7 │ // Unsorted: multiline-value `data` should move before the single-line props
+   > 8 │ <Hello
+       │ ^^^^^^
+   > 9 │   name="John"
+        ...
+  > 13 │   onClick={fn}
+  > 14 │ />;
+       │ ^^
+    15 │ 
+    16 │ // Correctly ordered: multiline `data` first, then REST (name), then CALLBACK (onClick)
+  
+  i Safe fix: Sort the JSX props.
+  
+     7  7 │   // Unsorted: multiline-value `data` should move before the single-line props
+     8  8 │   <Hello
+     9    │ - ··name="John"
+    10    │ - ··data={{
+    11    │ - ····a:·1,
+    12    │ - ··}}
+        9 │ + ··data={{
+       10 │ + ····a:·1,
+       11 │ + ··}}
+       12 │ + ··name="John"
+    13 13 │     onClick={fn}
+    14 14 │   />;
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-formatted.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-formatted.options.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":REST:", ":CALLBACK:"],
+						"multiline": "first"
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-first.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-first.jsx
@@ -1,0 +1,31 @@
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "groupFirst"
+// Within each group, multiline-value props are sub-grouped before single-line-value props.
+
+// Unsorted: single-line onClick before multiline onChange in CALLBACK group,
+// and key/disabled out of group order
+<Hello onClick={fn} onChange={(event) => {
+  handleChange(event);
+}} key="1" disabled name="John" />;
+
+// Unsorted: single-line key before multiline ref in RESERVED group
+<Hello key="1" ref={(el) => {
+  domRef.current = el;
+}} onClick={fn} name="John" />;
+
+// Both callback props have multiline values: sorted alphabetically (onChange < onClick)
+<Hello onClick={(e) => {
+  fn1(e);
+}} onChange={(e) => {
+  fn2(e);
+}} key="1" name="John" />;
+
+// Correctly ordered: RESERVED [multiline ref, single-line key],
+// CALLBACK [multiline onChange, single-line onClick], REST [name]
+<Hello ref={(el) => {
+  domRef.current = el;
+}} key="1" onChange={(event) => {
+  handleChange(event);
+}} onClick={fn} name="John" />;
+
+// Correctly ordered: no multiline-value props — groupFirst has no effect
+<Hello key="1" disabled onClick={fn} name="John" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-first.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-first.jsx.snap
@@ -1,0 +1,136 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: multiline-group-first.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "groupFirst"
+// Within each group, multiline-value props are sub-grouped before single-line-value props.
+
+// Unsorted: single-line onClick before multiline onChange in CALLBACK group,
+// and key/disabled out of group order
+<Hello onClick={fn} onChange={(event) => {
+  handleChange(event);
+}} key="1" disabled name="John" />;
+
+// Unsorted: single-line key before multiline ref in RESERVED group
+<Hello key="1" ref={(el) => {
+  domRef.current = el;
+}} onClick={fn} name="John" />;
+
+// Both callback props have multiline values: sorted alphabetically (onChange < onClick)
+<Hello onClick={(e) => {
+  fn1(e);
+}} onChange={(e) => {
+  fn2(e);
+}} key="1" name="John" />;
+
+// Correctly ordered: RESERVED [multiline ref, single-line key],
+// CALLBACK [multiline onChange, single-line onClick], REST [name]
+<Hello ref={(el) => {
+  domRef.current = el;
+}} key="1" onChange={(event) => {
+  handleChange(event);
+}} onClick={fn} name="John" />;
+
+// Correctly ordered: no multiline-value props — groupFirst has no effect
+<Hello key="1" disabled onClick={fn} name="John" />;
+
+```
+
+# Diagnostics
+```
+multiline-group-first.jsx:6:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     4 │ // Unsorted: single-line onClick before multiline onChange in CALLBACK group,
+     5 │ // and key/disabled out of group order
+   > 6 │ <Hello onClick={fn} onChange={(event) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 7 │   handleChange(event);
+   > 8 │ }} key="1" disabled name="John" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Unsorted: single-line key before multiline ref in RESERVED group
+  
+  i Safe fix: Sort the JSX props.
+  
+     4  4 │   // Unsorted: single-line onClick before multiline onChange in CALLBACK group,
+     5  5 │   // and key/disabled out of group order
+     6    │ - <Hello·onClick={fn}·onChange={(event)·=>·{
+     7    │ - ··handleChange(event);
+     8    │ - }}·key="1"·disabled·name="John"·/>;
+        6 │ + <Hello·key="1"·disabled·onChange={(event)·=>·{
+        7 │ + ··handleChange(event);
+        8 │ + }}·onClick={fn}·name="John"·/>;
+     9  9 │   
+    10 10 │   // Unsorted: single-line key before multiline ref in RESERVED group
+  
+
+```
+
+```
+multiline-group-first.jsx:11:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Unsorted: single-line key before multiline ref in RESERVED group
+  > 11 │ <Hello key="1" ref={(el) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 12 │   domRef.current = el;
+  > 13 │ }} onClick={fn} name="John" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+    15 │ // Both callback props have multiline values: sorted alphabetically (onChange < onClick)
+  
+  i Safe fix: Sort the JSX props.
+  
+     9  9 │   
+    10 10 │   // Unsorted: single-line key before multiline ref in RESERVED group
+    11    │ - <Hello·key="1"·ref={(el)·=>·{
+    12    │ - ··domRef.current·=·el;
+    13    │ - }}·onClick={fn}·name="John"·/>;
+       11 │ + <Hello·ref={(el)·=>·{
+       12 │ + ··domRef.current·=·el;
+       13 │ + }}·key="1"·onClick={fn}·name="John"·/>;
+    14 14 │   
+    15 15 │   // Both callback props have multiline values: sorted alphabetically (onChange < onClick)
+  
+
+```
+
+```
+multiline-group-first.jsx:16:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    15 │ // Both callback props have multiline values: sorted alphabetically (onChange < onClick)
+  > 16 │ <Hello onClick={(e) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^
+  > 17 │   fn1(e);
+  > 18 │ }} onChange={(e) => {
+  > 19 │   fn2(e);
+  > 20 │ }} key="1" name="John" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
+    22 │ // Correctly ordered: RESERVED [multiline ref, single-line key],
+  
+  i Safe fix: Sort the JSX props.
+  
+    14 14 │   
+    15 15 │   // Both callback props have multiline values: sorted alphabetically (onChange < onClick)
+    16    │ - <Hello·onClick={(e)·=>·{
+    17    │ - ··fn1(e);
+    18    │ - }}·onChange={(e)·=>·{
+       16 │ + <Hello·key="1"·onChange={(e)·=>·{
+    19 17 │     fn2(e);
+    20    │ - }}·key="1"·name="John"·/>;
+       18 │ + }}·onClick={(e)·=>·{
+       19 │ + ··fn1(e);
+       20 │ + }}·name="John"·/>;
+    21 21 │   
+    22 22 │   // Correctly ordered: RESERVED [multiline ref, single-line key],
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-first.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-first.options.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"],
+						"multiline": "groupFirst"
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-last.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-last.jsx
@@ -1,0 +1,28 @@
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "groupLast"
+// Within each group, single-line-value props come before multiline-value props.
+
+// Unsorted: multiline ref before single-line key in RESERVED group,
+// multiline onChange before single-line onClick in CALLBACK group
+<Hello ref={(el) => {
+  domRef.current = el;
+}} key="1" onChange={(e) => {
+  handleChange(e);
+}} onClick={fn} name="John" />;
+
+// Unsorted: group order wrong (callback before reserved) and multiline order wrong
+<Hello onChange={(e) => {
+  handleChange(e);
+}} onClick={fn} ref={(el) => {
+  domRef.current = el;
+}} key="1" name="John" />;
+
+// Correctly ordered: RESERVED [single-line key, multiline ref],
+// CALLBACK [single-line onClick, multiline onChange], REST [name]
+<Hello key="1" ref={(el) => {
+  domRef.current = el;
+}} onClick={fn} onChange={(e) => {
+  handleChange(e);
+}} name="John" />;
+
+// Correctly ordered: no multiline-value props — groupLast has no effect
+<Hello key="1" disabled onClick={fn} name="John" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-last.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-last.jsx.snap
@@ -1,0 +1,110 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: multiline-group-last.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "groupLast"
+// Within each group, single-line-value props come before multiline-value props.
+
+// Unsorted: multiline ref before single-line key in RESERVED group,
+// multiline onChange before single-line onClick in CALLBACK group
+<Hello ref={(el) => {
+  domRef.current = el;
+}} key="1" onChange={(e) => {
+  handleChange(e);
+}} onClick={fn} name="John" />;
+
+// Unsorted: group order wrong (callback before reserved) and multiline order wrong
+<Hello onChange={(e) => {
+  handleChange(e);
+}} onClick={fn} ref={(el) => {
+  domRef.current = el;
+}} key="1" name="John" />;
+
+// Correctly ordered: RESERVED [single-line key, multiline ref],
+// CALLBACK [single-line onClick, multiline onChange], REST [name]
+<Hello key="1" ref={(el) => {
+  domRef.current = el;
+}} onClick={fn} onChange={(e) => {
+  handleChange(e);
+}} name="John" />;
+
+// Correctly ordered: no multiline-value props — groupLast has no effect
+<Hello key="1" disabled onClick={fn} name="John" />;
+
+```
+
+# Diagnostics
+```
+multiline-group-last.jsx:6:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     4 │ // Unsorted: multiline ref before single-line key in RESERVED group,
+     5 │ // multiline onChange before single-line onClick in CALLBACK group
+   > 6 │ <Hello ref={(el) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^
+   > 7 │   domRef.current = el;
+   > 8 │ }} key="1" onChange={(e) => {
+   > 9 │   handleChange(e);
+  > 10 │ }} onClick={fn} name="John" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 
+    12 │ // Unsorted: group order wrong (callback before reserved) and multiline order wrong
+  
+  i Safe fix: Sort the JSX props.
+  
+     4  4 │   // Unsorted: multiline ref before single-line key in RESERVED group,
+     5  5 │   // multiline onChange before single-line onClick in CALLBACK group
+     6    │ - <Hello·ref={(el)·=>·{
+     7    │ - ··domRef.current·=·el;
+     8    │ - }}·key="1"·onChange={(e)·=>·{
+     9    │ - ··handleChange(e);
+    10    │ - }}·onClick={fn}·name="John"·/>;
+        6 │ + <Hello·key="1"·ref={(el)·=>·{
+        7 │ + ··domRef.current·=·el;
+        8 │ + }}·onClick={fn}·onChange={(e)·=>·{
+        9 │ + ··handleChange(e);
+       10 │ + }}·name="John"·/>;
+    11 11 │   
+    12 12 │   // Unsorted: group order wrong (callback before reserved) and multiline order wrong
+  
+
+```
+
+```
+multiline-group-last.jsx:13:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    12 │ // Unsorted: group order wrong (callback before reserved) and multiline order wrong
+  > 13 │ <Hello onChange={(e) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 14 │   handleChange(e);
+  > 15 │ }} onClick={fn} ref={(el) => {
+  > 16 │   domRef.current = el;
+  > 17 │ }} key="1" name="John" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    18 │ 
+    19 │ // Correctly ordered: RESERVED [single-line key, multiline ref],
+  
+  i Safe fix: Sort the JSX props.
+  
+    11 11 │   
+    12 12 │   // Unsorted: group order wrong (callback before reserved) and multiline order wrong
+    13    │ - <Hello·onChange={(e)·=>·{
+    14    │ - ··handleChange(e);
+    15    │ - }}·onClick={fn}·ref={(el)·=>·{
+    16    │ - ··domRef.current·=·el;
+    17    │ - }}·key="1"·name="John"·/>;
+       13 │ + <Hello·key="1"·ref={(el)·=>·{
+       14 │ + ··domRef.current·=·el;
+       15 │ + }}·onClick={fn}·onChange={(e)·=>·{
+       16 │ + ··handleChange(e);
+       17 │ + }}·name="John"·/>;
+    18 18 │   
+    19 19 │   // Correctly ordered: RESERVED [single-line key, multiline ref],
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-last.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group-last.options.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"],
+						"multiline": "groupLast"
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group.jsx
@@ -1,0 +1,17 @@
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "group"
+// Multiline-value props sort alphabetically within their group — no special positioning.
+
+// Unsorted within CALLBACK: onClick before onChange (onChange has multiline value but still sorts first)
+<Hello key="1" disabled onClick={fn} onChange={(e) => {
+  fn(e);
+}} />;
+
+// Unsorted group order and within group
+<Hello onClick={fn} onChange={(e) => {
+  fn(e);
+}} disabled key="1" />;
+
+// Correctly ordered: RESERVED, IMPLICIT, CALLBACK — onChange sorts before onClick alphabetically
+<Hello key="1" disabled onChange={(e) => {
+  fn(e);
+}} onClick={fn} />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group.jsx.snap
@@ -1,0 +1,86 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: multiline-group.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "group"
+// Multiline-value props sort alphabetically within their group — no special positioning.
+
+// Unsorted within CALLBACK: onClick before onChange (onChange has multiline value but still sorts first)
+<Hello key="1" disabled onClick={fn} onChange={(e) => {
+  fn(e);
+}} />;
+
+// Unsorted group order and within group
+<Hello onClick={fn} onChange={(e) => {
+  fn(e);
+}} disabled key="1" />;
+
+// Correctly ordered: RESERVED, IMPLICIT, CALLBACK — onChange sorts before onClick alphabetically
+<Hello key="1" disabled onChange={(e) => {
+  fn(e);
+}} onClick={fn} />;
+
+```
+
+# Diagnostics
+```
+multiline-group.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    4 │ // Unsorted within CALLBACK: onClick before onChange (onChange has multiline value but still sorts first)
+  > 5 │ <Hello key="1" disabled onClick={fn} onChange={(e) => {
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 6 │   fn(e);
+  > 7 │ }} />;
+      │ ^^^^^
+    8 │ 
+    9 │ // Unsorted group order and within group
+  
+  i Safe fix: Sort the JSX props.
+  
+     3  3 │   
+     4  4 │   // Unsorted within CALLBACK: onClick before onChange (onChange has multiline value but still sorts first)
+     5    │ - <Hello·key="1"·disabled·onClick={fn}·onChange={(e)·=>·{
+     6    │ - ··fn(e);
+     7    │ - }}·/>;
+        5 │ + <Hello·key="1"·disabled·onChange={(e)·=>·{
+        6 │ + ··fn(e);
+        7 │ + }}·onClick={fn}·/>;
+     8  8 │   
+     9  9 │   // Unsorted group order and within group
+  
+
+```
+
+```
+multiline-group.jsx:10:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     9 │ // Unsorted group order and within group
+  > 10 │ <Hello onClick={fn} onChange={(e) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 11 │   fn(e);
+  > 12 │ }} disabled key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    13 │ 
+    14 │ // Correctly ordered: RESERVED, IMPLICIT, CALLBACK — onChange sorts before onClick alphabetically
+  
+  i Safe fix: Sort the JSX props.
+  
+     8  8 │   
+     9  9 │   // Unsorted group order and within group
+    10    │ - <Hello·onClick={fn}·onChange={(e)·=>·{
+    11    │ - ··fn(e);
+    12    │ - }}·disabled·key="1"·/>;
+       10 │ + <Hello·key="1"·disabled·onChange={(e)·=>·{
+       11 │ + ··fn(e);
+       12 │ + }}·onClick={fn}·/>;
+    13 13 │   
+    14 14 │   // Correctly ordered: RESERVED, IMPLICIT, CALLBACK — onChange sorts before onClick alphabetically
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-group.options.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"],
+						"multiline": "group"
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-last.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-last.jsx
@@ -1,0 +1,24 @@
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "last"
+// Single-line props come before multiline-value props (sorted by groups within each part).
+// Note: is_multiline_prop checks text_with_trivia(), so a prop on its own line in a
+// multiline JSX element is also "multiline". Use inline JSX to isolate multiline values.
+
+// Unsorted: multiline-value style before single-line name
+<Hello style={{
+  color: "red",
+}} name="John" />;
+
+// Unsorted: multiline-value callback before single-line callback and REST prop
+<Hello onClick={
+  () => doSomething()
+} name="John" onChange={fn} />;
+
+// Correctly ordered: single-line REST first, then multiline-value REST
+<Hello name="John" style={{
+  color: "red",
+}} />;
+
+// Correctly ordered: single-line CALLBACK then REST, then multiline-value CALLBACK
+<Hello onChange={fn} name="John" onClick={
+  () => doSomething()
+} />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-last.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-last.jsx.snap
@@ -1,0 +1,93 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: multiline-last.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "last"
+// Single-line props come before multiline-value props (sorted by groups within each part).
+// Note: is_multiline_prop checks text_with_trivia(), so a prop on its own line in a
+// multiline JSX element is also "multiline". Use inline JSX to isolate multiline values.
+
+// Unsorted: multiline-value style before single-line name
+<Hello style={{
+  color: "red",
+}} name="John" />;
+
+// Unsorted: multiline-value callback before single-line callback and REST prop
+<Hello onClick={
+  () => doSomething()
+} name="John" onChange={fn} />;
+
+// Correctly ordered: single-line REST first, then multiline-value REST
+<Hello name="John" style={{
+  color: "red",
+}} />;
+
+// Correctly ordered: single-line CALLBACK then REST, then multiline-value CALLBACK
+<Hello onChange={fn} name="John" onClick={
+  () => doSomething()
+} />;
+
+```
+
+# Diagnostics
+```
+multiline-last.jsx:7:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     6 │ // Unsorted: multiline-value style before single-line name
+   > 7 │ <Hello style={{
+       │ ^^^^^^^^^^^^^^^
+   > 8 │   color: "red",
+   > 9 │ }} name="John" />;
+       │ ^^^^^^^^^^^^^^^^^
+    10 │ 
+    11 │ // Unsorted: multiline-value callback before single-line callback and REST prop
+  
+  i Safe fix: Sort the JSX props.
+  
+     5  5 │   
+     6  6 │   // Unsorted: multiline-value style before single-line name
+     7    │ - <Hello·style={{
+     8    │ - ··color:·"red",
+     9    │ - }}·name="John"·/>;
+        7 │ + <Hello·name="John"·style={{
+        8 │ + ··color:·"red",
+        9 │ + }}·/>;
+    10 10 │   
+    11 11 │   // Unsorted: multiline-value callback before single-line callback and REST prop
+  
+
+```
+
+```
+multiline-last.jsx:12:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    11 │ // Unsorted: multiline-value callback before single-line callback and REST prop
+  > 12 │ <Hello onClick={
+       │ ^^^^^^^^^^^^^^^^
+  > 13 │   () => doSomething()
+  > 14 │ } name="John" onChange={fn} />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ 
+    16 │ // Correctly ordered: single-line REST first, then multiline-value REST
+  
+  i Safe fix: Sort the JSX props.
+  
+    10 10 │   
+    11 11 │   // Unsorted: multiline-value callback before single-line callback and REST prop
+    12    │ - <Hello·onClick={
+    13    │ - ··()·=>·doSomething()
+    14    │ - }·name="John"·onChange={fn}·/>;
+       12 │ + <Hello·onChange={fn}·name="John"·onClick={
+       13 │ + ··()·=>·doSomething()
+       14 │ + }·/>;
+    15 15 │   
+    16 16 │   // Correctly ordered: single-line REST first, then multiline-value REST
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-last.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-last.options.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"],
+						"multiline": "last"
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-spread.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-spread.jsx
@@ -1,0 +1,19 @@
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "group" (default)
+// Spread fences apply independently: each segment is sorted by group order.
+
+// Unsorted segment before spread: CALLBACK before RESERVED and IMPLICIT
+<Hello onChange={(e) => {
+  fn(e);
+}} disabled key="1" {...rest} name="John" />;
+
+// Both segments unsorted
+<Hello onChange={(e) => {
+  fn(e);
+}} disabled {...rest} onBlur={(e) => {
+  fn(e);
+}} key="1" />;
+
+// Correctly sorted: RESERVED, IMPLICIT, CALLBACK in each segment
+<Hello key="1" disabled onChange={(e) => {
+  fn(e);
+}} {...rest} name="John" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-spread.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-spread.jsx.snap
@@ -1,0 +1,122 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: multiline-spread.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:], multiline: "group" (default)
+// Spread fences apply independently: each segment is sorted by group order.
+
+// Unsorted segment before spread: CALLBACK before RESERVED and IMPLICIT
+<Hello onChange={(e) => {
+  fn(e);
+}} disabled key="1" {...rest} name="John" />;
+
+// Both segments unsorted
+<Hello onChange={(e) => {
+  fn(e);
+}} disabled {...rest} onBlur={(e) => {
+  fn(e);
+}} key="1" />;
+
+// Correctly sorted: RESERVED, IMPLICIT, CALLBACK in each segment
+<Hello key="1" disabled onChange={(e) => {
+  fn(e);
+}} {...rest} name="John" />;
+
+```
+
+# Diagnostics
+```
+multiline-spread.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    4 │ // Unsorted segment before spread: CALLBACK before RESERVED and IMPLICIT
+  > 5 │ <Hello onChange={(e) => {
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 6 │   fn(e);
+  > 7 │ }} disabled key="1" {...rest} name="John" />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ // Both segments unsorted
+  
+  i Safe fix: Sort the JSX props.
+  
+     3  3 │   
+     4  4 │   // Unsorted segment before spread: CALLBACK before RESERVED and IMPLICIT
+     5    │ - <Hello·onChange={(e)·=>·{
+     6    │ - ··fn(e);
+     7    │ - }}·disabled·key="1"·{...rest}·name="John"·/>;
+        5 │ + <Hello·key="1"·disabled·onChange={(e)·=>·{
+        6 │ + ··fn(e);
+        7 │ + }}·{...rest}·name="John"·/>;
+     8  8 │   
+     9  9 │   // Both segments unsorted
+  
+
+```
+
+```
+multiline-spread.jsx:10:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     9 │ // Both segments unsorted
+  > 10 │ <Hello onChange={(e) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 11 │   fn(e);
+  > 12 │ }} disabled {...rest} onBlur={(e) => {
+  > 13 │   fn(e);
+  > 14 │ }} key="1" />;
+       │ ^^^^^^^^^^^^^
+    15 │ 
+    16 │ // Correctly sorted: RESERVED, IMPLICIT, CALLBACK in each segment
+  
+  i Safe fix: Sort the JSX props.
+  
+     8  8 │   
+     9  9 │   // Both segments unsorted
+    10    │ - <Hello·onChange={(e)·=>·{
+    11    │ - ··fn(e);
+    12    │ - }}·disabled·{...rest}·onBlur={(e)·=>·{
+       10 │ + <Hello·disabled·onChange={(e)·=>·{
+       11 │ + ··fn(e);
+       12 │ + }}·{...rest}·onBlur={(e)·=>·{
+    13 13 │     fn(e);
+    14 14 │   }} key="1" />;
+  
+
+```
+
+```
+multiline-spread.jsx:10:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     9 │ // Both segments unsorted
+  > 10 │ <Hello onChange={(e) => {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 11 │   fn(e);
+  > 12 │ }} disabled {...rest} onBlur={(e) => {
+  > 13 │   fn(e);
+  > 14 │ }} key="1" />;
+       │ ^^^^^^^^^^^^^
+    15 │ 
+    16 │ // Correctly sorted: RESERVED, IMPLICIT, CALLBACK in each segment
+  
+  i Safe fix: Sort the JSX props.
+  
+    10 10 │   <Hello onChange={(e) => {
+    11 11 │     fn(e);
+    12    │ - }}·disabled·{...rest}·onBlur={(e)·=>·{
+    13    │ - ··fn(e);
+    14    │ - }}·key="1"·/>;
+       12 │ + }}·disabled·{...rest}·key="1"·onBlur={(e)·=>·{
+       13 │ + ··fn(e);
+       14 │ + }}·/>;
+    15 15 │   
+    16 16 │   // Correctly sorted: RESERVED, IMPLICIT, CALLBACK in each segment
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-spread.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/multiline-spread.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_rule_options/src/use_sorted_attributes.rs
+++ b/crates/biome_rule_options/src/use_sorted_attributes.rs
@@ -1,11 +1,326 @@
 pub use crate::shared::sort_order::SortOrder;
+use biome_deserialize::{Deserializable, DeserializationContext, Text};
 use biome_deserialize_macros::{Deserializable, Merge};
+use biome_js_syntax::JsxAttribute;
+use biome_rowan::AstNode;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct UseSortedAttributesOptions {
+    /// Sort order to apply within each group (or globally when `sortScope` is `"global"`).
     #[serde(skip_serializing_if = "Option::<_>::is_none")]
     pub sort_order: Option<SortOrder>,
+
+    /// Groups control the ordering of special prop categories.
+    ///
+    /// Only active when `sortScope` is `"group"`.
+    /// When not configured, the default ordering is used:
+    /// `[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]`.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub groups: Option<AttributeGroups>,
+
+    /// Whether to ignore case when comparing prop names.
+    ///
+    /// When `sortScope` is `"global"`, applied to the flat sort.
+    /// When `sortScope` is `"group"`, applied independently within each group.
+    ///
+    /// Defaults to `false` (case-sensitive, preserving current behavior).
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub ignore_case: Option<bool>,
+
+    /// Controls how `sortOrder` and `ignoreCase` interact with `groups`.
+    ///
+    /// - `"global"` (default): flat sort across all props, groups ignored.
+    /// - `"group"`: sort within each group independently, then order by group.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub sort_scope: Option<SortScope>,
+
+    /// Controls how multiline props are ordered relative to single-line props.
+    ///
+    /// Only meaningful when `sortScope` is `"group"`. Defaults to `"group"` (mixed).
+    ///
+    /// - `"group"`: multiline props are sorted together with single-line props in their group.
+    /// - `"groupFirst"`: within each group, multiline props are placed before single-line props.
+    /// - `"groupLast"`: within each group, multiline props are placed after single-line props.
+    /// - `"first"`: all multiline props are collected across all groups, sorted by group order,
+    ///   and placed before all single-line groups.
+    /// - `"last"`: all multiline props are collected across all groups, sorted by group order,
+    ///   and placed after all single-line groups.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub multiline: Option<MultilineOrder>,
+}
+
+/// Controls how `sortOrder` and `ignoreCase` interact with `groups`.
+///
+/// - `global`: `sortOrder` and `ignoreCase` are applied over all props at once,
+///   ignoring the `groups` order. This preserves the original flat-sort behavior.
+/// - `group`: `sortOrder` and `ignoreCase` are applied independently within each
+///   group defined by `groups`. Props are first partitioned by group, sorted
+///   within each group, then concatenated in group order.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    serde::Deserialize,
+    serde::Serialize,
+    biome_deserialize_macros::Deserializable,
+    biome_deserialize_macros::Merge,
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub enum SortScope {
+    /// Apply `sortOrder` and `ignoreCase` globally across all props (default).
+    /// Group order is ignored; sorting is flat. Preserves existing behavior.
+    #[default]
+    Global,
+    /// Apply `sortOrder` and `ignoreCase` within each group independently.
+    /// Props are partitioned into groups, sorted within each group, then
+    /// concatenated in group-index order.
+    Group,
+}
+
+/// Controls where multiline props land relative to single-line props.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    serde::Deserialize,
+    serde::Serialize,
+    biome_deserialize_macros::Deserializable,
+    biome_deserialize_macros::Merge,
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub enum MultilineOrder {
+    /// Multiline props are mixed with single-line props in their group (default).
+    #[default]
+    Group,
+    /// Within each group, multiline props are sorted before single-line props.
+    GroupFirst,
+    /// Within each group, multiline props are sorted after single-line props.
+    GroupLast,
+    /// All multiline props are collected, sorted by group order, and placed before all non-multiline groups.
+    First,
+    /// All multiline props are collected, sorted by group order, and placed after all non-multiline groups.
+    Last,
+}
+
+/// The set of attribute groups for `useSortedAttributes`.
+///
+/// Groups control the position of special prop categories relative to each other
+/// when `sortScope` is set to `"group"`.
+///
+/// ## Predefined groups
+///
+/// - `:CALLBACK:` — Callback props: names beginning with `on` followed by an uppercase letter (e.g. `onClick`, `onChange`).
+/// - `:IMPLICIT:` — Implicit (boolean shorthand) props: props with no value (e.g. `<Foo disabled />`).
+/// - `:RESERVED:` — React reserved props: `key` and `ref`.
+/// - `:DOM_RESERVED:` — DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.
+/// - `:REST:` — Catch-all for props that don't match any other configured group.
+///   Sorted like a regular group, using `sortOrder` and `ignoreCase`.
+///
+/// ## Default ordering
+///
+/// When `groups` is not configured, the following default ordering is used
+/// (only active when `sortScope` is `"group"`):
+///
+/// ```json
+/// [":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]
+/// ```
+///
+/// If `:REST:` is omitted from a configured `groups` list, props that don't
+/// match any named group are instead placed after all named groups, in their
+/// original relative order (unsorted).
+///
+/// Multiline prop positioning is controlled separately via the `multiline` option.
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AttributeGroups(Box<[AttributeGroupPattern]>);
+
+impl Deserializable for AttributeGroups {
+    fn deserialize(
+        ctx: &mut impl DeserializationContext,
+        value: &impl biome_deserialize::DeserializableValue,
+        name: &str,
+    ) -> Option<Self> {
+        Deserializable::deserialize(ctx, value, name).map(Self)
+    }
+}
+
+impl AttributeGroups {
+    /// Returns `true` if no explicit group is configured.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the number of explicitly configured groups.
+    ///
+    /// This is also the index of the implicit "rest" bucket used for props
+    /// that don't match any named group.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns the group index for the given attribute.
+    ///
+    /// Returns the index of the first explicitly matching group. If no group
+    /// matches, returns the index of the configured `:REST:` group, if any.
+    /// Otherwise, returns `self.0.len()` (the implicit unsorted "rest"
+    /// bucket appended after all named groups).
+    pub fn group_index(&self, attr: &JsxAttribute) -> usize {
+        if let Some(pos) = self.0.iter().position(|group| group.is_match(attr)) {
+            return pos;
+        }
+        self.0
+            .iter()
+            .position(|group| matches!(group, AttributeGroupPattern::Rest))
+            .unwrap_or(self.0.len())
+    }
+}
+
+impl biome_deserialize::Merge for AttributeGroups {
+    fn merge_with(&mut self, other: Self) {
+        *self = other;
+    }
+}
+
+/// The default group ordering used when `sortScope` is `"group"` but no
+/// explicit `groups` configuration is provided.
+pub fn default_attribute_groups() -> AttributeGroups {
+    AttributeGroups(Box::new([
+        AttributeGroupPattern::Implicit,
+        AttributeGroupPattern::Reserved,
+        AttributeGroupPattern::DomReserved,
+        AttributeGroupPattern::Rest,
+        AttributeGroupPattern::Callback,
+    ]))
+}
+
+/// A predefined attribute group pattern.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum AttributeGroupPattern {
+    /// Callback props: names beginning with `on` followed by an uppercase letter.
+    #[serde(rename = ":CALLBACK:")]
+    Callback,
+    /// Implicit (boolean shorthand) props: props with no value.
+    #[serde(rename = ":IMPLICIT:")]
+    Implicit,
+    /// React reserved props: `key` and `ref`.
+    #[serde(rename = ":RESERVED:")]
+    Reserved,
+    /// DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.
+    #[serde(rename = ":DOM_RESERVED:")]
+    DomReserved,
+    /// Catch-all for props that don't match any other configured group.
+    ///
+    /// Unlike the other patterns, this never matches directly through
+    /// [`Self::is_match`]: its position is resolved separately by
+    /// [`AttributeGroups::group_index`] as a fallback for unmatched props.
+    #[serde(rename = ":REST:")]
+    Rest,
+}
+
+impl AttributeGroupPattern {
+    pub fn is_match(&self, attr: &JsxAttribute) -> bool {
+        match self {
+            Self::Callback => is_callback_prop(attr),
+            Self::Implicit => is_implicit_prop(attr),
+            Self::Reserved => is_reserved_prop(attr),
+            Self::DomReserved => is_dom_reserved_prop(attr),
+            // Resolved separately in `AttributeGroups::group_index`.
+            Self::Rest => false,
+        }
+    }
+}
+
+impl Deserializable for AttributeGroupPattern {
+    fn deserialize(
+        ctx: &mut impl DeserializationContext,
+        value: &impl biome_deserialize::DeserializableValue,
+        name: &str,
+    ) -> Option<Self> {
+        let text = Text::deserialize(ctx, value, name)?;
+        match text.text() {
+            ":CALLBACK:" => Some(Self::Callback),
+            ":IMPLICIT:" => Some(Self::Implicit),
+            ":RESERVED:" => Some(Self::Reserved),
+            ":DOM_RESERVED:" => Some(Self::DomReserved),
+            ":REST:" => Some(Self::Rest),
+            _ => {
+                // TODO: emit a proper deserialization diagnostic once the API stabilizes
+                None
+            }
+        }
+    }
+}
+
+impl biome_deserialize::Merge for AttributeGroupPattern {
+    fn merge_with(&mut self, other: Self) {
+        *self = other;
+    }
+}
+
+// ── Prop classification helpers ──────────────────────────────────────────────
+
+/// Returns `true` if the prop is a callback: name starts with `on` followed
+/// by an uppercase ASCII letter (e.g. `onClick`, `onChange`).
+fn is_callback_prop(attr: &JsxAttribute) -> bool {
+    let Ok(name) = attr.name() else {
+        return false;
+    };
+    let Ok(name) = name.name() else {
+        return false;
+    };
+    let text = name.text_trimmed();
+    let bytes = text.as_bytes();
+    bytes.len() > 2 && bytes[0] == b'o' && bytes[1] == b'n' && bytes[2].is_ascii_uppercase()
+}
+
+/// Returns `true` if the prop is implicit (boolean shorthand): has no value.
+fn is_implicit_prop(attr: &JsxAttribute) -> bool {
+    attr.initializer().is_none()
+}
+
+/// Returns `true` if the prop itself spans multiple lines (i.e. its value
+/// contains a newline).
+///
+/// Uses `text_trimmed()` rather than `text_with_trivia()` so that leading and
+/// trailing formatting trivia is excluded: in normally-formatted JSX every prop
+/// sits on its own line and would otherwise be misclassified as multiline.
+pub fn is_multiline_prop(attr: &JsxAttribute) -> bool {
+    attr.syntax().text_trimmed().contains_char('\n')
+}
+
+const RESERVED_PROPS: [&str; 2] = ["key", "ref"];
+const DOM_RESERVED_PROPS: [&str; 2] = ["children", "dangerouslySetInnerHTML"];
+
+/// Returns `true` if the prop is a React reserved prop (`key` or `ref`).
+fn is_reserved_prop(attr: &JsxAttribute) -> bool {
+    prop_name_in(attr, &RESERVED_PROPS)
+}
+
+/// Returns `true` if the prop is a DOM-only reserved prop
+/// (`children` or `dangerouslySetInnerHTML`).
+fn is_dom_reserved_prop(attr: &JsxAttribute) -> bool {
+    prop_name_in(attr, &DOM_RESERVED_PROPS)
+}
+
+fn prop_name_in(attr: &JsxAttribute, list: &[&str]) -> bool {
+    let Ok(name) = attr.name() else {
+        return false;
+    };
+    let Ok(name) = name.name() else {
+        return false;
+    };
+    let text = name.text_trimmed();
+    list.contains(&text)
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -5615,7 +5615,48 @@ Default: `natural`.
 	sortBareImports?: boolean;
 }
 export interface UseSortedAttributesOptions {
+	/**
+	* Groups control the ordering of special prop categories.
+
+Only active when `sortScope` is `"group"`.
+When not configured, the default ordering is used:
+`[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]`. 
+	 */
+	groups?: AttributeGroups;
+	/**
+	* Whether to ignore case when comparing prop names.
+
+When `sortScope` is `"global"`, applied to the flat sort.
+When `sortScope` is `"group"`, applied independently within each group.
+
+Defaults to `false` (case-sensitive, preserving current behavior). 
+	 */
+	ignoreCase?: boolean;
+	/**
+	* Controls how multiline props are ordered relative to single-line props.
+
+Only meaningful when `sortScope` is `"group"`. Defaults to `"group"` (mixed).
+
+- `"group"`: multiline props are sorted together with single-line props in their group.
+- `"groupFirst"`: within each group, multiline props are placed before single-line props.
+- `"groupLast"`: within each group, multiline props are placed after single-line props.
+- `"first"`: all multiline props are collected across all groups, sorted by group order,
+  and placed before all single-line groups.
+- `"last"`: all multiline props are collected across all groups, sorted by group order,
+  and placed after all single-line groups. 
+	 */
+	multiline?: MultilineOrder;
+	/**
+	 * Sort order to apply within each group (or globally when `sortScope` is `"global"`).
+	 */
 	sortOrder?: SortOrder;
+	/**
+	* Controls how `sortOrder` and `ignoreCase` interact with `groups`.
+
+- `"global"` (default): flat sort across all props, groups ignored.
+- `"group"`: sort within each group independently, then order by group. 
+	 */
+	sortScope?: SortScope;
 }
 export type UseSortedEnumMembersOptions = {};
 export type UseSortedInterfaceMembersOptions = {};
@@ -7864,6 +7905,56 @@ export interface RuleWithUseStrictModeOptions {
 export type ImportGroups = ImportGroup[];
 export type SortOrder = "natural" | "lexicographic";
 /**
+	* The set of attribute groups for `useSortedAttributes`.
+
+Groups control the position of special prop categories relative to each other
+when `sortScope` is set to `"group"`.
+
+## Predefined groups
+
+- `:CALLBACK:` — Callback props: names beginning with `on` followed by an uppercase letter (e.g. `onClick`, `onChange`).
+- `:IMPLICIT:` — Implicit (boolean shorthand) props: props with no value (e.g. `<Foo disabled />`).
+- `:RESERVED:` — React reserved props: `key` and `ref`.
+- `:DOM_RESERVED:` — DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.
+- `:REST:` — Catch-all for props that don't match any other configured group.
+  Sorted like a regular group, using `sortOrder` and `ignoreCase`.
+
+## Default ordering
+
+When `groups` is not configured, the following default ordering is used
+(only active when `sortScope` is `"group"`):
+
+```json
+[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]
+```
+
+If `:REST:` is omitted from a configured `groups` list, props that don't
+match any named group are instead placed after all named groups, in their
+original relative order (unsorted).
+
+Multiline prop positioning is controlled separately via the `multiline` option. 
+	 */
+export type AttributeGroups = AttributeGroupPattern[];
+/**
+ * Controls where multiline props land relative to single-line props.
+ */
+export type MultilineOrder =
+	| "group"
+	| "groupFirst"
+	| "groupLast"
+	| "first"
+	| "last";
+/**
+	* Controls how `sortOrder` and `ignoreCase` interact with `groups`.
+
+- `global`: `sortOrder` and `ignoreCase` are applied over all props at once,
+  ignoring the `groups` order. This preserves the original flat-sort behavior.
+- `group`: `sortOrder` and `ignoreCase` are applied independently within each
+  group defined by `groups`. Props are first partitioned by group, sorted
+  within each group, then concatenated in group order. 
+	 */
+export type SortScope = "global" | "group";
+/**
  * Used to identify the kind of code action emitted by a rule
  */
 export type FixKind = "none" | "safe" | "unsafe";
@@ -9108,6 +9199,15 @@ export interface UseRequiredScriptsOptions {
 export type UseStaticResponseMethodsOptions = {};
 export type UseStrictModeOptions = {};
 export type ImportGroup = null | GroupMatcher | GroupMatcher[];
+/**
+ * A predefined attribute group pattern.
+ */
+export type AttributeGroupPattern =
+	| ":CALLBACK:"
+	| ":IMPLICIT:"
+	| ":RESERVED:"
+	| ":DOM_RESERVED:"
+	| ":REST:";
 export type Visibility = "public" | "package" | "private";
 /**
  * Elements to restrict. Each key is the element name, and the value is the message to show when the element is used.

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -404,6 +404,41 @@
 			},
 			"additionalProperties": false
 		},
+		"AttributeGroupPattern": {
+			"description": "A predefined attribute group pattern.",
+			"oneOf": [
+				{
+					"description": "Callback props: names beginning with `on` followed by an uppercase letter.",
+					"type": "string",
+					"const": ":CALLBACK:"
+				},
+				{
+					"description": "Implicit (boolean shorthand) props: props with no value.",
+					"type": "string",
+					"const": ":IMPLICIT:"
+				},
+				{
+					"description": "React reserved props: `key` and `ref`.",
+					"type": "string",
+					"const": ":RESERVED:"
+				},
+				{
+					"description": "DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.",
+					"type": "string",
+					"const": ":DOM_RESERVED:"
+				},
+				{
+					"description": "Catch-all for props that don't match any other configured group.\n\nUnlike the other patterns, this never matches directly through\n[`Self::is_match`]: its position is resolved separately by\n[`AttributeGroups::group_index`] as a fallback for unmatched props.",
+					"type": "string",
+					"const": ":REST:"
+				}
+			]
+		},
+		"AttributeGroups": {
+			"description": "The set of attribute groups for `useSortedAttributes`.\n\nGroups control the position of special prop categories relative to each other\nwhen `sortScope` is set to `\"group\"`.\n\n## Predefined groups\n\n- `:CALLBACK:` — Callback props: names beginning with `on` followed by an uppercase letter (e.g. `onClick`, `onChange`).\n- `:IMPLICIT:` — Implicit (boolean shorthand) props: props with no value (e.g. `<Foo disabled />`).\n- `:RESERVED:` — React reserved props: `key` and `ref`.\n- `:DOM_RESERVED:` — DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.\n- `:REST:` — Catch-all for props that don't match any other configured group.\n  Sorted like a regular group, using `sortOrder` and `ignoreCase`.\n\n## Default ordering\n\nWhen `groups` is not configured, the following default ordering is used\n(only active when `sortScope` is `\"group\"`):\n\n```json\n[\":IMPLICIT:\", \":RESERVED:\", \":DOM_RESERVED:\", \":REST:\", \":CALLBACK:\"]\n```\n\nIf `:REST:` is omitted from a configured `groups` list, props that don't\nmatch any named group are instead placed after all named groups, in their\noriginal relative order (unsorted).\n\nMultiline prop positioning is controlled separately via the `multiline` option.",
+			"type": "array",
+			"items": { "$ref": "#/$defs/AttributeGroupPattern" }
+		},
 		"AttributePosition": { "type": "string", "enum": ["auto", "multiline"] },
 		"AvailabilityNamed": {
 			"description": "Named Baseline availability tiers.",
@@ -2916,6 +2951,36 @@
 			"type": "array",
 			"items": { "$ref": "#/$defs/RestrictedModifier" },
 			"uniqueItems": true
+		},
+		"MultilineOrder": {
+			"description": "Controls where multiline props land relative to single-line props.",
+			"oneOf": [
+				{
+					"description": "Multiline props are mixed with single-line props in their group (default).",
+					"type": "string",
+					"const": "group"
+				},
+				{
+					"description": "Within each group, multiline props are sorted before single-line props.",
+					"type": "string",
+					"const": "groupFirst"
+				},
+				{
+					"description": "Within each group, multiline props are sorted after single-line props.",
+					"type": "string",
+					"const": "groupLast"
+				},
+				{
+					"description": "All multiline props are collected, sorted by group order, and placed before all non-multiline groups.",
+					"type": "string",
+					"const": "first"
+				},
+				{
+					"description": "All multiline props are collected, sorted by group order, and placed after all non-multiline groups.",
+					"type": "string",
+					"const": "last"
+				}
+			]
 		},
 		"NegatableImportKindMatcher": {
 			"type": "string",
@@ -12760,6 +12825,21 @@
 			]
 		},
 		"SortOrder": { "type": "string", "enum": ["natural", "lexicographic"] },
+		"SortScope": {
+			"description": "Controls how `sortOrder` and `ignoreCase` interact with `groups`.\n\n- `global`: `sortOrder` and `ignoreCase` are applied over all props at once,\n  ignoring the `groups` order. This preserves the original flat-sort behavior.\n- `group`: `sortOrder` and `ignoreCase` are applied independently within each\n  group defined by `groups`. Props are first partitioned by group, sorted\n  within each group, then concatenated in group order.",
+			"oneOf": [
+				{
+					"description": "Apply `sortOrder` and `ignoreCase` globally across all props (default).\nGroup order is ignored; sorting is flat. Preserves existing behavior.",
+					"type": "string",
+					"const": "global"
+				},
+				{
+					"description": "Apply `sortOrder` and `ignoreCase` within each group independently.\nProps are partitioned into groups, sorted within each group, then\nconcatenated in group-index order.",
+					"type": "string",
+					"const": "group"
+				}
+			]
+		},
 		"Source": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",
@@ -16161,8 +16241,25 @@
 		"UseSortedAttributesOptions": {
 			"type": "object",
 			"properties": {
+				"groups": {
+					"description": "Groups control the ordering of special prop categories.\n\nOnly active when `sortScope` is `\"group\"`.\nWhen not configured, the default ordering is used:\n`[\":IMPLICIT:\", \":RESERVED:\", \":DOM_RESERVED:\", \":REST:\", \":CALLBACK:\"]`.",
+					"anyOf": [{ "$ref": "#/$defs/AttributeGroups" }, { "type": "null" }]
+				},
+				"ignoreCase": {
+					"description": "Whether to ignore case when comparing prop names.\n\nWhen `sortScope` is `\"global\"`, applied to the flat sort.\nWhen `sortScope` is `\"group\"`, applied independently within each group.\n\nDefaults to `false` (case-sensitive, preserving current behavior).",
+					"type": ["boolean", "null"]
+				},
+				"multiline": {
+					"description": "Controls how multiline props are ordered relative to single-line props.\n\nOnly meaningful when `sortScope` is `\"group\"`. Defaults to `\"group\"` (mixed).\n\n- `\"group\"`: multiline props are sorted together with single-line props in their group.\n- `\"groupFirst\"`: within each group, multiline props are placed before single-line props.\n- `\"groupLast\"`: within each group, multiline props are placed after single-line props.\n- `\"first\"`: all multiline props are collected across all groups, sorted by group order,\n  and placed before all single-line groups.\n- `\"last\"`: all multiline props are collected across all groups, sorted by group order,\n  and placed after all single-line groups.",
+					"anyOf": [{ "$ref": "#/$defs/MultilineOrder" }, { "type": "null" }]
+				},
 				"sortOrder": {
+					"description": "Sort order to apply within each group (or globally when `sortScope` is `\"global\"`).",
 					"anyOf": [{ "$ref": "#/$defs/SortOrder" }, { "type": "null" }]
+				},
+				"sortScope": {
+					"description": "Controls how `sortOrder` and `ignoreCase` interact with `groups`.\n\n- `\"global\"` (default): flat sort across all props, groups ignored.\n- `\"group\"`: sort within each group independently, then order by group.",
+					"anyOf": [{ "$ref": "#/$defs/SortScope" }, { "type": "null" }]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary

Add more options to the `useSortedAttributes`, keeping the original behavior intact but allowing the user to customize even more this rule

- `sortScope`: By default is `global`, but now you can use `groups` where props are partitioned into smaller groups, sorted within each group, then concatenated in group order. Props not matching any named group (and not covered by a `:REST:` group) preserve their original relative order.
- `groups`: Accepts an ordered list of predefined group tokens (`:CALLBACK:`, `:IMPLICIT:`, `:RESERVED:`, `:DOM_RESERVED:`, `:REST:`) that control where special prop categories appear relative to each other. `:REST:` is a catch-all for props matching no other group and, unlike the implicit fallback used when it's omitted, is sorted like a regular group.
- `ignoreCase`: Makes prop name comparisons case-insensitive.
- `multiline`: Controls how props with multiline values are ordered relative to single-line props. Accepted values are: `"group"` (default, no special treatment), `"groupFirst"` and `"groupLast"` (multiline props first or last within each group), and `"first"` and `"last"` (all multiline props before or after all single-line props across groups).

## Test Plan

Created a bunch of different test/snapshots covering a lot of combinations for the new options added

## Docs

The documentation is inline as comments in the rust file.

---

This PR was written primarily with Claude Code. I'm not a rust developer but I did my best checking the output for the `use_sorted_attributes.rs`. I defined all the scenarios I wanted to cover and the AI created them but I reviewed one by one to ensure they are ok.