### PR TITLE
fix(linter): correctly track is:global and current styles

### DIFF
--- a/.changeset/silver-parents-show.md
+++ b/.changeset/silver-parents-show.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed an issue where [`noUndeclaredClasses`](https://biomejs.dev/linter/rules/no-undeclared-classes) didn't correctly detect styles defined inside the Astro directive `is:global`.

--- a/.changeset/tired-grapes-know.md
+++ b/.changeset/tired-grapes-know.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed an issue where [`noUndeclaredClasses`](https://biomejs.dev/linter/rules/no-undeclared-classes) couldn't some styles weren't detected is some cases.

--- a/.changeset/tired-grapes-know.md
+++ b/.changeset/tired-grapes-know.md
@@ -2,4 +2,5 @@
 "@biomejs/biome": patch
 ---
 
-Fixed an issue where [`noUndeclaredClasses`](https://biomejs.dev/linter/rules/no-undeclared-classes) couldn't some styles weren't detected is some cases.
+Fixed an issue where [`noUndeclaredClasses`](https://biomejs.dev/linter/rules/no-undeclared-classes)
+ didn't detect styles declared inside HTML documents.

--- a/.changeset/tired-grapes-know.md
+++ b/.changeset/tired-grapes-know.md
@@ -2,5 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed an issue where [`noUndeclaredClasses`](https://biomejs.dev/linter/rules/no-undeclared-classes)
- didn't detect styles declared inside HTML documents.
+Fixed an issue where [`noUndeclaredClasses`](https://biomejs.dev/linter/rules/no-undeclared-classes) didn't detect styles declared inside HTML documents.

--- a/crates/biome_html_analyze/tests/specs/nursery/noUndeclaredClasses/mixedAstroSvelte/file.svelte
+++ b/crates/biome_html_analyze/tests/specs/nursery/noUndeclaredClasses/mixedAstroSvelte/file.svelte
@@ -1,0 +1,14 @@
+<!-- should not generate diagnostics -->
+<div class="app">
+	<label class="visually-hidden" for="filename">Component filename</label>
+</div>
+
+<style>
+	.app {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--bg);
+		color: var(--fg);
+	}
+</style>

--- a/crates/biome_html_analyze/tests/specs/nursery/noUndeclaredClasses/mixedAstroSvelte/file.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/noUndeclaredClasses/mixedAstroSvelte/file.svelte.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: file.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<div class="app">
+	<label class="visually-hidden" for="filename">Component filename</label>
+</div>
+
+<style>
+	.app {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--bg);
+		color: var(--fg);
+	}
+</style>
+
+```

--- a/crates/biome_html_analyze/tests/specs/nursery/noUndeclaredClasses/mixedAstroSvelte/index.astro
+++ b/crates/biome_html_analyze/tests/specs/nursery/noUndeclaredClasses/mixedAstroSvelte/index.astro
@@ -1,0 +1,25 @@
+<!-- should not generate diagnostics -->
+---
+export const prerender = true;
+
+import Playground from './file.svelte';
+---
+
+<!doctype html>
+<html lang="en">
+	<Playground client:only="svelte" />
+</html>
+
+<style is:global>
+	.visually-hidden {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+</style>

--- a/crates/biome_html_analyze/tests/specs/nursery/noUndeclaredClasses/mixedAstroSvelte/index.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/noUndeclaredClasses/mixedAstroSvelte/index.astro.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: index.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+---
+export const prerender = true;
+
+import Playground from './file.svelte';
+---
+
+<!doctype html>
+<html lang="en">
+	<Playground client:only="svelte" />
+</html>
+
+<style is:global>
+	.visually-hidden {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+</style>
+
+```

--- a/crates/biome_languages/src/css.rs
+++ b/crates/biome_languages/src/css.rs
@@ -55,6 +55,16 @@ pub enum EmbeddingStyleApplicability {
     Unknown,
 }
 
+impl EmbeddingStyleApplicability {
+    pub const fn is_local(&self) -> bool {
+        matches!(self, EmbeddingStyleApplicability::Local)
+    }
+
+    pub const fn is_global(&self) -> bool {
+        matches!(self, EmbeddingStyleApplicability::Global)
+    }
+}
+
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(
     Debug, Clone, Default, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,

--- a/crates/biome_module_graph/src/css_module_info/traverse.rs
+++ b/crates/biome_module_graph/src/css_module_info/traverse.rs
@@ -120,21 +120,30 @@ impl<'a> Iterator for ImportTreeTraversal<'a> {
                             })
                         })
                         .collect::<Vec<_>>(),
-                    ModuleInfoKind::Html(html_info) => html_info
-                        .imported_stylesheets
-                        .iter()
-                        .chain(html_info.static_import_paths.values())
-                        .chain(html_info.dynamic_import_paths.values())
-                        .filter_map(|stylesheet_path| {
-                            let path = stylesheet_path.as_path()?;
-                            let css_info = self.module_database.css_module_info_for_path(path)?;
+                    ModuleInfoKind::Html(html_info) => {
+                        let mut steps = html_info
+                            .imported_stylesheets
+                            .iter()
+                            .chain(html_info.static_import_paths.values())
+                            .chain(html_info.dynamic_import_paths.values())
+                            .filter_map(|stylesheet_path| {
+                                let path = stylesheet_path.as_path()?;
+                                let css_info =
+                                    self.module_database.css_module_info_for_path(path)?;
 
-                            Some(CssClassStep {
-                                css_path: path.to_path_buf(),
-                                css_classes: css_info.classes.clone(),
+                                Some(CssClassStep {
+                                    css_path: path.to_path_buf(),
+                                    css_classes: css_info.classes.clone(),
+                                })
                             })
-                        })
-                        .collect::<Vec<_>>(),
+                            .collect::<Vec<_>>();
+
+                        steps.push(CssClassStep {
+                            css_path: file_path.to_path_buf(),
+                            css_classes: html_info.get_global_styles(),
+                        });
+                        steps
+                    }
                     ModuleInfoKind::Css(_) => Vec::new(),
                 });
             }

--- a/crates/biome_module_graph/src/html_module_info/mod.rs
+++ b/crates/biome_module_graph/src/html_module_info/mod.rs
@@ -1,11 +1,11 @@
 mod visitor;
 
 use crate::css_module_info::{CssClassDefinition, CssClassReference};
-use biome_css_syntax::AnyCssRoot;
+use biome_css_syntax::{AnyCssRoot, TextRange};
 use biome_js_syntax::AnyJsRoot;
 use biome_languages::CssFileSource;
 use biome_resolver::ResolvedPath;
-use biome_rowan::{Text, TextSize};
+use biome_rowan::{Text, TextSize, TokenText};
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use std::collections::BTreeSet;
@@ -124,6 +124,17 @@ pub struct HtmlModuleInfoInner {
 
     /// Resolved paths of JS/TS modules imported from dynamic imports.
     pub dynamic_import_paths: IndexMap<Text, ResolvedPath>,
+}
+
+impl HtmlModuleInfoInner {
+    /// Returns CSS classes defined in `global` definitions
+    pub(crate) fn get_global_styles(&self) -> IndexMap<TextRange, TokenText> {
+        self.style_classes
+            .iter()
+            .filter(|declaration| declaration.applicability.is_global())
+            .map(|c| (c.range, c.name.clone()))
+            .collect()
+    }
 }
 
 #[derive(Debug)]

--- a/crates/biome_module_graph/src/html_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/html_module_info/visitor.rs
@@ -71,11 +71,7 @@ impl<'a> HtmlModuleVisitor<'a> {
                 continue;
             };
             if let Some(element) = HtmlElement::cast(node.clone()) {
-                self.visit_html_element(
-                    element,
-                    &mut referenced_classes,
-                    &mut imported_stylesheets,
-                );
+                self.visit_html_element(element, &mut referenced_classes);
             } else if let Some(element) = HtmlSelfClosingElement::cast(node) {
                 self.visit_self_closing_element(
                     element,
@@ -172,7 +168,6 @@ impl<'a> HtmlModuleVisitor<'a> {
         &self,
         element: HtmlElement,
         referenced_classes: &mut Vec<CssClassReference>,
-        _imported_stylesheets: &mut Vec<ResolvedPath>,
     ) {
         let Ok(opening) = element.opening_element() else {
             return;

--- a/crates/biome_service/src/embed/types.rs
+++ b/crates/biome_service/src/embed/types.rs
@@ -81,6 +81,9 @@ pub(crate) enum EmbedCandidate {
         /// Bare attributes like `setup` have `None` value.
         attributes: Vec<(TokenText, Option<TokenText>)>,
         content: EmbedContent,
+
+        /// Astro defines `is:global` as a directive attribute
+        is_global: bool,
     },
 
     /// Astro frontmatter block: `---\ncode\n---`.
@@ -218,6 +221,16 @@ impl EmbedCandidate {
             Self::Element { attributes, .. } => attributes
                 .iter()
                 .any(|(k, _)| k.text().eq_ignore_ascii_case(name)),
+            _ => false,
+        }
+    }
+
+    /// Whether this is a style element that should apply styles to the entire project.
+    ///
+    /// It usually maps to Astro `is:global` directive.
+    pub fn is_css_global(&self) -> bool {
+        match self {
+            Self::Element { is_global, .. } => *is_global,
             _ => false,
         }
     }

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
@@ -768,6 +768,21 @@ fn build_html_candidate(element: &HtmlElement) -> Option<EmbedCandidate> {
         .ok()
         .into_iter()
         .flat_map(|opening| opening.attributes())
+        .collect();
+
+    let is_global = attributes
+        .iter()
+        .filter_map(|attr| attr.as_any_astro_directive())
+        .filter_map(|directive| directive.as_astro_is_directive())
+        .any(|is_directive| {
+            is_directive
+                .value()
+                .and_then(|value| value.name())
+                .is_ok_and(|name| name.token_text_trimmed().as_deref() == Some("global"))
+        });
+
+    let attributes: Vec<_> = attributes
+        .iter()
         .filter_map(|attr| {
             let html_attr = attr.as_html_attribute()?;
             let name = html_attr
@@ -795,6 +810,7 @@ fn build_html_candidate(element: &HtmlElement) -> Option<EmbedCandidate> {
     Some(EmbedCandidate::Element {
         tag_name,
         attributes,
+        is_global,
         content: EmbedContent {
             element_range: content_child.range(),
             content_range: value_token.text_range(),
@@ -846,7 +862,7 @@ fn embedded_css_file_source(
             CssEmbeddingKind::Html(EmbeddingHtmlKind::Vue { applicability })
         }
         HtmlVariant::Astro => {
-            let applicability = if candidate.has_attribute("is:global") {
+            let applicability = if candidate.is_css_global() {
                 EmbeddingStyleApplicability::Global
             } else {
                 EmbeddingStyleApplicability::Local


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes two bugs for `noUndeclaredClasses`:
- how `is:global` is tracked
- include the styles declared inside the HTML document when traversing the "CSS steps"

I found the bug while testing the rule in another project.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a new case that checks for both.

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
