### PR TITLE
feat(lint): add ignorePrimitives option to useNullishCoalescing

### DIFF
--- a/.changeset/add-ignore-primitives.md
+++ b/.changeset/add-ignore-primitives.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added the option `ignorePrimitives` to [useNullishCoalescing](https://biomejs.dev/linter/rules/use-nullish-coalescing/). When enabled, Biome ignores `||`, `||=`, and ternary expressions whose non-nullish operands are all primitives the option opts out of. Use `true` to ignore all primitives, or an object selecting `string`, `number`, `boolean`, or `bigint`.

--- a/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
@@ -190,6 +190,39 @@ declare_lint_rule! {
     /// const r = Boolean(a || b);
     /// ```
     ///
+    /// ### ignorePrimitives
+    ///
+    /// Ignore `||`, `||=`, and ternary expressions when every non-nullish variant
+    /// of the operand is a primitive the option opts out of. Use `true` to ignore
+    /// all primitives, or an object selecting `string`, `number`, `boolean`, or
+    /// `bigint`. Default: none.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "ignorePrimitives": { "string": true }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// #### Invalid
+    ///
+    /// Primitive kinds that are not opted out of are still reported.
+    ///
+    /// ```ts,expect_diagnostic,use_options,file=invalid-primitives.ts
+    /// declare const count: number | null;
+    /// const value = count || 0;
+    /// ```
+    ///
+    /// #### Valid
+    ///
+    /// A `string` operand is not reported when `string` is ignored.
+    ///
+    /// ```ts,use_options,file=valid-primitives.ts
+    /// declare const name: string | null;
+    /// const value = name || 'default';
+    /// ```
+    ///
     pub UseNullishCoalescing {
         version: "2.4.5",
         name: "useNullishCoalescing",
@@ -445,6 +478,10 @@ fn run_logical_or(
         return None;
     }
 
+    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, &left_ty) {
+        return None;
+    }
+
     let can_fix =
         is_safe_type_for_replacement(&left_ty) && is_safe_syntax_context_for_replacement(logical);
 
@@ -491,6 +528,10 @@ fn run_logical_or_assignment(
         return None;
     }
 
+    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, &left_ty) {
+        return None;
+    }
+
     let can_fix = is_safe_type_for_replacement(&left_ty);
 
     Some(UseNullishCoalescingState::LogicalOrAssignment {
@@ -522,6 +563,44 @@ fn is_possibly_nullish(ty: &biome_js_type_info::Type) -> bool {
     } else {
         ty.conditional_semantics().is_nullish()
     }
+}
+
+/// Returns `true` when every non-nullish variant of `ty` is a primitive that the
+/// configured `ignorePrimitives` option suppresses. A non-union type is never
+/// ignored here, since the diagnostic only fires once the operand is a nullish
+/// union in the first place.
+fn should_ignore_for_primitives(
+    options: &UseNullishCoalescingOptions,
+    ty: &biome_js_type_info::Type,
+) -> bool {
+    if !ty.is_union() {
+        return false;
+    }
+    ty.flattened_union_variants()
+        .filter(|variant| !variant.conditional_semantics().is_nullish())
+        .all(|variant| is_ignored_primitive(options, &variant))
+}
+
+/// Maps a resolved primitive (or primitive literal) type to its matching
+/// `ignorePrimitives` selector. Non-primitive types are never ignored.
+fn is_ignored_primitive(
+    options: &UseNullishCoalescingOptions,
+    ty: &biome_js_type_info::Type,
+) -> bool {
+    ty.resolved_data().is_some_and(|data| match data.as_raw_data() {
+        TypeData::String => options.should_ignore_primitive_string(),
+        TypeData::Number => options.should_ignore_primitive_number(),
+        TypeData::Boolean => options.should_ignore_primitive_boolean(),
+        TypeData::BigInt => options.should_ignore_primitive_bigint(),
+        TypeData::Literal(literal) => match literal.as_ref() {
+            biome_js_type_info::Literal::String(_) => options.should_ignore_primitive_string(),
+            biome_js_type_info::Literal::Number(_) => options.should_ignore_primitive_number(),
+            biome_js_type_info::Literal::Boolean(_) => options.should_ignore_primitive_boolean(),
+            biome_js_type_info::Literal::BigInt(_) => options.should_ignore_primitive_bigint(),
+            _ => false,
+        },
+        _ => false,
+    })
 }
 
 fn is_safe_syntax_context_for_replacement(logical: &JsLogicalExpression) -> bool {
@@ -722,6 +801,14 @@ fn run_ternary(
 
     let (checked_expr, fallback_expr, is_positive, check_kind) =
         check_ternary_nullish_pattern(&test, &consequent, &alternate)?;
+
+    let options = ctx.options();
+    if options.has_any_ignore_primitives() {
+        let checked_ty = ctx.type_of_expression(&checked_expr);
+        if should_ignore_for_primitives(options, &checked_ty) {
+            return None;
+        }
+    }
 
     // The fix is unsafe when the checked expression contains calls or `new`, because
     // the ternary evaluates it twice (test + branch) while `??` evaluates it once.

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesAll.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesAll.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNullishCoalescing": {
+					"level": "error",
+					"options": {
+						"ignorePrimitives": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesAll.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesAll.ts
@@ -1,0 +1,34 @@
+// Tests for ignorePrimitives: true
+// `||` and `||=` on primitive-typed operands should NOT report; non-primitives still do.
+
+declare const s: string | null;
+declare const n: number | null;
+declare const b: boolean | null;
+declare const big: bigint | null;
+declare const fallbackS: string;
+declare const fallbackN: number;
+
+// primitive left operands: suppressed
+const r1 = s || fallbackS;
+const r2 = n || fallbackN;
+const r3 = b || false;
+const r4 = big || 0n;
+
+// ||= on a primitive: suppressed
+declare let assigned: string | null;
+assigned ||= fallbackS;
+
+// literal-typed unions: suppressed (exercises the TypeData::Literal arm)
+declare const litStr: 'a' | 'b' | null;
+declare const litNum: 0 | 1 | null;
+declare const litBool: true | null;
+declare const litBig: 1n | 2n | null;
+const r5 = litStr || 'c';
+const r6 = litNum || 2;
+const r7 = litBool || false;
+const r8 = litBig || 3n;
+
+// non-primitive (object) left operand: SHOULD still report
+declare const obj: { x: string } | null;
+declare const fallbackObj: { x: string };
+const r9 = obj || fallbackObj;

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesAll.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesAll.ts.snap
@@ -1,0 +1,71 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignorePrimitivesAll.ts
+---
+# Input
+```ts
+// Tests for ignorePrimitives: true
+// `||` and `||=` on primitive-typed operands should NOT report; non-primitives still do.
+
+declare const s: string | null;
+declare const n: number | null;
+declare const b: boolean | null;
+declare const big: bigint | null;
+declare const fallbackS: string;
+declare const fallbackN: number;
+
+// primitive left operands: suppressed
+const r1 = s || fallbackS;
+const r2 = n || fallbackN;
+const r3 = b || false;
+const r4 = big || 0n;
+
+// ||= on a primitive: suppressed
+declare let assigned: string | null;
+assigned ||= fallbackS;
+
+// literal-typed unions: suppressed (exercises the TypeData::Literal arm)
+declare const litStr: 'a' | 'b' | null;
+declare const litNum: 0 | 1 | null;
+declare const litBool: true | null;
+declare const litBig: 1n | 2n | null;
+const r5 = litStr || 'c';
+const r6 = litNum || 2;
+const r7 = litBool || false;
+const r8 = litBig || 3n;
+
+// non-primitive (object) left operand: SHOULD still report
+declare const obj: { x: string } | null;
+declare const fallbackObj: { x: string };
+const r9 = obj || fallbackObj;
+
+```
+
+# Diagnostics
+```
+ignorePrimitivesAll.ts:34:16 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    32 │ declare const obj: { x: string } | null;
+    33 │ declare const fallbackObj: { x: string };
+  > 34 │ const r9 = obj || fallbackObj;
+       │                ^^
+    35 │ 
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace || with ??.
+  
+    32 32 │   declare const obj: { x: string } | null;
+    33 33 │   declare const fallbackObj: { x: string };
+    34    │ - const·r9·=·obj·||·fallbackObj;
+       34 │ + const·r9·=·obj·??·fallbackObj;
+    35 35 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesDisabled.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesDisabled.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNullishCoalescing": {
+					"level": "error",
+					"options": {
+						"ignorePrimitives": false
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesDisabled.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesDisabled.ts
@@ -1,0 +1,8 @@
+// Tests for ignorePrimitives: false
+// The option is present but disabled, so primitive operands still report.
+
+declare const s: string | null;
+declare const n: number | null;
+
+const r1 = s || 'x';
+const r2 = n || 0;

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesDisabled.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesDisabled.ts.snap
@@ -1,0 +1,57 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignorePrimitivesDisabled.ts
+---
+# Input
+```ts
+// Tests for ignorePrimitives: false
+// The option is present but disabled, so primitive operands still report.
+
+declare const s: string | null;
+declare const n: number | null;
+
+const r1 = s || 'x';
+const r2 = n || 0;
+
+```
+
+# Diagnostics
+```
+ignorePrimitivesDisabled.ts:7:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    5 │ declare const n: number | null;
+    6 │ 
+  > 7 │ const r1 = s || 'x';
+      │              ^^
+    8 │ const r2 = n || 0;
+    9 │ 
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignorePrimitivesDisabled.ts:8:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    7 │ const r1 = s || 'x';
+  > 8 │ const r2 = n || 0;
+      │              ^^
+    9 │ 
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesSpecific.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesSpecific.options.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNullishCoalescing": {
+					"level": "error",
+					"options": {
+						"ignorePrimitives": {
+							"string": true,
+							"number": true
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesSpecific.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesSpecific.ts
@@ -1,0 +1,33 @@
+// Tests for ignorePrimitives: { string: true, number: true }
+// string/number operands suppressed; boolean/bigint still report.
+
+declare const s: string | null;
+declare const n: number | null;
+declare const b: boolean | null;
+declare const big: bigint | null;
+
+// ignored kinds: suppressed
+const r1 = s || 'x';
+const r2 = n || 0;
+
+// non-ignored kinds: SHOULD still report
+const r3 = b || false;
+const r4 = big || 0n;
+
+// string-literal union: suppressed (string ignored, exercises the literal arm)
+declare const litStr: 'a' | 'b' | null;
+const r5 = litStr || 'c';
+
+// every non-nullish variant ignored: suppressed
+declare const sn: string | number | null;
+const r6 = sn || 'x';
+
+// only some variants ignored (boolean not opted out): SHOULD still report
+declare const sb: string | boolean | null;
+const r7 = sb || 'x';
+
+// ternary on a string operand: suppressed (ignorePrimitives applies to ternary too)
+const r8 = s != null ? s : 'x';
+
+// ternary on a boolean operand: SHOULD still report
+const r9 = b != null ? b : false;

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesSpecific.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignorePrimitivesSpecific.ts.snap
@@ -1,0 +1,129 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignorePrimitivesSpecific.ts
+---
+# Input
+```ts
+// Tests for ignorePrimitives: { string: true, number: true }
+// string/number operands suppressed; boolean/bigint still report.
+
+declare const s: string | null;
+declare const n: number | null;
+declare const b: boolean | null;
+declare const big: bigint | null;
+
+// ignored kinds: suppressed
+const r1 = s || 'x';
+const r2 = n || 0;
+
+// non-ignored kinds: SHOULD still report
+const r3 = b || false;
+const r4 = big || 0n;
+
+// string-literal union: suppressed (string ignored, exercises the literal arm)
+declare const litStr: 'a' | 'b' | null;
+const r5 = litStr || 'c';
+
+// every non-nullish variant ignored: suppressed
+declare const sn: string | number | null;
+const r6 = sn || 'x';
+
+// only some variants ignored (boolean not opted out): SHOULD still report
+declare const sb: string | boolean | null;
+const r7 = sb || 'x';
+
+// ternary on a string operand: suppressed (ignorePrimitives applies to ternary too)
+const r8 = s != null ? s : 'x';
+
+// ternary on a boolean operand: SHOULD still report
+const r9 = b != null ? b : false;
+
+```
+
+# Diagnostics
+```
+ignorePrimitivesSpecific.ts:14:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    13 │ // non-ignored kinds: SHOULD still report
+  > 14 │ const r3 = b || false;
+       │              ^^
+    15 │ const r4 = big || 0n;
+    16 │ 
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignorePrimitivesSpecific.ts:15:16 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    13 │ // non-ignored kinds: SHOULD still report
+    14 │ const r3 = b || false;
+  > 15 │ const r4 = big || 0n;
+       │                ^^
+    16 │ 
+    17 │ // string-literal union: suppressed (string ignored, exercises the literal arm)
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignorePrimitivesSpecific.ts:27:15 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    25 │ // only some variants ignored (boolean not opted out): SHOULD still report
+    26 │ declare const sb: string | boolean | null;
+  > 27 │ const r7 = sb || 'x';
+       │               ^^
+    28 │ 
+    29 │ // ternary on a string operand: suppressed (ignorePrimitives applies to ternary too)
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignorePrimitivesSpecific.ts:33:12 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  i Prefer ?? over a ternary expression checking for nullish.
+  
+    32 │ // ternary on a boolean operand: SHOULD still report
+  > 33 │ const r9 = b != null ? b : false;
+       │            ^^^^^^^^^
+    34 │ 
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the ternary with ??.
+  
+    31 31 │   
+    32 32 │   // ternary on a boolean operand: SHOULD still report
+    33    │ - const·r9·=·b·!=·null·?·b·:·false;
+       33 │ + const·r9·=·b·??·false;
+    34 34 │   
+  
+
+```

--- a/crates/biome_rule_options/src/use_nullish_coalescing.rs
+++ b/crates/biome_rule_options/src/use_nullish_coalescing.rs
@@ -1,3 +1,6 @@
+use biome_deserialize::{
+    Deserializable, DeserializableType, DeserializableValue, DeserializationContext,
+};
 use biome_deserialize_macros::{Deserializable, Merge};
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +24,10 @@ pub struct UseNullishCoalescingOptions {
     /// Whether to ignore `||` and `||=` binary operations used inside a `Boolean()` call (default: `false`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_boolean_coercion: Option<bool>,
+
+    /// Whether to ignore `||` and `||=` operations whose non-nullish operand types are all primitives of the configured kinds. Accepts `true` for every primitive, or an object selecting `string`, `number`, `boolean`, `bigint` (default: none).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore_primitives: Option<IgnorePrimitives>,
 }
 
 impl UseNullishCoalescingOptions {
@@ -39,4 +46,151 @@ impl UseNullishCoalescingOptions {
     pub fn ignore_boolean_coercion(&self) -> bool {
         self.ignore_boolean_coercion.unwrap_or(false)
     }
+
+    /// Whether any `ignorePrimitives` selection is configured.
+    pub fn has_any_ignore_primitives(&self) -> bool {
+        self.ignore_primitives.is_some()
+    }
+
+    pub fn should_ignore_primitive_string(&self) -> bool {
+        self.ignore_primitives
+            .as_ref()
+            .is_some_and(IgnorePrimitives::should_ignore_string)
+    }
+
+    pub fn should_ignore_primitive_number(&self) -> bool {
+        self.ignore_primitives
+            .as_ref()
+            .is_some_and(IgnorePrimitives::should_ignore_number)
+    }
+
+    pub fn should_ignore_primitive_boolean(&self) -> bool {
+        self.ignore_primitives
+            .as_ref()
+            .is_some_and(IgnorePrimitives::should_ignore_boolean)
+    }
+
+    pub fn should_ignore_primitive_bigint(&self) -> bool {
+        self.ignore_primitives
+            .as_ref()
+            .is_some_and(IgnorePrimitives::should_ignore_bigint)
+    }
+}
+
+/// Selects which primitive types suppress `useNullishCoalescing` diagnostics.
+///
+/// `true` ignores every primitive; the object form selects individual kinds.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum IgnorePrimitives {
+    /// When `true`, ignore all primitive types (string, number, boolean, bigint).
+    All(bool),
+    /// Ignore specific primitive types.
+    Specific(IgnorePrimitivesOptions),
+}
+
+impl Default for IgnorePrimitives {
+    fn default() -> Self {
+        Self::All(false)
+    }
+}
+
+impl IgnorePrimitives {
+    pub fn should_ignore_string(&self) -> bool {
+        match self {
+            Self::All(all) => *all,
+            Self::Specific(opts) => opts.string.unwrap_or(false),
+        }
+    }
+
+    pub fn should_ignore_number(&self) -> bool {
+        match self {
+            Self::All(all) => *all,
+            Self::Specific(opts) => opts.number.unwrap_or(false),
+        }
+    }
+
+    pub fn should_ignore_boolean(&self) -> bool {
+        match self {
+            Self::All(all) => *all,
+            Self::Specific(opts) => opts.boolean.unwrap_or(false),
+        }
+    }
+
+    pub fn should_ignore_bigint(&self) -> bool {
+        match self {
+            Self::All(all) => *all,
+            Self::Specific(opts) => opts.bigint.unwrap_or(false),
+        }
+    }
+}
+
+impl biome_deserialize::Merge for IgnorePrimitives {
+    fn merge_with(&mut self, other: Self) {
+        *self = other;
+    }
+}
+
+impl Deserializable for IgnorePrimitives {
+    fn deserialize(
+        ctx: &mut impl DeserializationContext,
+        value: &impl DeserializableValue,
+        name: &str,
+    ) -> Option<Self> {
+        Some(if value.visitable_type()? == DeserializableType::Bool {
+            Self::All(<bool as Deserializable>::deserialize(ctx, value, name)?)
+        } else {
+            Self::Specific(<IgnorePrimitivesOptions as Deserializable>::deserialize(
+                ctx, value, name,
+            )?)
+        })
+    }
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for IgnorePrimitives {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("IgnorePrimitives")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "oneOf": [
+                {
+                    "type": "boolean",
+                    "description": "When true, ignore all primitive types."
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "string": { "type": "boolean" },
+                        "number": { "type": "boolean" },
+                        "boolean": { "type": "boolean" },
+                        "bigint": { "type": "boolean" }
+                    },
+                    "additionalProperties": false,
+                    "description": "Ignore specific primitive types."
+                }
+            ]
+        })
+    }
+}
+
+/// Options for ignoring specific primitive types in `||` expressions.
+#[derive(Clone, Debug, Default, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct IgnorePrimitivesOptions {
+    /// Ignore `string` and string literal types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub string: Option<bool>,
+    /// Ignore `number` and number literal types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number: Option<bool>,
+    /// Ignore `boolean` and boolean literal types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub boolean: Option<bool>,
+    /// Ignore `bigint` and bigint literal types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bigint: Option<bool>,
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8470,6 +8470,10 @@ export interface UseNullishCoalescingOptions {
 	 */
 	ignoreMixedLogicalExpressions?: boolean;
 	/**
+	 * Whether to ignore `||` and `||=` operations whose non-nullish operand types are all primitives of the configured kinds. Accepts `true` for every primitive, or an object selecting `string`, `number`, `boolean`, `bigint` (default: none).
+	 */
+	ignorePrimitives?: IgnorePrimitives;
+	/**
 	 * Ignore ternary expressions that check for `null` or `undefined` (default: `false`).
 	 */
 	ignoreTernaryTests?: boolean;
@@ -9213,6 +9217,9 @@ export type AvailabilityTarget = AvailabilityNamed | number;
  * The function to use for tests
  */
 export type TestFunctionKind = "it" | "test";
+export type IgnorePrimitives =
+	| boolean
+	| { bigint?: boolean; boolean?: boolean; number?: boolean; string?: boolean };
 export type ComponentDefinitionStyle =
 	| "functionDeclaration"
 	| "functionExpression"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2358,6 +2358,25 @@
 				}
 			]
 		},
+		"IgnorePrimitives": {
+			"oneOf": [
+				{
+					"description": "When true, ignore all primitive types.",
+					"type": "boolean"
+				},
+				{
+					"description": "Ignore specific primitive types.",
+					"type": "object",
+					"properties": {
+						"bigint": { "type": "boolean" },
+						"boolean": { "type": "boolean" },
+						"number": { "type": "boolean" },
+						"string": { "type": "boolean" }
+					},
+					"additionalProperties": false
+				}
+			]
+		},
 		"ImportGroup": {
 			"anyOf": [
 				{ "type": "null" },
@@ -15807,6 +15826,10 @@
 				"ignoreMixedLogicalExpressions": {
 					"description": "Whether to ignore `||` and `||=` binary operations that are part of a mixed logical expression with `&&` (default: `false`).",
 					"type": ["boolean", "null"]
+				},
+				"ignorePrimitives": {
+					"description": "Whether to ignore `||` and `||=` operations whose non-nullish operand types are all primitives of the configured kinds. Accepts `true` for every primitive, or an object selecting `string`, `number`, `boolean`, `bigint` (default: none).",
+					"anyOf": [{ "$ref": "#/$defs/IgnorePrimitives" }, { "type": "null" }]
 				},
 				"ignoreTernaryTests": {
 					"description": "Ignore ternary expressions that check for `null` or `undefined` (default: `false`).",


### PR DESCRIPTION
> This PR was created with AI assistance.

## Summary

adds the `ignorePrimitives` option to `useNullishCoalescing`, partially addressing #9232. this follows on from #9974 (`ignoreMixedLogicalExpressions`) and #10595 (`ignoreBooleanCoercion`).

when set, `||`, `||=`, and the ternary nullish checks are not reported if every non-nullish variant of the checked operand is a primitive you've opted out of. the option takes either `true` (ignore all primitives) or an object selecting `string`, `number`, `boolean`, `bigint` individually. literal types (`'a' | 'b'`, `0 | 1`, `true`, `1n`) are matched to their primitive kind. i kept the scope to just this one option so it stays easy to review. the last option from #9232 (`ignoreIfStatements`, plus the `if`-statement detection it needs) can come as a separate PR.

the check reuses the existing union/type plumbing: a small typed helper looks at the operand's flattened union, drops the nullish variants, and only suppresses when *all* the remaining variants are primitives that are opted out. a mixed union like `string | boolean | null` with only `string` ignored still reports, since not every variant is covered.

## Test Plan

the spec snapshots cover this, but to check it by hand:

1. drop a `biome.json` enabling the rule and option:

```json
{ "linter": { "rules": { "nursery": { "useNullishCoalescing": { "level": "error", "options": { "ignorePrimitives": { "string": true, "number": true } } } } } } }
```

2. make a `test.ts`:

```ts
declare const s: string | null;
declare const n: number | null;
declare const b: boolean | null;

const r1 = s || 'x';              // quiet (string ignored)
const r2 = n || 0;                // quiet (number ignored)
const r3 = b || false;            // reports (boolean not ignored)
const r4 = s != null ? s : 'x';   // quiet (applies to ternary too)
```

3. run `biome lint test.ts`. only `r3` should report.

4. flip the option to `true` and re-run: `r3` goes quiet too. set it to `false` and all four report.

things worth poking at for coverage:
- literal-typed unions (`'a' | 'b' | null`, `0 | 1 | null`) follow the same kind as their primitive (`string`, `number`, ...)
- a mixed union like `string | boolean | null` should still report when only `string` is ignored, since not every variant is opted out
- a non-primitive operand (`{ x: string } | null`) always reports

## Docs

the option is documented in the rule's rustdoc with a `### ignorePrimitives` invalid/valid section (with `file=` metadata) and validated by `rules_check`. no website PR needed while the rule is in nursery.
