### PR TITLE
fix(lint): support autocomplete contact detail tokens

### DIFF
--- a/.changeset/support-autocomplete-contact-detail-tokens.md
+++ b/.changeset/support-autocomplete-contact-detail-tokens.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fix useValidAutocomplete to support contact detail tokens.

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_autocomplete.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_autocomplete.rs
@@ -59,7 +59,7 @@ declare_lint_rule! {
 }
 
 // Sorted for binary search
-const VALID_AUTOCOMPLETE_VALUES: [&str; 55] = [
+const VALID_AUTOCOMPLETE_VALUES: [&str; 57] = [
     "additional-name",
     "address-level1",
     "address-level2",
@@ -109,6 +109,8 @@ const VALID_AUTOCOMPLETE_VALUES: [&str; 55] = [
     "tel-country-code",
     "tel-extension",
     "tel-local",
+    "tel-local-prefix",
+    "tel-local-suffix",
     "tel-national",
     "transaction-amount",
     "transaction-currency",
@@ -116,6 +118,31 @@ const VALID_AUTOCOMPLETE_VALUES: [&str; 55] = [
     "username",
     "webauthn",
 ];
+
+// Sorted for binary search
+const CONTACT_HINT_TOKENS: [&str; 5] = ["fax", "home", "mobile", "pager", "work"];
+
+// Sorted for binary search
+const CONTACT_FIELD_TOKENS: [&str; 10] = [
+    "email",
+    "impp",
+    "tel",
+    "tel-area-code",
+    "tel-country-code",
+    "tel-extension",
+    "tel-local",
+    "tel-local-prefix",
+    "tel-local-suffix",
+    "tel-national",
+];
+
+fn is_contact_hint_token(value: &str) -> bool {
+    CONTACT_HINT_TOKENS.binary_search(&value).is_ok()
+}
+
+fn is_contact_field_token(value: &str) -> bool {
+    CONTACT_FIELD_TOKENS.binary_search(&value).is_ok()
+}
 
 // Sorted for binary search
 const BILLING_AND_SHIPPING_ADDRESS: &[&str; 11] = &[
@@ -183,12 +210,13 @@ impl Rule for UseValidAutocomplete {
             )
             .note(markup! {
                 "The autocomplete attribute only accepts a certain number of specific fixed values."
-        }).note(markup!{
+            })
+            .note(markup!{
             "Follow the links for more information,
   "<Hyperlink href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose">"WCAG 1.3.5"</Hyperlink>"
   "<Hyperlink href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill">"HTML Living Standard autofill"</Hyperlink>"
   "<Hyperlink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete">"HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN"</Hyperlink>""
-        })
+            })
     )
     }
 }
@@ -205,16 +233,40 @@ fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
                 || VALID_AUTOCOMPLETE_VALUES.binary_search(&first).is_ok()
         }
         2.. => {
-            // SAFETY: the size of the slice is superior or equal to `2`
-            let first = autocomplete_values[0];
-            let second = autocomplete_values[1];
-            first.starts_with("section-")
-                || ["billing", "shipping"].contains(&first)
-                    && (BILLING_AND_SHIPPING_ADDRESS.contains(&second)
-                        || VALID_AUTOCOMPLETE_VALUES.binary_search(&second).is_ok())
-                || autocomplete_values
-                    .iter()
-                    .all(|val| VALID_AUTOCOMPLETE_VALUES.binary_search(val).is_ok())
+            let mut index = 0;
+
+            if autocomplete_values[index].starts_with("section-") {
+                index += 1;
+            }
+
+            let has_billing_or_shipping = autocomplete_values
+                .get(index)
+                .is_some_and(|value| matches!(*value, "billing" | "shipping"));
+
+            if has_billing_or_shipping {
+                index += 1;
+            }
+
+            if index >= autocomplete_values.len() {
+                return false;
+            }
+
+            if autocomplete_values
+                .get(index)
+                .is_some_and(|value| is_contact_hint_token(value))
+            {
+                index += 1;
+
+                return autocomplete_values.len() == index + 1
+                    && autocomplete_values
+                        .get(index)
+                        .is_some_and(|value| is_contact_field_token(value));
+            }
+
+            autocomplete_values[index..].iter().all(|val| {
+                VALID_AUTOCOMPLETE_VALUES.binary_search(val).is_ok()
+                    || has_billing_or_shipping && BILLING_AND_SHIPPING_ADDRESS.contains(val)
+            })
         }
     }
 }
