### PR TITLE
fix(lint): accept contact-type tokens in useValidAutocomplete

### DIFF
--- a/.changeset/fix-autocomplete-contact-type-tokens.md
+++ b/.changeset/fix-autocomplete-contact-type-tokens.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10743](https://github.com/biomejs/biome/issues/10743): The [`useValidAutocomplete`](https://biomejs.dev/linter/rules/use-valid-autocomplete/) rule now accepts a contact-type qualifier (`home`, `work`, `mobile`, `fax`, `pager`) before a telephone, email, or messaging field, matching the WHATWG autofill grammar.
+
+```html
+<!-- No longer reported -->
+<input type="tel" autocomplete="work tel" />
+<input type="email" autocomplete="home email" />
+```
+
+The qualifier still only applies to those fields, so `autocomplete="home url"` stays invalid.

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_autocomplete.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_autocomplete.rs
@@ -192,6 +192,23 @@ const BILLING_AND_SHIPPING_ADDRESS: phf::Set<&'static str> = phf_set! {
     "street-address",
 };
 
+/// Contact-type qualifiers that may precede a contact field name
+/// (`home work mobile fax pager`), per the WHATWG autofill grammar.
+const CONTACT_TYPE_TOKENS: [&str; 5] = ["home", "work", "mobile", "fax", "pager"];
+
+/// Field names that accept a leading contact-type qualifier: the telephone,
+/// email and messaging tokens from the "contact information" category.
+const CONTACT_FIELD_TOKENS: phf::Set<&'static str> = phf_set! {
+    "email",
+    "impp",
+    "tel",
+    "tel-area-code",
+    "tel-country-code",
+    "tel-extension",
+    "tel-local",
+    "tel-national",
+};
+
 /// Checks if the autocomplete attribute values are valid
 fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
     match autocomplete_values.len() {
@@ -211,9 +228,26 @@ fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
                 || ["billing", "shipping"].contains(&first)
                     && (BILLING_AND_SHIPPING_ADDRESS.contains(second)
                         || VALID_AUTOCOMPLETE_VALUES.contains(second))
+                || is_valid_contact(autocomplete_values)
                 || autocomplete_values
                     .iter()
                     .all(|val| VALID_AUTOCOMPLETE_VALUES.contains(val))
         }
     }
+}
+
+/// A contact-type qualifier (`work`, `home`, ...) followed by one or more
+/// contact field names, optionally trailed by `webauthn`. This mirrors the
+/// WHATWG grammar where `work tel` or `home email` are valid, but the
+/// qualifier only applies to telephone/email/messaging fields (so `home url`
+/// stays invalid).
+fn is_valid_contact(autocomplete_values: &[&str]) -> bool {
+    let [first, rest @ ..] = autocomplete_values else {
+        return false;
+    };
+    CONTACT_TYPE_TOKENS.contains(first)
+        && rest.iter().any(|val| CONTACT_FIELD_TOKENS.contains(val))
+        && rest
+            .iter()
+            .all(|val| CONTACT_FIELD_TOKENS.contains(val) || *val == "webauthn")
 }

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/html/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/html/invalid.html
@@ -3,3 +3,4 @@
 <input type="text" autocomplete="name invalid" />
 <input type="text" autocomplete="invalid name" />
 <input type="text" autocomplete="home url" />
+<input type="text" autocomplete="work name" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/html/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/html/invalid.html.snap
@@ -9,6 +9,7 @@ expression: invalid.html
 <input type="text" autocomplete="name invalid" />
 <input type="text" autocomplete="invalid name" />
 <input type="text" autocomplete="home url" />
+<input type="text" autocomplete="work name" />
 
 ```
 
@@ -66,7 +67,7 @@ invalid.html:4:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
   > 4 │ <input type="text" autocomplete="invalid name" />
       │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     5 │ <input type="text" autocomplete="home url" />
-    6 │ 
+    6 │ <input type="text" autocomplete="work name" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -87,7 +88,29 @@ invalid.html:5:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
     4 │ <input type="text" autocomplete="invalid name" />
   > 5 │ <input type="text" autocomplete="home url" />
       │                    ^^^^^^^^^^^^^^^^^^^^^^^
-    6 │ 
+    6 │ <input type="text" autocomplete="work name" />
+    7 │ 
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.html:6:20 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+    4 │ <input type="text" autocomplete="invalid name" />
+    5 │ <input type="text" autocomplete="home url" />
+  > 6 │ <input type="text" autocomplete="work name" />
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/html/valid.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/html/valid.html
@@ -7,4 +7,8 @@
 <input type="text" autocomplete="billing family-name" />
 <input type="text" autocomplete="section-blue shipping street-address" />
 <input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete="work tel" />
+<input type="text" autocomplete="mobile email" />
+<input type="text" autocomplete="home tel-national" />
+<input type="text" autocomplete="work tel webauthn" />
 <input type="text" autocomplete />

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/html/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAutocomplete/html/valid.html.snap
@@ -13,6 +13,10 @@ expression: valid.html
 <input type="text" autocomplete="billing family-name" />
 <input type="text" autocomplete="section-blue shipping street-address" />
 <input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete="work tel" />
+<input type="text" autocomplete="mobile email" />
+<input type="text" autocomplete="home tel-national" />
+<input type="text" autocomplete="work tel webauthn" />
 <input type="text" autocomplete />
 
 ```

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_autocomplete.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_autocomplete.rs
@@ -193,6 +193,23 @@ impl Rule for UseValidAutocomplete {
     }
 }
 
