### PR TITLE
feat(assist): add `groups` and `sortScope` options to useSortedAttributes

### DIFF
--- a/.changeset/add-use-sorted-attributes-groups-options.md
+++ b/.changeset/add-use-sorted-attributes-groups-options.md
@@ -1,0 +1,8 @@
+---
+"@biomejs/biome": minor
+---
+
+Added `groups` and `sortScope` options to [`useSortedAttributes`](https://biomejs.dev/assist/actions/use-sorted-attributes/).
+
+- `sortScope: "group"` enables group-aware sorting: props are partitioned into groups, sorted within each group using `sortOrder`, then concatenated in group order. When `sortScope` is `"global"` (the default), all existing behavior is preserved.
+- `groups` accepts an ordered list of predefined group tokens (`:CALLBACK:`, `:IMPLICIT:`, `:RESERVED:`, `:DOM_RESERVED:`, `:REST:`) that control where special prop categories appear relative to each other. Only active when `sortScope` is `"group"`. `:REST:` is a catch-all for props matching no other group and, unlike the implicit fallback used when it's omitted, is sorted like a regular group. The default group ordering is `[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]`.

--- a/crates/biome_js_analyze/src/assist/source/use_sorted_attributes.rs
+++ b/crates/biome_js_analyze/src/assist/source/use_sorted_attributes.rs
@@ -12,9 +12,10 @@ use biome_js_syntax::{
     AnyJsxAttribute, JsLanguage, JsxAttribute, JsxAttributeList, JsxOpeningElement,
     JsxSelfClosingElement,
 };
-use biome_rowan::{AstNode, AstNodeExt, BatchMutationExt, SyntaxToken};
-use biome_rule_options::use_sorted_attributes::{SortOrder, UseSortedAttributesOptions};
-
+use biome_rowan::{AstNode, AstNodeExt, BatchMutationExt, SyntaxToken, TriviaPieceKind};
+use biome_rule_options::use_sorted_attributes::{
+    AttributeGroups, SortOrder, SortScope, UseSortedAttributesOptions, default_attribute_groups,
+};
 use crate::JsRuleAction;
 
 declare_source_rule! {
@@ -71,6 +72,45 @@ declare_source_rule! {
     /// <Hello tel={5555555} {...this.props} opt1="John" opt2="" opt12="" opt11="" />;
     /// ```
     ///
+    /// ### `groups`
+    ///
+    /// Controls the ordering of special prop categories. Only active when
+    /// `sortScope` is `"group"`. Accepts an ordered array of predefined group
+    /// tokens. Props not matching any group are placed after all named groups.
+    ///
+    /// Available group tokens:
+    /// - `":CALLBACK:"` — Callback props: names starting with `on` + uppercase (e.g. `onClick`).
+    /// - `":IMPLICIT:"` — Implicit (boolean shorthand) props: no value (e.g. `<Foo disabled />`).
+    /// - `":RESERVED:"` — React reserved props: `key` and `ref`.
+    /// - `":DOM_RESERVED:"` — DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.
+    /// - `":REST:"` — Catch-all for props that don't match any other configured group.
+    ///   Sorted like a regular group, using `sortOrder`. If omitted from `groups`, unmatched
+    ///   props are instead placed after all named groups, in their original relative order (unsorted).
+    ///
+    /// When not configured, the default ordering is:
+    /// `[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]`.
+    ///
+    /// ### `sortScope`
+    ///
+    /// Controls how `sortOrder` interacts with `groups`.
+    ///
+    /// - `"global"` (default): flat sort across all props, groups are ignored.
+    ///   Preserves existing behavior.
+    /// - `"group"`: props are first partitioned into groups (defined by `groups`),
+    ///   sorted within each group using `sortOrder`, then concatenated in group order.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "sortScope": "group",
+    ///         "groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"]
+    ///     }
+    /// }
+    /// ```
+    /// ```jsx,use_options,expect_diagnostic
+    /// <Hello onClick={fn} disabled key="1" name="John" />;
+    /// ```
+    ///
     pub UseSortedAttributes {
         version: "2.0.0",
         name: "useSortedAttributes",
@@ -89,48 +129,44 @@ impl Rule for UseSortedAttributes {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let props = ctx.query();
-        let mut current_prop_group = AttributeGroup::default();
-        let mut prop_groups = Vec::new();
         let options = ctx.options();
-        let sort_by = options.sort_order.unwrap_or_default();
+        let comparator = select_comparator(options);
+        let sort_scope = options.sort_scope.unwrap_or_default();
+        let groups = resolve_groups(options, sort_scope);
 
-        let comparator = match sort_by {
-            SortOrder::Natural => SortableJsxAttribute::ascii_nat_cmp,
-            SortOrder::Lexicographic => SortableJsxAttribute::lexicographic_cmp,
-        };
-
-        // Convert to boolean-based comparator for is_sorted_by
-        let boolean_comparator = |a: &SortableJsxAttribute, b: &SortableJsxAttribute| {
-            comparator(a, b) != Ordering::Greater
-        };
+        let mut current_bucket: Vec<SortableJsxAttribute> = Vec::new();
+        let mut prop_groups: Vec<AttributeGroup<SortableJsxAttribute>> = Vec::new();
 
         for prop in props {
             match prop {
                 AnyJsxAttribute::JsxAttribute(attr) => {
-                    current_prop_group.attrs.push(SortableJsxAttribute(attr));
+                    current_bucket.push(SortableJsxAttribute(attr));
                 }
-                // spread or shorthand attribute resets sort order: it carries
+                // Spread or shorthand attribute resets sort order: it carries
                 // an opaque expression that may have side effects on the
                 // resulting prop set, so attributes on either side cannot be
                 // freely reordered across it.
                 AnyJsxAttribute::JsxSpreadAttribute(_)
                 | AnyJsxAttribute::JsxShorthandAttribute(_) => {
-                    if !current_prop_group.is_empty()
-                        && !current_prop_group.is_sorted(boolean_comparator)
-                    {
-                        prop_groups.push(current_prop_group);
-                        current_prop_group = AttributeGroup::default();
-                    } else {
-                        // Reuse the same buffer
-                        current_prop_group.clear();
-                    }
+                    flush_bucket(
+                        &mut current_bucket,
+                        &mut prop_groups,
+                        groups.as_ref(),
+                        sort_scope,
+                        comparator,
+                    );
                 }
                 AnyJsxAttribute::JsMetavariable(_) => {}
             }
         }
-        if !current_prop_group.is_empty() && !current_prop_group.is_sorted(boolean_comparator) {
-            prop_groups.push(current_prop_group);
-        }
+        flush_bucket(
+            &mut current_bucket,
+            &mut prop_groups,
+            groups.as_ref(),
+            sort_scope,
+            comparator,
+        );
+
         prop_groups.into_boxed_slice()
     }
 
@@ -155,15 +191,19 @@ impl Rule for UseSortedAttributes {
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
         let mut mutation = ctx.root().begin();
         let options = ctx.options();
-        let sort_by = options.sort_order.unwrap_or_default();
+        let comparator = select_comparator(options);
+        let sort_scope = options.sort_scope.unwrap_or_default();
+        let groups = resolve_groups(options, sort_scope);
 
-        let comparator = match sort_by {
-            SortOrder::Natural => SortableJsxAttribute::ascii_nat_cmp,
-            SortOrder::Lexicographic => SortableJsxAttribute::lexicographic_cmp,
+        let sorted = match sort_scope {
+            SortScope::Global => state.get_sorted_attributes(comparator)?,
+            SortScope::Group => {
+                get_sorted_by_groups(&state.attrs, groups.as_ref(), comparator)?
+            }
         };
 
         for (SortableJsxAttribute(attr), SortableJsxAttribute(sorted_attr)) in
-            zip(state.attrs.iter(), state.get_sorted_attributes(comparator)?)
+            zip(state.attrs.iter(), sorted)
         {
             mutation.replace_node_discard_trivia(attr.clone(), sorted_attr);
         }
@@ -176,6 +216,184 @@ impl Rule for UseSortedAttributes {
         ))
     }
 }
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Returns the effective `AttributeGroups` when `sort_scope` is `Group`.
+fn resolve_groups(
+    options: &UseSortedAttributesOptions,
+    sort_scope: SortScope,
+) -> Option<AttributeGroups> {
+    if sort_scope == SortScope::Global {
+        return None;
+    }
+    Some(
+        options
+            .groups
+            .clone()
+            .unwrap_or_else(default_attribute_groups),
+    )
+}
+
+type ComparatorFn = fn(&SortableJsxAttribute, &SortableJsxAttribute) -> Ordering;
+
+/// Selects the comparator based on `sortOrder`.
+fn select_comparator(options: &UseSortedAttributesOptions) -> ComparatorFn {
+    match options.sort_order.unwrap_or_default() {
+        SortOrder::Natural => SortableJsxAttribute::ascii_nat_cmp,
+        SortOrder::Lexicographic => SortableJsxAttribute::lexicographic_cmp,
+    }
+}
+
+/// Checks a bucket of props and, if unsorted, pushes an `AttributeGroup` to `out`.
+fn flush_bucket(
+    bucket: &mut Vec<SortableJsxAttribute>,
+    out: &mut Vec<AttributeGroup<SortableJsxAttribute>>,
+    groups: Option<&AttributeGroups>,
+    sort_scope: SortScope,
+    comparator: ComparatorFn,
+) {
+    if bucket.is_empty() {
+        return;
+    }
+
+    let is_already_sorted = match sort_scope {
+        SortScope::Global => {
+            let bc = |a: &SortableJsxAttribute, b: &SortableJsxAttribute| {
+                comparator(a, b) != Ordering::Greater
+            };
+            bucket.is_sorted_by(bc)
+        }
+        SortScope::Group => {
+            let sorted = get_sorted_by_groups(bucket, groups, comparator);
+            sorted.is_some_and(|sorted| bucket.iter().zip(sorted.iter()).all(|(a, b)| a.0 == b.0))
+        }
+    };
+
+    if is_already_sorted {
+        bucket.clear();
+    } else {
+        out.push(AttributeGroup {
+            attrs: std::mem::take(bucket),
+        });
+    }
+}
+
+/// Returns props sorted with group-aware logic.
+///
+/// Sorts independently-bucketed groups and concatenates them. The
+/// separating-whitespace fixup is applied **once** over the fully concatenated
+/// result (see [`ensure_separating_whitespace`]); doing it per-bucket would
+/// miss the seams between buckets and could emit mashed-together, invalid JSX.
+fn get_sorted_by_groups(
+    attrs: &[SortableJsxAttribute],
+    groups: Option<&AttributeGroups>,
+    comparator: ComparatorFn,
+) -> Option<Vec<SortableJsxAttribute>> {
+    let mut result = sort_into_buckets(attrs, groups, comparator)?;
+    ensure_separating_whitespace(&mut result)?;
+    Some(result)
+}
+
+/// Ensures every attribute except the last carries separating trailing
+/// whitespace.
+///
+/// Group sorting concatenates independently-sorted buckets. A bucket's last
+/// attribute may be the source's final prop (e.g. the one right before `/>` or
+/// `>`), which carries no trailing whitespace. Once reordered next to another
+/// bucket, the two attributes would render mashed together
+/// (`onClick={fn}key="1"`), producing invalid JSX. This pass runs once over the
+/// fully concatenated result, mirroring what
+/// `AttributeGroup::get_sorted_attributes` does for the global (flat) path.
+fn ensure_separating_whitespace(attrs: &mut [SortableJsxAttribute]) -> Option<()> {
+    let mut iter = attrs.iter_mut().peekable();
+    while let Some(attr) = iter.next() {
+        if iter.peek().is_some() {
+            let ends_in_whitespace = attr
+                .node()
+                .syntax()
+                .last_trailing_trivia()
+                .and_then(|last_trivia| last_trivia.last())
+                .is_some_and(|last| last.is_whitespace() || last.is_newline());
+
+            let next_starts_with_whitespace = iter
+                .peek()
+                .and_then(|next_attr| next_attr.node().syntax().first_leading_trivia())
+                .and_then(|first_trivia| first_trivia.first())
+                .is_some_and(|first| first.is_whitespace() || first.is_newline());
+
+            if !ends_in_whitespace && !next_starts_with_whitespace {
+                let old_last_token = attr.node().syntax().last_token()?;
+                let new_trailing_trivia: Vec<(TriviaPieceKind, String)> = old_last_token
+                    .trailing_trivia()
+                    .pieces()
+                    .map(|p| (p.kind(), p.text().to_string()))
+                    .chain(std::iter::once((TriviaPieceKind::Whitespace, " ".to_string())))
+                    .collect();
+                // Convert owned strings back to &str for with_trailing_trivia
+                let trivia_refs: Vec<(TriviaPieceKind, &str)> = new_trailing_trivia
+                    .iter()
+                    .map(|(k, s)| (*k, s.as_str()))
+                    .collect();
+                let new_last_token = old_last_token.with_trailing_trivia(trivia_refs);
+                *attr = attr.clone().replace_token(old_last_token, new_last_token)?;
+            }
+        }
+    }
+    Some(())
+}
+
+/// Assigns each prop to a group bucket, sorts named buckets, and concatenates.
+/// The implicit rest bucket (when `:REST:` is not configured) is left unsorted.
+fn sort_into_buckets(
+    attrs: &[SortableJsxAttribute],
+    groups: Option<&AttributeGroups>,
+    comparator: ComparatorFn,
+) -> Option<Vec<SortableJsxAttribute>> {
+    if attrs.is_empty() {
+        return Some(Vec::new());
+    }
+
+    // The implicit-fallback-bucket index is `groups.len()` (one past the
+    // last named group). `AttributeGroups::group_index` only ever returns
+    // this index for props that match neither a named group nor a
+    // configured `:REST:` group, so this bucket is only ever non-empty when
+    // `:REST:` isn't configured. Such props are NOT sorted — their original
+    // relative order is preserved. An explicit `:REST:` group, by contrast,
+    // occupies its own (sorted) bucket at its configured position.
+    let rest_index = groups.map_or(0, |g| g.len());
+
+    let annotated: Vec<(usize, SortableJsxAttribute)> = attrs
+        .iter()
+        .map(|attr| {
+            let idx = match groups {
+                Some(g) => g.group_index(&attr.0),
+                None => 0,
+            };
+            (idx, attr.clone())
+        })
+        .collect();
+
+    let max_bucket = annotated.iter().map(|(idx, _)| *idx).max().unwrap_or(0);
+    let mut buckets: Vec<Vec<SortableJsxAttribute>> = vec![Vec::new(); max_bucket + 1];
+    for (idx, attr) in annotated {
+        buckets[idx].push(attr);
+    }
+
+    let mut result: Vec<SortableJsxAttribute> = Vec::with_capacity(attrs.len());
+    for (idx, mut bucket) in buckets.into_iter().enumerate() {
+        // The rest bucket preserves source order; named buckets are sorted.
+        // Separating whitespace is fixed up once by the caller.
+        if idx != rest_index {
+            bucket.sort_by(comparator);
+        }
+        result.extend(bucket);
+    }
+
+    Some(result)
+}
+
+// ── SortableJsxAttribute ──────────────────────────────────────────────────────
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct SortableJsxAttribute(JsxAttribute);
@@ -205,3 +423,4 @@ impl SortableAttribute for SortableJsxAttribute {
         ))
     }
 }
