### PR TITLE
fix(useVueValidVOn): allow verb-modifier-only handlers and object syntax

### DIFF
--- a/.changeset/fix-use-vue-valid-v-on-verb-modifier-only.md
+++ b/.changeset/fix-use-vue-valid-v-on-verb-modifier-only.md
@@ -2,4 +2,6 @@
 "@biomejs/biome": patch
 ---
 
-[`useVueValidVOn`](https://biomejs.dev/linter/rules/use-vue-valid-v-on/) no longer reports a missing handler when the v-on directive uses a verb modifier (`.stop` or `.prevent`) without an expression. Modifier-only forms such as `<div @click.stop></div>` and `<form @submit.prevent></form>` carry an intrinsic side effect (`event.stopPropagation()` / `event.preventDefault()`) and are valid Vue syntax. This matches `eslint-plugin-vue`'s `valid-v-on`, which exempts the same `VERB_MODIFIERS` set.
+Fixed [#10772](https://github.com/biomejs/biome/issues/10772): [`useVueValidVOn`](https://biomejs.dev/linter/rules/use-vue-valid-v-on/) no longer reports a missing handler when the v-on directive uses a verb modifier (`.stop` or `.prevent`) without an expression. Modifier-only forms such as `<div @click.stop></div>` and `<form @submit.prevent></form>` carry an intrinsic side effect (`event.stopPropagation()` / `event.preventDefault()`) and are valid Vue syntax. This matches `eslint-plugin-vue`'s `valid-v-on`, which exempts the same `VERB_MODIFIERS` set.
+
+Additionally, fixed a related false positive where `<div v-on="$listeners"></div>` and other arg-less `v-on` with an object value were reported as missing an event name. An arg-less `v-on` with a value is the Vue object syntax (parallel to `<div v-bind="object"></div>`).

--- a/.changeset/fix-use-vue-valid-v-on-verb-modifier-only.md
+++ b/.changeset/fix-use-vue-valid-v-on-verb-modifier-only.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+[`useVueValidVOn`](https://biomejs.dev/linter/rules/use-vue-valid-v-on/) no longer reports a missing handler when the v-on directive uses a verb modifier (`.stop` or `.prevent`) without an expression. Modifier-only forms such as `<div @click.stop></div>` and `<form @submit.prevent></form>` carry an intrinsic side effect (`event.stopPropagation()` / `event.preventDefault()`) and are valid Vue syntax. This matches `eslint-plugin-vue`'s `valid-v-on`, which exempts the same `VERB_MODIFIERS` set.

--- a/.changeset/fix-use-vue-valid-v-on-verb-modifier-only.md
+++ b/.changeset/fix-use-vue-valid-v-on-verb-modifier-only.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10772](https://github.com/biomejs/biome/issues/10772): [`useVueValidVOn`](https://biomejs.dev/linter/rules/use-vue-valid-v-on/) no longer reports a missing handler when the v-on directive uses a verb modifier (`.stop` or `.prevent`) without an expression. Modifier-only forms such as `<div @click.stop></div>` and `<form @submit.prevent></form>` carry an intrinsic side effect (`event.stopPropagation()` / `event.preventDefault()`) and are valid Vue syntax. This matches `eslint-plugin-vue`'s `valid-v-on`, which exempts the same `VERB_MODIFIERS` set.
-
-Additionally, fixed a related false positive where `<div v-on="$listeners"></div>` and other arg-less `v-on` with an object value were reported as missing an event name. An arg-less `v-on` with a value is the Vue object syntax (parallel to `<div v-bind="object"></div>`).
+Fixed [#10772](https://github.com/biomejs/biome/issues/10772): [`useVueValidVOn`](https://biomejs.dev/linter/rules/use-vue-valid-v-on/) no longer reports a missing handler for v-on directives using a verb modifier (`.stop` / `.prevent`) without an expression, e.g. `<div @click.stop></div>`. The rule also accepts the arg-less object syntax `<div v-on="$listeners"></div>` instead of reporting a missing event name.

--- a/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_on.rs
+++ b/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_on.rs
@@ -13,15 +13,16 @@ declare_lint_rule! {
     ///
     /// This rule reports v-on directives in the following cases:
     /// - The directive has neither an event name nor a value (an arg-less
-    ///   `v-on` with a value is the object syntax, e.g. `<div v-on="$listeners"></div>`,
-    ///   which is valid).
+    ///   `v-on` with a value is the
+    ///   [object syntax](https://vuejs.org/api/built-in-directives.html#v-on),
+    ///   e.g. `<div v-on="$listeners"></div>`, which is valid).
     /// - The directive has invalid modifiers. E.g. `<div v-on:click.bogus="foo"></div>`
     /// - The directive is missing a handler expression, **unless one of the
-    ///   verb modifiers (`stop`, `prevent`) is present**. The verb modifiers
-    ///   carry an intrinsic side effect (`event.stopPropagation()` /
-    ///   `event.preventDefault()`) and are valid Vue syntax without a handler.
-    ///   E.g. `<div v-on:click></div>` is invalid but `<div @click.stop></div>`
-    ///   is valid.
+    ///   [verb modifiers](https://vuejs.org/guide/essentials/event-handling.html#event-modifiers)
+    ///   (`stop`, `prevent`) is present**. The verb modifiers carry an intrinsic
+    ///   side effect (`event.stopPropagation()` / `event.preventDefault()`) and
+    ///   are valid Vue syntax without a handler. E.g. `<div v-on:click></div>`
+    ///   is invalid but `<div @click.stop></div>` is valid.
     ///
     /// ## Examples
     ///
@@ -211,6 +212,8 @@ fn find_invalid_modifiers(
 ///
 /// This mirrors `eslint-plugin-vue`'s `VERB_MODIFIERS` set, which the
 /// upstream `valid-v-on` rule uses for the same purpose.
+///
+/// See <https://vuejs.org/guide/essentials/event-handling.html#event-modifiers>.
 fn has_verb_modifier(modifiers: &VueModifierList) -> bool {
     for modifier in modifiers {
         if modifier

--- a/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_on.rs
+++ b/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_on.rs
@@ -14,7 +14,12 @@ declare_lint_rule! {
     /// This rule reports v-on directives in the following cases:
     /// - The directive does not have an event name. E.g. `<div v-on="foo"></div>`
     /// - The directive has invalid modifiers. E.g. `<div v-on:click.bogus="foo"></div>`
-    /// - The directive is missing a handler expression. E.g. `<div v-on:click></div>`
+    /// - The directive is missing a handler expression, **unless one of the
+    ///   verb modifiers (`stop`, `prevent`) is present**. The verb modifiers
+    ///   carry an intrinsic side effect (`event.stopPropagation()` /
+    ///   `event.preventDefault()`) and are valid Vue syntax without a handler.
+    ///   E.g. `<div v-on:click></div>` is invalid but `<div @click.stop></div>`
+    ///   is valid.
     ///
     /// ## Examples
     ///
@@ -28,6 +33,10 @@ declare_lint_rule! {
     ///
     /// ```vue
     /// <Foo v-on:click="foo" />
+    /// ```
+    ///
+    /// ```vue
+    /// <div @click.stop></div>
     /// ```
     ///
     pub UseVueValidVOn {
@@ -68,15 +77,17 @@ impl Rule for UseVueValidVOn {
                     return Some(ViolationKind::MissingEventName);
                 }
 
+                let modifiers = vue_directive.modifiers();
+
                 // Check for invalid modifiers
                 if let Some(invalid_range) =
-                    find_invalid_modifiers(&vue_directive.modifiers(), options.modifiers.as_ref())
+                    find_invalid_modifiers(&modifiers, options.modifiers.as_ref())
                 {
                     return Some(ViolationKind::InvalidModifier(invalid_range));
                 }
 
                 // Check for missing handler
-                if vue_directive.initializer().is_none() {
+                if vue_directive.initializer().is_none() && !has_verb_modifier(&modifiers) {
                     return Some(ViolationKind::MissingHandler);
                 }
 
@@ -85,15 +96,17 @@ impl Rule for UseVueValidVOn {
             AnyVueDirective::VueVOnShorthandDirective(dir) => {
                 // Shorthand always has an argument (parser enforces this)
 
+                let modifiers = dir.modifiers();
+
                 // Check for invalid modifiers
                 if let Some(invalid_range) =
-                    find_invalid_modifiers(&dir.modifiers(), options.modifiers.as_ref())
+                    find_invalid_modifiers(&modifiers, options.modifiers.as_ref())
                 {
                     return Some(ViolationKind::InvalidModifier(invalid_range));
                 }
 
                 // Check for missing handler
-                if dir.initializer().is_none() {
+                if dir.initializer().is_none() && !has_verb_modifier(&modifiers) {
                     return Some(ViolationKind::MissingHandler);
                 }
 
@@ -161,7 +174,7 @@ fn find_invalid_modifiers(
 ) -> Option<TextRange> {
     for modifier in modifiers {
         if let Ok(modifier_token) = modifier.modifier_token() {
-            let modifier_text = modifier_token.text();
+            let modifier_text = modifier_token.text_trimmed();
             if modifier_text.len() == 1 {
                 // allow single character modifiers (e.g. key codes)
                 continue;
@@ -186,6 +199,27 @@ fn find_invalid_modifiers(
     }
     None
 }
+
+/// Returns `true` if any of the modifiers is a "verb" modifier
+/// (`.stop` or `.prevent`). Verb modifiers carry an intrinsic side
+/// effect (`event.stopPropagation()` / `event.preventDefault()`) and
+/// make the directive valid even without a handler expression.
+///
+/// This mirrors `eslint-plugin-vue`'s `VERB_MODIFIERS` set, which the
+/// upstream `valid-v-on` rule uses for the same purpose.
+fn has_verb_modifier(modifiers: &VueModifierList) -> bool {
+    for modifier in modifiers {
+        if modifier
+            .modifier_token()
+            .is_ok_and(|t| VERB_MODIFIERS.contains(t.text_trimmed()))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+static VERB_MODIFIERS: phf::Set<&'static str> = phf_set! { "stop", "prevent" };
 
 static VALID_MODIFIERS: phf::Set<&'static str> = phf_set! {
     "stop", "prevent", "capture", "self", "ctrl", "shift", "alt", "meta", "native", "once", "left",

--- a/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_on.rs
+++ b/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_on.rs
@@ -12,7 +12,9 @@ declare_lint_rule! {
     /// Enforce valid `v-on` directives with proper arguments, modifiers, and handlers.
     ///
     /// This rule reports v-on directives in the following cases:
-    /// - The directive does not have an event name. E.g. `<div v-on="foo"></div>`
+    /// - The directive has neither an event name nor a value (an arg-less
+    ///   `v-on` with a value is the object syntax, e.g. `<div v-on="$listeners"></div>`,
+    ///   which is valid).
     /// - The directive has invalid modifiers. E.g. `<div v-on:click.bogus="foo"></div>`
     /// - The directive is missing a handler expression, **unless one of the
     ///   verb modifiers (`stop`, `prevent`) is present**. The verb modifiers
@@ -72,8 +74,10 @@ impl Rule for UseVueValidVOn {
                     return None;
                 }
 
-                // Check for missing event name
-                if vue_directive.arg().is_none() {
+                // Check for missing event name. An arg-less `v-on` is the
+                // object syntax (`v-on="$listeners"`); only flag when there
+                // is also no value to spread.
+                if vue_directive.arg().is_none() && vue_directive.initializer().is_none() {
                     return Some(ViolationKind::MissingEventName);
                 }
 

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/invalid.vue
@@ -1,11 +1,8 @@
 <!-- should generate diagnostics -->
 
 <template>
-  <!-- Missing event name: long-form without an argument -->
+  <!-- Missing event name: long-form without an argument or value -->
   <div v-on></div>
-
-  <!-- Missing event name with value -->
-  <div v-on="foo"></div>
 
   <!-- Missing handler on long-form -->
   <div v-on:click></div>

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/invalid.vue.snap
@@ -7,11 +7,8 @@ expression: invalid.vue
 <!-- should generate diagnostics -->
 
 <template>
-  <!-- Missing event name: long-form without an argument -->
+  <!-- Missing event name: long-form without an argument or value -->
   <div v-on></div>
-
-  <!-- Missing event name with value -->
-  <div v-on="foo"></div>
 
   <!-- Missing handler on long-form -->
   <div v-on:click></div>
@@ -49,11 +46,11 @@ invalid.vue:5:8 lint/correctness/useVueValidVOn ━━━━━━━━━━�
   × The v-on directive is missing an event name.
   
     3 │ <template>
-    4 │   <!-- Missing event name: long-form without an argument -->
+    4 │   <!-- Missing event name: long-form without an argument or value -->
   > 5 │   <div v-on></div>
       │        ^^^^
     6 │ 
-    7 │   <!-- Missing event name with value -->
+    7 │   <!-- Missing handler on long-form -->
   
   i Provide an event name after the colon, e.g. v-on:click="handler".
   
@@ -63,15 +60,15 @@ invalid.vue:5:8 lint/correctness/useVueValidVOn ━━━━━━━━━━�
 ```
 invalid.vue:8:8 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The v-on directive is missing an event name.
+  × The v-on directive for this event is missing a handler expression.
   
-     7 │   <!-- Missing event name with value -->
-   > 8 │   <div v-on="foo"></div>
+     7 │   <!-- Missing handler on long-form -->
+   > 8 │   <div v-on:click></div>
        │        ^^^^^^^^^^
      9 │ 
-    10 │   <!-- Missing handler on long-form -->
+    10 │   <!-- Missing handler on shorthand -->
   
-  i Provide an event name after the colon, e.g. v-on:click="handler".
+  i Add a handler, e.g. v-on:click="onClick".
   
 
 ```
@@ -81,27 +78,11 @@ invalid.vue:11:8 lint/correctness/useVueValidVOn ━━━━━━━━━━�
 
   × The v-on directive for this event is missing a handler expression.
   
-    10 │   <!-- Missing handler on long-form -->
-  > 11 │   <div v-on:click></div>
-       │        ^^^^^^^^^^
-    12 │ 
-    13 │   <!-- Missing handler on shorthand -->
-  
-  i Add a handler, e.g. v-on:click="onClick".
-  
-
-```
-
-```
-invalid.vue:14:8 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The v-on directive for this event is missing a handler expression.
-  
-    13 │   <!-- Missing handler on shorthand -->
-  > 14 │   <div @click></div>
+    10 │   <!-- Missing handler on shorthand -->
+  > 11 │   <div @click></div>
        │        ^^^^^^
-    15 │ 
-    16 │   <!-- Invalid single modifier on long-form -->
+    12 │ 
+    13 │   <!-- Invalid single modifier on long-form -->
   
   i Add a handler, e.g. v-on:click="onClick".
   
@@ -109,15 +90,15 @@ invalid.vue:14:8 lint/correctness/useVueValidVOn ━━━━━━━━━━�
 ```
 
 ```
-invalid.vue:17:18 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:14:18 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Invalid v-on modifier.
   
-    16 │   <!-- Invalid single modifier on long-form -->
-  > 17 │   <div v-on:click.bogus="foo"></div>
+    13 │   <!-- Invalid single modifier on long-form -->
+  > 14 │   <div v-on:click.bogus="foo"></div>
        │                  ^^^^^^
-    18 │ 
-    19 │   <!-- Invalid modifier on shorthand -->
+    15 │ 
+    16 │   <!-- Invalid modifier on shorthand -->
   
   i Remove or correct the invalid modifier.
   
@@ -150,15 +131,15 @@ invalid.vue:17:18 lint/correctness/useVueValidVOn ━━━━━━━━━━
 ```
 
 ```
-invalid.vue:20:15 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:17:15 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Invalid v-on modifier.
   
-    19 │   <!-- Invalid modifier on shorthand -->
-  > 20 │   <span @click.badModifier="foo"></span>
+    16 │   <!-- Invalid modifier on shorthand -->
+  > 17 │   <span @click.badModifier="foo"></span>
        │               ^^^^^^^^^^^^
-    21 │ 
-    22 │   <!-- Mixed valid and invalid modifiers: 'stop' is valid, 'wrong' is not -->
+    18 │ 
+    19 │   <!-- Mixed valid and invalid modifiers: 'stop' is valid, 'wrong' is not -->
   
   i Remove or correct the invalid modifier.
   
@@ -191,15 +172,56 @@ invalid.vue:20:15 lint/correctness/useVueValidVOn ━━━━━━━━━━
 ```
 
 ```
-invalid.vue:23:17 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:20:17 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Invalid v-on modifier.
   
-    22 │   <!-- Mixed valid and invalid modifiers: 'stop' is valid, 'wrong' is not -->
-  > 23 │   <p @click.stop.wrong="foo"></p>
+    19 │   <!-- Mixed valid and invalid modifiers: 'stop' is valid, 'wrong' is not -->
+  > 20 │   <p @click.stop.wrong="foo"></p>
        │                 ^^^^^^
+    21 │ 
+    22 │   <!-- Dynamic argument is present but modifier is invalid -->
+  
+  i Remove or correct the invalid modifier.
+  
+  i Allowed modifiers:
+  
+  - delete
+  - native
+  - capture
+  - down
+  - self
+  - meta
+  - left
+  - stop
+  - enter
+  - space
+  - up
+  - once
+  - middle
+  - ctrl
+  - alt
+  - tab
+  - exact
+  - passive
+  - prevent
+  - esc
+  - right
+  - shift
+  
+
+```
+
+```
+invalid.vue:23:18 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Invalid v-on modifier.
+  
+    22 │   <!-- Dynamic argument is present but modifier is invalid -->
+  > 23 │   <p v-on:[event].notAValidModifier="foo"></p>
+       │                  ^^^^^^^^^^^^^^^^^^
     24 │ 
-    25 │   <!-- Dynamic argument is present but modifier is invalid -->
+    25 │   <!-- Multiple invalid modifiers -->
   
   i Remove or correct the invalid modifier.
   
@@ -236,52 +258,11 @@ invalid.vue:26:18 lint/correctness/useVueValidVOn ━━━━━━━━━━
 
   × Invalid v-on modifier.
   
-    25 │   <!-- Dynamic argument is present but modifier is invalid -->
-  > 26 │   <p v-on:[event].notAValidModifier="foo"></p>
-       │                  ^^^^^^^^^^^^^^^^^^
-    27 │ 
-    28 │   <!-- Multiple invalid modifiers -->
-  
-  i Remove or correct the invalid modifier.
-  
-  i Allowed modifiers:
-  
-  - delete
-  - native
-  - capture
-  - down
-  - self
-  - meta
-  - left
-  - stop
-  - enter
-  - space
-  - up
-  - once
-  - middle
-  - ctrl
-  - alt
-  - tab
-  - exact
-  - passive
-  - prevent
-  - esc
-  - right
-  - shift
-  
-
-```
-
-```
-invalid.vue:29:18 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Invalid v-on modifier.
-  
-    28 │   <!-- Multiple invalid modifiers -->
-  > 29 │   <button @submit.invalidModifier.anotherBad="handler"></button>
+    25 │   <!-- Multiple invalid modifiers -->
+  > 26 │   <button @submit.invalidModifier.anotherBad="handler"></button>
        │                  ^^^^^^^^^^^^^^^^
-    30 │ 
-    31 │   <!-- Component with invalid modifier -->
+    27 │ 
+    28 │   <!-- Component with invalid modifier -->
   
   i Remove or correct the invalid modifier.
   
@@ -314,15 +295,15 @@ invalid.vue:29:18 lint/correctness/useVueValidVOn ━━━━━━━━━━
 ```
 
 ```
-invalid.vue:32:22 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:29:22 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Invalid v-on modifier.
   
-    31 │   <!-- Component with invalid modifier -->
-  > 32 │   <MyComponent @click.weird="someHandler"></MyComponent>
+    28 │   <!-- Component with invalid modifier -->
+  > 29 │   <MyComponent @click.weird="someHandler"></MyComponent>
        │                      ^^^^^^
-    33 │ 
-    34 │   <!-- Missing handler with valid modifiers -->
+    30 │ 
+    31 │   <!-- Missing handler with valid modifiers -->
   
   i Remove or correct the invalid modifier.
   
@@ -355,14 +336,14 @@ invalid.vue:32:22 lint/correctness/useVueValidVOn ━━━━━━━━━━
 ```
 
 ```
-invalid.vue:35:8 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:32:8 lint/correctness/useVueValidVOn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The v-on directive for this event is missing a handler expression.
   
-    34 │   <!-- Missing handler with valid modifiers -->
-  > 35 │   <div @keyup.enter></div>
+    31 │   <!-- Missing handler with valid modifiers -->
+  > 32 │   <div @keyup.enter></div>
        │        ^^^^^^^^^^^^
-    36 │ </template>
+    33 │ </template>
   
   i Add a handler, e.g. v-on:click="onClick".
   

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue
@@ -52,6 +52,11 @@
   <!-- Multiple v-on directives on same element -->
   <div v-on:click="foo" @mouseenter="bar"></div>
 
+  <!-- Object syntax: arg-less v-on with a value spreads the object's
+       listeners onto the element. -->
+  <div v-on="$listeners"></div>
+  <div v-on="{ click: onClick, mouseenter: onHover }"></div>
+
   <!-- Component event handlers -->
   <MyComponent @click="handler" @custom-event="customHandler"></MyComponent>
 

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue
@@ -55,7 +55,7 @@
   <!-- Object syntax: arg-less v-on with a value spreads the object's
        listeners onto the element. -->
   <div v-on="$listeners"></div>
-  <div v-on="{ click: onClick, mouseenter: onHover }"></div>
+  <div v-on="listeners"></div>
 
   <!-- Component event handlers -->
   <MyComponent @click="handler" @custom-event="customHandler"></MyComponent>

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue
@@ -57,4 +57,20 @@
 
   <!-- Native modifier (Vue 2 compatibility) -->
   <div @click.native="handler"></div>
+
+  <!-- Verb modifiers (`stop`, `prevent`) carry an intrinsic side
+       effect and are valid without a handler. -->
+  <div @click.stop></div>
+  <form @submit.prevent></form>
+  <div v-on:click.stop></div>
+  <div v-on:submit.prevent></div>
+  <div @click.stop.prevent></div>
+  <div @click.prevent.exact></div>
+
+  <!-- Verb-modifier-only on a self-closing component (modifier is
+       followed by whitespace + `/>`, so the modifier-name lookup must
+       trim trivia). -->
+  <Foo @click.stop />
+  <Foo @submit.prevent />
+  <Foo v-on:click.stop />
 </template>

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue.snap
@@ -58,6 +58,11 @@ expression: valid.vue
   <!-- Multiple v-on directives on same element -->
   <div v-on:click="foo" @mouseenter="bar"></div>
 
+  <!-- Object syntax: arg-less v-on with a value spreads the object's
+       listeners onto the element. -->
+  <div v-on="$listeners"></div>
+  <div v-on="listeners"></div>
+
   <!-- Component event handlers -->
   <MyComponent @click="handler" @custom-event="customHandler"></MyComponent>
 

--- a/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/correctness/useVueValidVOn/valid.vue.snap
@@ -63,6 +63,22 @@ expression: valid.vue
 
   <!-- Native modifier (Vue 2 compatibility) -->
   <div @click.native="handler"></div>
+
+  <!-- Verb modifiers (`stop`, `prevent`) carry an intrinsic side
+       effect and are valid without a handler. -->
+  <div @click.stop></div>
+  <form @submit.prevent></form>
+  <div v-on:click.stop></div>
+  <div v-on:submit.prevent></div>
+  <div @click.stop.prevent></div>
+  <div @click.prevent.exact></div>
+
+  <!-- Verb-modifier-only on a self-closing component (modifier is
+       followed by whitespace + `/>`, so the modifier-name lookup must
+       trim trivia). -->
+  <Foo @click.stop />
+  <Foo @submit.prevent />
+  <Foo v-on:click.stop />
 </template>
 
 ```


### PR DESCRIPTION
## Summary

`useVueValidVOn` was reporting a missing handler for v-on directives that
use one of the verb modifiers (`.stop` / `.prevent`) without an
expression. Forms like `<div @click.stop></div>` and
`<form @submit.prevent></form>` are valid Vue syntax — the modifier
carries an intrinsic side effect (`event.stopPropagation()` /
`event.preventDefault()`) and the directive needs no handler. The fix
mirrors `eslint-plugin-vue`'s `VERB_MODIFIERS` set used by the upstream
`valid-v-on` rule.

A second commit fixes a related false positive where
`<div v-on="$listeners"></div>` and other arg-less `v-on` with an object
value were reported as missing an event name. An arg-less `v-on` with a
value is the Vue object syntax (parallel to `<div v-bind="object"></div>`,
fixed for v-bind in #9643).

While here, `find_invalid_modifiers` was switched to `text_trimmed()` so
the modifier-name lookup keeps working when the modifier is followed by
whitespace (`<Foo @click.stop />`). Same shape as the latent bug fixed
on the v-bind side in #10767. `no_vue_v_on_number_values` already uses
`text_trimmed()`.

Vue docs for the relevant syntax:
- Event modifiers: <https://vuejs.org/guide/essentials/event-handling.html#event-modifiers>
- v-on object syntax: <https://vuejs.org/api/built-in-directives.html#v-on>

fixes #10772

## AI assistance disclosure

Implemented with Claude Code under my direction and review.

## Test Plan

snapshots — `invalid.vue` drops the obsolete arg-less-with-value case;
`valid.vue` gains verb-modifier-only handlers (tag-closing and
self-closing components, longform/shorthand, verb+non-verb combos), the
arg-less `v-on="..."` object syntax, and a verb-modifier inside a
v-for.