### PR TITLE
fix(analyze): Solid domain matches solid-js package, not solid (#10742)

### DIFF
--- a/.changeset/fix-solid-domain-package-name.md
+++ b/.changeset/fix-solid-domain-package-name.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10742](https://github.com/biomejs/biome/issues/10742): Solid domain detection now uses the correct package name `solid-js`. Previously, projects listing `solid-js` as a dependency did not enable Solid-domain rules; the registry entry was the bare `solid` literal.

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -666,7 +666,7 @@ impl RuleDomain {
                 &("ava", ">=2.0.0"),
                 &("vitest", ">=1.0.0"),
             ],
-            Self::Solid => &[&("solid", ">=1.0.0")],
+            Self::Solid => &[&("solid-js", ">=1.0.0")],
             Self::Next => &[&("next", ">=14.0.0")],
             Self::Qwik => &[
                 &("@builder.io/qwik", ">=1.0.0"),
@@ -1812,5 +1812,37 @@ impl FromStr for RulePreset {
             "recommended" => Ok(Self::Recommended),
             _ => Err("Invalid rule preset."),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RuleDomain;
+
+    /// Regression test for https://github.com/biomejs/biome/issues/10742.
+    /// The Solid domain rules only fire when Biome detects that the project
+    /// is a Solid project. Detection is driven by the package name listed
+    /// in the project's `package.json` manifest. That package is published
+    /// on npm as `solid-js`; the bare `solid` package is unrelated and has
+    /// no Solid.js runtime, so the registry must not match it.
+    ///
+    /// If this test fails, `manifest_dependencies` regressed to use `solid`
+    /// instead of `solid-js` and `linters.recommended` will silently skip
+    /// Solid-domain rules (notably `noSolidDestructuredProps`) for real
+    /// Solid.js projects.
+    #[test]
+    fn solid_domain_manifest_uses_solid_js_package_name() {
+        let deps = RuleDomain::Solid.manifest_dependencies();
+
+        assert!(
+            deps.iter().any(|(name, _)| *name == "solid-js"),
+            "expected `solid-js` in RuleDomain::Solid manifest_dependencies, got {:?}",
+            deps,
+        );
+        assert!(
+            !deps.iter().any(|(name, _)| *name == "solid"),
+            "manifest_dependencies for Solid must not match the unrelated `solid` package; got {:?}",
+            deps,
+        );
     }
 }


### PR DESCRIPTION
Fixes #10742

## Summary

The `RuleDomain::Solid` entry in `crates/biome_analyze/src/rule.rs` declared its dependency as the bare literal `"solid"`. The console `npmjs` registry returns an unrelated package for that name; the actual Solid.js runtime is published as `solid-js`. As a result, projects depending on Solid.js did not have Solid-domain rules registered, and `noSolidDestructuredProps` in particular stayed silent.

This replaces the dep tuple with `("solid-js", ">=1.0.0")` to match the rest of the registry and pins the package name with a regression test.

## Test plan

- [ ] `cargo test -p biome_analyze rule::tests::solid_domain_manifest_uses_solid_js_package_name` passes (new test pins `"solid-js"` and forbids the bare `"solid"` string).
- [ ] `cargo test -p biome_analyze` has no other failures.

## AI assistance

Used an AI coding assistant to draft the diff; reviewed and edited every line in `crates/biome_analyze/src/rule.rs` and the change in `.changeset/fix-solid-domain-package-name.md`.
