### PR TITLE
perf(cli): don't drop file guard and reuse data

### DIFF
--- a/crates/biome_cli/src/runner/crawler.rs
+++ b/crates/biome_cli/src/runner/crawler.rs
@@ -7,9 +7,10 @@ use biome_diagnostics::{Error, Severity};
 use biome_fs::{BiomePath, FileSystem, PathInterner, TraversalContext, TraversalScope};
 use biome_service::Workspace;
 use biome_service::projects::ProjectKey;
+use biome_service::workspace::FeaturesSupported;
 use camino::Utf8PathBuf;
 use crossbeam::channel::{Sender, unbounded};
-use papaya::{HashSet, HashSetRef, LocalGuard};
+use papaya::{HashMap, HashSet, HashSetRef, LocalGuard};
 use std::hash::RandomState;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -127,6 +128,8 @@ pub trait CrawlerContext: TraversalContext {
     fn workspace(&self) -> &dyn Workspace;
     fn project_key(&self) -> ProjectKey;
     fn execution(&self) -> &dyn Execution;
+    fn insert_file_features(&self, path: BiomePath, features: FeaturesSupported);
+    fn get_file_features(&self, path: &BiomePath) -> Option<FeaturesSupported>;
 }
 
 /// Context object shared between directory traversal tasks
@@ -151,6 +154,8 @@ pub(crate) struct CrawlerOptions<'ctx, 'app, H, P> {
     pub(crate) messages: Sender<Message>,
     /// List of paths that should be processed
     pub(crate) evaluated_paths: papaya::HashSet<BiomePath>,
+    /// File features already computed during path evaluation.
+    pub(crate) file_features: papaya::HashMap<BiomePath, FeaturesSupported>,
     /// Maximum number of diagnostics to pull from the workspace.
     pub(crate) max_diagnostics: u32,
     /// Minimum severity for diagnostics to be included.
@@ -210,6 +215,14 @@ where
     fn execution(&self) -> &dyn Execution {
         self.execution
     }
+
+    fn insert_file_features(&self, path: BiomePath, features: FeaturesSupported) {
+        self.file_features.pin().insert(path, features);
+    }
+
+    fn get_file_features(&self, path: &BiomePath) -> Option<FeaturesSupported> {
+        self.file_features.pin().get(path).cloned()
+    }
 }
 
 impl<'ctx, 'app, I, P> CrawlerOptions<'ctx, 'app, I, P>
@@ -235,6 +248,7 @@ where
             interner,
             messages: sender,
             evaluated_paths: HashSet::default(),
+            file_features: HashMap::default(),
             handler: I::default(),
             changed: AtomicUsize::new(0),
             unchanged: AtomicUsize::new(0),

--- a/crates/biome_cli/src/runner/handler.rs
+++ b/crates/biome_cli/src/runner/handler.rs
@@ -101,7 +101,12 @@ pub trait Handler: Default + Send + Sync + Debug + std::panic::RefUnwindSafe {
             }
         };
 
-        execution.can_handle(file_features)
+        let can_handle = execution.can_handle(file_features.clone());
+        if can_handle {
+            ctx.insert_file_features(biome_path.clone(), file_features);
+        }
+
+        can_handle
     }
 
     /// This function wraps the [process_file] function implementing the traversal

