### PR TITLE
feat(css_formatter): format import media comments inline

### DIFF
--- a/.changeset/fix-css-import-comments.md
+++ b/.changeset/fix-css-import-comments.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed CSS formatter output for comments between import media queries.
+
+```diff
+-@import url("print.css") print,
+-/* comment */
+-screen;
++@import url("print.css") print, /* comment */ screen;
+```

--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -1,12 +1,13 @@
 use crate::prelude::*;
-use crate::utils::comment_trivia::is_trailing_comment_on_node;
+use crate::utils::comment_trivia::{is_leading_comment_on_node, is_trailing_comment_on_node};
 use crate::utils::scss_include_comments::{
     place_list_trailing_separator_comment, place_map_trailing_separator_comment,
     place_separated_list_comment,
 };
 use biome_css_syntax::{
-    AnyCssDeclarationName, AnyCssRoot, CssComplexSelector, CssDeclarationOrRuleBlock, CssFunction,
-    CssGenericComponentValueList, CssGenericProperty, CssIdentifier, CssLanguage, ScssAtRootAtRule,
+    AnyCssDeclarationName, AnyCssMediaQuery, AnyCssRoot, CssComplexSelector,
+    CssDeclarationOrRuleBlock, CssFunction, CssGenericComponentValueList, CssGenericProperty,
+    CssIdentifier, CssLanguage, CssMediaQueryList, CssSyntaxKind, ScssAtRootAtRule,
     ScssAtRootSelector, ScssEachHeader, ScssEachValueList, ScssExpression, ScssExpressionItemList,
     ScssIfAtRule, ScssListExpression, ScssListExpressionElement, ScssMapExpression,
     ScssMapExpressionPair, ScssVariableDeclaration, T, TextLen, TextSize,
@@ -19,7 +20,7 @@ use biome_formatter::comments::{
 };
 use biome_formatter::formatter::Formatter;
 use biome_formatter::{FormatResult, FormatRule, write};
-use biome_rowan::{AstSeparatedList, SyntaxTriviaPieceComments};
+use biome_rowan::{AstNode, AstSeparatedList, SyntaxTriviaPieceComments};
 use biome_suppression::{SuppressionKind, parse_suppression_comment};
 
 pub type CssComments = Comments<CssLanguage>;
@@ -117,6 +118,7 @@ impl CommentStyle for CssCommentStyle {
             .or_else(handle_scss_at_root_selector_comment)
             .or_else(handle_scss_else_clause_comment)
             .or_else(handle_function_comment)
+            .or_else(handle_media_separator_comment)
             // Handle SCSS variable name/colon comments before generic properties.
             .or_else(handle_scss_variable_declaration_comment)
             .or_else(handle_generic_property_comment)
@@ -315,6 +317,79 @@ fn handle_function_comment(
     } else {
         CommentPlacement::Default(comment)
     }
+}
+
+/// Attaches media-list comma comments to the following query.
+///
+/// ```scss
+/// @media print, // c
+/// screen {}
+/// ```
+fn handle_media_separator_comment(
+    comment: DecoratedComment<CssLanguage>,
+) -> CommentPlacement<CssLanguage> {
+    let Some(preceding_query) = comment
+        .preceding_node()
+        .and_then(AnyCssMediaQuery::cast_ref)
+    else {
+        return CommentPlacement::Default(comment);
+    };
+
+    let Some(following_query) = comment
+        .following_node()
+        .and_then(AnyCssMediaQuery::cast_ref)
+    else {
+        return CommentPlacement::Default(comment);
+    };
+
+    let Some(media_list) = preceding_query.parent::<CssMediaQueryList>() else {
+        return CommentPlacement::Default(comment);
+    };
+
+    if following_query
+        .parent::<CssMediaQueryList>()
+        .is_none_or(|following_list| following_list.syntax() != media_list.syntax())
+    {
+        return CommentPlacement::Default(comment);
+    }
+
+    if !is_media_separator_comment(&preceding_query, &following_query, &comment) {
+        return CommentPlacement::Default(comment);
+    }
+
+    CommentPlacement::leading(following_query.syntax().clone(), comment)
+}
+
+/// Returns true for comments in trivia after a media query comma.
+///
+/// ```scss
+/// @media print, // c
+/// screen {}
+/// ```
+fn is_media_separator_comment(
+    preceding_query: &AnyCssMediaQuery,
+    following_query: &AnyCssMediaQuery,
+    comment: &DecoratedComment<CssLanguage>,
+) -> bool {
+    let Some(comma_token) = preceding_query
+        .syntax()
+        .last_token()
+        .and_then(|token| token.next_token())
+        .filter(|token| token.kind() == CssSyntaxKind::COMMA)
+    else {
+        return false;
+    };
+
+    let comment_piece = comment.piece().as_piece();
+
+    if comma_token == comment_piece.token() {
+        return comma_token
+            .trailing_trivia()
+            .text_range()
+            .contains_range(comment_piece.text_range());
+    }
+
+    is_leading_comment_on_node(following_query.syntax(), comment.piece())
 }
 
 /// Attaches comments that belong to SCSS variable boundaries:

--- a/crates/biome_css_formatter/src/css/auxiliary/media_and_type_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_and_type_query.rs
@@ -1,10 +1,15 @@
 use crate::prelude::*;
+use crate::utils::media_query_comments::{fmt_media_query_leading, fmt_media_query_node};
 use biome_css_syntax::{CssMediaAndTypeQuery, CssMediaAndTypeQueryFields};
 use biome_formatter::write;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaAndTypeQuery;
 impl FormatNodeRule<CssMediaAndTypeQuery> for FormatCssMediaAndTypeQuery {
+    fn fmt_node(&self, node: &CssMediaAndTypeQuery, f: &mut CssFormatter) -> FormatResult<()> {
+        fmt_media_query_node(node.syntax(), f, |f| self.fmt_fields(node, f))
+    }
+
     fn fmt_fields(&self, node: &CssMediaAndTypeQuery, f: &mut CssFormatter) -> FormatResult<()> {
         let CssMediaAndTypeQueryFields {
             left,
@@ -22,5 +27,13 @@ impl FormatNodeRule<CssMediaAndTypeQuery> for FormatCssMediaAndTypeQuery {
                 right.format()
             ]
         )
+    }
+
+    fn fmt_leading_comments(
+        &self,
+        node: &CssMediaAndTypeQuery,
+        f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        fmt_media_query_leading(node.syntax(), f)
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_condition_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_condition_query.rs
@@ -1,13 +1,26 @@
 use crate::prelude::*;
+use crate::utils::media_query_comments::{fmt_media_query_leading, fmt_media_query_node};
 use biome_css_syntax::{CssMediaConditionQuery, CssMediaConditionQueryFields};
 use biome_formatter::write;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaConditionQuery;
 impl FormatNodeRule<CssMediaConditionQuery> for FormatCssMediaConditionQuery {
+    fn fmt_node(&self, node: &CssMediaConditionQuery, f: &mut CssFormatter) -> FormatResult<()> {
+        fmt_media_query_node(node.syntax(), f, |f| self.fmt_fields(node, f))
+    }
+
     fn fmt_fields(&self, node: &CssMediaConditionQuery, f: &mut CssFormatter) -> FormatResult<()> {
         let CssMediaConditionQueryFields { condition } = node.as_fields();
 
         write!(f, [condition.format()])
+    }
+
+    fn fmt_leading_comments(
+        &self,
+        node: &CssMediaConditionQuery,
+        f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        fmt_media_query_leading(node.syntax(), f)
     }
 }

--- a/crates/biome_css_formatter/src/css/auxiliary/media_type_query.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/media_type_query.rs
@@ -1,10 +1,15 @@
 use crate::prelude::*;
+use crate::utils::media_query_comments::{fmt_media_query_leading, fmt_media_query_node};
 use biome_css_syntax::{CssMediaTypeQuery, CssMediaTypeQueryFields};
 use biome_formatter::write;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaTypeQuery;
 impl FormatNodeRule<CssMediaTypeQuery> for FormatCssMediaTypeQuery {
+    fn fmt_node(&self, node: &CssMediaTypeQuery, f: &mut CssFormatter) -> FormatResult<()> {
+        fmt_media_query_node(node.syntax(), f, |f| self.fmt_fields(node, f))
+    }
+
     fn fmt_fields(&self, node: &CssMediaTypeQuery, f: &mut CssFormatter) -> FormatResult<()> {
         let CssMediaTypeQueryFields { modifier, ty } = node.as_fields();
 
@@ -13,5 +18,13 @@ impl FormatNodeRule<CssMediaTypeQuery> for FormatCssMediaTypeQuery {
         }
 
         write!(f, [ty.format()])
+    }
+
+    fn fmt_leading_comments(
+        &self,
+        node: &CssMediaTypeQuery,
+        f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        fmt_media_query_leading(node.syntax(), f)
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/media_query_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/media_query_list.rs
@@ -1,13 +1,17 @@
 use crate::prelude::*;
+use crate::utils::media_query_comments::fill_media_queries;
 use biome_css_syntax::CssMediaQueryList;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssMediaQueryList;
 impl FormatRule<CssMediaQueryList> for FormatCssMediaQueryList {
     type Context = CssFormatContext;
+
     fn fmt(&self, node: &CssMediaQueryList, f: &mut CssFormatter) -> FormatResult<()> {
-        f.fill()
-            .entries(&soft_line_break_or_space(), node.format_separated(","))
-            .finish()
+        let mut fill = f.fill();
+        fill_media_queries(node, |separator, formatted| {
+            fill.entry(separator, formatted);
+        });
+        fill.finish()
     }
 }

--- a/crates/biome_css_formatter/src/css/lists/parameter_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/parameter_list.rs
@@ -80,7 +80,13 @@ fn is_var_function_parameter_list(node: &CssParameterList) -> bool {
 
 /// Keeps a blank line after SCSS keyword parameters.
 ///
-/// Example: `foo($a: 1,\n\n$b: 2)` keeps the empty line before `$b`.
+/// ```scss
+/// foo(
+///   $a: 1,
+///
+///   $b: 2
+/// )
+/// ```
 fn should_preserve_blank_line_before_parameter(
     parameter: Option<&AnyCssExpression>,
     previous_was_keyword_argument: bool,
@@ -96,7 +102,10 @@ fn is_scss_keyword_parameter(parameter: Option<&AnyCssExpression>) -> bool {
 
 /// Keeps a closing line comment attached to a final SCSS spread argument.
 ///
-/// Example: `@include mix($args... // comment\n)`.
+/// ```scss
+/// @include mix($args... // comment
+/// );
+/// ```
 fn should_inline_arbitrary_argument_closing_comment(
     node: &CssParameterList,
     f: &CssFormatter,

--- a/crates/biome_css_formatter/src/css/statements/import_at_rule.rs
+++ b/crates/biome_css_formatter/src/css/statements/import_at_rule.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::utils::import::write_import_payload;
+use crate::utils::import::FormatImportClause;
 use biome_css_syntax::{CssImportAtRule, CssImportAtRuleFields};
 use biome_formatter::write;
 
@@ -17,7 +17,8 @@ impl FormatNodeRule<CssImportAtRule> for FormatCssImportAtRule {
         } = node.as_fields();
 
         write!(f, [import_token.format(), space()])?;
-        write_import_payload(f, &url, layer.as_ref(), supports.as_ref(), &media)?;
+        let import_clause = FormatImportClause::new(url, layer, supports, media);
+        write!(f, [group(&indent(&import_clause))])?;
 
         write!(f, [semicolon_token.format()])
     }

--- a/crates/biome_css_formatter/src/scss/auxiliary/media_query.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/media_query.rs
@@ -1,13 +1,26 @@
 use crate::prelude::*;
+use crate::utils::media_query_comments::{fmt_media_query_leading, fmt_media_query_node};
 use biome_css_syntax::{ScssMediaQuery, ScssMediaQueryFields};
 use biome_formatter::write;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssMediaQuery;
 impl FormatNodeRule<ScssMediaQuery> for FormatScssMediaQuery {
+    fn fmt_node(&self, node: &ScssMediaQuery, f: &mut CssFormatter) -> FormatResult<()> {
+        fmt_media_query_node(node.syntax(), f, |f| self.fmt_fields(node, f))
+    }
+
     fn fmt_fields(&self, node: &ScssMediaQuery, f: &mut CssFormatter) -> FormatResult<()> {
         let ScssMediaQueryFields { query } = node.as_fields();
 
         write!(f, [query.format()])
+    }
+
+    fn fmt_leading_comments(
+        &self,
+        node: &ScssMediaQuery,
+        f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        fmt_media_query_leading(node.syntax(), f)
     }
 }

--- a/crates/biome_css_formatter/src/scss/auxiliary/plain_import.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/plain_import.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use crate::utils::import::write_import_payload;
+use crate::utils::import::FormatImportClause;
 use biome_css_syntax::{ScssPlainImport, ScssPlainImportFields};
+use biome_formatter::write;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssPlainImport;
@@ -13,6 +14,8 @@ impl FormatNodeRule<ScssPlainImport> for FormatScssPlainImport {
             media,
         } = node.as_fields();
 
-        write_import_payload(f, &url, layer.as_ref(), supports.as_ref(), &media)
+        let import_clause = FormatImportClause::new(url, layer, supports, media);
+
+        write!(f, [group(&import_clause)])
     }
 }

--- a/crates/biome_css_formatter/src/scss/lists/import_item_list.rs
+++ b/crates/biome_css_formatter/src/scss/lists/import_item_list.rs
@@ -1,19 +1,73 @@
 use crate::prelude::*;
-use biome_css_syntax::ScssImportItemList;
+use crate::utils::comment_trivia::has_line_comment;
+use biome_css_syntax::{AnyScssImportItem, ScssImportAtRule, ScssImportItemList};
+use biome_formatter::write;
+use biome_rowan::{AstNode, AstSeparatedList};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssImportItemList;
 impl FormatRule<ScssImportItemList> for FormatScssImportItemList {
     type Context = CssFormatContext;
 
+    /// Fills SCSS imports, breaking before comment-started rows.
+    ///
+    /// ```scss
+    /// @import "a",
+    /// // c
+    /// "b";
+    /// ```
     fn fmt(&self, node: &ScssImportItemList, f: &mut CssFormatter) -> FormatResult<()> {
-        let separator = soft_line_break_or_space();
-        let mut joiner = f.join_with(&separator);
+        let mut fill = f.fill();
+        let import_line_comment = has_import_line_comment(node);
+        let mut prev_comment_row = false;
+        let mut is_first = true;
 
-        for formatted in node.format_separated(",") {
-            joiner.entry(&formatted);
+        for (element, formatted) in node.elements().zip(node.format_separated(",")) {
+            let item = element.node().ok();
+            let is_comment_row =
+                has_leading_line_comment(item) || (is_first && import_line_comment);
+            let break_before = prev_comment_row || is_comment_row;
+            let separator = format_once(move |f| {
+                if break_before {
+                    write!(f, [hard_line_break()])
+                } else {
+                    write!(f, [soft_line_break_or_space()])
+                }
+            });
+
+            fill.entry(&separator, &formatted);
+
+            prev_comment_row = is_comment_row;
+            is_first = false;
         }
 
-        joiner.finish()
+        fill.finish()
     }
+}
+
+/// Detects import items that start after a line comment.
+///
+/// ```scss
+/// @import "a",
+/// // c
+/// "b";
+/// ```
+fn has_leading_line_comment(item: Option<&AnyScssImportItem>) -> bool {
+    item.is_some_and(|item| {
+        item.syntax()
+            .first_token()
+            .is_some_and(|token| has_line_comment(token.leading_trivia()))
+    })
+}
+
+/// Detects line comments after the `@import` keyword.
+///
+/// ```scss
+/// @import // c
+/// "a";
+/// ```
+fn has_import_line_comment(node: &ScssImportItemList) -> bool {
+    node.parent::<ScssImportAtRule>()
+        .and_then(|rule| rule.import_token().ok())
+        .is_some_and(|token| has_line_comment(token.trailing_trivia()))
 }

--- a/crates/biome_css_formatter/src/scss/lists/map_expression_pair_list.rs
+++ b/crates/biome_css_formatter/src/scss/lists/map_expression_pair_list.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::utils::comment_trivia::is_leading_comment_on_node;
 use crate::utils::scss_expression::is_self_breaking_value;
 use crate::utils::scss_map_layout::is_direct_each_value_map;
 use biome_css_syntax::{
@@ -105,17 +106,7 @@ fn has_source_leading_comment(pair: &ScssMapExpressionPair, f: &CssFormatter) ->
     f.comments()
         .leading_comments(pair.syntax())
         .iter()
-        .any(|comment| {
-            let comment_piece = comment.piece().as_piece();
-
-            pair.syntax().first_token().is_some_and(|token| {
-                token == comment_piece.token()
-                    && token
-                        .leading_trivia()
-                        .text_range()
-                        .contains_range(comment_piece.text_range())
-            })
-        })
+        .any(|comment| is_leading_comment_on_node(pair.syntax(), comment.piece()))
 }
 
 /// Returns `true` for a last value that breaks itself, e.g. `key: (a: b)`.

--- a/crates/biome_css_formatter/src/utils/comment_trivia.rs
+++ b/crates/biome_css_formatter/src/utils/comment_trivia.rs
@@ -2,13 +2,26 @@ use crate::comments::CssCommentStyle;
 use crate::prelude::*;
 use biome_css_syntax::{CssLanguage, CssSyntaxNode, CssSyntaxToken};
 use biome_formatter::comments::{CommentKind, CommentStyle, DecoratedComment, SourceComment};
-use biome_rowan::{SyntaxResult, SyntaxTriviaPiece};
+use biome_rowan::syntax::SyntaxTrivia;
+use biome_rowan::{SyntaxResult, SyntaxTriviaPiece, SyntaxTriviaPieceComments};
 
 /// Returns `true` for CSS `/* ... */` comments.
 pub(crate) fn is_block_style_comment(piece: &SyntaxTriviaPiece<CssLanguage>) -> bool {
     piece
         .as_comments()
         .is_some_and(|comment| CssCommentStyle::get_comment_kind(&comment).is_inline())
+}
+
+/// Returns `true` for `// c` trivia.
+///
+/// ```scss
+/// color: red; // c
+/// ```
+pub(crate) fn has_line_comment(trivia: SyntaxTrivia<CssLanguage>) -> bool {
+    trivia
+        .pieces()
+        .filter_map(|piece| piece.as_comments())
+        .any(|comment| CssCommentStyle::get_comment_kind(&comment).is_line())
 }
 
 /// Returns `true` when the last leading block comment stays with this node.
@@ -46,6 +59,27 @@ pub(crate) fn is_trailing_comment_on_node(
         token == comment_piece.token()
             && token
                 .trailing_trivia()
+                .text_range()
+                .contains_range(comment_piece.text_range())
+    })
+}
+
+/// Returns `true` when `comment` is in a node's leading trivia.
+///
+/// ```scss
+/// // c
+/// $color: red;
+/// ```
+pub(crate) fn is_leading_comment_on_node(
+    node: &CssSyntaxNode,
+    comment: &SyntaxTriviaPieceComments<CssLanguage>,
+) -> bool {
+    let comment_piece = comment.as_piece();
+
+    node.first_token().is_some_and(|token| {
+        token == comment_piece.token()
+            && token
+                .leading_trivia()
                 .text_range()
                 .contains_range(comment_piece.text_range())
     })

--- a/crates/biome_css_formatter/src/utils/import.rs
+++ b/crates/biome_css_formatter/src/utils/import.rs
@@ -1,43 +1,71 @@
 use crate::CssFormatter;
 use crate::prelude::*;
+use crate::utils::media_query_comments::fill_media_queries;
 use biome_css_syntax::{AnyCssImportLayer, AnyCssImportUrl, CssImportSupports, CssMediaQueryList};
-use biome_formatter::{FormatResult, write};
+use biome_formatter::{Format, FormatResult, write};
 use biome_rowan::SyntaxResult;
 
-/// Formats the shared `@import` payload used by CSS imports and SCSS plain imports.
-pub(crate) fn write_import_payload(
-    f: &mut CssFormatter,
-    url: &SyntaxResult<AnyCssImportUrl>,
-    layer: Option<&AnyCssImportLayer>,
-    supports: Option<&CssImportSupports>,
-    media: &CssMediaQueryList,
-) -> FormatResult<()> {
-    let has_any_modifiers = layer.is_some() || supports.is_some() || !media.is_empty();
+/// Formats the shared import clause used by CSS imports and SCSS plain imports.
+///
+/// ```css
+/// @import "a.css" layer(base) screen;
+/// ```
+pub(crate) struct FormatImportClause {
+    url: SyntaxResult<AnyCssImportUrl>,
+    layer: Option<AnyCssImportLayer>,
+    supports: Option<CssImportSupports>,
+    media: CssMediaQueryList,
+}
 
-    if has_any_modifiers {
-        let modifiers = format_once(|f| {
+impl FormatImportClause {
+    /// Creates an import clause formatter.
+    ///
+    /// ```css
+    /// @import "a.css" layer(base) screen;
+    /// ```
+    pub(crate) fn new(
+        url: SyntaxResult<AnyCssImportUrl>,
+        layer: Option<AnyCssImportLayer>,
+        supports: Option<CssImportSupports>,
+        media: CssMediaQueryList,
+    ) -> Self {
+        Self {
+            url,
+            layer,
+            supports,
+            media,
+        }
+    }
+}
+
+impl Format<CssFormatContext> for FormatImportClause {
+    fn fmt(&self, f: &mut CssFormatter) -> FormatResult<()> {
+        let has_any_modifiers =
+            self.layer.is_some() || self.supports.is_some() || !self.media.is_empty();
+
+        if has_any_modifiers {
             let separator = soft_line_break_or_space();
             let mut fill = f.fill();
 
-            fill.entry(&separator, &url.format());
+            fill.entry(&separator, &self.url.format());
 
-            if let Some(layer) = layer {
+            if let Some(layer) = &self.layer {
                 fill.entry(&separator, &layer.format());
             }
 
-            if let Some(supports) = supports {
+            if let Some(supports) = &self.supports {
                 fill.entry(&separator, &supports.format());
             }
 
-            if !media.is_empty() {
-                fill.entry(&separator, &media.format());
+            if !self.media.is_empty() {
+                fill_media_queries(&self.media, |separator, formatted| {
+                    fill.entry(separator, formatted);
+                });
             }
 
             fill.finish()
-        });
-
-        write!(f, [group(&indent(&modifiers))])
-    } else {
-        write!(f, [url.format()])
+        } else {
+            write!(f, [self.url.format()])
+        }
     }
 }

--- a/crates/biome_css_formatter/src/utils/media_query_comments.rs
+++ b/crates/biome_css_formatter/src/utils/media_query_comments.rs
@@ -1,0 +1,109 @@
+use crate::prelude::*;
+use crate::utils::comment_trivia::has_line_comment;
+use biome_css_syntax::{AnyCssMediaQuery, CssMediaQueryList, CssSyntaxKind, CssSyntaxNode};
+use biome_formatter::write;
+use biome_rowan::AstSeparatedList;
+
+/// Fills media queries, breaking before comment-started rows.
+///
+/// ```scss
+/// @import "a.css" print,
+/// // c
+/// screen;
+/// ```
+pub(crate) fn fill_media_queries(
+    node: &CssMediaQueryList,
+    mut fill_entry: impl FnMut(&dyn Format<CssFormatContext>, &dyn Format<CssFormatContext>),
+) {
+    let mut prev_comment_row = false;
+
+    for (element, formatted) in node.elements().zip(node.format_separated(",")) {
+        let query = element.node().ok();
+        let is_comment_row = has_leading_line_comment(query);
+        let break_before = prev_comment_row || is_comment_row;
+        let separator = format_once(move |f| {
+            if break_before {
+                write!(f, [hard_line_break()])
+            } else {
+                write!(f, [soft_line_break_or_space()])
+            }
+        });
+
+        fill_entry(&separator, &formatted);
+
+        prev_comment_row = is_comment_row;
+    }
+}
+
+/// Prints a media query after separator-owned leading comments.
+///
+/// ```scss
+/// @media print,
+/// // c
+/// screen {}
+/// ```
+pub(crate) fn fmt_media_query_node(
+    node: &CssSyntaxNode,
+    f: &mut CssFormatter,
+    fmt_node: impl Fn(&mut CssFormatter) -> FormatResult<()>,
+) -> FormatResult<()> {
+    if has_comma_comment(node, f) {
+        format_leading_comments(node)
+            .with_following_content(fmt_node)
+            .fmt(f)
+    } else {
+        fmt_node(f)
+    }
+}
+
+/// Skips normal leading comments when the separator owns them.
+///
+/// ```scss
+/// @media print,
+/// // c
+/// screen {}
+/// ```
+pub(crate) fn fmt_media_query_leading(
+    node: &CssSyntaxNode,
+    f: &mut CssFormatter,
+) -> FormatResult<()> {
+    if has_comma_comment(node, f) {
+        Ok(())
+    } else {
+        format_leading_comments(node).fmt(f)
+    }
+}
+
+/// Detects comments attached to the comma before a media query.
+///
+/// ```scss
+/// @media print, // c
+/// screen {}
+/// ```
+fn has_comma_comment(node: &CssSyntaxNode, f: &CssFormatter) -> bool {
+    f.comments().leading_comments(node).iter().any(|comment| {
+        let comment_piece = comment.piece().as_piece();
+        let token = comment_piece.token();
+
+        token.kind() == CssSyntaxKind::COMMA
+            || token
+                .prev_token()
+                .is_some_and(|token| token.kind() == CssSyntaxKind::COMMA)
+    })
+}
+
+/// Detects media query rows that start with a line comment.
+///
+/// ```scss
+/// @media print,
+/// // c
+/// screen {}
+/// ```
+fn has_leading_line_comment(query: Option<&AnyCssMediaQuery>) -> bool {
+    query.is_some_and(|query| {
+        query
+            .syntax()
+            .first_token()
+            .is_some_and(|token| has_line_comment(token.leading_trivia()))
+    })
+}

--- a/crates/biome_css_formatter/src/utils/mod.rs
+++ b/crates/biome_css_formatter/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod block_like;
 pub(crate) mod comment_trivia;
 pub(crate) mod component_value_list;
 pub(crate) mod import;
+pub(crate) mod media_query_comments;
 pub(crate) mod scss_closing_comments;
 pub(crate) mod scss_control_condition;
 pub(crate) mod scss_each;

--- a/crates/biome_css_formatter/tests/specs/css/atrule/import-comments.css
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/import-comments.css
@@ -1,0 +1,17 @@
+@import   url("print.css")  print ,
+/* Comment */
+screen ;
+
+@import url("separator.css")  print,/* Separator */screen ;
+
+@import url("theme.css") layer(default)  supports(display:flex)  screen ,
+/* Comment */
+print ;
+
+@import url("responsive.css") print ,
+/* Comment */
+screen and  ( color ) ;
+
+@import url("condition.css") screen ,
+/* Comment */
+( prefers-color-scheme : dark ) ;

--- a/crates/biome_css_formatter/tests/specs/css/atrule/import-comments.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/atrule/import-comments.css.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/atrule/import-comments.css
+---
+
+# Input
+
+```css
+@import   url("print.css")  print ,
+/* Comment */
+screen ;
+
+@import url("separator.css")  print,/* Separator */screen ;
+
+@import url("theme.css") layer(default)  supports(display:flex)  screen ,
+/* Comment */
+print ;
+
+@import url("responsive.css") print ,
+/* Comment */
+screen and  ( color ) ;
+
+@import url("condition.css") screen ,
+/* Comment */
+( prefers-color-scheme : dark ) ;
+
+```
+
+
+# Formatted
+
+```css
+@import url("print.css") print, /* Comment */ screen;
+
+@import url("separator.css") print, /* Separator */ screen;
+
+@import url("theme.css") layer(default) supports(display: flex) screen,
+	/* Comment */ print;
+
+@import url("responsive.css") print, /* Comment */ screen and (color);
+
+@import url("condition.css") screen, /* Comment */ (prefers-color-scheme: dark);
+
+```

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/comments/4594.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/comments/4594.scss.snap
@@ -65,16 +65,6 @@ $my-map: (
  [href]:active & {
    .tooltip {
      opacity: 1;
-@@ -33,7 +35,8 @@
-   "variables",
-   // Comment
-   "reset",
--  "scaffolding", "type",
-+  "scaffolding",
-+  "type",
-   // Comment
-   "bar",
-   "tabs";
 ```
 
 # Output
@@ -117,8 +107,7 @@ $my-map: (
   "variables",
   // Comment
   "reset",
-  "scaffolding",
-  "type",
+  "scaffolding", "type",
   // Comment
   "bar",
   "tabs";

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/import-comments.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/import-comments.scss
@@ -1,0 +1,20 @@
+@import
+// Comment
+"mixins" ,
+"variables",
+// Comment
+"reset" ,
+"scaffolding"   ,"type",
+// Comment
+"bar" ,"tabs" ;
+
+@import  "print.css"  print,
+// Comment
+screen ;
+
+@import "separator.css" print,// Separator
+screen ;
+
+@import "theme.css"  print,
+// Comment
+#{$query} ;

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/import-comments.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/import-comments.scss.snap
@@ -1,0 +1,57 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/at-rule/import-comments.scss
+---
+
+# Input
+
+```scss
+@import
+// Comment
+"mixins" ,
+"variables",
+// Comment
+"reset" ,
+"scaffolding"   ,"type",
+// Comment
+"bar" ,"tabs" ;
+
+@import  "print.css"  print,
+// Comment
+screen ;
+
+@import "separator.css" print,// Separator
+screen ;
+
+@import "theme.css"  print,
+// Comment
+#{$query} ;
+
+```
+
+
+# Formatted
+
+```scss
+@import // Comment
+	"mixins",
+	"variables",
+	// Comment
+	"reset",
+	"scaffolding", "type",
+	// Comment
+	"bar",
+	"tabs";
+
+@import "print.css" print,
+	// Comment
+	screen;
+
+@import "separator.css" print, // Separator
+	screen;
+
+@import "theme.css" print,
+	// Comment
+	#{$query};
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/media-comments.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/media-comments.scss
@@ -1,0 +1,2 @@
+@media   print,// Separator
+screen{a{color:red}}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/media-comments.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/media-comments.scss.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/at-rule/media-comments.scss
+---
+
+# Input
+
+```scss
+@media   print,// Separator
+screen{a{color:red}}
+
+```
+
+
+# Formatted
+
+```scss
+@media print, // Separator
+	screen {
+	a {
+		color: red;
+	}
+}
+
+```


### PR DESCRIPTION
## Summary

Improved CSS/SCSS formatter output for comments between import media queries.

```diff
-@import "print.css" print,// comment
-screen;
+@import "print.css" print, // comment
+	screen;

-@media print,// comment
-screen{a{color:red}}
+@media print, // comment
+	screen {
+	a {
+		color: red;
+	}
+}
```


> This PR was implemented with guidance from Codex AI assistant.

## Test Plan

- cargo test -p biome_css_foramtter