### PR TITLE
fix(lint): report computed member access in noProcessEnv

### DIFF
--- a/.changeset/no-process-env-computed-member.md
+++ b/.changeset/no-process-env-computed-member.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10619](https://github.com/biomejs/biome/issues/10619): [`noProcessEnv`](https://biomejs.dev/linter/rules/no-process-env/) now also reports computed (bracket) member access. Previously only dot access was checked, so `process["env"]` and `env["NODE_ENV"]` (where `env` is imported from `node:process`) were missed. Both static and computed accesses are now reported.

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -2,9 +2,8 @@ use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, decl
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsImportLike, AnyJsNamedImportSpecifier, JsImport,
-    JsObjectBindingPatternShorthandProperty, JsStaticMemberExpression, JsVariableDeclarator,
-    global_identifier,
+    AnyJsExpression, AnyJsImportLike, AnyJsMemberExpression, AnyJsNamedImportSpecifier, JsImport,
+    JsObjectBindingPatternShorthandProperty, JsVariableDeclarator, global_identifier,
 };
 use biome_rowan::AstNode;
 use biome_rule_options::no_process_env::NoProcessEnvOptions;
@@ -52,7 +51,7 @@ declare_lint_rule! {
 }
 
 impl Rule for NoProcessEnv {
-    type Query = Semantic<JsStaticMemberExpression>;
+    type Query = Semantic<AnyJsMemberExpression>;
     type State = ();
     type Signals = Option<Self::State>;
     type Options = NoProcessEnvOptions;
@@ -61,17 +60,22 @@ impl Rule for NoProcessEnv {
         let node = ctx.query();
         let model = ctx.model();
         let object = node.object().ok()?;
-        let member = node.member().ok()?.as_js_name()?.to_trimmed_text();
 
         let (reference, name) = global_identifier(&object.as_any_global_identifier_expression()?)?;
 
-        if member.text() == "env" && name.text() == "process" {
+        // `process.env` and its computed form `process["env"]`.
+        if name.text() == "process"
+            && node
+                .member_name()
+                .is_some_and(|member| member.text() == "env")
+        {
             return match model.binding(&reference) {
                 None => Some(()),
                 Some(binding) => is_process_module_import(&binding).then_some(()),
             };
         }
 
+        // `env.X` / `env["X"]` where `env` is imported from `process`/`node:process`.
         model
             .binding(&reference)
             .filter(is_env_from_process)

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidComputedMember.js
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidComputedMember.js
@@ -1,0 +1,8 @@
+import { env } from "node:process";
+
+env["NODE_ENV"];
+env["HOME"];
+process["env"];
+process["env"].NODE_ENV;
+process["env"]["NODE_ENV"];
+process.env["NODE_ENV"];

--- a/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidComputedMember.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noProcessEnv/invalidComputedMember.js.snap
@@ -1,0 +1,117 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidComputedMember.js
+---
+# Input
+```js
+import { env } from "node:process";
+
+env["NODE_ENV"];
+env["HOME"];
+process["env"];
+process["env"].NODE_ENV;
+process["env"]["NODE_ENV"];
+process.env["NODE_ENV"];
+
+```
+
+# Diagnostics
+```
+invalidComputedMember.js:3:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    1 │ import { env } from "node:process";
+    2 │ 
+  > 3 │ env["NODE_ENV"];
+      │ ^^^^^^^^^^^^^^^
+    4 │ env["HOME"];
+    5 │ process["env"];
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```
+
+```
+invalidComputedMember.js:4:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    3 │ env["NODE_ENV"];
+  > 4 │ env["HOME"];
+      │ ^^^^^^^^^^^
+    5 │ process["env"];
+    6 │ process["env"].NODE_ENV;
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```
+
+```
+invalidComputedMember.js:5:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    3 │ env["NODE_ENV"];
+    4 │ env["HOME"];
+  > 5 │ process["env"];
+      │ ^^^^^^^^^^^^^^
+    6 │ process["env"].NODE_ENV;
+    7 │ process["env"]["NODE_ENV"];
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```
+
+```
+invalidComputedMember.js:6:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    4 │ env["HOME"];
+    5 │ process["env"];
+  > 6 │ process["env"].NODE_ENV;
+      │ ^^^^^^^^^^^^^^
+    7 │ process["env"]["NODE_ENV"];
+    8 │ process.env["NODE_ENV"];
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```
+
+```
+invalidComputedMember.js:7:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    5 │ process["env"];
+    6 │ process["env"].NODE_ENV;
+  > 7 │ process["env"]["NODE_ENV"];
+      │ ^^^^^^^^^^^^^^
+    8 │ process.env["NODE_ENV"];
+    9 │ 
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```
+
+```
+invalidComputedMember.js:8:1 lint/style/noProcessEnv ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use process.env.
+  
+    6 │ process["env"].NODE_ENV;
+    7 │ process["env"]["NODE_ENV"];
+  > 8 │ process.env["NODE_ENV"];
+      │ ^^^^^^^^^^^
+    9 │ 
+  
+  i Use a centralized configuration file instead for better maintainability and deployment consistency.
+  
+
+```


### PR DESCRIPTION
## Summary

Fixes #10619.

`noProcessEnv` used `type Query = Semantic<JsStaticMemberExpression>`, so it only saw dot access. Bracket (computed) access was never reported:

- `process["env"]`
- `env["NODE_ENV"]` where `env` is imported from `process` / `node:process`

The rule now queries `AnyJsMemberExpression` and resolves the member via `member_name()` (a `StaticValue` that covers both static and computed members), mirroring `noConsole`. Dot-access behavior is unchanged, and dynamic keys on non-env objects (e.g. `process[foo]`) stay valid.

## Test Plan

- Added `invalidComputedMember.js` covering `env["NODE_ENV"]`, `env["HOME"]`, `process["env"]`, `process["env"].NODE_ENV`, and `process.env["NODE_ENV"]`.
- All existing `noProcessEnv` specs pass unchanged (12 existing + 1 new = 13 passing); the pre-existing valid case `process[env]` (dynamic key) remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
