### PR TITLE
fix(migrate): preserve "preset" mapping for deprecated recommended boolean

### DIFF
--- a/.changeset/fix-migrate-recommended-preset.md
+++ b/.changeset/fix-migrate-recommended-preset.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10716](https://github.com/biomejs/biome/issues/10716): `biome migrate --write` now correctly preserves the `recommended` preset when migrating the deprecated `linter.rules.recommended: true` boolean to `linter.rules.preset`. The mapping was previously broken for inputs where whitespace was attached as token trivia, causing `true` to be rewritten to `preset: "none"` and silently disabling all rules.

--- a/crates/biome_migrate/src/analyzers/recommended.rs
+++ b/crates/biome_migrate/src/analyzers/recommended.rs
@@ -51,7 +51,7 @@ impl Rule for Recommended {
         let mut mutation = ctx.root().begin();
         let bool_value_str = bool_value.value_token().ok()?;
 
-        let new_value = if bool_value_str.text() == "true" {
+        let new_value = if bool_value_str.text_trimmed() == "true" {
             "recommended"
         } else {
             "none"

--- a/crates/biome_migrate/tests/specs/migrations/recommended/invalid.json
+++ b/crates/biome_migrate/tests/specs/migrations/recommended/invalid.json
@@ -1,0 +1,8 @@
+{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/crates/biome_migrate/tests/specs/migrations/recommended/invalid.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/recommended/invalid.json.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_migrate/tests/spec_tests.rs
+assertion_line: 50
+expression: invalid.json
+---
+# Input
+```json
+{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}
+
+```
+
+# Diagnostics
+```
+invalid.json:5:7 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The recommended option is deprecated.
+  
+    3 │     "enabled": true,
+    4 │     "rules": {
+  > 5 │       "recommended": true
+      │       ^^^^^^^^^^^^^^^^^^^
+    6 │     }
+    7 │   }
+  
+  i Safe fix: Use the new preset field instead.
+  
+    3  3 │       "enabled": true,
+    4  4 │       "rules": {
+    5    │ - ······"recommended":·true
+       5 │ + ······"preset"
+       6 │ + ·······:"recommended"
+    6  7 │       }
+    7  8 │     }
+  
+
+```

--- a/crates/biome_migrate/tests/specs/migrations/recommended/invalid_false.json
+++ b/crates/biome_migrate/tests/specs/migrations/recommended/invalid_false.json
@@ -1,0 +1,8 @@
+{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false
+    }
+  }
+}

--- a/crates/biome_migrate/tests/specs/migrations/recommended/invalid_false.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/recommended/invalid_false.json.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_migrate/tests/spec_tests.rs
+assertion_line: 50
+expression: invalid_false.json
+---
+# Input
+```json
+{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false
+    }
+  }
+}
+
+```
+
+# Diagnostics
+```
+invalid_false.json:5:7 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The recommended option is deprecated.
+  
+    3 │     "enabled": true,
+    4 │     "rules": {
+  > 5 │       "recommended": false
+      │       ^^^^^^^^^^^^^^^^^^^^
+    6 │     }
+    7 │   }
+  
+  i Safe fix: Use the new preset field instead.
+  
+    3  3 │       "enabled": true,
+    4  4 │       "rules": {
+    5    │ - ······"recommended":·false
+       5 │ + ······"preset"
+       6 │ + ·······:"none"
+    6  7 │       }
+    7  8 │     }
+  
+
+```


### PR DESCRIPTION
Fixes #10716

## Summary

`biome migrate --write` rewrote `linter.rules.recommended: true` to
`linter.rules.preset: "none"` -- the opposite of the intended
behaviour (`true` means the recommended rules are on).

Root cause: the analyzer compared `bool_value.value_token().text()`
against the literal string `"true"`. The green-token `text()` method
returns the token text **including any leading/trailing trivia**, so a
boolean whose surrounding whitespace attached as token trivia never
matched → it fell through to the `else` branch and emitted
`"preset": "none"`.

The sibling migrations `monorepo` (`#10716::monorepo:41`) and
`organize_imports` (`#:148`) already use `text_trimmed()` on a
boolean value_token() for the same reason.

## Test plan

- New spec tests in
  `crates/biome_migrate/tests/specs/migrations/recommended/`:
  - `invalid.json`  — input contains `"recommended": true`. The
    fix yields `"preset": "recommended"` (was `"none"`).
  - `invalid_false.json` — input contains `"recommended": false`.
    Yields `"preset": "none"` (this case was previously
    correct because `text() != "true"` falls through; the new
    `text_trimmed() != "true"` reaches the same branch).
- Manually re-checked the binary implementation against the JSON
  parser: trivia is attached to the value_token, so
  `text() == "true"` is unsafe for any input that has
  surrounding whitespace.

## AI assistance

This patch was drafted with the help of an AI coding assistant. The
bug analysis was verified against the existing `monorepo` /
`organize_imports` migrators which already use the same
`text_trimmed()` pattern. Per the Biome AI assistance notice this
disclosure is offered for transparency.