### PR TITLE
fix(lsp): shutdown the daemon on disconnect

### DIFF
--- a/.changeset/shy-laws-post.md
+++ b/.changeset/shy-laws-post.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed a bug where the Biome Daemon didn't correctly shutdown when closing the editor, the daemon was in the middle of an operation. This bug was more evident for operations such as scanning.
+Fixed a bug where the Biome Daemon did not correctly shut down when the editor was closed during an in-progress operation, especially while scanning.

--- a/.changeset/shy-laws-post.md
+++ b/.changeset/shy-laws-post.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where the Biome Daemon didn't correctly shutdown when closing the editor, the daemon was in the middle of an operation. This bug was more evident for operations such as scanning.

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -390,6 +390,9 @@ impl LanguageServer for LSPServer {
     }
 
     async fn shutdown(&self) -> LspResult<()> {
+        if self.stop_on_disconnect {
+            self.session.broadcast_shutdown();
+        }
         Ok(())
     }
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Bug that I found while exploring https://github.com/biomejs/biome/issues/10658 (it doesn't close the issue, but I think that the issue isn't a bug).

The bug was that when Biome is in the middle of an operation, the shutdown signal wasn't properly fired, and the operation wasn't cancelled. The bug is more evident when using Biome from the home directory, and the scanner starts crawling all folders. Closing the editor would trigger the shutdown signal; however, the current logic would call the cancellation signal once the operation is finished, and since the scanner takes a while... the daemon shuts down only once the scanner is finished. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Adding a test was difficult, but I tested locally and I could correctly see the logs that shutdown the daemon now

```
└─┐biome_service::scanner::scan_folder{folder="/Users/ema"}


  └─┐biome_lsp::handlers::formatting::format{params=DocumentFormattingParams { text_document: TextDocumentIdentifier { uri: Uri(Uri { scheme: "file", authority: Some(Authority { userinfo: None, host: "", host_parsed: RegName(""), port: None }), path: "/Users/ema/test.json", query: None, fragment: None }) }, options: FormattingOptions { tab_size: 2, insert_spaces: true, properties: {}, trim_trailing_whitespace: None, insert_final_newline: None, trim_final_newlines: None }, work_done_progress_params: WorkDoneProgressParams { work_done_token: None } }}
  ┌─┘
  ┌─┘
  ├─ INFO tower_lsp_server::service::layers shutdown request received, shutting down
INFO biome_cli::commands::daemon Received shutdown signal
```

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
