### PR TITLE
fix(cli): escape backslashes in JSON reporter file paths

### DIFF
--- a/.changeset/fix-json-reporter-path-escaping.md
+++ b/.changeset/fix-json-reporter-path-escaping.md
@@ -1,0 +1,10 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9899](https://github.com/biomejs/biome/issues/9899): the `json` and `json-pretty` reporters now escape backslashes in a diagnostic's `location.path`. Previously, paths containing backslashes (such as Windows-style paths) were emitted unescaped, producing invalid JSON.
+
+```diff
+-    "path": "src\account\setup-passkey.tsx",
++    "path": "src\\account\\setup-passkey.tsx",
+```

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -109,7 +109,9 @@ fn location_report_to_json(location: &LocationReport) -> AnyJsonValue {
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("path"))),
             token(T![:]),
-            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&location.path))),
+            AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(&json_escape(
+                &location.path,
+            )))),
         ),
         json_member(
             AnyJsonMemberName::JsonMemberName(json_member_name(json_string_literal("start"))),

--- a/crates/biome_cli/tests/cases/reporter_json.rs
+++ b/crates/biome_cli/tests/cases/reporter_json.rs
@@ -232,3 +232,58 @@ fn reports_diagnostics_json_with_escaped_quotes() {
         result,
     ));
 }
+
+// A file whose name literally contains backslashes mimics a Windows-style path
+// in `location.path`. The backslashes must be escaped so the report stays valid
+// JSON. See https://github.com/biomejs/biome/issues/9899
+const MAIN_WITH_BACKSLASH_PATH: &str = r#"function NaN() {}"#;
+
+#[test]
+fn reports_diagnostics_json_with_backslash_path() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new(r"src\app\main.ts");
+    fs.insert(file_path.into(), MAIN_WITH_BACKSLASH_PATH.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--reporter=json-pretty", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "reports_diagnostics_json_with_backslash_path",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn reports_diagnostics_json_compact_with_backslash_path() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new(r"src\app\main.ts");
+    fs.insert(file_path.into(), MAIN_WITH_BACKSLASH_PATH.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--reporter=json", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "reports_diagnostics_json_compact_with_backslash_path",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_compact_with_backslash_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_compact_with_backslash_path.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 549
+expression: redactor(content)
+---
+## `src\app\main.ts`
+
+```ts
+function NaN() {}
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+The --json option is unstable/experimental and its output might change between patches/minor releases.
+```
+
+```block
+{"summary":{"changed":0,"unchanged":1,"matches":0,"duration":"<TIME>","errors":2,"warnings":1,"infos":0,"skipped":0,"suggestedFixesSkipped":0,"diagnosticsNotPrinted":0,"scannerDuration":"<TIME>"},"diagnostics":[{"severity":"warning","message":"This function NaN is unused.","category":"lint/correctness/noUnusedVariables","location":{"path":"src\\app\\main.ts","start":{"line":1,"column":10},"end":{"line":1,"column":13}},"advices":[]},{"severity":"error","message":"Do not shadow the global \"NaN\" property.","category":"lint/suspicious/noShadowRestrictedNames","location":{"path":"src\\app\\main.ts","start":{"line":1,"column":10},"end":{"line":1,"column":13}},"advices":[]},{"severity":"error","message":"Formatter would have printed the following content:","category":"format","location":{"path":"src\\app\\main.ts","start":{"line":0,"column":0},"end":{"line":0,"column":0}},"advices":[]}],"command":"check"}
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_with_backslash_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_json/reports_diagnostics_json_with_backslash_path.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 549
+expression: redactor(content)
+---
+## `src\app\main.ts`
+
+```ts
+function NaN() {}
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+The --json option is unstable/experimental and its output might change between patches/minor releases.
+```
+
+```block
+{
+	"summary": {
+		"changed": 0,
+		"unchanged": 1,
+		"matches": 0,
+		"duration": "<TIME>",
+		"errors": 2,
+		"warnings": 1,
+		"infos": 0,
+		"skipped": 0,
+		"suggestedFixesSkipped": 0,
+		"diagnosticsNotPrinted": 0,
+		"scannerDuration": "<TIME>"
+	},
+	"diagnostics": [
+		{
+			"severity": "warning",
+			"message": "This function NaN is unused.",
+			"category": "lint/correctness/noUnusedVariables",
+			"location": {
+				"path": "src\\app\\main.ts",
+				"start": { "line": 1, "column": 10 },
+				"end": { "line": 1, "column": 13 }
+			},
+			"advices": []
+		},
+		{
+			"severity": "error",
+			"message": "Do not shadow the global \"NaN\" property.",
+			"category": "lint/suspicious/noShadowRestrictedNames",
+			"location": {
+				"path": "src\\app\\main.ts",
+				"start": { "line": 1, "column": 10 },
+				"end": { "line": 1, "column": 13 }
+			},
+			"advices": []
+		},
+		{
+			"severity": "error",
+			"message": "Formatter would have printed the following content:",
+			"category": "format",
+			"location": {
+				"path": "src\\app\\main.ts",
+				"start": { "line": 0, "column": 0 },
+				"end": { "line": 0, "column": 0 }
+			},
+			"advices": []
+		}
+	],
+	"command": "check"
+}
+
+```


### PR DESCRIPTION
## Summary

Fixes #9899. The `json` and `json-pretty` reporters emitted a diagnostic's `location.path` without escaping it, so paths containing backslashes (such as Windows paths) produced invalid JSON:

```
"path": "src\account\setup-passkey.tsx"
```

This wraps `location.path` in the existing `json_escape` helper, the same way `message` and `suggestion.text` are already handled in this reporter, so the path stays a valid JSON string while preserving the original separators.

A changeset is included.

## Test Plan

Added two regression tests in `crates/biome_cli/tests/cases/reporter_json.rs` that run `check` on a file whose name contains backslashes (a literal backslash is a valid filename character on Linux, so this reproduces the bug deterministically on any OS) and snapshot the output for both `--reporter=json` and `--reporter=json-pretty`. The emitted `location.path` is now `"src\\app\\main.ts"`, which parses as valid JSON.

## Docs

No docs change needed.

---

AI assistance disclosure: the code and tests in this PR were produced with the help of Claude Code and reviewed before submission.
