### PR TITLE
chore(xtask): migrate Error global type

### DIFF
--- a/.changeset/huge-parrots-jam.md
+++ b/.changeset/huge-parrots-jam.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved type-aware lint rule inference for built-in globals and indexed function calls. Biome now resolves `Error(...)`, `new Error(...)`, optional `Error#stack`, and calls through indexed function values such as `handlers[0]()` more accurately.

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/indexedFunctionCall.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/indexedFunctionCall.ts
@@ -1,0 +1,3 @@
+const handlers: Array<() => Promise<void>> = [() => Promise.resolve()];
+
+handlers[0]();

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/indexedFunctionCall.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/indexedFunctionCall.ts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: indexedFunctionCall.ts
+---
+# Input
+```ts
+const handlers: Array<() => Promise<void>> = [() => Promise.resolve()];
+
+handlers[0]();
+
+```
+
+# Diagnostics
+```
+indexedFunctionCall.ts:3:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    1 │ const handlers: Array<() => Promise<void>> = [() => Promise.resolve()];
+    2 │ 
+  > 3 │ handlers[0]();
+      │ ^^^^^^^^^^^^^^
+    4 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_type_info/src/flattening.rs
+++ b/crates/biome_js_type_info/src/flattening.rs
@@ -84,7 +84,7 @@ impl TypeData {
                 },
                 None => None,
             },
-            Self::TypeofExpression(expr) => flattened_expression(expr, resolver, 0),
+            Self::TypeofExpression(expr) => flattened_expression(expr, resolver),
             Self::TypeofType(reference) => resolver
                 .resolve_reference(reference.as_ref())
                 .map(Self::reference),

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -6,10 +6,10 @@ use hashbrown::{HashTable, hash_table::Entry};
 use rustc_hash::FxHasher;
 
 use crate::{
-    CallArgumentType, DestructureField, Function, FunctionParameter, Literal, MAX_FLATTEN_DEPTH,
-    Resolvable, ResolvedTypeData, ResolvedTypeId, ResolvedTypeMember, ResolverId, TypeData,
-    TypeMember, TypeReference, TypeResolver, TypeofCallExpression, TypeofDestructureExpression,
-    TypeofExpression,
+    CallArgumentType, ConstructorParameter, DestructureField, Function, FunctionParameter, Literal,
+    MAX_FLATTEN_DEPTH, Resolvable, ResolvedTypeData, ResolvedTypeId, ResolvedTypeMember,
+    ResolverId, TypeData, TypeMember, TypeReference, TypeResolver, TypeofCallExpression,
+    TypeofDestructureExpression, TypeofExpression,
     conditionals::{
         ConditionalType, reference_to_falsy_subset_of, reference_to_non_nullish_subset_of,
         reference_to_truthy_subset_of,
@@ -23,10 +23,12 @@ use crate::{
     },
 };
 
+/// Minimum call signatures required before a callable is treated as overloaded.
+const MIN_OVERLOAD_SIGNATURE_COUNT: usize = 2;
+
 pub(super) fn flattened_expression(
     expr: &TypeofExpression,
     resolver: &mut dyn TypeResolver,
-    depth: usize,
 ) -> Option<TypeData> {
     match expr {
         TypeofExpression::Addition(expr) => {
@@ -102,7 +104,7 @@ pub(super) fn flattened_expression(
                 })
         }
         TypeofExpression::Call(expr) => match resolver.resolve_and_get(&expr.callee) {
-            Some(callee) => flattened_call(expr, callee.to_data(), resolver, depth),
+            Some(callee) => flattened_call(expr, callee.to_data(), resolver),
             None => None,
         },
         TypeofExpression::Conditional(expr) => {
@@ -186,34 +188,7 @@ pub(super) fn flattened_expression(
                 None
             }
         }
-        TypeofExpression::New(expr) => {
-            let resolved = resolver.resolve_and_get(&expr.callee)?;
-            if let TypeData::Class(class) = resolved.as_raw_data() {
-                let num_args = expr.arguments.len();
-                let constructed_ty = class
-                    .members
-                    .iter()
-                    .find(|member| member.kind.is_constructor())
-                    .and_then(|member| {
-                        let constructor = resolver
-                            .resolve_and_get(&resolved.apply_module_id_to_reference(&member.ty))?;
-                        match constructor.to_data() {
-                            TypeData::Constructor(constructor) => {
-                                // TODO: We might need to make an attempt to match
-                                //       type signatures too.
-                                (constructor.parameters.len() == num_args)
-                                    .then_some(constructor.return_type)
-                                    .flatten()
-                            }
-                            _ => None,
-                        }
-                    })
-                    .unwrap_or_else(|| expr.callee.clone());
-                Some(TypeData::instance_of(constructed_ty))
-            } else {
-                None
-            }
-        }
+        TypeofExpression::New(expr) => flattened_new(expr, resolver),
         TypeofExpression::NullishCoalescing(expr) => {
             let left = resolver.resolve_and_get(&expr.left)?;
             let conditional = ConditionalType::from_resolved_data(left, resolver);
@@ -234,88 +209,17 @@ pub(super) fn flattened_expression(
         }
         TypeofExpression::StaticMember(expr) => {
             let object = resolver.resolve_and_get(&expr.object)?;
-            match object.as_raw_data() {
-                class @ TypeData::Class(_) => {
-                    let member = class
-                        .own_members()
-                        .find(|member| member.has_name(&expr.member) && member.is_static())?;
-                    let member = TypeMember {
-                        kind: member.kind.clone(),
-                        ty: object.apply_module_id_to_reference(&member.ty).into_owned(),
-                    };
-                    Some(TypeData::reference(member.deref_ty(resolver).into_owned()))
-                }
-
-                TypeData::ImportNamespace(module_id) => {
-                    let resolved_id =
-                        resolver.resolve_import_namespace_member(*module_id, &expr.member)?;
-                    resolver
-                        .get_by_resolved_id(resolved_id)
-                        .map(ResolvedTypeData::to_data)
-                }
-
-                TypeData::Tuple(_tuple) => {
-                    // Tuples are just fancy arrays, so make sure methods on
-                    // them can be looked up as such:
-                    let array = resolver
-                        .get_by_resolved_id(GLOBAL_ARRAY_ID)
-                        .expect("Array type must be registered");
-                    let member = array.find_member(resolver, |member| {
-                        member.has_name(&expr.member) && !member.is_static()
-                    })?;
-                    Some(TypeData::reference(member.ty().into_owned()))
-                }
-
-                TypeData::Union(_) => {
-                    // Resolve the requested member across union variants directly.
-                    // Avoid distributing `obj.member` into nested inferred expressions, which can
-                    // cause runaway type growth for patterns like `node = node.parent`.
-                    let mut types = Vec::new();
-                    for variant in object.flattened_union_variants(resolver) {
-                        if variant == GLOBAL_UNDEFINED_ID.into() {
-                            continue;
-                        }
-
-                        let Some(resolved) = resolver.resolve_and_get(&variant) else {
-                            types.push(TypeReference::unknown());
-                            continue;
-                        };
-
-                        if matches!(resolved.as_raw_data(), TypeData::TypeofExpression(_)) {
-                            return None;
-                        }
-
-                        if matches!(resolved.as_raw_data(), TypeData::Unknown) {
-                            types.push(TypeReference::unknown());
-                            continue;
-                        }
-
-                        let Some(member) = resolved
-                            .find_member(resolver, |member| member.has_name(&expr.member))
-                            .or_else(|| {
-                                resolved.find_index_signature_with_ty(resolver, |ty| ty.is_string())
-                            })
-                        else {
-                            continue;
-                        };
-                        types.push(member.deref_ty(resolver).into_owned());
-                    }
-
-                    if types.is_empty() {
-                        Some(TypeData::unknown())
-                    } else {
-                        Some(TypeData::union_of(resolver, types.into_boxed_slice()))
-                    }
-                }
-
-                _ => {
-                    let member = object
-                        .find_member(resolver, |member| member.has_name(&expr.member))
-                        .or_else(|| {
-                            object.find_index_signature_with_ty(resolver, |ty| ty.is_string())
-                        })?;
-                    Some(TypeData::reference(member.deref_ty(resolver).into_owned()))
-                }
+            if let TypeData::TypeofExpression(object_expr) = object.as_raw_data()
+                && should_flatten_static_member_object(object_expr)
+            {
+                let object = flattened_static_member_object_expression(
+                    object_expr.as_ref().clone(),
+                    resolver,
+                )?;
+                let object = resolved_type_data_from_data(&object, resolver)?;
+                flattened_static_member(object, &expr.member, resolver)
+            } else {
+                flattened_static_member(object, &expr.member, resolver)
             }
         }
         TypeofExpression::Super(expr) => {
@@ -350,49 +254,400 @@ pub(super) fn flattened_expression(
     }
 }
 
-/// Resolves a callee type through layers of indirection (`TypeofExpression`,
-/// `InstanceOf`, `Interface`, `Object`) until a `Function` is found.
-///
-/// Each invocation unwraps at most [`MAX_FLATTEN_DEPTH`] non-recursive layers.
-/// Flattening a `TypeofExpression` callee re-enters [`flattened_expression`],
-/// which can cycle back here for self-calling values (e.g. `ctrl = ctrl()`), so
-/// `depth` bounds that recursion and the function bails once it exceeds
-/// [`MAX_FLATTEN_DEPTH`].
-///
-/// Returns `None` if no function can be reached.
+/// Keeps scoped expressions lazy while allowing call/new member chains.
+fn should_flatten_static_member_object(expr: &TypeofExpression) -> bool {
+    matches!(
+        expr,
+        TypeofExpression::Call(_) | TypeofExpression::New(_) | TypeofExpression::StaticMember(_)
+    )
+}
+
+struct FixedStack<T, const CAPACITY: usize> {
+    items: [Option<T>; CAPACITY],
+    len: usize,
+}
+
+impl<T, const CAPACITY: usize> FixedStack<T, CAPACITY> {
+    fn new() -> Self {
+        Self {
+            items: std::array::from_fn(|_| None),
+            len: 0,
+        }
+    }
+
+    fn push(&mut self, item: T) -> Option<()> {
+        if self.len == CAPACITY {
+            return None;
+        }
+
+        self.items[self.len] = Some(item);
+        self.len += 1;
+        Some(())
+    }
+
+    fn pop(&mut self) -> Option<T> {
+        if self.len == 0 {
+            return None;
+        }
+
+        self.len -= 1;
+        self.items[self.len].take()
+    }
+
+    fn last(&self) -> Option<&T> {
+        self.len
+            .checked_sub(1)
+            .and_then(|index| self.items[index].as_ref())
+    }
+}
+
+/// Flattens the base of a lazy call/new/member chain before member lookup.
+fn flattened_static_member_object_expression(
+    mut expr: TypeofExpression,
+    resolver: &mut dyn TypeResolver,
+) -> Option<TypeData> {
+    let mut pending_members = FixedStack::<Text, MAX_FLATTEN_DEPTH>::new();
+    let mut remaining_depth = MAX_FLATTEN_DEPTH;
+
+    while remaining_depth > 0 {
+        remaining_depth -= 1;
+
+        match expr {
+            TypeofExpression::Call(expr) => {
+                let callee = resolver.resolve_and_get(&expr.callee)?;
+                let object = flattened_call(&expr, callee.to_data(), resolver)?;
+                return apply_static_member_chain(object, pending_members, resolver);
+            }
+            TypeofExpression::New(expr) => {
+                let object = flattened_new(&expr, resolver)?;
+                return apply_static_member_chain(object, pending_members, resolver);
+            }
+            TypeofExpression::StaticMember(member_expr) => {
+                let object = resolver.resolve_and_get(&member_expr.object)?;
+                if let TypeData::TypeofExpression(object_expr) = object.as_raw_data()
+                    && should_flatten_static_member_object(object_expr)
+                {
+                    pending_members.push(member_expr.member)?;
+                    expr = object_expr.as_ref().clone();
+                    continue;
+                }
+
+                let object = flattened_static_member(object, &member_expr.member, resolver)?;
+                return apply_static_member_chain(object, pending_members, resolver);
+            }
+            _ => return None,
+        }
+    }
+
+    None
+}
+
+/// Applies deferred member accesses after the chain base has been flattened.
+fn apply_static_member_chain(
+    mut object: TypeData,
+    mut pending_members: FixedStack<Text, MAX_FLATTEN_DEPTH>,
+    resolver: &mut dyn TypeResolver,
+) -> Option<TypeData> {
+    while let Some(member) = pending_members.pop() {
+        let resolved = resolved_type_data_from_data(&object, resolver)?;
+        object = flattened_static_member(resolved, &member, resolver)?;
+    }
+
+    Some(object)
+}
+
+/// Resolves references without registering already-owned type data.
+fn resolved_type_data_from_data<'a>(
+    data: &'a TypeData,
+    resolver: &'a dyn TypeResolver,
+) -> Option<ResolvedTypeData<'a>> {
+    match data {
+        TypeData::Reference(reference) => resolver.resolve_and_get(reference),
+        _ => Some(ResolvedTypeData::from((
+            ResolverId::from_level(resolver.level()),
+            data,
+        ))),
+    }
+}
+
+/// Looks up a static member on already-resolved object data.
+fn flattened_static_member(
+    object: ResolvedTypeData,
+    member_name: &Text,
+    resolver: &dyn TypeResolver,
+) -> Option<TypeData> {
+    match object.as_raw_data() {
+        class @ TypeData::Class(_) => {
+            let member = class.own_members().find(|member| {
+                member.has_name(member_name) && member.is_static() && !member.is_constructor()
+            })?;
+            Some(type_data_from_resolved_member(
+                ResolvedTypeMember::from((object.resolver_id(), member)),
+                resolver,
+            ))
+        }
+
+        TypeData::ImportNamespace(module_id) => {
+            let resolved_id = resolver.resolve_import_namespace_member(*module_id, member_name)?;
+            resolver
+                .get_by_resolved_id(resolved_id)
+                .map(ResolvedTypeData::to_data)
+        }
+
+        TypeData::Tuple(_tuple) => {
+            // Tuples are just fancy arrays, so make sure methods on
+            // them can be looked up as such:
+            let array = resolver.get_by_resolved_id(GLOBAL_ARRAY_ID)?;
+            let member = array.find_member(resolver, |member| {
+                member.has_name(member_name) && !member.is_static()
+            })?;
+            Some(type_data_from_resolved_member(member, resolver))
+        }
+
+        TypeData::Union(_) => {
+            // Keep nested inferred expressions lazy; otherwise nested member
+            // chains can grow without adding useful type information.
+            let mut types = None;
+            for variant in object.flattened_union_variants(resolver) {
+                if variant == GLOBAL_UNDEFINED_ID.into() {
+                    continue;
+                }
+
+                let Some(resolved) = resolver.resolve_and_get(&variant) else {
+                    types
+                        .get_or_insert_with(Vec::new)
+                        .push(TypeReference::unknown());
+                    continue;
+                };
+
+                if matches!(resolved.as_raw_data(), TypeData::TypeofExpression(_)) {
+                    return None;
+                }
+
+                if matches!(resolved.as_raw_data(), TypeData::Unknown) {
+                    types
+                        .get_or_insert_with(Vec::new)
+                        .push(TypeReference::unknown());
+                    continue;
+                }
+
+                let Some(member) = resolved
+                    .find_member(resolver, |member| {
+                        static_member_matches(resolved, member, member_name)
+                    })
+                    .or_else(|| {
+                        resolved.find_index_signature_with_ty(resolver, |data| data.is_string())
+                    })
+                else {
+                    continue;
+                };
+                let is_optional = member.kind().is_optional();
+                let member_reference = member.deref_ty(resolver).into_owned();
+                push_member_reference(
+                    types.get_or_insert_with(Vec::new),
+                    member_reference,
+                    is_optional,
+                );
+            }
+
+            if let Some(types) = types {
+                Some(TypeData::union_of(resolver, types.into_boxed_slice()))
+            } else {
+                Some(TypeData::unknown())
+            }
+        }
+
+        _ => {
+            let member = object
+                .find_member(resolver, |member| {
+                    static_member_matches(object, member, member_name)
+                })
+                .or_else(|| {
+                    object.find_index_signature_with_ty(resolver, |data| data.is_string())
+                })?;
+            Some(type_data_from_resolved_member(member, resolver))
+        }
+    }
+}
+
+/// Matches static properties on class values and instance members elsewhere.
+fn static_member_matches(
+    object: ResolvedTypeData,
+    member: &ResolvedTypeMember,
+    name: &str,
+) -> bool {
+    member.has_name(name)
+        && match object.as_raw_data() {
+            TypeData::Class(_) => member.is_static() && !member.kind().is_constructor(),
+            _ => !member.is_static(),
+        }
+}
+
+/// Resolves the instance type produced by a `new` expression.
+fn flattened_new(
+    expr: &crate::TypeofNewExpression,
+    resolver: &mut dyn TypeResolver,
+) -> Option<TypeData> {
+    let resolved = resolver.resolve_and_get(&expr.callee)?;
+    if let TypeData::Class(class) = resolved.as_raw_data() {
+        let argument_count = expr.arguments.len();
+        let constructed_reference = class
+            .members
+            .iter()
+            .filter(|member| member.kind.is_constructor())
+            .find_map(|member| {
+                let constructor =
+                    resolver.resolve_and_get(&resolved.apply_module_id_to_reference(&member.ty))?;
+                match constructor.to_data() {
+                    TypeData::Constructor(constructor) => {
+                        constructor_accepts_argument_count(&constructor.parameters, argument_count)
+                            .then_some(constructor.return_type)
+                            .flatten()
+                    }
+                    _ => None,
+                }
+            })
+            .unwrap_or_else(|| expr.callee.clone());
+        Some(TypeData::instance_of(constructed_reference))
+    } else {
+        None
+    }
+}
+
+/// Builds the member access result from resolved member metadata.
+fn type_data_from_resolved_member(
+    member: ResolvedTypeMember<'_>,
+    resolver: &dyn TypeResolver,
+) -> TypeData {
+    let is_optional = member.kind().is_optional();
+    let member_reference = member.deref_ty(resolver).into_owned();
+    type_data_from_member_reference(member_reference, is_optional, resolver)
+}
+
+/// Builds the destructured binding type while preserving optional members.
+fn type_data_from_destructured_member(
+    member: ResolvedTypeMember<'_>,
+    resolver: &dyn TypeResolver,
+) -> Option<TypeData> {
+    let member_reference = member.deref_ty(resolver).into_owned();
+    if member.kind().is_optional() {
+        Some(type_data_from_member_reference(
+            member_reference,
+            true,
+            resolver,
+        ))
+    } else {
+        resolver
+            .resolve_and_get(&member_reference)
+            .map(ResolvedTypeData::to_data)
+    }
+}
+
+/// Builds the member access result, including `undefined` for optional members.
+fn type_data_from_member_reference(
+    reference: TypeReference,
+    is_optional: bool,
+    resolver: &dyn TypeResolver,
+) -> TypeData {
+    if is_optional {
+        TypeData::union_of(resolver, [reference, GLOBAL_UNDEFINED_ID.into()].into())
+    } else {
+        TypeData::reference(reference)
+    }
+}
+
+/// Adds a member reference to a union result.
+fn push_member_reference(
+    types: &mut Vec<TypeReference>,
+    reference: TypeReference,
+    is_optional: bool,
+) {
+    types.push(reference);
+    if is_optional {
+        types.push(GLOBAL_UNDEFINED_ID.into());
+    }
+}
+
+enum CalleeContinuation {
+    Call(TypeofCallExpression),
+    Member(Text),
+}
+
+/// Resolves a callee through lazy expression wrappers and callable object
+/// indirections without recursive call flattening. Every wrapper transition
+/// consumes one shared depth step.
 fn resolve_callee_to_function(
     callee: TypeData,
     resolver: &mut dyn TypeResolver,
-    mut depth: usize,
 ) -> Option<Box<Function>> {
-    depth += 1;
-    if depth > MAX_FLATTEN_DEPTH {
-        return None;
-    }
-
     let mut callee = callee;
-    for _ in 0..MAX_FLATTEN_DEPTH {
+    let mut continuations = FixedStack::<CalleeContinuation, MAX_FLATTEN_DEPTH>::new();
+    let mut remaining_steps = MAX_FLATTEN_DEPTH;
+
+    loop {
+        if let TypeData::TypeofExpression(expr) = callee {
+            remaining_steps = remaining_steps.checked_sub(1)?;
+
+            match *expr {
+                TypeofExpression::Call(expr) => {
+                    callee = resolver.resolve_and_get(&expr.callee)?.to_data();
+                    continuations.push(CalleeContinuation::Call(expr))?;
+                    continue;
+                }
+                TypeofExpression::New(expr) => {
+                    callee = flattened_new(&expr, resolver)?;
+                    continue;
+                }
+                TypeofExpression::StaticMember(expr) => {
+                    callee = resolver.resolve_and_get(&expr.object)?.to_data();
+                    continuations.push(CalleeContinuation::Member(expr.member))?;
+                    continue;
+                }
+                expression => {
+                    callee = flattened_expression(&expression, resolver)?;
+                    continue;
+                }
+            }
+        }
+
+        if matches!(continuations.last(), Some(CalleeContinuation::Member(_))) {
+            let member = match continuations.pop()? {
+                CalleeContinuation::Member(member) => member,
+                CalleeContinuation::Call(_) => return None,
+            };
+            let resolved = resolved_type_data_from_data(&callee, resolver)?;
+            callee = flattened_static_member(resolved, &member, resolver)?;
+            continue;
+        }
+
         match callee {
-            TypeData::Function(function) => return Some(function),
-            // Cross-module generic wrappers (e.g. `export const f = trace(asyncFn)`)
-            // are represented as unflattened `TypeofExpression` nodes when imported.
-            // Eagerly flatten them so the underlying function type is reachable.
-            TypeData::TypeofExpression(expr) => {
-                callee = flattened_expression(&expr, resolver, depth)?;
+            TypeData::Function(function) => {
+                if let Some(CalleeContinuation::Call(expr)) = continuations.pop() {
+                    callee = flattened_function_call(&expr, &function, resolver)?;
+                    continue;
+                }
+
+                return Some(function);
             }
             TypeData::InstanceOf(instance) => {
-                let instance_callee = resolver.resolve_and_get(&instance.ty)?;
-                callee = if instance_callee.is_function() {
-                    instance_callee.to_data()
-                } else {
-                    instance_callee
-                        .find_member(resolver, |member| member.kind().is_call_signature())
-                        .map(ResolvedTypeMember::to_member)
-                        .and_then(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))?
-                        .to_data()
-                };
+                remaining_steps = remaining_steps.checked_sub(1)?;
+
+                callee = resolve_instance_callable(&instance.ty, resolver)?;
             }
-            TypeData::Interface(_) | TypeData::Object(_) => {
+            TypeData::Class(_) | TypeData::Interface(_) | TypeData::Object(_) => {
+                remaining_steps = remaining_steps.checked_sub(1)?;
+
+                if let Some(CalleeContinuation::Call(expr)) = continuations.last() {
+                    match select_overload(&callee, &expr.arguments, resolver) {
+                        OverloadSelection::Selected(function) => {
+                            callee = TypeData::Function(function);
+                            continue;
+                        }
+                        OverloadSelection::NoMatch => return None,
+                        OverloadSelection::NotOverloaded => {}
+                    }
+                }
+
                 callee =
                     ResolvedTypeData::from((ResolverId::from_level(resolver.level()), &callee))
                         .find_member(resolver, |member| member.kind().is_call_signature())
@@ -400,17 +655,68 @@ fn resolve_callee_to_function(
                         .and_then(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))?
                         .to_data();
             }
-            _ => break,
+            _ => return None,
         }
     }
-    None
+}
+
+/// Matches constructor overloads by arity, including optional and rest params.
+fn constructor_accepts_argument_count(
+    parameters: &[ConstructorParameter],
+    argument_count: usize,
+) -> bool {
+    let required_count = parameters
+        .iter()
+        .filter(|parameter| {
+            !function_parameter_is_optional(&parameter.parameter)
+                && !function_parameter_is_rest(&parameter.parameter)
+        })
+        .count();
+    let has_rest = parameters
+        .iter()
+        .any(|parameter| function_parameter_is_rest(&parameter.parameter));
+
+    required_count <= argument_count && (has_rest || argument_count <= parameters.len())
+}
+
+/// Resolves callable instance types without treating class value signatures as instance calls.
+fn resolve_instance_callable(
+    instance_type: &TypeReference,
+    resolver: &dyn TypeResolver,
+) -> Option<TypeData> {
+    let resolved = resolver.resolve_and_get(instance_type)?;
+    match resolved.as_raw_data() {
+        TypeData::Function(_) => Some(resolved.to_data()),
+        TypeData::Interface(_) | TypeData::Object(_) => resolved
+            .find_member(resolver, |member| member.kind().is_call_signature())
+            .map(ResolvedTypeMember::to_member)
+            .and_then(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))
+            .map(ResolvedTypeData::to_data),
+        TypeData::Class(_) => None,
+        _ => None,
+    }
+}
+
+/// Reads optionality from either supported parameter shape.
+fn function_parameter_is_optional(parameter: &FunctionParameter) -> bool {
+    match parameter {
+        FunctionParameter::Named(parameter) => parameter.is_optional,
+        FunctionParameter::Pattern(parameter) => parameter.is_optional,
+    }
+}
+
+/// Reads rest-parameter status from either supported parameter shape.
+fn function_parameter_is_rest(parameter: &FunctionParameter) -> bool {
+    match parameter {
+        FunctionParameter::Named(parameter) => parameter.is_rest,
+        FunctionParameter::Pattern(parameter) => parameter.is_rest,
+    }
 }
 
 fn flattened_call(
     expr: &TypeofCallExpression,
     callee: TypeData,
     resolver: &mut dyn TypeResolver,
-    depth: usize,
 ) -> Option<TypeData> {
     match callee {
         TypeData::Union(union) => {
@@ -435,7 +741,7 @@ fn flattened_call(
                     _ => {}
                 }
                 if let Some(function) =
-                    resolve_callee_to_function(resolved.to_data(), resolver, depth)
+                    resolve_callee_for_call(resolved.to_data(), &expr.arguments, resolver)
                     && let Some(result) = flattened_function_call(expr, &function, resolver)
                 {
                     return_types.push(result);
@@ -443,32 +749,38 @@ fn flattened_call(
             }
             match return_types.len() {
                 0 => None,
-                1 => Some(return_types.into_iter().next().unwrap()),
+                1 => return_types.into_iter().next(),
                 _ => {
-                    let refs: Vec<_> = return_types
+                    let references = return_types
                         .into_iter()
-                        .map(|ty| {
-                            let id = resolver.register_type(Cow::Owned(ty));
-                            TypeReference::from(ResolvedTypeId::new(resolver.level(), id))
+                        .map(|return_type| {
+                            let type_id = resolver.register_type(Cow::Owned(return_type));
+                            TypeReference::from(ResolvedTypeId::new(resolver.level(), type_id))
                         })
-                        .collect();
-                    Some(TypeData::union_of(resolver, refs.into_boxed_slice()))
+                        .collect::<Box<[_]>>();
+                    Some(TypeData::union_of(resolver, references))
                 }
             }
         }
         callee => {
-            let function = match select_overload(&callee, &expr.arguments, resolver) {
-                OverloadSelection::Selected(function) => function,
-                // The callee is an overload set, but no signature accepts the
-                // arguments. Its result type is unknown, so we must *not* fall
-                // back to silently picking the first call signature.
-                OverloadSelection::NoMatch => return None,
-                OverloadSelection::NotOverloaded => {
-                    resolve_callee_to_function(callee, resolver, depth)?
-                }
-            };
+            let function = resolve_callee_for_call(callee, &expr.arguments, resolver)?;
             flattened_function_call(expr, &function, resolver)
         }
+    }
+}
+
+/// Resolves the callable target for a call expression, selecting overloads first.
+fn resolve_callee_for_call(
+    callee: TypeData,
+    arguments: &[CallArgumentType],
+    resolver: &mut dyn TypeResolver,
+) -> Option<Box<Function>> {
+    match select_overload(&callee, arguments, resolver) {
+        OverloadSelection::Selected(function) => Some(function),
+        // The callee is an overload set, but no signature accepts the arguments.
+        // Its result type is unknown, so do not fall back to the first signature.
+        OverloadSelection::NoMatch => None,
+        OverloadSelection::NotOverloaded => resolve_callee_to_function(callee, resolver),
     }
 }
 
@@ -500,32 +812,64 @@ fn select_overload(
     arguments: &[CallArgumentType],
     resolver: &dyn TypeResolver,
 ) -> OverloadSelection {
-    let resolved = ResolvedTypeData::from((ResolverId::from_level(resolver.level()), callee));
-    let signatures: Vec<TypeReference> = resolved
+    match callee {
+        TypeData::InstanceOf(instance) => {
+            let Some(instance_type) = resolver.resolve_and_get(&instance.ty) else {
+                return OverloadSelection::NotOverloaded;
+            };
+            if matches!(
+                instance_type.as_raw_data(),
+                TypeData::Class(_) | TypeData::Function(_)
+            ) {
+                return OverloadSelection::NotOverloaded;
+            }
+            select_overload_from_resolved(instance_type, arguments, resolver)
+        }
+        _ => {
+            let resolved =
+                ResolvedTypeData::from((ResolverId::from_level(resolver.level()), callee));
+            select_overload_from_resolved(resolved, arguments, resolver)
+        }
+    }
+}
+
+/// Selects an overload from a resolved callable object or interface.
+fn select_overload_from_resolved(
+    resolved: ResolvedTypeData,
+    arguments: &[CallArgumentType],
+    resolver: &dyn TypeResolver,
+) -> OverloadSelection {
+    let mut call_signature_count = 0;
+    let mut selected_function = None;
+
+    for member in resolved
         .all_members(resolver)
         .filter(|member| member.kind().is_call_signature())
-        .map(|member| member.to_member().deref_ty(resolver).into_owned())
-        .collect();
-    if signatures.len() < 2 {
-        return OverloadSelection::NotOverloaded;
+    {
+        call_signature_count += 1;
+
+        if selected_function.is_none() {
+            let member = member.to_member();
+            let signature = member.deref_ty(resolver);
+            if let Some(TypeData::Function(function)) = resolver
+                .resolve_and_get(&signature)
+                .map(ResolvedTypeData::to_data)
+                && signature_accepts_arguments(&function, arguments, resolver)
+            {
+                selected_function = Some(function);
+            }
+        }
+
+        if call_signature_count >= MIN_OVERLOAD_SIGNATURE_COUNT && selected_function.is_some() {
+            break;
+        }
     }
 
-    signatures
-        .iter()
-        .find_map(|signature| {
-            match resolver
-                .resolve_and_get(signature)
-                .map(ResolvedTypeData::to_data)
-            {
-                Some(TypeData::Function(function))
-                    if signature_accepts_arguments(&function, arguments, resolver) =>
-                {
-                    Some(function)
-                }
-                _ => None,
-            }
-        })
-        .map_or(OverloadSelection::NoMatch, OverloadSelection::Selected)
+    if call_signature_count < MIN_OVERLOAD_SIGNATURE_COUNT {
+        OverloadSelection::NotOverloaded
+    } else {
+        selected_function.map_or(OverloadSelection::NoMatch, OverloadSelection::Selected)
+    }
 }
 
 /// Narrow applicability heuristic used for overload selection.
@@ -576,22 +920,41 @@ fn signature_accepts_arguments(
         })
 }
 
-fn resolve_function(ty: &TypeReference, resolver: &dyn TypeResolver) -> Option<Box<Function>> {
-    match resolver.resolve_and_get(ty)?.to_data() {
-        TypeData::Function(function) => Some(function),
-        // Callable interfaces/objects: `interface Cb { (): Promise<void> }`
-        TypeData::Interface(interface) => interface
-            .members
-            .iter()
-            .find(|m| m.kind.is_call_signature())
-            .and_then(|m| resolve_function(&m.ty, resolver)),
-        TypeData::Object(object) => object
-            .members
-            .iter()
-            .find(|m| m.kind.is_call_signature())
-            .and_then(|m| resolve_function(&m.ty, resolver)),
-        _ => None,
+fn resolve_function(
+    type_reference: &TypeReference,
+    resolver: &dyn TypeResolver,
+) -> Option<Box<Function>> {
+    let mut current_type_reference = Cow::Borrowed(type_reference);
+    let mut remaining_steps = MAX_FLATTEN_DEPTH;
+
+    while remaining_steps > 0 {
+        remaining_steps -= 1;
+
+        let resolved = resolver.resolve_and_get(current_type_reference.as_ref())?;
+        match resolved.as_raw_data() {
+            TypeData::Function(function) => return Some(function.clone()),
+            // Callable interfaces/objects: `interface Cb { (): Promise<void> }`
+            TypeData::Interface(interface) => {
+                let member = interface
+                    .members
+                    .iter()
+                    .find(|member| member.kind.is_call_signature())?;
+                let member = ResolvedTypeMember::from((resolved.resolver_id(), member));
+                current_type_reference = Cow::Owned(member.deref_ty(resolver).into_owned());
+            }
+            TypeData::Object(object) => {
+                let member = object
+                    .members
+                    .iter()
+                    .find(|member| member.kind.is_call_signature())?;
+                let member = ResolvedTypeMember::from((resolved.resolver_id(), member));
+                current_type_reference = Cow::Owned(member.deref_ty(resolver).into_owned());
+            }
+            _ => return None,
+        }
     }
+
+    None
 }
 
 fn function_returns_promise(function: &Function, resolver: &dyn TypeResolver) -> bool {
@@ -623,21 +986,24 @@ fn flattened_destructure(
                     .find_member(resolver, |member| {
                         !member.is_static() && member.has_name(name.text())
                     })
-                    .or_else(|| subject.find_index_signature_with_ty(resolver, |ty| ty.is_string()))
+                    .or_else(|| {
+                        subject.find_index_signature_with_ty(resolver, |data| data.is_string())
+                    })
             })
-            .and_then(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))
-            .map(ResolvedTypeData::to_data),
+            .and_then(|member| type_data_from_destructured_member(member, resolver)),
         (TypeData::InstanceOf(subject_instance), DestructureField::RestExcept(names)) => resolver
             .resolve_and_get(&resolved.apply_module_id_to_reference(&subject_instance.ty))
             .map(|subject| flattened_rest_object(resolver, subject, names)),
         (subject @ TypeData::Class(_), DestructureField::Name(name)) => {
-            let member_ty = subject
+            let member = subject
                 .own_members()
-                .find(|own_member| own_member.is_static() && own_member.has_name(name.text()))
-                .map(|member| resolved.apply_module_id_to_reference(&member.ty))?;
-            resolver
-                .resolve_and_get(&member_ty)
-                .map(ResolvedTypeData::to_data)
+                .find(|own_member| {
+                    own_member.is_static()
+                        && !own_member.is_constructor()
+                        && own_member.has_name(name.text())
+                })
+                .map(|member| ResolvedTypeMember::from((resolved.resolver_id(), member)))?;
+            type_data_from_destructured_member(member, resolver)
         }
         (subject @ TypeData::Class(_), DestructureField::RestExcept(names)) => {
             let members = subject
@@ -654,10 +1020,10 @@ fn flattened_destructure(
         (_, DestructureField::Name(name)) => {
             let member = resolved
                 .find_member(resolver, |member| member.has_name(name.text()))
-                .or_else(|| resolved.find_index_signature_with_ty(resolver, |ty| ty.is_string()))?;
-            resolver
-                .resolve_and_get(&member.deref_ty(resolver))
-                .map(ResolvedTypeData::to_data)
+                .or_else(|| {
+                    resolved.find_index_signature_with_ty(resolver, |data| data.is_string())
+                })?;
+            type_data_from_destructured_member(member, resolver)
         }
         (_, DestructureField::RestExcept(excluded_names)) => {
             Some(flattened_rest_object(resolver, resolved, excluded_names))
@@ -670,46 +1036,80 @@ fn flattened_function_call(
     function: &Function,
     resolver: &mut dyn TypeResolver,
 ) -> Option<TypeData> {
-    let return_ty_reference = function.return_type.as_type()?;
-    let mut return_ty = resolver.resolve_and_get(return_ty_reference)?.to_data();
+    let return_type_reference = function.return_type.as_type()?;
+    let mut return_type = resolver.resolve_and_get(return_type_reference)?.to_data();
 
-    let generic_references = match &return_ty {
-        TypeData::InstanceOf(instance) => {
-            let mut generic_references = match resolver.resolve_and_get(&instance.ty) {
-                Some(resolved) if resolved.is_generic() => vec![instance.ty.clone()],
-                _ => Vec::new(),
-            };
-            for param in &instance.type_parameters {
-                match resolver.resolve_and_get(param) {
-                    Some(resolved) if resolved.is_generic() => {
-                        generic_references.push(param.clone())
-                    }
-                    _ => {}
-                }
-            }
-            generic_references
+    let generic_reference = match &return_type {
+        TypeData::InstanceOf(instance)
+            if resolver
+                .resolve_and_get(&instance.ty)
+                .is_some_and(|resolved| resolved.is_generic()) =>
+        {
+            Some(instance.ty.clone())
         }
-        _ => Vec::new(),
+        _ => None,
     };
+    if let Some(generic_reference) = generic_reference {
+        infer_generic_arguments(
+            resolver,
+            &mut return_type,
+            return_type_reference,
+            &generic_reference,
+            function,
+            expr,
+        );
+    }
 
-    // The time complexity is not great on this, but fortunately most functions
-    // have very few generics and not too many arguments either.
-    for generic_reference in generic_references {
-        for (index, param) in function.parameters.iter().enumerate() {
-            if let Some(arg) = expr.arguments.get(index) {
-                infer_generic_arg(
-                    resolver,
-                    &mut return_ty,
-                    return_ty_reference,
-                    &generic_reference,
-                    param,
-                    arg,
-                );
-            }
+    let mut type_parameter_index = 0;
+    while let TypeData::InstanceOf(instance) = &return_type {
+        let generic_reference = {
+            let Some(type_parameter) = instance.type_parameters.get(type_parameter_index) else {
+                break;
+            };
+            type_parameter_index += 1;
+            resolver
+                .resolve_and_get(type_parameter)
+                .is_some_and(|resolved| resolved.is_generic())
+                .then(|| type_parameter.clone())
+        };
+
+        if let Some(generic_reference) = generic_reference {
+            infer_generic_arguments(
+                resolver,
+                &mut return_type,
+                return_type_reference,
+                &generic_reference,
+                function,
+                expr,
+            );
         }
     }
 
-    Some(return_ty)
+    Some(return_type)
+}
+
+fn infer_generic_arguments(
+    resolver: &dyn TypeResolver,
+    target: &mut TypeData,
+    target_reference: &TypeReference,
+    generic_reference: &TypeReference,
+    function: &Function,
+    expr: &TypeofCallExpression,
+) {
+    // The time complexity is not great on this, but fortunately most functions
+    // have very few generics and not too many arguments either.
+    for (index, parameter) in function.parameters.iter().enumerate() {
+        if let Some(argument) = expr.arguments.get(index) {
+            infer_generic_arg(
+                resolver,
+                target,
+                target_reference,
+                generic_reference,
+                parameter,
+                argument,
+            );
+        }
+    }
 }
 
 fn infer_generic_arg(
@@ -771,10 +1171,9 @@ fn flattened_rest_object(
     object: ResolvedTypeData,
     excluded_names: &[Text],
 ) -> TypeData {
-    // We need to look up the prototype chain, which may yield duplicate member
-    // names. We deduplicate using a hash table so that we can maintain the
-    // original order in a vector.
-    let mut table: HashTable<usize> = HashTable::default();
+    // Prototype lookup may yield duplicate names; keep the first member in
+    // lookup order.
+    let mut seen_names: HashTable<usize> = HashTable::default();
     let mut members: Vec<TypeMember> = Vec::new();
     for member in object.all_members(resolver) {
         let Some(name) = &member.name() else {
@@ -784,14 +1183,15 @@ fn flattened_rest_object(
             continue;
         }
 
-        let entry = table.entry(
+        let entry = seen_names.entry(
             hash_text(name),
-            |i| members[*i].name().as_ref().is_some_and(|n| n == name),
-            |i| {
-                let name = members[*i].name();
-                let name = name.as_ref().expect("only named members may be added");
-                hash_text(name)
+            |index| {
+                members[*index]
+                    .name()
+                    .as_ref()
+                    .is_some_and(|member_name| member_name == name)
             },
+            |index| members[*index].name().as_ref().map_or(0, hash_text),
         );
         if let Entry::Vacant(entry) = entry {
             let index = members.len();
@@ -835,5 +1235,41 @@ fn flattened_typeof_data(resolved: ResolvedTypeData) -> TypeData {
         TypeData::Symbol => TypeData::reference(GLOBAL_SYMBOL_STRING_LITERAL_ID),
         TypeData::Undefined => TypeData::reference(GLOBAL_UNDEFINED_STRING_LITERAL_ID),
         _ => TypeData::reference(GLOBAL_TYPEOF_OPERATOR_RETURN_UNION_ID),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NamedFunctionParameter;
+
+    fn constructor_parameter(is_optional: bool, is_rest: bool) -> ConstructorParameter {
+        ConstructorParameter {
+            parameter: FunctionParameter::Named(NamedFunctionParameter {
+                name: Text::new_static("args"),
+                ty: TypeReference::unknown(),
+                is_optional,
+                is_rest,
+            }),
+            accessibility: None,
+        }
+    }
+
+    #[test]
+    fn rest_constructor_accepts_zero_arguments() {
+        let parameters = [constructor_parameter(false, true)];
+
+        assert!(constructor_accepts_argument_count(&parameters, 0));
+    }
+
+    #[test]
+    fn required_constructor_parameter_still_requires_an_argument() {
+        let parameters = [
+            constructor_parameter(false, false),
+            constructor_parameter(false, true),
+        ];
+
+        assert!(!constructor_accepts_argument_count(&parameters, 0));
+        assert!(constructor_accepts_argument_count(&parameters, 1));
     }
 }

--- a/crates/biome_js_type_info/src/generated/global_types.rs
+++ b/crates/biome_js_type_info/src/generated/global_types.rs
@@ -3,11 +3,78 @@
 // Generated from microsoft/TypeScript v6.0.3 (git commit 050880ce59e30b356b686bd3144efe24f875ebc8).
 
 /// Predefined global IDs whose `TypeData` is supplied by this generated module.
-pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[];
+pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
+    crate::globals::ERROR_ID_GLOBAL_TYPE_ID,
+    crate::globals::ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID,
+    crate::globals::ERROR_CALL_ID_GLOBAL_TYPE_ID,
+];
 
 /// Registers all generated global type data into the resolver builder.
 pub(crate) fn set_generated_global_type_data(
     builder: &mut crate::globals_builder::GlobalsResolverBuilder,
 ) {
-    let _ = builder;
+    let data = crate::TypeData::Class(Box::new(crate::Class {
+        name: Some(biome_rowan::Text::new_static("Error")),
+        type_parameters: Box::default(),
+        extends: None,
+        implements: Box::default(),
+        members: Box::new([
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::Named(biome_rowan::Text::new_static("name")),
+                ty: crate::globals::GLOBAL_STRING_ID.into(),
+            },
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::Named(biome_rowan::Text::new_static("message")),
+                ty: crate::globals::GLOBAL_STRING_ID.into(),
+            },
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::NamedOptional(biome_rowan::Text::new_static("stack")),
+                ty: crate::globals::GLOBAL_STRING_ID.into(),
+            },
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::Constructor,
+                ty: crate::globals::GLOBAL_ERROR_CONSTRUCTOR_ID.into(),
+            },
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::CallSignature,
+                ty: crate::globals::GLOBAL_ERROR_CALL_ID.into(),
+            },
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::NamedStatic(biome_rowan::Text::new_static(
+                    "prototype",
+                )),
+                ty: crate::globals::GLOBAL_INSTANCEOF_ERROR_ID.into(),
+            },
+        ]),
+    }));
+    builder.set_type_data(crate::globals::ERROR_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Constructor(Box::new(crate::Constructor {
+        type_parameters: Box::default(),
+        parameters: Box::new([crate::ConstructorParameter {
+            parameter: crate::FunctionParameter::Named(crate::NamedFunctionParameter {
+                name: biome_rowan::Text::new_static("message"),
+                ty: crate::globals::GLOBAL_STRING_ID.into(),
+                is_optional: true,
+                is_rest: false,
+            }),
+            accessibility: None,
+        }]),
+        return_type: Some(crate::globals::GLOBAL_ERROR_ID.into()),
+    }));
+    builder.set_type_data(crate::globals::ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Function(Box::new(crate::Function {
+        is_async: false,
+        type_parameters: Box::default(),
+        name: Some(biome_rowan::Text::new_static("Error")),
+        parameters: Box::new([crate::FunctionParameter::Named(
+            crate::NamedFunctionParameter {
+                name: biome_rowan::Text::new_static("message"),
+                ty: crate::globals::GLOBAL_STRING_ID.into(),
+                is_optional: true,
+                is_rest: false,
+            },
+        )]),
+        return_type: crate::ReturnType::Type(crate::globals::GLOBAL_INSTANCEOF_ERROR_ID.into()),
+    }));
+    builder.set_type_data(crate::globals::ERROR_CALL_ID_GLOBAL_TYPE_ID, data);
 }

--- a/crates/biome_js_type_info/src/globals_builder.rs
+++ b/crates/biome_js_type_info/src/globals_builder.rs
@@ -5,7 +5,7 @@ use crate::{NUM_PREDEFINED_TYPES, TypeData, TypeStore};
 
 use super::{globals::GlobalsResolver, globals_ids::GlobalTypeId};
 
-/// Requires every predefined manifest slot to be populated before producing a [`GlobalsResolver`].
+/// Tracks predefined manifest slots before producing a [`GlobalsResolver`].
 pub(crate) struct GlobalsResolverBuilder {
     /// `None` reserves a manifest row until its `TypeData` is written.
     types: Vec<Option<TypeData>>,
@@ -50,6 +50,13 @@ impl GlobalsResolverBuilder {
 
     /// Consumes the builder and produces the immutable [`GlobalsResolver`].
     pub(crate) fn build(self) -> GlobalsResolver {
+        for (index, slot) in self.types.iter().enumerate() {
+            debug_assert!(
+                slot.is_some(),
+                "global type resolver slot {index} was not populated"
+            );
+        }
+
         let types: Vec<Arc<TypeData>> = self
             .types
             .into_iter()
@@ -89,5 +96,11 @@ mod tests {
         let mut builder = GlobalsResolverBuilder::default();
         builder.set_type_data(UNKNOWN_ID_GLOBAL_TYPE_ID, TypeData::Unknown);
         builder.set_type_data(UNKNOWN_ID_GLOBAL_TYPE_ID, TypeData::Unknown);
+    }
+
+    #[test]
+    #[should_panic(expected = "global type resolver slot 0 was not populated")]
+    fn build_panics_on_missing_slot() {
+        GlobalsResolverBuilder::with_capacity(1).build();
     }
 }

--- a/crates/biome_js_type_info/src/globals_ids.rs
+++ b/crates/biome_js_type_info/src/globals_ids.rs
@@ -12,7 +12,7 @@ use crate::{ResolvedTypeId, TypeId, TypeMember, TypeMemberKind};
 use super::globals::GLOBAL_LEVEL;
 
 /// Compile-time guard for manifest length; ordering is checked by `manifest_names_match_id_name_constants`.
-const PREDEFINED_TYPE_COUNT: usize = 63;
+const PREDEFINED_TYPE_COUNT: usize = 65;
 
 /// Type ID that is known to index the predefined global resolver.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -265,11 +265,16 @@ predefined_globals! {
     (INSTANCEOF_ERROR_ID, INSTANCEOF_ERROR_ID_NAME, INSTANCEOF_ERROR_ID_GLOBAL_TYPE_ID, GLOBAL_INSTANCEOF_ERROR_ID, "instanceof Error", Helper),
     (ERROR_ID, ERROR_ID_NAME, ERROR_ID_GLOBAL_TYPE_ID, GLOBAL_ERROR_ID, "Error", ManualGlobal),
     (BOOLEAN_ID, BOOLEAN_ID_NAME, BOOLEAN_ID_GLOBAL_TYPE_ID, GLOBAL_BOOLEAN_ID, "boolean", Primitive),
+    (ERROR_CONSTRUCTOR_ID, ERROR_CONSTRUCTOR_ID_NAME, ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID, GLOBAL_ERROR_CONSTRUCTOR_ID, "Error.constructor", ManualSynthetic),
+    (ERROR_CALL_ID, ERROR_CALL_ID_NAME, ERROR_CALL_ID_GLOBAL_TYPE_ID, GLOBAL_ERROR_CALL_ID, "Error.call", ManualSynthetic),
 }
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::*;
+    use crate::{GlobalsResolver, TypeData, TypeResolver, Union};
 
     #[test]
     fn num_predefined_types_matches_manifest_len() {
@@ -351,6 +356,8 @@ mod tests {
             (INSTANCEOF_ERROR_ID, INSTANCEOF_ERROR_ID_NAME),
             (ERROR_ID, ERROR_ID_NAME),
             (BOOLEAN_ID, BOOLEAN_ID_NAME),
+            (ERROR_CONSTRUCTOR_ID, ERROR_CONSTRUCTOR_ID_NAME),
+            (ERROR_CALL_ID, ERROR_CALL_ID_NAME),
         ];
         assert_eq!(pairs.len(), NUM_PREDEFINED_TYPES);
         assert_eq!(pairs.len(), PREDEFINED_ID_ROWS.len());
@@ -439,6 +446,8 @@ mod tests {
             (GLOBAL_INSTANCEOF_ERROR_ID, INSTANCEOF_ERROR_ID),
             (GLOBAL_ERROR_ID, ERROR_ID),
             (GLOBAL_BOOLEAN_ID, BOOLEAN_ID),
+            (GLOBAL_ERROR_CONSTRUCTOR_ID, ERROR_CONSTRUCTOR_ID),
+            (GLOBAL_ERROR_CALL_ID, ERROR_CALL_ID),
         ];
         assert_eq!(pairs.len(), NUM_PREDEFINED_TYPES);
         for (resolved_id, id) in pairs {
@@ -452,13 +461,31 @@ mod tests {
     }
 
     #[test]
-    fn migrated_predefined_ids_require_structural_diff_harness() {
+    fn error_global_is_migrated() {
         let migrated = crate::generated::global_types::MIGRATED_PREDEFINED_IDS;
+        assert_eq!(
+            migrated,
+            &[
+                ERROR_ID_GLOBAL_TYPE_ID,
+                ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID,
+                ERROR_CALL_ID_GLOBAL_TYPE_ID,
+            ]
+        );
+    }
+
+    #[test]
+    fn optional_string_is_not_named_like_error_stack() {
+        let mut resolver = GlobalsResolver::default();
+        let optional_string = TypeData::Union(Box::new(Union(Box::new([
+            GLOBAL_STRING_ID.into(),
+            GLOBAL_UNDEFINED_ID.into(),
+        ]))));
+        let id = resolver.register_type(Cow::Owned(optional_string));
+
         assert!(
-            migrated.is_empty(),
-            "Non-empty MIGRATED_PREDEFINED_IDS ({} entries) requires the structural diff comparator: \
-             crates/biome_js_type_info/tests/generated_equivalence.rs + tests/fixtures/manual_globals.rs.",
-            migrated.len()
+            id.index() >= NUM_PREDEFINED_TYPES,
+            "generic optional string must not reuse predefined name {:?}",
+            global_type_name(id),
         );
     }
 

--- a/crates/biome_js_type_info/src/helpers.rs
+++ b/crates/biome_js_type_info/src/helpers.rs
@@ -297,6 +297,7 @@ impl TypeData {
                                 entry.insert(index);
                             }
                         }
+                        continue;
                     }
                     _ => {}
                 }

--- a/crates/biome_js_type_info/tests/flattening.rs
+++ b/crates/biome_js_type_info/tests/flattening.rs
@@ -1,7 +1,8 @@
 mod utils;
 
 use biome_js_type_info::{
-    GlobalsResolver, Literal, ScopeId, TypeData, TypeReference, TypeResolver, TypeofExpression,
+    Function, FunctionParameter, GlobalsResolver, Literal, NamedFunctionParameter, ReturnType,
+    ScopeId, TypeData, TypeMember, TypeMemberKind, TypeReference, TypeResolver, TypeofExpression,
     TypeofStaticMemberExpression,
 };
 
@@ -224,6 +225,85 @@ returnsPromise()"#;
 }
 
 #[test]
+fn infer_flattened_type_from_indexed_function_call() {
+    const CODE: &str = r#"const fns = [() => "value"];
+
+fns[0]()"#;
+
+    let root = parse_ts(CODE);
+    let declaration = get_variable_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let bindings = TypeData::typed_bindings_from_js_variable_declaration(
+        &mut resolver,
+        ScopeId::GLOBAL,
+        &declaration,
+    );
+    resolver.run_inference();
+
+    let [(name, reference)] = bindings.as_ref() else {
+        panic!("expected exactly one binding");
+    };
+    assert_eq!(name.text(), "fns");
+    let function_tuple = resolver
+        .resolve_and_get(reference)
+        .expect("fns should resolve")
+        .to_data();
+
+    let expression = get_expression(&root);
+    let mut resolver = HardcodedSymbolResolver::new("fns", function_tuple, resolver);
+    let expression_type =
+        TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expression);
+    resolver.run_inference();
+    let expression_type = expression_type.inferred(&mut resolver);
+
+    assert_eq!(expression_type.to_string(), "string: value");
+}
+
+#[test]
+fn nested_overloaded_call_replays_inner_overload_selection() {
+    const CODE: &str = r#"makeCallback("sync")()"#;
+
+    let root = parse_ts(CODE);
+    let mut resolver = GlobalsResolver::default();
+
+    let string_reference = resolver.reference_to_owned_data(TypeData::String);
+    let void_reference = resolver.reference_to_owned_data(TypeData::VoidKeyword);
+    let promise_reference = resolver.reference_to_owned_data(TypeData::promise_of(
+        ScopeId::GLOBAL,
+        void_reference.clone(),
+    ));
+    let void_callback_reference = function_reference(&mut resolver, [], void_reference.clone());
+    let promise_callback_reference =
+        function_reference(&mut resolver, [], promise_reference.clone());
+    let returns_promise_callback_reference =
+        function_reference(&mut resolver, [], promise_callback_reference);
+    let returns_void_callback_reference = function_reference(
+        &mut resolver,
+        [named_parameter("mode", string_reference)],
+        void_callback_reference,
+    );
+    let overloads = TypeData::object_with_members(Box::new([
+        TypeMember {
+            kind: TypeMemberKind::CallSignature,
+            ty: returns_promise_callback_reference,
+        },
+        TypeMember {
+            kind: TypeMemberKind::CallSignature,
+            ty: returns_void_callback_reference,
+        },
+    ]));
+
+    let expression = get_expression(&root);
+    let mut resolver = HardcodedSymbolResolver::new("makeCallback", overloads, resolver);
+    let expression_type =
+        TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expression);
+    resolver.run_inference();
+    let expression_type = expression_type.inferred(&mut resolver);
+
+    assert_eq!(expression_type.to_string(), "void");
+}
+
+#[test]
 fn infer_flattened_type_from_chained_invocation_of_promise_returning_function() {
     const CODE: &str = r#"function returnsPromise(): Promise<number> {
     return Promise.resolved(true);
@@ -250,6 +330,29 @@ returnsPromise().then(() => {})"#;
         &resolver,
         "infer_flattened_type_from_chained_invocation_of_promise_returning_function",
     )
+}
+
+fn function_reference<const PARAMETER_COUNT: usize>(
+    resolver: &mut dyn TypeResolver,
+    parameters: [FunctionParameter; PARAMETER_COUNT],
+    return_type: TypeReference,
+) -> TypeReference {
+    resolver.reference_to_owned_data(TypeData::Function(Box::new(Function {
+        is_async: false,
+        type_parameters: Box::default(),
+        name: None,
+        parameters: Box::new(parameters),
+        return_type: ReturnType::Type(return_type),
+    })))
+}
+
+fn named_parameter(name: &'static str, type_reference: TypeReference) -> FunctionParameter {
+    FunctionParameter::Named(NamedFunctionParameter {
+        name: Text::new_static(name),
+        ty: type_reference,
+        is_optional: false,
+        is_rest: false,
+    })
 }
 
 #[test]
@@ -316,6 +419,103 @@ fn infer_flattened_type_from_direct_builtin_class_instances() {
 
         assert_eq!(expr_ty.to_string(), expected);
     }
+}
+
+#[test]
+fn infer_flattened_type_from_generated_error_members() {
+    for (code, expected) in [
+        (r#"new Error().message"#, "string"),
+        (r#"new Error("message").name"#, "string"),
+        (r#"new Error().stack"#, "string | undefined"),
+        (r#"Error().message"#, "string"),
+        (r#"Error.prototype.message"#, "string"),
+    ] {
+        let root = parse_ts(code);
+        let expr = get_expression(&root);
+        let mut resolver = GlobalsResolver::default();
+        let expression_type =
+            TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expr);
+        let expression_type = expression_type.inferred(&mut resolver);
+
+        assert_eq!(expression_type.to_string(), expected);
+    }
+}
+
+#[test]
+fn generated_error_value_members_do_not_leak_to_instances() {
+    for code in [
+        r#"Error.message"#,
+        r#"Error.constructor"#,
+        r#"new Error()()"#,
+        r#"new Error().prototype"#,
+    ] {
+        let root = parse_ts(code);
+        let expr = get_expression(&root);
+        let mut resolver = GlobalsResolver::default();
+        let expression_type =
+            TypeData::from_any_js_expression(&mut resolver, ScopeId::GLOBAL, &expr);
+        let expression_type = expression_type.inferred(&mut resolver);
+
+        assert!(
+            matches!(expression_type, TypeData::TypeofExpression(_)),
+            "expected invalid Error access to stay unresolved, got: {expression_type}",
+        );
+    }
+}
+
+#[test]
+fn infer_flattened_type_of_destructured_error_stack() {
+    const CODE: &str = r#"const { stack } = new Error();"#;
+
+    let root = parse_ts(CODE);
+    let declaration = get_variable_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let bindings = TypeData::typed_bindings_from_js_variable_declaration(
+        &mut resolver,
+        ScopeId::GLOBAL,
+        &declaration,
+    );
+    resolver.run_inference();
+
+    let [(name, reference)] = bindings.as_ref() else {
+        panic!("expected exactly one binding");
+    };
+    assert_eq!(name.text(), "stack");
+    let stack_type = resolver
+        .resolve_and_get(reference)
+        .expect("stack should resolve")
+        .to_data();
+
+    assert_eq!(stack_type.to_string(), "string | undefined");
+}
+
+#[test]
+fn generated_error_constructor_is_not_a_destructured_static_property() {
+    const CODE: &str = r#"const { constructor } = Error;"#;
+
+    let root = parse_ts(CODE);
+    let declaration = get_variable_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let bindings = TypeData::typed_bindings_from_js_variable_declaration(
+        &mut resolver,
+        ScopeId::GLOBAL,
+        &declaration,
+    );
+    resolver.run_inference();
+
+    let [(name, reference)] = bindings.as_ref() else {
+        panic!("expected exactly one binding");
+    };
+    assert_eq!(name.text(), "constructor");
+    let constructor_type = resolver
+        .resolve_and_get(reference)
+        .expect("constructor should resolve")
+        .to_data();
+
+    assert!(
+        matches!(constructor_type, TypeData::TypeofExpression(_)),
+        "expected invalid destructured property to stay unresolved, got: {constructor_type}",
+    );
 }
 
 #[test]

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_static_member_on_union.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_static_member_on_union.snap
@@ -18,7 +18,7 @@ parentNode.parentNode;
 ## Result
 
 ```
