### PR TITLE
fix(css/analyzer): scope noDescendingSpecificity to cascade layers

### DIFF
--- a/.changeset/fix-css-descending-specificity-layers.md
+++ b/.changeset/fix-css-descending-specificity-layers.md
@@ -1,0 +1,15 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7533](https://github.com/biomejs/biome/issues/7533): [`noDescendingSpecificity`](https://biomejs.dev/linter/rules/no-descending-specificity/) no longer reports false positives across `@layer` blocks. Specificity only matters within a single cascade layer, so selectors in different layers are no longer compared.
+
+```css
+@layer one {
+	b a { color: green; }
+}
+
+@layer two {
+	a { color: blue; }
+}
+```

--- a/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
@@ -3,7 +3,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_css_semantic::model::{Rule as CssSemanticRule, RuleId, SemanticModel, Specificity};
-use biome_css_syntax::{AnyCssRoot, AnyCssSelector};
+use biome_css_syntax::{AnyCssRoot, AnyCssSelector, CssLayerDeclaration, CssSyntaxNode};
 use biome_diagnostics::Severity;
 use biome_rowan::TextRange;
 
@@ -127,6 +127,32 @@ fn find_tail_selector_str(selector: &AnyCssSelector) -> Option<String> {
     }
 }
 
+/// Computes a cascade-layer scope for a selector. Specificity only matters
+/// within a single `@layer`, so selectors in different layers must not be
+/// compared. Re-opened named layers share a scope; each anonymous
+/// `@layer { ... }` block is treated as its own scope.
+fn layer_scope(node: &CssSyntaxNode) -> String {
+    let mut scopes: Vec<String> = Vec::new();
+    for ancestor in node.ancestors() {
+        let Some(declaration) = CssLayerDeclaration::cast(ancestor) else {
+            continue;
+        };
+        let name = declaration
+            .references()
+            .syntax()
+            .text_trimmed()
+            .to_string();
+        if name.is_empty() {
+            // Anonymous layer: keep each block distinct via its position.
+            scopes.push(format!("@{:?}", declaration.range().start()));
+        } else {
+            scopes.push(name);
+        }
+    }
+    scopes.reverse();
+    scopes.join("/")
+}
+
 /// This function traverses the CSS rules starting from the given rule and checks for selectors that have the same tail selector.
 /// For each selector, it compares its specificity with the previously encountered specificity of the same tail selector.
 /// If a lower specificity selector is found after a higher specificity selector with the same tail selector, it records this as a descending selector.
@@ -135,7 +161,7 @@ fn find_descending_selector(
     rule: &CssSemanticRule,
     model: &SemanticModel,
     visited_rules: &mut FxHashSet<RuleId>,
-    visited_selectors: &mut FxHashMap<String, (TextRange, Specificity)>,
+    visited_selectors: &mut FxHashMap<(String, String), (TextRange, Specificity)>,
     descending_selectors: &mut Vec<DescendingSelector>,
 ) {
     if !visited_rules.insert(rule.id()) {
@@ -151,8 +177,10 @@ fn find_descending_selector(
             continue;
         };
 
-        if let Some((last_text_range, last_specificity)) = visited_selectors.get(&tail_selector_str)
-        {
+        // Scope comparisons to the selector's cascade layer.
+        let key = (layer_scope(casted_selector.syntax()), tail_selector_str);
+
+        if let Some((last_text_range, last_specificity)) = visited_selectors.get(&key) {
             if last_specificity > &selector.specificity() {
                 descending_selectors.push(DescendingSelector {
                     high: (*last_text_range, *last_specificity),
@@ -160,10 +188,7 @@ fn find_descending_selector(
                 });
             }
         } else {
-            visited_selectors.insert(
-                tail_selector_str,
-                (selector.range(root), selector.specificity()),
-            );
+            visited_selectors.insert(key, (selector.range(root), selector.specificity()));
         }
     }
 

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid.layer.css
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid.layer.css
@@ -1,0 +1,8 @@
+@layer one {
+	b a {
+		color: green;
+	}
+	a {
+		color: blue;
+	}
+}

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid.layer.css.snap
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid.layer.css.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: invalid.layer.css
+---
+# Input
+```css
+@layer one {
+	b a {
+		color: green;
+	}
+	a {
+		color: blue;
+	}
+}
+
+```
+
+# Diagnostics
+```
+invalid.layer.css:5:2 lint/style/noDescendingSpecificity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Descending specificity selector found. This selector specificity is (0, 0, 1)
+  
+    3 │ 		color: green;
+    4 │ 	}
+  > 5 │ 	a {
+      │ 	^
+    6 │ 		color: blue;
+    7 │ 	}
+  
+  i This selector specificity is (0, 0, 2)
+  
+    1 │ @layer one {
+  > 2 │ 	b a {
+      │ 	^^^
+    3 │ 		color: green;
+    4 │ 	}
+  
+  i Descending specificity selector may not be applied. Consider rearranging the order of the selectors. See MDN web docs for more details.
+  
+
+```

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/valid.layer.css
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/valid.layer.css
@@ -1,0 +1,14 @@
+/* should not generate diagnostics: specificity only matters within a layer */
+@layer one, two;
+
+@layer one {
+	b a {
+		color: green;
+	}
+}
+
+@layer two {
+	a {
+		color: blue;
+	}
+}

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/valid.layer.css.snap
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/valid.layer.css.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: valid.layer.css
+---
+# Input
+```css
+/* should not generate diagnostics: specificity only matters within a layer */
+@layer one, two;
+
+@layer one {
+	b a {
+		color: green;
+	}
+}
+
+@layer two {
+	a {
+		color: blue;
+	}
+}
+
+```


### PR DESCRIPTION
Fixes #7533.

## Summary

`noDescendingSpecificity` compared selector specificity across the entire stylesheet, including across different `@layer` blocks. Specificity only matters within a single cascade layer, so this produced false positives:

```css
@layer one {
	b a { color: green; }   /* (0,0,2) */
}

@layer two {
	a { color: blue; }      /* (0,0,1) — different layer, not a descending conflict */
}
```

Comparisons are now keyed by the selector's cascade layer. Re-opened named layers share a scope (specificity still compared); each anonymous `@layer { ... }` block is its own scope. Descending specificity within a single layer is still reported.

## Changes

- `crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs`: compute a cascade-layer scope per selector and key the visited-selectors map by `(layer, tail selector)`.
- Tests: added `valid.layer.css` (cross-layer, no diagnostic) and `invalid.layer.css` (within-layer, still reported) + snapshots.
- Added a changeset.