### PR TITLE
Detect CSS modules from paths regardless of extension case

### DIFF
--- a/.changeset/css-module-detection-case-insensitive.md
+++ b/.changeset/css-module-detection-case-insensitive.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed CSS Module detection so files are recognized regardless of extension case. Previously a path like `Foo.MODULE.CSS` was classified as plain CSS instead of a CSS Module because the well-known suffix check was case-sensitive, mirroring the existing case-insensitive handling in `JsFileSource`.

--- a/crates/biome_languages/src/css.rs
+++ b/crates/biome_languages/src/css.rs
@@ -230,15 +230,22 @@ impl CssFileSource {
 
     /// Try to return the CSS file source corresponding to this file name from well-known files
     pub fn try_from_well_known(path: &Utf8Path) -> Result<Self, FileSourceError> {
-        // Be careful with definition files, because `Path::extension()` only
-        // returns the extension after the _last_ dot:
-        let file_name = path.file_name().ok_or(FileSourceError::MissingFileName)?;
+        // Be careful with files that use more than one dot in their extension,
+        // such as CSS modules, because `Path::extension()` only returns the
+        // extension after the _last_ dot.
+        //
+        // We assume the file extensions are case-insensitive, so the file name
+        // and extension are normalized to lowercase before pattern matching.
+        let file_name = path
+            .file_name()
+            .map(|file_name| file_name.to_ascii_lowercase_cow())
+            .ok_or(FileSourceError::MissingFileName)?;
         if file_name.ends_with(".module.css") {
             return Self::try_from_extension("module.css");
         }
 
         match path.extension() {
-            Some(extension) => Self::try_from_extension(extension),
+            Some(extension) => Self::try_from_extension(&extension.to_ascii_lowercase_cow()),
             None => Err(FileSourceError::MissingFileExtension),
         }
     }
@@ -286,5 +293,31 @@ impl TryFrom<&Utf8Path> for CssFileSource {
         // We assume the file extensions are case-insensitive
         // and we use the lowercase form of them for pattern matching
         Self::try_from_extension(&extension.to_ascii_lowercase_cow())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_css_modules_case_insensitively() {
+        let source = CssFileSource::try_from(Utf8Path::new("Foo.MODULE.CSS")).unwrap();
+        assert!(source.is_css_modules());
+
+        let source = CssFileSource::try_from(Utf8Path::new("foo.Module.css")).unwrap();
+        assert!(source.is_css_modules());
+
+        let source = CssFileSource::try_from(Utf8Path::new("foo.module.css")).unwrap();
+        assert!(source.is_css_modules());
+    }
+
+    #[test]
+    fn plain_css_is_not_detected_as_css_modules() {
+        let source = CssFileSource::try_from(Utf8Path::new("foo.css")).unwrap();
+        assert!(!source.is_css_modules());
+
+        let source = CssFileSource::try_from(Utf8Path::new("Foo.CSS")).unwrap();
+        assert!(!source.is_css_modules());
     }
 }


### PR DESCRIPTION
## Summary

`CssFileSource::try_from_well_known` matched the `.module.css` suffix case-sensitively and forwarded the raw extension to `try_from_extension`, which expects a lowercased value. As a result a file like `Foo.MODULE.CSS` was classified as plain CSS rather than a CSS Module: the well-known branch missed the `ends_with` check, and the `DocumentFileSource::try_from_path` fallback then landed on the bare `css` extension.

This mirrors the existing `JsFileSource::try_from_well_known` pattern by normalizing the file name and the fallthrough extension to lowercase via `to_ascii_lowercase_cow`, so CSS Module detection is case-insensitive.

A changeset is included.

## Test Plan

Added unit tests in `crates/biome_languages/src/css.rs`:
- `detects_css_modules_case_insensitively` — `Foo.MODULE.CSS`, `foo.Module.css`, and `foo.module.css` all detect as CSS Modules.
- `plain_css_is_not_detected_as_css_modules` — `foo.css` and `Foo.CSS` are not mis-classified as modules.

Verified locally:
- `cargo check -p biome_languages --features lang_css` — clean.
- `cargo test -p biome_languages --features all` — 8 passed, 0 failed (including the two new tests).

## Docs

No documentation changes; this is an internal file-source classification fix.

## AI assistance notice

This change was prepared with AI assistance. The fix, tests, and changeset were authored with an AI coding assistant and reviewed before submission, disclosed per the CONTRIBUTING AI-assistance notice.