-Global TypeId(0) | Global TypeId(1) | Global TypeId(2)
+Global TypeId(0) | Global TypeId(1)
 ```
 
 ## Registered types

--- a/xtask/codegen/src/generate_global_types.rs
+++ b/xtask/codegen/src/generate_global_types.rs
@@ -5,7 +5,10 @@ use anyhow::bail;
 use std::path::Path;
 
 pub mod collect;
+pub mod compare;
 mod emit;
+pub mod lower;
+pub mod manifest;
 pub mod source;
 
 pub const DEFAULT_TYPESCRIPT_TAG: &str = "v6.0.3";
@@ -62,20 +65,26 @@ pub fn run_with_workspace_root(
     let checkout = source::acquire(pin, opts)?;
     let libs = source::parse_lib_entries(&checkout)?;
     let source_files = source::discover(&checkout, &libs, source::PROFILE_ROOTS)?;
-    collect_discovered_sources(&source_files)?;
+    let records = collect_discovered_sources(&source_files)?;
+    let manifest = manifest::build_global_manifest(records);
+    let lowered = lower::lower_global_types(&manifest, &source_files)?;
+    compare::compare_lowered_globals(&lowered)?;
 
-    emit::emit_global_types(checkout.pin(), workspace_root)?;
+    emit::emit_global_types(checkout.pin(), workspace_root, &lowered)?;
     Ok(())
 }
 
 /// Runs the typed declaration collector over every discovered source and
 /// fails the run if any pinned file produced a fatal parser diagnostic.
-fn collect_discovered_sources(source_files: &[source::DiscoveredFile]) -> anyhow::Result<()> {
+fn collect_discovered_sources(
+    source_files: &[source::DiscoveredFile],
+) -> anyhow::Result<Vec<collect::DeclarationRecord>> {
+    let mut records = Vec::new();
     let mut fatal_diagnostics = Vec::new();
 
     for source_file in source_files {
         let output = collect::collect(source_file);
-        fatal_diagnostics.extend(output.coverage.into_iter().filter_map(|outcome| {
+        fatal_diagnostics.extend(output.coverage.iter().filter_map(|outcome| {
             let collect::CoverageOutcome::Diagnostic(diagnostic) = outcome else {
                 return None;
             };
@@ -94,6 +103,7 @@ fn collect_discovered_sources(source_files: &[source::DiscoveredFile]) -> anyhow
                 )
             })
         }));
+        records.extend(output.records);
     }
 
     if !fatal_diagnostics.is_empty() {
@@ -103,7 +113,7 @@ fn collect_discovered_sources(source_files: &[source::DiscoveredFile]) -> anyhow
         );
     }
 
-    Ok(())
+    Ok(records)
 }
 
 /// Categories that should abort codegen instead of being recorded as

--- a/xtask/codegen/src/generate_global_types/compare.rs
+++ b/xtask/codegen/src/generate_global_types/compare.rs
@@ -1,0 +1,247 @@
+//! Structural checks for lowered generated globals.
+
+use anyhow::{Result, bail};
+
+use super::lower::{
+    LoweredClass, LoweredConstructor, LoweredFunction, LoweredFunctionParameter,
+    LoweredGlobalTypes, LoweredMemberKind, LoweredTypeData, LoweredTypeReference,
+};
+
+/// Number of `Error` class members expected in generated output.
+const ERROR_MEMBER_COUNT: usize = 6;
+/// Number of generated globals expected for `Error`.
+const ERROR_GLOBAL_COUNT: usize = 3;
+
+/// Validates lowered generated globals before they are emitted.
+pub fn compare_lowered_globals(lowered: &LoweredGlobalTypes) -> Result<()> {
+    if lowered.globals().len() != ERROR_GLOBAL_COUNT {
+        bail!(
+            "generated Error global has {} globals, expected {}",
+            lowered.globals().len(),
+            ERROR_GLOBAL_COUNT
+        );
+    }
+
+    let Some(error) = lowered.global("Error") else {
+        bail!("generated globals are missing the Error global");
+    };
+    if error.id_constant() != "ERROR_ID_GLOBAL_TYPE_ID" {
+        bail!(
+            "generated Error global targets {}, expected ERROR_ID_GLOBAL_TYPE_ID",
+            error.id_constant()
+        );
+    }
+
+    let LoweredTypeData::Class(class) = error.data() else {
+        bail!("generated Error global is not a class");
+    };
+    if class.name() != "Error" {
+        bail!(
+            "generated Error class has name {}, expected Error",
+            class.name()
+        );
+    }
+
+    assert_error_named_string_member(lowered, "name", false)?;
+    assert_error_named_string_member(lowered, "message", false)?;
+    assert_error_stack_member(lowered)?;
+    assert_error_constructor_member(lowered)?;
+    assert_error_call_member(lowered)?;
+    assert_error_prototype_member(lowered)?;
+
+    if class.members().len() != ERROR_MEMBER_COUNT {
+        bail!(
+            "generated Error global has {} members, expected {}",
+            class.members().len(),
+            ERROR_MEMBER_COUNT
+        );
+    }
+
+    let constructor = generated_constructor(lowered)?;
+    assert_error_constructor_shape(constructor)?;
+
+    let call = generated_call(lowered)?;
+    assert_error_call_shape(call)?;
+
+    Ok(())
+}
+
+/// Returns the generated `Error` class.
+fn generated_error_class(lowered: &LoweredGlobalTypes) -> Result<&LoweredClass> {
+    let Some(error) = lowered.global("Error") else {
+        bail!("generated globals are missing the Error global");
+    };
+    let LoweredTypeData::Class(class) = error.data() else {
+        bail!("generated Error global is not a class");
+    };
+    Ok(class)
+}
+
+/// Returns the generated constructor helper for `new Error(...)`.
+fn generated_constructor(lowered: &LoweredGlobalTypes) -> Result<&LoweredConstructor> {
+    let Some(constructor) = lowered.global("Error.constructor") else {
+        bail!("generated globals are missing the Error constructor helper");
+    };
+    if constructor.id_constant() != "ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID" {
+        bail!(
+            "generated Error constructor targets {}, expected ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID",
+            constructor.id_constant()
+        );
+    }
+    let LoweredTypeData::Constructor(constructor) = constructor.data() else {
+        bail!("generated Error constructor helper is not constructor data");
+    };
+    Ok(constructor)
+}
+
+/// Returns the generated call helper for `Error(...)`.
+fn generated_call(lowered: &LoweredGlobalTypes) -> Result<&LoweredFunction> {
+    let Some(call) = lowered.global("Error.call") else {
+        bail!("generated globals are missing the Error call helper");
+    };
+    if call.id_constant() != "ERROR_CALL_ID_GLOBAL_TYPE_ID" {
+        bail!(
+            "generated Error call targets {}, expected ERROR_CALL_ID_GLOBAL_TYPE_ID",
+            call.id_constant()
+        );
+    }
+    let LoweredTypeData::Function(call) = call.data() else {
+        bail!("generated Error call helper is not function data");
+    };
+    Ok(call)
+}
+
+/// Validates a required `Error` string field such as `name` or `message`.
+fn assert_error_named_string_member(
+    lowered: &LoweredGlobalTypes,
+    name: &str,
+    optional: bool,
+) -> Result<()> {
+    let class = generated_error_class(lowered)?;
+    let Some(member) = class.member(name) else {
+        bail!("missing required Error member {name}");
+    };
+    if member.kind() != &(LoweredMemberKind::Named { optional }) {
+        bail!(
+            "generated Error member {} has unexpected kind",
+            member.name()
+        );
+    }
+    if member.type_reference() != &LoweredTypeReference::Predefined("GLOBAL_STRING_ID") {
+        bail!(
+            "generated Error member {} has unexpected type",
+            member.name()
+        );
+    }
+    Ok(())
+}
+
+/// Validates the optional `Error#stack` member.
+fn assert_error_stack_member(lowered: &LoweredGlobalTypes) -> Result<()> {
+    let class = generated_error_class(lowered)?;
+    let Some(member) = class.member("stack") else {
+        bail!("missing required Error member stack");
+    };
+    if member.kind() != &(LoweredMemberKind::Named { optional: true }) {
+        bail!("generated Error member stack has unexpected kind");
+    }
+    if member.type_reference() != &LoweredTypeReference::Predefined("GLOBAL_STRING_ID") {
+        bail!("generated Error member stack has unexpected type");
+    }
+    Ok(())
+}
+
+/// Validates `ErrorConstructor.prototype`.
+fn assert_error_prototype_member(lowered: &LoweredGlobalTypes) -> Result<()> {
+    let class = generated_error_class(lowered)?;
+    let Some(member) = class.member("prototype") else {
+        bail!("missing required Error prototype member");
+    };
+    if member.kind() != &LoweredMemberKind::NamedStatic {
+        bail!("generated Error prototype member has unexpected kind");
+    }
+    if member.type_reference() != &LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_ERROR_ID") {
+        bail!("generated Error prototype member has unexpected type");
+    }
+    Ok(())
+}
+
+/// Validates the `new Error(...)` construct signature member.
+fn assert_error_constructor_member(lowered: &LoweredGlobalTypes) -> Result<()> {
+    let class = generated_error_class(lowered)?;
+    let Some(member) = class.member("constructor") else {
+        bail!("missing required Error constructor member");
+    };
+    if member.kind() != &LoweredMemberKind::Constructor {
+        bail!("generated Error constructor member has unexpected kind");
+    }
+    if member.type_reference() != &LoweredTypeReference::Predefined("GLOBAL_ERROR_CONSTRUCTOR_ID") {
+        bail!("generated Error constructor member has unexpected type");
+    }
+    Ok(())
+}
+
+/// Validates the `Error(...)` call signature member.
+fn assert_error_call_member(lowered: &LoweredGlobalTypes) -> Result<()> {
+    let class = generated_error_class(lowered)?;
+    let Some(member) = class.member("call") else {
+        bail!("missing required Error call signature member");
+    };
+    if member.kind() != &LoweredMemberKind::CallSignature {
+        bail!("generated Error call signature member has unexpected kind");
+    }
+    if member.type_reference() != &LoweredTypeReference::Predefined("GLOBAL_ERROR_CALL_ID") {
+        bail!("generated Error call signature member has unexpected type");
+    }
+    Ok(())
+}
+
+/// Validates the generated constructor helper shape.
+fn assert_error_constructor_shape(constructor: &LoweredConstructor) -> Result<()> {
+    assert_single_optional_message_parameter(
+        constructor.parameters(),
+        "generated Error constructor",
+    )?;
+    if constructor.return_type() != Some(&LoweredTypeReference::Predefined("GLOBAL_ERROR_ID")) {
+        bail!("generated Error constructor has unexpected return type");
+    }
+    Ok(())
+}
+
+/// Validates the generated call helper shape.
+fn assert_error_call_shape(call: &LoweredFunction) -> Result<()> {
+    if call.name() != Some("Error") {
+        bail!("generated Error call helper has unexpected function name");
+    }
+    assert_single_optional_message_parameter(call.parameters(), "generated Error call")?;
+    if call.return_type() != &LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_ERROR_ID") {
+        bail!("generated Error call has unexpected return type");
+    }
+    Ok(())
+}
+
+/// Validates the shared optional `message?: string` parameter.
+fn assert_single_optional_message_parameter(
+    parameters: &[LoweredFunctionParameter],
+    owner: &str,
+) -> Result<()> {
+    let [parameter] = parameters else {
+        bail!(
+            "{owner} has {} parameters, expected one message parameter",
+            parameters.len()
+        );
+    };
+    if parameter.name() != "message" {
+        bail!("{owner} has unexpected parameter name {}", parameter.name());
+    }
+    if parameter.type_reference() != &LoweredTypeReference::Predefined("GLOBAL_STRING_ID") {
+        bail!("{owner} message parameter has unexpected type");
+    }
+    if !parameter.is_optional() {
+        bail!("{owner} message parameter must be optional");
+    }
+    if parameter.is_rest() {
+        bail!("{owner} message parameter must not be rest");
+    }
+    Ok(())
+}

