### PR TITLE
feat(lint): add ignoreIfStatements option to useNullishCoalescing

### DIFF
--- a/.changeset/add-ignore-if-statements.md
+++ b/.changeset/add-ignore-if-statements.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added the option `ignoreIfStatements` to [useNullishCoalescing](https://biomejs.dev/linter/rules/use-nullish-coalescing/). Biome now flags `if` statements that only assign to a nullish variable (such as `if (!a) { a = b }`) and can rewrite them to `??=`. When enabled, Biome ignores those `if` statements.

--- a/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
@@ -6,15 +6,15 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
-    AnyJsAssignmentPattern, AnyJsExpression, JsAssignmentExpression, JsAssignmentOperator,
-    JsBinaryOperator, JsCallArgumentList, JsCallArguments, JsCallExpression,
-    JsConditionalExpression, JsDoWhileStatement, JsForStatement, JsIfStatement,
-    JsLogicalExpression, JsLogicalOperator, JsParenthesizedExpression, JsSyntaxKind,
-    JsWhileStatement, OperatorPrecedence, T,
+    AnyJsAssignment, AnyJsAssignmentPattern, AnyJsExpression, AnyJsStatement, JsAssignmentExpression,
+    JsAssignmentOperator, JsBinaryOperator, JsCallArgumentList, JsCallArguments, JsCallExpression,
+    JsConditionalExpression, JsDoWhileStatement, JsForStatement,
+    JsIfStatement, JsLogicalExpression, JsLogicalOperator, JsParenthesizedExpression, JsSyntaxKind,
+    JsUnaryOperator, JsWhileStatement, OperatorPrecedence, T,
 };
 use biome_js_type_info::{IgnoredPrimitiveTypes, InferredType};
 use biome_rowan::{
-    AstNode, BatchMutationExt, SyntaxResult, TextRange, declare_node_union,
+    AstNode, AstNodeList, BatchMutationExt, Direction, SyntaxResult, TextRange, declare_node_union,
     trim_leading_trivia_pieces,
 };
 use biome_rule_options::use_nullish_coalescing::UseNullishCoalescingOptions;
@@ -53,6 +53,17 @@ declare_lint_rule! {
     /// ```ts,expect_diagnostic
     /// declare const x: string | null;
     /// const value = x == null ? 'default' : x;
+    /// ```
+    ///
+    /// An `if` statement that only assigns to a nullish variable is also reported,
+    /// since it can be rewritten as `??=`.
+    ///
+    /// ```ts,expect_diagnostic,file=invalid-if-assignment.ts
+    /// declare let a: { x: string } | null;
+    /// declare function makeA(): { x: string };
+    /// if (!a) {
+    ///     a = makeA();
+    /// }
     /// ```
     ///
     /// ### Valid
@@ -223,6 +234,41 @@ declare_lint_rule! {
     /// const value = name || 'default';
     /// ```
     ///
+    /// ### ignoreIfStatements
+    ///
+    /// By default, Biome reports an `if` statement that only assigns to a
+    /// nullish variable, since it can be rewritten as `??=`. Set this to `true`
+    /// to ignore those statements. Default: `false`.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "ignoreIfStatements": true
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// #### Invalid
+    ///
+    /// `||` and `||=` are still reported when only `if` statements are ignored.
+    ///
+    /// ```ts,expect_diagnostic,use_options,file=invalid-if-statements.ts
+    /// declare const maybeString: string | null;
+    /// const value = maybeString || 'default';
+    /// ```
+    ///
+    /// #### Valid
+    ///
+    /// An `if` statement performing a nullish assignment is not reported.
+    ///
+    /// ```ts,use_options,file=valid-if-statements.ts
+    /// declare let a: { x: string } | null;
+    /// declare function makeA(): { x: string };
+    /// if (!a) {
+    ///     a = makeA();
+    /// }
+    /// ```
+    ///
     pub UseNullishCoalescing {
         version: "2.4.5",
         name: "useNullishCoalescing",
@@ -237,7 +283,7 @@ declare_lint_rule! {
 }
 
 declare_node_union! {
-    pub UseNullishCoalescingQuery = JsLogicalExpression | JsAssignmentExpression | JsConditionalExpression
+    pub UseNullishCoalescingQuery = JsLogicalExpression | JsAssignmentExpression | JsConditionalExpression | JsIfStatement
 }
 
 declare_node_union! {
@@ -273,6 +319,12 @@ pub enum UseNullishCoalescingState {
         is_positive: bool,
         can_fix: bool,
     },
+    IfStatement {
+        if_range: TextRange,
+        assignment_target: AnyJsAssignmentPattern,
+        assignment_value: AnyJsExpression,
+        can_fix: bool,
+    },
 }
 
 impl Rule for UseNullishCoalescing {
@@ -292,6 +344,7 @@ impl Rule for UseNullishCoalescing {
             UseNullishCoalescingQuery::JsConditionalExpression(ternary) => {
                 run_ternary(ctx, ternary)
             }
+            UseNullishCoalescingQuery::JsIfStatement(if_stmt) => run_if_statement(ctx, if_stmt),
         }
     }
 
@@ -329,6 +382,18 @@ impl Rule for UseNullishCoalescing {
                         "Prefer "<Emphasis>"??"</Emphasis>" over a ternary expression checking for nullish."
                     },
                 ),
+            ),
+            UseNullishCoalescingState::IfStatement { if_range, .. } => Some(
+                RuleDiagnostic::new(
+                    rule_category!(),
+                    *if_range,
+                    markup! {
+                        "Use "<Emphasis>"??="</Emphasis>" instead of an "<Emphasis>"if"</Emphasis>" statement for nullish assignment."
+                    },
+                )
+                .note(markup! {
+                    "This "<Emphasis>"if"</Emphasis>" statement only assigns when the variable is nullish, which "<Emphasis>"??="</Emphasis>" expresses directly."
+                }),
             ),
         }
     }
