### PR TITLE
docs(js-api): correct "If" to "It" in BiomeCommon method JSDoc

### DIFF
--- a/packages/@biomejs/js-api/src/common.ts
+++ b/packages/@biomejs/js-api/src/common.ts
@@ -235,7 +235,7 @@ export class BiomeCommon<Configuration, Diagnostic> {
 	/**
 	 * Allows to apply a custom configuration.
 	 *
-	 * If fails when the configuration is incorrect.
+	 * It fails when the configuration is incorrect.
 	 *
 	 * @param projectKey The identifier of the project
 	 * @param configuration
@@ -301,7 +301,7 @@ export class BiomeCommon<Configuration, Diagnostic> {
 	): FormatDebugResult<Diagnostic>;
 
 	/**
-	 * If formats some content.
+	 * It formats some content.
 	 *
 	 * @param projectKey The identifier of the project
 	 * @param content The content to format


### PR DESCRIPTION
Two `BiomeCommon` method descriptions begin with "If" where "It" is meant:

- `applyConfiguration`: "If fails when the configuration is incorrect."
- `formatContent`: "If formats some content."

These ship in the published `@biomejs/js-api` types, so they surface on hover. Corrected both to "It".