--- a/xtask/codegen/src/generate_global_types/emit.rs
+++ b/xtask/codegen/src/generate_global_types/emit.rs
@@ -1,33 +1,277 @@
 use std::path::Path;
 
+use anyhow::{Result, bail};
+
+use super::lower::{
+    LoweredClass, LoweredConstructor, LoweredFunction, LoweredFunctionParameter, LoweredGlobal,
+    LoweredGlobalTypes, LoweredMemberKind, LoweredTypeData, LoweredTypeMember,
+    LoweredTypeReference,
+};
+
 /// Relative path of the generated global types module from the workspace root.
 const OUTPUT_RELATIVE_PATH: &str = "crates/biome_js_type_info/src/generated/global_types.rs";
+
+/// Stable generated global emission order for generated globals with fixed IDs.
+const GLOBAL_ID_EMIT_ORDER: [&str; 3] = [
+    "ERROR_ID_GLOBAL_TYPE_ID",
+    "ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID",
+    "ERROR_CALL_ID_GLOBAL_TYPE_ID",
+];
 
 /// Emits the global types module with LF-normalized output.
 pub(super) fn emit_global_types(
     pin: &crate::generate_global_types::SourcePin,
     workspace_root: &Path,
+    lowered: &LoweredGlobalTypes,
 ) -> anyhow::Result<crate::UpdateResult> {
     let path = workspace_root.join(OUTPUT_RELATIVE_PATH);
     let formatted =
-        xtask_glue::reformat_with_command(generated_body(pin), "just gen-global-types")?;
+        xtask_glue::reformat_with_command(generated_body(pin, lowered)?, "just gen-global-types")?;
     crate::update(&path, &formatted, &xtask_glue::Mode::Overwrite)
 }
 
 /// Renders the unformatted Rust body for the generated module.