+/// Contact-type qualifiers that may precede a contact field name
+/// (`home work mobile fax pager`), per the WHATWG autofill grammar.
+const CONTACT_TYPE_TOKENS: [&str; 5] = ["home", "work", "mobile", "fax", "pager"];
+
+/// Field names that accept a leading contact-type qualifier: the telephone,
+/// email and messaging tokens from the "contact information" category.
+const CONTACT_FIELD_TOKENS: [&str; 8] = [
+    "email",
+    "impp",
+    "tel",
+    "tel-area-code",
+    "tel-country-code",
+    "tel-extension",
+    "tel-local",
+    "tel-national",
+];
+
 /// Checks if the autocomplete attribute values are valid
 fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
     match autocomplete_values.len() {
@@ -212,11 +229,28 @@ fn is_valid_autocomplete(autocomplete_values: &[&str]) -> bool {
                 || ["billing", "shipping"].contains(&first)
                     && (BILLING_AND_SHIPPING_ADDRESS.contains(&second)
                         || VALID_AUTOCOMPLETE_VALUES.binary_search(&second).is_ok())
+                || is_valid_contact(autocomplete_values)
                 || autocomplete_values
                     .iter()
                     .all(|val| VALID_AUTOCOMPLETE_VALUES.binary_search(val).is_ok())
         }
     }
+}
+
+/// A contact-type qualifier (`work`, `home`, ...) followed by one or more
+/// contact field names, optionally trailed by `webauthn`. This mirrors the
+/// WHATWG grammar where `work tel` or `home email` are valid, but the
+/// qualifier only applies to telephone/email/messaging fields (so `home url`
+/// stays invalid).
+fn is_valid_contact(autocomplete_values: &[&str]) -> bool {
+    let [first, rest @ ..] = autocomplete_values else {
+        return false;
+    };
+    CONTACT_TYPE_TOKENS.contains(first)
+        && rest.iter().any(|val| CONTACT_FIELD_TOKENS.contains(val))
+        && rest
+            .iter()
+            .all(|val| CONTACT_FIELD_TOKENS.contains(val) || *val == "webauthn")
 }
 
 #[test]

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx
@@ -4,6 +4,7 @@
 	<input type="text" autocomplete="name invalid" />
 	<input type="text" autocomplete="invalid name" />
 	<input type="text" autocomplete="home url" />
+	<input type="text" autocomplete="work name" />
 	<Bar autocomplete="baz"></Bar>
 	<Input type="text" autocomplete="baz" />
 	<Input type="text" autoComplete="baz" />

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/invalid.jsx.snap
@@ -10,6 +10,7 @@ expression: invalid.jsx
 	<input type="text" autocomplete="name invalid" />
 	<input type="text" autocomplete="invalid name" />
 	<input type="text" autocomplete="home url" />
+	<input type="text" autocomplete="work name" />
 	<Bar autocomplete="baz"></Bar>
 	<Input type="text" autocomplete="baz" />
 	<Input type="text" autoComplete="baz" />
@@ -72,7 +73,7 @@ invalid.jsx:5:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
   > 5 │ 	<input type="text" autocomplete="invalid name" />
       │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     6 │ 	<input type="text" autocomplete="home url" />
-    7 │ 	<Bar autocomplete="baz"></Bar>
+    7 │ 	<input type="text" autocomplete="work name" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -93,8 +94,8 @@ invalid.jsx:6:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
     5 │ 	<input type="text" autocomplete="invalid name" />
   > 6 │ 	<input type="text" autocomplete="home url" />
       │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^
-    7 │ 	<Bar autocomplete="baz"></Bar>
-    8 │ 	<Input type="text" autocomplete="baz" />
+    7 │ 	<input type="text" autocomplete="work name" />
+    8 │ 	<Bar autocomplete="baz"></Bar>
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -107,16 +108,16 @@ invalid.jsx:6:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
 ```
 
 ```
-invalid.jsx:7:7 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.jsx:7:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Use valid values for the autocomplete attribute.
   
     5 │ 	<input type="text" autocomplete="invalid name" />
     6 │ 	<input type="text" autocomplete="home url" />
