### PR TITLE
fix(biome_html_analyze): treat `<slot>` as content in useAnchorContent (#10663)

### DIFF
--- a/.changeset/fix-use-anchor-content-slot.md
+++ b/.changeset/fix-use-anchor-content-slot.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10663](https://github.com/biomejs/biome/issues/10663): the `useAnchorContent` rule no longer reports anchors whose only content is a `<slot>` element.
+
+`<slot>` (in Vue, Svelte, and Astro components, as well as web components) renders content provided by the parent or assigned nodes, which the linter cannot see. Such anchors are therefore no longer flagged as empty, matching how the rule already treats custom (PascalCase) components.
+
+```vue
+<!-- No longer reported -->
+<a><slot /></a>
+```

--- a/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
@@ -3,7 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlContent, AnyHtmlElement, HtmlAttribute, HtmlElementList};
+use biome_html_syntax::{AnyHtmlContent, AnyHtmlElement, HtmlAttribute, HtmlElement, HtmlElementList};
 use biome_languages::HtmlFileSource;
 use biome_rowan::{AstNode, BatchMutationExt};
 use biome_rule_options::use_anchor_content::UseAnchorContentOptions;
@@ -190,6 +190,11 @@ fn has_accessible_content(html_child_list: &HtmlElementList, is_astro: bool) -> 
         AnyHtmlElement::HtmlElement(element) => {
             if html_element_has_truthy_aria_hidden(element) {
                 false
+            } else if is_slot_element(element) {
+                // `<slot>` renders content provided by the parent component or
+                // assigned nodes, which the linter cannot see, so assume it may
+                // provide accessible content.
+                true
             } else {
                 has_accessible_content(&element.children(), is_astro)
             }
@@ -229,6 +234,9 @@ fn has_accessible_content(html_child_list: &HtmlElementList, is_astro: bool) -> 
                     });
                     !is_hidden
                 }
+                // `<slot>` renders content provided by the parent component or
+                // assigned nodes, which the linter cannot see.
+                Some(name) if name.eq_ignore_ascii_case("slot") => true,
                 // Custom components (PascalCase) may render accessible content
                 Some(name) if name.starts_with(|c: char| c.is_uppercase()) => true,
                 _ => false,
@@ -236,6 +244,19 @@ fn has_accessible_content(html_child_list: &HtmlElementList, is_astro: bool) -> 
         }
         AnyHtmlElement::HtmlBogusElement(_) | AnyHtmlElement::HtmlCdataSection(_) => true,
     })
+}
+
+/// Returns `true` if `element` is a `<slot>` element. `<slot>` (Vue, Svelte,
+/// Astro, and web components) renders content provided by the parent or assigned
+/// nodes, which the linter cannot see, so an anchor containing one should not be
+/// reported as empty.
+fn is_slot_element(element: &HtmlElement) -> bool {
+    element
+        .opening_element()
+        .ok()
+        .and_then(|opening| opening.name().ok())
+        .and_then(|name| name.token_text_trimmed())
+        .is_some_and(|name| name.as_ref().eq_ignore_ascii_case("slot"))
 }
 
 /// Checks if the content node contains non-empty text.

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro
@@ -21,3 +21,7 @@
 <!-- Accessible via aria-label or title alone -->
 <a aria-label="Navigate to dashboard"></a>
 <a title="Go to settings page"></a>
+
+<!-- <slot> renders content provided by the parent component -->
+<a><slot /></a>
+<a><slot></slot></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro.snap
@@ -28,4 +28,8 @@ expression: valid.astro
 <a aria-label="Navigate to dashboard"></a>
 <a title="Go to settings page"></a>
 
+<!-- <slot> renders content provided by the parent component -->
+<a><slot /></a>
+<a><slot></slot></a>
+
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/svelte/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/svelte/valid.svelte
@@ -21,3 +21,7 @@
 <!-- Custom components may render accessible content -->
 <a><Image alt="description" /></a>
 <a><CustomIcon /></a>
+
+<!-- <slot> renders content provided by the parent component -->
+<a><slot /></a>
+<a><slot></slot></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/svelte/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/svelte/valid.svelte.snap
@@ -28,4 +28,8 @@ expression: valid.svelte
 <a><Image alt="description" /></a>
 <a><CustomIcon /></a>
 
+<!-- <slot> renders content provided by the parent component -->
+<a><slot /></a>
+<a><slot></slot></a>
+
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/valid.html
@@ -32,3 +32,6 @@
 
 <!-- Anchor with both aria-label and title -->
 <a aria-label="Home" title="Navigate home"></a>
+
+<!-- <slot> (web component) renders assigned nodes -->
+<a><slot></slot></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/valid.html.snap
@@ -39,4 +39,7 @@ expression: valid.html
 <!-- Anchor with both aria-label and title -->
 <a aria-label="Home" title="Navigate home"></a>
 
+<!-- <slot> (web component) renders assigned nodes -->
+<a><slot></slot></a>
+
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/vue/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/vue/valid.vue
@@ -21,4 +21,8 @@
   <!-- Custom components may render accessible content -->
   <a><Image alt="description" /></a>
   <a><CustomIcon /></a>
+
+  <!-- <slot> renders content provided by the parent component -->
+  <a><slot /></a>
+  <a><slot></slot></a>
 </template>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/vue/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/vue/valid.vue.snap
@@ -27,6 +27,10 @@ expression: valid.vue
   <!-- Custom components may render accessible content -->
   <a><Image alt="description" /></a>
   <a><CustomIcon /></a>
+
+  <!-- <slot> renders content provided by the parent component -->
+  <a><slot /></a>
+  <a><slot></slot></a>
 </template>
 
 ```


### PR DESCRIPTION
## Summary

Fixes #10663.

`a11y/useAnchorContent` reported anchors whose only content is a `<slot>` element:

```vue
<a><slot /></a>
```

`<slot>` (in Vue, Svelte, and Astro components, and in web components) renders content
provided by the parent component or assigned nodes, which the linter cannot see statically.
Flagging such anchors as empty is a false positive — analogous to custom (PascalCase)
components, which `has_accessible_content` already treats as potentially providing accessible
content.

## Change

In `has_accessible_content` (`crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs`),
a `<slot>` element is now treated as accessible content. Both forms are handled:

- self-closing `<slot />` (the case in the issue), and
- the element form `<slot></slot>`.

The check is case-insensitive and applies across the HTML / Vue / Svelte / Astro sources the
rule supports.

## Tests

Added `<slot />` and `<slot></slot>` cases to the `valid` spec fixtures for HTML, Vue, Svelte,
and Astro, and regenerated the snapshots. With the fix they emit **no** diagnostics. Reverting
only the rule change makes all four `valid_*` specs fail (slots wrongly flagged) while the
`invalid_*` specs stay green — confirming fails-before / passes-after.

```
$ cargo test -p biome_html_analyze --test spec_tests use_anchor_content
test result: ok. 8 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy -p biome_html_analyze --all-features -- -D warnings` are
clean. A changeset is included.

## AI disclosure

Per Biome's contributing guidelines: this PR was prepared with AI assistance (Claude Code). I
have reviewed and understand every change, and verified it locally.
