### PR TITLE
fix(formatter): keep parens around await/yield in instantiation expressions

### DIFF
--- a/.changeset/fix-instantiation-expression-parens.md
+++ b/.changeset/fix-instantiation-expression-parens.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10697](https://github.com/biomejs/biome/issues/10697): The formatter no longer removes the parentheses around an `await` or `yield` expression used as the target of a TypeScript instantiation expression. For example, `(await makeFactory)<Value>` is no longer reformatted to `await makeFactory<Value>`, which would change the meaning of the code.

--- a/crates/biome_js_formatter/tests/specs/ts/expression/instantiation_expression.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/instantiation_expression.ts
@@ -1,0 +1,17 @@
+const a = makeFactory<Value>;
+const b = obj.makeFactory<Value>;
+
+// Parentheses around await/yield must be kept, otherwise the type
+// arguments would bind to the inner expression and change the meaning.
+async function withAwait() {
+  const c = (await makeFactory)<Value>;
+}
+
+function* withYield() {
+  const d = (yield* makeFactory)<Value>;
+  const e = (yield makeFactory)<Value>;
+}
+
+// Parentheses around other lower-precedence expressions must be kept too.
+const f = (cond ? a : b)<Value>;
+const g = (x++)<Value>;

--- a/crates/biome_js_formatter/tests/specs/ts/expression/instantiation_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/instantiation_expression.ts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/expression/instantiation_expression.ts
+---
+
+# Input
+
+```ts
+const a = makeFactory<Value>;
+const b = obj.makeFactory<Value>;
+
+// Parentheses around await/yield must be kept, otherwise the type
+// arguments would bind to the inner expression and change the meaning.
+async function withAwait() {
+  const c = (await makeFactory)<Value>;
+}
+
+function* withYield() {
+  const d = (yield* makeFactory)<Value>;
+  const e = (yield makeFactory)<Value>;
+}
+
+// Parentheses around other lower-precedence expressions must be kept too.
+const f = (cond ? a : b)<Value>;
+const g = (x++)<Value>;
+
+```
+
+
+# Formatted
+
+```ts
+const a = makeFactory<Value>;
+const b = obj.makeFactory<Value>;
+
+// Parentheses around await/yield must be kept, otherwise the type
+// arguments would bind to the inner expression and change the meaning.
+async function withAwait() {
+	const c = (await makeFactory)<Value>;
+}
+
+function* withYield() {
+	const d = (yield* makeFactory)<Value>;
+	const e = (yield makeFactory)<Value>;
+}
+
+// Parentheses around other lower-precedence expressions must be kept too.
+const f = (cond ? a : b)<Value>;
+const g = (x++)<Value>;
+
+```

--- a/crates/biome_js_syntax/src/parentheses/expression.rs
+++ b/crates/biome_js_syntax/src/parentheses/expression.rs
@@ -954,6 +954,8 @@ fn update_or_lower_expression_needs_parens(
         parent.kind(),
         JsSyntaxKind::JS_EXTENDS_CLAUSE
             | JsSyntaxKind::TS_NON_NULL_ASSERTION_EXPRESSION
+            // Instantiation expression
+            | JsSyntaxKind::TS_INSTANTIATION_EXPRESSION
             // Callee
             | JsSyntaxKind::JS_CALL_EXPRESSION
             | JsSyntaxKind::JS_NEW_EXPRESSION

--- a/crates/biome_js_syntax/src/parentheses/expression.rs
+++ b/crates/biome_js_syntax/src/parentheses/expression.rs
@@ -954,7 +954,6 @@ fn update_or_lower_expression_needs_parens(
         parent.kind(),
         JsSyntaxKind::JS_EXTENDS_CLAUSE
             | JsSyntaxKind::TS_NON_NULL_ASSERTION_EXPRESSION
-            // Instantiation expression
             | JsSyntaxKind::TS_INSTANTIATION_EXPRESSION
             // Callee
             | JsSyntaxKind::JS_CALL_EXPRESSION


### PR DESCRIPTION
## Summary

Closes #10697. The formatter was dropping the parentheses around an `await` or `yield` expression used as the target of a TypeScript instantiation expression, e.g. `(await makeFactory)<Value>` was reformatted to `await makeFactory<Value>`. That changes the meaning, since the type arguments then bind to the inner expression.

The fix adds `TS_INSTANTIATION_EXPRESSION` to `update_or_lower_expression_needs_parens`, alongside the existing call/member/new cases, so lower-precedence operands (await, yield, conditional, update expressions) keep their parentheses when they are the target of an instantiation expression.

## Test Plan

Added a formatter spec at `ts/expression/instantiation_expression.ts` covering await/yield/conditional/update targets. The full `biome_js_formatter` spec and prettier-compat suites pass with no other snapshot changes.

This PR was written with the help of Claude Code (AI assistance), including the test and this description; the change was reviewed and verified by me.