-fn generated_body(pin: &crate::generate_global_types::SourcePin) -> String {
-    format!(
+fn generated_body(
+    pin: &crate::generate_global_types::SourcePin,
+    lowered: &LoweredGlobalTypes,
+) -> Result<String> {
+    let migrated_ids = render_migrated_ids(lowered)?;
+    let registrations = render_registrations(lowered)?;
+
+    Ok(format!(
         r#"// Generated from microsoft/TypeScript {typescript_tag} (git commit {typescript_sha}).
 
 /// Predefined global IDs whose `TypeData` is supplied by this generated module.
-pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[];
+pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
+{migrated_ids}];
 
 /// Registers all generated global type data into the resolver builder.
 pub(crate) fn set_generated_global_type_data(builder: &mut crate::globals_builder::GlobalsResolverBuilder) {{
-    let _ = builder;
-}}
+{registrations}}}
 "#,
         typescript_tag = pin.tag(),
         typescript_sha = pin.sha(),
+    ))
+}
+
+/// Builds the migrated ID slice body.
+fn render_migrated_ids(lowered: &LoweredGlobalTypes) -> Result<String> {
+    let mut ids = String::new();
+    for global in sorted_globals(lowered)? {
+        ids.push_str("    crate::globals::");
+        ids.push_str(global.id_constant());
+        ids.push_str(",\n");
+    }
+    Ok(ids)
+}
+
+/// Builds the resolver registration statements.
+fn render_registrations(lowered: &LoweredGlobalTypes) -> Result<String> {
+    let mut registrations = String::new();
+    for global in sorted_globals(lowered)? {
+        registrations.push_str("    let data = ");
+        registrations.push_str(&render_type_data(global.data()));
+        registrations.push_str(";\n");
+        registrations.push_str("    builder.set_type_data(crate::globals::");
+        registrations.push_str(global.id_constant());
+        registrations.push_str(", data);\n");
+    }
+    Ok(registrations)
+}
+
+/// Dispatches lowered data to its Rust expression renderer.
+fn render_type_data(data: &LoweredTypeData) -> String {
+    match data {
+        LoweredTypeData::Class(class) => render_class(class),
+        LoweredTypeData::Constructor(constructor) => render_constructor(constructor),
+        LoweredTypeData::Function(function) => render_function(function),
+    }
+}
+
+/// Builds a `TypeData::Class` expression.
+fn render_class(class: &LoweredClass) -> String {
+    format!(
+        "crate::TypeData::Class(Box::new(crate::Class {{
+            name: Some(biome_rowan::Text::new_static({name})),
+            type_parameters: Box::default(),
+            extends: None,
+            implements: Box::default(),
+            members: Box::new([{members}]),
+        }}))",
+        name = rust_string_literal(class.name()),
+        members = render_members(class.members()),
     )
