### PR TITLE
fix(lint): handle TypeScript wrappers in unsafe optional chains

### DIFF
--- a/.changeset/fix-unsafe-optional-chain-ts-wrappers.md
+++ b/.changeset/fix-unsafe-optional-chain-ts-wrappers.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10698](https://github.com/biomejs/biome/issues/10698): The [`noUnsafeOptionalChaining`](https://biomejs.dev/linter/rules/no-unsafe-optional-chaining/) rule now reports unsafe optional chains wrapped in TypeScript `as`, `satisfies`, type assertion, and instantiation expressions, such as `new (value?.constructor as Constructor)()`.

--- a/crates/biome_js_analyze/src/lint/correctness/no_unsafe_optional_chaining.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unsafe_optional_chaining.rs
@@ -10,7 +10,8 @@ use biome_js_syntax::{
     JsInExpression, JsInitializerClause, JsInstanceofExpression, JsLogicalExpression,
     JsLogicalOperator, JsNewExpression, JsObjectAssignmentPatternProperty, JsObjectMemberList,
     JsParenthesizedExpression, JsSequenceExpression, JsSpread, JsStaticMemberExpression,
-    JsTemplateExpression, JsVariableDeclarator, JsWithStatement,
+    JsTemplateExpression, JsVariableDeclarator, JsWithStatement, TsAsExpression,
+    TsInstantiationExpression, TsSatisfiesExpression, TsTypeAssertionExpression,
 };
 use biome_rowan::{AstNode, TextRange, declare_node_union};
 use biome_rule_options::no_unsafe_optional_chaining::NoUnsafeOptionalChainingOptions;
@@ -103,6 +104,12 @@ impl Rule for NoUnsafeOptionalChaining {
                     parent = expression.parent::<RuleNode>()
                 }
                 RuleNode::JsAwaitExpression(expression) => parent = expression.parent::<RuleNode>(),
+                RuleNode::TsAsExpression(_)
+                | RuleNode::TsSatisfiesExpression(_)
+                | RuleNode::TsTypeAssertionExpression(_)
+                | RuleNode::TsInstantiationExpression(_) => {
+                    parent = current_parent.parent::<RuleNode>()
+                }
                 RuleNode::JsExtendsClause(extends) => {
                     // class A extends obj?.foo {}
                     return Some(extends.syntax().text_trimmed_range());
@@ -333,6 +340,10 @@ declare_node_union! {
     | JsExtendsClause
     | JsInExpression
     | JsInstanceofExpression
+    | TsAsExpression
+    | TsSatisfiesExpression
+    | TsTypeAssertionExpression
+    | TsInstantiationExpression
 }
 
 impl From<AnyJsOptionalChainExpression> for RuleNode {

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/invalid.ts
@@ -1,3 +1,4 @@
+/* should generate diagnostics */
 new (a?.b as any)();
 (a?.b as any)();
 (a?.b as any).c;

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/invalid.ts
@@ -1,0 +1,7 @@
+new (a?.b as any)();
+(a?.b as any)();
+(a?.b as any).c;
+(a?.b satisfies any).c;
+(<any>a?.b)();
+new (a?.b<string>)();
+for (const x of a?.b as any[]);

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/invalid.ts.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 196
 expression: invalid.ts
 ---
 # Input
 ```ts
+/* should generate diagnostics */
 new (a?.b as any)();
 (a?.b as any)();
 (a?.b as any).c;
@@ -16,43 +18,23 @@ for (const x of a?.b as any[]);
 
 # Diagnostics
 ```
-invalid.ts:1:7 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:2:7 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unsafe usage of optional chaining.
   
-  > 1 │ new (a?.b as any)();
+    1 │ /* should generate diagnostics */
+  > 2 │ new (a?.b as any)();
       │       ^^
-    2 │ (a?.b as any)();
-    3 │ (a?.b as any).c;
+    3 │ (a?.b as any)();
+    4 │ (a?.b as any).c;
   
   i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
   
-  > 1 │ new (a?.b as any)();
+    1 │ /* should generate diagnostics */
+  > 2 │ new (a?.b as any)();
       │ ^^^^^^^^^^^^^^^^^^^
-    2 │ (a?.b as any)();
-    3 │ (a?.b as any).c;
-  
-
-```
-
-```
-invalid.ts:2:3 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unsafe usage of optional chaining.
-  
-    1 │ new (a?.b as any)();
-  > 2 │ (a?.b as any)();
-      │   ^^
-    3 │ (a?.b as any).c;
-    4 │ (a?.b satisfies any).c;
-  
-  i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
-  
-    1 │ new (a?.b as any)();
-  > 2 │ (a?.b as any)();
-      │              ^^
-    3 │ (a?.b as any).c;
-    4 │ (a?.b satisfies any).c;
+    3 │ (a?.b as any)();
+    4 │ (a?.b as any).c;
   
 
 ```
@@ -62,21 +44,21 @@ invalid.ts:3:3 lint/correctness/noUnsafeOptionalChaining ━━━━━━━�
 
   × Unsafe usage of optional chaining.
   
-    1 │ new (a?.b as any)();
-    2 │ (a?.b as any)();
-  > 3 │ (a?.b as any).c;
+    1 │ /* should generate diagnostics */
+    2 │ new (a?.b as any)();
+  > 3 │ (a?.b as any)();
       │   ^^
-    4 │ (a?.b satisfies any).c;
-    5 │ (<any>a?.b)();
+    4 │ (a?.b as any).c;
+    5 │ (a?.b satisfies any).c;
   
   i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
   
-    1 │ new (a?.b as any)();
-    2 │ (a?.b as any)();
-  > 3 │ (a?.b as any).c;
-      │               ^
-    4 │ (a?.b satisfies any).c;
-    5 │ (<any>a?.b)();
+    1 │ /* should generate diagnostics */
+    2 │ new (a?.b as any)();
+  > 3 │ (a?.b as any)();
+      │              ^^
+    4 │ (a?.b as any).c;
+    5 │ (a?.b satisfies any).c;
   
 
 ```
@@ -86,91 +68,115 @@ invalid.ts:4:3 lint/correctness/noUnsafeOptionalChaining ━━━━━━━�
 
   × Unsafe usage of optional chaining.
   
-    2 │ (a?.b as any)();
-    3 │ (a?.b as any).c;
-  > 4 │ (a?.b satisfies any).c;
+    2 │ new (a?.b as any)();
+    3 │ (a?.b as any)();
+  > 4 │ (a?.b as any).c;
       │   ^^
-    5 │ (<any>a?.b)();
-    6 │ new (a?.b<string>)();
+    5 │ (a?.b satisfies any).c;
+    6 │ (<any>a?.b)();
   
   i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
   
-    2 │ (a?.b as any)();
-    3 │ (a?.b as any).c;
-  > 4 │ (a?.b satisfies any).c;
+    2 │ new (a?.b as any)();
+    3 │ (a?.b as any)();
+  > 4 │ (a?.b as any).c;
+      │               ^
+    5 │ (a?.b satisfies any).c;
+    6 │ (<any>a?.b)();
+  
+
+```
+
+```
+invalid.ts:5:3 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unsafe usage of optional chaining.
+  
+    3 │ (a?.b as any)();
+    4 │ (a?.b as any).c;
+  > 5 │ (a?.b satisfies any).c;
+      │   ^^
+    6 │ (<any>a?.b)();
+    7 │ new (a?.b<string>)();
+  
+  i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
+  
+    3 │ (a?.b as any)();
+    4 │ (a?.b as any).c;
+  > 5 │ (a?.b satisfies any).c;
       │                      ^
-    5 │ (<any>a?.b)();
-    6 │ new (a?.b<string>)();
+    6 │ (<any>a?.b)();
+    7 │ new (a?.b<string>)();
   
 
 ```
 
 ```
-invalid.ts:5:8 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:6:8 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unsafe usage of optional chaining.
   
-    3 │ (a?.b as any).c;
-    4 │ (a?.b satisfies any).c;
-  > 5 │ (<any>a?.b)();
+    4 │ (a?.b as any).c;
+    5 │ (a?.b satisfies any).c;
+  > 6 │ (<any>a?.b)();
       │        ^^
-    6 │ new (a?.b<string>)();
-    7 │ for (const x of a?.b as any[]);
+    7 │ new (a?.b<string>)();
+    8 │ for (const x of a?.b as any[]);
   
   i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
   
-    3 │ (a?.b as any).c;
-    4 │ (a?.b satisfies any).c;
-  > 5 │ (<any>a?.b)();
+    4 │ (a?.b as any).c;
+    5 │ (a?.b satisfies any).c;
+  > 6 │ (<any>a?.b)();
       │            ^^
-    6 │ new (a?.b<string>)();
-    7 │ for (const x of a?.b as any[]);
+    7 │ new (a?.b<string>)();
+    8 │ for (const x of a?.b as any[]);
   
 
 ```
 
 ```
-invalid.ts:6:7 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:7:7 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unsafe usage of optional chaining.
   
-    4 │ (a?.b satisfies any).c;
-    5 │ (<any>a?.b)();
-  > 6 │ new (a?.b<string>)();
+    5 │ (a?.b satisfies any).c;
+    6 │ (<any>a?.b)();
+  > 7 │ new (a?.b<string>)();
       │       ^^
-    7 │ for (const x of a?.b as any[]);
-    8 │ 
+    8 │ for (const x of a?.b as any[]);
+    9 │ 
   
   i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
   
-    4 │ (a?.b satisfies any).c;
-    5 │ (<any>a?.b)();
-  > 6 │ new (a?.b<string>)();
+    5 │ (a?.b satisfies any).c;
+    6 │ (<any>a?.b)();
+  > 7 │ new (a?.b<string>)();
       │ ^^^^^^^^^^^^^^^^^^^^
-    7 │ for (const x of a?.b as any[]);
-    8 │ 
+    8 │ for (const x of a?.b as any[]);
+    9 │ 
   
 
 ```
 
 ```
-invalid.ts:7:18 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:8:18 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Unsafe usage of optional chaining.
   
-    5 │ (<any>a?.b)();
-    6 │ new (a?.b<string>)();
-  > 7 │ for (const x of a?.b as any[]);
+    6 │ (<any>a?.b)();
+    7 │ new (a?.b<string>)();
+  > 8 │ for (const x of a?.b as any[]);
       │                  ^^
-    8 │ 
+    9 │ 
   
   i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
   
-    5 │ (<any>a?.b)();
-    6 │ new (a?.b<string>)();
-  > 7 │ for (const x of a?.b as any[]);
+    6 │ (<any>a?.b)();
+    7 │ new (a?.b<string>)();
+  > 8 │ for (const x of a?.b as any[]);
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    8 │ 
+    9 │ 
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/invalid.ts.snap
@@ -1,0 +1,176 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```ts
+new (a?.b as any)();
+(a?.b as any)();
+(a?.b as any).c;
+(a?.b satisfies any).c;
+(<any>a?.b)();
+new (a?.b<string>)();
+for (const x of a?.b as any[]);
+
+```
+
+# Diagnostics
+```
+invalid.ts:1:7 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unsafe usage of optional chaining.
+  
+  > 1 │ new (a?.b as any)();
+      │       ^^
+    2 │ (a?.b as any)();
+    3 │ (a?.b as any).c;
+  
+  i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
+  
+  > 1 │ new (a?.b as any)();
+      │ ^^^^^^^^^^^^^^^^^^^
+    2 │ (a?.b as any)();
+    3 │ (a?.b as any).c;
+  
+
+```
+
+```
+invalid.ts:2:3 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unsafe usage of optional chaining.
+  
+    1 │ new (a?.b as any)();
+  > 2 │ (a?.b as any)();
+      │   ^^
+    3 │ (a?.b as any).c;
+    4 │ (a?.b satisfies any).c;
+  
+  i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
+  
+    1 │ new (a?.b as any)();
+  > 2 │ (a?.b as any)();
+      │              ^^
+    3 │ (a?.b as any).c;
+    4 │ (a?.b satisfies any).c;
+  
+
+```
+
+```
+invalid.ts:3:3 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unsafe usage of optional chaining.
+  
+    1 │ new (a?.b as any)();
+    2 │ (a?.b as any)();
+  > 3 │ (a?.b as any).c;
+      │   ^^
+    4 │ (a?.b satisfies any).c;
+    5 │ (<any>a?.b)();
+  
+  i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
+  
+    1 │ new (a?.b as any)();
+    2 │ (a?.b as any)();
+  > 3 │ (a?.b as any).c;
+      │               ^
+    4 │ (a?.b satisfies any).c;
+    5 │ (<any>a?.b)();
+  
+
+```
+
+```
+invalid.ts:4:3 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unsafe usage of optional chaining.
+  
+    2 │ (a?.b as any)();
+    3 │ (a?.b as any).c;
+  > 4 │ (a?.b satisfies any).c;
+      │   ^^
+    5 │ (<any>a?.b)();
+    6 │ new (a?.b<string>)();
+  
+  i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
+  
+    2 │ (a?.b as any)();
+    3 │ (a?.b as any).c;
+  > 4 │ (a?.b satisfies any).c;
+      │                      ^
+    5 │ (<any>a?.b)();
+    6 │ new (a?.b<string>)();
+  
+
+```
+
+```
+invalid.ts:5:8 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unsafe usage of optional chaining.
+  
+    3 │ (a?.b as any).c;
+    4 │ (a?.b satisfies any).c;
+  > 5 │ (<any>a?.b)();
+      │        ^^
+    6 │ new (a?.b<string>)();
+    7 │ for (const x of a?.b as any[]);
+  
+  i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
+  
+    3 │ (a?.b as any).c;
+    4 │ (a?.b satisfies any).c;
+  > 5 │ (<any>a?.b)();
+      │            ^^
+    6 │ new (a?.b<string>)();
+    7 │ for (const x of a?.b as any[]);
+  
+
+```
+
+```
+invalid.ts:6:7 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unsafe usage of optional chaining.
+  
+    4 │ (a?.b satisfies any).c;
+    5 │ (<any>a?.b)();
+  > 6 │ new (a?.b<string>)();
+      │       ^^
+    7 │ for (const x of a?.b as any[]);
+    8 │ 
+  
+  i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
+  
+    4 │ (a?.b satisfies any).c;
+    5 │ (<any>a?.b)();
+  > 6 │ new (a?.b<string>)();
+      │ ^^^^^^^^^^^^^^^^^^^^
+    7 │ for (const x of a?.b as any[]);
+    8 │ 
+  
+
+```
+
+```
+invalid.ts:7:18 lint/correctness/noUnsafeOptionalChaining ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unsafe usage of optional chaining.
+  
+    5 │ (<any>a?.b)();
+    6 │ new (a?.b<string>)();
+  > 7 │ for (const x of a?.b as any[]);
+      │                  ^^
+    8 │ 
+  
+  i If it short-circuits with 'undefined' the evaluation will throw TypeError here:
+  
+    5 │ (<any>a?.b)();
+    6 │ new (a?.b<string>)();
+  > 7 │ for (const x of a?.b as any[]);
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/valid.ts
@@ -1,0 +1,4 @@
+/* should not generate diagnostics */
+new (a?.b as any ?? Fallback)();
+(a?.b as any)?.();
+new (a?.b<string> ?? Fallback)();

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnsafeOptionalChaining/valid.ts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+new (a?.b as any ?? Fallback)();
+(a?.b as any)?.();
+new (a?.b<string> ?? Fallback)();
+
+```


### PR DESCRIPTION
## Summary

Fixes #10698.

`noUnsafeOptionalChaining` now looks through TypeScript-only wrappers (`as`, `satisfies`, type assertions, and instantiation expressions) when checking whether an optional chain is used in an unsafe context.

I left `a?.b!` behavior unchanged in this PR. `AnyJsExpression::inner_expression()` treats non-null assertions as transparent, but `noNonNullAssertedOptionalChain` already reports that pattern, so I think that boundary is better set by maintainers.

## Test Plan

- Added TypeScript spec fixtures for invalid and valid `noUnsafeOptionalChaining` cases.
- `cargo format`
- `cargo test -p biome_js_analyze --test spec_tests specs::correctness::no_unsafe_optional_chaining`
- `cargo test -p biome_js_analyze`
- `cargo lint`

## Docs

N/A. A changeset is included.

## AI assistance

This PR was implemented with assistance from Codex. I reviewed the changes and verified them locally.