+

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.jsx
@@ -1,0 +1,55 @@
+// sortScope: "group" with default groups [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+// Complex components exercising all five group types.
+
+// Unsorted: all five group types mixed
+<Hello
+  onFocus={handleFocus}
+  name="John"
+  children={<Avatar />}
+  active
+  ref={myRef}
+  onChange={handleChange}
+  lastName="Smith"
+  dangerouslySetInnerHTML={{ __html: html }}
+  disabled
+  key="user-1"
+/>;
+
+// Correctly sorted: [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+// within each group sorted alphabetically
+<Hello
+  active
+  disabled
+  key="user-1"
+  ref={myRef}
+  children={<Avatar />}
+  dangerouslySetInnerHTML={{ __html: html }}
+  lastName="Smith"
+  name="John"
+  onChange={handleChange}
+  onFocus={handleFocus}
+/>;
+
+// Unsorted: RESERVED group — key after REST prop
+<Hello name="John" key="1" />;
+
+// Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+<Hello name="John" key="1" children={<Foo />} />;
+
+// Unsorted: multiple callbacks out of alphabetical order, after implicit props
+<Hello onFocus={fn} onClick={fn} active name="John" />;
+
+// Unsorted with spread fence: each segment covers all group types
+<Hello
+  onClick={handleClick}
+  name="John"
+  disabled
+  key="user-1"
+  children={<Avatar />}
+  {...defaults}
+  onFocus={handleFocus}
+  lastName="Smith"
+  active
+  ref={myRef}
+  dangerouslySetInnerHTML={{ __html: html }}
+/>;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.jsx.snap
@@ -1,0 +1,251 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 150
+expression: groups-all-types.jsx
+---
+# Input
+```jsx
+// sortScope: "group" with default groups [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+// Complex components exercising all five group types.
+
+// Unsorted: all five group types mixed
+<Hello
+  onFocus={handleFocus}
+  name="John"
+  children={<Avatar />}
+  active
+  ref={myRef}
+  onChange={handleChange}
+  lastName="Smith"
+  dangerouslySetInnerHTML={{ __html: html }}
+  disabled
+  key="user-1"
+/>;
+
+// Correctly sorted: [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+// within each group sorted alphabetically
+<Hello
+  active
+  disabled
+  key="user-1"
+  ref={myRef}
+  children={<Avatar />}
+  dangerouslySetInnerHTML={{ __html: html }}
+  lastName="Smith"
+  name="John"
+  onChange={handleChange}
+  onFocus={handleFocus}
+/>;
+
+// Unsorted: RESERVED group — key after REST prop
+<Hello name="John" key="1" />;
+
+// Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+<Hello name="John" key="1" children={<Foo />} />;
+
+// Unsorted: multiple callbacks out of alphabetical order, after implicit props
+<Hello onFocus={fn} onClick={fn} active name="John" />;
+
+// Unsorted with spread fence: each segment covers all group types
+<Hello
+  onClick={handleClick}
+  name="John"
+  disabled
+  key="user-1"
+  children={<Avatar />}
+  {...defaults}
+  onFocus={handleFocus}
+  lastName="Smith"
+  active
+  ref={myRef}
+  dangerouslySetInnerHTML={{ __html: html }}
+/>;
+
+```
+
+# Diagnostics
+```
+groups-all-types.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     4 │ // Unsorted: all five group types mixed
+   > 5 │ <Hello
+       │ ^^^^^^
+   > 6 │   onFocus={handleFocus}
+        ...
+  > 15 │   key="user-1"
+  > 16 │ />;
+       │ ^^
+    17 │ 
+    18 │ // Correctly sorted: [:IMPLICIT:, :RESERVED:, :DOM_RESERVED:, :REST:, :CALLBACK:]
+  
+  i Safe fix: Sort the JSX props.
+  
+     4  4 │   // Unsorted: all five group types mixed
+     5  5 │   <Hello
+     6    │ - ··onFocus={handleFocus}
+     7    │ - ··name="John"
+     8    │ - ··children={<Avatar·/>}
+     9    │ - ··active
+    10    │ - ··ref={myRef}
+    11    │ - ··onChange={handleChange}
+        6 │ + ··active
+        7 │ + ··disabled
+        8 │ + ··key="user-1"
+        9 │ + ··ref={myRef}
+       10 │ + ··children={<Avatar·/>}
+       11 │ + ··dangerouslySetInnerHTML={{·__html:·html·}}
+    12 12 │     lastName="Smith"
+    13    │ - ··dangerouslySetInnerHTML={{·__html:·html·}}
+    14    │ - ··disabled
+    15    │ - ··key="user-1"
+       13 │ + ··name="John"
+       14 │ + ··onChange={handleChange}
+       15 │ + ··onFocus={handleFocus}
+    16 16 │   />;
+    17 17 │   
+  
+
+```
+
+```
+groups-all-types.jsx:34:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    33 │ // Unsorted: RESERVED group — key after REST prop
+  > 34 │ <Hello name="John" key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    35 │ 
+    36 │ // Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+  
+  i Safe fix: Sort the JSX props.
+  
+    32 32 │   
+    33 33 │   // Unsorted: RESERVED group — key after REST prop
+    34    │ - <Hello·name="John"·key="1"·/>;
+       34 │ + <Hello·key="1"·name="John"·/>;
+    35 35 │   
+    36 36 │   // Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+  
+
+```
+
+```
+groups-all-types.jsx:37:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    36 │ // Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+  > 37 │ <Hello name="John" key="1" children={<Foo />} />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    38 │ 
+    39 │ // Unsorted: multiple callbacks out of alphabetical order, after implicit props
+  
+  i Safe fix: Sort the JSX props.
+  
+    35 35 │   
+    36 36 │   // Unsorted: DOM_RESERVED group — children before REST props (should follow RESERVED)
+    37    │ - <Hello·name="John"·key="1"·children={<Foo·/>}·/>;
+       37 │ + <Hello·key="1"·children={<Foo·/>}·name="John"·/>;
+    38 38 │   
+    39 39 │   // Unsorted: multiple callbacks out of alphabetical order, after implicit props
+  
+
+```
+
+```
+groups-all-types.jsx:40:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    39 │ // Unsorted: multiple callbacks out of alphabetical order, after implicit props
+  > 40 │ <Hello onFocus={fn} onClick={fn} active name="John" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    41 │ 
+    42 │ // Unsorted with spread fence: each segment covers all group types
+  
+  i Safe fix: Sort the JSX props.
+  
+    38 38 │   
+    39 39 │   // Unsorted: multiple callbacks out of alphabetical order, after implicit props
+    40    │ - <Hello·onFocus={fn}·onClick={fn}·active·name="John"·/>;
+       40 │ + <Hello·active·name="John"·onClick={fn}·onFocus={fn}·/>;
+    41 41 │   
+    42 42 │   // Unsorted with spread fence: each segment covers all group types
+  
+
+```
+
+```
+groups-all-types.jsx:43:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    42 │ // Unsorted with spread fence: each segment covers all group types
+  > 43 │ <Hello
+       │ ^^^^^^
+  > 44 │   onClick={handleClick}
+        ...
+  > 53 │   ref={myRef}
+  > 54 │   dangerouslySetInnerHTML={{ __html: html }}
+  > 55 │ />;
+       │ ^^
+    56 │ 
+  
+  i Safe fix: Sort the JSX props.
+  
+    48 48 │     children={<Avatar />}
+    49 49 │     {...defaults}
+    50    │ - ··onFocus={handleFocus}
+    51    │ - ··lastName="Smith"
+    52    │ - ··active
+    53    │ - ··ref={myRef}
+    54    │ - ··dangerouslySetInnerHTML={{·__html:·html·}}
+       50 │ + ··active
+       51 │ + ··ref={myRef}
+       52 │ + ··dangerouslySetInnerHTML={{·__html:·html·}}
+       53 │ + ··lastName="Smith"
+       54 │ + ··onFocus={handleFocus}
+    55 55 │   />;
+    56 56 │   
+  
+
+```
+
+```
+groups-all-types.jsx:43:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    42 │ // Unsorted with spread fence: each segment covers all group types
+  > 43 │ <Hello
+       │ ^^^^^^
+  > 44 │   onClick={handleClick}
+        ...
+  > 53 │   ref={myRef}
+  > 54 │   dangerouslySetInnerHTML={{ __html: html }}
+  > 55 │ />;
+       │ ^^
+    56 │ 
+  
+  i Safe fix: Sort the JSX props.
+  
+    42 42 │   // Unsorted with spread fence: each segment covers all group types
+    43 43 │   <Hello
+    44    │ - ··onClick={handleClick}
+    45    │ - ··name="John"
+    46    │ - ··disabled
+    47    │ - ··key="user-1"
+    48    │ - ··children={<Avatar·/>}
+       44 │ + ··disabled
+       45 │ + ··key="user-1"
+       46 │ + ··children={<Avatar·/>}
+       47 │ + ··name="John"
+       48 │ + ··onClick={handleClick}
+    49 49 │     {...defaults}
+    50 50 │     onFocus={handleFocus}
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-all-types.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group"
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.jsx
@@ -1,0 +1,11 @@
+// Custom groups order: [:CALLBACK:, :RESERVED:, :IMPLICIT:]
+// Callbacks first, then reserved (key/ref), then implicit (shorthand), then rest
+
+// Unsorted: implicit before callback
+<Hello disabled key="1" onChange={fn} name="John" />;
+
+// Unsorted: reserved (key) after callback but implicit in wrong position
+<Hello name="John" onChange={fn} disabled key="1" />;
+
+// Correctly ordered: callback, reserved, implicit, rest
+<Hello onChange={fn} key="1" disabled name="John" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.jsx.snap
@@ -1,0 +1,67 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 154
+expression: groups-custom-order.jsx
+---
+# Input
+```jsx
+// Custom groups order: [:CALLBACK:, :RESERVED:, :IMPLICIT:]
+// Callbacks first, then reserved (key/ref), then implicit (shorthand), then rest
+
+// Unsorted: implicit before callback
+<Hello disabled key="1" onChange={fn} name="John" />;
+
+// Unsorted: reserved (key) after callback but implicit in wrong position
+<Hello name="John" onChange={fn} disabled key="1" />;
+
+// Correctly ordered: callback, reserved, implicit, rest
+<Hello onChange={fn} key="1" disabled name="John" />;
+
+```
+
+# Diagnostics
+```
+groups-custom-order.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    4 │ // Unsorted: implicit before callback
+  > 5 │ <Hello disabled key="1" onChange={fn} name="John" />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ // Unsorted: reserved (key) after callback but implicit in wrong position
+  
+  i Safe fix: Sort the JSX props.
+  
+     3  3 │   
+     4  4 │   // Unsorted: implicit before callback
+     5    │ - <Hello·disabled·key="1"·onChange={fn}·name="John"·/>;
+        5 │ + <Hello·onChange={fn}·key="1"·disabled·name="John"·/>;
+     6  6 │   
+     7  7 │   // Unsorted: reserved (key) after callback but implicit in wrong position
+  
+
+```
+
+```
+groups-custom-order.jsx:8:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     7 │ // Unsorted: reserved (key) after callback but implicit in wrong position
+   > 8 │ <Hello name="John" onChange={fn} disabled key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Correctly ordered: callback, reserved, implicit, rest
+  
+  i Safe fix: Sort the JSX props.
+  
+     6  6 │   
+     7  7 │   // Unsorted: reserved (key) after callback but implicit in wrong position
+     8    │ - <Hello·name="John"·onChange={fn}·disabled·key="1"·/>;
+        8 │ + <Hello·onChange={fn}·key="1"·disabled·name="John"·/>;
+     9  9 │   
+    10 10 │   // Correctly ordered: callback, reserved, implicit, rest
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-custom-order.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":CALLBACK:", ":RESERVED:", ":IMPLICIT:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.jsx
@@ -1,0 +1,7 @@
+// sortScope: "group", groups: []
+// An empty groups list disables group sorting: every prop falls into the
+// implicit (unsorted) rest bucket, so source order is always preserved and the
+// rule never reports. This pins that behavior.
+
+// Clearly unsorted by name, but no diagnostic is emitted (no-op)
+<Hello zebra="z" apple="a" key="1" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.jsx.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-empty.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: []
+// An empty groups list disables group sorting: every prop falls into the
+// implicit (unsorted) rest bucket, so source order is always preserved and the
+// rule never reports. This pins that behavior.
+
+// Clearly unsorted by name, but no diagnostic is emitted (no-op)
+<Hello zebra="z" apple="a" key="1" />;
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-empty.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": []
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.jsx
@@ -1,0 +1,9 @@
+// sortScope: "group", sortOrder: "lexicographic", groups: [:RESERVED:, :REST:]
+// Lexicographic (byte) order applies within each group: "item10" sorts before
+// "item2" (unlike natural order), and uppercase sorts before lowercase.
+
+// Unsorted REST: lexicographic puts Zebra before apple, and item10 before item2
+<Hello item2="a" key="1" item10="b" apple="c" Zebra="d" />;
+
+// Correctly ordered: reserved key, then REST in lexicographic order
+<Hello key="1" Zebra="d" apple="c" item10="b" item2="a" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.jsx.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-lexicographic.jsx
+---
+# Input
+```jsx
+// sortScope: "group", sortOrder: "lexicographic", groups: [:RESERVED:, :REST:]
+// Lexicographic (byte) order applies within each group: "item10" sorts before
+// "item2" (unlike natural order), and uppercase sorts before lowercase.
+
+// Unsorted REST: lexicographic puts Zebra before apple, and item10 before item2
+<Hello item2="a" key="1" item10="b" apple="c" Zebra="d" />;
+
+// Correctly ordered: reserved key, then REST in lexicographic order
+<Hello key="1" Zebra="d" apple="c" item10="b" item2="a" />;
+
+```
+
+# Diagnostics
+```
+groups-lexicographic.jsx:6:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    5 │ // Unsorted REST: lexicographic puts Zebra before apple, and item10 before item2
+  > 6 │ <Hello item2="a" key="1" item10="b" apple="c" Zebra="d" />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
+    8 │ // Correctly ordered: reserved key, then REST in lexicographic order
+  
+  i Safe fix: Sort the JSX props.
+  
+     4  4 │   
+     5  5 │   // Unsorted REST: lexicographic puts Zebra before apple, and item10 before item2
+     6    │ - <Hello·item2="a"·key="1"·item10="b"·apple="c"·Zebra="d"·/>;
+        6 │ + <Hello·key="1"·Zebra="d"·apple="c"·item10="b"·item2="a"·/>;
+     7  7 │   
+     8  8 │   // Correctly ordered: reserved key, then REST in lexicographic order
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-lexicographic.options.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"sortOrder": "lexicographic",
+						"groups": [":RESERVED:", ":REST:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.jsx
@@ -1,0 +1,14 @@
+// sortScope: "group", groups: [:CALLBACK:, :RESERVED:]
+// Regression: the source-final prop carries no trailing whitespace (it sits
+// right before `/>` or `>`). When a group moves it off the end, the result must
+// still keep a separating space, otherwise the props mash into invalid JSX
+// (e.g. `onClick={fn}key="1"`).
+
+// Self-closing, no space before `/>`: reserved key moved after callback
+<Hello key="1" onClick={fn}/>;
+
+// Opening element, no space before `>`
+<Hello key="1" onClick={fn}>x</Hello>;
+
+// Already in group order (callback, then reserved): no diagnostic
+<Hello onClick={fn} key="1"/>;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.jsx.snap
@@ -1,0 +1,69 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-no-trailing-space.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:CALLBACK:, :RESERVED:]
+// Regression: the source-final prop carries no trailing whitespace (it sits
+// right before `/>` or `>`). When a group moves it off the end, the result must
+// still keep a separating space, otherwise the props mash into invalid JSX
+// (e.g. `onClick={fn}key="1"`).
+
+// Self-closing, no space before `/>`: reserved key moved after callback
+<Hello key="1" onClick={fn}/>;
+
+// Opening element, no space before `>`
+<Hello key="1" onClick={fn}>x</Hello>;
+
+// Already in group order (callback, then reserved): no diagnostic
+<Hello onClick={fn} key="1"/>;
+
+```
+
+# Diagnostics
+```
+groups-no-trailing-space.jsx:8:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     7 │ // Self-closing, no space before `/>`: reserved key moved after callback
+   > 8 │ <Hello key="1" onClick={fn}/>;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Opening element, no space before `>`
+  
+  i Safe fix: Sort the JSX props.
+  
+     6  6 │   
+     7  7 │   // Self-closing, no space before `/>`: reserved key moved after callback
+     8    │ - <Hello·key="1"·onClick={fn}/>;
+        8 │ + <Hello·onClick={fn}·key="1"·/>;
+     9  9 │   
+    10 10 │   // Opening element, no space before `>`
+  
+
+```
+
+```
+groups-no-trailing-space.jsx:11:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Opening element, no space before `>`
+  > 11 │ <Hello key="1" onClick={fn}>x</Hello>;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // Already in group order (callback, then reserved): no diagnostic
+  
+  i Safe fix: Sort the JSX props.
+  
+     9  9 │   
+    10 10 │   // Opening element, no space before `>`
+    11    │ - <Hello·key="1"·onClick={fn}>x</Hello>;
+       11 │ + <Hello·onClick={fn}·key="1"·>x</Hello>;
+    12 12 │   
+    13 13 │   // Already in group order (callback, then reserved): no diagnostic
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-no-trailing-space.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":CALLBACK:", ":RESERVED:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.jsx
@@ -1,0 +1,10 @@
+// Custom groups with an explicit :REST: placement: [:RESERVED:, :REST:, :CALLBACK:]
+// :REST: catches everything not explicitly listed (including implicit/dom-reserved
+// props, since :IMPLICIT: and :DOM_RESERVED: aren't configured here) and sorts
+// them like a regular group, instead of leaving them unsorted at the end.
+
+// Unsorted: reserved not first, rest props out of order
+<Hello zebra="z" key="1" apple="a" onClick={fn} disabled />;
+
+// Correctly ordered: reserved, then rest (sorted, including "disabled"), then callback
+<Hello key="1" apple="a" disabled zebra="z" onClick={fn} />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.jsx.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-rest-explicit.jsx
+---
+# Input
+```jsx
+// Custom groups with an explicit :REST: placement: [:RESERVED:, :REST:, :CALLBACK:]
+// :REST: catches everything not explicitly listed (including implicit/dom-reserved
+// props, since :IMPLICIT: and :DOM_RESERVED: aren't configured here) and sorts
+// them like a regular group, instead of leaving them unsorted at the end.
+
+// Unsorted: reserved not first, rest props out of order
+<Hello zebra="z" key="1" apple="a" onClick={fn} disabled />;
+
+// Correctly ordered: reserved, then rest (sorted, including "disabled"), then callback
+<Hello key="1" apple="a" disabled zebra="z" onClick={fn} />;
+
+```
+
+# Diagnostics
+```
+groups-rest-explicit.jsx:7:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    6 │ // Unsorted: reserved not first, rest props out of order
+  > 7 │ <Hello zebra="z" key="1" apple="a" onClick={fn} disabled />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ // Correctly ordered: reserved, then rest (sorted, including "disabled"), then callback
+  
+  i Safe fix: Sort the JSX props.
+  
+     5  5 │   
+     6  6 │   // Unsorted: reserved not first, rest props out of order
+     7    │ - <Hello·zebra="z"·key="1"·apple="a"·onClick={fn}·disabled·/>;
+        7 │ + <Hello·key="1"·apple="a"·disabled·zebra="z"·onClick={fn}·/>;
+     8  8 │   
+     9  9 │   // Correctly ordered: reserved, then rest (sorted, including "disabled"), then callback
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-rest-explicit.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":REST:", ":CALLBACK:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.jsx
@@ -1,0 +1,20 @@
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:]
+// Spread props act as fences: each batch between spreads is sorted independently.
+
+// Unsorted batch before a spread
+<Hello onChange={fn} disabled key="1" {...this.props} />;
+
+// Unsorted batch after a spread
+<Hello {...this.props} onChange={fn} disabled key="1" />;
+
+// Both batches unsorted
+<Hello onChange={fn} disabled key="1" {...this.props} onChange={fn} disabled key="2" />;
+
+// First batch sorted, second unsorted
+<Hello key="1" disabled onChange={fn} {...this.props} onChange={fn} disabled key="2" />;
+
+// Correctly sorted: all batches already in group order — no diagnostic
+<Hello key="1" disabled onChange={fn} {...this.props} key="2" disabled onChange={fn} />;
+
+// Multiple spreads: each segment sorted independently
+<Hello onChange={fn} disabled {...props1} lastName="Smith" firstName="John" {...props2} onChange={fn} key="1" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.jsx.snap
@@ -1,0 +1,186 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: groups-spread.jsx
+---
+# Input
+```jsx
+// sortScope: "group", groups: [:RESERVED:, :IMPLICIT:, :CALLBACK:]
+// Spread props act as fences: each batch between spreads is sorted independently.
+
+// Unsorted batch before a spread
+<Hello onChange={fn} disabled key="1" {...this.props} />;
+
+// Unsorted batch after a spread
+<Hello {...this.props} onChange={fn} disabled key="1" />;
+
+// Both batches unsorted
+<Hello onChange={fn} disabled key="1" {...this.props} onChange={fn} disabled key="2" />;
+
+// First batch sorted, second unsorted
+<Hello key="1" disabled onChange={fn} {...this.props} onChange={fn} disabled key="2" />;
+
+// Correctly sorted: all batches already in group order — no diagnostic
+<Hello key="1" disabled onChange={fn} {...this.props} key="2" disabled onChange={fn} />;
+
+// Multiple spreads: each segment sorted independently
+<Hello onChange={fn} disabled {...props1} lastName="Smith" firstName="John" {...props2} onChange={fn} key="1" />;
+
+```
+
+# Diagnostics
+```
+groups-spread.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    4 │ // Unsorted batch before a spread
+  > 5 │ <Hello onChange={fn} disabled key="1" {...this.props} />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ // Unsorted batch after a spread
+  
+  i Safe fix: Sort the JSX props.
+  
+     3  3 │   
+     4  4 │   // Unsorted batch before a spread
+     5    │ - <Hello·onChange={fn}·disabled·key="1"·{...this.props}·/>;
+        5 │ + <Hello·key="1"·disabled·onChange={fn}·{...this.props}·/>;
+     6  6 │   
+     7  7 │   // Unsorted batch after a spread
+  
+
+```
+
+```
+groups-spread.jsx:8:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+     7 │ // Unsorted batch after a spread
+   > 8 │ <Hello {...this.props} onChange={fn} disabled key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Both batches unsorted
+  
+  i Safe fix: Sort the JSX props.
+  
+     6  6 │   
+     7  7 │   // Unsorted batch after a spread
+     8    │ - <Hello·{...this.props}·onChange={fn}·disabled·key="1"·/>;
+        8 │ + <Hello·{...this.props}·key="1"·disabled·onChange={fn}·/>;
+     9  9 │   
+    10 10 │   // Both batches unsorted
+  
+
+```
+
+```
+groups-spread.jsx:11:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Both batches unsorted
+  > 11 │ <Hello onChange={fn} disabled key="1" {...this.props} onChange={fn} disabled key="2" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // First batch sorted, second unsorted
+  
+  i Safe fix: Sort the JSX props.
+  
+     9  9 │   
+    10 10 │   // Both batches unsorted
+    11    │ - <Hello·onChange={fn}·disabled·key="1"·{...this.props}·onChange={fn}·disabled·key="2"·/>;
+       11 │ + <Hello·key="1"·disabled·onChange={fn}·{...this.props}·onChange={fn}·disabled·key="2"·/>;
+    12 12 │   
+    13 13 │   // First batch sorted, second unsorted
+  
+
+```
+
+```
+groups-spread.jsx:11:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    10 │ // Both batches unsorted
+  > 11 │ <Hello onChange={fn} disabled key="1" {...this.props} onChange={fn} disabled key="2" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // First batch sorted, second unsorted
+  
+  i Safe fix: Sort the JSX props.
+  
+     9  9 │   
+    10 10 │   // Both batches unsorted
+    11    │ - <Hello·onChange={fn}·disabled·key="1"·{...this.props}·onChange={fn}·disabled·key="2"·/>;
+       11 │ + <Hello·onChange={fn}·disabled·key="1"·{...this.props}·key="2"·disabled·onChange={fn}·/>;
+    12 12 │   
+    13 13 │   // First batch sorted, second unsorted
+  
+
+```
+
+```
+groups-spread.jsx:14:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    13 │ // First batch sorted, second unsorted
+  > 14 │ <Hello key="1" disabled onChange={fn} {...this.props} onChange={fn} disabled key="2" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ 
+    16 │ // Correctly sorted: all batches already in group order — no diagnostic
+  
+  i Safe fix: Sort the JSX props.
+  
+    12 12 │   
+    13 13 │   // First batch sorted, second unsorted
+    14    │ - <Hello·key="1"·disabled·onChange={fn}·{...this.props}·onChange={fn}·disabled·key="2"·/>;
+       14 │ + <Hello·key="1"·disabled·onChange={fn}·{...this.props}·key="2"·disabled·onChange={fn}·/>;
+    15 15 │   
+    16 16 │   // Correctly sorted: all batches already in group order — no diagnostic
+  
+
+```
+
+```
+groups-spread.jsx:20:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    19 │ // Multiple spreads: each segment sorted independently
+  > 20 │ <Hello onChange={fn} disabled {...props1} lastName="Smith" firstName="John" {...props2} onChange={fn} key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
+  
+  i Safe fix: Sort the JSX props.
+  
+    18 18 │   
+    19 19 │   // Multiple spreads: each segment sorted independently
+    20    │ - <Hello·onChange={fn}·disabled·{...props1}·lastName="Smith"·firstName="John"·{...props2}·onChange={fn}·key="1"·/>;
+       20 │ + <Hello·onChange={fn}·disabled·{...props1}·lastName="Smith"·firstName="John"·{...props2}·key="1"·onChange={fn}·/>;
+    21 21 │   
+  
+
+```
+
+```
+groups-spread.jsx:20:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted. 
+  
+    19 │ // Multiple spreads: each segment sorted independently
+  > 20 │ <Hello onChange={fn} disabled {...props1} lastName="Smith" firstName="John" {...props2} onChange={fn} key="1" />;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
+  
+  i Safe fix: Sort the JSX props.
+  
+    18 18 │   
+    19 19 │   // Multiple spreads: each segment sorted independently
+    20    │ - <Hello·onChange={fn}·disabled·{...props1}·lastName="Smith"·firstName="John"·{...props2}·onChange={fn}·key="1"·/>;
+       20 │ + <Hello·disabled·onChange={fn}·{...props1}·lastName="Smith"·firstName="John"·{...props2}·onChange={fn}·key="1"·/>;
+    21 21 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/groups-spread.options.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"useSortedAttributes": {
+					"level": "on",
+					"options": {
+						"sortScope": "group",
+						"groups": [":RESERVED:", ":IMPLICIT:", ":CALLBACK:"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_rule_options/src/use_sorted_attributes.rs
+++ b/crates/biome_rule_options/src/use_sorted_attributes.rs
@@ -1,11 +1,262 @@
 pub use crate::shared::sort_order::SortOrder;
+use biome_deserialize::{Deserializable, DeserializationContext, Text};
 use biome_deserialize_macros::{Deserializable, Merge};
+use biome_js_syntax::JsxAttribute;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct UseSortedAttributesOptions {
+    /// Sort order to apply within each group (or globally when `sortScope` is `"global"`).
     #[serde(skip_serializing_if = "Option::<_>::is_none")]
     pub sort_order: Option<SortOrder>,
+
+    /// Groups control the ordering of special prop categories.
+    ///
+    /// Only active when `sortScope` is `"group"`.
+    /// When not configured, the default ordering is used:
+    /// `[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]`.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub groups: Option<AttributeGroups>,
+
+    /// Controls how `sortOrder` interacts with `groups`.
+    ///
+    /// - `"global"` (default): flat sort across all props, groups ignored.
+    /// - `"group"`: sort within each group independently, then order by group.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub sort_scope: Option<SortScope>,
+}
+
+/// Controls how `sortOrder` interacts with `groups`.
+///
+/// - `global`: `sortOrder` is applied over all props at once, ignoring the
+///   `groups` order. This preserves the original flat-sort behavior.
+/// - `group`: `sortOrder` is applied independently within each group defined
+///   by `groups`. Props are first partitioned by group, sorted within each
+///   group, then concatenated in group order.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    serde::Deserialize,
+    serde::Serialize,
+    biome_deserialize_macros::Deserializable,
+    biome_deserialize_macros::Merge,
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub enum SortScope {
+    /// Apply `sortOrder` globally across all props (default).
+    /// Group order is ignored; sorting is flat. Preserves existing behavior.
+    #[default]
+    Global,
+    /// Apply `sortOrder` within each group independently.
+    /// Props are partitioned into groups, sorted within each group, then
+    /// concatenated in group-index order.
+    Group,
+}
+
+/// The set of attribute groups for `useSortedAttributes`.
+///
+/// Groups control the position of special prop categories relative to each other
+/// when `sortScope` is set to `"group"`.
+///
+/// ## Predefined groups
+///
+/// - `:CALLBACK:` — Callback props: names beginning with `on` followed by an uppercase letter (e.g. `onClick`, `onChange`).
+/// - `:IMPLICIT:` — Implicit (boolean shorthand) props: props with no value (e.g. `<Foo disabled />`).
+/// - `:RESERVED:` — React reserved props: `key` and `ref`.
+/// - `:DOM_RESERVED:` — DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.
+/// - `:REST:` — Catch-all for props that don't match any other configured group.
+///   Sorted like a regular group, using `sortOrder`.
+///
+/// ## Default ordering
+///
+/// When `groups` is not configured, the following default ordering is used
+/// (only active when `sortScope` is `"group"`):
+///
+/// ```json
+/// [":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]
+/// ```
+///
+/// If `:REST:` is omitted from a configured `groups` list, props that don't
+/// match any named group are instead placed after all named groups, in their
+/// original relative order (unsorted).
+///
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AttributeGroups(Box<[AttributeGroupPattern]>);
+
+impl Deserializable for AttributeGroups {
+    fn deserialize(
+        ctx: &mut impl DeserializationContext,
+        value: &impl biome_deserialize::DeserializableValue,
+        name: &str,
+    ) -> Option<Self> {
+        Deserializable::deserialize(ctx, value, name).map(Self)
+    }
+}
+
+impl AttributeGroups {
+    /// Returns `true` if no explicit group is configured.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the number of explicitly configured groups.
+    ///
+    /// This is also the index of the implicit "rest" bucket used for props
+    /// that don't match any named group.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns the group index for the given attribute.
+    ///
+    /// Returns the index of the first explicitly matching group. If no group
+    /// matches, returns the index of the configured `:REST:` group, if any.
+    /// Otherwise, returns `self.0.len()` (the implicit unsorted "rest"
+    /// bucket appended after all named groups).
+    pub fn group_index(&self, attr: &JsxAttribute) -> usize {
+        if let Some(pos) = self.0.iter().position(|group| group.is_match(attr)) {
+            return pos;
+        }
+        self.0
+            .iter()
+            .position(|group| matches!(group, AttributeGroupPattern::Rest))
+            .unwrap_or(self.0.len())
+    }
+}
+
+impl biome_deserialize::Merge for AttributeGroups {
+    fn merge_with(&mut self, other: Self) {
+        *self = other;
+    }
+}
+
+/// The default group ordering used when `sortScope` is `"group"` but no
+/// explicit `groups` configuration is provided.
+pub fn default_attribute_groups() -> AttributeGroups {
+    AttributeGroups(Box::new([
+        AttributeGroupPattern::Implicit,
+        AttributeGroupPattern::Reserved,
+        AttributeGroupPattern::DomReserved,
+        AttributeGroupPattern::Rest,
+        AttributeGroupPattern::Callback,
+    ]))
+}
+
+/// A predefined attribute group pattern.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum AttributeGroupPattern {
+    /// Callback props: names beginning with `on` followed by an uppercase letter.
+    #[serde(rename = ":CALLBACK:")]
+    Callback,
+    /// Implicit (boolean shorthand) props: props with no value.
+    #[serde(rename = ":IMPLICIT:")]
+    Implicit,
+    /// React reserved props: `key` and `ref`.
+    #[serde(rename = ":RESERVED:")]
+    Reserved,
+    /// DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.
+    #[serde(rename = ":DOM_RESERVED:")]
+    DomReserved,
+    /// Catch-all for props that don't match any other configured group.
+    ///
+    /// Unlike the other patterns, this never matches directly through
+    /// [`Self::is_match`]: its position is resolved separately by
+    /// [`AttributeGroups::group_index`] as a fallback for unmatched props.
+    #[serde(rename = ":REST:")]
+    Rest,
+}
+
+impl AttributeGroupPattern {
+    pub fn is_match(&self, attr: &JsxAttribute) -> bool {
+        match self {
+            Self::Callback => is_callback_prop(attr),
+            Self::Implicit => is_implicit_prop(attr),
+            Self::Reserved => is_reserved_prop(attr),
+            Self::DomReserved => is_dom_reserved_prop(attr),
+            // Resolved separately in `AttributeGroups::group_index`.
+            Self::Rest => false,
+        }
+    }
+}
+
+impl Deserializable for AttributeGroupPattern {
+    fn deserialize(
+        ctx: &mut impl DeserializationContext,
+        value: &impl biome_deserialize::DeserializableValue,
+        name: &str,
+    ) -> Option<Self> {
+        let text = Text::deserialize(ctx, value, name)?;
+        match text.text() {
+            ":CALLBACK:" => Some(Self::Callback),
+            ":IMPLICIT:" => Some(Self::Implicit),
+            ":RESERVED:" => Some(Self::Reserved),
+            ":DOM_RESERVED:" => Some(Self::DomReserved),
+            ":REST:" => Some(Self::Rest),
+            _ => {
+                // TODO: emit a proper deserialization diagnostic once the API stabilizes
+                None
+            }
+        }
+    }
+}
+
+impl biome_deserialize::Merge for AttributeGroupPattern {
+    fn merge_with(&mut self, other: Self) {
+        *self = other;
+    }
+}
+
+// ── Prop classification helpers ──────────────────────────────────────────────
+
+/// Returns `true` if the prop is a callback: name starts with `on` followed
+/// by an uppercase ASCII letter (e.g. `onClick`, `onChange`).
+fn is_callback_prop(attr: &JsxAttribute) -> bool {
+    let Ok(name) = attr.name() else {
+        return false;
+    };
+    let Ok(name) = name.name() else {
+        return false;
+    };
+    let text = name.text_trimmed();
+    let bytes = text.as_bytes();
+    bytes.len() > 2 && bytes[0] == b'o' && bytes[1] == b'n' && bytes[2].is_ascii_uppercase()
+}
+
+/// Returns `true` if the prop is implicit (boolean shorthand): has no value.
+fn is_implicit_prop(attr: &JsxAttribute) -> bool {
+    attr.initializer().is_none()
+}
+
+const RESERVED_PROPS: [&str; 2] = ["key", "ref"];
+const DOM_RESERVED_PROPS: [&str; 2] = ["children", "dangerouslySetInnerHTML"];
+
+/// Returns `true` if the prop is a React reserved prop (`key` or `ref`).
+fn is_reserved_prop(attr: &JsxAttribute) -> bool {
+    prop_name_in(attr, &RESERVED_PROPS)
+}
+
+/// Returns `true` if the prop is a DOM-only reserved prop
+/// (`children` or `dangerouslySetInnerHTML`).
+fn is_dom_reserved_prop(attr: &JsxAttribute) -> bool {
+    prop_name_in(attr, &DOM_RESERVED_PROPS)
+}
+
+fn prop_name_in(attr: &JsxAttribute, list: &[&str]) -> bool {
+    let Ok(name) = attr.name() else {
+        return false;
+    };
+    let Ok(name) = name.name() else {
+        return false;
+    };
+    let text = name.text_trimmed();
+    list.contains(&text)
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -5599,7 +5599,25 @@ Default: `natural`.
 	sortBareImports?: boolean;
 }
 export interface UseSortedAttributesOptions {
+	/**
+	* Groups control the ordering of special prop categories.
+
+Only active when `sortScope` is `"group"`.
+When not configured, the default ordering is used:
+`[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]`. 
+	 */
+	groups?: AttributeGroups;
+	/**
+	 * Sort order to apply within each group (or globally when `sortScope` is `"global"`).
+	 */
 	sortOrder?: SortOrder;
+	/**
+	* Controls how `sortOrder` interacts with `groups`.
+
+- `"global"` (default): flat sort across all props, groups ignored.
+- `"group"`: sort within each group independently, then order by group. 
+	 */
+	sortScope?: SortScope;
 }
 export type UseSortedEnumMembersOptions = {};
 export type UseSortedInterfaceMembersOptions = {};
