### PR TITLE
fix(useVueValidVBind): accept Vue 3.4+ same-name shorthand

### DIFF
--- a/.changeset/fix-use-vue-valid-v-bind-same-name-shorthand.md
+++ b/.changeset/fix-use-vue-valid-v-bind-same-name-shorthand.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10754](https://github.com/biomejs/biome/issues/10754): [`useVueValidVBind`](https://biomejs.dev/linter/rules/use-vue-valid-v-bind/) no longer reports the Vue 3.4+ same-name shorthand as missing a value. `:foo` and `v-bind:foo` are now accepted as equivalent to `:foo="foo"`, while `v-bind`, `v-bind:[dynamicArg]`, and `:[dynamicArg]` without a value continue to be reported.

--- a/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_bind.rs
+++ b/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_bind.rs
@@ -3,7 +3,9 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyVueDirective, VueModifierList};
+use biome_html_syntax::{
+    AnyVueDirective, AnyVueDirectiveArgument, VueDirectiveArgument, VueModifierList,
+};
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_vue_valid_v_bind::UseVueValidVBindOptions;
 
@@ -11,7 +13,10 @@ declare_lint_rule! {
     /// Forbids `v-bind` directives with missing values or invalid modifiers.
     ///
     /// This rule reports v-bind directives in the following cases:
-    /// - The directive does not have a value. E.g. `<div v-bind:aaa></div>`
+    /// - The directive has neither a value nor a static argument from which to
+    ///   derive one. E.g. `<div v-bind></div>` or `<div v-bind:[foo]></div>`.
+    ///   `v-bind:foo` and `:foo` are accepted because they are valid Vue 3.4+
+    ///   same-name shorthand for `:foo="foo"`.
     /// - The directive has invalid modifiers. E.g. `<div v-bind:aaa.bbb="ccc"></div>`
     ///
     /// ## Examples
@@ -30,6 +35,10 @@ declare_lint_rule! {
     ///
     /// ```vue
     /// <Foo v-bind:foo="foo" />
+    /// ```
+    ///
+    /// ```vue
+    /// <Foo :foo />
     /// ```
     ///
     pub UseVueValidVBind {
@@ -64,7 +73,9 @@ impl Rule for UseVueValidVBind {
                     return None;
                 }
 
-                if vue_directive.initializer().is_none() {
+                if vue_directive.initializer().is_none()
+                    && !vue_directive.arg().is_some_and(|arg| is_static_arg(&arg))
+                {
                     return Some(ViolationKind::MissingValue);
                 }
 
@@ -77,7 +88,9 @@ impl Rule for UseVueValidVBind {
             AnyVueDirective::VueVBindShorthandDirective(dir) => {
                 // missing argument would be caught by the parser
 
-                if dir.initializer().is_none() {
+                if dir.initializer().is_none()
+                    && !dir.arg().is_ok_and(|arg| is_static_arg(&arg))
+                {
                     return Some(ViolationKind::MissingValue);
                 }
 
@@ -131,4 +144,15 @@ fn find_invalid_modifiers(modifiers: &VueModifierList) -> Option<TextRange> {
         }
     }
     None
+}
+
+/// Returns `true` if the directive argument is a static identifier
+/// (e.g. `foo` in `:foo`), as opposed to a dynamic expression
+/// (e.g. `[foo]` in `:[foo]`). Only static arguments can be the
+/// source of a Vue 3.4+ same-name shorthand binding.
+fn is_static_arg(arg: &VueDirectiveArgument) -> bool {
+    matches!(
+        arg.arg().ok(),
+        Some(AnyVueDirectiveArgument::VueStaticArgument(_))
+    )
 }

--- a/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_bind.rs
+++ b/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_bind.rs
@@ -16,7 +16,8 @@ declare_lint_rule! {
     /// - The directive has neither a value nor a static argument from which to
     ///   derive one. E.g. `<div v-bind></div>` or `<div v-bind:[foo]></div>`.
     ///   `v-bind:foo` and `:foo` are accepted because they are valid Vue 3.4+
-    ///   same-name shorthand for `:foo="foo"`.
+    ///   [same-name shorthand](https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand)
+    ///   for `:foo="foo"`.
     /// - The directive has invalid modifiers. E.g. `<div v-bind:aaa.bbb="ccc"></div>`
     ///
     /// ## Examples
@@ -150,6 +151,8 @@ fn find_invalid_modifiers(modifiers: &VueModifierList) -> Option<TextRange> {
 /// (e.g. `foo` in `:foo`), as opposed to a dynamic expression
 /// (e.g. `[foo]` in `:[foo]`). Only static arguments can be the
 /// source of a Vue 3.4+ same-name shorthand binding.
+///
+/// See <https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand>.
 fn is_static_arg(arg: &VueDirectiveArgument) -> bool {
     matches!(
         arg.arg().ok(),

--- a/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_bind.rs
+++ b/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_bind.rs
@@ -139,7 +139,7 @@ impl Rule for UseVueValidVBind {
 
 fn find_invalid_modifiers(modifiers: &VueModifierList) -> Option<TextRange> {
     for modifier in modifiers {
-        if !VALID_MODIFIERS.contains(&modifier.modifier_token().ok()?.text()) {
+        if !VALID_MODIFIERS.contains(&modifier.modifier_token().ok()?.text_trimmed()) {
             return Some(modifier.range());
         }
     }

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/invalid.vue
@@ -1,9 +1,13 @@
 <!-- should generate diagnostics -->
 
 <template>
-  <!-- Missing value -->
-  <Foo v-bind:foo />
-  <Foo :foo />
+  <!-- Missing value with no argument -->
+  <Foo v-bind />
+  <div v-bind></div>
+
+  <!-- Missing value with a dynamic argument: no static name to derive a binding from -->
+  <Foo v-bind:[dynamic] />
+  <Foo :[dynamic] />
 
   <!-- Missing value with modifier -->
   <div v-bind.prop></div>

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/invalid.vue.snap
@@ -7,9 +7,13 @@ expression: invalid.vue
 <!-- should generate diagnostics -->
 
 <template>
-  <!-- Missing value -->
-  <Foo v-bind:foo />
-  <Foo :foo />
+  <!-- Missing value with no argument -->
+  <Foo v-bind />
+  <div v-bind></div>
+
+  <!-- Missing value with a dynamic argument: no static name to derive a binding from -->
+  <Foo v-bind:[dynamic] />
+  <Foo :[dynamic] />
 
   <!-- Missing value with modifier -->
   <div v-bind.prop></div>
@@ -42,10 +46,10 @@ invalid.vue:5:8 lint/correctness/useVueValidVBind ━━━━━━━━━━
   × This v-bind directive is missing a value.
   
     3 │ <template>
-    4 │   <!-- Missing value -->
-  > 5 │   <Foo v-bind:foo />
-      │        ^^^^^^^^^^
-    6 │   <Foo :foo />
+    4 │   <!-- Missing value with no argument -->
+  > 5 │   <Foo v-bind />
+      │        ^^^^^^
+    6 │   <div v-bind></div>
     7 │ 
   
   i v-bind directives require a value.
@@ -60,12 +64,12 @@ invalid.vue:6:8 lint/correctness/useVueValidVBind ━━━━━━━━━━
 
   × This v-bind directive is missing a value.
   
-    4 │   <!-- Missing value -->
-    5 │   <Foo v-bind:foo />
-  > 6 │   <Foo :foo />
-      │        ^^^^
+    4 │   <!-- Missing value with no argument -->
+    5 │   <Foo v-bind />
+  > 6 │   <div v-bind></div>
+      │        ^^^^^^
     7 │ 
-    8 │   <!-- Missing value with modifier -->
+    8 │   <!-- Missing value with a dynamic argument: no static name to derive a binding from -->
   
   i v-bind directives require a value.
   
@@ -79,11 +83,11 @@ invalid.vue:9:8 lint/correctness/useVueValidVBind ━━━━━━━━━━
 
   × This v-bind directive is missing a value.
   
-     8 │   <!-- Missing value with modifier -->
-   > 9 │   <div v-bind.prop></div>
-       │        ^^^^^^^^^^^
-    10 │ 
-    11 │   <!-- Invalid single modifier on long-form -->
+     8 │   <!-- Missing value with a dynamic argument: no static name to derive a binding from -->
+   > 9 │   <Foo v-bind:[dynamic] />
+       │        ^^^^^^^^^^^^^^^^
+    10 │   <Foo :[dynamic] />
+    11 │ 
   
   i v-bind directives require a value.
   
@@ -93,15 +97,52 @@ invalid.vue:9:8 lint/correctness/useVueValidVBind ━━━━━━━━━━
 ```
 
 ```
-invalid.vue:12:18 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:10:8 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This v-bind directive is missing a value.
+  
+     8 │   <!-- Missing value with a dynamic argument: no static name to derive a binding from -->
+     9 │   <Foo v-bind:[dynamic] />
+  > 10 │   <Foo :[dynamic] />
+       │        ^^^^^^^^^^
+    11 │ 
+    12 │   <!-- Missing value with modifier -->
+  
+  i v-bind directives require a value.
+  
+  i Add a value to the directive, e.g. v-bind:foo="bar".
+  
+
+```
+
+```
+invalid.vue:13:8 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This v-bind directive is missing a value.
+  
+    12 │   <!-- Missing value with modifier -->
+  > 13 │   <div v-bind.prop></div>
+       │        ^^^^^^^^^^^
+    14 │ 
+    15 │   <!-- Invalid single modifier on long-form -->
+  
+  i v-bind directives require a value.
+  
+  i Add a value to the directive, e.g. v-bind:foo="bar".
+  
+
+```
+
+```
+invalid.vue:16:18 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This v-bind directive has an invalid modifier.
   
-    11 │   <!-- Invalid single modifier on long-form -->
-  > 12 │   <div v-bind:foo.invalid="bar"></div>
+    15 │   <!-- Invalid single modifier on long-form -->
+  > 16 │   <div v-bind:foo.invalid="bar"></div>
        │                  ^^^^^^^^
-    13 │ 
-    14 │   <!-- Invalid modifier on shorthand -->
+    17 │ 
+    18 │   <!-- Invalid modifier on shorthand -->
   
   i Only the following modifiers are allowed on v-bind directives: prop, camel, sync, and attr.
   
@@ -111,15 +152,15 @@ invalid.vue:12:18 lint/correctness/useVueValidVBind ━━━━━━━━━�
 ```
 
 ```
-invalid.vue:15:13 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:19:13 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This v-bind directive has an invalid modifier.
   
-    14 │   <!-- Invalid modifier on shorthand -->
-  > 15 │   <span :bar.badModifier="baz"></span>
+    18 │   <!-- Invalid modifier on shorthand -->
+  > 19 │   <span :bar.badModifier="baz"></span>
        │             ^^^^^^^^^^^^
-    16 │ 
-    17 │   <!-- Mixed valid and invalid modifiers: 'prop' is valid, 'wrong' is not -->
+    20 │ 
+    21 │   <!-- Mixed valid and invalid modifiers: 'prop' is valid, 'wrong' is not -->
   
   i Only the following modifiers are allowed on v-bind directives: prop, camel, sync, and attr.
   
@@ -129,15 +170,15 @@ invalid.vue:15:13 lint/correctness/useVueValidVBind ━━━━━━━━━�
 ```
 
 ```
-invalid.vue:18:15 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:22:15 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This v-bind directive has an invalid modifier.
   
-    17 │   <!-- Mixed valid and invalid modifiers: 'prop' is valid, 'wrong' is not -->
-  > 18 │   <p :baz.prop.wrong="value"></p>
+    21 │   <!-- Mixed valid and invalid modifiers: 'prop' is valid, 'wrong' is not -->
+  > 22 │   <p :baz.prop.wrong="value"></p>
        │               ^^^^^^
-    19 │ 
-    20 │   <!-- Dynamic argument is present but modifier is invalid -->
+    23 │ 
+    24 │   <!-- Dynamic argument is present but modifier is invalid -->
   
   i Only the following modifiers are allowed on v-bind directives: prop, camel, sync, and attr.
   
@@ -147,15 +188,15 @@ invalid.vue:18:15 lint/correctness/useVueValidVBind ━━━━━━━━━�
 ```
 
 ```
-invalid.vue:21:22 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:25:22 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This v-bind directive has an invalid modifier.
   
-    20 │   <!-- Dynamic argument is present but modifier is invalid -->
-  > 21 │   <p v-bind:[dynamic].notAValidModifier="value"></p>
+    24 │   <!-- Dynamic argument is present but modifier is invalid -->
+  > 25 │   <p v-bind:[dynamic].notAValidModifier="value"></p>
        │                      ^^^^^^^^^^^^^^^^^^
-    22 │ 
-    23 │   <!-- Multiple invalid modifiers -->
+    26 │ 
+    27 │   <!-- Multiple invalid modifiers -->
   
   i Only the following modifiers are allowed on v-bind directives: prop, camel, sync, and attr.
   
@@ -165,15 +206,15 @@ invalid.vue:21:22 lint/correctness/useVueValidVBind ━━━━━━━━━�
 ```
 
 ```
-invalid.vue:24:20 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:28:20 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This v-bind directive has an invalid modifier.
   
-    23 │   <!-- Multiple invalid modifiers -->
-  > 24 │   <button :disabled.once="true"></button>
+    27 │   <!-- Multiple invalid modifiers -->
+  > 28 │   <button :disabled.once="true"></button>
        │                    ^^^^^
-    25 │ 
-    26 │   <!-- Component binding with unknown modifier -->
+    29 │ 
+    30 │   <!-- Component binding with unknown modifier -->
   
   i Only the following modifiers are allowed on v-bind directives: prop, camel, sync, and attr.
   
@@ -183,15 +224,15 @@ invalid.vue:24:20 lint/correctness/useVueValidVBind ━━━━━━━━━�
 ```
 
 ```
-invalid.vue:27:31 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:31:31 lint/correctness/useVueValidVBind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This v-bind directive has an invalid modifier.
   
-    26 │   <!-- Component binding with unknown modifier -->
-  > 27 │   <MyComponent v-bind:propName.weird="someValue"></MyComponent>
+    30 │   <!-- Component binding with unknown modifier -->
+  > 31 │   <MyComponent v-bind:propName.weird="someValue"></MyComponent>
        │                               ^^^^^^
-    28 │ </template>
-    29 │ 
+    32 │ </template>
+    33 │ 
   
   i Only the following modifiers are allowed on v-bind directives: prop, camel, sync, and attr.
   

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/valid.vue
@@ -14,6 +14,13 @@
 <Foo v-bind:foo />
 <Foo v-bind:foo-bar />
 
+<!-- Same-name shorthand combined with valid modifiers. -->
+<Foo :foo.prop />
+<Foo v-bind:foo.prop />
+
+<!-- Same-name shorthand referencing a v-for iteration variable. -->
+<Foo v-for="foo of foos" :key="foo.id" :foo />
+
 <!-- Valid modifiers from the rule: prop, camel, sync, attr -->
 <div v-bind:foo.prop="bar"></div>
 <div v-bind:foo.camel="bar"></div>

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/valid.vue
@@ -8,6 +8,12 @@
 <div v-bind="props"></div>
 <Foo v-bind="props" />
 
+<!-- Vue 3.4+ same-name shorthand: `:foo` is equivalent to `:foo="foo"`. -->
+<Foo :foo />
+<Foo :foo-bar />
+<Foo v-bind:foo />
+<Foo v-bind:foo-bar />
+
 <!-- Valid modifiers from the rule: prop, camel, sync, attr -->
 <div v-bind:foo.prop="bar"></div>
 <div v-bind:foo.camel="bar"></div>

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/valid.vue.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_html_analyze/tests/spec_tests.rs
-assertion_line: 77
 expression: valid.vue
 ---
 # Input
@@ -14,6 +13,12 @@ expression: valid.vue
 <!-- Object syntax without an argument is valid -->
 <div v-bind="props"></div>
 <Foo v-bind="props" />
+
+<!-- Vue 3.4+ same-name shorthand: `:foo` is equivalent to `:foo="foo"`. -->
+<Foo :foo />
+<Foo :foo-bar />
+<Foo v-bind:foo />
+<Foo v-bind:foo-bar />
 
 <!-- Valid modifiers from the rule: prop, camel, sync, attr -->
 <div v-bind:foo.prop="bar"></div>

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVBind/valid.vue.snap
@@ -20,6 +20,13 @@ expression: valid.vue
 <Foo v-bind:foo />
 <Foo v-bind:foo-bar />
 
+<!-- Same-name shorthand combined with valid modifiers. -->
+<Foo :foo.prop />
+<Foo v-bind:foo.prop />
+
+<!-- Same-name shorthand referencing a v-for iteration variable. -->
+<Foo v-for="foo of foos" :key="foo.id" :foo />
+
 <!-- Valid modifiers from the rule: prop, camel, sync, attr -->
 <div v-bind:foo.prop="bar"></div>
 <div v-bind:foo.camel="bar"></div>


### PR DESCRIPTION
## Summary

`useVueValidVBind` was flagging the Vue 3.4+ same-name shorthand
(`:foo` ≡ `:foo="foo"`) as a missing value. The rule now skips the
missing-value report when the directive has a static argument; dynamic
arguments (`:[expr]`, `v-bind:[expr]`) without a value are still
reported.

Vue docs for the shorthand:
<https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand>.

A second commit fixes a latent bug this change exposed:
`find_invalid_modifiers` compared modifier names via `text()`, which
includes trailing trivia. In every prior fixture the modifier was
followed by `="value"` so the trivia was empty; with the shorthand
change a modifier can now be followed by whitespace and `/>`, so
`text()` returned `"prop "` and a valid modifier like `prop` was
mis-flagged as invalid. Switched to `text_trimmed()` to match
`no_vue_v_on_number_values`.

fixes #10754

## AI assistance disclosure

Implemented with Claude Code under my direction and review.

## Test Plan

snapshots — `invalid.vue` gains dynamic-argument no-value cases;
`valid.vue` gains plain same-name shorthand, shorthand combined with a
modifier, and shorthand referencing a v-for iteration variable.