### PR TITLE
fix(biome_js_analyze): useValidAutocomplete matches camelCase autoComplete

### DIFF
--- a/.changeset/fix-use-valid-autocomplete-camelcase.md
+++ b/.changeset/fix-use-valid-autocomplete-camelcase.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10739](https://github.com/biomejs/biome/issues/10739): [`useValidAutocomplete`](https://biomejs.dev/linter/rules/use-valid-autocomplete/) now recognizes React's camelCase `autoComplete` attribute. Previously the rule only matched the lowercase `autocomplete` spelling, so invalid autocomplete values written in idiomatic JSX/TSX were never reported.

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_autocomplete.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_autocomplete.rs
@@ -3,8 +3,10 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::jsx_ext::AnyJsxElement;
-use biome_rowan::{AstNode, TextRange};
+use biome_js_syntax::{
+    AnyJsxAttribute, AnyJsxAttributeName, JsxAttribute, jsx_ext::AnyJsxElement,
+};
+use biome_rowan::{AstNode, AstNodeList, TextRange};
 use biome_rule_options::use_valid_autocomplete::UseValidAutocompleteOptions;
 
 declare_lint_rule! {
@@ -154,7 +156,7 @@ impl Rule for UseValidAutocomplete {
             return None;
         }
 
-        let autocomplete_attribute = node.attributes().find_by_name("autocomplete")?;
+        let autocomplete_attribute = find_autocomplete_attribute(node)?;
         let autocomplete_val = autocomplete_attribute.as_static_value()?;
         let autocompletes = autocomplete_val
             .text()
@@ -188,6 +190,22 @@ impl Rule for UseValidAutocomplete {
         })
     )
     }
+}
+
+fn find_autocomplete_attribute(node: &AnyJsxElement) -> Option<JsxAttribute> {
+    node.attributes().iter().find_map(|attribute| {
+        if let AnyJsxAttribute::JsxAttribute(attribute) = attribute
+            && let Ok(AnyJsxAttributeName::JsxName(name)) = attribute.name()
+            && name
+                .value_token()
+                .ok()?
+                .text_trimmed()
+                .eq_ignore_ascii_case("autocomplete")
+        {
+            return Some(attribute);
+        }
+        None
+    })
 }
 
 /// Checks if the autocomplete attribute values are valid

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx
@@ -1,6 +1,8 @@
 /* should generate diagnostics */
 <>
 	<input type="text" autocomplete="foo" />
+	<input type="text" autoComplete="foo" />
+	<input type="text" autoCOMPLETE="bar" />
 	<input type="text" autocomplete="name invalid" />
 	<input type="text" autocomplete="invalid name" />
 	<input type="text" autocomplete="home url" />

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx.snap
@@ -7,6 +7,8 @@ expression: invalid.jsx
 /* should generate diagnostics */
 <>
 	<input type="text" autocomplete="foo" />
+	<input type="text" autoComplete="foo" />
+	<input type="text" autoCOMPLETE="bar" />
 	<input type="text" autocomplete="name invalid" />
 	<input type="text" autocomplete="invalid name" />
 	<input type="text" autocomplete="home url" />
@@ -26,8 +28,8 @@ invalid.jsx:3:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
     2 │ <>
   > 3 │ 	<input type="text" autocomplete="foo" />
       │ 	                   ^^^^^^^^^^^^^^^^^^
-    4 │ 	<input type="text" autocomplete="name invalid" />
-    5 │ 	<input type="text" autocomplete="invalid name" />
+    4 │ 	<input type="text" autoComplete="foo" />
+    5 │ 	<input type="text" autoCOMPLETE="bar" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -46,10 +48,10 @@ invalid.jsx:4:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
   
     2 │ <>
     3 │ 	<input type="text" autocomplete="foo" />
-  > 4 │ 	<input type="text" autocomplete="name invalid" />
-      │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    5 │ 	<input type="text" autocomplete="invalid name" />
-    6 │ 	<input type="text" autocomplete="home url" />
+  > 4 │ 	<input type="text" autoComplete="foo" />
+      │ 	                   ^^^^^^^^^^^^^^^^^^
+    5 │ 	<input type="text" autoCOMPLETE="bar" />
+    6 │ 	<input type="text" autocomplete="name invalid" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -67,11 +69,11 @@ invalid.jsx:5:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
   × Use valid values for the autocomplete attribute.
   
     3 │ 	<input type="text" autocomplete="foo" />
-    4 │ 	<input type="text" autocomplete="name invalid" />
-  > 5 │ 	<input type="text" autocomplete="invalid name" />
-      │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    6 │ 	<input type="text" autocomplete="home url" />
-    7 │ 	<Bar autocomplete="baz"></Bar>
+    4 │ 	<input type="text" autoComplete="foo" />
+  > 5 │ 	<input type="text" autoCOMPLETE="bar" />
+      │ 	                   ^^^^^^^^^^^^^^^^^^
+    6 │ 	<input type="text" autocomplete="name invalid" />
+    7 │ 	<input type="text" autocomplete="invalid name" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -88,12 +90,12 @@ invalid.jsx:6:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
 
   × Use valid values for the autocomplete attribute.
   
-    4 │ 	<input type="text" autocomplete="name invalid" />
-    5 │ 	<input type="text" autocomplete="invalid name" />
-  > 6 │ 	<input type="text" autocomplete="home url" />
-      │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^
-    7 │ 	<Bar autocomplete="baz"></Bar>
-    8 │ 	<Input type="text" autocomplete="baz" />
+    4 │ 	<input type="text" autoComplete="foo" />
+    5 │ 	<input type="text" autoCOMPLETE="bar" />
+  > 6 │ 	<input type="text" autocomplete="name invalid" />
+      │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 	<input type="text" autocomplete="invalid name" />
+    8 │ 	<input type="text" autocomplete="home url" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -106,16 +108,16 @@ invalid.jsx:6:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
 ```
 
 ```
