### PR TITLE
fix(lint/noMisusedPromises): report Promise coerced to string

### DIFF
--- a/.changeset/fix-no-misused-promises-stringification.md
+++ b/.changeset/fix-no-misused-promises-stringification.md
@@ -1,0 +1,15 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8816](https://github.com/biomejs/biome/issues/8816): [`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/) now reports a Promise that is coerced to a string through template literal interpolation or the `+` operator.
+
+```ts
+const promise = Promise.resolve("value");
+
+// Both of these coerce the Promise to "[object Promise]".
+const a = `wtf ${promise}`;
+const b = "wtf " + promise;
+```
+
+Tagged templates are left untouched, since the tag receives the raw values instead of the coerced string.

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -4,8 +4,8 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
-    AnyJsCallArgument, AnyJsExpression, JsCallArgumentList, JsCallExpression,
-    JsConditionalExpression, JsNewExpression, JsSyntaxKind,
+    AnyJsCallArgument, AnyJsExpression, JsBinaryExpression, JsBinaryOperator, JsCallArgumentList,
+    JsCallExpression, JsConditionalExpression, JsNewExpression, JsSyntaxKind, JsTemplateExpression,
 };
 use biome_js_type_info::{Type, TypeMemberKind};
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TriviaPieceKind};
@@ -97,6 +97,7 @@ pub enum NoMisusedPromisesState {
     Conditional,
     ConditionalReturn,
     Spread,
+    Stringification,
     VoidReturn,
 }
 
@@ -178,6 +179,22 @@ impl Rule for NoMisusedPromises {
                     "Promise needs to be `await`-ed to take its value."
                 }),
             ),
+            NoMisusedPromisesState::Stringification => Some(
+                RuleDiagnostic::new(
+                    rule_category!(),
+                    node.range(),
+                    markup! {
+                        "A Promise was found where a string was expected."
+                    },
+                )
+                .note(markup! {
+                    "A Promise is coerced to \"[object Promise]\", so this is "
+                    "most likely a mistake."
+                })
+                .note(markup! {
+                    "You may have intended to `await` the Promise instead."
+                }),
+            ),
         }
     }
 
