### PR TITLE
fix(lint): detect Solid destructured props in JSX children

### DIFF
--- a/.changeset/fix-solid-destructured-props-jsx.md
+++ b/.changeset/fix-solid-destructured-props-jsx.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10742](https://github.com/biomejs/biome/issues/10742): `noSolidDestructuredProps` now reports destructured props in Solid function components and JSX children.

--- a/.changeset/fix-solid-destructured-props-jsx.md
+++ b/.changeset/fix-solid-destructured-props-jsx.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10742](https://github.com/biomejs/biome/issues/10742): `noSolidDestructuredProps` now reports destructured props in Solid function components and JSX children.
+Fixed [#10742](https://github.com/biomejs/biome/issues/10742): [`noSolidDestructuredProps`](https://biomejs.dev/linter/rules/no-solid-destructured-props) now reports destructured props in Solid function components and JSX children.

--- a/crates/biome_js_analyze/src/lint/correctness/no_solid_destructured_props.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_solid_destructured_props.rs
@@ -181,7 +181,9 @@ fn is_inside_jsx_component(parameters: &JsParameters) -> Option<bool> {
     }
 
     if let Some(function_declaration) = JsFunctionExportDefaultDeclaration::cast(parent.clone()) {
-        let id = function_declaration.id()?;
+        let Some(id) = function_declaration.id() else {
+            return Some(true);
+        };
         let id = id.as_js_identifier_binding()?;
         let text = id.name_token().ok()?;
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_solid_destructured_props.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_solid_destructured_props.rs
@@ -6,8 +6,9 @@ use biome_console::markup;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     AnyJsArrayBindingPatternElement, AnyJsBinding, AnyJsBindingPattern,
-    AnyJsObjectBindingPatternMember, JsArrowFunctionExpression, JsLanguage, JsObjectBindingPattern,
-    JsParameters, JsVariableDeclarator, JsxExpressionAttributeValue,
+    AnyJsObjectBindingPatternMember, JsArrowFunctionExpression, JsFunctionDeclaration,
+    JsFunctionExportDefaultDeclaration, JsFunctionExpression, JsLanguage, JsObjectBindingPattern,
+    JsParameters, JsVariableDeclarator, JsxExpressionAttributeValue, JsxExpressionChild,
 };
 use biome_rowan::{AstNode, AstSeparatedList, AstSeparatedListNodesIterator, TextRange};
 use biome_rule_options::no_solid_destructured_props::NoSolidDestructuredPropsOptions;
@@ -110,7 +111,7 @@ impl Rule for NoSolidDestructuredProps {
                     binding_pattern.properties().iter(),
                 ));
                 for binding in iter {
-                    if let Some(range) = is_binding_a_jsx_prop(&binding, model) {
+                    if let Some(range) = is_binding_used_in_jsx(&binding, model) {
                         bindings.push(Violation::WithProps(range))
                     }
                 }
@@ -160,25 +161,58 @@ impl Rule for NoSolidDestructuredProps {
 }
 
 fn is_inside_jsx_component(parameters: &JsParameters) -> Option<bool> {
-    let arrow_function_expression = parameters
-        .syntax()
-        .parent()
-        .and_then(JsArrowFunctionExpression::cast)?;
+    let parent = parameters.syntax().parent()?;
 
-    let variable_declarator = arrow_function_expression
-        .syntax()
-        .grand_parent()
-        .and_then(JsVariableDeclarator::cast)?;
+    if let Some(arrow_function_expression) = JsArrowFunctionExpression::cast(parent.clone()) {
+        let variable_declarator = arrow_function_expression
+            .syntax()
+            .grand_parent()
+            .and_then(JsVariableDeclarator::cast)?;
 
-    let name = variable_declarator.id().ok()?;
-    let name = name.as_any_js_binding()?.as_js_identifier_binding()?;
+        return is_variable_declarator_pascal_case(&variable_declarator);
+    }
 
-    let text = name.name_token().ok()?;
+    if let Some(function_declaration) = JsFunctionDeclaration::cast(parent.clone()) {
+        let id = function_declaration.id().ok()?;
+        let id = id.as_js_identifier_binding()?;
+        let text = id.name_token().ok()?;
 
-    Some(Case::identify(text.text_trimmed(), false) == Case::Pascal)
+        return Some(is_pascal_case(text.text_trimmed()));
+    }
+
+    if let Some(function_declaration) = JsFunctionExportDefaultDeclaration::cast(parent.clone()) {
+        let id = function_declaration.id()?;
+        let id = id.as_js_identifier_binding()?;
+        let text = id.name_token().ok()?;
+
+        return Some(is_pascal_case(text.text_trimmed()));
+    }
+
+    if let Some(function_expression) = JsFunctionExpression::cast(parent) {
+        let variable_declarator = function_expression
+            .syntax()
+            .grand_parent()
+            .and_then(JsVariableDeclarator::cast)?;
+
+        return is_variable_declarator_pascal_case(&variable_declarator);
+    }
+
+    None
 }
 
-fn is_binding_a_jsx_prop(binding: &AnyJsBinding, model: &SemanticModel) -> Option<TextRange> {
+fn is_variable_declarator_pascal_case(variable_declarator: &JsVariableDeclarator) -> Option<bool> {
+    let name = variable_declarator.id().ok()?;
+    let name = name.as_any_js_binding()?.as_js_identifier_binding()?;
+    let text = name.name_token().ok()?;
+
+    Some(is_pascal_case(text.text_trimmed()))
+}
+
+fn is_pascal_case(name: &str) -> bool {
+    Case::identify(name, false) == Case::Pascal
+}
+
+fn is_binding_used_in_jsx(binding: &AnyJsBinding, model: &SemanticModel) -> Option<TextRange> {
     if let Some(binding) = binding
         .as_js_identifier_binding()
         .map(|b| model.as_binding(b))
@@ -188,8 +222,10 @@ fn is_binding_a_jsx_prop(binding: &AnyJsBinding, model: &SemanticModel) -> Optio
                 .syntax()
                 .ancestors()
                 .skip(1)
-                .find_map(JsxExpressionAttributeValue::cast)
-                .is_some()
+                .any(|ancestor| {
+                    JsxExpressionAttributeValue::can_cast(ancestor.kind())
+                        || JsxExpressionChild::can_cast(ancestor.kind())
+                })
             {
                 return Some(reference.syntax().text_trimmed_range());
             }

--- a/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/anonymousDefaultExport.tsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/anonymousDefaultExport.tsx
@@ -1,0 +1,3 @@
+export default function ({ a }) {
+	return <div>{a}</div>;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/anonymousDefaultExport.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/anonymousDefaultExport.tsx.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: anonymousDefaultExport.tsx
+---
+# Input
+```tsx
+export default function ({ a }) {
+	return <div>{a}</div>;
+}
+
+```
+
+# Diagnostics
+```
+anonymousDefaultExport.tsx:2:15 lint/correctness/noSolidDestructuredProps ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This variable shouldn't be destructured.
+  
+    1 │ export default function ({ a }) {
+  > 2 │ 	return <div>{a}</div>;
+      │ 	             ^
+    3 │ }
+    4 │ 
+  
+  i This is where the props were destructured.
+  
+  > 1 │ export default function ({ a }) {
+      │                          ^^^^^
+    2 │ 	return <div>{a}</div>;
+    3 │ }
+  
+  i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
+  
+  i Remove the destructuring and use props.foo instead.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/invalid.tsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/invalid.tsx
@@ -61,3 +61,29 @@ let Component = ({ a = 5, ...rest }) => <div a={a} b={rest.b} />;
 let Component = ({ ["a" + ""]: A = 5, ...rest }) => <div a={A} b={rest.b} />;
 
 let Component = ({ prop1, prop2 }: Props) => <div p1={prop1} p2={prop2} />;
+
+function Component({ a }) {
+	return <div a={a} />;
+}
+
+let Component = ({ a }) => <div>{a}</div>;
+
+function Component({ a }) {
+	return <div>{a}</div>;
+}
+
+let Component = function ({ a }) {
+	return <div>{a}</div>;
+};
+
+let Component = function ({ a }) {
+	return <div a={a} />;
+};
+
+export function Component({ a }) {
+	return <div>{a}</div>;
+}
+
+export default function Component({ a }) {
+	return <div>{a}</div>;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/invalid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/invalid.tsx.snap
@@ -68,6 +68,32 @@ let Component = ({ ["a" + ""]: A = 5, ...rest }) => <div a={A} b={rest.b} />;
 
 let Component = ({ prop1, prop2 }: Props) => <div p1={prop1} p2={prop2} />;
 
+function Component({ a }) {
+	return <div a={a} />;
+}
+
+let Component = ({ a }) => <div>{a}</div>;
+
+function Component({ a }) {
+	return <div>{a}</div>;
+}
+
+let Component = function ({ a }) {
+	return <div>{a}</div>;
+};
+
+let Component = function ({ a }) {
+	return <div a={a} />;
+};
+
+export function Component({ a }) {
+	return <div>{a}</div>;
+}
+
+export default function Component({ a }) {
+	return <div>{a}</div>;
+}
+
 ```
 
 # Diagnostics
@@ -1047,6 +1073,7 @@ invalid.tsx:63:55 lint/correctness/noSolidDestructuredProps ━━━━━━�
   > 63 │ let Component = ({ prop1, prop2 }: Props) => <div p1={prop1} p2={prop2} />;
        │                                                       ^^^^^
     64 │ 
+    65 │ function Component({ a }) {
   
   i This is where the props were destructured.
   
@@ -1055,6 +1082,7 @@ invalid.tsx:63:55 lint/correctness/noSolidDestructuredProps ━━━━━━�
   > 63 │ let Component = ({ prop1, prop2 }: Props) => <div p1={prop1} p2={prop2} />;
        │                  ^^^^^^^^^^^^^^^^
     64 │ 
+    65 │ function Component({ a }) {
   
   i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
   
@@ -1073,6 +1101,7 @@ invalid.tsx:63:66 lint/correctness/noSolidDestructuredProps ━━━━━━�
   > 63 │ let Component = ({ prop1, prop2 }: Props) => <div p1={prop1} p2={prop2} />;
        │                                                                  ^^^^^
     64 │ 
+    65 │ function Component({ a }) {
   
   i This is where the props were destructured.
   
@@ -1081,6 +1110,197 @@ invalid.tsx:63:66 lint/correctness/noSolidDestructuredProps ━━━━━━�
   > 63 │ let Component = ({ prop1, prop2 }: Props) => <div p1={prop1} p2={prop2} />;
        │                  ^^^^^^^^^^^^^^^^
     64 │ 
+    65 │ function Component({ a }) {
+  
+  i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
+  
+  i Remove the destructuring and use props.foo instead.
+  
+
+```
+
+```
+invalid.tsx:66:17 lint/correctness/noSolidDestructuredProps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This variable shouldn't be destructured.
+  
+    65 │ function Component({ a }) {
+  > 66 │ 	return <div a={a} />;
+       │ 	               ^
+    67 │ }
+    68 │ 
+  
+  i This is where the props were destructured.
+  
+    63 │ let Component = ({ prop1, prop2 }: Props) => <div p1={prop1} p2={prop2} />;
+    64 │ 
+  > 65 │ function Component({ a }) {
+       │                    ^^^^^
+    66 │ 	return <div a={a} />;
+    67 │ }
+  
+  i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
+  
+  i Remove the destructuring and use props.foo instead.
+  
+
+```
+
+```
+invalid.tsx:69:34 lint/correctness/noSolidDestructuredProps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This variable shouldn't be destructured.
+  
+    67 │ }
+    68 │ 
+  > 69 │ let Component = ({ a }) => <div>{a}</div>;
+       │                                  ^
+    70 │ 
+    71 │ function Component({ a }) {
+  
+  i This is where the props were destructured.
+  
+    67 │ }
+    68 │ 
+  > 69 │ let Component = ({ a }) => <div>{a}</div>;
+       │                  ^^^^^
+    70 │ 
+    71 │ function Component({ a }) {
+  
+  i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
+  
+  i Remove the destructuring and use props.foo instead.
+  
+
+```
+
+```
+invalid.tsx:72:15 lint/correctness/noSolidDestructuredProps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This variable shouldn't be destructured.
+  
+    71 │ function Component({ a }) {
+  > 72 │ 	return <div>{a}</div>;
+       │ 	             ^
+    73 │ }
+    74 │ 
+  
+  i This is where the props were destructured.
+  
+    69 │ let Component = ({ a }) => <div>{a}</div>;
+    70 │ 
+  > 71 │ function Component({ a }) {
+       │                    ^^^^^
+    72 │ 	return <div>{a}</div>;
+    73 │ }
+  
+  i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
+  
+  i Remove the destructuring and use props.foo instead.
+  
+
+```
+
+```
+invalid.tsx:76:15 lint/correctness/noSolidDestructuredProps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This variable shouldn't be destructured.
+  
+    75 │ let Component = function ({ a }) {
+  > 76 │ 	return <div>{a}</div>;
+       │ 	             ^
+    77 │ };
+    78 │ 
+  
+  i This is where the props were destructured.
+  
+    73 │ }
+    74 │ 
+  > 75 │ let Component = function ({ a }) {
+       │                           ^^^^^
+    76 │ 	return <div>{a}</div>;
+    77 │ };
+  
+  i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
+  
+  i Remove the destructuring and use props.foo instead.
+  
+
+```
+
+```
+invalid.tsx:80:17 lint/correctness/noSolidDestructuredProps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This variable shouldn't be destructured.
+  
+    79 │ let Component = function ({ a }) {
+  > 80 │ 	return <div a={a} />;
+       │ 	               ^
+    81 │ };
+    82 │ 
+  
+  i This is where the props were destructured.
+  
+    77 │ };
+    78 │ 
+  > 79 │ let Component = function ({ a }) {
+       │                           ^^^^^
+    80 │ 	return <div a={a} />;
+    81 │ };
+  
+  i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
+  
+  i Remove the destructuring and use props.foo instead.
+  
+
+```
+
+```
+invalid.tsx:84:15 lint/correctness/noSolidDestructuredProps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This variable shouldn't be destructured.
+  
+    83 │ export function Component({ a }) {
+  > 84 │ 	return <div>{a}</div>;
+       │ 	             ^
+    85 │ }
+    86 │ 
+  
+  i This is where the props were destructured.
+  
+    81 │ };
+    82 │ 
+  > 83 │ export function Component({ a }) {
+       │                           ^^^^^
+    84 │ 	return <div>{a}</div>;
+    85 │ }
+  
+  i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
+  
+  i Remove the destructuring and use props.foo instead.
+  
+
+```
+
+```
+invalid.tsx:88:15 lint/correctness/noSolidDestructuredProps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This variable shouldn't be destructured.
+  
+    87 │ export default function Component({ a }) {
+  > 88 │ 	return <div>{a}</div>;
+       │ 	             ^
+    89 │ }
+    90 │ 
+  
+  i This is where the props were destructured.
+  
+    85 │ }
+    86 │ 
+  > 87 │ export default function Component({ a }) {
+       │                                   ^^^^^
+    88 │ 	return <div>{a}</div>;
+    89 │ }
   
   i In Solid, props must be used with property accesses (props.foo) to preserve reactivity.
   

--- a/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/valid.tsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/valid.tsx
@@ -45,3 +45,7 @@ let Component = (props) => {
 let element = <div />;
 
 let Component = (props: Props) => <div />;
+
+function helper({ a }) {
+	return <div>{a}</div>;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/valid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noSolidDestructuredProps/valid.tsx.snap
@@ -52,4 +52,8 @@ let element = <div />;
 
 let Component = (props: Props) => <div />;
 
+function helper({ a }) {
+	return <div>{a}</div>;
+}
+
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #10742

`noSolidDestructuredProps` now reports destructured props in Solid function components and JSX children.

> AI assistance disclosure: I used Codex to help implement this fix and tests. I reviewed and validated the changes locally.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added regression cases for function components, JSX children, function expressions, and exported functions.

Ran:

```shell
cargo test -p biome_js_analyze --test spec_tests no_solid_destructured_props
cargo test -p biome_js_analyze
cargo lint
cargo fmt --check
cargo format
pnpm format
cargo run -p xtask_codegen -- analyzer
cargo run -p xtask_codegen --features configuration -- configuration
```

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->