+}
+
+/// Builds a `TypeData::Constructor` expression.
+fn render_constructor(constructor: &LoweredConstructor) -> String {
+    let return_type = constructor.return_type().map_or_else(
+        || "None".to_string(),
+        |return_type| format!("Some({})", render_type_reference(return_type)),
+    );
+
+    format!(
+        "crate::TypeData::Constructor(Box::new(crate::Constructor {{
+            type_parameters: Box::default(),
+            parameters: Box::new([{parameters}]),
+            return_type: {return_type},
+        }}))",
+        parameters = render_constructor_parameters(constructor.parameters()),
+    )
+}
+
+/// Builds a `TypeData::Function` expression.
+fn render_function(function: &LoweredFunction) -> String {
+    let name = function.name().map_or_else(
+        || "None".to_string(),
+        |name| {
+            format!(
+                "Some(biome_rowan::Text::new_static({}))",
+                rust_string_literal(name)
+            )
+        },
+    );
+
+    format!(
+        "crate::TypeData::Function(Box::new(crate::Function {{
+            is_async: false,
+            type_parameters: Box::default(),
+            name: {name},
+            parameters: Box::new([{parameters}]),
+            return_type: crate::ReturnType::Type({return_type}),
+        }}))",
+        parameters = render_function_parameters(function.parameters()),
+        return_type = render_type_reference(function.return_type()),
+    )
+}
+
+/// Builds the class member expression list.
+fn render_members(members: &[LoweredTypeMember]) -> String {
+    let mut rendered = String::new();
+    for member in members {
+        rendered.push_str(&render_member(member));
+        rendered.push(',');
+    }
+    rendered
+}
+
+/// Builds one `TypeMember` expression.
+fn render_member(member: &LoweredTypeMember) -> String {
+    format!(
+        "crate::TypeMember {{
+            kind: {kind},
+            ty: {type_reference},
+        }}",
+        kind = render_member_kind(member),
+        type_reference = render_type_reference(member.type_reference()),
+    )
+}
+
+/// Builds the `TypeMemberKind` expression for a member.
+fn render_member_kind(member: &LoweredTypeMember) -> String {
+    match member.kind() {
+        LoweredMemberKind::Named { optional: false } => {
+            format!(
+                "crate::TypeMemberKind::Named(biome_rowan::Text::new_static({}))",
+                rust_string_literal(member.name()),
+            )
+        }
+        LoweredMemberKind::Named { optional: true } => {
+            format!(
+                "crate::TypeMemberKind::NamedOptional(biome_rowan::Text::new_static({}))",
+                rust_string_literal(member.name()),
+            )
+        }
+        LoweredMemberKind::NamedStatic => {
+            format!(
+                "crate::TypeMemberKind::NamedStatic(biome_rowan::Text::new_static({}))",
+                rust_string_literal(member.name()),
+            )
+        }
+        LoweredMemberKind::Constructor => "crate::TypeMemberKind::Constructor".to_string(),
+        LoweredMemberKind::CallSignature => "crate::TypeMemberKind::CallSignature".to_string(),
+    }
+}
+
+/// Builds constructor parameter expressions.
+fn render_constructor_parameters(parameters: &[LoweredFunctionParameter]) -> String {
+    let mut rendered = String::new();
+    for parameter in parameters {
+        rendered.push_str("crate::ConstructorParameter { parameter: ");
+        rendered.push_str(&render_function_parameter(parameter));
+        rendered.push_str(", accessibility: None },");
+    }
+    rendered
+}
+
+/// Builds function parameter expressions.
+fn render_function_parameters(parameters: &[LoweredFunctionParameter]) -> String {
+    let mut rendered = String::new();
+    for parameter in parameters {
+        rendered.push_str(&render_function_parameter(parameter));
+        rendered.push(',');
+    }
+    rendered
+}
+
+/// Builds one named parameter expression.
+fn render_function_parameter(parameter: &LoweredFunctionParameter) -> String {
+    format!(
+        "crate::FunctionParameter::Named(crate::NamedFunctionParameter {{
+            name: biome_rowan::Text::new_static({name}),
+            ty: {type_reference},
+            is_optional: {is_optional},
+            is_rest: {is_rest},
+        }})",
+        name = rust_string_literal(parameter.name()),
+        type_reference = render_type_reference(parameter.type_reference()),
+        is_optional = parameter.is_optional(),
+        is_rest = parameter.is_rest(),
+    )
+}
+
+/// Builds a generated `TypeReference` expression.
+fn render_type_reference(reference: &LoweredTypeReference) -> String {
+    match reference {
+        LoweredTypeReference::Predefined(id) => {
+            format!("crate::globals::{id}.into()")
+        }
+    }
+}
+
+/// Quotes a string for generated Rust source.
+fn rust_string_literal(value: &str) -> String {
+    format!("{value:?}")
+}
+
+fn global_with_id_constant<'a>(
+    lowered: &'a LoweredGlobalTypes,
+    id_constant: &str,
+) -> Result<&'a LoweredGlobal> {
+    for global in lowered.globals() {
+        if global.id_constant() == id_constant {
+            return Ok(global);
+        }
+    }
+
+    bail!("generated global output is missing {id_constant}");
+}
+
+/// Returns generated globals in the sorted predefined-ID order.
+fn sorted_globals(lowered: &LoweredGlobalTypes) -> Result<[&LoweredGlobal; 3]> {
+    for global in lowered.globals() {
+        if !GLOBAL_ID_EMIT_ORDER.contains(&global.id_constant()) {
+            bail!(
+                "generated global {} targets {}, but the ID is missing from GLOBAL_ID_EMIT_ORDER",
+                global.name(),
+                global.id_constant()
+            );
+        }
+    }
+
+    Ok([
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[0])?,
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[1])?,
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[2])?,
+    ])
 }

