### PR TITLE
fix(noBannedTypes): allow empty object in non-nullish constraint unions

### DIFF
--- a/.changeset/fix-no-banned-types-nullable-constraint.md
+++ b/.changeset/fix-no-banned-types-nullable-constraint.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8434](https://github.com/biomejs/biome/issues/8434): [`noBannedTypes`](https://biomejs.dev/linter/rules/no-banned-types/) no longer reports the empty object type `{}` when it is used in a type-parameter constraint union that expresses a non-nullish type, such as `<T extends {} | null>` or `<T extends {} | undefined>`. These are common idioms for "any value except `null`/`undefined`", just like the already-allowed `<T extends {}>`. `{} | null | undefined` is still reported because it is equivalent to `unknown`.

--- a/crates/biome_js_analyze/src/lint/complexity/no_banned_types.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_banned_types.rs
@@ -6,8 +6,8 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
-    JsReferenceIdentifier, JsSyntaxKind, TextRange, TsIntersectionTypeElementList, TsObjectType,
-    TsReferenceType, TsTypeConstraintClause,
+    AnyTsType, JsReferenceIdentifier, JsSyntaxKind, TextRange, TsIntersectionTypeElementList,
+    TsObjectType, TsReferenceType, TsTypeConstraintClause, TsUnionType, TsUnionTypeVariantList,
 };
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, declare_node_union};
 use biome_rule_options::no_banned_types::NoBannedTypesOptions;
