### PR TITLE
fix(lsp): improved configuration loading

### DIFF
--- a/.changeset/fuzzy-worlds-worry.md
+++ b/.changeset/fuzzy-worlds-worry.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9566](https://github.com/biomejs/biome/issues/9566). Improved how the Biome Language Server loads multiple configuration files inside a workspace.

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -97,10 +97,10 @@ async fn ensure_project_for_opened_document(
             // Use the per-file resolved configurationPath so each workspace folder
             // uses its own config, even when a project is already open.
             if let Some(resolved_path) = config_path {
-                session.set_configuration_status(ConfigurationStatus::Loading);
                 let status = session
                     .load_biome_configuration_file(resolved_path.clone(), false)
                     .await;
+                session.set_configuration_status(project_key, status);
                 load_status = Some(status);
             }
         }
@@ -112,15 +112,18 @@ async fn ensure_project_for_opened_document(
     }
 
     if load_status.is_none() {
-        session.set_configuration_status(ConfigurationStatus::Loading);
         if !session.has_initialized() {
             session.load_extension_settings(None).await;
         }
-        load_status = Some(load_from_workspace_root_for_path(session, path, config_path).await);
+        let status = load_from_workspace_root_for_path(session, path, config_path).await;
+        // On success the project was created during loading, so it can now be
+        // resolved from the path and the status recorded against it.
+        if let Some(project_key) = session.project_for_path(path) {
+            session.set_configuration_status(project_key, status);
+        }
+        load_status = Some(status);
     }
     let status = load_status.expect("load_status should be set");
-
-    session.set_configuration_status(status);
 
     if status.is_loaded() {
         session.project_for_path(path).or_else(|| {

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -5106,6 +5106,135 @@ async fn relative_configuration_path_resolves_against_correct_workspace_folder()
     Ok(())
 }
 
+/// Regression test for <https://github.com/biomejs/biome/issues/9566>.
+///
+/// In a multi-root workspace, a configuration that fails to load in one workspace
+/// folder must not disable lint/assist diagnostics for files in another, healthy
+/// workspace folder.
+#[tokio::test]
+#[expect(deprecated)]
+async fn broken_configuration_in_one_workspace_folder_does_not_disable_another() -> Result<()> {
+    let fs = MemoryFileSystem::default();
+
+    // `good` has a valid config that enables a lint rule; `bad` has a malformed
+    // config that cannot be parsed, so loading it yields an error status.
+    let good_config = r#"{
+        "linter": {
+            "rules": {
+                "recommended": false,
+                "suspicious": { "noDoubleEquals": "error" }
+            }
+        }
+    }"#;
+    let bad_config = r#"{ "linter": { "rules": "#;
+
+    fs.insert(to_utf8_file_path_buf(uri!("good/biome.json")), good_config);
+    fs.insert(to_utf8_file_path_buf(uri!("bad/biome.json")), bad_config);
+
+    let factory = ServerFactory::new_with_fs(Arc::new(fs));
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    let _res: InitializeResult = server
+        .request(
+            "initialize",
+            "_init",
+            InitializeParams {
+                process_id: None,
+                root_path: None,
+                root_uri: Some(uri!("/")),
+                initialization_options: None,
+                capabilities: ClientCapabilities::default(),
+                trace: None,
+                workspace_folders: Some(vec![
+                    WorkspaceFolder {
+                        name: "good".to_string(),
+                        uri: uri!("good"),
+                    },
+                    WorkspaceFolder {
+                        name: "bad".to_string(),
+                        uri: uri!("bad"),
+                    },
+                ]),
+                client_info: None,
+                locale: None,
+                work_done_progress_params: Default::default(),
+            },
+        )
+        .await?
+        .context("initialize returned None")?;
+
+    server.initialized().await?;
+
+    let good_uri = uri!("good/document.js");
+
+    // Open the healthy file: it must produce a lint diagnostic.
+    server
+        .open_named_document("a == b;", good_uri.clone(), "javascript")
+        .await?;
+
+    let notification = wait_for_notification(
+        &mut receiver,
+        |n| matches!(n, ServerNotification::PublishDiagnostics(params) if params.uri == good_uri),
+    )
+    .await;
+    let Some(ServerNotification::PublishDiagnostics(params)) = notification else {
+        panic!("Expected PublishDiagnostics for the healthy file, got {notification:?}");
+    };
+    assert!(
+        !params.diagnostics.is_empty(),
+        "Expected a lint diagnostic for the healthy file on open"
+    );
+
+    // Open a file in the folder with the broken configuration. Its configuration
+    // fails to load; previously this overwrote the shared status.
+    server
+        .open_named_document("a == b;", uri!("bad/document.js"), "javascript")
+        .await?;
+
+    // Re-trigger diagnostics for the healthy file. The lint diagnostic must still
+    // be reported, proving the broken folder did not disable the healthy one.
+    server
+        .notify(
+            "textDocument/didChange",
+            lsp::DidChangeTextDocumentParams {
+                text_document: lsp::VersionedTextDocumentIdentifier {
+                    uri: good_uri.clone(),
+                    version: 1,
+                },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "a == b;".to_string(),
+                }],
+            },
+        )
+        .await?;
+
+    let notification = wait_for_notification(
+        &mut receiver,
+        |n| matches!(n, ServerNotification::PublishDiagnostics(params) if params.uri == good_uri),
+    )
+    .await;
+    let Some(ServerNotification::PublishDiagnostics(params)) = notification else {
+        panic!("Expected PublishDiagnostics for the healthy file, got {notification:?}");
+    };
+    assert!(
+        !params.diagnostics.is_empty(),
+        "The healthy file must keep its lint diagnostic even after a sibling \
+         workspace folder failed to load its configuration"
+    );
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
 /// Verifies that an absolute `configurationPath` (e.g. `C:/shared-config/biome.json`)
 /// pointing to a file outside the workspace roots properly attributes the registered
 /// project to the workspace root, so that files opened inside the workspace are

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -33,13 +33,13 @@ use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use futures::StreamExt;
 use futures::stream::futures_unordered::FuturesUnordered;
-use papaya::HashMap;
+use papaya::{HashMap, HashSet};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde_json::Value;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::sync::atomic::{AtomicBool, AtomicU8};
 use tokio::spawn;
 use tokio::sync::Notify;
 use tokio::sync::OnceCell;
@@ -92,11 +92,13 @@ pub(crate) struct Session {
 
     pub(crate) workspace: Arc<dyn Workspace>,
 
-    configuration_status: AtomicU8,
+    /// Configuration status tracked independently per project key.
+    configuration_status: HashMap<ProjectKey, ConfigurationStatus>,
 
-    /// A flag to notify a message to the user when the configuration is broken, and the LSP attempts
-    /// to update the diagnostics
-    notified_broken_configuration: AtomicBool,
+    /// Remembers which projects we have already warned the user about having a
+    /// broken configuration, so we don't show the same warning again every time
+    /// we refresh that project's diagnostics.
+    notified_broken_configuration: HashSet<ProjectKey>,
 
     /// Tracks whether the initialized() notification has been received
     initialized: AtomicBool,
@@ -226,12 +228,12 @@ impl Session {
             client,
             initialize_params: OnceCell::default(),
             workspace,
-            configuration_status: AtomicU8::new(ConfigurationStatus::Missing as u8),
+            configuration_status: Default::default(),
             projects: Default::default(),
             documents: Default::default(),
             extension_settings: config,
             cancellation,
-            notified_broken_configuration: AtomicBool::new(false),
+            notified_broken_configuration: Default::default(),
             initialized: AtomicBool::new(false),
             service_rx,
             loading_operations: Default::default(),
@@ -417,19 +419,20 @@ impl Session {
     ) -> Result<(), LspError> {
         let biome_path = self.file_path(&url)?;
 
-        if !self.notified_broken_configuration() {
-            if self.configuration_status().is_editorconfig_error() {
-                self.set_notified_broken_configuration();
+        let configuration_status = self.configuration_status(doc.project_key);
+        if !self.notified_broken_configuration(doc.project_key) {
+            if configuration_status.is_editorconfig_error() {
+                self.set_notified_broken_configuration(doc.project_key);
                 self.client
                     .show_message(MessageType::WARNING, "The .editorconfig file has errors. Biome will report only parsing errors until the file is fixed or its usage is disabled.")
                     .await
-            } else if self.configuration_status().is_error() {
-                self.set_notified_broken_configuration();
+            } else if configuration_status.is_error() {
+                self.set_notified_broken_configuration(doc.project_key);
                 self.client
                     .show_message(MessageType::WARNING, "The configuration file has errors. Biome will report only parsing errors until the configuration is fixed.")
                     .await;
-            } else if self.configuration_status().is_plugin_error() {
-                self.set_notified_broken_configuration();
+            } else if configuration_status.is_plugin_error() {
+                self.set_notified_broken_configuration(doc.project_key);
                 self.client.show_message(MessageType::WARNING, "The plugin loading has failed. Biome will report only parsing errors until the file is fixed or its usage is disabled.").await
             }
         }
@@ -454,7 +457,7 @@ impl Session {
 
         let diagnostics: Vec<Diagnostic> = {
             let mut categories = RuleCategoriesBuilder::default().with_syntax();
-            if self.configuration_status().is_loaded() {
+            if configuration_status.is_loaded() {
                 if file_features.supports_lint() {
                     categories = categories.with_lint();
                 }
@@ -822,16 +825,14 @@ impl Session {
     pub(crate) async fn load_workspace_settings(self: &Arc<Self>, reload: bool) {
         if let Some(config_path) = self.resolve_configuration_path(None) {
             info!("Detected configuration path in the workspace settings.");
-            self.set_configuration_status(ConfigurationStatus::Loading);
-
+            let config_file_path = config_path.to_path_buf();
             let status = self
                 .load_biome_configuration_file(config_path, reload)
                 .await;
             debug!("Configuration status: {:?}", status);
-            self.set_configuration_status(status);
+            self.record_configuration_status(config_file_path.as_deref(), status);
         } else if let Some(folders) = self.get_workspace_folders() {
             info!("Detected workspace folder.");
-            self.set_configuration_status(ConfigurationStatus::Loading);
             for folder in folders {
                 info!("Attempt to load the configuration file in {:?}", folder.uri);
                 let base_path = folder.uri.to_file_path().map(|p| {
@@ -841,12 +842,12 @@ impl Session {
                     Some(base_path) => {
                         let status = self
                             .load_biome_configuration_file(
-                                ConfigurationPathHint::FromWorkspace(base_path),
+                                ConfigurationPathHint::FromWorkspace(base_path.clone()),
                                 reload,
                             )
                             .await;
                         debug!("Configuration status: {:?}", status);
-                        self.set_configuration_status(status);
+                        self.record_configuration_status(Some(&base_path), status);
                     }
                     None => {
                         error!(
@@ -861,8 +862,9 @@ impl Session {
                 None => ConfigurationPathHint::default(),
                 Some(path) => ConfigurationPathHint::FromLsp(path),
             };
+            let config_file_path = base_path.to_path_buf();
             let status = self.load_biome_configuration_file(base_path, reload).await;
-            self.set_configuration_status(status);
+            self.record_configuration_status(config_file_path.as_deref(), status);
         }
     }
 
@@ -1286,28 +1288,42 @@ impl Session {
         })
     }
 
-    /// Retrieves information regarding the configuration status
-    pub(crate) fn configuration_status(&self) -> ConfigurationStatus {
+    /// Retrieves the configuration status of the given project, defaulting to
+    /// [`ConfigurationStatus::Missing`] when the project has no recorded status.
+    pub(crate) fn configuration_status(&self, project_key: ProjectKey) -> ConfigurationStatus {
         self.configuration_status
-            .load(Ordering::Relaxed)
-            .try_into()
-            .unwrap()
+            .pin()
+            .get(&project_key)
+            .copied()
+            .unwrap_or(ConfigurationStatus::Missing)
     }
 
-    /// Updates the status of the configuration
-    pub(super) fn set_configuration_status(&self, status: ConfigurationStatus) {
+    /// Updates the status of the configuration for the given project.
+    pub(super) fn set_configuration_status(
+        &self,
+        project_key: ProjectKey,
+        status: ConfigurationStatus,
+    ) {
         self.notified_broken_configuration
-            .store(false, Ordering::Relaxed);
-        self.configuration_status
-            .store(status as u8, Ordering::Relaxed);
+            .pin()
+            .remove(&project_key);
+        self.configuration_status.pin().insert(project_key, status);
     }
 
-    fn notified_broken_configuration(&self) -> bool {
-        self.notified_broken_configuration.load(Ordering::Relaxed)
+    /// Records the configuration status for the project that owns `path`.
+    fn record_configuration_status(&self, path: Option<&Utf8Path>, status: ConfigurationStatus) {
+        if let Some(project_key) = path.and_then(|path| self.project_for_path(path)) {
+            self.set_configuration_status(project_key, status);
+        }
     }
-    fn set_notified_broken_configuration(&self) {
+
+    fn notified_broken_configuration(&self, project_key: ProjectKey) -> bool {
         self.notified_broken_configuration
-            .store(true, Ordering::Relaxed);
+            .pin()
+            .contains(&project_key)
+    }
+    fn set_notified_broken_configuration(&self, project_key: ProjectKey) {
+        self.notified_broken_configuration.pin().insert(project_key);
     }
 
     pub(crate) fn requires_configuration(&self) -> bool {
@@ -1329,8 +1345,7 @@ impl Session {
     }
 
     pub(crate) fn is_linting_and_formatting_disabled(&self) -> bool {
-        debug!("configuration status {:?}", self.configuration_status());
-        match self.configuration_status() {
+        let disabled_for = |status: ConfigurationStatus| match status {
             ConfigurationStatus::Loaded => false,
             ConfigurationStatus::Missing => self
                 .extension_settings
@@ -1341,7 +1356,17 @@ impl Session {
             | ConfigurationStatus::EditorConfigError
             | ConfigurationStatus::PluginError => false,
             ConfigurationStatus::Loading => true,
+        };
+
+        // This is a single on/off switch for the whole editor: formatting and
+        // code actions are turned on once, not per file. Each request later checks
+        // the file's own project again, so we keep them on as long as at least one
+        // project can use them, and only turn them off when every project would.
+        let statuses = self.configuration_status.pin();
+        if statuses.is_empty() {
+            return self.requires_configuration();
         }
+        statuses.values().all(|status| disabled_for(*status))
     }
 
     pub fn position_encoding(&self) -> PositionEncoding {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> [!NOTE]
> I used an agent to craft the solution, and then improved it by removing its jargon.

The configuration status is now tracked per project via `ProjectKey`, because in a workspace environment the language server might be loading multiple configurations at once. 

Closes #9566

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a regression test

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