--- a/xtask/codegen/src/generate_global_types/lower.rs
+++ b/xtask/codegen/src/generate_global_types/lower.rs
@@ -1,0 +1,788 @@
+//! Lowers collected global declaration groups into a codegen-friendly model.
+
+use anyhow::{Context, Result, bail};
+use biome_js_parser::{JsParserOptions, parse};
+use biome_js_syntax::{
+    AnyJsBindingPattern, AnyJsFormalParameter, AnyJsObjectMemberName, AnyJsParameter, AnyJsRoot,
+    AnyTsReturnType, AnyTsType, AnyTsTypeMember, AnyTsVariableAnnotation, JsParameters,
+    JsVariableDeclarator, TsCallSignatureTypeMember, TsConstructSignatureTypeMember,
+    TsDeclarationModule, TsInterfaceDeclaration, TsPropertySignatureTypeMember,
+};
+use biome_languages::JsFileSource;
+use biome_rowan::{AstNode, Text};
+
+use crate::generate_global_types::{
+    collect::{DeclarationKind, DeclarationRecord},
+    manifest::{GlobalDeclarationRole, GlobalManifest},
+    source::DiscoveredFile,
+};
+
+/// Lowered definitions selected for generated globals output.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoweredGlobalTypes {
+    globals: Box<[LoweredGlobal]>,
+}
+
+impl LoweredGlobalTypes {
+    /// Returns all lowered globals in deterministic output order.
+    pub fn globals(&self) -> &[LoweredGlobal] {
+        &self.globals
+    }
+
+    /// Returns one lowered global by TypeScript global name.
+    pub fn global(&self, name: &str) -> Option<&LoweredGlobal> {
+        self.globals.iter().find(|global| global.name() == name)
+    }
+}
+
+/// One lowered predefined global entry.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoweredGlobal {
+    name: Text,
+    id_constant: &'static str,
+    data: LoweredTypeData,
+}
+
+impl LoweredGlobal {
+    /// TypeScript global name.
+    pub fn name(&self) -> &str {
+        self.name.text()
+    }
+
+    /// Rust constant used by `GlobalsResolverBuilder::set_type_data`.
+    pub fn id_constant(&self) -> &'static str {
+        self.id_constant
+    }
+
+    /// Lowered type data for this global.
+    pub fn data(&self) -> &LoweredTypeData {
+        &self.data
+    }
+}
+
+/// Lowered type data variants supported by the generator.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LoweredTypeData {
+    Class(LoweredClass),
+    Constructor(LoweredConstructor),
+    Function(LoweredFunction),
+}
+
+/// Lowered class-like global.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoweredClass {
+    name: Text,
+    members: Box<[LoweredTypeMember]>,
+}
+
+impl LoweredClass {
+    /// Class name.
+    pub fn name(&self) -> &str {
+        self.name.text()
+    }
+
+    /// Class members in declaration order.
+    pub fn members(&self) -> &[LoweredTypeMember] {
+        &self.members
+    }
+
+    /// Returns the first member with `name`.
+    pub fn member(&self, name: &str) -> Option<&LoweredTypeMember> {
+        self.members
+            .iter()
+            .find(|member| member.name.text() == name)
+    }
+}
+
+/// Lowered constructor helper data.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoweredConstructor {
+    parameters: Box<[LoweredFunctionParameter]>,
+    return_type: Option<LoweredTypeReference>,
+}
+
+impl LoweredConstructor {
+    /// Constructor parameters in declaration order.
+    pub fn parameters(&self) -> &[LoweredFunctionParameter] {
+        &self.parameters
+    }
+
+    /// Constructor return type.
+    pub fn return_type(&self) -> Option<&LoweredTypeReference> {
+        self.return_type.as_ref()
+    }
+}
+
+/// Lowered function helper data.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoweredFunction {
+    name: Option<Text>,
+    parameters: Box<[LoweredFunctionParameter]>,
+    return_type: LoweredTypeReference,
+}
+
+impl LoweredFunction {
+    /// Function name, if present.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_ref().map(Text::text)
+    }
+
+    /// Function parameters in declaration order.
+    pub fn parameters(&self) -> &[LoweredFunctionParameter] {
+        &self.parameters
+    }
+
+    /// Function return type.
+    pub fn return_type(&self) -> &LoweredTypeReference {
+        &self.return_type
+    }
+}
+
+/// Lowered named function parameter.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoweredFunctionParameter {
+    name: Text,
+    type_reference: LoweredTypeReference,
+    is_optional: bool,
+    is_rest: bool,
+}
+
+impl LoweredFunctionParameter {
+    /// Parameter binding name.
+    pub fn name(&self) -> &str {
+        self.name.text()
+    }
+
+    /// Parameter type.
+    pub fn type_reference(&self) -> &LoweredTypeReference {
+        &self.type_reference
+    }
+
+    /// Returns whether this parameter is optional.
+    pub fn is_optional(&self) -> bool {
+        self.is_optional
+    }
+
+    /// Returns whether this parameter is a rest parameter.
+    pub fn is_rest(&self) -> bool {
+        self.is_rest
+    }
+}
+
+/// Lowered class/interface member.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoweredTypeMember {
+    name: Text,
+    kind: LoweredMemberKind,
+    type_reference: LoweredTypeReference,
+}
+
+impl LoweredTypeMember {
+    /// Member name.
+    pub fn name(&self) -> &str {
+        self.name.text()
+    }
+
+    /// Member kind.
+    pub fn kind(&self) -> &LoweredMemberKind {
+        &self.kind
+    }
+
+    /// Member type.
+    pub fn type_reference(&self) -> &LoweredTypeReference {
+        &self.type_reference
+    }
+}
+
+/// Lowered member kind.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LoweredMemberKind {
+    Named { optional: bool },
+    NamedStatic,
+    Constructor,
+    CallSignature,
+}
+
+/// Lowered type reference.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LoweredTypeReference {
+    Predefined(&'static str),
+}
+
+/// Lowers supported global groups into generated global type definitions.
+pub fn lower_global_types(
+    manifest: &GlobalManifest,
+    source_files: &[DiscoveredFile],
+) -> Result<LoweredGlobalTypes> {
+    let mut source_cache = ParsedSourceCache::new(source_files);
+    let Some(error_group) = manifest.global_group("Error") else {
+        return Ok(LoweredGlobalTypes {
+            globals: Box::default(),
+        });
+    };
+    if !error_group.has_role(GlobalDeclarationRole::Type) {
+        bail!("Error global must have a type-side declaration");
+    }
+    if !error_group.has_role(GlobalDeclarationRole::Value) {
+        bail!("Error global must have a value-side declaration");
+    }
+    ensure_error_value_references_constructor(error_group.declarations(), &mut source_cache)?;
+
+    let Some(error_constructor_group) = manifest.global_group("ErrorConstructor") else {
+        bail!("Error global value side references missing ErrorConstructor group");
+    };
+    if !error_constructor_group.has_role(GlobalDeclarationRole::Type) {
+        bail!("ErrorConstructor must have a type-side declaration");
+    }
+
+    let mut members = Vec::new();
+    let mut saw_error_interface = false;
+    for record in error_group.declarations() {
+        match &record.kind {
+            DeclarationKind::Interface => {
+                saw_error_interface = true;
+            }
+            DeclarationKind::TypeAlias => {
+                bail!("type aliases are not supported in the Error global")
+            }
+            DeclarationKind::DeclareFunction
+            | DeclarationKind::VariableDeclarator { .. }
+            | DeclarationKind::ImportEquals => {
+                continue;
+            }
+        }
+        let declaration = source_cache
+            .find_interface_declaration(record)?
+            .with_context(|| {
+                format!(
+                    "failed to find interface declaration {} at {:?}",
+                    record.declared_name.text(),
+                    record.text_range
+                )
+            })?;
+        lower_error_interface_members(&declaration, &mut members)?;
+    }
+    if !saw_error_interface {
+        bail!("Error global must include an interface declaration");
+    }
+
+    let ErrorConstructorSignatures {
+        constructor,
+        call,
+        prototype,
+    } = lower_error_constructor_signatures(
+        error_constructor_group.declarations(),
+        &mut source_cache,
+    )?;
+
+    members.push(LoweredTypeMember {
+        name: Text::from("constructor"),
+        kind: LoweredMemberKind::Constructor,
+        type_reference: LoweredTypeReference::Predefined("GLOBAL_ERROR_CONSTRUCTOR_ID"),
+    });
+    members.push(LoweredTypeMember {
+        name: Text::from("call"),
+        kind: LoweredMemberKind::CallSignature,
+        type_reference: LoweredTypeReference::Predefined("GLOBAL_ERROR_CALL_ID"),
+    });
+    if let Some(prototype) = prototype {
+        members.push(prototype);
+    }
+
+    Ok(LoweredGlobalTypes {
+        globals: Box::new([
+            LoweredGlobal {
+                name: Text::from("Error"),
+                id_constant: "ERROR_ID_GLOBAL_TYPE_ID",
+                data: LoweredTypeData::Class(LoweredClass {
+                    name: Text::from("Error"),
+                    members: members.into_boxed_slice(),
+                }),
+            },
+            LoweredGlobal {
+                name: Text::from("Error.constructor"),
+                id_constant: "ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID",
+                data: LoweredTypeData::Constructor(constructor),
+            },
+            LoweredGlobal {
+                name: Text::from("Error.call"),
+                id_constant: "ERROR_CALL_ID_GLOBAL_TYPE_ID",
+                data: LoweredTypeData::Function(call),
+            },
+        ]),
+    })
+}
+
+/// Lowered pieces extracted from `interface ErrorConstructor`.
+struct ErrorConstructorSignatures {
+    constructor: LoweredConstructor,
+    call: LoweredFunction,
+    prototype: Option<LoweredTypeMember>,
+}
+
+struct ParsedSource<'a> {
+    repo_relative: &'a str,
+    module: TsDeclarationModule,
+}
+
+struct ParsedSourceCache<'a> {
+    source_files: &'a [DiscoveredFile],
+    parsed: Vec<ParsedSource<'a>>,
+}
+
+impl<'a> ParsedSourceCache<'a> {
+    fn new(source_files: &'a [DiscoveredFile]) -> Self {
+        Self {
+            source_files,
+            parsed: Vec::new(),
+        }
+    }
+
+    fn module_for(&mut self, record: &DeclarationRecord) -> Result<&TsDeclarationModule> {
+        let repo_relative = record.file_repo_relative.as_ref();
+        if let Some(index) = self
+            .parsed
+            .iter()
+            .position(|source| source.repo_relative == repo_relative)
+        {
+            return Ok(&self.parsed[index].module);
+        }
+
+        let source_file = self
+            .source_files
+            .iter()
+            .find(|source_file| source_file.repo_relative == repo_relative)
+            .with_context(|| {
+                format!("collector record references missing source file {repo_relative}")
+            })?;
+        let source = std::str::from_utf8(&source_file.bytes)
+            .with_context(|| format!("{} is not valid UTF-8", source_file.repo_relative))?;
+        let parsed = parse(source, JsFileSource::d_ts(), JsParserOptions::default());
+        let AnyJsRoot::TsDeclarationModule(module) = parsed.tree() else {
+            bail!(
+                "{} is not a TypeScript declaration module",
+                source_file.repo_relative
+            );
+        };
+
+        self.parsed.push(ParsedSource {
+            repo_relative: source_file.repo_relative.as_str(),
+            module,
+        });
+
+        self.parsed
+            .last()
+            .map(|parsed_source| &parsed_source.module)
+            .context("parsed source cache did not retain pushed source")
+    }
+
+    /// Finds the AST node for a collected interface record.
+    fn find_interface_declaration(
+        &mut self,
+        record: &DeclarationRecord,
+    ) -> Result<Option<TsInterfaceDeclaration>> {
+        let module = self.module_for(record)?;
+        for node in module.syntax().descendants() {
+            if node.kind() == record.syntax_kind && node.text_trimmed_range() == record.text_range {
+                return Ok(TsInterfaceDeclaration::cast(node));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Finds the AST node for a collected variable declarator.
+    fn find_variable_declarator(
+        &mut self,
+        record: &DeclarationRecord,
+    ) -> Result<Option<JsVariableDeclarator>> {
+        let module = self.module_for(record)?;
+        for node in module.syntax().descendants() {
+            if node.kind() == record.syntax_kind && node.text_trimmed_range() == record.text_range {
+                return Ok(JsVariableDeclarator::cast(node));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+/// Lowers supported members from `interface Error`.
+fn lower_error_interface_members(
+    declaration: &TsInterfaceDeclaration,
+    members: &mut Vec<LoweredTypeMember>,
+) -> Result<()> {
+    if declaration.extends_clause().is_some() {
+        bail!("Error interface extends clauses are not supported");
+    }
+
+    for member in declaration.members() {
+        if let Some(lowered) = lower_error_type_member(member)? {
+            members.push(lowered);
+        }
+    }
+    Ok(())
+}
+
+/// Lowers one supported `Error` instance member.
+fn lower_error_type_member(member: AnyTsTypeMember) -> Result<Option<LoweredTypeMember>> {
+    match member {
+        AnyTsTypeMember::TsPropertySignatureTypeMember(property) => {
+            let name = lower_object_member_name(property.name()?)?;
+            let optional = property.optional_token().is_some();
+            let type_reference = property
+                .type_annotation()
+                .with_context(|| format!("Error member {name} is missing a type annotation"))?
+                .ty()
+                .with_context(|| format!("Error member {name} has a malformed type annotation"))
+                .and_then(|type_node| lower_type_reference(&type_node))?;
+            let type_reference = if optional {
+                lower_optional_error_member_reference(&name, type_reference)?
+            } else {
+                type_reference
+            };
+            Ok(Some(LoweredTypeMember {
+                name,
+                kind: LoweredMemberKind::Named { optional },
+                type_reference,
+            }))
+        }
+        AnyTsTypeMember::TsMethodSignatureTypeMember(_) => {
+            bail!("method signatures are not supported in the Error global")
+        }
+        AnyTsTypeMember::TsCallSignatureTypeMember(_)
+        | AnyTsTypeMember::TsConstructSignatureTypeMember(_) => {
+            bail!("Error global signatures must be declared on ErrorConstructor")
+        }
+        AnyTsTypeMember::JsBogusMember(_) => {
+            bail!("bogus members are not supported in the Error global")
+        }
+        AnyTsTypeMember::TsGetterSignatureTypeMember(_) => {
+            bail!("getter signatures are not supported in the Error global")
+        }
+        AnyTsTypeMember::TsIndexSignatureTypeMember(_) => {
+            bail!("index signatures are not supported in the Error global")
+        }
+        AnyTsTypeMember::TsSetterSignatureTypeMember(_) => {
+            bail!("setter signatures are not supported in the Error global")
+        }
+    }
+}
+
+/// Validates supported optional `Error` members.
+fn lower_optional_error_member_reference(
+    name: &Text,
+    type_reference: LoweredTypeReference,
+) -> Result<LoweredTypeReference> {
+    match (name.text(), type_reference) {
+        ("stack", LoweredTypeReference::Predefined("GLOBAL_STRING_ID")) => {
+            Ok(LoweredTypeReference::Predefined("GLOBAL_STRING_ID"))
+        }
+        (name, type_reference) => {
+            bail!("unsupported optional Error member {name} with type {type_reference:?}")
+        }
+    }
+}
+
+/// Checks that `declare var Error` points at `ErrorConstructor`.
+fn ensure_error_value_references_constructor(
+    records: &[DeclarationRecord],
+    source_cache: &mut ParsedSourceCache,
+) -> Result<()> {
+    let mut found_value_side = false;
+    for record in records {
+        match &record.kind {
+            DeclarationKind::VariableDeclarator { .. } => {}
+            DeclarationKind::DeclareFunction | DeclarationKind::ImportEquals => {
+                bail!("unsupported value-side Error declaration {:?}", record.kind)
+            }
+            DeclarationKind::Interface | DeclarationKind::TypeAlias => {
+                continue;
+            }
+        }
+        let declarator = source_cache
+            .find_variable_declarator(record)?
+            .with_context(|| {
+                format!(
+                    "failed to find variable declaration {} at {:?}",
+                    record.declared_name.text(),
+                    record.text_range
+                )
+            })?;
+        let Some(annotation) = declarator.variable_annotation() else {
+            bail!("declare var Error is missing a type annotation");
+        };
+        let AnyTsVariableAnnotation::TsTypeAnnotation(annotation) = annotation else {
+            bail!("declare var Error uses unsupported definite assignment annotation");
+        };
+        let type_reference = lower_type_reference(&annotation.ty()?)?;
+        if type_reference != LoweredTypeReference::Predefined("GLOBAL_ERROR_CONSTRUCTOR_ID") {
+            bail!("declare var Error must reference ErrorConstructor, got {type_reference:?}");
+        }
+        found_value_side = true;
+    }
+
+    if !found_value_side {
+        bail!("Error global must include declare var Error");
+    }
+
+    Ok(())
+}
+
+/// Lowers signatures and static members from `interface ErrorConstructor`.
+fn lower_error_constructor_signatures(
+    records: &[DeclarationRecord],
+    source_cache: &mut ParsedSourceCache,
+) -> Result<ErrorConstructorSignatures> {
+    let mut constructor = None;
+    let mut call = None;
+    let mut prototype = None;
+
+    for record in records {
+        match &record.kind {
+            DeclarationKind::Interface => {}
+            DeclarationKind::TypeAlias => {
+                bail!("type aliases are not supported in ErrorConstructor")
+            }
+            DeclarationKind::DeclareFunction
+            | DeclarationKind::VariableDeclarator { .. }
+            | DeclarationKind::ImportEquals => {
+                bail!("value-side ErrorConstructor declarations are not supported")
+            }
+        }
+        let declaration = source_cache
+            .find_interface_declaration(record)?
+            .with_context(|| {
+                format!(
+                    "failed to find interface declaration {} at {:?}",
+                    record.declared_name.text(),
+                    record.text_range
+                )
+            })?;
+        if declaration.extends_clause().is_some() {
+            bail!("ErrorConstructor extends clauses are not supported");
+        }
+
+        for member in declaration.members() {
+            match member {
+                AnyTsTypeMember::TsConstructSignatureTypeMember(member) => {
+                    let lowered = lower_construct_signature(&member)?;
+                    if constructor.replace(lowered).is_some() {
+                        bail!("ErrorConstructor has multiple construct signatures");
+                    }
+                }
+                AnyTsTypeMember::TsCallSignatureTypeMember(member) => {
+                    let lowered = lower_call_signature(&member)?;
+                    if call.replace(lowered).is_some() {
+                        bail!("ErrorConstructor has multiple call signatures");
+                    }
+                }
+                AnyTsTypeMember::TsPropertySignatureTypeMember(member) => {
+                    let lowered = lower_error_constructor_property_member(&member)?;
+                    if prototype.replace(lowered).is_some() {
+                        bail!("ErrorConstructor has multiple prototype properties");
+                    }
+                }
+                AnyTsTypeMember::TsMethodSignatureTypeMember(_) => {
+                    bail!("method signatures are not supported in ErrorConstructor")
+                }
+                AnyTsTypeMember::JsBogusMember(_) => {
+                    bail!("bogus members are not supported in ErrorConstructor")
+                }
+                AnyTsTypeMember::TsGetterSignatureTypeMember(_) => {
+                    bail!("getter signatures are not supported in ErrorConstructor")
+                }
+                AnyTsTypeMember::TsIndexSignatureTypeMember(_) => {
+                    bail!("index signatures are not supported in ErrorConstructor")
+                }
+                AnyTsTypeMember::TsSetterSignatureTypeMember(_) => {
+                    bail!("setter signatures are not supported in ErrorConstructor")
+                }
+            }
+        }
+    }
+
+    Ok(ErrorConstructorSignatures {
+        constructor: constructor.context("ErrorConstructor is missing a construct signature")?,
+        call: call.context("ErrorConstructor is missing a call signature")?,
+        prototype,
+    })
+}
+
+/// Lowers supported `ErrorConstructor` static properties.
+fn lower_error_constructor_property_member(
+    property: &TsPropertySignatureTypeMember,
+) -> Result<LoweredTypeMember> {
+    let name = lower_object_member_name(property.name()?)?;
+    if name.text() != "prototype" {
+        bail!("unsupported ErrorConstructor property {name}");
+    }
+    if property.optional_token().is_some() {
+        bail!("ErrorConstructor.prototype must not be optional");
+    }
+    let type_reference = property
+        .type_annotation()
+        .context("ErrorConstructor.prototype is missing a type annotation")?
+        .ty()
+        .context("ErrorConstructor.prototype has malformed type annotation")
+        .and_then(|type_node| lower_type_reference(&type_node))
+        .map(instance_return_reference)?;
+
+    Ok(LoweredTypeMember {
+        name,
+        kind: LoweredMemberKind::NamedStatic,
+        type_reference,
+    })
+}
+
+/// Lowers the `new Error(...)` construct signature.
+fn lower_construct_signature(
+    member: &TsConstructSignatureTypeMember,
+) -> Result<LoweredConstructor> {
+    if member.type_parameters().is_some() {
+        bail!("generic Error constructor signatures are not supported");
+    }
+    let return_type = member
+        .type_annotation()
+        .context("ErrorConstructor construct signature is missing a return type")?
+        .ty()
+        .context("ErrorConstructor construct signature has malformed return type")
+        .and_then(|type_node| lower_type_reference(&type_node))?;
+
+    Ok(LoweredConstructor {
+        parameters: lower_parameters(member.parameters()?)?,
+        return_type: Some(return_type),
+    })
+}
+
+/// Lowers the `Error(...)` call signature.
+fn lower_call_signature(member: &TsCallSignatureTypeMember) -> Result<LoweredFunction> {
+    if member.type_parameters().is_some() {
+        bail!("generic Error call signatures are not supported");
+    }
+    let return_type = member
+        .return_type_annotation()
+        .context("ErrorConstructor call signature is missing a return type")?
+        .ty()
+        .context("ErrorConstructor call signature has malformed return type")
+        .and_then(|return_type_node| lower_return_type_reference(&return_type_node))?;
+
+    Ok(LoweredFunction {
+        name: Some(Text::from("Error")),
+        parameters: lower_parameters(member.parameters()?)?,
+        return_type: instance_return_reference(return_type),
+    })
+}
+
+/// Lowers function-like parameters for the `ErrorConstructor`.
+fn lower_parameters(parameters: JsParameters) -> Result<Box<[LoweredFunctionParameter]>> {
+    let mut lowered = Vec::new();
+    for parameter in parameters.items() {
+        match parameter? {
+            AnyJsParameter::AnyJsFormalParameter(parameter) => {
+                let AnyJsFormalParameter::JsFormalParameter(parameter) = parameter else {
+                    bail!("unsupported ErrorConstructor formal parameter");
+                };
+                let name = lower_binding_name(parameter.binding()?)?;
+                let is_optional = parameter.question_mark_token().is_some();
+                let type_reference = parameter
+                    .type_annotation()
+                    .context("ErrorConstructor parameter is missing a type annotation")?
+                    .ty()
+                    .context("ErrorConstructor parameter has malformed type annotation")
+                    .and_then(|type_node| lower_type_reference(&type_node))?;
+                lowered.push(LoweredFunctionParameter {
+                    name,
+                    type_reference,
+                    is_optional,
+                    is_rest: false,
+                });
+            }
+            AnyJsParameter::JsRestParameter(parameter) => {
+                let name = lower_binding_name(parameter.binding()?)?;
+                let type_reference = parameter
+                    .type_annotation()
+                    .context("ErrorConstructor rest parameter is missing a type annotation")?
+                    .ty()
+                    .context("ErrorConstructor rest parameter has malformed type annotation")
+                    .and_then(|type_node| lower_type_reference(&type_node))?;
+                lowered.push(LoweredFunctionParameter {
+                    name,
+                    type_reference,
+                    is_optional: false,
+                    is_rest: true,
+                });
+            }
+            AnyJsParameter::TsThisParameter(_) => {
+                bail!("this parameters are not supported in ErrorConstructor")
+            }
+        }
+    }
+
+    Ok(lowered.into_boxed_slice())
+}
+
+/// Extracts a simple identifier binding name.
+fn lower_binding_name(binding: AnyJsBindingPattern) -> Result<Text> {
+    let Some(binding) = binding.as_any_js_binding() else {
+        bail!("unsupported destructured ErrorConstructor parameter");
+    };
+    let Some(binding) = binding.as_js_identifier_binding() else {
+        bail!("unsupported ErrorConstructor parameter binding");
+    };
+    Ok(Text::from(binding.name_token()?.token_text_trimmed()))
+}
+
+/// Extracts a supported object member name.
+fn lower_object_member_name(name: AnyJsObjectMemberName) -> Result<Text> {
+    match name {
+        AnyJsObjectMemberName::JsLiteralMemberName(name) => Ok(Text::from(name.name()?)),
+        AnyJsObjectMemberName::JsComputedMemberName(_)
+        | AnyJsObjectMemberName::JsMetavariable(_) => {
+            bail!("unsupported computed or metavariable member name in Error global")
+        }
+    }
+}
+
+/// Maps a supported TypeScript type node to a lowered reference.
+fn lower_type_reference(type_node: &AnyTsType) -> Result<LoweredTypeReference> {
+    match type_node {
+        AnyTsType::TsStringType(_) => Ok(LoweredTypeReference::Predefined("GLOBAL_STRING_ID")),
+        AnyTsType::TsVoidType(_) => Ok(LoweredTypeReference::Predefined("GLOBAL_VOID_ID")),
+        AnyTsType::TsReferenceType(reference) => {
+            let name = reference.name().context("missing type reference name")?;
+            let biome_js_syntax::AnyTsName::JsReferenceIdentifier(identifier) = name else {
+                bail!("qualified type references are not supported in Error global")
+            };
+            let name = Text::from(identifier.value_token()?.token_text_trimmed());
+            Ok(match name.text() {
+                "Error" => LoweredTypeReference::Predefined("GLOBAL_ERROR_ID"),
+                "ErrorConstructor" => {
+                    LoweredTypeReference::Predefined("GLOBAL_ERROR_CONSTRUCTOR_ID")
+                }
+                _ => bail!("unresolved type reference {name} in Error global"),
+            })
+        }
+        _ => bail!("unsupported type reference in Error global: {type_node:?}"),
+    }
+}
+
+/// Maps a supported return type node to a lowered reference.
+fn lower_return_type_reference(return_type_node: &AnyTsReturnType) -> Result<LoweredTypeReference> {
+    match return_type_node {
+        AnyTsReturnType::AnyTsType(type_node) => lower_type_reference(type_node),
+        AnyTsReturnType::TsAssertsReturnType(_) | AnyTsReturnType::TsPredicateReturnType(_) => {
+            bail!("predicate return types are not supported in Error global")
+        }
+    }
+}
+
+/// Converts constructor returns from `Error` to `InstanceOf<Error>`.
+fn instance_return_reference(reference: LoweredTypeReference) -> LoweredTypeReference {
+    match reference {
+        LoweredTypeReference::Predefined("GLOBAL_ERROR_ID") => {
+            LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_ERROR_ID")
+        }
+        reference => reference,
+    }
+}

--- a/xtask/codegen/src/generate_global_types/manifest.rs
+++ b/xtask/codegen/src/generate_global_types/manifest.rs
@@ -1,0 +1,134 @@
+//! Role-aware declaration manifest for global types codegen.
+
+use biome_rowan::Text;
+
+use crate::generate_global_types::collect::{DeclarationKind, DeclarationRecord, ScopePath};
+
+/// Role a declaration contributes to a global name.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GlobalDeclarationRole {
+    Type,
+    Value,
+}
+
+/// Ordered manifest of global declaration groups.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GlobalManifest {
+    groups: Box<[GlobalDeclarationGroup]>,
+}
+
+impl GlobalManifest {
+    /// Returns the global group with the given name.
+    pub fn global_group(&self, name: &str) -> Option<&GlobalDeclarationGroup> {
+        self.groups.iter().find(|group| group.name.text() == name)
+    }
+}
+
+/// Declarations for one global name and scope.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GlobalDeclarationGroup {
+    scope: ScopePath,
+    name: Text,
+    declarations: Box<[DeclarationRecord]>,
+    has_type: bool,
+    has_value: bool,
+}
+
+impl GlobalDeclarationGroup {
+    /// Source-order declarations that contributed to this group.
+    pub fn declarations(&self) -> &[DeclarationRecord] {
+        &self.declarations
+    }
+
+    /// Returns whether this group has the requested declaration role.
+    pub fn has_role(&self, role: GlobalDeclarationRole) -> bool {
+        match role {
+            GlobalDeclarationRole::Type => self.has_type,
+            GlobalDeclarationRole::Value => self.has_value,
+        }
+    }
+}
+
+/// Mutable builder used while records for one global group are collected.
+struct GlobalDeclarationGroupBuilder {
+    scope: ScopePath,
+    name: Text,
+    pending_declarations: Vec<DeclarationRecord>,
+    has_type: bool,
+    has_value: bool,
+}
+
+impl GlobalDeclarationGroupBuilder {
+    /// Starts a group from its first declaration.
+    fn new(record: DeclarationRecord) -> Self {
+        let role = role_for_kind(&record.kind);
+        Self {
+            scope: record.scope.clone(),
+            name: Text::from(record.declared_name.clone()),
+            pending_declarations: vec![record],
+            has_type: role == GlobalDeclarationRole::Type,
+            has_value: role == GlobalDeclarationRole::Value,
+        }
+    }
+
+    /// Adds another declaration to the group.
+    fn push(&mut self, record: DeclarationRecord) {
+        match role_for_kind(&record.kind) {
+            GlobalDeclarationRole::Type => self.has_type = true,
+            GlobalDeclarationRole::Value => self.has_value = true,
+        }
+        self.pending_declarations.push(record);
+    }
+
+    /// Freezes the builder into the manifest representation.
+    fn into_group(self) -> GlobalDeclarationGroup {
+        GlobalDeclarationGroup {
+            scope: self.scope,
+            name: self.name,
+            declarations: self.pending_declarations.into_boxed_slice(),
+            has_type: self.has_type,
+            has_value: self.has_value,
+        }
+    }
+}
+
+/// Builds the global manifest from collector records.
+pub fn build_global_manifest(records: Vec<DeclarationRecord>) -> GlobalManifest {
+    let mut groups: Vec<GlobalDeclarationGroupBuilder> = Vec::new();
+
+    for record in records {
+        if !is_global_scope(&record.scope) {
+            continue;
+        }
+
+        if let Some(group) = groups.iter_mut().find(|group| {
+            group.scope == record.scope && group.name.text() == record.declared_name.text()
+        }) {
+            group.push(record);
+        } else {
+            groups.push(GlobalDeclarationGroupBuilder::new(record));
+        }
+    }
+
+    GlobalManifest {
+        groups: groups
+            .into_iter()
+            .map(GlobalDeclarationGroupBuilder::into_group)
+            .collect(),
+    }
+}
+
+/// Returns whether a record belongs to the top-level global scope.
+fn is_global_scope(scope: &ScopePath) -> bool {
+    matches!(scope, ScopePath::Global)
+}
+
+/// Classifies a declaration kind by its TypeScript global role.
+fn role_for_kind(kind: &DeclarationKind) -> GlobalDeclarationRole {
+    match kind {
+        DeclarationKind::Interface | DeclarationKind::TypeAlias => GlobalDeclarationRole::Type,
+        DeclarationKind::DeclareFunction
+        | DeclarationKind::VariableDeclarator { .. }
+        | DeclarationKind::ImportEquals => GlobalDeclarationRole::Value,
+    }
+}

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-constructor-extends.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-constructor-extends.d.ts
@@ -1,0 +1,17 @@
+interface BaseErrorConstructor {
+    readonly captureStackTrace: Error;
+}
+
+interface Error {
+    name: string;
+    message: string;
+    stack?: string;
+}
+
+interface ErrorConstructor extends BaseErrorConstructor {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-constructor-type-alias.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-constructor-type-alias.d.ts
@@ -1,0 +1,19 @@
+interface Error {
+    name: string;
+    message: string;
+    stack?: string;
+}
+
+interface ErrorConstructor {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+type ErrorConstructor = {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+};
+
+declare var Error: ErrorConstructor;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-constructor-unsupported-value.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-constructor-unsupported-value.d.ts
@@ -1,0 +1,14 @@
+interface Error {
+    name: string;
+    message: string;
+    stack?: string;
+}
+
+interface ErrorConstructor {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;
+declare var ErrorConstructor: ErrorConstructor;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-extends.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-extends.d.ts
@@ -1,0 +1,17 @@
+interface BaseError {
+    cause?: unknown;
+}
+
+interface Error extends BaseError {
+    name: string;
+    message: string;
+    stack?: string;
+}
+
+interface ErrorConstructor {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-missing-message.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-missing-message.d.ts
@@ -1,0 +1,12 @@
+interface Error {
+    name: string;
+    stack?: string;
+}
+
+interface ErrorConstructor {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-named-reference.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-named-reference.d.ts
@@ -1,0 +1,17 @@
+interface ErrorOptions {
+    cause?: unknown;
+}
+
+interface Error {
+    name: string;
+    message: ErrorOptions;
+    stack?: string;
+}
+
+interface ErrorConstructor {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-unsupported-index.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-unsupported-index.d.ts
@@ -1,0 +1,14 @@
+interface Error {
+    name: string;
+    message: string;
+    stack?: string;
+    [key: string]: string;
+}
+
+interface ErrorConstructor {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-unsupported-value.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-unsupported-value.d.ts
@@ -1,0 +1,14 @@
+interface Error {
+    name: string;
+    message: string;
+    stack?: string;
+}
+
+interface ErrorConstructor {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;
+declare function Error(message?: string): Error;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-wrong-constructor-return.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-wrong-constructor-return.d.ts
@@ -1,0 +1,16 @@
+interface Error {
+    name: string;
+}
+
+interface Error {
+    message: string;
+    stack?: string;
+}
+
+interface ErrorConstructor {
+    new(message?: string): void;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error.d.ts
@@ -1,0 +1,28 @@
+interface Error {
+    name: string;
+}
+
+interface Error {
+    message: string;
+    stack?: string;
+}
+
+interface ErrorConstructor {
+    new(message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;
+
+declare global {
+    interface TypeError extends Error {
+        code?: string;
+    }
+}
+
+declare module "external" {
+    interface ExternalError {
+        ignored: string;
+    }
+}

--- a/xtask/codegen/tests/global_types_codegen.rs
+++ b/xtask/codegen/tests/global_types_codegen.rs
@@ -14,7 +14,16 @@ use anyhow::{Context as _, Result, bail};
 use xtask_codegen::generate_global_types::{
     SourcePin,
     collect::{CollectorOutput, CoverageOutcome, collect},
-    source::{CanonicalPath, LibEntries, SourceOptions, acquire, discover, parse_lib_entries},
+    compare::compare_lowered_globals,
+    lower::{
+        LoweredGlobalTypes, LoweredMemberKind, LoweredTypeData, LoweredTypeReference,
+        lower_global_types,
+    },
+    manifest::{GlobalDeclarationRole, GlobalManifest, build_global_manifest},
+    source::{
+        CanonicalPath, DiscoveredFile, LibEntries, SourceOptions, acquire, discover,
+        parse_lib_entries,
+    },
 };
 
 const TEMP_CREATE_RETRIES: usize = 32;
@@ -162,6 +171,7 @@ impl Drop for PathCleanup {
         let _ = fs::remove_dir_all(&self.path);
     }
 }
+
 /// Builds a source pin from fixture tag/SHA values.
 fn source_pin(tag: &str, sha: &str) -> SourcePin {
     SourcePin::new(tag, sha)
@@ -203,6 +213,19 @@ fn write_typescript_fixture_files(repo: &Path, lib_entries: &str) -> Result<()> 
         repo.join("lib/lib.second.d.ts"),
         "interface SecondDuplicate {}\n",
     )?;
+    Ok(())
+}
+
+/// Writes placeholder files for every production profile root that a fixture
+/// does not explicitly override.
+fn write_profile_root_placeholders(repo: &Path) -> Result<()> {
+    for filename in xtask_codegen::generate_global_types::source::PROFILE_ROOTS {
+        let path = repo.join("lib").join(filename);
+        if !path.exists() {
+            fs::write(&path, "")?;
+        }
+    }
+
     Ok(())
 }
 
@@ -504,6 +527,29 @@ fn fixture_git_repo_with_malformed_lib() -> Result<FixtureRepo> {
         head,
     })
 }
+
+/// Builds a fixture whose selected lib contains the Error global declarations
+/// used by the generated globals output.
+fn fixture_git_repo_with_error_global() -> Result<FixtureRepo> {
+    let repo = fixture_git_repo(SINGLE_LIB_ENTRY)?;
+    write_profile_root_placeholders(repo.path())?;
+    let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(COLLECTOR_FIXTURE_DIR)
+        .join("manifest.error.d.ts");
+    fs::copy(&fixture_path, repo.path().join("lib/lib.es5.d.ts"))
+        .with_context(|| format!("failed to copy {}", fixture_path.display()))?;
+    run_git(repo.path(), &["add", "."])?;
+    run_git(repo.path(), &["commit", "-m", "add error global"])?;
+    let head = git_stdout_trimmed(repo.path(), &["rev-parse", "HEAD"])?;
+    run_git(repo.path(), &["tag", "-f", repo.tag.as_str()])?;
+
+    Ok(FixtureRepo {
+        temp: repo.temp,
+        tag: repo.tag,
+        head,
+    })
+}
+
 /// Seeds the TypeScript cache from a fixture repository using a real git clone.
 fn seed_cache_from_repo(pin: &SourcePin, repo: &Path) -> Result<PathCleanup> {
     let cache_path = typescript_cache_path(pin);
@@ -598,6 +644,36 @@ fn expect_error_contains<T>(result: Result<T>, expected: &str) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Reads a global-types fixture as a discovered TypeScript declaration file.
+fn discovered_fixture(dts_name: &str) -> Result<DiscoveredFile> {
+    let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join(COLLECTOR_FIXTURE_DIR);
+    let dts_path = fixture_root.join(dts_name);
+    let bytes = fs::read(&dts_path)
+        .with_context(|| format!("failed to read global-types fixture {}", dts_path.display()))?;
+    let canonical_path = CanonicalPath::from_within(&fixture_root, dts_name)?;
+
+    Ok(DiscoveredFile {
+        path: canonical_path,
+        repo_relative: dts_name.to_string(),
+        bytes,
+    })
+}
+
+/// Builds the global declaration manifest from one global-types fixture.
+fn manifest_from_fixture(dts_name: &str) -> Result<GlobalManifest> {
+    let discovered = discovered_fixture(dts_name)?;
+    let output = collect(&discovered);
+    Ok(build_global_manifest(output.records))
+}
+
+/// Lowers one global-types fixture through the manifest pipeline.
+fn lowered_from_fixture(dts_name: &str) -> Result<LoweredGlobalTypes> {
+    let source_files = [discovered_fixture(dts_name)?];
+    let output = collect(&source_files[0]);
+    let manifest = build_global_manifest(output.records);
+    lower_global_types(&manifest, &source_files)
 }
 
 /// Asserts that every expected fragment appears somewhere in an error chain.
@@ -903,6 +979,39 @@ mod tests {
     }
 
     #[test]
+    fn run_emits_error_global_registration() -> Result<()> {
+        let repo = fixture_git_repo_with_error_global()?;
+        let pin = repo.source_pin();
+        let _cache_cleanup = seed_cache_from_repo(&pin, repo.path())?;
+        let workspace = TempDir::new("bgt-workspace")?;
+
+        xtask_codegen::generate_global_types::run_with_workspace_root(
+            &pin,
+            &SourceOptions::default(),
+            workspace.path(),
+        )?;
+
+        let output_path = workspace.path().join(COMMITTED_CODEGEN_PATH);
+        let generated = fs::read_to_string(&output_path)
+            .with_context(|| format!("failed to read {}", output_path.display()))?;
+
+        assert!(generated.contains("crate::globals::ERROR_ID_GLOBAL_TYPE_ID"));
+        assert!(generated.contains("crate::globals::ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID"));
+        assert!(generated.contains("crate::globals::ERROR_CALL_ID_GLOBAL_TYPE_ID"));
+        assert!(generated.contains("builder.set_type_data("));
+        assert!(generated.contains("crate::TypeData::Constructor("));
+        assert!(generated.contains("crate::TypeData::Function("));
+        assert!(generated.contains("biome_rowan::Text::new_static(\"name\")"));
+        assert!(generated.contains("biome_rowan::Text::new_static(\"message\")"));
+        assert!(generated.contains("crate::TypeMemberKind::NamedOptional("));
+        assert!(generated.contains("\"stack\""));
+        assert!(generated.contains("crate::TypeMemberKind::NamedStatic("));
+        assert!(generated.contains("\"prototype\""));
+
+        Ok(())
+    }
+
+    #[test]
     fn collector_fixture_round_trip() -> Result<()> {
         let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join(COLLECTOR_FIXTURE_DIR);
         assert!(
@@ -962,6 +1071,205 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn manifest_groups_global_type_and_value_roles() -> Result<()> {
+        let manifest = manifest_from_fixture("manifest.error.d.ts")?;
+        let error = manifest
+            .global_group("Error")
+            .expect("Error group should be present");
+        assert!(error.has_role(GlobalDeclarationRole::Type));
+        assert!(error.has_role(GlobalDeclarationRole::Value));
+        assert_eq!(
+            error.declarations().len(),
+            3,
+            "two interfaces and one declare var should merge into Error"
+        );
+
+        let error_constructor = manifest
+            .global_group("ErrorConstructor")
+            .expect("ErrorConstructor group should be present");
+        assert!(error_constructor.has_role(GlobalDeclarationRole::Type));
+        assert!(!error_constructor.has_role(GlobalDeclarationRole::Value));
+
+        let type_error = manifest
+            .global_group("TypeError")
+            .expect("declare global TypeError should be present as a global");
+        assert!(type_error.has_role(GlobalDeclarationRole::Type));
+
+        assert!(
+            manifest.global_group("ExternalError").is_none(),
+            "external module declarations must not enter the global manifest"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn lowerer_lowers_error_interface_members_to_generated_class() -> Result<()> {
+        let lowered = lowered_from_fixture("manifest.error.d.ts")?;
+        let error = lowered
+            .global("Error")
+            .expect("Error should be lowered as the first generated Error global");
+
+        assert_eq!(error.id_constant(), "ERROR_ID_GLOBAL_TYPE_ID");
+        let LoweredTypeData::Class(class) = error.data() else {
+            bail!("Error should lower to class data");
+        };
+        assert_eq!(class.name(), "Error");
+
+        let name = class.member("name").expect("name member should be lowered");
+        assert_eq!(name.kind(), &LoweredMemberKind::Named { optional: false });
+        assert_eq!(
+            name.type_reference(),
+            &LoweredTypeReference::Predefined("GLOBAL_STRING_ID")
+        );
+
+        let message = class
+            .member("message")
+            .expect("message member should be lowered");
+        assert_eq!(
+            message.kind(),
+            &LoweredMemberKind::Named { optional: false }
+        );
+        assert_eq!(
+            message.type_reference(),
+            &LoweredTypeReference::Predefined("GLOBAL_STRING_ID")
+        );
+        let stack = class
+            .member("stack")
+            .expect("stack member should be lowered");
+        assert_eq!(stack.kind(), &LoweredMemberKind::Named { optional: true });
+        assert_eq!(
+            stack.type_reference(),
+            &LoweredTypeReference::Predefined("GLOBAL_STRING_ID")
+        );
+        let prototype = class
+            .member("prototype")
+            .expect("prototype member should be lowered");
+        assert_eq!(prototype.kind(), &LoweredMemberKind::NamedStatic);
+        assert_eq!(
+            prototype.type_reference(),
+            &LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_ERROR_ID")
+        );
+        assert!(class.member("code").is_none());
+        assert_eq!(
+            class
+                .members()
+                .iter()
+                .filter(|member| matches!(member.kind(), LoweredMemberKind::Constructor))
+                .count(),
+            1
+        );
+        assert_eq!(
+            class
+                .members()
+                .iter()
+                .filter(|member| matches!(member.kind(), LoweredMemberKind::CallSignature))
+                .count(),
+            1
+        );
+
+        let constructor = lowered
+            .global("Error.constructor")
+            .expect("Error constructor helper should be lowered");
+        assert_eq!(
+            constructor.id_constant(),
+            "ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID"
+        );
+
+        let call = lowered
+            .global("Error.call")
+            .expect("Error call helper should be lowered");
+        assert_eq!(call.id_constant(), "ERROR_CALL_ID_GLOBAL_TYPE_ID");
+
+        Ok(())
+    }
+
+    #[test]
+    fn lowerer_rejects_error_interface_extends_clause() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.error-extends.d.ts"),
+            "Error interface extends clauses are not supported",
+        )
+    }
+
+    #[test]
+    fn lowerer_rejects_error_constructor_extends_clause() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.error-constructor-extends.d.ts"),
+            "ErrorConstructor extends clauses are not supported",
+        )
+    }
+
+    #[test]
+    fn lowerer_rejects_error_constructor_type_alias() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.error-constructor-type-alias.d.ts"),
+            "type aliases are not supported in ErrorConstructor",
+        )
+    }
+
+    #[test]
+    fn lowerer_rejects_error_constructor_value_declarations() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.error-constructor-unsupported-value.d.ts"),
+            "value-side ErrorConstructor declarations are not supported",
+        )
+    }
+
+    #[test]
+    fn comparator_accepts_error_member_divergence() -> Result<()> {
+        let lowered = lowered_from_fixture("manifest.error.d.ts")?;
+
+        compare_lowered_globals(&lowered)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn comparator_rejects_missing_error_members() -> Result<()> {
+        let lowered = lowered_from_fixture("manifest.error-missing-message.d.ts")?;
+
+        expect_error_contains(
+            compare_lowered_globals(&lowered),
+            "missing required Error member message",
+        )
+    }
+
+    #[test]
+    fn comparator_rejects_wrong_error_constructor_return() -> Result<()> {
+        let lowered = lowered_from_fixture("manifest.error-wrong-constructor-return.d.ts")?;
+
+        expect_error_contains(
+            compare_lowered_globals(&lowered),
+            "generated Error constructor has unexpected return type",
+        )
+    }
+
+    #[test]
+    fn lowerer_rejects_unsupported_error_members() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.error-unsupported-index.d.ts"),
+            "index signatures are not supported in the Error global",
+        )
+    }
+
+    #[test]
+    fn lowerer_rejects_unresolved_error_member_references() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.error-named-reference.d.ts"),
+            "unresolved type reference ErrorOptions in Error global",
+        )
+    }
+
+    #[test]
+    fn lowerer_rejects_unsupported_error_value_declarations() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.error-unsupported-value.d.ts"),
+            "unsupported value-side Error declaration",
+        )
     }
 
     #[test]


### PR DESCRIPTION
This PR was implemented with AI assistance from Codex.

## Summary

Foundation for #5977. Migrates the `Error` global through the generated global-types pipeline, including manifest/lowering/comparison, value-side constructor/call helpers, and generated resolver registration.

## Test Plan

Added global-types codegen coverage for manifest grouping, `Error` lowering, comparator failures, and generated registration output.

Added type-info flattening coverage for generated `Error` globals, optional `Error#stack`, static/instance separation, and indexed function calls.

Ran:
- `cargo test -p xtask_codegen --features=global_types --test global_types_codegen`
- `cargo test -p biome_js_type_info --test flattening`
- `cargo fmt --all --check`