@@ -222,5 +274,7 @@ fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
 #[test]
 fn test_order() {
     assert!(VALID_AUTOCOMPLETE_VALUES.is_sorted());
+    assert!(CONTACT_HINT_TOKENS.is_sorted());
+    assert!(CONTACT_FIELD_TOKENS.is_sorted());
     assert!(BILLING_AND_SHIPPING_ADDRESS.is_sorted());
 }

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx
@@ -1,6 +1,14 @@
 /* should generate diagnostics */
 <>
 	<input type="text" autocomplete="foo" />
+	<input type="text" autocomplete="work" />
+	<input type="text" autocomplete="mobile" />
+	<input type="text" autocomplete="home" />
+	<input type="text" autocomplete="fax" />
+	<input type="text" autocomplete="pager" />
+	<input type="text" autocomplete="work tel-nope" />
+	<input type="text" autocomplete="work name" />
+	<input type="text" autocomplete="shipping work" />
 	<input type="text" autocomplete="name invalid" />
 	<input type="text" autocomplete="invalid name" />
 	<input type="text" autocomplete="home url" />

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx.snap
@@ -7,6 +7,14 @@ expression: invalid.jsx
 /* should generate diagnostics */
 <>
 	<input type="text" autocomplete="foo" />
+	<input type="text" autocomplete="work" />
+	<input type="text" autocomplete="mobile" />
+	<input type="text" autocomplete="home" />
+	<input type="text" autocomplete="fax" />
+	<input type="text" autocomplete="pager" />
+	<input type="text" autocomplete="work tel-nope" />
+	<input type="text" autocomplete="work name" />
+	<input type="text" autocomplete="shipping work" />
 	<input type="text" autocomplete="name invalid" />
 	<input type="text" autocomplete="invalid name" />
 	<input type="text" autocomplete="home url" />
@@ -27,8 +35,8 @@ invalid.jsx:3:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
     2 │ <>
   > 3 │ 	<input type="text" autocomplete="foo" />
       │ 	                   ^^^^^^^^^^^^^^^^^^
-    4 │ 	<input type="text" autocomplete="name invalid" />
-    5 │ 	<input type="text" autocomplete="invalid name" />
+    4 │ 	<input type="text" autocomplete="work" />
+    5 │ 	<input type="text" autocomplete="mobile" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -47,10 +55,10 @@ invalid.jsx:4:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
   
     2 │ <>
     3 │ 	<input type="text" autocomplete="foo" />
-  > 4 │ 	<input type="text" autocomplete="name invalid" />
-      │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    5 │ 	<input type="text" autocomplete="invalid name" />
-    6 │ 	<input type="text" autocomplete="home url" />
+  > 4 │ 	<input type="text" autocomplete="work" />
+      │ 	                   ^^^^^^^^^^^^^^^^^^^
+    5 │ 	<input type="text" autocomplete="mobile" />
+    6 │ 	<input type="text" autocomplete="home" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -68,11 +76,11 @@ invalid.jsx:5:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
   × Use valid values for the autocomplete attribute.
   
     3 │ 	<input type="text" autocomplete="foo" />
-    4 │ 	<input type="text" autocomplete="name invalid" />
-  > 5 │ 	<input type="text" autocomplete="invalid name" />
-      │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    6 │ 	<input type="text" autocomplete="home url" />
-    7 │ 	<Bar autocomplete="baz"></Bar>
+    4 │ 	<input type="text" autocomplete="work" />
+  > 5 │ 	<input type="text" autocomplete="mobile" />
+      │ 	                   ^^^^^^^^^^^^^^^^^^^^^
+    6 │ 	<input type="text" autocomplete="home" />
+    7 │ 	<input type="text" autocomplete="fax" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -89,12 +97,12 @@ invalid.jsx:6:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
 
   × Use valid values for the autocomplete attribute.
   
