### PR TITLE
perf(core): save Settings via Arc

### DIFF
--- a/crates/biome_service/src/projects.rs
+++ b/crates/biome_service/src/projects.rs
@@ -1,7 +1,8 @@
 use crate::WorkspaceError;
 use crate::file_handlers::Capabilities;
-use crate::settings::{Settings, SettingsWithEditor};
+use crate::settings::{Settings, SettingsWithEditor, VcsIgnoredPatterns};
 use crate::workspace::{FeatureName, FeaturesSupported, FileFeaturesResult, IgnoreKind};
+use biome_configuration::vcs::VcsClientKind;
 use biome_fs::{ConfigName, FileSystem};
 use biome_languages::DocumentFileSource;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -11,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::{debug, instrument};
 
@@ -36,11 +38,11 @@ struct ProjectData {
     ///
     /// Usually inferred from the **top-level** configuration file,
     /// e.g. `biome.json`.
-    root_settings: Settings,
+    root_settings: Arc<Settings>,
 
     /// Optional nested settings, usually populated in monorepo
     /// projects.
-    nested_settings: BTreeMap<Utf8PathBuf, Settings>,
+    nested_settings: BTreeMap<Utf8PathBuf, Arc<Settings>>,
 }
 
 /// Type that holds all the settings and information for different projects
@@ -76,7 +78,7 @@ impl Projects {
             key,
             ProjectData {
                 path,
-                root_settings: Settings::default(),
+                root_settings: Arc::new(Settings::default()),
                 nested_settings: Default::default(),
             },
         );