@@ -431,6 +496,42 @@ impl Rule for UseNullishCoalescing {
                     new_expr,
                 );
                 markup! { "Replace the ternary with "<Emphasis>"??"</Emphasis>"." }.to_owned()
+            }
+            (
+                UseNullishCoalescingState::IfStatement {
+                    assignment_target,
+                    assignment_value,
+                    can_fix,
+                    ..
+                },
+                UseNullishCoalescingQuery::JsIfStatement(if_stmt),
+            ) => {
+                if !can_fix {
+                    return None;
+                }
+                let target = assignment_target.clone().trim_trivia()?;
+                let value = assignment_value.clone().trim_trivia()?;
+
+                let new_assignment = make::js_assignment_expression(
+                    target,
+                    make::token_decorated_with_space(T![??=]),
+                    value,
+                );
+
+                let new_stmt = make::js_expression_statement(AnyJsExpression::from(new_assignment))
+                    .with_semicolon_token(make::token(T![;]))
+                    .build();
+
+                // Transfer leading/trailing trivia from the original if statement.
+                let new_stmt = AnyJsStatement::from(new_stmt)
+                    .prepend_trivia_pieces(if_stmt.syntax().first_leading_trivia()?.pieces())?
+                    .append_trivia_pieces(if_stmt.syntax().last_trailing_trivia()?.pieces())?;
+
+                mutation.replace_node_discard_trivia(
+                    AnyJsStatement::from(if_stmt.clone()),
+                    new_stmt,
+                );
+                markup! { "Replace the "<Emphasis>"if"</Emphasis>" statement with "<Emphasis>"??="</Emphasis>"." }.to_owned()
             }
             _ => return None,
         };
@@ -538,6 +639,309 @@ fn run_logical_or_assignment(
         operator_range: assignment.operator_token().ok()?.text_trimmed_range(),
         can_fix,
     })
