### PR TITLE
fix(css/parser): allow Tailwind variant and utility names to start with a digit

### DIFF
--- a/.changeset/fix-css-tailwind-leading-digit-names.md
+++ b/.changeset/fix-css-tailwind-leading-digit-names.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8269](https://github.com/biomejs/biome/issues/8269): the CSS parser now accepts Tailwind `@variant` and `@utility` names that start with a digit, such as the `2xl` breakpoint.
+
+```css
+@utility container {
+	@variant 2xl {
+		max-width: 1400px;
+	}
+}
+```

--- a/crates/biome_css_parser/src/lexer/mod.rs
+++ b/crates/biome_css_parser/src/lexer/mod.rs
@@ -69,7 +69,8 @@ pub enum CssLexContext {
     /// Applied when lexing Tailwind CSS utility classes.
     /// Currently, only applicable to when we encounter a `@apply` rule.
     TailwindUtility,
-    /// Applied when lexing Tailwind CSS utility names in `@utility`.
+    /// Applied when lexing Tailwind CSS utility and variant names in
+    /// `@utility` and `@variant`.
     TailwindUtilityName,
 }
 
@@ -1547,6 +1548,22 @@ impl<'src> CssLexer<'src> {
     fn consume_token_tailwind_utility_name(&mut self, current: u8) -> CssSyntaxKind {
         if self.is_ident_start() {
             return self.consume_identifier_with_slash(true);
+        }
+
+        // Tailwind utility and variant names may start with a digit, such as
+        // the `2xl` breakpoint in `@utility 2xl` or `@variant 2xl`. The default
+        // CSS lexer would split that into a number and an identifier, so consume
+        // the whole run as a single identifier here.
+        if current.is_ascii_digit() {
+            while let Some(byte) = self.current_byte() {
+                if byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_' || !byte.is_ascii()
+                {
+                    self.advance_byte_or_char(byte);
+                } else {
+                    break;
+                }
+            }
+            return T![ident];
         }
 
         self.consume_token(current)

--- a/crates/biome_css_parser/src/lexer/mod.rs
+++ b/crates/biome_css_parser/src/lexer/mod.rs
@@ -1554,13 +1554,12 @@ impl<'src> CssLexer<'src> {
         // the `2xl` breakpoint in `@utility 2xl` or `@variant 2xl`. The default
         // CSS lexer would split that into a number and an identifier, so consume
         // the whole run as a single identifier here.
-        if current.is_ascii_digit() {
+        let dispatched = lookup_byte(current);
+        if matches!(dispatched, DIG | ZER) {
             while let Some(byte) = self.current_byte() {
-                if byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_' || !byte.is_ascii()
-                {
-                    self.advance_byte_or_char(byte);
-                } else {
-                    break;
+                match lookup_byte(byte) {
+                    DIG | ZER | IDT | UNI | MIN => self.advance_byte_or_char(byte),
+                    _ => break,
                 }
             }
             return T![ident];

--- a/crates/biome_css_parser/src/syntax/at_rule/tailwind.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/tailwind.rs
@@ -103,7 +103,7 @@ pub(crate) fn parse_variant_at_rule(p: &mut CssParser) -> ParsedSyntax {
     }
 
     let m = p.start();
-    p.bump(T![variant]);
+    p.bump_with_context(T![variant], CssLexContext::TailwindUtilityName);
 
     if !is_at_identifier(p) {
         p.error(expected_identifier(p, p.cur_range()));

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/leading-digit.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/leading-digit.css
@@ -1,0 +1,3 @@
+@utility 2xl {
+	width: 100%;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/leading-digit.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/leading-digit.css.snap
@@ -1,0 +1,90 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@utility 2xl {
+	width: 100%;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: TwUtilityAtRule {
+                utility_token: UTILITY_KW@1..9 "utility" [] [Whitespace(" ")],
+                name: CssIdentifier {
+                    value_token: IDENT@9..13 "2xl" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@13..14 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@14..21 "width" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@21..23 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssPercentage {
+                                            value_token: CSS_NUMBER_LITERAL@23..26 "100" [] [],
+                                            percent_token: PERCENT@26..27 "%" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@27..28 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@28..30 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@30..31 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..31
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..30
+    0: CSS_AT_RULE@0..30
+      0: AT@0..1 "@" [] []
+      1: TW_UTILITY_AT_RULE@1..30
+        0: UTILITY_KW@1..9 "utility" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@9..13
+          0: IDENT@9..13 "2xl" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@13..30
+          0: L_CURLY@13..14 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@14..28
+            0: CSS_DECLARATION_WITH_SEMICOLON@14..28
+              0: CSS_DECLARATION@14..27
+                0: CSS_GENERIC_PROPERTY@14..27
+                  0: CSS_IDENTIFIER@14..21
+                    0: IDENT@14..21 "width" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@21..23 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@23..27
+                    0: CSS_PERCENTAGE@23..27
+                      0: CSS_NUMBER_LITERAL@23..26 "100" [] []
+                      1: PERCENT@26..27 "%" [] []
+                1: (empty)
+              1: SEMICOLON@27..28 ";" [] []
+          2: R_CURLY@28..30 "}" [Newline("\n")] []
+  2: EOF@30..31 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/variant-leading-digit.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/variant-leading-digit.css
@@ -1,0 +1,12 @@
+@variant 2xl {
+	max-width: 1400px;
+}
+
+@utility container {
+	padding-inline: 1rem;
+	margin-inline: auto;
+
+	@variant 2xl {
+		max-width: 1400px;
+	}
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/variant-leading-digit.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/variant-leading-digit.css.snap
@@ -1,0 +1,237 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@variant 2xl {
+	max-width: 1400px;
+}
+
+@utility container {
+	padding-inline: 1rem;
+	margin-inline: auto;
+
+	@variant 2xl {
+		max-width: 1400px;
+	}
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: TwVariantAtRule {
+                variant_token: VARIANT_KW@1..9 "variant" [] [Whitespace(" ")],
+                name: CssIdentifier {
+                    value_token: IDENT@9..13 "2xl" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@13..14 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@14..25 "max-width" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@25..27 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@27..31 "1400" [] [],
+                                            unit_token: IDENT@31..33 "px" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@33..34 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@34..36 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@36..39 "@" [Newline("\n"), Newline("\n")] [],
+            rule: TwUtilityAtRule {
+                utility_token: UTILITY_KW@39..47 "utility" [] [Whitespace(" ")],
+                name: CssIdentifier {
+                    value_token: IDENT@47..57 "container" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@57..58 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@58..74 "padding-inline" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@74..76 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@76..77 "1" [] [],
+                                            unit_token: IDENT@77..80 "rem" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@80..81 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@81..96 "margin-inline" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@96..98 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@98..102 "auto" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@102..103 ";" [] [],
+                        },
+                        CssAtRule {
+                            at_token: AT@103..107 "@" [Newline("\n"), Newline("\n"), Whitespace("\t")] [],
+                            rule: TwVariantAtRule {
+                                variant_token: VARIANT_KW@107..115 "variant" [] [Whitespace(" ")],
+                                name: CssIdentifier {
+                                    value_token: IDENT@115..119 "2xl" [] [Whitespace(" ")],
+                                },
+                                block: CssDeclarationOrRuleBlock {
+                                    l_curly_token: L_CURLY@119..120 "{" [] [],
+                                    items: CssDeclarationOrRuleList [
+                                        CssDeclarationWithSemicolon {
+                                            declaration: CssDeclaration {
+                                                property: CssGenericProperty {
+                                                    name: CssIdentifier {
+                                                        value_token: IDENT@120..132 "max-width" [Newline("\n"), Whitespace("\t\t")] [],
+                                                    },
+                                                    colon_token: COLON@132..134 ":" [] [Whitespace(" ")],
+                                                    value: CssGenericComponentValueList [
+                                                        CssRegularDimension {
+                                                            value_token: CSS_NUMBER_LITERAL@134..138 "1400" [] [],
+                                                            unit_token: IDENT@138..140 "px" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                                important: missing (optional),
+                                            },
+                                            semicolon_token: SEMICOLON@140..141 ";" [] [],
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@141..144 "}" [Newline("\n"), Whitespace("\t")] [],
+                                },
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@144..146 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@146..147 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..147
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..146
+    0: CSS_AT_RULE@0..36
+      0: AT@0..1 "@" [] []
+      1: TW_VARIANT_AT_RULE@1..36
+        0: VARIANT_KW@1..9 "variant" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@9..13
+          0: IDENT@9..13 "2xl" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@13..36
+          0: L_CURLY@13..14 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@14..34
+            0: CSS_DECLARATION_WITH_SEMICOLON@14..34
+              0: CSS_DECLARATION@14..33
+                0: CSS_GENERIC_PROPERTY@14..33
+                  0: CSS_IDENTIFIER@14..25
+                    0: IDENT@14..25 "max-width" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@25..27 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@27..33
+                    0: CSS_REGULAR_DIMENSION@27..33
+                      0: CSS_NUMBER_LITERAL@27..31 "1400" [] []
+                      1: IDENT@31..33 "px" [] []
+                1: (empty)
+              1: SEMICOLON@33..34 ";" [] []
+          2: R_CURLY@34..36 "}" [Newline("\n")] []
+    1: CSS_AT_RULE@36..146
+      0: AT@36..39 "@" [Newline("\n"), Newline("\n")] []
+      1: TW_UTILITY_AT_RULE@39..146
+        0: UTILITY_KW@39..47 "utility" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@47..57
+          0: IDENT@47..57 "container" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@57..146
+          0: L_CURLY@57..58 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@58..144
+            0: CSS_DECLARATION_WITH_SEMICOLON@58..81
+              0: CSS_DECLARATION@58..80
+                0: CSS_GENERIC_PROPERTY@58..80
+                  0: CSS_IDENTIFIER@58..74
+                    0: IDENT@58..74 "padding-inline" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@74..76 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@76..80
+                    0: CSS_REGULAR_DIMENSION@76..80
+                      0: CSS_NUMBER_LITERAL@76..77 "1" [] []
+                      1: IDENT@77..80 "rem" [] []
+                1: (empty)
+              1: SEMICOLON@80..81 ";" [] []
+            1: CSS_DECLARATION_WITH_SEMICOLON@81..103
+              0: CSS_DECLARATION@81..102
+                0: CSS_GENERIC_PROPERTY@81..102
+                  0: CSS_IDENTIFIER@81..96
+                    0: IDENT@81..96 "margin-inline" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@96..98 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@98..102
+                    0: CSS_IDENTIFIER@98..102
+                      0: IDENT@98..102 "auto" [] []
+                1: (empty)
+              1: SEMICOLON@102..103 ";" [] []
+            2: CSS_AT_RULE@103..144
+              0: AT@103..107 "@" [Newline("\n"), Newline("\n"), Whitespace("\t")] []
+              1: TW_VARIANT_AT_RULE@107..144
+                0: VARIANT_KW@107..115 "variant" [] [Whitespace(" ")]
+                1: CSS_IDENTIFIER@115..119
+                  0: IDENT@115..119 "2xl" [] [Whitespace(" ")]
+                2: CSS_DECLARATION_OR_RULE_BLOCK@119..144
+                  0: L_CURLY@119..120 "{" [] []
+                  1: CSS_DECLARATION_OR_RULE_LIST@120..141
+                    0: CSS_DECLARATION_WITH_SEMICOLON@120..141
+                      0: CSS_DECLARATION@120..140
+                        0: CSS_GENERIC_PROPERTY@120..140
+                          0: CSS_IDENTIFIER@120..132
+                            0: IDENT@120..132 "max-width" [Newline("\n"), Whitespace("\t\t")] []
+                          1: COLON@132..134 ":" [] [Whitespace(" ")]
+                          2: CSS_GENERIC_COMPONENT_VALUE_LIST@134..140
+                            0: CSS_REGULAR_DIMENSION@134..140
+                              0: CSS_NUMBER_LITERAL@134..138 "1400" [] []
+                              1: IDENT@138..140 "px" [] []
+                        1: (empty)
+                      1: SEMICOLON@140..141 ";" [] []
+                  2: R_CURLY@141..144 "}" [Newline("\n"), Whitespace("\t")] []
+          2: R_CURLY@144..146 "}" [Newline("\n")] []
+  2: EOF@146..147 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
Fixes #8269.

## Summary

Tailwind allows utility and variant names that begin with a digit, such as the `2xl` breakpoint. The CSS parser lexed `2xl` as a number (`2`) followed by an identifier (`xl`), so both `@variant 2xl { … }` and `@utility 2xl { … }` failed to parse with `Expected an identifier but instead found '2'`.

```css
@utility container {
	@variant 2xl {
		max-width: 1400px;
	}
}
```

## Changes

- `crates/biome_css_parser/src/lexer/mod.rs`: in the `TailwindUtilityName` lex context, a digit-leading run (e.g. `2xl`) is now consumed as a single identifier instead of a number followed by an identifier.
- `crates/biome_css_parser/src/syntax/at_rule/tailwind.rs`: `parse_variant_at_rule` now bumps `@variant` in the `TailwindUtilityName` context (as `@utility` already does), so the name is lexed with the same rules.
- Tests: added `ok/tailwind/variant-leading-digit.css` and `ok/tailwind/utility/leading-digit.css` fixtures with accepted snapshots.
- Added a changeset.