@@ -93,7 +95,7 @@ impl Projects {
         &self,
         project_key: ProjectKey,
         file_path: &Utf8Path,
-    ) -> Option<Settings> {
+    ) -> Option<Arc<Settings>> {
         let projects = self.0.pin();
         let data = projects.get(&project_key)?;
 
@@ -111,7 +113,7 @@ impl Projects {
         &self,
         project_key: ProjectKey,
         file_path: &Utf8Path,
-    ) -> Option<(Utf8PathBuf, Settings)> {
+    ) -> Option<(Utf8PathBuf, Arc<Settings>)> {
         let projects = self.0.pin();
         let data = projects.get(&project_key)?;
 
@@ -129,7 +131,7 @@ impl Projects {
         &self,
         project_key: ProjectKey,
         file_path: &Utf8Path,
-    ) -> Option<Settings> {
+    ) -> Option<Arc<Settings>> {
         let projects = self.0.pin();
         let data = projects.get(&project_key)?;
 
@@ -147,11 +149,19 @@ impl Projects {
         self.0.pin().get(&project_key).is_some()
     }
 
-    pub fn get_root_settings(&self, project_key: ProjectKey) -> Option<Settings> {
+    pub fn get_root_settings(&self, project_key: ProjectKey) -> Option<Arc<Settings>> {
         self.0
             .pin()
             .get(&project_key)
             .map(|data| data.root_settings.clone())
+    }
+
+    /// Returns a dereferenced pointer to the root settings. This is an unsafe function and should be used for testing only
+    pub fn get_mut_root_settings(&self, project_key: ProjectKey) -> Option<Settings> {
+        self.0
+            .pin()
+            .get(&project_key)
+            .map(|data| (*data.root_settings).clone())
     }
 
     /// Returns whether a path is force-ignored using a forced negation (`!!`)
@@ -318,9 +328,48 @@ impl Projects {
     pub fn set_root_settings(&self, project_key: ProjectKey, settings: Settings) {
         self.0.pin().update(project_key, |data| ProjectData {
             path: data.path.clone(),
-            root_settings: settings.clone(),
+            root_settings: Arc::new(settings.clone()),
             nested_settings: data.nested_settings.clone(),
         });
+    }
+
+    pub fn store_nested_ignore_patterns(
+        &self,
+        project_key: ProjectKey,
+        payload: Vec<(Utf8PathBuf, Vec<String>)>,
+    ) -> Result<(), WorkspaceError> {
+        let root_settings = self
+            .get_root_settings(project_key)
+            .ok_or_else(WorkspaceError::no_project)?;
+
+        let git_ignores = match root_settings.vcs_settings.client_kind {
+            Some(VcsClientKind::Git) => payload
+                .iter()
+                .map(|(path, patterns)| {
+                    let patterns = patterns.iter().map(String::as_str).collect::<Vec<_>>();
+                    VcsIgnoredPatterns::git_ignore(path.as_path(), patterns.as_slice())
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            None => Vec::new(),
+        };
+
+        self.0.pin().update(project_key, |data| {
+            let mut root_settings = data.root_settings.clone();
+            let settings = Arc::make_mut(&mut root_settings);
+            if let Some(ignore_matches) = settings.vcs_settings.ignore_matches.as_mut() {
+                for git_ignore in &git_ignores {
+                    ignore_matches.insert_git_match(git_ignore.clone());
+                }
+            }
+
+            ProjectData {
+                path: data.path.clone(),
+                root_settings,
+                nested_settings: data.nested_settings.clone(),
+            }
+        });
+
+        Ok(())
     }
 
     /// Inserts a nested setting.
@@ -335,7 +384,7 @@ impl Projects {
         debug!("Set nested settings for {path}");
         self.0.pin().update(project_key, |data| {
             let mut nested_settings = data.nested_settings.clone();
-            nested_settings.insert(path.clone(), settings.clone());
+            nested_settings.insert(path.clone(), Arc::new(settings.clone()));
 
             ProjectData {
                 path: data.path.clone(),

--- a/crates/biome_service/src/projects.rs
+++ b/crates/biome_service/src/projects.rs
@@ -156,7 +156,7 @@ impl Projects {
             .map(|data| data.root_settings.clone())
     }
 
-    /// Returns a dereferenced pointer to the root settings. This is an unsafe function and should be used for testing only
+    /// Returns a dereferenced pointer to the root settings. This inefficient and shouldn't be used other than testing.
     pub fn get_mut_root_settings(&self, project_key: ProjectKey) -> Option<Settings> {
         self.0
             .pin()

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -61,7 +61,7 @@ use std::sync::{Arc, RwLock};
 /// These can be either root settings, or settings for a section of the project.
 #[derive(Clone, Debug, Default)]
 pub struct Settings {
-    /// The configuration that originated this setting, if applicable.
+    /// The configuration that originated this setting if applicable.
     source: Option<Arc<ConfigurationSource>>,
 
     pub(crate) module_graph_resolution_kind: ModuleGraphResolutionKind,
@@ -1168,25 +1168,6 @@ impl VcsSettings {
 
         Ok(())
     }
-
-    /// Stores a list of patterns inside as a nested ignore file
-    pub fn store_nested_ignore_patterns(
-        &mut self,
-        path: &Utf8Path,
-        patterns: &[&str],
-    ) -> Result<(), WorkspaceError> {
-        match self.client_kind {
-            Some(VcsClientKind::Git) => {
-                let git_ignore = VcsIgnoredPatterns::git_ignore(path, patterns)?;
-                if let Some(ignore_matches) = self.ignore_matches.as_mut() {
-                    ignore_matches.insert_git_match(git_ignore);
-                }
-            }
-            None => {}
-        };
-
-        Ok(())
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -1277,7 +1258,10 @@ impl VcsIgnoredPatterns {
     /// ## Error
     ///
     /// If the patterns are invalid
-    fn git_ignore(path: &Utf8Path, patterns: &[&str]) -> Result<Gitignore, WorkspaceError> {
+    pub(crate) fn git_ignore(
+        path: &Utf8Path,
+        patterns: &[&str],
+    ) -> Result<Gitignore, WorkspaceError> {
         let mut gitignore_builder = GitignoreBuilder::new(path.as_std_path());
 
         for the_match in patterns {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1658,14 +1658,17 @@ impl Workspace for WorkspaceServer {
             if let Some(workspace_directory) = &workspace_directory {
                 self.projects
                     .get_nested_settings(project_key, workspace_directory.as_path())
+                    .map(|settings| (*settings).clone())
                     .unwrap_or_default()
             } else {
                 return Err(WorkspaceError::no_workspace_directory());
             }
         } else {
-            self.projects
+            (*self
+                .projects
                 .get_root_settings(project_key)
-                .ok_or_else(WorkspaceError::no_project)?
+                .ok_or_else(WorkspaceError::no_project)?)
+            .clone()
         };
         settings.module_graph_resolution_kind = module_graph_resolution_kind;
 
@@ -1705,7 +1708,7 @@ impl Workspace for WorkspaceServer {
             self.projects.set_nested_settings(
                 project_key,
                 nested_workspace_directory.clone(),
-                settings,
+                settings.clone(),
             );
             self.refresh_pnpm_workspace_catalogs_for_scope(
                 project_key,
@@ -3308,12 +3311,12 @@ impl WorkspaceScannerBridge for WorkspaceServer {
             .projects
             .get_project_path(project_key)
             .ok_or_else(WorkspaceError::no_project)?;
-        let mut settings = self
+        let settings = self
             .projects
             .get_root_settings(project_key)
             .ok_or_else(WorkspaceError::no_project)?;
 
-        let vcs_settings = &mut settings.vcs_settings;
+        let vcs_settings = &settings.vcs_settings;
 
         if !vcs_settings.is_enabled() || !vcs_settings.should_use_ignore_file() {
             return Ok(());
@@ -3324,6 +3327,8 @@ impl WorkspaceScannerBridge for WorkspaceServer {
             // SAFETY: the paths received are files, so it's safe to assume they have a parent folder
             project_path.as_path() != path.parent().unwrap()
         });
+
+        let mut payload = vec![];
         for path in filtered_paths {
             let is_in_project_path = path.starts_with(&project_path);
 
@@ -3332,12 +3337,13 @@ impl WorkspaceScannerBridge for WorkspaceServer {
 
             if vcs_settings.is_ignore_file(path) && is_in_project_path {
                 let content = self.fs.read_file_from_path(path)?;
-                let patterns = content.lines().collect::<Vec<_>>();
-                vcs_settings.store_nested_ignore_patterns(dir_ignore_file, patterns.as_slice())?;
+                let patterns = content.lines().map(String::from).collect::<Vec<_>>();
+                payload.push((dir_ignore_file.to_path_buf(), patterns));
             }
         }
 
-        self.projects.set_root_settings(project_key, settings);
+        self.projects
+            .store_nested_ignore_patterns(project_key, payload)?;
 
         Ok(())
     }

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -180,7 +180,7 @@ pub fn create_parser_options<L: ServiceLanguage>(
         Default::default()
     } else {
         let configuration = loaded_configuration.configuration;
-        let mut settings = projects.get_root_settings(key).unwrap_or_default();
+        let mut settings = projects.get_mut_root_settings(key).unwrap_or_default();
         settings
             .merge_with_configuration(
                 configuration,
@@ -230,7 +230,7 @@ where
         Default::default()
     } else {
         let configuration = loaded_configuration.configuration;
-        let mut settings = projects.get_root_settings(key).unwrap_or_default();
+        let mut settings = projects.get_mut_root_settings(key).unwrap_or_default();
         settings
             .merge_with_configuration(
                 configuration,


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary


Two savings:
- `Settings` are now stored under an `Arc`, so they are now cheap when closed
- Updated the function that updates the nested VCS settings. This is now done once, so that the original `Settings` is pinned once, instead of many times

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Existing tests should pass

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
