### PR TITLE
fix(css/analyzer): noUnknownFunction no longer flags SCSS functions

### DIFF
--- a/.changeset/fix-css-no-unknown-function-scss.md
+++ b/.changeset/fix-css-no-unknown-function-scss.md
@@ -1,0 +1,19 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10800](https://github.com/biomejs/biome/issues/10800): [`noUnknownFunction`](https://biomejs.dev/linter/rules/no-unknown-function/) no longer reports false positives in SCSS. SCSS allows user-defined `@function`s and provides built-in module functions (such as `nth`, `length`, and `map.get`) that are not CSS value functions, so the rule now skips SCSS files.
+
+```scss
+@function fibonacci($n) {
+	$sequence: 0 1;
+	@for $_ from 1 through $n {
+		$sequence: append($sequence, nth($sequence, length($sequence)));
+	}
+	@return nth($sequence, length($sequence));
+}
+
+.sidebar {
+	margin-left: fibonacci(4) * 1px;
+}
+```

--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_function.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_function.rs
@@ -6,6 +6,7 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_css_syntax::CssFunction;
 use biome_diagnostics::Severity;
+use biome_languages::CssFileSource;
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::no_unknown_function::NoUnknownFunctionOptions;
 
@@ -77,6 +78,13 @@ impl Rule for NoUnknownFunction {
     type Options = NoUnknownFunctionOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        // SCSS allows user-defined `@function`s and provides built-in module
+        // functions (e.g. `nth`, `length`, `map.get`) that are not CSS value
+        // functions, so this rule does not apply to SCSS.
+        if ctx.source_type::<CssFileSource>().is_scss() {
+            return None;
+        }
+
         let node = ctx.query();
         let binding = node.name().ok().and_then(|name| {
             name.as_css_identifier()

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.scss
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.scss
@@ -1,0 +1,13 @@
+/* should not generate diagnostics */
+@function fibonacci($n) {
+	$sequence: 0 1;
+	@for $_ from 1 through $n {
+		$new: nth($sequence, length($sequence)) + nth($sequence, length($sequence) - 1);
+		$sequence: append($sequence, $new);
+	}
+	@return nth($sequence, length($sequence));
+}
+
+.sidebar {
+	margin-left: fibonacci(4) * 1px;
+}

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.scss.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownFunction/valid.scss.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: valid.scss
+---
+# Input
+```css
+/* should not generate diagnostics */
+@function fibonacci($n) {
+	$sequence: 0 1;
+	@for $_ from 1 through $n {
+		$new: nth($sequence, length($sequence)) + nth($sequence, length($sequence) - 1);
+		$sequence: append($sequence, $new);
+	}
+	@return nth($sequence, length($sequence));
+}
+
+.sidebar {
+	margin-left: fibonacci(4) * 1px;
+}
+
+```


### PR DESCRIPTION
Fixes #10800.

## Summary

`noUnknownFunction` reported false positives in SCSS. SCSS allows user-defined `@function` declarations and provides built-in module functions — such as `nth`, `length`, `append`, and `map.get` — that are not CSS value functions. The rule flagged all of them as "unknown".

```scss
@function fibonacci($n) {
	$sequence: 0 1;
	@for $_ from 1 through $n {
		$sequence: append($sequence, nth($sequence, length($sequence)));
	}
	@return nth($sequence, length($sequence));
}

.sidebar {
	margin-left: fibonacci(4) * 1px;
}
```

The rule's `run` already notes it has no semantic model to resolve functions defined elsewhere, so it cannot reason about SCSS functions. This matches `noUnknownPseudoClass` / `noUnknownPseudoElement`, which already skip SCSS.

## Changes

- `crates/biome_css_analyze/src/lint/correctness/no_unknown_function.rs`: skip the rule when the file source is SCSS (`ctx.source_type::<CssFileSource>().is_scss()`).
- Tests: added `noUnknownFunction/valid.scss` fixture + accepted snapshot (no diagnostics). Existing CSS specs are unchanged.
- Added a changeset.