+}
+
+fn run_if_statement(
+    ctx: &RuleContext<UseNullishCoalescing>,
+    if_stmt: &JsIfStatement,
+) -> Option<UseNullishCoalescingState> {
+    let options = ctx.options();
+    if options.ignore_if_statements() {
+        return None;
+    }
+
+    // An `else` branch means the statement does more than a nullish fallback.
+    if if_stmt.else_clause().is_some() {
+        return None;
+    }
+
+    let assignment = extract_if_body_assignment(if_stmt)?;
+
+    let left = assignment.left().ok()?;
+    if !matches!(
+        left.syntax().kind(),
+        JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT
+            | JsSyntaxKind::JS_STATIC_MEMBER_ASSIGNMENT
+            | JsSyntaxKind::JS_COMPUTED_MEMBER_ASSIGNMENT
+    ) {
+        return None;
+    }
+
+    // The test must check the same reference that is assigned in the body.
+    let test = if_stmt.test().ok()?;
+    let (subject, test_kind) = extract_if_null_check(&test)?;
+    if !subject_matches_assignment_target(&subject, &left) {
+        return None;
+    }
+
+    let subject_ty = ctx.type_of_expression(&subject)?;
+    if !subject_ty.has_nullish_variant()? {
+        return None;
+    }
+    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, subject_ty)? {
+        return None;
+    }
+
+    // The fix to `??=` is only safe when the test catches exactly `null`/`undefined`.
+    // A `!x` truthiness test also catches other falsy values (`0`, `''`, `false`), so it
+    // is only safe when the non-nullish part of the type cannot itself be falsy. A single
+    // strict check (`x === null`) misses the other nullish value, mirroring the ternary path.
+    let type_allows_fix = match test_kind {
+        IfTestKind::Truthiness => subject_ty.is_safe_for_nullish_coalescing()?,
+        IfTestKind::Nullish(NullishCheckKind::Loose | NullishCheckKind::Compound) => true,
+        IfTestKind::Nullish(NullishCheckKind::StrictSingle(lit)) => match lit {
+            NullishLiteral::Null => !subject_ty.has_undefined_variant()?,
+            NullishLiteral::Undefined => !subject_ty.has_null_variant()?,
+        },
+    };
+
+    // The original `if` evaluates the subject twice (test + assignment) while `??=`
+    // evaluates it once, so the rewrite only preserves semantics when re-evaluating the
+    // reference is side-effect-free and stable (e.g. `getObj().x` or `arr[i++]` are not).
+    // Inner comments would be discarded by the rewrite, so skip the fix in that case too.
+    let can_fix = type_allows_fix
+        && is_stable_reference(&subject)
+        && !if_statement_has_inner_comments(if_stmt);
+
+    Some(UseNullishCoalescingState::IfStatement {
+        if_range: if_stmt.syntax().text_trimmed_range(),
+        assignment_target: assignment.left().ok()?,
+        assignment_value: assignment.right().ok()?,
+        can_fix,
+    })
+}
+
+/// How an `if` condition tests its subject for nullishness.
+#[derive(Clone, Copy)]
+enum IfTestKind {
+    /// `!x` truthiness negation. Catches every falsy value, not only nullish ones.
+    Truthiness,
+    /// A comparison against `null`/`undefined`, carrying the same coverage kinds
+    /// as the ternary path.
+    Nullish(NullishCheckKind),
+}
+
+/// Returns the single plain `=` assignment in an `if` body.
+/// Handles both `if (test) { target = value; }` and `if (test) target = value;`.
+/// `||=`/`??=` bodies are left to the operator logic, avoiding a double report.
+fn extract_if_body_assignment(if_stmt: &JsIfStatement) -> Option<JsAssignmentExpression> {
+    let consequent = if_stmt.consequent().ok()?;
+
+    // Unwrap a block body to its sole statement. An empty body has nothing to
+    // rewrite, and a body with several statements does more than a fallback.
+    let statement = match consequent {
+        AnyJsStatement::JsBlockStatement(block) => {
+            let mut statements = block.statements().iter();
+            let first = statements.next()?;
+            if statements.next().is_some() {
+                return None;
+            }
+            first
+        }
+        statement => statement,
+    };
+
+    // Only an expression statement can hold the plain `target = value;`
+    // assignment; any other kind (a declaration, a nested `if`, a `return`,
+    // ...) means the body is not a nullish fallback.
+    let AnyJsStatement::JsExpressionStatement(expr_stmt) = statement else {
+        return None;
+    };
+
+    let assignment = expr_stmt
+        .expression()
+        .ok()?
+        .as_js_assignment_expression()?
+        .clone();
+    (assignment.operator().ok()? == JsAssignmentOperator::Assign).then_some(assignment)
+}
+
+/// Whether the `if` test's `subject` and the body's assignment `target` reference the
+/// same value. Assignment targets and expressions have different node kinds, so each
+/// shape is compared field by field instead of as a single subtree.
+fn subject_matches_assignment_target(
+    subject: &AnyJsExpression,
+    target: &AnyJsAssignmentPattern,
+) -> bool {
+    let AnyJsAssignmentPattern::AnyJsAssignment(target) = target else {
+        return false;
+    };
+    match (subject, target) {
+        (
+            AnyJsExpression::JsIdentifierExpression(subject),
+            AnyJsAssignment::JsIdentifierAssignment(target),
+        ) => subject.name().is_ok_and(|name| {
+            name.value_token().is_ok_and(|token| {
+                target
+                    .name_token()
+                    .is_ok_and(|target_token| token.text_trimmed() == target_token.text_trimmed())
+            })
+        }),
+        (
+            AnyJsExpression::JsStaticMemberExpression(subject),
+            AnyJsAssignment::JsStaticMemberAssignment(target),
+        ) => {
+            let same_object = subject
+                .object()
+                .ok()
+                .zip(target.object().ok())
+                .is_some_and(|(a, b)| expressions_equivalent(&a, &b));
+            let same_member = subject
+                .member()
+                .ok()
+                .zip(target.member().ok())
+                .is_some_and(|(a, b)| is_node_equal(a.syntax(), b.syntax()));
+            same_object && same_member
+        }
+        (
+            AnyJsExpression::JsComputedMemberExpression(subject),
+            AnyJsAssignment::JsComputedMemberAssignment(target),
+        ) => {
+            let same_object = subject
+                .object()
+                .ok()
+                .zip(target.object().ok())
+                .is_some_and(|(a, b)| expressions_equivalent(&a, &b));
+            let same_member = subject
+                .member()
+                .ok()
+                .zip(target.member().ok())
+                .is_some_and(|(a, b)| expressions_equivalent(&a, &b));
+            same_object && same_member
+        }
+        _ => false,
+    }
+}
+
+/// Classifies an `if` test as a truthiness negation (`!x`) or a nullish comparison,
+/// returning the tested reference and the kind.
+///
+/// Supported tests:
+/// - `!x`
+/// - `x == null` / `x == undefined` (and reversed operands)
+/// - `x === null` / `x === undefined` (and reversed operands)
+/// - `x === null || x === undefined`
+fn extract_if_null_check(test: &AnyJsExpression) -> Option<(AnyJsExpression, IfTestKind)> {
+    match test {
+        AnyJsExpression::JsUnaryExpression(unary) => {
+            if unary.operator().ok()? != JsUnaryOperator::LogicalNot {
+                return None;
+            }
+            let arg = unary.argument().ok()?;
+            is_member_access_like_expr(&arg).then_some((arg, IfTestKind::Truthiness))
+        }
+        AnyJsExpression::JsBinaryExpression(_) => {
+            let (subject, kind) = match test.as_js_binary_expression()?.operator().ok()? {
+                JsBinaryOperator::Equality => {
+                    let (subject, _) =
+                        extract_nullish_comparison_operand(test, JsBinaryOperator::Equality)?;
+                    (subject, NullishCheckKind::Loose)
+                }
+                JsBinaryOperator::StrictEquality => {
+                    let (subject, lit) =
+                        extract_nullish_comparison_operand(test, JsBinaryOperator::StrictEquality)?;
+                    (subject, NullishCheckKind::StrictSingle(lit))
+                }
+                _ => return None,
+            };
+            is_member_access_like_expr(&subject).then_some((subject, IfTestKind::Nullish(kind)))
+        }
+        AnyJsExpression::JsLogicalExpression(logical) => {
+            if logical.operator().ok()? != JsLogicalOperator::LogicalOr {
+                return None;
+            }
+            let left = logical.left().ok()?;
+            let right = logical.right().ok()?;
+            let (left_subject, left_lit) =
+                extract_nullish_comparison_operand(&left, JsBinaryOperator::StrictEquality)?;
+            let (right_subject, right_lit) =
+                extract_nullish_comparison_operand(&right, JsBinaryOperator::StrictEquality)?;
+            if !is_member_access_like_expr(&left_subject)
+                || !expressions_equivalent(&left_subject, &right_subject)
+            {
+                return None;
+            }
+            // Distinct literals (one null, one undefined) cover both nullish values.
+            let kind = if left_lit != right_lit {
+                NullishCheckKind::Compound
+            } else {
+                NullishCheckKind::StrictSingle(left_lit)
+            };
+            Some((left_subject, IfTestKind::Nullish(kind)))
+        }
+        _ => None,
+    }
+}
+
+fn is_member_access_like_expr(expr: &AnyJsExpression) -> bool {
+    matches!(
+        expr,
+        AnyJsExpression::JsIdentifierExpression(_)
+            | AnyJsExpression::JsStaticMemberExpression(_)
+            | AnyJsExpression::JsComputedMemberExpression(_)
+    )
+}
+
+/// Whether re-evaluating `expr` is side-effect-free and yields the same reference.
+/// Rewriting an `if` into `??=` collapses two evaluations of the subject into one, so
+/// the rewrite only preserves semantics for stable references. Calls, updates
+/// (`i++`), and other observable expressions anywhere in the reference are rejected.
+fn is_stable_reference(expr: &AnyJsExpression) -> bool {
+    let mut current = expr.clone();
+    loop {
+        current = match current {
+            AnyJsExpression::JsIdentifierExpression(_) | AnyJsExpression::JsThisExpression(_) => {
+                return true;
+            }
+            AnyJsExpression::JsParenthesizedExpression(paren) => match paren.expression() {
+                Ok(inner) => inner,
+                Err(_) => return false,
+            },
+            AnyJsExpression::JsStaticMemberExpression(member) => match member.object() {
+                Ok(object) => object,
+                Err(_) => return false,
+            },
+            AnyJsExpression::JsComputedMemberExpression(member) => {
+                if !member.member().is_ok_and(|index| is_stable_index(&index)) {
+                    return false;
+                }
+                match member.object() {
+                    Ok(object) => object,
+                    Err(_) => return false,
+                }
+            }
+            _ => return false,
+        };
+    }
+}
+
+/// A computed-member index is stable when it is a literal or another stable reference,
+/// so `obj['a']` and `obj[key]` are fixable but `arr[i++]` is not.
+fn is_stable_index(expr: &AnyJsExpression) -> bool {
+    matches!(expr, AnyJsExpression::AnyJsLiteralExpression(_)) || is_stable_reference(expr)
+}
+
+/// Whether the `if` statement carries comments that the `??=` rewrite would discard.
+/// The rewrite preserves the statement's leading trivia (comments above the `if`) and
+/// its trailing trivia, but drops everything in between, so those are ignored here.
+fn if_statement_has_inner_comments(if_stmt: &JsIfStatement) -> bool {
+    let mut tokens = if_stmt.syntax().descendants_tokens(Direction::Next).peekable();
+    let Some(first) = tokens.next() else {
+        return false;
+    };
+    if first.has_trailing_comments() {
+        return true;
+    }
+    while let Some(token) = tokens.next() {
+        if token.has_leading_comments() {
+            return true;
+        }
+        let is_last = tokens.peek().is_none();
+        if !is_last && token.has_trailing_comments() {
+            return true;
+        }
+    }
+    false
 }
 
 /// Returns `true` when every non-nullish variant of `ty` is a primitive that the

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsDisabled.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsDisabled.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNullishCoalescing": {
+					"level": "error",
+					"options": {
+						"ignoreIfStatements": false
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsDisabled.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsDisabled.ts
@@ -1,0 +1,142 @@
+// Tests for ignoreIfStatements: false (default detection on).
+// An if that only assigns to a nullish variable reports; the ??= fix is offered
+// only when the test catches exactly null/undefined.
+
+declare let obj: { x: number } | null;
+declare function makeObj(): { x: number };
+
+// `!obj` on an object union: truthiness is equivalent to a null check, fix is safe.
+if (!obj) {
+	obj = makeObj();
+}
+
+// single-statement body without braces, also safe.
+if (!obj) obj = makeObj();
+
+// loose null check: always safe to fix.
+declare let loose: string | null;
+if (loose == null) {
+	loose = 'default';
+}
+
+// compound strict check: always safe to fix.
+declare let compound: string | null;
+if (compound === null || compound === undefined) {
+	compound = 'default';
+}
+
+// `!str` on a string union: '' is falsy but not nullish, so report WITHOUT a fix.
+declare let str: string | null;
+if (!str) {
+	str = 'default';
+}
+
+// single strict check that misses undefined: report WITHOUT a fix.
+declare let maybe: string | null | undefined;
+if (maybe === null) {
+	maybe = 'default';
+}
+
+// single strict `=== null` on a union without undefined: safe to fix.
+declare let onlyNull: string | null;
+if (onlyNull === null) {
+	onlyNull = 'default';
+}
+
+// `=== undefined` on a union without null: safe to fix.
+declare let onlyUndef: string | undefined;
+if (onlyUndef === undefined) {
+	onlyUndef = 'default';
+}
+
+// `=== undefined` on a union that also has null: report WITHOUT a fix.
+declare let undefCheck: string | null | undefined;
+if (undefCheck === undefined) {
+	undefCheck = 'default';
+}
+
+// reversed operand order: safe to fix.
+declare let reversed: string | null;
+if (null == reversed) {
+	reversed = 'default';
+}
+
+// vacuous compound (same literal twice) still misses undefined: report WITHOUT a fix.
+declare let vacuous: string | null | undefined;
+if (vacuous === null || vacuous === null) {
+	vacuous = 'default';
+}
+
+// static member subject: safe to fix.
+declare let rec: { a: number | null };
+if (rec.a == null) {
+	rec.a = 1;
+}
+
+// computed member subject: safe to fix.
+declare let rec2: { a: number | null };
+if (rec2['a'] == null) {
+	rec2['a'] = 1;
+}
+
+// computed member subject with interior whitespace vs. the assignment: still the
+// same reference, safe to fix.
+declare let rec3: { a: number | null };
+if (rec3[ 'a' ] == null) {
+	rec3['a'] = 1;
+}
+
+// member subject with a side-effecting object: report WITHOUT a fix, since the
+// original evaluates `getRec()` twice but `??=` would evaluate it once.
+declare function getRec(): { a: number | null };
+if (getRec().a == null) {
+	getRec().a = 1;
+}
+
+// computed member on a side-effecting object: report WITHOUT a fix.
+if (getRec()['a'] == null) {
+	getRec()['a'] = 1;
+}
+
+// inner comment would be dropped by the rewrite: report WITHOUT a fix.
+declare let commented: string | null;
+if (commented == null) {
+	// keep me
+	commented = 'default';
+}
+
+// Negative: else branch present.
+declare let withElse: { x: number } | null;
+if (!withElse) {
+	withElse = makeObj();
+} else {
+	withElse = makeObj();
+}
+
+// Negative: subject is not nullish.
+declare let notNullish: { x: number };
+if (!notNullish) {
+	notNullish = makeObj();
+}
+
+// Negative: more than one statement in the body.
+declare let multi: { x: number } | null;
+if (!multi) {
+	multi = makeObj();
+	sideEffect();
+}
+
+// Negative: a ||= body is left to the operator logic, so the if is not reported twice.
+declare let assign: { x: number } | null;
+if (!assign) {
+	assign ||= makeObj();
+}
+
+// Negative: the test checks a different reference than the body assigns.
+declare let mismatchA: { x: number } | null;
+declare let mismatchB: { x: number } | null;
+if (!mismatchA) {
+	mismatchB = makeObj();
+}
+
+declare function sideEffect(): void;

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsDisabled.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsDisabled.ts.snap
@@ -1,0 +1,692 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignoreIfStatementsDisabled.ts
+---
+# Input
+```ts
+// Tests for ignoreIfStatements: false (default detection on).
+// An if that only assigns to a nullish variable reports; the ??= fix is offered
+// only when the test catches exactly null/undefined.
+
+declare let obj: { x: number } | null;
+declare function makeObj(): { x: number };
+
+// `!obj` on an object union: truthiness is equivalent to a null check, fix is safe.
+if (!obj) {
+	obj = makeObj();
+}
+
+// single-statement body without braces, also safe.
+if (!obj) obj = makeObj();
+
+// loose null check: always safe to fix.
+declare let loose: string | null;
+if (loose == null) {
+	loose = 'default';
+}
+
+// compound strict check: always safe to fix.
+declare let compound: string | null;
+if (compound === null || compound === undefined) {
+	compound = 'default';
+}
+
+// `!str` on a string union: '' is falsy but not nullish, so report WITHOUT a fix.
+declare let str: string | null;
+if (!str) {
+	str = 'default';
+}
+
+// single strict check that misses undefined: report WITHOUT a fix.
+declare let maybe: string | null | undefined;
+if (maybe === null) {
+	maybe = 'default';
+}
+
+// single strict `=== null` on a union without undefined: safe to fix.
+declare let onlyNull: string | null;
+if (onlyNull === null) {
+	onlyNull = 'default';
+}
+
+// `=== undefined` on a union without null: safe to fix.
+declare let onlyUndef: string | undefined;
+if (onlyUndef === undefined) {
+	onlyUndef = 'default';
+}
+
+// `=== undefined` on a union that also has null: report WITHOUT a fix.
+declare let undefCheck: string | null | undefined;
+if (undefCheck === undefined) {
+	undefCheck = 'default';
+}
+
+// reversed operand order: safe to fix.
+declare let reversed: string | null;
+if (null == reversed) {
+	reversed = 'default';
+}
+
+// vacuous compound (same literal twice) still misses undefined: report WITHOUT a fix.
+declare let vacuous: string | null | undefined;
+if (vacuous === null || vacuous === null) {
+	vacuous = 'default';
+}
+
+// static member subject: safe to fix.
+declare let rec: { a: number | null };
+if (rec.a == null) {
+	rec.a = 1;
+}
+
+// computed member subject: safe to fix.
+declare let rec2: { a: number | null };
+if (rec2['a'] == null) {
+	rec2['a'] = 1;
+}
+
+// computed member subject with interior whitespace vs. the assignment: still the
+// same reference, safe to fix.
+declare let rec3: { a: number | null };
+if (rec3[ 'a' ] == null) {
+	rec3['a'] = 1;
+}
+
+// member subject with a side-effecting object: report WITHOUT a fix, since the
+// original evaluates `getRec()` twice but `??=` would evaluate it once.
+declare function getRec(): { a: number | null };
+if (getRec().a == null) {
+	getRec().a = 1;
+}
+
+// computed member on a side-effecting object: report WITHOUT a fix.
+if (getRec()['a'] == null) {
+	getRec()['a'] = 1;
+}
+
+// inner comment would be dropped by the rewrite: report WITHOUT a fix.
+declare let commented: string | null;
+if (commented == null) {
+	// keep me
+	commented = 'default';
+}
+
+// Negative: else branch present.
+declare let withElse: { x: number } | null;
+if (!withElse) {
+	withElse = makeObj();
+} else {
+	withElse = makeObj();
+}
+
+// Negative: subject is not nullish.
+declare let notNullish: { x: number };
+if (!notNullish) {
+	notNullish = makeObj();
+}
+
+// Negative: more than one statement in the body.
+declare let multi: { x: number } | null;
+if (!multi) {
+	multi = makeObj();
+	sideEffect();
+}
+
+// Negative: a ||= body is left to the operator logic, so the if is not reported twice.
+declare let assign: { x: number } | null;
+if (!assign) {
+	assign ||= makeObj();
+}
+
+// Negative: the test checks a different reference than the body assigns.
+declare let mismatchA: { x: number } | null;
+declare let mismatchB: { x: number } | null;
+if (!mismatchA) {
+	mismatchB = makeObj();
+}
+
+declare function sideEffect(): void;
+
+```
+
+# Diagnostics
+```
+ignoreIfStatementsDisabled.ts:9:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+     8 │ // `!obj` on an object union: truthiness is equivalent to a null check, fix is safe.
+   > 9 │ if (!obj) {
+       │ ^^^^^^^^^^^
+  > 10 │ 	obj = makeObj();
+  > 11 │ }
+       │ ^
+    12 │ 
+    13 │ // single-statement body without braces, also safe.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+      7   7 │   
+      8   8 │   // `!obj` on an object union: truthiness is equivalent to a null check, fix is safe.
+      9     │ - if·(!obj)·{
+     10     │ - → obj·=·makeObj();
+     11     │ - }
+          9 │ + obj·??=·makeObj();
+     12  10 │   
+     13  11 │   // single-statement body without braces, also safe.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:14:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    13 │ // single-statement body without braces, also safe.
+  > 14 │ if (!obj) obj = makeObj();
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ 
+    16 │ // loose null check: always safe to fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+     12  12 │   
+     13  13 │   // single-statement body without braces, also safe.
+     14     │ - if·(!obj)·obj·=·makeObj();
+         14 │ + obj·??=·makeObj();
+     15  15 │   
+     16  16 │   // loose null check: always safe to fix.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:18:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    16 │ // loose null check: always safe to fix.
+    17 │ declare let loose: string | null;
+  > 18 │ if (loose == null) {
+       │ ^^^^^^^^^^^^^^^^^^^^
+  > 19 │ 	loose = 'default';
+  > 20 │ }
+       │ ^
+    21 │ 
+    22 │ // compound strict check: always safe to fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+     16  16 │   // loose null check: always safe to fix.
+     17  17 │   declare let loose: string | null;
+     18     │ - if·(loose·==·null)·{
+     19     │ - → loose·=·'default';
+     20     │ - }
+         18 │ + loose·??=·'default';
+     21  19 │   
+     22  20 │   // compound strict check: always safe to fix.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:24:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    22 │ // compound strict check: always safe to fix.
+    23 │ declare let compound: string | null;
+  > 24 │ if (compound === null || compound === undefined) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 25 │ 	compound = 'default';
+  > 26 │ }
+       │ ^
+    27 │ 
+    28 │ // `!str` on a string union: '' is falsy but not nullish, so report WITHOUT a fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+     22  22 │   // compound strict check: always safe to fix.
+     23  23 │   declare let compound: string | null;
+     24     │ - if·(compound·===·null·||·compound·===·undefined)·{
+     25     │ - → compound·=·'default';
+     26     │ - }
+         24 │ + compound·??=·'default';
+     27  25 │   
+     28  26 │   // `!str` on a string union: '' is falsy but not nullish, so report WITHOUT a fix.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:30:1 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    28 │ // `!str` on a string union: '' is falsy but not nullish, so report WITHOUT a fix.
+    29 │ declare let str: string | null;
+  > 30 │ if (!str) {
+       │ ^^^^^^^^^^^
+  > 31 │ 	str = 'default';
+  > 32 │ }
+       │ ^
+    33 │ 
+    34 │ // single strict check that misses undefined: report WITHOUT a fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:36:1 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    34 │ // single strict check that misses undefined: report WITHOUT a fix.
+    35 │ declare let maybe: string | null | undefined;
+  > 36 │ if (maybe === null) {
+       │ ^^^^^^^^^^^^^^^^^^^^^
+  > 37 │ 	maybe = 'default';
+  > 38 │ }
+       │ ^
+    39 │ 
+    40 │ // single strict `=== null` on a union without undefined: safe to fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:42:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    40 │ // single strict `=== null` on a union without undefined: safe to fix.
+    41 │ declare let onlyNull: string | null;
+  > 42 │ if (onlyNull === null) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^
+  > 43 │ 	onlyNull = 'default';
+  > 44 │ }
+       │ ^
+    45 │ 
+    46 │ // `=== undefined` on a union without null: safe to fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+     40  40 │   // single strict `=== null` on a union without undefined: safe to fix.
+     41  41 │   declare let onlyNull: string | null;
+     42     │ - if·(onlyNull·===·null)·{
+     43     │ - → onlyNull·=·'default';
+     44     │ - }
+         42 │ + onlyNull·??=·'default';
+     45  43 │   
+     46  44 │   // `=== undefined` on a union without null: safe to fix.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:48:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    46 │ // `=== undefined` on a union without null: safe to fix.
+    47 │ declare let onlyUndef: string | undefined;
+  > 48 │ if (onlyUndef === undefined) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 49 │ 	onlyUndef = 'default';
+  > 50 │ }
+       │ ^
+    51 │ 
+    52 │ // `=== undefined` on a union that also has null: report WITHOUT a fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+     46  46 │   // `=== undefined` on a union without null: safe to fix.
+     47  47 │   declare let onlyUndef: string | undefined;
+     48     │ - if·(onlyUndef·===·undefined)·{
+     49     │ - → onlyUndef·=·'default';
+     50     │ - }
+         48 │ + onlyUndef·??=·'default';
+     51  49 │   
+     52  50 │   // `=== undefined` on a union that also has null: report WITHOUT a fix.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:54:1 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    52 │ // `=== undefined` on a union that also has null: report WITHOUT a fix.
+    53 │ declare let undefCheck: string | null | undefined;
+  > 54 │ if (undefCheck === undefined) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 55 │ 	undefCheck = 'default';
+  > 56 │ }
+       │ ^
+    57 │ 
+    58 │ // reversed operand order: safe to fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:60:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    58 │ // reversed operand order: safe to fix.
+    59 │ declare let reversed: string | null;
+  > 60 │ if (null == reversed) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
+  > 61 │ 	reversed = 'default';
+  > 62 │ }
+       │ ^
+    63 │ 
+    64 │ // vacuous compound (same literal twice) still misses undefined: report WITHOUT a fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+     58  58 │   // reversed operand order: safe to fix.
+     59  59 │   declare let reversed: string | null;
+     60     │ - if·(null·==·reversed)·{
+     61     │ - → reversed·=·'default';
+     62     │ - }
+         60 │ + reversed·??=·'default';
+     63  61 │   
+     64  62 │   // vacuous compound (same literal twice) still misses undefined: report WITHOUT a fix.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:66:1 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    64 │ // vacuous compound (same literal twice) still misses undefined: report WITHOUT a fix.
+    65 │ declare let vacuous: string | null | undefined;
+  > 66 │ if (vacuous === null || vacuous === null) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 67 │ 	vacuous = 'default';
+  > 68 │ }
+       │ ^
+    69 │ 
+    70 │ // static member subject: safe to fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:72:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    70 │ // static member subject: safe to fix.
+    71 │ declare let rec: { a: number | null };
+  > 72 │ if (rec.a == null) {
+       │ ^^^^^^^^^^^^^^^^^^^^
+  > 73 │ 	rec.a = 1;
+  > 74 │ }
+       │ ^
+    75 │ 
+    76 │ // computed member subject: safe to fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+     70  70 │   // static member subject: safe to fix.
+     71  71 │   declare let rec: { a: number | null };
+     72     │ - if·(rec.a·==·null)·{
+     73     │ - → rec.a·=·1;
+     74     │ - }
+         72 │ + rec.a·??=·1;
+     75  73 │   
+     76  74 │   // computed member subject: safe to fix.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:78:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    76 │ // computed member subject: safe to fix.
+    77 │ declare let rec2: { a: number | null };
+  > 78 │ if (rec2['a'] == null) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^
+  > 79 │ 	rec2['a'] = 1;
+  > 80 │ }
+       │ ^
+    81 │ 
+    82 │ // computed member subject with interior whitespace vs. the assignment: still the
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+     76  76 │   // computed member subject: safe to fix.
+     77  77 │   declare let rec2: { a: number | null };
+     78     │ - if·(rec2['a']·==·null)·{
+     79     │ - → rec2['a']·=·1;
+     80     │ - }
+         78 │ + rec2['a']·??=·1;
+     81  79 │   
+     82  80 │   // computed member subject with interior whitespace vs. the assignment: still the
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:85:1 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    83 │ // same reference, safe to fix.
+    84 │ declare let rec3: { a: number | null };
+  > 85 │ if (rec3[ 'a' ] == null) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 86 │ 	rec3['a'] = 1;
+  > 87 │ }
+       │ ^
+    88 │ 
+    89 │ // member subject with a side-effecting object: report WITHOUT a fix, since the
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace the if statement with ??=.
+  
+     83  83 │   // same reference, safe to fix.
+     84  84 │   declare let rec3: { a: number | null };
+     85     │ - if·(rec3[·'a'·]·==·null)·{
+     86     │ - → rec3['a']·=·1;
+     87     │ - }
+         85 │ + rec3['a']·??=·1;
+     88  86 │   
+     89  87 │   // member subject with a side-effecting object: report WITHOUT a fix, since the
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:92:1 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    90 │ // original evaluates `getRec()` twice but `??=` would evaluate it once.
+    91 │ declare function getRec(): { a: number | null };
+  > 92 │ if (getRec().a == null) {
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 93 │ 	getRec().a = 1;
+  > 94 │ }
+       │ ^
+    95 │ 
+    96 │ // computed member on a side-effecting object: report WITHOUT a fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:97:1 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+     96 │ // computed member on a side-effecting object: report WITHOUT a fix.
+   > 97 │ if (getRec()['a'] == null) {
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 98 │ 	getRec()['a'] = 1;
+   > 99 │ }
+        │ ^
+    100 │ 
+    101 │ // inner comment would be dropped by the rewrite: report WITHOUT a fix.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:103:1 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of an if statement for nullish assignment.
+  
+    101 │ // inner comment would be dropped by the rewrite: report WITHOUT a fix.
+    102 │ declare let commented: string | null;
+  > 103 │ if (commented == null) {
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^
+  > 104 │ 	// keep me
+  > 105 │ 	commented = 'default';
+  > 106 │ }
+        │ ^
+    107 │ 
+    108 │ // Negative: else branch present.
+  
+  i This if statement only assigns when the variable is nullish, which ??= expresses directly.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreIfStatementsDisabled.ts:132:9 lint/nursery/useNullishCoalescing  FIXABLE  ━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    130 │ declare let assign: { x: number } | null;
+    131 │ if (!assign) {
+  > 132 │ 	assign ||= makeObj();
+        │ 	       ^^^
+    133 │ }
+    134 │ 
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Replace ||= with ??=.
+  
+    130 130 │   declare let assign: { x: number } | null;
+    131 131 │   if (!assign) {
+    132     │ - → assign·||=·makeObj();
+        132 │ + → assign·??=·makeObj();
+    133 133 │   }
+    134 134 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsEnabled.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsEnabled.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNullishCoalescing": {
+					"level": "error",
+					"options": {
+						"ignoreIfStatements": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsEnabled.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsEnabled.ts
@@ -1,0 +1,22 @@
+// Tests for ignoreIfStatements: true.
+// if statements assigning to a nullish variable are ignored, but || and ||= still report.
+
+declare let a: string | null;
+
+// ignored
+if (!a) {
+	a = 'default';
+}
+
+// ignored
+if (a == null) {
+	a = 'fallback';
+}
+
+// || still reported
+declare const s: string | null;
+const r1 = s || 'x';
+
+// ||= still reported
+declare let b: string | null;
+b ||= 'y';

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsEnabled.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/ignoreIfStatementsEnabled.ts.snap
@@ -1,0 +1,72 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignoreIfStatementsEnabled.ts
+---
+# Input
+```ts
+// Tests for ignoreIfStatements: true.
+// if statements assigning to a nullish variable are ignored, but || and ||= still report.
+
+declare let a: string | null;
+
+// ignored
+if (!a) {
+	a = 'default';
+}
+
+// ignored
+if (a == null) {
+	a = 'fallback';
+}
+
+// || still reported
+declare const s: string | null;
+const r1 = s || 'x';
+
+// ||= still reported
+declare let b: string | null;
+b ||= 'y';
+
+```
+
+# Diagnostics
+```
+ignoreIfStatementsEnabled.ts:18:14 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ?? instead of ||.
+  
+    16 │ // || still reported
+    17 │ declare const s: string | null;
+  > 18 │ const r1 = s || 'x';
+       │              ^^
+    19 │ 
+    20 │ // ||= still reported
+  
+  i The || operator checks for all falsy values (including 0, '', and false), while ?? only checks for null and undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+ignoreIfStatementsEnabled.ts:22:3 lint/nursery/useNullishCoalescing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use ??= instead of ||=.
+  
+    20 │ // ||= still reported
+    21 │ declare let b: string | null;
+  > 22 │ b ||= 'y';
+       │   ^^^
+    23 │ 
+  
+  i The ||= operator assigns when the left side is falsy, while ??= only assigns when it is null or undefined.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/8043 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_rule_options/src/use_nullish_coalescing.rs
+++ b/crates/biome_rule_options/src/use_nullish_coalescing.rs
@@ -28,6 +28,10 @@ pub struct UseNullishCoalescingOptions {
     /// Whether to ignore `||` and `||=` operations whose non-nullish operand types are all primitives of the configured kinds. Accepts `true` for every primitive, or an object selecting `string`, `number`, `boolean`, `bigint` (default: none).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_primitives: Option<IgnorePrimitives>,
+
+    /// Whether to ignore `if` statements that only assign to a nullish variable and could be rewritten as `??=` (default: `false`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore_if_statements: Option<bool>,
 }
 
 impl UseNullishCoalescingOptions {
@@ -45,6 +49,10 @@ impl UseNullishCoalescingOptions {
 
     pub fn ignore_boolean_coercion(&self) -> bool {
         self.ignore_boolean_coercion.unwrap_or(false)
+    }
+
+    pub fn ignore_if_statements(&self) -> bool {
+        self.ignore_if_statements.unwrap_or(false)
     }
 
     /// Whether any `ignorePrimitives` selection is configured.

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8514,6 +8514,10 @@ export interface UseNullishCoalescingOptions {
 	 */
 	ignoreConditionalTests?: boolean;
 	/**
+	 * Whether to ignore `if` statements that only assign to a nullish variable and could be rewritten as `??=` (default: `false`).
+	 */
+	ignoreIfStatements?: boolean;
+	/**
 	 * Whether to ignore `||` and `||=` binary operations that are part of a mixed logical expression with `&&` (default: `false`).
 	 */
 	ignoreMixedLogicalExpressions?: boolean;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -15918,6 +15918,10 @@
 					"description": "Ignore `||` expressions in conditional test positions (default: `true`).",
 					"type": ["boolean", "null"]
 				},
+				"ignoreIfStatements": {
+					"description": "Whether to ignore `if` statements that only assign to a nullish variable and could be rewritten as `??=` (default: `false`).",
+					"type": ["boolean", "null"]
+				},
 				"ignoreMixedLogicalExpressions": {
 					"description": "Whether to ignore `||` and `||=` binary operations that are part of a mixed logical expression with `&&` (default: `false`).",
 					"type": ["boolean", "null"]


### PR DESCRIPTION
> This PR was created with AI assistance.

## Summary

adds the `ignoreIfStatements` option to `useNullishCoalescing`, the last option from #9232. this follows on from #9974 (`ignoreMixedLogicalExpressions`), #10595 (`ignoreBooleanCoercion`), and #10798 (`ignorePrimitives`). Closes #9232.

unlike the earlier options, which only *suppress* existing diagnostics, this one adds new detection. the rule now flags `if` statements that only assign to a nullish variable and can be rewritten as `??=`, e.g.:

```ts
declare let a: string | null;

// before
if (!a) {
  a = 'default';
}

// after
a ??= 'default';
```

detection covers the same nullish shapes as the rest of the rule: `!a`, `a == null`, `a === null`, and the compound `a === null || a === undefined`. the subject can be an identifier, a static member (`obj.prop`), or a computed member (`obj['prop']`).

because this changes default behavior (new diagnostics appear without any config), `ignoreIfStatements` (default `false`, matching `@typescript-eslint/prefer-nullish-coalescing`) turns the detection back off.

the `??=` fix is gated exactly like the existing `||` path — offered only when the test catches *exactly* `null`/`undefined`:

- loose (`== null`) and compound (`=== null || === undefined`) checks: always fixable
- `!a`: fixable only when the non-nullish part of the type can't be falsy (so `{ x } | null` is fixable, `string | null` reports without a fix since `''` is falsy but not nullish)
- single strict (`=== null` / `=== undefined`): fixable only when the *other* nullish literal is absent from the type

otherwise the diagnostic is reported without a fix. only plain `=` bodies are treated as if-assignments, so a `||=`/`??=` body inside an `if` is left to the operator logic and never double-reported. i kept the scope to just this one option so it stays easy to review.

## Test Plan

the spec snapshots cover this, but to check it by hand:

1. drop a `biome.json` enabling the rule:

```json
{ "linter": { "rules": { "nursery": { "useNullishCoalescing": { "level": "error", "options": { "ignoreIfStatements": true } } } } } }
```

2. make a `test.ts`:

```ts
declare let o: { x: number } | null;
declare function make(): { x: number };
declare let a: string | null;
declare let s: string | null | undefined;

if (!o) { o = make(); }        // if-assignment, fixable ??=
if (a == null) { a = 'x'; }    // if-assignment, fixable ??=
if (s === null) { s = 'x'; }   // if-assignment, reports without a fix (misses undefined)
a ||= 'x';                     // ||= path, unaffected by this option
```

3. run `biome lint test.ts`. with the option `true`, the three `if` statements are quiet and only `a ||= 'x'` reports.

4. flip the option to `false` (or remove it) and re-run: the three `if` statements now report too, the first two with a `??=` fix and the `=== null` one without.

things worth poking at for coverage:

- `!str` on a `string | null` reports but offers no fix, since `''` is falsy but not nullish
- static and computed member subjects (`obj.prop`, `obj['prop']`) are detected
- a `||=` or `??=` body inside the `if` is left to the operator logic and not reported twice
- an `else` branch, a multi-statement body, or a test/body reference mismatch (`if (!a) { b = c }`) are not reported

## Docs

the option is documented in the rule's rustdoc with a `### ignoreIfStatements` invalid/valid section (with `file=` metadata) and validated by `rules_check`. no website PR needed while the rule is in nursery.
