### PR TITLE
ci: ignore quick-xml RustSec advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -13,5 +13,7 @@ multiple-versions = "allow"
 unmaintained = "workspace"
 ignore       = [
   { id = "RUSTSEC-2026-0097", reason = "Upgrading the `rand` crate to a newer version requires `grit-pattern-matcher` to also update the dependency. Also, the current version of Boa depends on a different version of `rand`, and its also affected by this advisory. It's more work than it's worth to fix it right now." },
-  { id = "RUSTSEC-2026-0173", reason = "Currently there's no alternative" }
+  { id = "RUSTSEC-2026-0173", reason = "Currently there's no alternative" },
+  { id = "RUSTSEC-2026-0194", reason = "`quick-xml` is pulled in by `self_update` and `quick-junit`; no released compatible upgrade avoids the advisory yet." },
+  { id = "RUSTSEC-2026-0195", reason = "`quick-xml` is pulled in by `self_update` and `quick-junit`; no released compatible upgrade avoids the advisory yet." }
 ]


### PR DESCRIPTION
## Summary

Adds temporary Cargo Deny ignores for `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` because the affected `quick-xml` versions are pulled in transitively by `self_update` and `quick-junit`, and there is no released compatible upgrade path for those dependency roots yet.

No changeset: this only updates CI dependency-advisory configuration.

> This PR was created with AI assistance (Claude Code).

## Test Plan

Not run locally. This should be verified by the PR CI/CD Cargo Deny check.

## Docs

N/A