### PR TITLE
fix(workspace_db): `The file biome.json does not exist in the workspace`

### DIFF
--- a/.changeset/young-groups-rule.md
+++ b/.changeset/young-groups-rule.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10268](https://github.com/biomejs/biome/issues/10268) where a race condition resulted in internal errors such as: `The file biome.json does not exist in the workspace`.

--- a/crates/biome_workspace_db/src/lib.rs
+++ b/crates/biome_workspace_db/src/lib.rs
@@ -41,8 +41,11 @@ impl WorkspaceDb {
     pub fn insert_source(&mut self, document_file_source: DocumentFileSource) -> usize {
         self.file_sources
             .iter()
-            .position(|(_, file_source)| *file_source == document_file_source)
-            .unwrap_or_else(|| self.file_sources.push(document_file_source))
+            .find(|(_, file_source)| **file_source == document_file_source)
+            .map_or_else(
+                || self.file_sources.push(document_file_source),
+                |(index, _)| index,
+            )
     }
 
     pub fn insert_file(&mut self, path: &Utf8Path, file: ParsedSource) {


### PR DESCRIPTION
## Summary

My understanding of what was wrong here:
1. `WorkspaceDb::insert_source()` is supposed to look for an existing `DocumentFileSource` and return its index.
2. If the source does not exist yet, it should add it to `file_sources` and return the new index.
3. In `boxcar::Vec`, the iterator yields `(index, &value)`, where `index` is the actual stable source index.
4. `position()` ignores this actual `index` and instead returns the current count of slots.
5. That count can be wrong for `boxcar::Vec`, when an insertion is in progress or when the internal storage contains inactive slots. see https://github.com/biomejs/biome/issues/10268#issuecomment-4805403288
6. Using that wrong count as an index later causes the service to look up the wrong file source or to fail.

What this fix does:
- replaces `.position` with `.find`. `.find` returns the actual index along with the indexed item.

**motivation** 
```console
/home/repo/biome.json internalError/fs  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  × The file /home/repo/biome.json does not exist in the workspace.
  
  ! This diagnostic was derived from an internal Biome error. Potential bug, please report it if necessary.
  

/home/repo/project/dir/biome.json internalError/fs  INTERNAL  ━━━━━━━━━━━━━━━━━━━

  × The file /home/repo/project/dir/biome.json does not exist in the workspace.
  
  ! This diagnostic was derived from an internal Biome error. Potential bug, please report it if necessary.
  

configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  × Biome exited because the configuration resulted in errors. Please fix them.
```

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
https://github.com/biomejs/biome/issues/10268

## Test Plan
I struggled with this. Reproducing the error itself was especially challenging with it being a race and I never managed to do it locally, only in CI on a machine with 60+ cores. If there's a suggestion for how to write a test on this, I'd be happy to author one. 

> AI Notice: Claude Code helped me root cause the issue and helped me summarize. I reviewed the changes, rephrased things into my own words. 
