### PR TITLE
fix(html): apply unsafe fixes to Astro template expressions

### DIFF
--- a/.changeset/fix-astro-template-expression-fixes.md
+++ b/.changeset/fix-astro-template-expression-fixes.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9181](https://github.com/biomejs/biome/issues/9181). When HTML full support is enabled, Biome now applies unsafe fixes to expressions embedded in `{...}` template expressions of `.astro` files. Previously the fix for a rule such as [`useSortedClasses`](https://biomejs.dev/linter/rules/use-sorted-classes/) was computed but never written back into the document.

--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -296,6 +296,48 @@ schema + sure()
 }
 
 #[test]
+fn sort_classes_in_template_expression() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{
+            "html": { "experimentalFullSupportEnabled": true },
+            "linter": { "rules": { "nursery": { "useSortedClasses": "error" } } }
+        }"#
+        .as_bytes(),
+    );
+
+    let astro_file_path = Utf8Path::new("file.astro");
+    fs.insert(
+        astro_file_path.into(),
+        r#"---
+---
+<div class="hover:focus:m-2 bar hover:p-2 px-2 mx-2 foo" />
+<div>{(<div class="hover:focus:m-2 bar hover:p-2 px-2 mx-2 foo" />)}</div>
+"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", "--write", "--unsafe", astro_file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "sort_classes_in_template_expression",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn lint_and_fix_astro_files() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sort_classes_in_template_expression.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sort_classes_in_template_expression.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": { "experimentalFullSupportEnabled": true },
+  "linter": { "rules": { "nursery": { "useSortedClasses": "error" } } }
+}
+```
+
+## `file.astro`
+
+```astro
+---
+---
+<div class="hover:focus:m-2 bar hover:p-2 px-2 mx-2 foo" />
+<div>{(<div class="bar foo mx-2 px-2 hover:p-2 hover:focus:m-2" />)}</div>
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_html_syntax/src/element_ext.rs
+++ b/crates/biome_html_syntax/src/element_ext.rs
@@ -2,7 +2,8 @@ use crate::{
     AnyHtmlAttribute, AnyHtmlContent, AnyHtmlElement, AnyHtmlTagName, AnyHtmlTextExpression,
     AnySvelteBlock, AnyVueDirective, AstroEmbeddedContent, HtmlAttribute, HtmlAttributeList,
     HtmlElement, HtmlEmbeddedContent, HtmlOpeningElement, HtmlProcessingInstruction,
-    HtmlSelfClosingElement, HtmlSyntaxToken, HtmlTagName, ScriptType, inner_string_text,
+    HtmlSelfClosingElement, HtmlSyntaxToken, HtmlTagName, HtmlTextExpression, ScriptType,
+    inner_string_text,
 };
 use biome_aria::Attribute;
 use biome_rowan::{AstNodeList, SyntaxResult, TokenText, declare_node_union};
@@ -780,7 +781,7 @@ mod tests {
 }
 
 declare_node_union! {
-    pub AnyEmbeddedContent = HtmlEmbeddedContent | AstroEmbeddedContent
+    pub AnyEmbeddedContent = HtmlEmbeddedContent | AstroEmbeddedContent | HtmlTextExpression
 }
 
 impl AnyEmbeddedContent {
@@ -788,6 +789,7 @@ impl AnyEmbeddedContent {
         match self {
             Self::HtmlEmbeddedContent(node) => node.value_token().ok(),
             Self::AstroEmbeddedContent(node) => node.content_token(),
+            Self::HtmlTextExpression(node) => node.html_literal_token().ok(),
         }
     }
 }


### PR DESCRIPTION
**Title:** `fix(html): apply unsafe fixes to Astro template expressions`

## Summary

Closes #9181.

With HTML full support enabled, a fix such as `useSortedClasses` inside an Astro `{...}` template expression was computed but never written back to the file. Running `biome lint --write --unsafe` reported "No fixes applied" and left the source unchanged, while the same fix applied correctly to top-level markup and to the frontmatter.

The workspace runs `fix_all` on each embedded snippet and then splices the results back into the host document through `update_snippets`, which walks the tree for `AnyEmbeddedContent` nodes and replaces the matched token. That node union covered `HtmlEmbeddedContent` (script/style) and `AstroEmbeddedContent` (frontmatter) but not `HtmlTextExpression`, the node that holds a `{...}` expression. So the snippet range never matched a node and the splice was a no-op.

This adds `HtmlTextExpression` to `AnyEmbeddedContent` and returns its `html_literal_token` as the value token. The snippet range already points at the text expression, so the existing range match in `update_snippets` now lines up.

## Test Plan

Added `sort_classes_in_template_expression` in `crates/biome_cli/tests/cases/handle_astro_files.rs`, which runs `lint --write --unsafe` on an `.astro` file with unsorted classes both in top-level markup and in a `{...}` template expression. The snapshot shows the template expression sorted; the top-level plain-HTML `<div>` correctly stays unsorted, since `useSortedClasses` does not apply to plain HTML markup.

## AI assistance

The code and tests in this PR were written with Claude Code. I reviewed the diagnosis and the fix, and confirmed the behavior against the reproduction in the issue.