-invalid.jsx:7:7 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.jsx:7:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Use valid values for the autocomplete attribute.
   
-    5 │ 	<input type="text" autocomplete="invalid name" />
-    6 │ 	<input type="text" autocomplete="home url" />
-  > 7 │ 	<Bar autocomplete="baz"></Bar>
-      │ 	     ^^^^^^^^^^^^^^^^^^
-    8 │ 	<Input type="text" autocomplete="baz" />
-    9 │ </>
+    5 │ 	<input type="text" autoCOMPLETE="bar" />
+    6 │ 	<input type="text" autocomplete="name invalid" />
+  > 7 │ 	<input type="text" autocomplete="invalid name" />
+      │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 	<input type="text" autocomplete="home url" />
+    9 │ 	<Bar autocomplete="baz"></Bar>
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -132,12 +134,56 @@ invalid.jsx:8:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
 
   × Use valid values for the autocomplete attribute.
   
-     6 │ 	<input type="text" autocomplete="home url" />
-     7 │ 	<Bar autocomplete="baz"></Bar>
-   > 8 │ 	<Input type="text" autocomplete="baz" />
+     6 │ 	<input type="text" autocomplete="name invalid" />
+     7 │ 	<input type="text" autocomplete="invalid name" />
+   > 8 │ 	<input type="text" autocomplete="home url" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 	<Bar autocomplete="baz"></Bar>
+    10 │ 	<Input type="text" autocomplete="baz" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:9:7 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+     7 │ 	<input type="text" autocomplete="invalid name" />
+     8 │ 	<input type="text" autocomplete="home url" />
+   > 9 │ 	<Bar autocomplete="baz"></Bar>
+       │ 	     ^^^^^^^^^^^^^^^^^^
+    10 │ 	<Input type="text" autocomplete="baz" />
+    11 │ </>
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:10:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+     8 │ 	<input type="text" autocomplete="home url" />
+     9 │ 	<Bar autocomplete="baz"></Bar>
+  > 10 │ 	<Input type="text" autocomplete="baz" />
        │ 	                   ^^^^^^^^^^^^^^^^^^
-     9 │ </>
-    10 │ 
+    11 │ </>
+    12 │ 
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx
@@ -2,10 +2,12 @@
 <>
 	<input type="text" />
 	<input type="text" autocomplete="name" />
+	<input type="text" autoComplete="name" />
 	<input type="text" autocomplete="" />
 	<input type="text" autocomplete="off" />
 	<input type="text" autocomplete="on" />
 	<input type="text" autocomplete="billing family-name" />
+	<input type="text" autoComplete="billing family-name" />
 	<input type="text" autocomplete="section-blue shipping street-address" />
 	<input type="text" autocomplete="section-somewhere shipping work email" />
 	<input type="text" autocomplete />

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx.snap
@@ -8,10 +8,12 @@ expression: valid.jsx
 <>
 	<input type="text" />
 	<input type="text" autocomplete="name" />
+	<input type="text" autoComplete="name" />
 	<input type="text" autocomplete="" />
 	<input type="text" autocomplete="off" />
 	<input type="text" autocomplete="on" />
 	<input type="text" autocomplete="billing family-name" />
+	<input type="text" autoComplete="billing family-name" />
 	<input type="text" autocomplete="section-blue shipping street-address" />
 	<input type="text" autocomplete="section-somewhere shipping work email" />
 	<input type="text" autocomplete />


### PR DESCRIPTION
## Summary

Fixes #10739.

`useValidAutocomplete` resolved the autocomplete attribute with a case-sensitive lookup for the literal name `autocomplete`:

```rust
node.attributes().find_by_name("autocomplete")?
```

`JsxAttributeList::find_by_name` compares the raw source text with no case normalization, so React's idiomatic camelCase spelling `autoComplete` never matched. As a result the rule never fired on real React/TSX code, only catching the lowercase `autocomplete` spelling that React itself warns about at runtime. The upstream `eslint-plugin-jsx-a11y` rule `autocomplete-valid` does flag `autoComplete`.

This PR resolves the attribute case-insensitively within the rule via `eq_ignore_ascii_case`, so `autoComplete`, `autocomplete`, and `autoCOMPLETE` all resolve. The shared `find_by_name` helper is left untouched to avoid changing behavior across every other JSX rule; only `useValidAutocomplete` gets the case-insensitive lookup. The rest of the validation logic (allowed-token / detail-token checks, the `none` special case, the diagnostic) is unchanged.

A changeset is included.

## Test Plan

Added spec coverage to the existing rule fixtures and regenerated the snapshots:

- `invalid.jsx`: added `<input type="text" autoComplete="foo" />` and `<input type="text" autoCOMPLETE="bar" />`, which now produce diagnostics.
- `valid.jsx`: added `<input type="text" autoComplete="name" />` and `<input type="text" autoComplete="billing family-name" />`, which produce no diagnostics.
- Existing lowercase cases remain as regression guards.

`cargo test -p biome_js_analyze -- use_valid_autocomplete` passes green (all 4 spec tests).

## Docs

No documentation changes are required: this is a behavioral bug fix to an existing rule whose documented examples (lowercase `autocomplete`) remain valid. The rule's examples and options are unchanged.

<!-- AI assistance notice -->
This PR was implemented with AI assistance.
