### PR TITLE
fix(lsp): debounce diagnostics after rapid changes

### DIFF
--- a/.changeset/six-wasps-do.md
+++ b/.changeset/six-wasps-do.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the Biome Language Server DX by orchestrating certain operations, so that they won't block the editor during typing. This improvement is more visible in large documents.

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -37,7 +37,7 @@ parking_lot          = { workspace = true }
 rustc-hash           = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }
-tokio                = { workspace = true, features = ["io-std", "rt"] }
+tokio                = { workspace = true, features = ["io-std", "rt", "time"] }
 tower-lsp-server     = { workspace = true }
 tracing              = { workspace = true, features = ["attributes"] }
 url                  = { workspace = true }

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -71,9 +71,7 @@ pub(crate) async fn did_open(
 
     session.insert_document(url.clone(), doc);
 
-    if let Err(err) = session.update_diagnostics(url).await {
-        error!("Failed to update diagnostics: {}", err);
-    }
+    session.schedule_diagnostics(url, version);
 
     Ok(())
 }
@@ -186,7 +184,7 @@ fn resolve_workspace_base_path(session: &Session, project_path: &Utf8Path) -> Ut
 /// Handler for `textDocument/didChange` LSP notification
 #[tracing::instrument(level = "debug", skip_all, fields(url = field::display(&params.text_document.uri.as_str()), version = params.text_document.version), err)]
 pub(crate) async fn did_change(
-    session: &Session,
+    session: &Arc<Session>,
     params: lsp::DidChangeTextDocumentParams,
 ) -> Result<(), LspError> {
     let url = params.text_document.uri;
@@ -234,9 +232,7 @@ pub(crate) async fn did_change(
         editor_features: None,
     })?;
 
-    if let Err(err) = session.update_diagnostics(url).await {
-        error!("Failed to update diagnostics: {}", err);
-    }
+    session.schedule_diagnostics(url, version);
 
     Ok(())
 }
@@ -287,6 +283,7 @@ pub(crate) async fn did_close(
     params: lsp::DidCloseTextDocumentParams,
 ) -> Result<(), LspError> {
     let uri = params.text_document.uri;
+    session.close_diagnostics(&uri);
     let path = session.file_path(&uri)?;
     let Some(project_key) = session.remove_document(&uri) else {
         debug!("Document wasn't open: {}", uri.as_str());

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -122,6 +122,14 @@ fn create_document_content_change_event() -> Vec<TextDocumentContentChangeEvent>
     ]
 }
 
+fn full_document_change(text: impl Into<String>) -> Vec<TextDocumentContentChangeEvent> {
+    vec![TextDocumentContentChangeEvent {
+        range: None,
+        range_length: None,
+        text: text.into(),
+    }]
+}
+
 const EXPECTED_CST: &str = "0: JS_MODULE@0..57
   0: (empty)
   1: (empty)
@@ -559,6 +567,88 @@ async fn pull_diagnostics() -> Result<()> {
     );
 
     server.close_document().await?;
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn debounces_diagnostics_after_rapid_changes() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server.open_document("const a = 1; a = 2;").await?;
+    let _ = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+
+    server
+        .change_document(1, full_document_change("const b = 1; b = 2;"))
+        .await?;
+    server
+        .change_document(2, full_document_change("const c = 1; c = 2;"))
+        .await?;
+
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+    let Some(ServerNotification::PublishDiagnostics(params)) = notification else {
+        panic!("expected publishDiagnostics notification");
+    };
+
+    assert_eq!(params.version, Some(2));
+
+    server.close_document().await?;
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn does_not_publish_debounced_diagnostics_after_close() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server.open_document("const a = 1; a = 2;").await?;
+    let _ = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+
+    server
+        .change_document(1, full_document_change("const b = 1; b = 2;"))
+        .await?;
+    server.close_document().await?;
+
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+    assert_eq!(
+        notification,
+        Some(ServerNotification::PublishDiagnostics(
+            PublishDiagnosticsParams {
+                uri: uri!("document.js"),
+                version: None,
+                diagnostics: vec![],
+            }
+        ))
+    );
+
+    wait_for_no_notification(&mut receiver, Duration::from_millis(750), |n| {
+        n.is_publish_diagnostics()
+    })
+    .await;
 
     server.shutdown().await?;
     reader.abort();

--- a/crates/biome_lsp/src/server_test_utils.rs
+++ b/crates/biome_lsp/src/server_test_utils.rs
@@ -432,6 +432,22 @@ pub(crate) async fn wait_for_notification(
     }
 }
 
