### PR TITLE
feat(useDomQuerySelector): add ignore option

### DIFF
--- a/.changeset/plain-houses-join.md
+++ b/.changeset/plain-houses-join.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10824](https://github.com/biomejs/biome/issues/10824): [`useDomQuerySelector`](https://biomejs.dev/linter/rules/use-dom-query-selector/) now supports an `ignore` option for receiver identifiers that should not be reported.

--- a/.claude/skills/lint-rule-development/SKILL.md
+++ b/.claude/skills/lint-rule-development/SKILL.md
@@ -381,13 +381,16 @@ impl Rule for UseMyRuleName {
 
 **Step 3.** Test with `options.json` in the test directory (see [references/OPTIONS.md](references/OPTIONS.md) for examples).
 
-**Step 4.** Run codegen: `just gen-rules && just gen-configuration`
+**Step 4.** Document the options in the rule's rustdoc comments, including valid and invalid test cases for each option.
+
+**Step 5.** Run codegen: `just gen-rules && just gen-configuration`
 
 **Key rules:**
 - All fields must be `Option<T>` for config merging to work
 - Use `Box<[Box<str>]>` instead of `Vec<String>` for collection fields
 - Use `#[derive(Merge)]` for simple cases, implement `Merge` manually for collections
 - Only add options when truly needed (conflicting community preferences, multiple valid interpretations)
+- All options must be documented in the rule's documentation.
 
 ## Tips
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_dom_query_selector.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_dom_query_selector.rs
@@ -10,7 +10,7 @@ use biome_js_factory::make::{
 };
 use biome_js_syntax::{
     AnyJsExpression, AnyJsMemberExpression, AnyJsTemplateElement, JsCallExpression,
-    JsTemplateExpression, T, static_value::StaticValue,
+    JsTemplateExpression, T, global_identifier, static_value::StaticValue,
 };
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, TextRange};
 use biome_rule_options::use_dom_query_selector::UseDomQuerySelectorOptions;
@@ -50,6 +50,31 @@ declare_lint_rule! {
     ///
     /// ```js
     /// document.querySelectorAll(".foo.bar");
+    /// ```
+    ///
+    /// ## Options
+    ///
+    /// ### `ignore`
+    ///
+    /// Allow specific variables to use the older DOM query APIs.
+    /// This is useful if your application has APIs that expose methods with
+    /// the same names as DOM query APIs.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "ignore": ["store", "customApi"]
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// #### Valid
+    ///
+    /// These are ignored, so they are not flagged.
+    ///
+    /// ```js,use_options
+    /// store.getElementById("COVER_IMAGE");
+    /// customApi.getElementsByClassName("item");
     /// ```
     ///
     pub UseDomQuerySelector {
@@ -96,7 +121,8 @@ impl Rule for UseDomQuerySelector {
         let method = QueryMethod::from_name(method_name.text())?;
 
         let argument = first_and_only_argument(call)?;
-        if is_definitely_not_dom_node(&member.object().ok()?.omit_parentheses()) {
+        let object = member.object().ok()?.omit_parentheses();
+        if is_ignored(&object, ctx.options()) || is_definitely_not_dom_node(&object) {
             return None;
         }
 
@@ -251,6 +277,21 @@ fn is_definitely_not_dom_node(expr: &AnyJsExpression) -> bool {
     ) || expr
         .as_static_value()
         .is_some_and(|value| matches!(value, StaticValue::Undefined(_)))
+}
+
+fn is_ignored(expr: &AnyJsExpression, options: &UseDomQuerySelectorOptions) -> bool {
+    let Some(ignore) = &options.ignore else {
+        return false;
+    };
+
+    let Some((_, name)) = expr
+        .as_any_global_identifier_expression()
+        .and_then(|expr| global_identifier(&expr))
+    else {
+        return false;
+    };
+
+    ignore.iter().any(|ignored| ignored.as_ref() == name.text())
 }
 
 /// Returns `true` when the query argument can be safely converted into a CSS

--- a/crates/biome_js_analyze/tests/specs/nursery/useDomQuerySelector/validIgnore.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useDomQuerySelector/validIgnore.options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useDomQuerySelector": {
+					"level": "error",
+					"options": {
+						"ignore": ["store", "customApi"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useDomQuerySelector/validIgnore.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useDomQuerySelector/validIgnore.ts
@@ -1,0 +1,14 @@
+/* should not generate diagnostics */
+interface CanvasStore {
+	getElementById(id: string): { id: string } | undefined;
+}
+
+const store: CanvasStore = {
+	getElementById(id) {
+		return { id };
+	},
+};
+
+export const canvasElement = store.getElementById("COVER_IMAGE");
+
+customApi.getElementById("foo");

--- a/crates/biome_js_analyze/tests/specs/nursery/useDomQuerySelector/validIgnore.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useDomQuerySelector/validIgnore.ts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validIgnore.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+interface CanvasStore {
+	getElementById(id: string): { id: string } | undefined;
+}
+
+const store: CanvasStore = {
+	getElementById(id) {
+		return { id };
+	},
+};
+
+export const canvasElement = store.getElementById("COVER_IMAGE");
+
+customApi.getElementById("foo");
+
+```

--- a/crates/biome_rule_options/src/use_dom_query_selector.rs
+++ b/crates/biome_rule_options/src/use_dom_query_selector.rs
@@ -3,4 +3,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
-pub struct UseDomQuerySelectorOptions {}
+pub struct UseDomQuerySelectorOptions {
+    /// A list of receiver identifiers to ignore.
+    ///
+    /// In the expression `document.querySelector('div')`, the receiver is `document`.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub ignore: Option<Box<[Box<str>]>>,
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8423,7 +8423,14 @@ Default: `"it"`
 }
 export type UseDisposablesOptions = {};
 export type UseDomNodeTextContentOptions = {};
-export type UseDomQuerySelectorOptions = {};
+export interface UseDomQuerySelectorOptions {
+	/**
+	* A list of receiver identifiers to ignore.
+
+In the expression `document.querySelector('div')`, the receiver is `document`. 
+	 */
+	ignore?: string[];
+}
 export type UseExhaustiveSwitchCasesOptions = {};
 export type UseExpectOptions = {};
 /**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -15104,6 +15104,13 @@
 		},
 		"UseDomQuerySelectorOptions": {
 			"type": "object",
+			"properties": {
+				"ignore": {
+					"description": "A list of receiver identifiers to ignore.\n\nIn the expression `document.querySelector('div')`, the receiver is `document`.",
+					"type": ["array", "null"],
+					"items": { "type": "string" }
+				}
+			},
 			"additionalProperties": false
 		},
 		"UseEnumInitializersConfiguration": {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This adds an escape hatch option to `useDomQuerySelector` to ignore certain identifiers.

The rule is still in nursery, so adding the option is not a `minor` change.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #10824

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
