### PR TITLE
fix(lint): noMisleadingReturnType reads type assertions as their asserted type

### DIFF
--- a/.changeset/curly-pillows-attack.md
+++ b/.changeset/curly-pillows-attack.md
@@ -1,0 +1,18 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [`noMisleadingReturnType`](https://biomejs.dev/linter/rules/no-misleading-return-type/) false positive on returns that use a widening type assertion: `"a" as string` is no longer reported as misleading. The rule now also reports a literal-pinning assertion such as `false as false`, matching the existing `as const` behavior.
+
+```ts
+// No longer flagged (returns are `string`):
+function getValue(b: boolean): string {
+  if (b) return "a" as string;
+  return "b" as string;
+}
+
+// Now also reported, like `as const` (returns `false`):
+function isReady(): boolean {
+  return false as false;
+}
+```

--- a/.changeset/proud-otters-thenable.md
+++ b/.changeset/proud-otters-thenable.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [`useAwaitThenable`](https://biomejs.dev/linter/rules/use-await-thenable/) false positive when awaiting a custom thenable that is not the global `Promise`. A value with a callable `then` member is now recognized as awaitable.
+
+```ts
+interface Thenable<T> { then(onfulfilled: (value: T) => void): void; }
+declare const t: Thenable<number>;
+async function f() {
+  await t;
+}
+```

--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
@@ -16,7 +16,9 @@ use biome_js_syntax::{
     TsReferenceType, TsTypeAliasDeclaration, TsTypeAssertionExpression,
 };
 use biome_js_semantic::ScopeId;
-use biome_js_type_info::{Class, Literal, Type, TypeData, TypeMemberKind, TypeReferenceQualifier};
+use biome_js_type_info::{
+    Class, Literal, Type, TypeData, TypeMemberKind, TypeReferenceQualifier,
+};
 use biome_rowan::{AstNode, Text, TextRange, declare_node_union};
 use biome_rule_options::no_misleading_return_type::NoMisleadingReturnTypeOptions;
 use smallvec::{SmallVec, smallvec};
@@ -892,12 +894,18 @@ struct ReturnInfo {
     /// TypeScript `object` keyword, such as members, tuples, functions, or
     /// class instances.
     has_narrower_than_object: bool,
+    /// Whether a return pins its type with a non-`const` `as`/`<>` assertion,
+    /// so its literal does not widen.
+    has_pinning_assertion: bool,
 }
 
 impl ReturnInfo {
-    /// Single-return whose inferred type is a primitive literal and no `as const`.
+    /// Single-return whose inferred type is a primitive literal and no `as const` or pinning assertion.
     fn is_single_primitive_literal(&self) -> bool {
-        self.types.len() == 1 && !self.has_any_const && is_literal_of_primitive(&self.types[0])
+        self.types.len() == 1
+            && !self.has_any_const
+            && !self.has_pinning_assertion
+            && is_literal_of_primitive(&self.types[0])
     }
 
     /// Every return carries an object-wide cast target (and no `as const`).
@@ -934,6 +942,7 @@ fn collect_return_info(
                     info.has_narrower_than_object = true;
                 }
             }
+            info.has_pinning_assertion |= is_pinned_by_assertion(expr);
             info.types.push(infer_expression_type(ctx, expr));
         }
     }
@@ -967,6 +976,7 @@ fn collect_block_returns(
                     info.has_narrower_than_object = true;
                 }
             }
+            info.has_pinning_assertion |= is_pinned_by_assertion(&expr);
             info.types.push(infer_expression_type(ctx, &expr));
         }
     }