+pub(crate) async fn wait_for_no_notification(
+    receiver: &mut (impl Stream<Item = ServerNotification> + Unpin),
+    duration: Duration,
+    check: impl Fn(&ServerNotification) -> bool,
+) {
+    loop {
+        match tokio::time::timeout(duration, receiver.next()).await {
+            Ok(Some(notification)) if check(&notification) => {
+                panic!("unexpected server notification: {notification:?}");
+            }
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => return,
+        }
+    }
+}
+
 /// Basic handler for requests and notifications coming from the server for tests
 pub(crate) async fn client_handler<I, O>(
     stream: I,

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -38,14 +38,16 @@ use parking_lot::RwLock;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde_json::Value;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicI32};
+use std::time::Duration;
 use tokio::spawn;
 use tokio::sync::Notify;
 use tokio::sync::OnceCell;
 use tokio::sync::RwLock as TokioRwLock;
 use tokio::sync::watch;
 use tokio::task::spawn_blocking;
+use tokio::time::sleep;
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types::{
     self as lsp, ClientCapabilities, Diagnostic, MessageType, ProgressToken, Registration,
@@ -71,6 +73,31 @@ pub(crate) struct SessionKey(pub u64);
 struct ConfigurationCacheKey {
     base_path: Utf8PathBuf,
     settings_path: Option<Utf8PathBuf>,
+}
+
+const DIAGNOSTICS_DEBOUNCE: Duration = Duration::from_millis(250);
+
+struct DiagnosticsEntry {
+    /// The version of the document that was last scheduled for diagnostics.
+    scheduled_version: AtomicI32,
+    /// Whether diagnostics are currently being computed for this document.
+    running: AtomicBool,
+    /// Whether diagnostics should be recomputed after the current one completes.
+    /// This is used when multiple calls are queued, and we need to re-compute diagnostics for the last version of the document.
+    rerun_after_current: AtomicBool,
+    /// Whether the diagnostics entry has been closed.
+    closed: AtomicBool,
+}
+
+impl DiagnosticsEntry {
+    fn new(version: i32) -> Self {
+        Self {
+            scheduled_version: AtomicI32::new(version),
+            running: AtomicBool::new(false),
+            rerun_after_current: AtomicBool::new(false),
+            closed: AtomicBool::new(false),
+        }
+    }
 }
 
 /// Represents the state of an LSP server session.
@@ -109,6 +136,9 @@ pub(crate) struct Session {
 
     /// Documents opened in this session.
     documents: HashMap<Uri, Document, FxBuildHasher>,
+
+    /// Pending and active diagnostic refreshes for open documents.
+    diagnostics: HashMap<Uri, Arc<DiagnosticsEntry>, FxBuildHasher>,
 
     pub(crate) cancellation: Arc<Notify>,
 
@@ -231,6 +261,7 @@ impl Session {
             configuration_status: Default::default(),
             projects: Default::default(),
             documents: Default::default(),
+            diagnostics: Default::default(),
             extension_settings: config,
             cancellation,
             notified_broken_configuration: Default::default(),
@@ -383,6 +414,91 @@ impl Session {
         self.documents.pin().remove(url).map(|doc| doc.project_key)
     }
 
+    fn diagnostics_entry(&self, url: Uri, version: i32) -> Arc<DiagnosticsEntry> {
+        Arc::clone(
+            self.diagnostics
+                .pin()
+                .get_or_insert_with(url, || Arc::new(DiagnosticsEntry::new(version))),
+        )
+    }
+
+    pub(crate) fn close_diagnostics(&self, url: &Uri) {
+        let entry = self.diagnostics.pin().remove(url).cloned();
+        if let Some(entry) = entry {
+            entry.closed.store(true, Ordering::Release);
+        }
+    }
+
+    pub(crate) fn schedule_diagnostics(self: &Arc<Self>, url: Uri, version: i32) {
+        let entry = self.diagnostics_entry(url.clone(), version);
+        entry.closed.store(false, Ordering::Release);
+        entry.scheduled_version.store(version, Ordering::Release);
+
+        self.spawn_delayed_diagnostics(url, entry, version);
+    }
+
+    fn spawn_delayed_diagnostics(
+        self: &Arc<Self>,
+        url: Uri,
+        entry: Arc<DiagnosticsEntry>,
+        version: i32,
+    ) {
+        let session = Arc::clone(self);
+        spawn(async move {
+            sleep(DIAGNOSTICS_DEBOUNCE).await;
+            session.run_debounced_diagnostics(url, entry, version).await;
+        });
+    }
+
+    async fn run_debounced_diagnostics(
+        self: Arc<Self>,
+        url: Uri,
+        entry: Arc<DiagnosticsEntry>,
+        version: i32,
+    ) {
+        if entry.closed.load(Ordering::Acquire)
+            || entry.scheduled_version.load(Ordering::Acquire) != version
+        {
+            return;
+        }
+
+        // Only one diagnostics update should run for a document at a time.
+        // This tries to change `running` from `false` to `true`. If it works,
+        // this task owns the update. `AcqRel` is used for that successful claim,
+        // so this task sees the latest state, and other tasks see that this task
+        // claimed the update. If it fails, another task already owns the update,
+        // so `Acquire` is enough because we only need to read that state.
+        if entry
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            entry.rerun_after_current.store(true, Ordering::Release);
+            return;
+        }
+
+        if let Err(err) = self
+            .update_diagnostics_for_version(url.clone(), version, &entry)
+            .await
+        {
+            error!("Failed to update diagnostics: {err}");
+        }
+
+        entry.running.store(false, Ordering::Release);
+
+        // A newer change may have arrived while this update was running. This
+        // resets the flag back to `false` and tells us whether another update
+        // was requested. `AcqRel` makes the reset visible to other tasks and
+        // also lets this task see the latest request before deciding whether to
+        // schedule another diagnostics update.
+        if entry.rerun_after_current.swap(false, Ordering::AcqRel) {
+            let latest_version = entry.scheduled_version.load(Ordering::Acquire);
+            if latest_version != version && !entry.closed.load(Ordering::Acquire) {
+                self.spawn_delayed_diagnostics(url, entry, latest_version);
+            }
+        }
+    }
+
     pub(crate) fn file_path(&self, url: &Uri) -> Result<BiomePath> {
         let path_to_file = match url.to_file_path() {
             None => {
@@ -405,7 +521,24 @@ impl Session {
         let Some(doc) = self.document(&url) else {
             return Ok(());
         };
-        self.update_diagnostics_for_document(url.clone(), doc).await
+        self.update_diagnostics_for_document(url.clone(), doc, None)
+            .await
+    }
+
+    async fn update_diagnostics_for_version(
+        &self,
+        url: Uri,
+        version: i32,
+        entry: &DiagnosticsEntry,
+    ) -> Result<(), LspError> {
+        let Some(doc) = self.document(&url) else {
+            return Ok(());
+        };
+        if doc.version != version || entry.closed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        self.update_diagnostics_for_document(url.clone(), doc, Some(entry))
+            .await
     }
 
     /// Computes diagnostics for the file matching the provided url and publishes
@@ -416,6 +549,7 @@ impl Session {
         &self,
         url: Uri,
         doc: Document,
+        entry: Option<&DiagnosticsEntry>,
     ) -> Result<(), LspError> {
         let biome_path = self.file_path(&url)?;
 
@@ -449,6 +583,9 @@ impl Session {
         })?;
 
         if !file_features.supports_lint() && !file_features.supports_assist() {
+            if !self.can_publish_diagnostics(&url, doc.version, entry) {
+                return Ok(());
+            }
             self.client
                 .publish_diagnostics(url.clone(), vec![], Some(doc.version))
                 .await;
@@ -523,11 +660,30 @@ impl Session {
 
         info!("Diagnostics sent to the client {}", diagnostics.len());
 
+        if !self.can_publish_diagnostics(&url, doc.version, entry) {
+            return Ok(());
+        }
+
         self.client
             .publish_diagnostics(url.clone(), diagnostics, Some(doc.version))
             .await;
 
         Ok(())
+    }
+
+    fn is_document_current(&self, url: &Uri, version: i32) -> bool {
+        self.document(url)
+            .is_some_and(|document| document.version == version)
+    }
+
+    fn can_publish_diagnostics(
+        &self,
+        url: &Uri,
+        version: i32,
+        entry: Option<&DiagnosticsEntry>,
+    ) -> bool {
+        !entry.is_some_and(|entry| entry.closed.load(Ordering::Acquire))
+            && self.is_document_current(url, version)
     }
 
     /// Updates diagnostics for every [`Document`] in this [`Session`]
@@ -537,7 +693,7 @@ impl Session {
             .documents
             .pin()
             .iter()
-            .map(|(url, doc)| self.update_diagnostics_for_document(url.clone(), doc.clone()))
+            .map(|(url, doc)| self.update_diagnostics_for_document(url.clone(), doc.clone(), None))
             .collect();
 
         while let Some(result) = futures.next().await {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Part of https://github.com/biomejs/biome/issues/10768

It doesn't fix the whole problem yet, I have other fixes in mind.

This PR makes the `update_diagnostics` work using a debounce mechanism. The mechanism works **for document**, so it's not atomic for the whole language server. 

I will call "query" the "update diagnostics" operation. The mechanism is the following:
- First query arrives, triggered by `change_file`
- We create a `DiagnosticEntry`. The entry isn't for this document isn't busy, so we call a `spawn` task and retrieve the diagnostics. 
- This entry is running.
- Second query arrives
- There's an existing entry for this document, but we bump its revision. 
- The query doesn't run, and we update `latest_revision`
- Third query arrives
- There's an existing entry for this document, but we bump its revision. 
- The query doesn't run, and we update `latest_revision`
- First query finishes
- `latest_revision` **isn't** the current revision, which means we have to pull diagnostics again for the last revision (third one). 
- Run query

> [!NOTE] 
> I authored the code via coding agent, but reviewed multiple times, and made sure I understood the code. Comments were authored in areas where things were more complex.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