-    4 │ 	<input type="text" autocomplete="name invalid" />
-    5 │ 	<input type="text" autocomplete="invalid name" />
-  > 6 │ 	<input type="text" autocomplete="home url" />
-      │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^
-    7 │ 	<Bar autocomplete="baz"></Bar>
-    8 │ 	<Input type="text" autocomplete="baz" />
+    4 │ 	<input type="text" autocomplete="work" />
+    5 │ 	<input type="text" autocomplete="mobile" />
+  > 6 │ 	<input type="text" autocomplete="home" />
+      │ 	                   ^^^^^^^^^^^^^^^^^^^
+    7 │ 	<input type="text" autocomplete="fax" />
+    8 │ 	<input type="text" autocomplete="pager" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -107,16 +115,16 @@ invalid.jsx:6:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
 ```
 
 ```
-invalid.jsx:7:7 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.jsx:7:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Use valid values for the autocomplete attribute.
   
-    5 │ 	<input type="text" autocomplete="invalid name" />
-    6 │ 	<input type="text" autocomplete="home url" />
-  > 7 │ 	<Bar autocomplete="baz"></Bar>
-      │ 	     ^^^^^^^^^^^^^^^^^^
-    8 │ 	<Input type="text" autocomplete="baz" />
-    9 │ 	<Input type="text" autoComplete="baz" />
+    5 │ 	<input type="text" autocomplete="mobile" />
+    6 │ 	<input type="text" autocomplete="home" />
+  > 7 │ 	<input type="text" autocomplete="fax" />
+      │ 	                   ^^^^^^^^^^^^^^^^^^
+    8 │ 	<input type="text" autocomplete="pager" />
+    9 │ 	<input type="text" autocomplete="work tel-nope" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -133,12 +141,12 @@ invalid.jsx:8:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
 
   × Use valid values for the autocomplete attribute.
   
-     6 │ 	<input type="text" autocomplete="home url" />
-     7 │ 	<Bar autocomplete="baz"></Bar>
-   > 8 │ 	<Input type="text" autocomplete="baz" />
-       │ 	                   ^^^^^^^^^^^^^^^^^^
-     9 │ 	<Input type="text" autoComplete="baz" />
-    10 │ </>
+     6 │ 	<input type="text" autocomplete="home" />
+     7 │ 	<input type="text" autocomplete="fax" />
+   > 8 │ 	<input type="text" autocomplete="pager" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^^^
+     9 │ 	<input type="text" autocomplete="work tel-nope" />
+    10 │ 	<input type="text" autocomplete="work name" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -155,12 +163,188 @@ invalid.jsx:9:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
 
   × Use valid values for the autocomplete attribute.
   