@@ -192,10 +192,11 @@ impl Rule for NoBannedTypes {
                 // type NonNull<T> = T & {}
                 // ```
                 if ts_object_type.members().is_empty()
-                    && (ts_object_type.parent::<TsTypeConstraintClause>().is_none()
-                        && ts_object_type
-                            .parent::<TsIntersectionTypeElementList>()
-                            .is_none())
+                    && ts_object_type.parent::<TsTypeConstraintClause>().is_none()
+                    && ts_object_type
+                        .parent::<TsIntersectionTypeElementList>()
+                        .is_none()
+                    && !is_empty_object_in_nullable_constraint(ts_object_type)
                 {
                     return Some(State {
                         banned_type: BannedType::EmptyObject,
@@ -264,6 +265,52 @@ impl Rule for NoBannedTypes {
             mutation,
         ))
     }
+}
+
+/// Returns `true` when the empty object type is used to express a non-nullish
+/// constraint, i.e. it is a member of a `{} | null` or `{} | undefined` union
+/// that constrains a type parameter (`<T extends {} | null>`). These are common
+/// idioms for "any value except `undefined`/`null`", just like the already
+/// allowed `<T extends {}>` form.
+///
+/// `{} | null | undefined` is intentionally not allowed: it collapses to
+/// `unknown`, which is exactly the kind of misleading usage the rule warns
+/// about, so it keeps being reported.
+fn is_empty_object_in_nullable_constraint(ts_object_type: &TsObjectType) -> bool {
+    let Some(union) = ts_object_type
+        .parent::<TsUnionTypeVariantList>()
+        .and_then(|variants| variants.parent::<TsUnionType>())
+    else {
+        return false;
+    };
+
+    if union.parent::<TsTypeConstraintClause>().is_none() {
+        return false;
+    }
+
+    let mut empty_object_seen = false;
+    let mut nullish_seen = false;
+    for variant in union.types() {
+        match variant {
+            Ok(AnyTsType::TsObjectType(object)) if object.members().is_empty() => {
+                if empty_object_seen {
+                    return false;
+                }
+                empty_object_seen = true;
+            }
+            // Reject `{} | null | undefined`: a second nullish member makes the
+            // union equivalent to `unknown`.
+            Ok(AnyTsType::TsNullLiteralType(_) | AnyTsType::TsUndefinedType(_)) => {
+                if nullish_seen {
+                    return false;
+                }
+                nullish_seen = true;
+            }
+            _ => return false,
+        }
+    }
+
+    empty_object_seen && nullish_seen
 }
 
 declare_node_union! {

--- a/crates/biome_js_analyze/tests/specs/complexity/noBannedTypes/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/noBannedTypes/invalid.ts
@@ -43,3 +43,7 @@ const curly1: {
 } = 1;
 
 const curly2: {} = { a: 'string' };
+
+// `{} | null | undefined` collapses to `unknown`, so the empty object type is
+// still reported even inside a constraint.
+function stillBanned<T extends {} | null | undefined>(value: T) {}

--- a/crates/biome_js_analyze/tests/specs/complexity/noBannedTypes/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noBannedTypes/invalid.ts.snap
@@ -50,6 +50,10 @@ const curly1: {
 
 const curly2: {} = { a: 'string' };
 
+// `{} | null | undefined` collapses to `unknown`, so the empty object type is
+// still reported even inside a constraint.
+function stillBanned<T extends {} | null | undefined>(value: T) {}
+
 ```
 
 # Diagnostics
@@ -750,6 +754,29 @@ invalid.ts:45:15 lint/complexity/noBannedTypes ━━━━━━━━━━━
   > 45 │ const curly2: {} = { a: 'string' };
        │               ^^
     46 │ 
+    47 │ // `{} | null | undefined` collapses to `unknown`, so the empty object type is
+  
+  i '{}' accepts any non-nullish value, including non-object primitives like '123' and 'true'.
+    - If you want a type meaning "any arbitrary object", use 'object' instead.
+    - If you want a type meaning "any value", use 'unknown' instead.
+    - If you want a type meaning "an object whose properties cannot be used", use '{ [k: keyof any]: never }' or 'Record<keyof any, never>' instead.
+    - If you want a type meaning "an object that cannot contain any properties whatsoever", use '{ [uniqueSymbol]?: never }' with an unexported unique symbol in the same file.
+  
+  i If that's really what you want, use an inline disable comment.
+  
+
+```
+
+```
+invalid.ts:49:32 lint/complexity/noBannedTypes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't use '{}' as a type.
+  
+    47 │ // `{} | null | undefined` collapses to `unknown`, so the empty object type is
+    48 │ // still reported even inside a constraint.
+  > 49 │ function stillBanned<T extends {} | null | undefined>(value: T) {}
+       │                                ^^
+    50 │ 
   
   i '{}' accepts any non-nullish value, including non-object primitives like '123' and 'true'.
     - If you want a type meaning "any arbitrary object", use 'object' instead.

--- a/crates/biome_js_analyze/tests/specs/complexity/noBannedTypes/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/noBannedTypes/valid.ts
@@ -31,3 +31,9 @@ type PhoneNumber = number | null | undefined;
 type NonNullablePhoneNumber = PhoneNumber & {};
 
 function consumeNonNullableValue<T extends {}>(value: T) {}
+
+// `{}` in a constraint union with a single nullish member expresses a
+// non-undefined / non-null type, just like `<T extends {}>` (#8434).
+function nonNull<T extends {} | null>(value: T) {}
+function nonUndefined<T extends {} | undefined>(value: T) {}
+type NonNullAlias<T extends {} | null> = T;

--- a/crates/biome_js_analyze/tests/specs/complexity/noBannedTypes/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noBannedTypes/valid.ts.snap
@@ -38,4 +38,10 @@ type NonNullablePhoneNumber = PhoneNumber & {};
 
 function consumeNonNullableValue<T extends {}>(value: T) {}
 
+// `{}` in a constraint union with a single nullish member expresses a
+// non-undefined / non-null type, just like `<T extends {}>` (#8434).
+function nonNull<T extends {} | null>(value: T) {}
+function nonUndefined<T extends {} | undefined>(value: T) {}
+type NonNullAlias<T extends {} | null> = T;
+
 ```


### PR DESCRIPTION
Fixes #8434.

`noBannedTypes` already allows the empty object type when it expresses a non-nullish value: in a type-parameter constraint (`<T extends {}>`) and in an intersection (`T & {}`). The same intent written with an explicit nullish member was still reported:

```ts
function nonNull<T extends {} | null>(value: T) {}      // reported on main
function nonUndefined<T extends {} | undefined>(value: T) {} // reported on main
```

These are common idioms for "any value except `null`/`undefined`".

The exception now also covers `{}` that is a member of a union constraining a type parameter whose only other member is `null` or `undefined`. `{} | null | undefined` keeps being reported, since it is equivalent to `unknown`:

```ts
function stillBanned<T extends {} | null | undefined>(value: T) {} // still reported
```

Added valid cases for the nullish unions and an invalid case for the triple union; the full `biome_js_analyze` spec suite stays green.
