### PR TITLE
fix(json): detect global Zed settings as JSONC on macOS and Windows

### DIFF
--- a/.changeset/fix-zed-global-settings-jsonc-macos.md
+++ b/.changeset/fix-zed-global-settings-jsonc-macos.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed Biome reporting parse errors for comments and trailing commas in Zed's global settings file (`~/.config/zed/settings.json`) on macOS and Windows. Biome's scanner resolved Zed's config directory using platform conventions, but Zed uses `~/.config/zed` on macOS and `%APPDATA%\Zed` on Windows, so the file is now correctly recognized as JSONC.
+Fixed an issue where Biome was resolving [the well-known Zed settings file](https://biomejs.dev/guides/configure-biome/#well-known-files) from the wrong location on macOS and Windows. 

--- a/.changeset/fix-zed-global-settings-jsonc-macos.md
+++ b/.changeset/fix-zed-global-settings-jsonc-macos.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed an issue where Biome was resolving [the well-known Zed settings file](https://biomejs.dev/guides/configure-biome/#well-known-files) from the wrong location on macOS and Windows. 
+Fixed an issue where Biome was resolving [the well-known Zed settings file](https://biomejs.dev/guides/configure-biome/#well-known-files) from the wrong location on macOS and Windows.

--- a/.changeset/fix-zed-global-settings-jsonc-macos.md
+++ b/.changeset/fix-zed-global-settings-jsonc-macos.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed Biome reporting parse errors for comments and trailing commas in Zed's global settings file (`~/.config/zed/settings.json`) on macOS and Windows. Biome's scanner resolved Zed's config directory using platform conventions, but Zed uses `~/.config/zed` on macOS and `%APPDATA%\Zed` on Windows, so the file is now correctly recognized as JSONC.

--- a/crates/biome_languages/src/json.rs
+++ b/crates/biome_languages/src/json.rs
@@ -2,7 +2,7 @@ use biome_rowan::FileSourceError;
 use biome_string_case::StrLikeExtension;
 use camino::Utf8Path;
 use core::str;
-use directories::{BaseDirs, ProjectDirs};
+use directories::ProjectDirs;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -367,12 +367,10 @@ fn vscode_global_directory() -> Option<ProjectDirs> {
 }
 
 fn zed_global_directory() -> Option<PathBuf> {
-    if cfg!(target_os = "macos") {
-        BaseDirs::new().map(|dirs| dirs.home_dir().join(".config").join("zed"))
-    } else if cfg!(target_os = "windows") {
-        BaseDirs::new().map(|dirs| dirs.config_dir().join("Zed"))
-    } else {
-        ProjectDirs::from("", "", "zed").map(|dirs| dirs.config_dir().to_path_buf())
+    cfg_select! {
+        target_os = "macos" => directories::BaseDirs::new().map(|dirs| dirs.home_dir().join(".config").join("zed")) ,
+        target_os = "windows" => directories::BaseDirs::new().map(|dirs| dirs.config_dir().join("Zed")),
+        _ =>  directories::ProjectDirs::from("", "", "zed").map(|dirs| dirs.config_dir().to_path_buf())
     }
 }
 
@@ -406,13 +404,13 @@ mod tests {
 
         #[cfg(target_os = "macos")]
         {
-            let base = BaseDirs::new().expect("Failed to get base dirs");
+            let base = directories::BaseDirs::new().expect("Failed to get base dirs");
             assert_eq!(dir, base.home_dir().join(".config").join("zed"));
         }
 
         #[cfg(target_os = "windows")]
         {
-            let base = BaseDirs::new().expect("Failed to get base dirs");
+            let base = directories::BaseDirs::new().expect("Failed to get base dirs");
             assert_eq!(dir, base.config_dir().join("Zed"));
         }
 

--- a/crates/biome_languages/src/json.rs
+++ b/crates/biome_languages/src/json.rs
@@ -2,8 +2,9 @@ use biome_rowan::FileSourceError;
 use biome_string_case::StrLikeExtension;
 use camino::Utf8Path;
 use core::str;
-use directories::ProjectDirs;
+use directories::{BaseDirs, ProjectDirs};
 use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -281,7 +282,7 @@ impl JsonFileSource {
             return Ok(Self::json_allow_comments_and_trailing_commas(extension));
         }
 
-        if zed_global_directory().is_some_and(|dir| path.starts_with(dir.config_dir()))
+        if zed_global_directory().is_some_and(|dir| path.starts_with(&dir))
             || vscode_global_directory().is_some_and(|dir| path.starts_with(dir.config_dir()))
             || cursor_global_directory().is_some_and(|dir| path.starts_with(dir.config_dir()))
         {
@@ -365,8 +366,14 @@ fn vscode_global_directory() -> Option<ProjectDirs> {
     ProjectDirs::from("", "Code", "User")
 }
 
-fn zed_global_directory() -> Option<ProjectDirs> {
-    ProjectDirs::from("", "", "zed")
+fn zed_global_directory() -> Option<PathBuf> {
+    if cfg!(target_os = "macos") {
+        BaseDirs::new().map(|dirs| dirs.home_dir().join(".config").join("zed"))
+    } else if cfg!(target_os = "windows") {
+        BaseDirs::new().map(|dirs| dirs.config_dir().join("Zed"))
+    } else {
+        ProjectDirs::from("", "", "zed").map(|dirs| dirs.config_dir().to_path_buf())
+    }
 }
 
 #[cfg(test)]
@@ -395,10 +402,21 @@ mod tests {
 
     #[test]
     fn test_global_zed_settings() {
-        let path = zed_global_directory()
-            .expect("Failed to get config directory")
-            .config_dir()
-            .join("settings.json");
+        let dir = zed_global_directory().expect("Failed to get config directory");
+
+        #[cfg(target_os = "macos")]
+        {
+            let base = BaseDirs::new().expect("Failed to get base dirs");
+            assert_eq!(dir, base.home_dir().join(".config").join("zed"));
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            let base = BaseDirs::new().expect("Failed to get base dirs");
+            assert_eq!(dir, base.config_dir().join("Zed"));
+        }
+
+        let path = dir.join("settings.json");
         let path = Utf8Path::from_path(path.as_path()).expect("Failed to create Utf8Path");
         let file_source =
             JsonFileSource::try_from_well_known(path).expect("Failed to create JsonFileSource");


### PR DESCRIPTION
The `biome_languages::json::zed_global_directory` function relied on `ProjectDirs`, whose `config_dir` follows platform conventions:

* `~/Library/Application Support/zed` on macOS
* `%APPDATA%\zed\config` on Windows

Zed actually stores its global config at `~/.config/zed` (macOS) and `%APPDATA%\Zed` (Windows), so the path check never matched and the file fell back to strict JSON.

These changes update `zed_global_directory` to resolve the directory the way Zed does per OS:

* `~/.config/zed` on macOS
* `%APPDATA%\Zed` on Windows
* `$XDG_CONFIG_HOME/zed` on Linux

> After finding a way to reproduce this issue, AI was used to confirm the suspicion as I'm not familiar with Biome's codebase, as well as to update the code and tests accordingly.

## Summary

When using Zed to edit its own settings file (`zed: open settings file`), errors were being reported for the file, even though that doesn't happen out of the box. I was able to confirm this only happened after installing Biome.

Some time later I also noticed that this bug didn't happen when a different JSON file was opened first, say, the default vim key bindings file (`assets/keymaps/vim.json`) . I confirmed that Zed does send `languageId: "jsonc"` when sending the `didOpen` message to Biome for its settings file but it seemed to be ignored when opening the settings file first.

When looking closer, I believe this bug was happening in the following fasion:

1. Open Zed's settings file when Biome hasn't started yet
    This will send `languageId: "jsonc"` to Biome and no errors will be shown
2. Biome kicks off it's project scanner
3. When the scanner looks at `~/.config/zed/settings.json` it doesn't identify it as Zed's global settings file and assumes `JSON` instead of `JSONC`
4. Diagnostics are now updated and Biome complains about the comments in Zed's settings file

It seems an issue had already been open with a similar report https://github.com/biomejs/biome/issues/6589 .

## Test Plan

Testing was done by first building the language server from `main`, pointing Zed to use this build and confirming that Biome reported the errors for `~/.config/zed/settings.json` . After updating the way Biome detects if the file is Zed's global settings file, a new build was used to confirm that, even if Biome's scanner finishes after opening `~/.config/zed/settings.json`, no errors are reported, as Biome now assumes `JSONC` as the language for this path.

The existing `biome_languages::json::tests::test_global_zed_settings` test has also been updated to check against the correct paths for both macOS and Windows. 

## Docs

N/A