### PR TITLE
feat(languages): support Google Apps Script (.gs) files

### DIFF
--- a/.changeset/add-google-apps-script-gs-support.md
+++ b/.changeset/add-google-apps-script-gs-support.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added support for Google Apps Script (`.gs`) files. Since Google Apps Script is plain JavaScript running on the V8 runtime (with a shared global scope and no ES module system), `.gs` files are now recognized and processed as JavaScript scripts by the formatter and linter. Closes [#8267](https://github.com/biomejs/biome/issues/8267).

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -264,6 +264,35 @@ fn write() {
 }
 
 #[test]
+fn formats_google_apps_script_gs_file() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // Google Apps Script `.gs` files are plain JavaScript and should be
+    // formatted like any other JS file. See https://github.com/biomejs/biome/issues/8267.
+    let file_path = Utf8Path::new("Code.gs");
+    fs.insert(file_path.into(), UNFORMATTED.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--write", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, file_path, FORMATTED);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "formats_google_apps_script_gs_file",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn format_shows_parse_diagnostics() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_commands_format/formats_google_apps_script_gs_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/formats_google_apps_script_gs_file.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `Code.gs`
+
+```gs
+statement();
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_languages/src/javascript.rs
+++ b/crates/biome_languages/src/javascript.rs
@@ -586,6 +586,10 @@ impl JsFileSource {
             "vue" => Ok(Self::vue()),
             // TODO: Remove once we have full support of svelte files
             "svelte" => Ok(Self::svelte()),
+            // Google Apps Script is plain JavaScript running on the V8 runtime.
+            // It has no ES module system: files share a single global scope and
+            // cannot use `import`/`export`, so it is parsed as a script.
+            "gs" => Ok(Self::js_script()),
 
             _ => Err(FileSourceError::UnknownExtension),
         }
@@ -619,6 +623,8 @@ impl JsFileSource {
             "vue" | "vuejs" => Ok(Self::vue()),
             // TODO: Remove once we have full support of svelte files
             "svelte" => Ok(Self::svelte()),
+            // Google Apps Script — see the `"gs"` extension mapping above.
+            "appsscript" => Ok(Self::js_script()),
             _ => Err(FileSourceError::UnknownLanguageId),
         }
     }
@@ -692,5 +698,21 @@ mod tests {
 
         assert!(source.is_svelte_source_module());
         assert!(!source.is_typescript());
+    }
+
+    #[test]
+    fn detects_google_apps_script_files_as_javascript() {
+        let source = JsFileSource::try_from(Utf8Path::new("Code.gs")).unwrap();
+
+        assert_eq!(source.language, Language::JavaScript);
+        assert_eq!(source.module_kind, ModuleKind::Script);
+    }
+
+    #[test]
+    fn detects_google_apps_script_language_id() {
+        let source = JsFileSource::try_from_language_id("appsscript").unwrap();
+
+        assert_eq!(source.language, Language::JavaScript);
+        assert_eq!(source.module_kind, ModuleKind::Script);
     }
 }


### PR DESCRIPTION
## Summary

Closes #8267 (supersedes the stale draft #8267).

[Google Apps Script](https://developers.google.com/apps-script) `.gs` files are plain JavaScript running on the V8 runtime — files share a single global scope and there is no ES module system (no `import` / `export`). So this maps the `.gs` extension to a JavaScript **script** source, and the `appsscript` language id to the same, in `JsFileSource` (`crates/biome_languages/src/javascript.rs`).

Because `DocumentFileSource::try_from_extension` delegates to `JsFileSource::try_from_extension` (there is no separate extension allowlist), this one mapping is enough for `.gs` files to be recognized, **formatted, and linted as JavaScript** by both the CLI (explicit paths and directory traversal) and the LSP.

`js_script()` (rather than `js_module()`) is used deliberately: it matches GAS semantics — global/sloppy scope and no ES modules — so `import`/`export` in a `.gs` file is correctly reported as invalid. Happy to switch to module mode if maintainers prefer.

Out of scope (kept minimal): bundling Google Apps Script globals (`SpreadsheetApp`, `Logger`, …) to reduce `noUndeclaredVariables` noise — that can follow up.

## Test Plan

- Unit tests in `biome_languages`: `Code.gs` resolves to JavaScript / script module, and the `appsscript` language id does too.
- CLI end-to-end test: `biome format --write Code.gs` formats the file as JavaScript (`formats_google_apps_script_gs_file`, with snapshot).
- Full `commands::format` suite passes (110) with no snapshot changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