--- a/crates/biome_cli/src/runner/process_file.rs
+++ b/crates/biome_cli/src/runner/process_file.rs
@@ -263,18 +263,17 @@ impl<'ctx, 'app> WorkspaceFile<'ctx, 'app> {
             .open_with_options(path.as_path(), open_options)
             .with_file_path(path.to_string())?;
 
-        let mut input = String::new();
-        file.read_to_string(&mut input)
-            .with_file_path(path.to_string())?;
-
-        let guard = FileGuard::new(ctx.workspace(), ctx.project_key(), path.clone())
-            .with_file_path_and_code(path.to_string(), category!("internalError/fs"))?;
-
         if ctx.workspace().file_exists(FileExistsParams {
             file_path: path.clone(),
         })? {
+            let guard = FileGuard::borrowed(ctx.workspace(), ctx.project_key(), path.clone())
+                .with_file_path_and_code(path.to_string(), category!("internalError/fs"))?;
+
             Ok(Self { guard, path, file })
         } else {
+            let guard = FileGuard::new(ctx.workspace(), ctx.project_key(), path.clone())
+                .with_file_path_and_code(path.to_string(), category!("internalError/fs"))?;
+
             let mut input = String::new();
             file.read_to_string(&mut input)
                 .with_file_path(path.to_string())?;
@@ -315,5 +314,232 @@ impl<'ctx, 'app> WorkspaceFile<'ctx, 'app> {
         self.guard
             .change_file(self.file.file_version(), new_content)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WorkspaceFile;
+    use crate::runner::crawler::CrawlerContext;
+    use crate::runner::execution::{AnalyzerSelectors, Execution};
+    use crate::runner::process_file::Message;
+    use biome_console::MarkupBuf;
+    use biome_diagnostics::{Category, Error, category};
+    use biome_fs::{BiomePath, FileSystem, MemoryFileSystem, PathInterner, TraversalContext};
+    use biome_service::projects::ProjectKey;
+    use biome_service::workspace::{
+        FeatureName, FeaturesBuilder, FeaturesSupported, FileContent, GetFileContentParams,
+        OpenFileParams, OpenProjectParams, OpenProjectResult, SupportKind, server,
+    };
+    use biome_service::{Workspace, WorkspaceError};
+    use camino::Utf8PathBuf;
+    use papaya::{HashSet, HashSetRef, LocalGuard};
+    use std::hash::RandomState;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[derive(Debug)]
+    struct TestExecution {
+        write: bool,
+    }
+
+    impl Execution for TestExecution {
+        fn wanted_features(&self) -> FeatureName {
+            FeaturesBuilder::new().with_all().build()
+        }
+
+        fn not_requested_features(&self) -> FeatureName {
+            FeaturesBuilder::new().build()
+        }
+
+        fn can_handle(&self, _features: FeaturesSupported) -> bool {
+            true
+        }
+
+        fn is_vcs_targeted(&self) -> bool {
+            false
+        }
+
+        fn supports_kind(&self, _file_features: &FeaturesSupported) -> Option<SupportKind> {
+            None
+        }
+
+        fn get_stdin_file_path(&self) -> Option<&str> {
+            None
+        }
+
+        fn as_diagnostic_category(&self) -> &'static Category {
+            category!("check")
+        }
+
+        fn requires_write_access(&self) -> bool {
+            self.write
+        }
+
+        fn analyzer_selectors(&self) -> AnalyzerSelectors {
+            AnalyzerSelectors::default()
+        }
+
+        fn summary_phrase(&self, _files: usize, _duration: &Duration) -> MarkupBuf {
+            MarkupBuf::default()
+        }
+    }
+
+    struct TestContext<'a> {
+        fs: Arc<MemoryFileSystem>,
+        workspace: &'a dyn Workspace,
+        project_key: ProjectKey,
+        execution: TestExecution,
+        interner: PathInterner,
+        evaluated_paths: HashSet<BiomePath>,
+    }
+
+    impl CrawlerContext for TestContext<'_> {
+        fn increment_changed(&self, _path: &BiomePath) {}
+
+        fn increment_unchanged(&self) {}
+
+        fn increment_matches(&self, _num_matches: usize) {}
+
+        fn increment_skipped(&self) {}
+
+        fn push_message(&self, _msg: Message) {}
+
+        fn fs(&self) -> &dyn FileSystem {
+            self.fs.as_ref()
+        }
+
+        fn workspace(&self) -> &dyn Workspace {
+            self.workspace
+        }
+
+        fn project_key(&self) -> ProjectKey {
+            self.project_key
+        }
+
+        fn execution(&self) -> &dyn Execution {
+            &self.execution
+        }
+    }
+
+    impl TraversalContext for TestContext<'_> {
+        fn interner(&self) -> &PathInterner {
+            &self.interner
+        }
+
+        fn push_diagnostic(&self, _error: Error) {}
+
+        fn can_handle(&self, _path: &BiomePath) -> bool {
+            true
+        }
+
+        fn handle_path(&self, _path: BiomePath) {}
+
+        fn store_path(&self, path: BiomePath) {
+            self.evaluated_paths.pin().insert(path);
+        }
+
+        fn evaluated_paths(&self) -> HashSetRef<'_, BiomePath, RandomState, LocalGuard<'_>> {
+            self.evaluated_paths.pin()
+        }
+    }
+
+    #[test]
+    fn workspace_file_borrows_existing_document() {
+        const SOURCE: &str = "const value = 1;";
+
+        let file_path = Utf8PathBuf::from("/project/file.js");
+        let fs = Arc::new(MemoryFileSystem::default());
+        fs.insert(file_path.clone(), SOURCE);
+
+        let workspace = server(fs.clone(), None);
+        let OpenProjectResult { project_key } = workspace
+            .open_project(OpenProjectParams {
+                path: BiomePath::new("/project"),
+                open_uninitialized: true,
+            })
+            .unwrap();
+        let path = BiomePath::new(&file_path);
+        workspace
+            .open_file(OpenFileParams {
+                project_key,
+                path: path.clone(),
+                content: FileContent::from_client(SOURCE),
+                document_file_source: None,
+                persist_node_cache: false,
+                inline_config: None,
+                editor_features: None,
+            })
+            .unwrap();
+
+        let (interner, _path_receiver) = PathInterner::new();
+        let ctx = TestContext {
+            fs,
+            workspace: workspace.as_ref(),
+            project_key,
+            execution: TestExecution { write: false },
+            interner,
+            evaluated_paths: HashSet::default(),
+        };
+
+        {
+            let _workspace_file = WorkspaceFile::new(&ctx, path.clone()).unwrap();
+        }
+
+        let content = workspace
+            .get_file_content(GetFileContentParams { project_key, path })
+            .unwrap();
+
+        assert_eq!(content, SOURCE);
+    }
+
+    #[test]
+    fn workspace_file_opens_updates_and_closes_new_document() {
+        const SOURCE: &str = "const value = 1;";
+        const UPDATED: &str = "const value = 2;";
+
+        let file_path = Utf8PathBuf::from("/project/file.js");
+        let fs = Arc::new(MemoryFileSystem::default());
+        fs.insert(file_path.clone(), SOURCE);
+
+        let workspace = server(fs.clone(), None);
+        let OpenProjectResult { project_key } = workspace
+            .open_project(OpenProjectParams {
+                path: BiomePath::new("/project"),
+                open_uninitialized: true,
+            })
+            .unwrap();
+        let path = BiomePath::new(&file_path);
+
+        let (interner, _path_receiver) = PathInterner::new();
+        let ctx = TestContext {
+            fs,
+            workspace: workspace.as_ref(),
+            project_key,
+            execution: TestExecution { write: true },
+            interner,
+            evaluated_paths: HashSet::default(),
+        };
+
+        {
+            let mut workspace_file = WorkspaceFile::new(&ctx, path.clone()).unwrap();
+            assert_eq!(workspace_file.input().unwrap(), SOURCE);
+
+            workspace_file.update_file(UPDATED).unwrap();
+            let content = workspace
+                .get_file_content(GetFileContentParams {
+                    project_key,
+                    path: path.clone(),
+                })
+                .unwrap();
+
+            assert_eq!(content, UPDATED);
+        }
+
+        let error = workspace
+            .get_file_content(GetFileContentParams { project_key, path })
+            .expect_err("new document should be closed on drop");
+
+        assert!(matches!(error, WorkspaceError::NotFound(_)));
     }
 }

