### PR TITLE
refactor(useFlatMap): improve docs and diagnostics

### DIFF
--- a/.changeset/sharp-nights-divide.md
+++ b/.changeset/sharp-nights-divide.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the diagnostic and the documentation of [`useFlatMap`](https://biomejs.dev/linter/rules/use-flat-map/).

--- a/crates/biome_cli/tests/snapshots/main_cases_vcs_ignored_files/ignore_vcs_ignored_file_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_vcs_ignored_files/ignore_vcs_ignored_file_via_cli.snap
@@ -32,6 +32,8 @@ file1.js:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━
   > 1 │ array.map(sentence => sentence.split(' ')).flat();
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
+  i Using .flatMap() avoids the creation of an intermediate array.
+  
   i Safe fix: Replace the chain with .flatMap().
   
   - array.map(sentence·=>·sentence.split('·')).flat();

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_not_disable_recommended_rules_for_a_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_not_disable_recommended_rules_for_a_group.snap
@@ -54,6 +54,8 @@ fix.js:3:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━�
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ 		
   
+  i Using .flatMap() avoids the creation of an intermediate array.
+  
   i Safe fix: Replace the chain with .flatMap().
   
     1 1 │   const array = ["split", "the text", "into words"];

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_disable_recommended_rules_for_a_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_not_disable_recommended_rules_for_a_group.snap
@@ -43,6 +43,8 @@ fix.js:3:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━�
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ 		
   
+  i Using .flatMap() avoids the creation of an intermediate array.
+  
   i Safe fix: Replace the chain with .flatMap().
   
     1 1 │   const array = ["split", "the text", "into words"];

--- a/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
@@ -11,6 +11,9 @@ use biome_rule_options::use_flat_map::UseFlatMapOptions;
 declare_lint_rule! {
     /// Promotes the use of `.flatMap()` when `map().flat()` are used together.
     ///
+    /// Using `.flatMap()` instead of `map().flat()` avoids the creation of
+    /// an intermediate array.
+    ///
     /// ## Examples
     ///
     /// ### Invalid
@@ -97,7 +100,9 @@ impl Rule for UseFlatMap {
             markup! {
                 "The call chain "<Emphasis>".map().flat()"</Emphasis>" can be replaced with a single "<Emphasis>".flatMap()"</Emphasis>" call."
             },
-        ))
+        ).note(markup! {
+            "Using "<Emphasis>".flatMap()"</Emphasis>" avoids the creation of an intermediate array."
+        }))
     }
 
     fn action(ctx: &RuleContext<Self>, flat_call: &Self::State) -> Option<JsRuleAction> {

--- a/crates/biome_js_analyze/tests/specs/complexity/useFlatMap/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useFlatMap/invalid.jsonc.snap
@@ -16,6 +16,8 @@ invalid.jsonc:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━�
   > 1 │ [0, [12]].map(Number).flat();
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
+  i Using .flatMap() avoids the creation of an intermediate array.
+  
   i Safe fix: Replace the chain with .flatMap().
   
   - [0,·[12]].map(Number).flat();
@@ -37,6 +39,8 @@ invalid.jsonc:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━�
   
   > 1 │ [0, [12], [[16]]].map(Number).flat(1);
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i Using .flatMap() avoids the creation of an intermediate array.
   
   i Safe fix: Replace the chain with .flatMap().
   
@@ -60,6 +64,8 @@ invalid.jsonc:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━�
   > 1 │ [0, [12], [[16]]].map((element) => {}).flat(1);
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
+  i Using .flatMap() avoids the creation of an intermediate array.
+  
   i Safe fix: Replace the chain with .flatMap().
   
   - [0,·[12],·[[16]]].map((element)·=>·{}).flat(1);
@@ -82,6 +88,8 @@ invalid.jsonc:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━�
   > 1 │ [0, [12], [[16]]].map((element, index) => {}).flat(1);
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
+  i Using .flatMap() avoids the creation of an intermediate array.
+  
   i Safe fix: Replace the chain with .flatMap().
   
   - [0,·[12],·[[16]]].map((element,·index)·=>·{}).flat(1);
@@ -103,6 +111,8 @@ invalid.jsonc:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━�
   
   > 1 │ [0, [12], [[16]]].map((element, index, array) => {}).flat(1);
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i Using .flatMap() avoids the creation of an intermediate array.
   
   i Safe fix: Replace the chain with .flatMap().
   


### PR DESCRIPTION
## Summary

While I was preparing the video for JSNation, I noticed that `useFlatMap` was pretty concise in its diagnostics.
This PR fixes that by adding a small note.

## Test Plan

I updated the test snapshots.

## Docs

I added a changeset.