-     7 │ 	<Bar autocomplete="baz"></Bar>
-     8 │ 	<Input type="text" autocomplete="baz" />
-   > 9 │ 	<Input type="text" autoComplete="baz" />
+     7 │ 	<input type="text" autocomplete="fax" />
+     8 │ 	<input type="text" autocomplete="pager" />
+   > 9 │ 	<input type="text" autocomplete="work tel-nope" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 	<input type="text" autocomplete="work name" />
+    11 │ 	<input type="text" autocomplete="shipping work" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:10:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+     8 │ 	<input type="text" autocomplete="pager" />
+     9 │ 	<input type="text" autocomplete="work tel-nope" />
+  > 10 │ 	<input type="text" autocomplete="work name" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 	<input type="text" autocomplete="shipping work" />
+    12 │ 	<input type="text" autocomplete="name invalid" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:11:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+     9 │ 	<input type="text" autocomplete="work tel-nope" />
+    10 │ 	<input type="text" autocomplete="work name" />
+  > 11 │ 	<input type="text" autocomplete="shipping work" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 	<input type="text" autocomplete="name invalid" />
+    13 │ 	<input type="text" autocomplete="invalid name" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:12:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    10 │ 	<input type="text" autocomplete="work name" />
+    11 │ 	<input type="text" autocomplete="shipping work" />
+  > 12 │ 	<input type="text" autocomplete="name invalid" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ 	<input type="text" autocomplete="invalid name" />
+    14 │ 	<input type="text" autocomplete="home url" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:13:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    11 │ 	<input type="text" autocomplete="shipping work" />
+    12 │ 	<input type="text" autocomplete="name invalid" />
+  > 13 │ 	<input type="text" autocomplete="invalid name" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 	<input type="text" autocomplete="home url" />
+    15 │ 	<Bar autocomplete="baz"></Bar>
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:14:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    12 │ 	<input type="text" autocomplete="name invalid" />
+    13 │ 	<input type="text" autocomplete="invalid name" />
+  > 14 │ 	<input type="text" autocomplete="home url" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ 	<Bar autocomplete="baz"></Bar>
+    16 │ 	<Input type="text" autocomplete="baz" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:15:7 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    13 │ 	<input type="text" autocomplete="invalid name" />
+    14 │ 	<input type="text" autocomplete="home url" />
+  > 15 │ 	<Bar autocomplete="baz"></Bar>
+       │ 	     ^^^^^^^^^^^^^^^^^^
+    16 │ 	<Input type="text" autocomplete="baz" />
+    17 │ 	<Input type="text" autoComplete="baz" />
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:16:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    14 │ 	<input type="text" autocomplete="home url" />
+    15 │ 	<Bar autocomplete="baz"></Bar>
+  > 16 │ 	<Input type="text" autocomplete="baz" />
        │ 	                   ^^^^^^^^^^^^^^^^^^
-    10 │ </>
-    11 │ 
+    17 │ 	<Input type="text" autoComplete="baz" />
+    18 │ </>
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:17:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    15 │ 	<Bar autocomplete="baz"></Bar>
+    16 │ 	<Input type="text" autocomplete="baz" />
+  > 17 │ 	<Input type="text" autoComplete="baz" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^
+    18 │ </>
+    19 │ 
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx
@@ -6,6 +6,12 @@
 	<input type="text" autocomplete="off" />
 	<input type="text" autocomplete="on" />
 	<input type="text" autocomplete="billing family-name" />
+	<input type="tel" autocomplete="work tel" />
+	<input type="tel" autocomplete="mobile tel" />
+	<input type="text" autocomplete="home email" />
+	<input type="tel" autocomplete="fax tel-national" />
+	<input type="text" autocomplete="pager impp" />
+	<input type="tel" autocomplete="billing fax tel-extension" />
 	<input type="text" autocomplete="section-blue shipping street-address" />
 	<input type="text" autocomplete="section-somewhere shipping work email" />
 	<input type="text" autocomplete />

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 196
 expression: valid.jsx
 ---
 # Input
@@ -12,6 +13,12 @@ expression: valid.jsx
 	<input type="text" autocomplete="off" />
 	<input type="text" autocomplete="on" />
 	<input type="text" autocomplete="billing family-name" />
+	<input type="tel" autocomplete="work tel" />
+	<input type="tel" autocomplete="mobile tel" />
+	<input type="text" autocomplete="home email" />
+	<input type="tel" autocomplete="fax tel-national" />
+	<input type="text" autocomplete="pager impp" />
+	<input type="tel" autocomplete="billing fax tel-extension" />
 	<input type="text" autocomplete="section-blue shipping street-address" />
 	<input type="text" autocomplete="section-somewhere shipping work email" />
 	<input type="text" autocomplete />


### PR DESCRIPTION
Fixes #10743
## Summary

Fixes `useValidAutocomplete` so contact detail tokens such as `work`, `home`, `mobile`, `fax`, and `pager` are accepted when they are used before contact-related fields like `tel`, `tel-*`, `email`, or `impp`.

This makes values such as `autocomplete="work tel"` valid while still keeping standalone values like `autocomplete="work"` invalid.

## Test Plan

```sh
cargo fmt --all
cargo test -p biome_js_analyze --test spec_tests use_valid_autocomplete
```