--- a/crates/biome_cli/src/runner/process_file.rs
+++ b/crates/biome_cli/src/runner/process_file.rs
@@ -147,23 +147,29 @@ pub(crate) trait ProcessFile: Send + Sync + std::panic::RefUnwindSafe {
     where
         Ctx: CrawlerContext,
     {
-        let FileFeaturesResult {
-            features_supported: file_features,
-        } = ctx
-            .workspace()
-            .file_features(SupportsFeatureParams {
-                project_key: ctx.project_key(),
-                path: biome_path.clone(),
-                features: ctx.execution().wanted_features(),
-                inline_config: None,
-                skip_ignore_check: false,
-                not_requested_features: ctx.execution().not_requested_features(),
-            })
-            .with_file_path_and_code_and_tags(
-                biome_path.to_string(),
-                category!("files/missingHandler"),
-                DiagnosticTags::VERBOSE,
-            )?;
+        let file_features = if let Some(file_features) = ctx.get_file_features(biome_path) {
+            file_features
+        } else {
+            let FileFeaturesResult {
+                features_supported: file_features,
+            } = ctx
+                .workspace()
+                .file_features(SupportsFeatureParams {
+                    project_key: ctx.project_key(),
+                    path: biome_path.clone(),
+                    features: ctx.execution().wanted_features(),
+                    inline_config: None,
+                    skip_ignore_check: false,
+                    not_requested_features: ctx.execution().not_requested_features(),
+                })
+                .with_file_path_and_code_and_tags(
+                    biome_path.to_string(),
+                    category!("files/missingHandler"),
+                    DiagnosticTags::VERBOSE,
+                )?;
+
+            file_features
+        };
 
         // first we stop if there are some files that don't have ALL features enabled, e.g. images, fonts, etc.
         if file_features.is_ignored() || file_features.is_not_enabled() {
@@ -319,12 +325,12 @@ impl<'ctx, 'app> WorkspaceFile<'ctx, 'app> {
 
 #[cfg(test)]
 mod tests {
-    use super::WorkspaceFile;
+    use super::{FileStatus, ProcessFile, WorkspaceFile};
     use crate::runner::crawler::CrawlerContext;
     use crate::runner::execution::{AnalyzerSelectors, Execution};
     use crate::runner::process_file::Message;
     use biome_console::MarkupBuf;
-    use biome_diagnostics::{Category, Error, category};
+    use biome_diagnostics::{Category, Error, Severity, category};
     use biome_fs::{BiomePath, FileSystem, MemoryFileSystem, PathInterner, TraversalContext};
     use biome_service::projects::ProjectKey;
     use biome_service::workspace::{
@@ -333,7 +339,7 @@ mod tests {
     };
     use biome_service::{Workspace, WorkspaceError};
     use camino::Utf8PathBuf;
-    use papaya::{HashSet, HashSetRef, LocalGuard};
+    use papaya::{HashMap, HashSet, HashSetRef, LocalGuard};
     use std::hash::RandomState;
     use std::sync::Arc;
     use std::time::Duration;
@@ -392,6 +398,7 @@ mod tests {
         execution: TestExecution,
         interner: PathInterner,
         evaluated_paths: HashSet<BiomePath>,
+        file_features: HashMap<BiomePath, FeaturesSupported>,
     }
 
     impl CrawlerContext for TestContext<'_> {
@@ -419,6 +426,14 @@ mod tests {
 
         fn execution(&self) -> &dyn Execution {
             &self.execution
+        }
+
+        fn insert_file_features(&self, path: BiomePath, features: FeaturesSupported) {
+            self.file_features.pin().insert(path, features);
+        }
+
+        fn get_file_features(&self, path: &BiomePath) -> Option<FeaturesSupported> {
+            self.file_features.pin().get(path).cloned()
         }
     }
 
@@ -480,6 +495,7 @@ mod tests {
             execution: TestExecution { write: false },
             interner,
             evaluated_paths: HashSet::default(),
+            file_features: HashMap::default(),
         };
 
         {
@@ -519,6 +535,7 @@ mod tests {
             execution: TestExecution { write: true },
             interner,
             evaluated_paths: HashSet::default(),
+            file_features: HashMap::default(),
         };
 
         {
@@ -541,5 +558,36 @@ mod tests {
             .expect_err("new document should be closed on drop");
 
         assert!(matches!(error, WorkspaceError::NotFound(_)));
+    }
+
+    #[test]
+    fn process_file_uses_cached_file_features() {
+        let file_path = Utf8PathBuf::from("/project/missing.js");
+        let fs = Arc::new(MemoryFileSystem::default());
+        let workspace = server(fs.clone(), None);
+        let OpenProjectResult { project_key } = workspace
+            .open_project(OpenProjectParams {
+                path: BiomePath::new("/project"),
+                open_uninitialized: true,
+            })
+            .unwrap();
+        let path = BiomePath::new(&file_path);
+        let (interner, _path_receiver) = PathInterner::new();
+        let ctx = TestContext {
+            fs,
+            workspace: workspace.as_ref(),
+            project_key,
+            execution: TestExecution { write: false },
+            interner,
+            evaluated_paths: HashSet::default(),
+            file_features: HashMap::default(),
+        };
+        let mut file_features = FeaturesSupported::default();
+        file_features.set_ignored_for_all_features();
+        ctx.insert_file_features(path.clone(), file_features);
+
+        let result = <() as ProcessFile>::execute(&ctx, &path, u32::MAX, Severity::Hint).unwrap();
+
+        assert!(matches!(result, FileStatus::Ignored));
     }
 }

--- a/crates/biome_service/src/scanner.tests.rs
+++ b/crates/biome_service/src/scanner.tests.rs
@@ -1,6 +1,6 @@
 use biome_configuration::Configuration;
 use biome_deserialize::json::deserialize_from_json_str;
-use biome_fs::{BiomePath, FileSystem, OsFileSystem};
+use biome_fs::{BiomePath, FileSystem, MemoryFileSystem, OsFileSystem};
 use biome_json_parser::JsonParserOptions;
 use camino::Utf8PathBuf;
 
@@ -9,6 +9,37 @@ use crate::scanner::WorkspaceScannerBridge;
 use crate::settings::ModuleGraphResolutionKind;
 use crate::test_utils::setup_workspace_and_open_project;
 use crate::workspace::{GetFileContentParams, ScanKind, ScanProjectParams, UpdateSettingsParams};
+
+#[test]
+fn scan_project_result_does_not_expose_source_file_candidates() {
+    const SOURCE: &str = "const value = 1;";
+
+    let fs = MemoryFileSystem::default();
+    let file_path = Utf8PathBuf::from("/project/file.js");
+    fs.insert(file_path.clone(), SOURCE);
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/project");
+
+    let result = workspace
+        .scan_project(ScanProjectParams {
+            project_key,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::Project,
+            verbose: false,
+        })
+        .unwrap();
+
+    let content = workspace
+        .get_file_content(GetFileContentParams {
+            project_key,
+            path: BiomePath::new(file_path),
+        })
+        .unwrap();
+
+    assert_eq!(content, SOURCE);
+    assert!(result.configuration_files.is_empty());
+}
 
 #[test]
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -1844,6 +1844,7 @@ pub struct FileGuard<'app, W: Workspace + ?Sized> {
     workspace: &'app W,
     project_key: ProjectKey,
     path: BiomePath,
+    close_on_drop: bool,
 }
 
 impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
@@ -1856,6 +1857,20 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
             workspace,
             project_key,
             path,
+            close_on_drop: true,
+        })
+    }
+
+    pub fn borrowed(
+        workspace: &'app W,
+        project_key: ProjectKey,
+        path: BiomePath,
+    ) -> Result<Self, WorkspaceError> {
+        Ok(Self {
+            workspace,
+            project_key,
+            path,
+            close_on_drop: false,
         })
     }
 
@@ -2034,6 +2049,10 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
 
 impl<W: Workspace + ?Sized> Drop for FileGuard<'_, W> {
     fn drop(&mut self) {
+        if !self.close_on_drop {
+            return;
+        }
+
         self.workspace
             .close_file(CloseFileParams {
                 project_key: self.project_key,

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -1,8 +1,8 @@
 use super::{
     CloseFileParams, CloseProjectParams, FileContent, FileFeaturesResult, FileGuard,
-    GetFileContentParams, GetModuleGraphParams, GetSyntaxTreeParams, OpenFileParams, OpenProjectParams,
-    OpenProjectResult, PullDiagnosticsParams, ScanKind, ScanProjectParams, UpdateKind,
-    UpdateModuleGraphParams, UpdateSettingsParams, server,
+    GetFileContentParams, GetModuleGraphParams, GetSyntaxTreeParams, OpenFileParams,
+    OpenProjectParams, OpenProjectResult, PullDiagnosticsParams, ScanKind, ScanProjectParams,
+    UpdateKind, UpdateModuleGraphParams, UpdateSettingsParams, server,
 };
 use crate::projects::ProjectKey;
 use crate::settings::ModuleGraphResolutionKind;

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -1,6 +1,6 @@
 use super::{
     CloseFileParams, CloseProjectParams, FileContent, FileFeaturesResult, FileGuard,
-    GetModuleGraphParams, GetSyntaxTreeParams, OpenFileParams, OpenProjectParams,
+    GetFileContentParams, GetModuleGraphParams, GetSyntaxTreeParams, OpenFileParams, OpenProjectParams,
     OpenProjectResult, PullDiagnosticsParams, ScanKind, ScanProjectParams, UpdateKind,
     UpdateModuleGraphParams, UpdateSettingsParams, server,
 };
@@ -35,6 +35,35 @@ fn create_server() -> (Box<dyn Workspace>, ProjectKey) {
         .unwrap();
 
     (workspace, project_key)
+}
+
+#[test]
+fn borrowed_file_guard_does_not_close_file() {
+    const SOURCE: &str = "const value = 1;";
+
+    let (workspace, project_key) = create_server();
+    let path = BiomePath::new("file.js");
+    workspace
+        .open_file(OpenFileParams {
+            project_key,
+            path: path.clone(),
+            content: FileContent::from_client(SOURCE),
+            document_file_source: Some(DocumentFileSource::from(JsFileSource::default())),
+            persist_node_cache: false,
+            inline_config: None,
+            editor_features: None,
+        })
+        .unwrap();
+
+    {
+        let _guard = FileGuard::borrowed(workspace.as_ref(), project_key, path.clone()).unwrap();
+    }
+
+    let content = workspace
+        .get_file_content(GetFileContentParams { project_key, path })
+        .unwrap();
+
+    assert_eq!(content, SOURCE);
 }
 
 #[test]


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Two small optimisations written with an AI agent:
- Don't drop the `WorkspaceGuard` if the file exists in the workspace.
- Re-use the result of `FeaturesSupported` during scanning.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests. Green CI.
No changeset since this is just an internal change.

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