@@ -217,15 +234,36 @@ fn find_misused_promise_expression(
     let parent = expression.syntax().parent()?;
     let state = match parent.kind() {
         JsSyntaxKind::JS_CONDITIONAL_EXPRESSION
-            if JsConditionalExpression::cast(parent)
-                .is_some_and(|conditional| conditional.test().is_ok_and(|test| test == *expression))
-            => {
-                NoMisusedPromisesState::Conditional
-            }
+            if JsConditionalExpression::cast(parent.clone()).is_some_and(|conditional| {
+                conditional.test().is_ok_and(|test| test == *expression)
+            }) =>
+        {
+            NoMisusedPromisesState::Conditional
+        }
         JsSyntaxKind::JS_DO_WHILE_STATEMENT => NoMisusedPromisesState::Conditional,
         JsSyntaxKind::JS_IF_STATEMENT => NoMisusedPromisesState::Conditional,
         JsSyntaxKind::JS_SPREAD => NoMisusedPromisesState::Spread,
         JsSyntaxKind::JS_WHILE_STATEMENT => NoMisusedPromisesState::Conditional,
+        // A Promise interpolated in a template literal is coerced to a string,
+        // unless the template is tagged, in which case the raw value is passed
+        // to the tag function and no coercion happens.
+        JsSyntaxKind::JS_TEMPLATE_ELEMENT
+            if parent
+                .ancestors()
+                .find_map(JsTemplateExpression::cast)
+                .is_some_and(|template| template.tag().is_none()) =>
+        {
+            NoMisusedPromisesState::Stringification
+        }
+        // A Promise used as an operand of `+` is coerced to a string, since `+`
+        // on a Promise is only valid when the other operand is a string.
+        JsSyntaxKind::JS_BINARY_EXPRESSION
+            if JsBinaryExpression::cast(parent.clone())
+                .and_then(|binary| binary.operator().ok())
+                .is_some_and(|operator| operator == JsBinaryOperator::Plus) =>
+        {
+            NoMisusedPromisesState::Stringification
+        }
         _ => return None,
     };
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksStringificationInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksStringificationInvalid.ts
@@ -1,0 +1,15 @@
+const promise = Promise.resolve('value');
+
+const a = `wtf ${promise}`;
+
+const b = 'wtf ' + promise;
+
+const c = promise + ' wtf';
+
+const d = `${promise} and ${promise}`;
+
+const getData = (): Promise<string> => fetch('/').then((r) => r.text());
+
+const e = `data: ${getData()}`;
+
+const f = 'data: ' + getData();

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksStringificationInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksStringificationInvalid.ts.snap
@@ -1,0 +1,170 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: checksStringificationInvalid.ts
+---
+# Input
+```ts
+const promise = Promise.resolve('value');
+
+const a = `wtf ${promise}`;
+
+const b = 'wtf ' + promise;
+
+const c = promise + ' wtf';
+
+const d = `${promise} and ${promise}`;
+
+const getData = (): Promise<string> => fetch('/').then((r) => r.text());
+
+const e = `data: ${getData()}`;
+
+const f = 'data: ' + getData();
+
+```
+
+# Diagnostics
+```
+checksStringificationInvalid.ts:3:18 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a string was expected.
+  
+    1 │ const promise = Promise.resolve('value');
+    2 │ 
+  > 3 │ const a = `wtf ${promise}`;
+      │                  ^^^^^^^
+    4 │ 
+    5 │ const b = 'wtf ' + promise;
+  
+  i A Promise is coerced to "[object Promise]", so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+checksStringificationInvalid.ts:5:20 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a string was expected.
+  
+    3 │ const a = `wtf ${promise}`;
+    4 │ 
+  > 5 │ const b = 'wtf ' + promise;
+      │                    ^^^^^^^
+    6 │ 
+    7 │ const c = promise + ' wtf';
+  
+  i A Promise is coerced to "[object Promise]", so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+checksStringificationInvalid.ts:7:11 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a string was expected.
+  
+    5 │ const b = 'wtf ' + promise;
+    6 │ 
+  > 7 │ const c = promise + ' wtf';
+      │           ^^^^^^^
+    8 │ 
+    9 │ const d = `${promise} and ${promise}`;
+  
+  i A Promise is coerced to "[object Promise]", so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+checksStringificationInvalid.ts:9:14 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a string was expected.
+  
+     7 │ const c = promise + ' wtf';
+     8 │ 
+   > 9 │ const d = `${promise} and ${promise}`;
+       │              ^^^^^^^
+    10 │ 
+    11 │ const getData = (): Promise<string> => fetch('/').then((r) => r.text());
+  
+  i A Promise is coerced to "[object Promise]", so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+checksStringificationInvalid.ts:9:29 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a string was expected.
+  
+     7 │ const c = promise + ' wtf';
+     8 │ 
+   > 9 │ const d = `${promise} and ${promise}`;
+       │                             ^^^^^^^
+    10 │ 
+    11 │ const getData = (): Promise<string> => fetch('/').then((r) => r.text());
+  
+  i A Promise is coerced to "[object Promise]", so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+checksStringificationInvalid.ts:13:20 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a string was expected.
+  
+    11 │ const getData = (): Promise<string> => fetch('/').then((r) => r.text());
+    12 │ 
+  > 13 │ const e = `data: ${getData()}`;
+       │                    ^^^^^^^^^
+    14 │ 
+    15 │ const f = 'data: ' + getData();
+  
+  i A Promise is coerced to "[object Promise]", so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+checksStringificationInvalid.ts:15:22 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a string was expected.
+  
+    13 │ const e = `data: ${getData()}`;
+    14 │ 
+  > 15 │ const f = 'data: ' + getData();
+       │                      ^^^^^^^^^
+    16 │ 
+  
+  i A Promise is coerced to "[object Promise]", so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksStringificationValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksStringificationValid.ts
@@ -1,0 +1,23 @@
+/* should not generate diagnostics */
+
+const promise = Promise.resolve('value');
+
+// Always `await` the Promise before coercing it to a string
+const a = `wtf ${await promise}`;
+
+const b = 'wtf ' + (await promise);
+
+const resolved = await promise;
+const c = `wtf ${resolved}`;
+
+// A tagged template receives the raw value, so no coercion happens
+function tag(strings: TemplateStringsArray, ...values: unknown[]) {
+  return values;
+}
+const d = tag`wtf ${promise}`;
+
+// Numeric addition does not coerce to a string
+const count = 1 + 2;
+
+// String concatenation of plain strings
+const e = 'wtf ' + 'more';

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksStringificationValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksStringificationValid.ts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: checksStringificationValid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+const promise = Promise.resolve('value');
+
+// Always `await` the Promise before coercing it to a string
+const a = `wtf ${await promise}`;
+
+const b = 'wtf ' + (await promise);
+
+const resolved = await promise;
+const c = `wtf ${resolved}`;
+
+// A tagged template receives the raw value, so no coercion happens
+function tag(strings: TemplateStringsArray, ...values: unknown[]) {
+  return values;
+}
+const d = tag`wtf ${promise}`;
+
+// Numeric addition does not coerce to a string
+const count = 1 + 2;
+
+// String concatenation of plain strings
+const e = 'wtf ' + 'more';
+
+```


### PR DESCRIPTION
## Summary

Closes #8816.

`noMisusedPromises` flags a Promise used in a conditional, a spread, or a callback, but it did not flag a Promise coerced to a string. Interpolating a Promise in a template literal or concatenating it with `+` produces `"[object Promise]"`, which is almost always a missing `await`.

This extends `find_misused_promise_expression` with two parent kinds:

- `JS_TEMPLATE_ELEMENT`, unless the enclosing template is tagged (a tag receives the raw values, so no coercion happens).
- `JS_BINARY_EXPRESSION` with the `+` operator.

Both cases reuse the existing Promise type check, so only actual Promise-typed operands are reported. A new `Stringification` diagnostic explains the coercion and suggests awaiting.

```ts
const promise = Promise.resolve("value");
const a = `wtf ${promise}`; // reported
const b = "wtf " + promise; // reported
const c = `wtf ${await promise}`; // ok
```

## Test Plan

Added `checksStringificationInvalid.ts` and `checksStringificationValid.ts` under the `noMisusedPromises` specs. The invalid file covers template interpolation, both `+` operand positions, multiple interpolations, and a Promise-returning call. The valid file covers awaited Promises, a tagged template, numeric addition, and plain string concatenation. `cargo test -p biome_js_analyze --test spec_tests checks_stringification` passes.

## Docs

The rule's rustdoc already documents the existing cases; no website change is needed for this behavior extension of a nursery rule.

---

AI assistance disclosure: I used Claude Code to help write the implementation and tests. I reviewed the change, confirmed the type gating, and verified the snapshots by running the spec tests.