-  > 7 │ 	<Bar autocomplete="baz"></Bar>
-      │ 	     ^^^^^^^^^^^^^^^^^^
-    8 │ 	<Input type="text" autocomplete="baz" />
-    9 │ 	<Input type="text" autoComplete="baz" />
+  > 7 │ 	<input type="text" autocomplete="work name" />
+      │ 	                   ^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 	<Bar autocomplete="baz"></Bar>
+    9 │ 	<Input type="text" autocomplete="baz" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -129,16 +130,16 @@ invalid.jsx:7:7 lint/a11y/useValidAutocomplete ━━━━━━━━━━━
 ```
 
 ```
-invalid.jsx:8:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.jsx:8:7 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Use valid values for the autocomplete attribute.
   
      6 │ 	<input type="text" autocomplete="home url" />
-     7 │ 	<Bar autocomplete="baz"></Bar>
-   > 8 │ 	<Input type="text" autocomplete="baz" />
-       │ 	                   ^^^^^^^^^^^^^^^^^^
-     9 │ 	<Input type="text" autoComplete="baz" />
-    10 │ </>
+     7 │ 	<input type="text" autocomplete="work name" />
+   > 8 │ 	<Bar autocomplete="baz"></Bar>
+       │ 	     ^^^^^^^^^^^^^^^^^^
+     9 │ 	<Input type="text" autocomplete="baz" />
+    10 │ 	<Input type="text" autoComplete="baz" />
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   
@@ -155,12 +156,34 @@ invalid.jsx:9:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━�
 
   × Use valid values for the autocomplete attribute.
   
-     7 │ 	<Bar autocomplete="baz"></Bar>
-     8 │ 	<Input type="text" autocomplete="baz" />
-   > 9 │ 	<Input type="text" autoComplete="baz" />
+     7 │ 	<input type="text" autocomplete="work name" />
+     8 │ 	<Bar autocomplete="baz"></Bar>
+   > 9 │ 	<Input type="text" autocomplete="baz" />
        │ 	                   ^^^^^^^^^^^^^^^^^^
-    10 │ </>
-    11 │ 
+    10 │ 	<Input type="text" autoComplete="baz" />
+    11 │ </>
+  
+  i The autocomplete attribute only accepts a certain number of specific fixed values.
+  
+  i Follow the links for more information,
+      WCAG 1.3.5
+      HTML Living Standard autofill
+      HTML attribute: autocomplete - HTML: HyperText Markup Language | MDN
+  
+
+```
+
+```
+invalid.jsx:10:21 lint/a11y/useValidAutocomplete ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use valid values for the autocomplete attribute.
+  
+     8 │ 	<Bar autocomplete="baz"></Bar>
+     9 │ 	<Input type="text" autocomplete="baz" />
+  > 10 │ 	<Input type="text" autoComplete="baz" />
+       │ 	                   ^^^^^^^^^^^^^^^^^^
+    11 │ </>
+    12 │ 
   
   i The autocomplete attribute only accepts a certain number of specific fixed values.
   

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx
@@ -8,6 +8,10 @@
 	<input type="text" autocomplete="billing family-name" />
 	<input type="text" autocomplete="section-blue shipping street-address" />
 	<input type="text" autocomplete="section-somewhere shipping work email" />
+	<input type="text" autocomplete="work tel" />
+	<input type="text" autocomplete="mobile email" />
+	<input type="text" autocomplete="home tel-national" />
+	<input type="text" autocomplete="work tel webauthn" />
 	<input type="text" autocomplete />
 	<input type="text" autocomplete={autocompl} />
 	<input type="text" autocomplete={autocompl || "name"} />

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAutocomplete/valid.jsx.snap
@@ -14,6 +14,10 @@ expression: valid.jsx
 	<input type="text" autocomplete="billing family-name" />
 	<input type="text" autocomplete="section-blue shipping street-address" />
 	<input type="text" autocomplete="section-somewhere shipping work email" />
+	<input type="text" autocomplete="work tel" />
+	<input type="text" autocomplete="mobile email" />
+	<input type="text" autocomplete="home tel-national" />
+	<input type="text" autocomplete="work tel webauthn" />
 	<input type="text" autocomplete />
 	<input type="text" autocomplete={autocompl} />
 	<input type="text" autocomplete={autocompl || "name"} />


### PR DESCRIPTION
Closes #10743.

`useValidAutocomplete` rejected valid `autocomplete` values where a contact-type qualifier (`home`, `work`, `mobile`, `fax`, `pager`) precedes a telephone, email, or messaging field:

```html
<input type="tel" autocomplete="work tel" />    <!-- was reported -->
<input type="email" autocomplete="home email" />
```

Per the [WHATWG autofill grammar](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) these qualifiers are allowed before the contact fields (`tel`, `tel-*`, `email`, `impp`). The fix accepts them there and keeps them invalid before any other field, so `autocomplete="home url"` and `autocomplete="work name"` remain reported.

Applied to both the HTML and JS/JSX implementations, with valid/invalid spec cases added to each.