### PR TITLE
fix(lint): ignore custom elements in noInteractiveElementToNoninteractiveRole

### DIFF
--- a/.changeset/fix-no-interactive-role-custom-element.md
+++ b/.changeset/fix-no-interactive-role-custom-element.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#2862](https://github.com/biomejs/biome/issues/2862): [`noInteractiveElementToNoninteractiveRole`](https://biomejs.dev/linter/rules/no-interactive-element-to-noninteractive-role/) no longer reports custom elements (a tag name containing a dash, e.g. `<my-button role="img" />`). Per the [W3C HTML-ARIA specification](https://www.w3.org/TR/html-aria/#el-autonomous-custom-element), a custom element may be given any role or none.

--- a/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
@@ -38,6 +38,14 @@ declare_lint_rule! {
     /// <canvas role="img" />;
     /// ```
     ///
+    /// Custom elements (a tag name containing a dash) may be given any role or none:
+    ///
+    /// ```jsx
+    /// <>
+    ///     <my-button role="img" />
+    /// </>;
+    /// ```
+    ///
     pub NoInteractiveElementToNoninteractiveRole {
         version: "1.3.0",
         name: "noInteractiveElementToNoninteractiveRole",
@@ -60,6 +68,11 @@ impl Rule for NoInteractiveElementToNoninteractiveRole {
         if !node.is_element() {
             return None;
         }
+
+        if node.is_custom_element() {
+            return None;
+        }
+
         let role_attribute = node.find_attribute_by_name("role")?;
         let role_attribute_static_value = role_attribute.as_static_value()?;
         let role_attribute_value = role_attribute_static_value.text();

--- a/crates/biome_js_analyze/tests/specs/a11y/noInteractiveElementToNoninteractiveRole/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noInteractiveElementToNoninteractiveRole/valid.jsx
@@ -276,4 +276,10 @@
     src={'/assets/head.png'}
     alt='An ASCII-style headshot'
   />
-</picture>
+</picture>;
+/* Custom elements can have any role or none (https://www.w3.org/TR/html-aria/#el-autonomous-custom-element) */
+<>
+	<my-button role="img" />
+	<my-element role="listitem" />
+	<custom-card role="button" />
+</>;

--- a/crates/biome_js_analyze/tests/specs/a11y/noInteractiveElementToNoninteractiveRole/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noInteractiveElementToNoninteractiveRole/valid.jsx.snap
@@ -282,6 +282,12 @@ expression: valid.jsx
     src={'/assets/head.png'}
     alt='An ASCII-style headshot'
   />
-</picture>
+</picture>;
+/* Custom elements can have any role or none (https://www.w3.org/TR/html-aria/#el-autonomous-custom-element) */
+<>
+	<my-button role="img" />
+	<my-element role="listitem" />
+	<custom-card role="button" />
+</>;
 
 ```


### PR DESCRIPTION
## Summary

Fixes #2862. `noInteractiveElementToNoninteractiveRole` reported a false positive for autonomous custom elements (a tag name containing a dash, e.g. `<my-button role="img" />`). Per the [W3C HTML-ARIA spec](https://www.w3.org/TR/html-aria/#el-autonomous-custom-element), an autonomous custom element may be given any role or none, so it carries no inherent interactivity for a non-interactive role to override.

The fix adds an early return using the existing `AnyJsxElement::is_custom_element()` helper — the same guard `noStaticElementInteractions` already uses (added in #10191). The rule already returns early for components via the `is_element()` check, so only `is_custom_element()` is needed (adding `is_custom_component()` would be dead code).

A changeset is included.

## Test Plan

Added three cases to the rule's `valid.jsx` spec fixture — `<my-button role="img" />`, `<my-element role="listitem" />`, and `<custom-card role="button" />` — which previously triggered the rule and now produce no diagnostics. `invalid.jsx` is unchanged, so no existing diagnostic regresses.

## Docs

No documentation change needed.

---

AI assistance disclosure: the code, tests, and this PR description were produced with the help of Claude Code and reviewed by me before submission.
