### PR TITLE
fix(lsp): disable go-to definition by default

### DIFF
--- a/.changeset/neat-trams-add.md
+++ b/.changeset/neat-trams-add.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10658](https://github.com/biomejs/biome/issues/10658). The issue was caused by the "Go-to definition" editor feature, which was enabled by default. The feature is now **disabled by default**. To work, the feature triggers the scanner to build the module graph. This caused memory leak issues in cases where Biome starts in the home directory to modify files.
+
+If you relied on this new feature, you must now turn on using the [editor settings] of the extension e.g. [Zed](https://biomejs.dev/reference/zed/#goto_definition) and [VSCode](https://biomejs.dev/reference/vscode/#biomegotodefinition).

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -34,7 +34,7 @@ pub struct WorkspaceSettings {
     /// Inline configuration, which gets merged before applying querying instructions via workspace
     pub inline_config: Option<Configuration>,
 
-    /// Enables the "go-to" features, by-passing the use of linting or assist. Enabled by default.
+    /// Enables the "go-to" features, by-passing the use of linting or assist. Disabled by default.
     pub go_to_definition: Option<bool>,
 }
 
@@ -85,7 +85,7 @@ impl ExtensionSettings {
     }
 
     pub(crate) fn editor_features(&self) -> EditorFeatures {
-        let go_to_definition = self.settings.go_to_definition.unwrap_or(true);
+        let go_to_definition = self.settings.go_to_definition.unwrap_or_default();
         let mut features = EditorFeatures::default();
         if go_to_definition {
             features.insert(EditorFeature::GotoDefinition);


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #10658

I didn't realise the feature would have caused such an issue, so I prefer to turn it off by default, since it's not a core issue.

We will find a better heuristic in the future. Plus, I already saw two issues filed regarding this feature, so it's safe to turn it off.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Manually tested. Green CI

<!-- What demonstrates that your implementation is correct? -->

## Docs

I'll send a PR to update the docs too

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
