### PR TITLE
fix(useHookAtTopLevel): recognize forwardRef two-parameter components

### DIFF
--- a/.changeset/fix-use-hook-at-top-level-forward-ref.md
+++ b/.changeset/fix-use-hook-at-top-level-forward-ref.md
@@ -1,0 +1,16 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9195](https://github.com/biomejs/biome/issues/9195): [`useHookAtTopLevel`](https://biomejs.dev/linter/rules/use-hook-at-top-level/) no longer reports a false positive for hooks called at the top level of a `forwardRef` component written as a two-parameter function declaration whose second parameter is `ref`.
+
+```jsx
+// This component is passed to `forwardRef` elsewhere, so it takes a second
+// `ref` parameter. The hook is at the top level of the component and is no
+// longer flagged.
+function MyComponent(props, ref) {
+	useEffect(() => {}, []);
+	return <div ref={ref} />;
+}
+const Forwarded = forwardRef(MyComponent);
+```

--- a/crates/biome_js_analyze/src/react/components.rs
+++ b/crates/biome_js_analyze/src/react/components.rs
@@ -84,7 +84,9 @@ impl ReactComponentInfo {
     ) -> Option<Self> {
         let name = function_declaration.name()?;
 
-        if function_declaration.param_count()? > REACT_COMPONENT_PARAMS_LIMIT {
+        if function_declaration.param_count()? > REACT_COMPONENT_PARAMS_LIMIT
+            && !function_declaration.is_forward_ref_signature()
+        {
             return None;
         }
 
@@ -495,6 +497,41 @@ impl AnyJsFunctionOrMethodDeclaration {
             Self::JsMethodObjectMember(method) => method.parameters(),
         };
         parameters.ok().map(|params| params.items().len())
+    }
+
+    /// Returns `true` when the declaration has the canonical `forwardRef` render
+    /// signature: exactly two parameters whose second parameter is the
+    /// identifier `ref`. React passes the forwarded ref as the second argument,
+    /// so such a component legitimately takes two parameters even though a plain
+    /// function component takes a single `props` parameter. Without this, the
+    /// component is not recognized and hooks called at its top level are
+    /// wrongly flagged by `useHookAtTopLevel` (see #9195).
+    fn is_forward_ref_signature(&self) -> bool {
+        let parameters = match self {
+            Self::JsFunctionExportDefaultDeclaration(decl) => decl.parameters(),
+            Self::JsFunctionDeclaration(decl) => decl.parameters(),
+            Self::JsMethodClassMember(method) => method.parameters(),
+            Self::JsMethodObjectMember(method) => method.parameters(),
+        };
+        let Ok(parameters) = parameters else {
+            return false;
+        };
+        let items = parameters.items();
+        if items.len() != 2 {
+            return false;
+        }
+        let Some(Ok(second)) = items.iter().nth(1) else {
+            return false;
+        };
+        second
+            .as_any_js_formal_parameter()
+            .and_then(|formal| formal.as_js_formal_parameter())
+            .and_then(|formal| formal.binding().ok())
+            .as_ref()
+            .and_then(|binding| binding.as_any_js_binding())
+            .and_then(|binding| binding.as_js_identifier_binding())
+            .and_then(|ident| ident.name_token().ok())
+            .is_some_and(|name| name.text_trimmed() == "ref")
     }
 
     fn start_range(&self) -> TextRange {

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/validForwardRef.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/validForwardRef.jsx
@@ -1,0 +1,24 @@
+/* should not generate diagnostics */
+import { forwardRef } from "react";
+
+// All of these are valid: the hook is called at the top level of a React
+// component whose second parameter is the `ref` of a `forwardRef` component.
+
+// 1. forwardRef wrapping an arrow expression (wrapper visible at initializer)
+const ArrowForwardRef = forwardRef((props, ref) => {
+	useEffect(() => {}, []);
+	return <div ref={ref} />;
+});
+
+// 2. forwardRef wrapping an anonymous function expression
+const FnExprForwardRef = forwardRef(function (props, ref) {
+	useEffect(() => {}, []);
+	return <div ref={ref} />;
+});
+
+// 3. A two-parameter function *declaration* forwarded separately
+function DeclForwardRef(props, ref) {
+	useEffect(() => {}, []);
+	return <div ref={ref} />;
+}
+const Forwarded = forwardRef(DeclForwardRef);

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/validForwardRef.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/validForwardRef.jsx.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validForwardRef.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+import { forwardRef } from "react";
+
+// All of these are valid: the hook is called at the top level of a React
+// component whose second parameter is the `ref` of a `forwardRef` component.
+
+// 1. forwardRef wrapping an arrow expression (wrapper visible at initializer)
+const ArrowForwardRef = forwardRef((props, ref) => {
+	useEffect(() => {}, []);
+	return <div ref={ref} />;
+});
+
+// 2. forwardRef wrapping an anonymous function expression
+const FnExprForwardRef = forwardRef(function (props, ref) {
+	useEffect(() => {}, []);
+	return <div ref={ref} />;
+});
+
+// 3. A two-parameter function *declaration* forwarded separately
+function DeclForwardRef(props, ref) {
+	useEffect(() => {}, []);
+	return <div ref={ref} />;
+}
+const Forwarded = forwardRef(DeclForwardRef);
+```


### PR DESCRIPTION
## Summary

Fixes #9195.

`useHookAtTopLevel` finds the enclosing component through `ReactComponentInfo::from_function`. For a function declaration, that path returned early whenever the function had more than one parameter (`param_count > REACT_COMPONENT_PARAMS_LIMIT`), on the assumption that a component only ever takes a single `props` argument.

That assumption does not hold for `forwardRef` render functions. React passes the forwarded ref as the second argument, so a valid component is written with two parameters:

```jsx
function MyComponent(props, ref) {
	useEffect(() => {}, []);
	return <div ref={ref} />;
}
const Forwarded = forwardRef(MyComponent);
```

Because the two-parameter declaration was rejected, the component was never recognized and every hook called at its top level was reported as a false positive.

This narrows the early return so it still rejects functions that genuinely have too many parameters, except when the declaration matches the canonical `forwardRef` signature: exactly two parameters whose second parameter is the identifier `ref`. The existing parameter limit stays intact for every other case; only the real forwardRef shape is admitted.

## Test Plan

- Added `validForwardRef.jsx` under `crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/`, covering a hook at the top level of a `(props, ref)` component — it is no longer flagged.
- The existing invalid specs still flag misplaced hooks, so the rule is not weakened.
- `cargo test -p biome_js_analyze --test spec_tests -- use_hook_at_top_level` → 17 passed, 0 failed.
- `cargo fmt` and `cargo clippy -p biome_js_analyze` are clean.

## Docs

No documentation change: this is a detection bug fix for an existing rule, with no new options or behavior to document. A changeset is included.

---

This supersedes #10791, which I restructured to follow the PR template after the earlier description was too sparse.