@@ -1524,11 +1534,17 @@ fn unwrap_type_wrappers(expr: &AnyJsExpression) -> AnyJsExpression {
     let mut current = expr.clone();
     loop {
         if let Some(cast) = AnyTsCastExpression::cast(current.syntax().clone()) {
-            let Some(inner) = cast.inner_expression() else {
-                return current;
-            };
-            current = inner;
-            continue;
+            // Only `satisfies` and `as const` are transparent; keep a widening
+            // `as T` so its target type is read, not the inner literal.
+            let is_transparent = matches!(current, AnyJsExpression::TsSatisfiesExpression(_))
+                || is_const_reference_type(&cast.cast_type());
+            if is_transparent {
+                let Some(inner) = cast.inner_expression() else {
+                    return current;
+                };
+                current = inner;
+                continue;
+            }
         }
         match &current {
             AnyJsExpression::JsParenthesizedExpression(e) => match e.expression() {
@@ -1538,6 +1554,15 @@ fn unwrap_type_wrappers(expr: &AnyJsExpression) -> AnyJsExpression {
             _ => return current,
         }
     }
+}
+
+/// Whether the return keeps a non-`const` `as`/`<>` cast after `satisfies` and
+/// `as const` are unwrapped.
+fn is_pinned_by_assertion(expr: &AnyJsExpression) -> bool {
+    matches!(
+        unwrap_type_wrappers(expr),
+        AnyJsExpression::TsAsExpression(_) | AnyJsExpression::TsTypeAssertionExpression(_)
+    )
 }
 
 fn has_const_assertion(expr: &AnyJsExpression) -> bool {
@@ -1974,7 +1999,9 @@ fn is_union_wider(annotated: &Type, inferred: &Type) -> bool {
 fn types_match(a: &Type, b: &Type) -> bool {
     let mut a = a.clone();
     let mut b = b.clone();
-    loop {
+    // Resolving `InstanceOf` bases loops forever on a circular alias (`type R = R`),
+    // so bound the walk like the rule's other type traversals.
+    for _ in 0..MAX_TYPE_TRAVERSAL_ITERATIONS {
         match (&*a, &*b) {
             (TypeData::String, TypeData::String)
             | (TypeData::Number, TypeData::Number)
@@ -2028,4 +2055,5 @@ fn types_match(a: &Type, b: &Type) -> bool {
             _ => return false,
         }
     }
+    false
 }

--- a/crates/biome_js_analyze/src/lint/nursery/use_await_thenable.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_await_thenable.rs
@@ -64,8 +64,9 @@ impl Rule for UseAwaitThenable {
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");
 
-        let is_maybe_promise =
-            ty.is_promise_instance() || ty.has_variant(|ty| ty.is_promise_instance());
+        let is_maybe_promise = ty.is_promise_instance()
+            || ty.is_thenable()
+            || ty.has_variant(|ty| ty.is_promise_instance() || ty.is_thenable());
         (ty.is_inferred() && !is_maybe_promise).then_some(())
     }
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts
@@ -204,3 +204,8 @@ async function asyncUnionBothReturns(b: boolean): Promise<string | null> {
 function partialAbsorbUnion(b: boolean): "a" | "b" | string | null { if (b) return "a"; return null; }
 
 function crossPrimitiveUnion(): "a" | string | 1 { return "a"; }
+
+function literalAssertionNarrows(b: boolean): string { if (b) return "a" as "a"; return "b" as "b"; }
+function satisfiesDoesNotWiden(b: boolean): string { if (b) return "a" satisfies string; return "b" satisfies string; }
+function doubleCastNarrows(b: boolean): string { if (b) return "a" as unknown as "a"; return "b" as unknown as "b"; }
+function singleAssertedBooleanLiteral(): boolean { return false as false; }

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts.snap
@@ -211,6 +211,11 @@ function partialAbsorbUnion(b: boolean): "a" | "b" | string | null { if (b) retu
 
 function crossPrimitiveUnion(): "a" | string | 1 { return "a"; }
 
+function literalAssertionNarrows(b: boolean): string { if (b) return "a" as "a"; return "b" as "b"; }
+function satisfiesDoesNotWiden(b: boolean): string { if (b) return "a" satisfies string; return "b" satisfies string; }
+function doubleCastNarrows(b: boolean): string { if (b) return "a" as unknown as "a"; return "b" as unknown as "b"; }
+function singleAssertedBooleanLiteral(): boolean { return false as false; }
+
 ```
 
 # Diagnostics
@@ -2394,10 +2399,101 @@ invalid.ts:206:31 lint/nursery/noMisleadingReturnType ━━━━━━━━�
   > 206 │ function crossPrimitiveUnion(): "a" | string | 1 { return "a"; }
         │                               ^^^^^^^^^^^^^^^^^^
     207 │ 
+    208 │ function literalAssertionNarrows(b: boolean): string { if (b) return "a" as "a"; return "b" as "b"; }
   
   i A wider return type hides the precise types that callers could rely on.
   
   i Consider using "a" as the return type.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:208:45 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    206 │ function crossPrimitiveUnion(): "a" | string | 1 { return "a"; }
+    207 │ 
+  > 208 │ function literalAssertionNarrows(b: boolean): string { if (b) return "a" as "a"; return "b" as "b"; }
+        │                                             ^^^^^^^^
+    209 │ function satisfiesDoesNotWiden(b: boolean): string { if (b) return "a" satisfies string; return "b" satisfies string; }
+    210 │ function doubleCastNarrows(b: boolean): string { if (b) return "a" as unknown as "a"; return "b" as unknown as "b"; }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Consider using "a" | "b" as the return type.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:209:43 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    208 │ function literalAssertionNarrows(b: boolean): string { if (b) return "a" as "a"; return "b" as "b"; }
+  > 209 │ function satisfiesDoesNotWiden(b: boolean): string { if (b) return "a" satisfies string; return "b" satisfies string; }
+        │                                           ^^^^^^^^
+    210 │ function doubleCastNarrows(b: boolean): string { if (b) return "a" as unknown as "a"; return "b" as unknown as "b"; }
+    211 │ function singleAssertedBooleanLiteral(): boolean { return false as false; }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Consider using "a" | "b" as the return type.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:210:39 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    208 │ function literalAssertionNarrows(b: boolean): string { if (b) return "a" as "a"; return "b" as "b"; }
+    209 │ function satisfiesDoesNotWiden(b: boolean): string { if (b) return "a" satisfies string; return "b" satisfies string; }
+  > 210 │ function doubleCastNarrows(b: boolean): string { if (b) return "a" as unknown as "a"; return "b" as unknown as "b"; }
+        │                                       ^^^^^^^^
+    211 │ function singleAssertedBooleanLiteral(): boolean { return false as false; }
+    212 │ 
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Consider using "a" | "b" as the return type.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:211:40 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    209 │ function satisfiesDoesNotWiden(b: boolean): string { if (b) return "a" satisfies string; return "b" satisfies string; }
+    210 │ function doubleCastNarrows(b: boolean): string { if (b) return "a" as unknown as "a"; return "b" as unknown as "b"; }
+  > 211 │ function singleAssertedBooleanLiteral(): boolean { return false as false; }
+        │                                        ^^^^^^^^^
+    212 │ 
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Consider using false as the return type.
   
   i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts
@@ -309,3 +309,9 @@ function collapseNumber(): 1 | 2 | number { return 1; }
 function collapseBigint(): 1n | bigint { return 1n; }
 
 function collapseMismatchLiteral(): "a" | string { return "b"; }
+
+function widenStringAssertion(b: boolean): string { if (b) return "a" as string; return "b" as string; }
+function widenSatisfiesAssertion(b: boolean): string { if (b) return ("a" as string) satisfies string; return "b" as string; }
+type WidenedAlias = string;
+function widenAliasAssertion(b: boolean): WidenedAlias { if (b) return "a" as WidenedAlias; return "b" as WidenedAlias; }
+function assertedBooleanLiteralsCollapse(b: boolean): boolean { if (b) return true as true; return false as false; }

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts.snap
@@ -316,4 +316,10 @@ function collapseBigint(): 1n | bigint { return 1n; }
 
 function collapseMismatchLiteral(): "a" | string { return "b"; }
 
+function widenStringAssertion(b: boolean): string { if (b) return "a" as string; return "b" as string; }
+function widenSatisfiesAssertion(b: boolean): string { if (b) return ("a" as string) satisfies string; return "b" as string; }
+type WidenedAlias = string;
+function widenAliasAssertion(b: boolean): WidenedAlias { if (b) return "a" as WidenedAlias; return "b" as WidenedAlias; }
+function assertedBooleanLiteralsCollapse(b: boolean): boolean { if (b) return true as true; return false as false; }
+
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableInvalid.ts
@@ -1,0 +1,8 @@
+/* should generate diagnostics */
+
+// A non-callable `then` member does not make a thenable, so `await` is still reported.
+interface NotThenable { then: number; }
+declare const value: unknown;
+async function awaitNonCallableThen(): Promise<void> {
+    await (value as NotThenable);
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableInvalid.ts.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: thenableInvalid.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+
+// A non-callable `then` member does not make a thenable, so `await` is still reported.
+interface NotThenable { then: number; }
+declare const value: unknown;
+async function awaitNonCallableThen(): Promise<void> {
+    await (value as NotThenable);
+}
+
+```
+
+# Diagnostics
+```
+thenableInvalid.ts:7:5 lint/nursery/useAwaitThenable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i `await` used on a non-Promise value.
+  
+    5 │ declare const value: unknown;
+    6 │ async function awaitNonCallableThen(): Promise<void> {
+  > 7 │     await (value as NotThenable);
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ }
+    9 │ 
+  
+  i This may happen if you accidentally used `await` on a synchronous value.
+  
+  i Please ensure the value is not a custom "thenable" implementation before removing the `await`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableValid.ts
@@ -1,0 +1,15 @@
+/* should not generate diagnostics */
+
+interface Thenable<T> { then(onfulfilled: (value: T) => void): void; }
+declare const thenable: Thenable<number>;
+declare const value: unknown;
+
+// Awaiting a value typed as a custom thenable (a callable `then`) is valid.
+async function awaitDeclaredThenable(): Promise<void> {
+    await thenable;
+}
+
+// Awaiting a value cast to a custom thenable is valid.
+async function awaitCastThenable(): Promise<void> {
+    await (value as Thenable<number>);
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableValid.ts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: thenableValid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+interface Thenable<T> { then(onfulfilled: (value: T) => void): void; }
+declare const thenable: Thenable<number>;
+declare const value: unknown;
+
+// Awaiting a value typed as a custom thenable (a callable `then`) is valid.
+async function awaitDeclaredThenable(): Promise<void> {
+    await thenable;
+}
+
+// Awaiting a value cast to a custom thenable is valid.
+async function awaitCastThenable(): Promise<void> {
+    await (value as Thenable<number>);
+}
+
+```

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -606,7 +606,7 @@ impl TypeData {
                 if is_const_reference_type(&annotation) {
                     type_data_from_const_assertion_expression(resolver, scope_id, &inner)
                 } else {
-                    Self::unknown()
+                    Self::from_any_ts_type(resolver, scope_id, &annotation)
                 }
             }
             AnyJsExpression::TsTypeAssertionExpression(expr) => {
@@ -619,7 +619,7 @@ impl TypeData {
                 if is_const_reference_type(&annotation) {
                     type_data_from_const_assertion_expression(resolver, scope_id, &inner)
                 } else {
-                    Self::unknown()
+                    Self::from_any_ts_type(resolver, scope_id, &annotation)
                 }
             }
             AnyJsExpression::JsUnaryExpression(expr) => {

--- a/crates/biome_js_type_info/src/type.rs
+++ b/crates/biome_js_type_info/src/type.rs
@@ -287,6 +287,12 @@ impl Type {
             .is_some_and(|ty| ty.is_instance_of(self.resolver.as_ref(), GLOBAL_PROMISE_ID))
     }
 
+    /// Returns whether this type is a thenable (has a callable `then` member).
+    pub fn is_thenable(&self) -> bool {
+        self.find_member_type("then")
+            .is_some_and(|then_ty| then_ty.is_function())
+    }
+
     /// Returns whether this type is an instance of `RegExp`.
     pub fn is_regexp_instance(&self) -> bool {
         self.resolved_data()


### PR DESCRIPTION
This PR was implemented with AI assistance from Codex

## Summary
Addresses the widening-assertion false positive listed in #9810

`noMisleadingReturnType` read a return's cast as its inner literal, so `"a" as string` under `: string` was wrongly flagged. A non-`const` `as T` / `<T>` now resolves to its asserted type `T`. A narrowing assertion (`"a" as "a"`, `false as false`) is still reported, like `as const`

`useAwaitThenable` only recognized the global `Promise`, so awaiting a custom thenable (a value with a callable `then`) was wrongly flagged. Any such value is now treated as awaitable, while a non-callable `then` is still reported. It is a first step toward thenable detection (#8343)

## Test Plan
Snapshot tests




