### PR TITLE
fix(analyzer): exclude plugins via filters

### DIFF
--- a/.changeset/loose-rockets-stare.md
+++ b/.changeset/loose-rockets-stare.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10652](https://github.com/biomejs/biome/issues/10652). Biome plugins are no longer executed when the `--only` flag is used.

--- a/.changeset/loose-rockets-stare.md
+++ b/.changeset/loose-rockets-stare.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10652](https://github.com/biomejs/biome/issues/10652). Biome plugins are no longer executed when the `--only` flag is used.
+Fixed [#10652](https://github.com/biomejs/biome/issues/10652). Biome plugins are now properly filtered when using `--only` and `--skip` flags.

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -809,6 +809,9 @@ pub struct SuppressionCommentEmitterPayload<'a, L: Language> {
 
 type SignalHandler<'a, L, Break> = &'a mut dyn FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<Break>;
 
+/// Reserved group name used to select analyzer plugins through [RuleFilter::Group].
+pub const PLUGIN_GROUP: &str = "plugin";
+
 /// Allow filtering a single rule or group of rules by their names
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum RuleFilter<'a> {
@@ -930,6 +933,15 @@ impl<'analysis> AnalysisFilter<'analysis> {
                 .iter()
                 .any(|filter| filter.match_rule::<R>())
     }
+
+    /// Return `true` if analyzer plugins match this filter.
+    pub fn match_plugins(&self) -> bool {
+        self.categories.is_lint()
+            && !self
+                .disabled_rules
+                .iter()
+                .any(|filter| matches!(filter, RuleFilter::Group(group) if *group == PLUGIN_GROUP))
+    }
 }
 
 /// Utility type to be used as a default value for the `B` generic type on
@@ -959,3 +971,50 @@ pub enum Never {}
 /// (`Option<Never>` has a size of 0 and can be elided, while `Option<()>` has
 /// a size of 1 as it still need to store a discriminant)
 pub type ControlFlow<B = Never> = ops::ControlFlow<B>;
+
+#[cfg(test)]
+mod tests {
+    use crate::{AnalysisFilter, PLUGIN_GROUP, RuleCategories, RuleCategory, RuleFilter};
+
+    fn lint_filter<'a>(
+        enabled: Option<&'a [RuleFilter<'a>]>,
+        disabled: &'a [RuleFilter<'a>],
+    ) -> AnalysisFilter<'a> {
+        AnalysisFilter {
+            categories: RuleCategories::all(),
+            enabled_rules: enabled,
+            disabled_rules: disabled,
+            range: None,
+        }
+    }
+
+    #[test]
+    fn plugins_match_by_default() {
+        // Normal run: rules are enabled by config, plugins are not in `disabled_rules`.
+        let enabled = [RuleFilter::Rule("suspicious", "noDebugger")];
+        assert!(lint_filter(Some(&enabled), &[]).match_plugins());
+        assert!(lint_filter(None, &[]).match_plugins());
+    }
+
+    #[test]
+    fn plugins_do_not_match_when_group_is_disabled() {
+        // The caller adds the reserved `plugin` group to `disabled_rules` when `--only`
+        // excludes plugins or `--skip=plugin` is used.
+        let disabled = [RuleFilter::Group(PLUGIN_GROUP)];
+        assert!(!lint_filter(None, &disabled).match_plugins());
+
+        // Disabling wins even if the group also appears in `enabled_rules`.
+        let enabled = [RuleFilter::Group(PLUGIN_GROUP)];
+        assert!(!lint_filter(Some(&enabled), &disabled).match_plugins());
+    }
+
+    #[test]
+    fn plugins_do_not_match_outside_lint() {
+        // Plugins are lint diagnostics; an assist-only pass must not run them.
+        let filter = AnalysisFilter {
+            categories: RuleCategories::from(RuleCategory::Action),
+            ..AnalysisFilter::default()
+        };
+        assert!(!filter.match_plugins());
+    }
+}

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -207,24 +207,25 @@ pub enum BiomeCommand {
         /// Run only the given lint rule, assist action, group of rules and actions, or domain.
         /// If the severity level of a rule is `off`,
         /// then the severity level of the rule is set to `error` if it is a recommended rule or `warn` otherwise.
+        /// Use the `plugin` group to run only the analyzer plugins.
         ///
         /// Example:
         ///
         /// ```shell
-        /// biome check --only=correctness/noUnusedVariables --only=suspicious --only=test
+        /// biome check --only=correctness/noUnusedVariables --only=suspicious --only=test --only=plugin
         /// ```
-        #[bpaf(long("only"), argument("GROUP|RULE|DOMAIN|ACTION"))]
+        #[bpaf(long("only"), argument("GROUP|RULE|DOMAIN|ACTION|PLUGIN"))]
         only: Vec<AnalyzerSelector>,
 
         /// Skip the given lint rule, assist action, group of rules and actions, or domain by setting the severity level of the rules to `off`.
-        /// This option takes precedence over `--only`.
+        /// This option takes precedence over `--only`. Use the `plugin` group to skip the analyzer plugins.
         ///
         /// Example:
         ///
         /// ```shell
-        /// biome check --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+        /// biome check --skip=correctness/noUnusedVariables --skip=suspicious --skip=project --skip=plugin
         /// ```
-        #[bpaf(long("skip"), argument("GROUP|RULE|DOMAIN|ACTION"))]
+        #[bpaf(long("skip"), argument("GROUP|RULE|DOMAIN|ACTION|PLUGIN"))]
         skip: Vec<AnalyzerSelector>,
 
         /// Enables the watch mode to re-run the check automatically when any non-excluded file in the workspace has changed.
@@ -294,24 +295,25 @@ pub enum BiomeCommand {
         /// Run only the given lint rule, assist action, group of rules and actions, or domain.
         /// If the severity level of a rule is `off`,
         /// then the severity level of the rule is set to `error` if it is a recommended rule or `warn` otherwise.
+        /// Use the `plugin` group to run only the analyzer plugins.
         ///
         /// Example:
         ///
         /// ```shell
-        /// biome lint --only=correctness/noUnusedVariables --only=suspicious --only=test
+        /// biome lint --only=correctness/noUnusedVariables --only=suspicious --only=test --only=plugin
         /// ```
-        #[bpaf(long("only"), argument("GROUP|RULE|DOMAIN|ACTION"))]
+        #[bpaf(long("only"), argument("GROUP|RULE|DOMAIN|ACTION|PLUGIN"))]
         only: Vec<AnalyzerSelector>,
 
         /// Skip the given lint rule, assist action, group of rules and actions, or domain by setting the severity level of the rules to `off`.
-        /// This option takes precedence over `--only`.
+        /// This option takes precedence over `--only`. Use the `plugin` group to skip the analyzer plugins.
         ///
         /// Example:
         ///
         /// ```shell
-        /// biome lint --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+        /// biome lint --skip=correctness/noUnusedVariables --skip=suspicious --skip=project --skip=plugin
         /// ```
-        #[bpaf(long("skip"), argument("GROUP|RULE|DOMAIN|ACTION"))]
+        #[bpaf(long("skip"), argument("GROUP|RULE|DOMAIN|ACTION|PLUGIN"))]
         skip: Vec<AnalyzerSelector>,
 
         /// Use this option when you want to format code piped from `stdin`, and print the output to `stdout`.
@@ -505,24 +507,25 @@ pub enum BiomeCommand {
         /// Run only the given lint rule, assist action, group of rules and actions, or domain.
         /// If the severity level of a rule is `off`,
         /// then the severity level of the rule is set to `error` if it is a recommended rule or `warn` otherwise.
+        /// Use the `plugin` group to run only the analyzer plugins.
         ///
         /// Example:
         ///
         /// ```shell
-        /// biome ci --only=correctness/noUnusedVariables --only=suspicious --only=test
+        /// biome ci --only=correctness/noUnusedVariables --only=suspicious --only=test --only=plugin
         /// ```
-        #[bpaf(long("only"), argument("GROUP|RULE|DOMAIN|ACTION"))]
+        #[bpaf(long("only"), argument("GROUP|RULE|DOMAIN|ACTION|PLUGIN"))]
         only: Vec<AnalyzerSelector>,
 
         /// Skip the given lint rule, assist action, group of rules and actions, or domain by setting the severity level of the rules to `off`.
-        /// This option takes precedence over `--only`.
+        /// This option takes precedence over `--only`. Use the `plugin` group to skip the analyzer plugins.
         ///
         /// Example:
         ///
         /// ```shell
-        /// biome ci --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+        /// biome ci --skip=correctness/noUnusedVariables --skip=suspicious --skip=project --skip=plugin
         /// ```
-        #[bpaf(long("skip"), argument("GROUP|RULE|DOMAIN|ACTION"))]
+        #[bpaf(long("skip"), argument("GROUP|RULE|DOMAIN|ACTION|PLUGIN"))]
         skip: Vec<AnalyzerSelector>,
 
         /// Single file, single path or list of paths

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -4391,3 +4391,167 @@ fn should_not_choke_on_recursive_function_call() {
         result,
     ));
 }
+
+#[test]
+fn only_should_skip_plugin() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        Utf8PathBuf::from("biome.json"),
+        br#"{
+    "plugins": ["noManualZIndex.grit"]
+}
+"#,
+    );
+
+    fs.insert(
+        Utf8PathBuf::from("noManualZIndex.grit"),
+        br#"`$fn($args)` where {
+    $fn <: `Object.assign`,
+    register_diagnostic(
+        span = $fn,
+        message = "Prefer object spread instead of Object.assign()",
+        severity = "warn"
+    )
+}"#,
+    );
+
+    let file_path = "file.js";
+    fs.insert(
+        file_path.into(),
+        br#"const merged = Object.assign({}, a, b);
+debugger"#,
+    );
+
+    let (fs, result) = run_cli_with_server_workspace(
+        fs,
+        &mut console,
+        Args::from(["lint", "--only=noDebugger", file_path].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "only_should_skip_plugin",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn only_plugin_runs_only_plugins() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        Utf8PathBuf::from("biome.json"),
+        br#"{
+    "plugins": ["noManualZIndex.grit"]
+}
+"#,
+    );
+
+    fs.insert(
+        Utf8PathBuf::from("noManualZIndex.grit"),
+        br#"`$fn($args)` where {
+    $fn <: `Object.assign`,
+    register_diagnostic(
+        span = $fn,
+        message = "Prefer object spread instead of Object.assign()",
+        severity = "warn"
+    )
+}"#,
+    );
+
+    let file_path = "file.js";
+    fs.insert(
+        file_path.into(),
+        br#"const merged = Object.assign({}, a, b);
+debugger"#,
+    );
+
+    let (fs, result) = run_cli_with_server_workspace(
+        fs,
+        &mut console,
+        Args::from(["lint", "--only=plugin", file_path].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "only_plugin_runs_only_plugins",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn skip_plugin_skips_plugins() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        Utf8PathBuf::from("biome.json"),
+        br#"{
+    "plugins": ["noManualZIndex.grit"]
+}
+"#,
+    );
+
+    fs.insert(
+        Utf8PathBuf::from("noManualZIndex.grit"),
+        br#"`$fn($args)` where {
+    $fn <: `Object.assign`,
+    register_diagnostic(
+        span = $fn,
+        message = "Prefer object spread instead of Object.assign()",
+        severity = "warn"
+    )
+}"#,
+    );
+
+    let file_path = "file.js";
+    fs.insert(
+        file_path.into(),
+        br#"const merged = Object.assign({}, a, b);
+debugger"#,
+    );
+
+    let (fs, result) = run_cli_with_server_workspace(
+        fs,
+        &mut console,
+        Args::from(["lint", "--skip=plugin", file_path].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "skip_plugin_skips_plugins",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn only_per_plugin_selector_is_rejected() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = "file.js";
+    fs.insert(file_path.into(), b"debugger");
+
+    let (fs, result) = run_cli_with_server_workspace(
+        fs,
+        &mut console,
+        Args::from(["lint", "--only=plugin/foo", file_path].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "only_per_plugin_selector_is_rejected",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
@@ -9,7 +9,8 @@ Runs formatter, linter and import sorting to the requested files.
 
 Usage: check [--write] [--unsafe] [--assist-enabled=<true|false>] [--enforce-assist=<true|false>] [
 --format-with-errors=<true|false>] [--profile-rules] [--staged] [--changed] [--since=REF] [--only=
-<GROUP|RULE|DOMAIN|ACTION>]... [--skip=<GROUP|RULE|DOMAIN|ACTION>]... [--watch] [PATH]...
+<GROUP|RULE|DOMAIN|ACTION|PLUGIN>]... [--skip=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>]... [--watch] [PATH
+]...
 
 Options that changes how the JSON parser behaves
         --json-parse-allow-comments=<true|false>  Allow parsing comments in `.json` files
@@ -395,20 +396,22 @@ Available options:
         --since=REF           Use this to specify the base branch to compare against when you're
                               using the --changed flag and the `defaultBranch` is not set in your
                               `biome.json`
-        --only=<GROUP|RULE|DOMAIN|ACTION>  Run only the given lint rule, assist action, group of
-                              rules and actions, or domain. If the severity level of a rule is
+        --only=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>  Run only the given lint rule, assist action, group
+                              of rules and actions, or domain. If the severity level of a rule is
                               `off`, then the severity level of the rule is set to `error` if it is
-                              a recommended rule or `warn` otherwise.
+                              a recommended rule or `warn` otherwise. Use the `plugin` group to run
+                              only the analyzer plugins.
                               Example:
                               ```shell
-                              biome check --only=correctness/noUnusedVariables --only=suspicious --only=test
+                              biome check --only=correctness/noUnusedVariables --only=suspicious --only=test --only=plugin
                               ```
-        --skip=<GROUP|RULE|DOMAIN|ACTION>  Skip the given lint rule, assist action, group of rules
-                              and actions, or domain by setting the severity level of the rules to
-                              `off`. This option takes precedence over `--only`.
+        --skip=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>  Skip the given lint rule, assist action, group of
+                              rules and actions, or domain by setting the severity level of the
+                              rules to `off`. This option takes precedence over `--only`. Use the
+                              `plugin` group to skip the analyzer plugins.
                               Example:
                               ```shell
-                              biome check --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+                              biome check --skip=correctness/noUnusedVariables --skip=suspicious --skip=project --skip=plugin
                               ```
         --watch               Enables the watch mode to re-run the check automatically when any
                               non-excluded file in the workspace has changed.

--- a/crates/biome_cli/tests/snapshots/main_cases_help/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/ci_help.snap
@@ -10,7 +10,8 @@ Files won't be modified, the command is a read-only operation.
 
 Usage: ci [--formatter-enabled=<true|false>] [--linter-enabled=<true|false>] [--assist-enabled=
 <true|false>] [--format-with-errors=<true|false>] [--enforce-assist=<true|false>] [--changed] [
---since=REF] [--only=<GROUP|RULE|DOMAIN|ACTION>]... [--skip=<GROUP|RULE|DOMAIN|ACTION>]... [PATH]...
+--since=REF] [--only=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>]... [--skip=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>
+]... [PATH]...
 
 Options that changes how the JSON parser behaves
         --json-parse-allow-comments=<true|false>  Allow parsing comments in `.json` files
@@ -377,20 +378,22 @@ Available options:
         --threads=NUMBER      The number of threads to use. This is useful when running the CLI in
                               environments with limited resource, for example CI.
                               [env:BIOME_THREADS: N/A]
-        --only=<GROUP|RULE|DOMAIN|ACTION>  Run only the given lint rule, assist action, group of
-                              rules and actions, or domain. If the severity level of a rule is
+        --only=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>  Run only the given lint rule, assist action, group
+                              of rules and actions, or domain. If the severity level of a rule is
                               `off`, then the severity level of the rule is set to `error` if it is
-                              a recommended rule or `warn` otherwise.
+                              a recommended rule or `warn` otherwise. Use the `plugin` group to run
+                              only the analyzer plugins.
                               Example:
                               ```shell
-                              biome ci --only=correctness/noUnusedVariables --only=suspicious --only=test
+                              biome ci --only=correctness/noUnusedVariables --only=suspicious --only=test --only=plugin
                               ```
-        --skip=<GROUP|RULE|DOMAIN|ACTION>  Skip the given lint rule, assist action, group of rules
-                              and actions, or domain by setting the severity level of the rules to
-                              `off`. This option takes precedence over `--only`.
+        --skip=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>  Skip the given lint rule, assist action, group of
+                              rules and actions, or domain by setting the severity level of the
+                              rules to `off`. This option takes precedence over `--only`. Use the
+                              `plugin` group to skip the analyzer plugins.
                               Example:
                               ```shell
-                              biome ci --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+                              biome ci --skip=correctness/noUnusedVariables --skip=suspicious --skip=project --skip=plugin
                               ```
     -h, --help                Prints help information
 

--- a/crates/biome_cli/tests/snapshots/main_cases_help/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/lint_help.snap
@@ -7,9 +7,9 @@ expression: redactor(content)
 ```block
 Run various checks on a set of files.
 
-Usage: lint [--write] [--unsafe] [--suppress] [--reason=STRING] [--only=<GROUP|RULE|DOMAIN|ACTION>
-]... [--skip=<GROUP|RULE|DOMAIN|ACTION>]... [--staged] [--changed] [--since=REF] [--profile-rules] [
---watch] [PATH]...
+Usage: lint [--write] [--unsafe] [--suppress] [--reason=STRING] [--only=
+<GROUP|RULE|DOMAIN|ACTION|PLUGIN>]... [--skip=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>]... [--staged] [
+--changed] [--since=REF] [--profile-rules] [--watch] [PATH]...
 
 Options that changes how the JSON parser behaves
         --json-parse-allow-comments=<true|false>  Allow parsing comments in `.json` files
@@ -108,20 +108,22 @@ Available options:
         --suppress            Fixes lint rule violations with comment suppressions instead of using
                               a rule code action (fix)
         --reason=STRING       Explanation for suppressing diagnostics with `--suppress`
-        --only=<GROUP|RULE|DOMAIN|ACTION>  Run only the given lint rule, assist action, group of
-                              rules and actions, or domain. If the severity level of a rule is
+        --only=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>  Run only the given lint rule, assist action, group
+                              of rules and actions, or domain. If the severity level of a rule is
                               `off`, then the severity level of the rule is set to `error` if it is
-                              a recommended rule or `warn` otherwise.
+                              a recommended rule or `warn` otherwise. Use the `plugin` group to run
+                              only the analyzer plugins.
                               Example:
                               ```shell
-                              biome lint --only=correctness/noUnusedVariables --only=suspicious --only=test
+                              biome lint --only=correctness/noUnusedVariables --only=suspicious --only=test --only=plugin
                               ```
-        --skip=<GROUP|RULE|DOMAIN|ACTION>  Skip the given lint rule, assist action, group of rules
-                              and actions, or domain by setting the severity level of the rules to
-                              `off`. This option takes precedence over `--only`.
+        --skip=<GROUP|RULE|DOMAIN|ACTION|PLUGIN>  Skip the given lint rule, assist action, group of
+                              rules and actions, or domain by setting the severity level of the
+                              rules to `off`. This option takes precedence over `--only`. Use the
+                              `plugin` group to skip the analyzer plugins.
                               Example:
                               ```shell
-                              biome lint --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+                              biome lint --skip=correctness/noUnusedVariables --skip=suspicious --skip=project --skip=plugin
                               ```
         --stdin-file-path=PATH  Use this option when you want to format code piped from `stdin`, and
                               print the output to `stdout`.

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/only_per_plugin_selector_is_rejected.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/only_per_plugin_selector_is_rejected.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `file.js`
+
+```js
+debugger
+```
+
+# Termination Message
+
+```block
+flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Failed to parse CLI arguments.
+    
+    Caused by:
+      couldn't parse `plugin/foo`: Per-plugin selection is not supported. Use `plugin` to target all
+      plugins.
+  
+
+
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/only_plugin_runs_only_plugins.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/only_plugin_runs_only_plugins.snap
@@ -1,0 +1,50 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "plugins": ["noManualZIndex.grit"]
+}
+```
+
+## `file.js`
+
+```js
+const merged = Object.assign({}, a, b);
+debugger
+```
+
+## `noManualZIndex.grit`
+
+```grit
+`$fn($args)` where {
+    $fn <: `Object.assign`,
+    register_diagnostic(
+        span = $fn,
+        message = "Prefer object spread instead of Object.assign()",
+        severity = "warn"
+    )
+}
+```
+
+# Emitted Messages
+
+```block
+file.js:1:16 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Prefer object spread instead of Object.assign()
+  
+  > 1 │ const merged = Object.assign({}, a, b);
+      │                ^^^^^^^^^^^^^
+    2 │ debugger
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 warning.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/only_should_skip_plugin.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/only_should_skip_plugin.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "plugins": ["noManualZIndex.grit"]
+}
+```
+
+## `file.js`
+
+```js
+const merged = Object.assign({}, a, b);
+debugger
+```
+
+## `noManualZIndex.grit`
+
+```grit
+`$fn($args)` where {
+    $fn <: `Object.assign`,
+    register_diagnostic(
+        span = $fn,
+        message = "Prefer object spread instead of Object.assign()",
+        severity = "warn"
+    )
+}
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This is an unexpected use of the debugger statement.
+  
+    1 │ const merged = Object.assign({}, a, b);
+  > 2 │ debugger
+      │ ^^^^^^^^
+  
+  i Unsafe fix: Remove debugger statement
+  
+    1 1 │   const merged = Object.assign({}, a, b);
+    2   │ - debugger
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/skip_plugin_skips_plugins.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/skip_plugin_skips_plugins.snap
@@ -1,0 +1,87 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "plugins": ["noManualZIndex.grit"]
+}
+```
+
+## `file.js`
+
+```js
+const merged = Object.assign({}, a, b);
+debugger
+```
+
+## `noManualZIndex.grit`
+
+```grit
+`$fn($args)` where {
+    $fn <: `Object.assign`,
+    register_diagnostic(
+        span = $fn,
+        message = "Prefer object spread instead of Object.assign()",
+        severity = "warn"
+    )
+}
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.js:1:7 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable merged is unused.
+  
+  > 1 │ const merged = Object.assign({}, a, b);
+      │       ^^^^^^
+    2 │ debugger
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend merged with an underscore.
+  
+    1   │ - const·merged·=·Object.assign({},·a,·b);
+      1 │ + const·_merged·=·Object.assign({},·a,·b);
+    2 2 │   debugger
+  
+
+```
+
+```block
+file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This is an unexpected use of the debugger statement.
+  
+    1 │ const merged = Object.assign({}, a, b);
+  > 2 │ debugger
+      │ ^^^^^^^^
+  
+  i Unsafe fix: Remove debugger statement
+  
+    1 1 │   const merged = Object.assign({}, a, b);
+    2   │ - debugger
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+Found 1 warning.
+```

--- a/crates/biome_configuration/src/analyzer/mod.rs
+++ b/crates/biome_configuration/src/analyzer/mod.rs
@@ -6,7 +6,7 @@ use crate::analyzer::assist::Actions;
 pub use crate::analyzer::linter::*;
 use crate::analyzer::presets::PresetConfig;
 use biome_analyze::options::RuleOptions;
-use biome_analyze::{FixKind, Rule, RuleCategory, RuleDomain, RuleFilter};
+use biome_analyze::{FixKind, PLUGIN_GROUP, Rule, RuleCategory, RuleDomain, RuleFilter};
 use biome_deserialize::{
     Deserializable, DeserializableType, DeserializableValue, DeserializationContext, Merge,
 };
@@ -571,6 +571,7 @@ where
 pub enum AnalyzerSelector {
     Rule(RuleSelector),
     Domain(DomainSelector),
+    Plugin,
 }
 
 impl AnalyzerSelector {
@@ -581,6 +582,7 @@ impl AnalyzerSelector {
         match self {
             Self::Rule(rule) => rule.match_rule::<R>(),
             Self::Domain(domain) => domain.match_rule::<R>(),
+            Self::Plugin => false,
         }
     }
 }
@@ -608,6 +610,7 @@ impl Display for AnalyzerSelector {
         match self {
             Self::Rule(group) => Display::fmt(group, f),
             Self::Domain(domain) => Display::fmt(domain, f),
+            Self::Plugin => f.write_str(PLUGIN_GROUP),
         }
     }
 }
@@ -616,6 +619,23 @@ impl FromStr for AnalyzerSelector {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // The reserved `plugin` group selects every analyzer plugin. Accept `plugin` and,
+        // for parity with the rule syntax, the `plugin/plugin` alias (each optionally with
+        // a `lint/` prefix). Plugins have no per-instance identity, so any other
+        // `plugin/<name>` is rejected.
+        let plugin_selector = s.strip_prefix("lint/").unwrap_or(s);
+        if plugin_selector == PLUGIN_GROUP || plugin_selector == "plugin/plugin" {
+            return Ok(Self::Plugin);
+        }
+        if plugin_selector
+            .strip_prefix(PLUGIN_GROUP)
+            .is_some_and(|rest| rest.starts_with('/'))
+        {
+            return Err(
+                "Per-plugin selection is not supported. Use `plugin` to target all plugins.",
+            );
+        }
+
         RuleSelector::from_str(s)
             .map(Self::Rule)
             .or(DomainSelector::from_str(s).map(Self::Domain))
@@ -628,6 +648,7 @@ impl serde::Serialize for AnalyzerSelector {
         match self {
             Self::Rule(rule) => rule.serialize(serializer),
             Self::Domain(domain) => domain.serialize(serializer),
+            Self::Plugin => serializer.serialize_str(PLUGIN_GROUP),
         }
     }
 }
@@ -1260,6 +1281,34 @@ mod test {
         assert_eq!(
             RuleSelector::from_str("assist/source/useSortedKeys").unwrap(),
             RuleSelector::Rule("source", "useSortedKeys")
+        );
+    }
+
+    #[test]
+    fn parses_plugin_selector() {
+        use crate::analyzer::AnalyzerSelector;
+
+        for selector in [
+            "plugin",
+            "lint/plugin",
+            "plugin/plugin",
+            "lint/plugin/plugin",
+        ] {
+            assert_eq!(
+                AnalyzerSelector::from_str(selector).unwrap(),
+                AnalyzerSelector::Plugin,
+                "{selector} should parse as the plugin selector"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_per_plugin_selector() {
+        use crate::analyzer::AnalyzerSelector;
+
+        assert_eq!(
+            AnalyzerSelector::from_str("plugin/foo"),
+            Err("Per-plugin selection is not supported. Use `plugin` to target all plugins.")
         );
     }
 }

--- a/crates/biome_css_analyze/src/lib.rs
+++ b/crates/biome_css_analyze/src/lib.rs
@@ -191,7 +191,7 @@ where
         .cloned()
         .collect();
 
-    if !css_plugins.is_empty() {
+    if filter.match_plugins() && !css_plugins.is_empty() {
         // SAFETY: All plugins have been verified to target CSS above.
         unsafe {
             analyzer.add_visitor(

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -230,7 +230,7 @@ where
         .cloned()
         .collect();
 
-    if !js_plugins.is_empty() {
+    if filter.match_plugins() && !js_plugins.is_empty() {
         // SAFETY: All plugins have been verified to target JavaScript above.
         unsafe {
             analyzer.add_visitor(

--- a/crates/biome_json_analyze/src/lib.rs
+++ b/crates/biome_json_analyze/src/lib.rs
@@ -143,7 +143,7 @@ where
         .cloned()
         .collect();
 
-    if !json_plugins.is_empty() {
+    if filter.match_plugins() && !json_plugins.is_empty() {
         // SAFETY: All plugins have been verified to target JSON above.
         unsafe {
             analyzer.add_visitor(

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -38,8 +38,8 @@ use crate::workspace::{
 use biome_analyze::options::JsxRuntime;
 use biome_analyze::{
     ActionFilter, AnalyzerAction, AnalyzerDiagnostic, AnalyzerOptions, AnalyzerPluginVec,
-    AnalyzerSignal, ControlFlow, FixKind, GroupCategory, Never, Queryable, RegistryVisitor, Rule,
-    RuleCategories, RuleCategory, RuleError, RuleFilter, RuleGroup,
+    AnalyzerSignal, ControlFlow, FixKind, GroupCategory, Never, PLUGIN_GROUP, Queryable,
+    RegistryVisitor, Rule, RuleCategories, RuleCategory, RuleError, RuleFilter, RuleGroup,
 };
 use biome_configuration::Rules;
 use biome_configuration::analyzer::{AnalyzerSelector, RuleDomainValue};
@@ -1434,6 +1434,7 @@ impl<'a, 'b> LintVisitor<'a, 'b> {
                             self.enabled_rules.extend(selector.as_rule_filters());
                         }
                     }
+                    AnalyzerSelector::Plugin => {}
                 }
             }
         }
@@ -1451,6 +1452,7 @@ impl<'a, 'b> LintVisitor<'a, 'b> {
                             self.disabled_rules.extend(selector.as_rule_filters());
                         }
                     }
+                    AnalyzerSelector::Plugin => {}
                 }
             }
         }
@@ -1636,6 +1638,7 @@ impl<'a, 'b> AssistsVisitor<'a, 'b> {
                             self.enabled_rules.extend(domain.as_rule_filters());
                         }
                     }
+                    AnalyzerSelector::Plugin => {}
                 }
             }
         }
@@ -1654,6 +1657,8 @@ impl<'a, 'b> AssistsVisitor<'a, 'b> {
                             self.disabled_rules.extend(domain.as_rule_filters());
                         }
                     }
+                    // Plugins are lint-only; ignore them for assists.
+                    AnalyzerSelector::Plugin => {}
                 }
             }
         }
@@ -1958,9 +1963,26 @@ impl<'b> AnalyzerVisitorBuilder<'b> {
                     AnalyzerSelector::Domain(domain) => {
                         enabled_rules.extend(domain.as_rule_filters())
                     }
+                    // Plugins are configured through the `plugins` field, not `rules`.
+                    AnalyzerSelector::Plugin => {}
                 }
             }
         }
+
+        // Plugins run by default. Turn them off by adding the reserved `plugin` group to
+        // `disabled_rules`, which `AnalysisFilter::plugins_enabled` reads. Plugins are
+        // disabled when explicitly skipped, or when `--only` restricts the run to other
+        // selectors. `--skip` takes precedence over `--only`, matching rule semantics.
+        let only_excludes_plugins = self
+            .only
+            .is_some_and(|only| !only.is_empty() && !only.contains(&AnalyzerSelector::Plugin));
+        let plugins_skipped = self
+            .skip
+            .is_some_and(|skip| skip.contains(&AnalyzerSelector::Plugin));
+        if only_excludes_plugins || plugins_skipped {
+            disabled_rules.push(RuleFilter::Group(PLUGIN_GROUP));
+        }
+
         let mut syntax = SyntaxVisitor::default();
 
         biome_js_analyze::visit_registry(&mut syntax);


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/10652

Now `--only` and `--skip` take the plugins in consideration, and they work as expected. It wasn't working because the `plugin` "group" wasn't part of the filtering at all.

It seems like a feature, seeing all the new snapshots and all; however, we've been having plugins for a long time, so it should count as a fix.

The fix was quite mechanical, so I used a couple of LLMs to implement the fix. I then changed a few things. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new fix

<!-- What demonstrates that your implementation is correct? -->

## Docs

Probably not needed

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
