### PR TITLE
fix(lint): preserve template literal class boundaries in useSortedClasses

### DIFF
--- a/.changeset/fix-use-sorted-classes-template-space.md
+++ b/.changeset/fix-use-sorted-classes-template-space.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10297](https://github.com/biomejs/biome/issues/10297): The `useSortedClasses` unsafe fix now preserves template literal boundary spaces required to keep conditional class names separated.

--- a/.changeset/fix-use-sorted-classes-template-space.md
+++ b/.changeset/fix-use-sorted-classes-template-space.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10297](https://github.com/biomejs/biome/issues/10297): The `useSortedClasses` unsafe fix now preserves template literal boundary spaces required to keep conditional class names separated.
+Fixed [#10297](https://github.com/biomejs/biome/issues/10297): The [`useSortedClasses`](https://biomejs.dev/linter/rules/use-sorted-classes/) unsafe fix now preserves template literal boundary spaces required to keep conditional class names separated.

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
@@ -1,4 +1,4 @@
-use biome_js_syntax::{JsTemplateChunkElement, JsTemplateElement};
+use biome_js_syntax::{JsStringLiteralExpression, JsSyntaxNode, JsTemplateChunkElement, JsTemplateElement};
 use biome_rowan::{AstNode, TextRange, TextSize, TokenText};
 use std::cmp::Ordering;
 
@@ -267,6 +267,79 @@ impl TemplateLiteralSpaceContext {
         })
     }
 
+    pub(crate) fn from_string_literal(string_literal: &JsStringLiteralExpression) -> Option<Self> {
+        let value = string_literal.inner_string_text().ok()?;
+        let value = value.text();
+        if value.trim().is_empty() {
+            return None;
+        }
+
+        let Some(template_element) = string_literal
+            .syntax()
+            .ancestors()
+            .find_map(JsTemplateElement::cast)
+        else {
+            return None;
+        };
+        let syntax = template_element.syntax();
+
+        let prefix_is_var = syntax
+            .prev_sibling()
+            .is_some_and(Self::needs_leading_boundary_protection);
+        let postfix_is_var = syntax
+            .next_sibling()
+            .is_some_and(Self::needs_trailing_boundary_protection);
+
+        if !prefix_is_var && !postfix_is_var {
+            return None;
+        }
+
+        Some(Self {
+            prefix_is_var,
+            postfix_is_var,
+            leading_space: value.starts_with(' '),
+            trailing_space: value.ends_with(' '),
+        })
+    }
+
+    fn needs_leading_boundary_protection(sibling: JsSyntaxNode) -> bool {
+        if JsTemplateElement::can_cast(sibling.kind()) {
+            return true;
+        }
+
+        JsTemplateChunkElement::cast(sibling).is_some_and(|chunk| {
+            chunk.template_chunk_token().ok().is_some_and(|token| {
+                let value = token.text_trimmed();
+                if value.is_empty() {
+                    return chunk
+                        .syntax()
+                        .prev_sibling()
+                        .is_some_and(|sibling| JsTemplateElement::can_cast(sibling.kind()));
+                }
+                !value.ends_with(' ')
+            })
+        })
+    }
+
+    fn needs_trailing_boundary_protection(sibling: JsSyntaxNode) -> bool {
+        if JsTemplateElement::can_cast(sibling.kind()) {
+            return true;
+        }
+
+        JsTemplateChunkElement::cast(sibling).is_some_and(|chunk| {
+            chunk.template_chunk_token().ok().is_some_and(|token| {
+                let value = token.text_trimmed();
+                if value.is_empty() {
+                    return chunk
+                        .syntax()
+                        .next_sibling()
+                        .is_some_and(|sibling| JsTemplateElement::can_cast(sibling.kind()));
+                }
+                !value.starts_with(' ')
+            })
+        })
+    }
+
     /// Skip first class from sorting when it's connected to a variable: `${var}px-2 m-4`
     #[inline]
     pub(crate) fn ignore_prefix(&self) -> bool {
@@ -300,6 +373,9 @@ pub(crate) fn get_template_literal_space_context(
     node: &AnyClassStringLike,
 ) -> Option<TemplateLiteralSpaceContext> {
     match node {
+        AnyClassStringLike::JsStringLiteralExpression(string_literal) => {
+            TemplateLiteralSpaceContext::from_string_literal(string_literal)
+        }
         AnyClassStringLike::JsTemplateChunkElement(chunk) => {
             TemplateLiteralSpaceContext::from_chunk(chunk)
         }

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
@@ -274,13 +274,10 @@ impl TemplateLiteralSpaceContext {
             return None;
         }
 
-        let Some(template_element) = string_literal
+        let template_element = string_literal
             .syntax()
             .ancestors()
-            .find_map(JsTemplateElement::cast)
-        else {
-            return None;
-        };
+            .find_map(JsTemplateElement::cast)?;
         let syntax = template_element.syntax();
 
         let prefix_is_var = syntax

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issues_10297.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issues_10297.jsx
@@ -1,0 +1,10 @@
+function Example({ isActive }) {
+	return (
+		<>
+			<span className={`map-panel-basemap-map-a${isActive ? ' active' : ''}`} />
+			<span className={`map-panel-basemap-map-a${isActive ? ' active ' : ''}map-panel-overlay`} />
+			<span className={`${isActive ? 'active ' : ''}map-panel-basemap-map-a`} />
+			<span className={`map-panel-basemap-map-a ${isActive ? ' active ' : ''} map-panel-overlay`} />
+		</>
+	);
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issues_10297.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issues_10297.jsx.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issues_10297.jsx
+---
+# Input
+```jsx
+function Example({ isActive }) {
+	return (
+		<>
+			<span className={`map-panel-basemap-map-a${isActive ? ' active' : ''}`} />
+			<span className={`map-panel-basemap-map-a${isActive ? ' active ' : ''}map-panel-overlay`} />
+			<span className={`${isActive ? 'active ' : ''}map-panel-basemap-map-a`} />
+			<span className={`map-panel-basemap-map-a ${isActive ? ' active ' : ''} map-panel-overlay`} />
+		</>
+	);
+}
+
+```
+
+# Diagnostics
+```
+issues_10297.jsx:7:59 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    5 │ 			<span className={`map-panel-basemap-map-a${isActive ? ' active ' : ''}map-panel-overlay`} />
+    6 │ 			<span className={`${isActive ? 'active ' : ''}map-panel-basemap-map-a`} />
+  > 7 │ 			<span className={`map-panel-basemap-map-a ${isActive ? ' active ' : ''} map-panel-overlay`} />
+      │ 			                                                       ^^^^^^^^^^
+    8 │ 		</>
+    9 │ 	);
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/1274 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Sort the classes.
+  
+    7 │ → → → <span·className={`map-panel-basemap-map-a·${isActive·?·'·active·'·:·''}·map-panel-overlay`}·/>
+      │                                                               -      -                              
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

Fixes #10297

The `useSortedClasses` unsafe fix now preserves template literal boundary spaces required to keep conditional class names separated.

> This PR was implemented with AI assistance. I reproduced the issue, defined the regression cases and scope of the fix, reviewed the generated changes, and validated the result. The AI assistant helped inspect the relevant code paths, draft the implementation, and update the regression snapshot and changeset.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- Added regression coverage in `issues_10297.jsx`.
- `cargo fmt --all --check`
- `cargo test`
- `cargo test -p biome_js_analyze -- use_sorted_classes --show-output`
- `just test-lintrule useSortedClasses`
- `just l`

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

- Not applicable. This fixes existing lint rule behavior and does not add a new rule, option, or user-facing API.