### PR TITLE
fix(css/analyzer): don't flag @tailwind under noUnknownAtRules in Tailwind mode

### DIFF
--- a/.changeset/fix-css-tailwind-at-rules.md
+++ b/.changeset/fix-css-tailwind-at-rules.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7899](https://github.com/biomejs/biome/issues/7899): [`noUnknownAtRules`](https://biomejs.dev/linter/rules/no-unknown-at-rules/) no longer reports `@tailwind` at-rules (such as `@tailwind base;`) when Tailwind directives are enabled.
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```

--- a/crates/biome_css_analyze/src/lint/suspicious/no_unknown_at_rules.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_unknown_at_rules.rs
@@ -4,8 +4,14 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_css_syntax::{AnyCssUnknownAtRuleName, CssUnknownBlockAtRule, CssUnknownValueAtRule};
 use biome_diagnostics::Severity;
+use biome_languages::CssFileSource;
 use biome_rowan::{AstNode, TextRange, declare_node_union};
 use biome_rule_options::no_unknown_at_rules::NoUnknownAtRulesOptions;
+
+/// Tailwind at-rules that Biome does not model as dedicated nodes, so they are
+/// parsed as unknown at-rules. They are valid when Tailwind directives are
+/// enabled and should not be reported.
+const TAILWIND_AT_RULES: &[&str] = &["tailwind"];
 
 declare_lint_rule! {
     /// Disallow unknown at-rules.
@@ -120,6 +126,16 @@ impl Rule for NoUnknownAtRules {
 
         // Check if this unknown at-rule should be ignored
         if should_ignore(&name, ctx.options()) {
+            return None;
+        }
+
+        // Tailwind at-rules such as `@tailwind base;` are valid when Tailwind
+        // directives are enabled, but Biome parses them as unknown at-rules.
+        if ctx.source_type::<CssFileSource>().is_tailwind_css()
+            && TAILWIND_AT_RULES
+                .iter()
+                .any(|rule| name.eq_ignore_ascii_case(rule))
+        {
             return None;
         }
 

--- a/crates/biome_css_analyze/tests/specs/suspicious/noUnknownAtRules/valid.tailwind.css
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noUnknownAtRules/valid.tailwind.css
@@ -1,0 +1,4 @@
+/* should not generate diagnostics */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/crates/biome_css_analyze/tests/specs/suspicious/noUnknownAtRules/valid.tailwind.css.snap
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noUnknownAtRules/valid.tailwind.css.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: valid.tailwind.css
+---
+# Input
+```css
+/* should not generate diagnostics */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+```

--- a/crates/biome_css_analyze/tests/specs/suspicious/noUnknownAtRules/valid.tailwind.options.json
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noUnknownAtRules/valid.tailwind.options.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  }
+}


### PR DESCRIPTION
Fixes #7899.

## Summary

With `css.parser.tailwindDirectives` enabled, `noUnknownAtRules` still reported `@tailwind` directives as unknown:

```css
@tailwind base;
@tailwind components;
@tailwind utilities;
```

Biome does not model `@tailwind` as a dedicated node, so it is parsed as an unknown at-rule. Enabling Tailwind directives sets the file's variant to Tailwind, so the rule can now detect that context (`CssFileSource::is_tailwind_css()`) and skip Tailwind at-rules. `@tailwind` is still reported in non-Tailwind files.

## Changes

- `crates/biome_css_analyze/src/lint/suspicious/no_unknown_at_rules.rs`: skip a small set of Tailwind at-rule names (`@tailwind`) when the file is in Tailwind mode.
- Tests: added `noUnknownAtRules/valid.tailwind.css` fixture + options + accepted snapshot. Existing specs unchanged.
- Added a changeset.