### PR TITLE
fix(linter): ignore svelte special elements in noStaticElementInteractions

### DIFF
--- a/.changeset/fix-no-static-element-interactions-svelte.md
+++ b/.changeset/fix-no-static-element-interactions-svelte.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10636](https://github.com/biomejs/biome/issues/10636): [noStaticElementInteractions](https://biomejs.dev/linter/rules/no-static-element-interactions/) no longer reports a false positive for event handlers on Svelte special elements such as `<svelte:window>`, `<svelte:document>`, and `<svelte:body>`. These are not real DOM elements, so they are now ignored by the rule.

--- a/crates/biome_html_analyze/src/lint/a11y/no_static_element_interactions.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_static_element_interactions.rs
@@ -73,6 +73,11 @@ impl Rule for NoStaticElementInteractions {
             return None;
         }
 
+        // Svelte special elements (e.g. `<svelte:window>`) are not real DOM elements.
+        if node.is_svelte_special_element() {
+            return None;
+        }
+
         if is_hidden_from_screen_reader(node) {
             return None;
         }

--- a/crates/biome_html_analyze/tests/specs/a11y/noStaticElementInteractions/svelte/special-elements.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noStaticElementInteractions/svelte/special-elements.svelte
@@ -1,0 +1,11 @@
+<!-- should not generate diagnostics -->
+<!-- Svelte special elements are not real DOM elements. -->
+<svelte:window
+	onkeydown={(e) => {
+		if (e.key === ' ') {
+			e.preventDefault()
+		}
+	}}
+/>
+<svelte:document onmousemove={() => void 0} />
+<svelte:body onmouseenter={() => void 0} />

--- a/crates/biome_html_analyze/tests/specs/a11y/noStaticElementInteractions/svelte/special-elements.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noStaticElementInteractions/svelte/special-elements.svelte.snap
@@ -1,0 +1,19 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: special-elements.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<!-- Svelte special elements are not real DOM elements. -->
+<svelte:window
+	onkeydown={(e) => {
+		if (e.key === ' ') {
+			e.preventDefault()
+		}
+	}}
+/>
+<svelte:document onmousemove={() => void 0} />
+<svelte:body onmouseenter={() => void 0} />
+
+```

--- a/crates/biome_html_syntax/src/element_ext.rs
+++ b/crates/biome_html_syntax/src/element_ext.rs
@@ -609,6 +609,16 @@ impl AnyHtmlTagElement {
     pub fn is_custom_component(&self) -> bool {
         self.name().is_ok_and(|it| it.as_html_tag_name().is_none())
     }
+
+    /// Returns `true` if the element is a Svelte special element, such as
+    /// `<svelte:window>`, `<svelte:document>`, `<svelte:body>` or `<svelte:head>`.
+    ///
+    /// These elements are not real DOM elements, so they shouldn't be treated as
+    /// regular HTML tags.
+    pub fn is_svelte_special_element(&self) -> bool {
+        self.tag_name()
+            .is_some_and(|name| name.text().starts_with("svelte:"))
+    }
 }
 
 impl biome_aria::Element for AnyHtmlTagElement {


### PR DESCRIPTION
## Summary

Closes #10636. `noStaticElementInteractions` reported a false positive for event handlers on Svelte special elements like `<svelte:window onkeydown={...} />`, `<svelte:document>`, and `<svelte:body>`. These aren't real DOM elements, so the static-element check shouldn't apply to them.

Added `AnyHtmlTagElement::is_svelte_special_element` (tag name starting with `svelte:`) and the rule now bails out early for those elements.

## Test Plan

Added a Svelte spec (`noStaticElementInteractions/svelte/special-elements.svelte`) with handlers on `<svelte:window>`, `<svelte:document>`, and `<svelte:body>`; it produces no diagnostics. The rule's existing specs still pass.

This PR was written with the help of Claude Code (AI assistance), including the test and this description; the change was reviewed and verified by me.