@@ -7839,6 +7857,45 @@ export interface RuleWithUseStrictModeOptions {
 export type ImportGroups = ImportGroup[];
 export type SortOrder = "natural" | "lexicographic";
 /**
+	* The set of attribute groups for `useSortedAttributes`.
+
+Groups control the position of special prop categories relative to each other
+when `sortScope` is set to `"group"`.
+
+## Predefined groups
+
+- `:CALLBACK:` — Callback props: names beginning with `on` followed by an uppercase letter (e.g. `onClick`, `onChange`).
+- `:IMPLICIT:` — Implicit (boolean shorthand) props: props with no value (e.g. `<Foo disabled />`).
+- `:RESERVED:` — React reserved props: `key` and `ref`.
+- `:DOM_RESERVED:` — DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.
+- `:REST:` — Catch-all for props that don't match any other configured group.
+  Sorted like a regular group, using `sortOrder`.
+
+## Default ordering
+
+When `groups` is not configured, the following default ordering is used
+(only active when `sortScope` is `"group"`):
+
+```json
+[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]
+```
+
+If `:REST:` is omitted from a configured `groups` list, props that don't
+match any named group are instead placed after all named groups, in their
+original relative order (unsorted). 
+	 */
+export type AttributeGroups = AttributeGroupPattern[];
+/**
+	* Controls how `sortOrder` interacts with `groups`.
+
+- `global`: `sortOrder` is applied over all props at once, ignoring the
+  `groups` order. This preserves the original flat-sort behavior.
+- `group`: `sortOrder` is applied independently within each group defined
+  by `groups`. Props are first partitioned by group, sorted within each
+  group, then concatenated in group order. 
+	 */
+export type SortScope = "global" | "group";
+/**
  * Used to identify the kind of code action emitted by a rule
  */
 export type FixKind = "none" | "safe" | "unsafe";
@@ -9071,6 +9128,15 @@ export type UseNumberToFixedDigitsArgumentOptions = {};
 export type UseStaticResponseMethodsOptions = {};
 export type UseStrictModeOptions = {};
 export type ImportGroup = null | GroupMatcher | GroupMatcher[];
+/**
+ * A predefined attribute group pattern.
+ */
+export type AttributeGroupPattern =
+	| ":CALLBACK:"
+	| ":IMPLICIT:"
+	| ":RESERVED:"
+	| ":DOM_RESERVED:"
+	| ":REST:";
 export type Visibility = "public" | "package" | "private";
 /**
  * Elements to restrict. Each key is the element name, and the value is the message to show when the element is used.

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -397,6 +397,41 @@
 			},
 			"additionalProperties": false
 		},
+		"AttributeGroupPattern": {
+			"description": "A predefined attribute group pattern.",
+			"oneOf": [
+				{
+					"description": "Callback props: names beginning with `on` followed by an uppercase letter.",
+					"type": "string",
+					"const": ":CALLBACK:"
+				},
+				{
+					"description": "Implicit (boolean shorthand) props: props with no value.",
+					"type": "string",
+					"const": ":IMPLICIT:"
+				},
+				{
+					"description": "React reserved props: `key` and `ref`.",
+					"type": "string",
+					"const": ":RESERVED:"
+				},
+				{
+					"description": "DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.",
+					"type": "string",
+					"const": ":DOM_RESERVED:"
+				},
+				{
+					"description": "Catch-all for props that don't match any other configured group.\n\nUnlike the other patterns, this never matches directly through\n[`Self::is_match`]: its position is resolved separately by\n[`AttributeGroups::group_index`] as a fallback for unmatched props.",
+					"type": "string",
+					"const": ":REST:"
+				}
+			]
+		},
+		"AttributeGroups": {
+			"description": "The set of attribute groups for `useSortedAttributes`.\n\nGroups control the position of special prop categories relative to each other\nwhen `sortScope` is set to `\"group\"`.\n\n## Predefined groups\n\n- `:CALLBACK:` — Callback props: names beginning with `on` followed by an uppercase letter (e.g. `onClick`, `onChange`).\n- `:IMPLICIT:` — Implicit (boolean shorthand) props: props with no value (e.g. `<Foo disabled />`).\n- `:RESERVED:` — React reserved props: `key` and `ref`.\n- `:DOM_RESERVED:` — DOM-only reserved props: `children` and `dangerouslySetInnerHTML`.\n- `:REST:` — Catch-all for props that don't match any other configured group.\n  Sorted like a regular group, using `sortOrder`.\n\n## Default ordering\n\nWhen `groups` is not configured, the following default ordering is used\n(only active when `sortScope` is `\"group\"`):\n\n```json\n[\":IMPLICIT:\", \":RESERVED:\", \":DOM_RESERVED:\", \":REST:\", \":CALLBACK:\"]\n```\n\nIf `:REST:` is omitted from a configured `groups` list, props that don't\nmatch any named group are instead placed after all named groups, in their\noriginal relative order (unsorted).",
+			"type": "array",
+			"items": { "$ref": "#/$defs/AttributeGroupPattern" }
+		},
 		"AttributePosition": { "type": "string", "enum": ["auto", "multiline"] },
 		"AvailabilityNamed": {
 			"description": "Named Baseline availability tiers.",
@@ -12985,6 +13020,21 @@
 			]
 		},
 		"SortOrder": { "type": "string", "enum": ["natural", "lexicographic"] },
+		"SortScope": {
+			"description": "Controls how `sortOrder` interacts with `groups`.\n\n- `global`: `sortOrder` is applied over all props at once, ignoring the\n  `groups` order. This preserves the original flat-sort behavior.\n- `group`: `sortOrder` is applied independently within each group defined\n  by `groups`. Props are first partitioned by group, sorted within each\n  group, then concatenated in group order.",
+			"oneOf": [
+				{
+					"description": "Apply `sortOrder` globally across all props (default).\nGroup order is ignored; sorting is flat. Preserves existing behavior.",
+					"type": "string",
+					"const": "global"
+				},
+				{
+					"description": "Apply `sortOrder` within each group independently.\nProps are partitioned into groups, sorted within each group, then\nconcatenated in group-index order.",
+					"type": "string",
+					"const": "group"
+				}
+			]
+		},
 		"Source": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",
@@ -16056,8 +16106,17 @@
 		"UseSortedAttributesOptions": {
 			"type": "object",
 			"properties": {
+				"groups": {
+					"description": "Groups control the ordering of special prop categories.\n\nOnly active when `sortScope` is `\"group\"`.\nWhen not configured, the default ordering is used:\n`[\":IMPLICIT:\", \":RESERVED:\", \":DOM_RESERVED:\", \":REST:\", \":CALLBACK:\"]`.",
+					"anyOf": [{ "$ref": "#/$defs/AttributeGroups" }, { "type": "null" }]
+				},
 				"sortOrder": {
+					"description": "Sort order to apply within each group (or globally when `sortScope` is `\"global\"`).",
 					"anyOf": [{ "$ref": "#/$defs/SortOrder" }, { "type": "null" }]
+				},
+				"sortScope": {
+					"description": "Controls how `sortOrder` interacts with `groups`.\n\n- `\"global\"` (default): flat sort across all props, groups ignored.\n- `\"group\"`: sort within each group independently, then order by group.",
+					"anyOf": [{ "$ref": "#/$defs/SortScope" }, { "type": "null" }]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary

Add `groups` and `sortScope` options to the useSortedAttributes, allowing the user to customize even more this rule

- `sortScope`: By default is `global` keeping the original sorting behavior, but also you can use `group` where props are partitioned into smaller groups, sorted within each group, then concatenated in group order. Props not matching any named group (and not covered by a `:REST:` group) preserve their original relative order.
- `groups`: Accepts an ordered list of predefined group tokens (`:CALLBACK:`, `:IMPLICIT:`, `:RESERVED:`, `:DOM_RESERVED:`, `:REST:`) that control where special prop categories appear relative to each other. `:REST:` is a catch-all for props matching no other group and, unlike the implicit fallback used when it's omitted, is sorted like a regular group. Default: `[":IMPLICIT:", ":RESERVED:", ":DOM_RESERVED:", ":REST:", ":CALLBACK:"]`

## Test Plan

Created a bunch of different test/snapshots covering new options

## Docs

The documentation is inline as comments in the rust file.

---

This PR was written primarily with Claude Code. I'm not a rust developer but I did my best checking the output for the use_sorted_attributes.rs. I defined all the scenarios I wanted to cover and the AI created them I reviewed one by one to ensure they are ok.
