### PR TITLE
fix(cli): respect --config-path and BIOME_CONFIG_PATH in rage command

### DIFF
--- a/.changeset/fix-rage-config-path.md
+++ b/.changeset/fix-rage-config-path.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6686](https://github.com/biomejs/biome/issues/6686): the `rage` command now respects the `--config-path` option and the `BIOME_CONFIG_PATH` environment variable when loading the Biome configuration. Previously it always used the default configuration resolution and reported the configuration as `Not set` when no `biome.json` existed in the working directory.

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -1,9 +1,10 @@
+use crate::cli_options::CliOptions;
 use crate::commands::daemon::read_most_recent_log_file;
 use crate::service::enumerate_pipes;
 use crate::{CliDiagnostic, CliSession, VERSION, service};
 use biome_analyze::RuleFilter;
+use biome_configuration::Rules;
 use biome_configuration::analyzer::{DomainSelector, RuleDomainValue};
-use biome_configuration::{ConfigurationPathHint, Rules};
 use biome_console::fmt::{Display, Formatter};
 use biome_console::{
     ConsoleExt, DebugDisplay, DisplayOption, HorizontalLine, KeyValuePair, Padding, SOFT_LINE, fmt,
@@ -27,6 +28,7 @@ use tokio::runtime::Runtime;
 /// Handler for the `rage` command
 pub(crate) fn rage(
     session: CliSession,
+    cli_options: &CliOptions,
     daemon_logs: bool,
     formatter: bool,
     linter: bool,
@@ -52,7 +54,7 @@ pub(crate) fn rage(
     {EnvVarOs("JS_RUNTIME_NAME")}
     {EnvVarOs("NODE_PACKAGE_MANAGER")}
 
-    {RageConfiguration { fs: session.app.workspace.fs(), formatter, linter }}
+    {RageConfiguration { fs: session.app.workspace.fs(), formatter, linter, cli_options }}
     {WorkspaceRage(session.app.workspace.deref())}
     ));
 
@@ -199,13 +201,18 @@ struct RageConfiguration<'a> {
     fs: &'a dyn FsWithResolverProxy,
     formatter: bool,
     linter: bool,
+    cli_options: &'a CliOptions,
 }
 
 impl Display for RageConfiguration<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
         Section("Biome Configuration").fmt(fmt)?;
 
-        match load_configuration(self.fs, ConfigurationPathHint::default()) {
+        let working_dir = self.fs.working_directory().unwrap_or_default();
+        let path_hint = self
+            .cli_options
+            .as_configuration_path_hint(working_dir.as_path());
+        match load_configuration(self.fs, path_hint) {
             Ok(loaded_configuration) => {
                 if loaded_configuration.directory_path.is_none() {
                     markup! {

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -71,8 +71,8 @@ impl<'app> CliSession<'app> {
         match command {
             BiomeCommand::Version(_) => commands::version::full_version(self),
             BiomeCommand::Upgrade => commands::upgrade::upgrade(self),
-            BiomeCommand::Rage(_, _, daemon_logs, formatter, linter) => {
-                commands::rage::rage(self, daemon_logs, formatter, linter)
+            BiomeCommand::Rage(cli_options, _, daemon_logs, formatter, linter) => {
+                commands::rage::rage(self, &cli_options, daemon_logs, formatter, linter)
             }
             BiomeCommand::Clean => commands::clean::clean(self),
             BiomeCommand::Start {

--- a/crates/biome_cli/tests/commands/rage.rs
+++ b/crates/biome_cli/tests/commands/rage.rs
@@ -54,6 +54,64 @@ fn with_configuration() {
     ));
 }
 
+// The configuration lives at a non-default path and is selected via `--config-path`.
+// Because bpaf populates the same `config_path` field from either the flag or the
+// `BIOME_CONFIG_PATH` env var, exercising the flag also covers the env var, without
+// mutating the process environment. See https://github.com/biomejs/biome/issues/6686
+#[test]
+#[serial]
+fn with_custom_config_path() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+    fs.insert(
+        Utf8Path::new("custom/biome.json").to_path_buf(),
+        r#"{
+  "formatter": {
+    "enabled": false
+  }
+}"#,
+    );
+
+    let (fs, result) = run_rage(
+        fs,
+        &mut console,
+        Args::from(["rage", "--config-path=custom/biome.json"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_rage_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "with_custom_config_path",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+#[serial]
+fn with_missing_custom_config_path() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let (fs, result) = run_rage(
+        fs,
+        &mut console,
+        Args::from(["rage", "--config-path=missing/biome.json"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_rage_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "with_missing_custom_config_path",
+        fs,
+        console,
+        result,
+    ));
+}
+
 #[test]
 #[serial]
 fn with_no_configuration() {

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_custom_config_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_custom_config_path.snap
@@ -1,0 +1,60 @@
+---
+source: crates/biome_cli/tests/commands/rage.rs
+assertion_line: 384
+expression: content
+---
+## `custom/biome.json`
+
+```json
+{
+  "formatter": {
+    "enabled": false
+  }
+}
+```
+
+# Emitted Messages
+
+```block
+CLI:
+  Version:                      0.0.0
+  Color support:                **PLACEHOLDER**
+
+Platform:
+  CPU Architecture:             **PLACEHOLDER**
+  OS:                           **PLACEHOLDER**
+
+Environment:
+  BIOME_DISTRIBUTION:                unset
+  BIOME_LOG_PATH:                    **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:             unset
+  BIOME_LOG_LEVEL:                   unset
+  BIOME_LOG_KIND:                    unset
+  BIOME_CONFIG_PATH:                 unset
+  BIOME_THREADS:                     unset
+  BIOME_WATCHER_KIND:                unset
+  BIOME_WATCHER_POLLING_INTERVAL:    unset
+  NO_COLOR:                     **PLACEHOLDER**
+  TERM:                         **PLACEHOLDER**
+  JS_RUNTIME_VERSION:           unset
+  JS_RUNTIME_NAME:              unset
+  NODE_PACKAGE_MANAGER:         unset
+
+Biome Configuration:
+  Status:                       Loaded successfully.
+  Path:                         custom/biome.json
+  Formatter enabled:            false
+  Linter enabled:               true
+  Assist enabled:               true
+  VCS enabled:                  false
+  HTML full support enabled:    unset
+
+Server:
+  Version:                      0.0.0
+  Name:                         biome_lsp
+  CPU Architecture:             **PLACEHOLDER**
+  OS:                           **PLACEHOLDER**
+
+Workspace:
+  Open Documents:               0
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_missing_custom_config_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_missing_custom_config_path.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_cli/tests/commands/rage.rs
+assertion_line: 384
+expression: content
+---
+# Emitted Messages
+
+```block
+CLI:
+  Version:                      0.0.0
+  Color support:                **PLACEHOLDER**
+
+Platform:
+  CPU Architecture:             **PLACEHOLDER**
+  OS:                           **PLACEHOLDER**
+
+Environment:
+  BIOME_DISTRIBUTION:                unset
+  BIOME_LOG_PATH:                    **PLACEHOLDER**
+  BIOME_LOG_PREFIX_NAME:             unset
+  BIOME_LOG_LEVEL:                   unset
+  BIOME_LOG_KIND:                    unset
+  BIOME_CONFIG_PATH:                 unset
+  BIOME_THREADS:                     unset
+  BIOME_WATCHER_KIND:                unset
+  BIOME_WATCHER_POLLING_INTERVAL:    unset
+  NO_COLOR:                     **PLACEHOLDER**
+  TERM:                         **PLACEHOLDER**
+  JS_RUNTIME_VERSION:           unset
+  JS_RUNTIME_NAME:              unset
+  NODE_PACKAGE_MANAGER:         unset
+
+Biome Configuration:
+  Status:                       Failed to load
+  Error:                        Biome couldn't find a configuration in the directory missing/biome.json.
+
+Server:
+  Version:                      0.0.0
+  Name:                         biome_lsp
+  CPU Architecture:             **PLACEHOLDER**
+  OS:                           **PLACEHOLDER**
+
+Workspace:
+  Open Documents:               0
+```


### PR DESCRIPTION
## Summary

Fixes #6686. The `rage` command always loaded the configuration with the default path resolution, so `--config-path` and the `BIOME_CONFIG_PATH` environment variable were ignored — `rage` reported the configuration as `Not set` even when the user pointed at a config elsewhere.

The `BiomeCommand::Rage` variant already parses `CliOptions`, but the call site discarded it. This threads `CliOptions` into the rage handler and reuses `CliOptions::as_configuration_path_hint` — the same helper the runner uses — so the user-supplied path is honored.

A changeset is included.

## Test Plan

Added two tests in `crates/biome_cli/tests/commands/rage.rs`:

- `with_custom_config_path`: a config at a non-default path selected via `--config-path`; the snapshot now shows it `Loaded successfully` with `Path: custom/biome.json`.
- `with_missing_custom_config_path`: an invalid `--config-path` is reported as `Failed to load`.

The tests pass `--config-path` through `Args` against a `MemoryFileSystem` and do **not** mutate the process environment. Because bpaf populates the same `config_path` field from both the flag and `BIOME_CONFIG_PATH`, this also covers the env var without needing an `EnvVarGuard`/`Mutex` (the test-safety concern that stalled the earlier attempt in #6843).

## Docs

No docs change needed.

---

AI assistance disclosure: the code and tests in this PR were produced with the help of Claude Code and reviewed before submission.
