### PR TITLE
perf(core): embedded ranges plumbing

### DIFF
--- a/crates/biome_js_formatter/benches/js_formatter.rs
+++ b/crates/biome_js_formatter/benches/js_formatter.rs
@@ -49,7 +49,7 @@ fn bench_js_formatter(criterion: &mut Criterion) {
                             let formatted = biome_js_formatter::format_node(
                                 JsFormatOptions::default(),
                                 root.syntax(),
-                                false,
+                                Vec::new(),
                             )
                             .unwrap();
                             let printed = formatted.print();

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -10,6 +10,7 @@ use biome_formatter::{
 };
 use biome_js_syntax::{AnyJsFunctionBody, JsLanguage};
 use biome_languages::JsFileSource;
+use biome_rowan::TextRange;
 use std::fmt;
 use std::fmt::Debug;
 use std::rc::Rc;
@@ -47,7 +48,10 @@ pub struct JsFormatContext {
 
     source_map: Option<TransformSourceMap>,
 
-    should_delegate_fmt_embedded_nodes: bool,
+    /// Ranges of template chunks whose content was parsed as an embedded
+    /// language. Formatting them is delegated to the corresponding language
+    /// formatter, see [crate::format_node].
+    embedded_node_ranges: Vec<TextRange>,
 }
 
 impl JsFormatContext {
@@ -57,7 +61,7 @@ impl JsFormatContext {
             comments: Rc::new(comments),
             cached_function_body: None,
             source_map: None,
-            should_delegate_fmt_embedded_nodes: false,
+            embedded_node_ranges: Vec::new(),
         }
     }
 
@@ -96,13 +100,16 @@ impl JsFormatContext {
         self
     }
 
-    pub fn with_fmt_embedded_nodes(mut self) -> Self {
-        self.should_delegate_fmt_embedded_nodes = true;
+    pub fn with_embedded_node_ranges(mut self, embedded_node_ranges: Vec<TextRange>) -> Self {
+        self.embedded_node_ranges = embedded_node_ranges;
         self
     }
 
-    pub fn should_delegate_fmt_embedded_nodes(&self) -> bool {
-        self.should_delegate_fmt_embedded_nodes
+    /// Ranges of template chunks whose content was parsed as an embedded
+    /// language, and whose formatting is therefore delegated to the
+    /// corresponding language formatter.
+    pub fn embedded_node_ranges(&self) -> &[TextRange] {
+        &self.embedded_node_ranges
     }
 }
 

--- a/crates/biome_js_formatter/src/js/auxiliary/template_chunk_element.rs
+++ b/crates/biome_js_formatter/src/js/auxiliary/template_chunk_element.rs
@@ -2,11 +2,8 @@ use crate::prelude::*;
 use biome_formatter::FormatContext;
 use biome_formatter::write;
 
-use biome_js_syntax::{
-    AnyJsExpression, JsCallArgumentList, JsCallArguments, JsCallExpression, JsSyntaxToken,
-    JsTemplateChunkElement, JsTemplateExpression, TsTemplateChunkElement,
-};
-use biome_rowan::{AstNode, SyntaxResult, declare_node_union};
+use biome_js_syntax::{JsSyntaxToken, JsTemplateChunkElement, TsTemplateChunkElement};
+use biome_rowan::{SyntaxResult, declare_node_union};
 use biome_text_size::TextRange;
 
 #[derive(Debug, Clone, Default)]
@@ -26,22 +23,8 @@ impl FormatNodeRule<JsTemplateChunkElement> for FormatJsTemplateChunkElement {
         node: &JsTemplateChunkElement,
         f: &mut JsFormatter,
     ) -> Option<TextRange> {
-        if !f.context().should_delegate_fmt_embedded_nodes() {
-            return None;
-        }
-
-        // Only mark template chunks that belong to a plausible embed candidate.
-        // A template is a candidate when it has a tag (e.g. css``, gql``, styled.div``)
-        // or is an argument to a simple call expression (e.g. graphql(`...`)).
-        // Plain templates like console.log(`test`) must NOT be marked, otherwise
-        // the formatter emits StartEmbedded/EndEmbedded tags that never get resolved
-        // and corrupt the printer's tag stack.
-        let template = node
-            .syntax()
-            .ancestors()
-            .find_map(JsTemplateExpression::cast)?;
-
-        if !is_plausible_embed_template(&template)? {
+        let embedded_node_ranges = f.context().embedded_node_ranges();
+        if embedded_node_ranges.is_empty() {
             return None;
         }
 
@@ -55,85 +38,13 @@ impl FormatNodeRule<JsTemplateChunkElement> for FormatJsTemplateChunkElement {
             .source_map()
             .map_or(transformed_range, |map| map.source_range(transformed_range));
 
-        Some(source_range)
+        // Only chunks whose range was registered by the embedding service are
+        // delegated. Marking any other chunk would emit StartEmbedded/EndEmbedded
+        // tags that never get resolved, losing the chunk's content.
+        embedded_node_ranges
+            .contains(&source_range)
+            .then_some(source_range)
     }
-}
-
-/// Known identifier tag names that produce embedded languages.
-/// Must stay in sync with the `TemplateTag` entries in `JS_DETECTORS`.
-const KNOWN_EMBED_TAGS: &[&str] = &["css", "gql", "graphql"];
-
-/// Known object/callee names for member expressions (`styled.div```)
-/// and call expressions (`styled(Comp)```, `graphql(``)`).
-/// Must stay in sync with the `TemplateExpression` entries in `JS_DETECTORS`.
-const KNOWN_EMBED_OBJECTS: &[&str] = &["styled", "graphql"];
-
-/// Check whether a template expression is a known embed candidate.
-///
-/// Returns `Some(true)` only for templates whose tag or call pattern matches
-/// one of the known embed detectors:
-/// - `css```, `gql```, `graphql``` (identifier tag)
-/// - `styled.div```, `styled(Comp)``` (member/call with known object)
-/// - `graphql(`...`)` (untagged template as argument to known callee)
-///
-/// Returns `None` when the AST is malformed.
-fn is_plausible_embed_template(expr: &JsTemplateExpression) -> Option<bool> {
-    // The service currently only extracts embedded snippets from single-chunk
-    // templates. Keep the formatter in sync so it doesn't emit StartEmbedded /
-    // EndEmbedded tags for ranges that won't be resolved later.
-    if expr.elements().len() != 1 {
-        return Some(false);
-    }
-
-    if let Some(tag) = expr.tag() {
-        return Some(match tag {
-            // css``, gql``, graphql``
-            AnyJsExpression::JsIdentifierExpression(ident) => {
-                let name = ident.name().ok()?.value_token().ok()?;
-                KNOWN_EMBED_TAGS
-                    .iter()
-                    .any(|known| name.text_trimmed() == *known)
-            }
-            // styled.div``
-            AnyJsExpression::JsStaticMemberExpression(member) => {
-                let AnyJsExpression::JsIdentifierExpression(ident) = member.object().ok()? else {
-                    return Some(false);
-                };
-                let name = ident.name().ok()?.value_token().ok()?;
-                KNOWN_EMBED_OBJECTS
-                    .iter()
-                    .any(|known| name.text_trimmed() == *known)
-            }
-            // styled(Component)``
-            AnyJsExpression::JsCallExpression(call) => {
-                let AnyJsExpression::JsIdentifierExpression(ident) = call.callee().ok()? else {
-                    return Some(false);
-                };
-                let name = ident.name().ok()?.value_token().ok()?;
-                KNOWN_EMBED_OBJECTS
-                    .iter()
-                    .any(|known| name.text_trimmed() == *known)
-            }
-            _ => false,
-        });
-    }
-
-    // No tag — check if template is an argument to a known call expression.
-    // e.g. graphql(`query { ... }`)
-    let call = expr
-        .parent::<JsCallArgumentList>()?
-        .parent::<JsCallArguments>()?
-        .parent::<JsCallExpression>()?;
-
-    let AnyJsExpression::JsIdentifierExpression(ident) = call.callee().ok()? else {
-        return Some(false);
-    };
-    let name = ident.name().ok()?.value_token().ok()?;
-    Some(
-        KNOWN_EMBED_OBJECTS
-            .iter()
-            .any(|known| name.text_trimmed() == *known),
-    )
 }
 
 declare_node_union! {

--- a/crates/biome_js_formatter/src/lib.rs
+++ b/crates/biome_js_formatter/src/lib.rs
@@ -519,10 +519,22 @@ impl IntoFormat<JsFormatContext> for JsSyntaxToken {
 #[derive(Debug, Clone)]
 pub struct JsFormatLanguage {
     options: JsFormatOptions,
+    /// Ranges of template chunks whose content was parsed as an embedded
+    /// language. Formatting them is delegated to the corresponding language
+    /// formatter, see [crate::format_node].
+    embedded_node_ranges: Vec<TextRange>,
 }
 impl JsFormatLanguage {
     pub fn new(options: JsFormatOptions) -> Self {
-        Self { options }
+        Self {
+            options,
+            embedded_node_ranges: Vec::new(),
+        }
+    }
+
+    pub fn with_embedded_node_ranges(mut self, embedded_node_ranges: Vec<TextRange>) -> Self {
+        self.embedded_node_ranges = embedded_node_ranges;
+        self
     }
 }
 
@@ -567,7 +579,7 @@ impl FormatLanguage for JsFormatLanguage {
         let comments = Comments::from_node(root, &JsCommentStyle, source_map.as_ref());
         let mut ctx = JsFormatContext::new(self.options, comments).with_source_map(source_map);
         if delegate_fmt_embedded_nodes {
-            ctx = ctx.with_fmt_embedded_nodes();
+            ctx = ctx.with_embedded_node_ranges(self.embedded_node_ranges);
         }
         ctx
     }
@@ -595,14 +607,21 @@ pub fn format_range(
 /// Formats a JavaScript (and its super languages) file based on its features.
 ///
 /// It returns a [Formatted] result, which the user can use to override a file.
+///
+/// `embedded_node_ranges` contains the ranges of template chunks that were
+/// parsed as embedded languages. Their content isn't formatted; instead, the
+/// formatter emits `StartEmbedded`/`EndEmbedded` tags that the caller must
+/// resolve via [Formatted::format_embedded]. Pass an empty [Vec] when
+/// embedded snippets aren't formatted separately.
 pub fn format_node(
     options: JsFormatOptions,
     root: &JsSyntaxNode,
-    delegate_fmt_embedded_nodes: bool,
+    embedded_node_ranges: Vec<TextRange>,
 ) -> FormatResult<Formatted<JsFormatContext>> {
+    let delegate_fmt_embedded_nodes = !embedded_node_ranges.is_empty();
     biome_formatter::format_node(
         root,
-        JsFormatLanguage::new(options),
+        JsFormatLanguage::new(options).with_embedded_node_ranges(embedded_node_ranges),
         delegate_fmt_embedded_nodes,
     )
 }

--- a/crates/biome_js_formatter/tests/quick_test.rs
+++ b/crates/biome_js_formatter/tests/quick_test.rs
@@ -99,7 +99,7 @@ fn test_trailing_newline_enabled() {
     let options =
         JsFormatOptions::new(source_type).with_trailing_newline(TrailingNewline::from(true));
 
-    let doc = format_node(options, &tree.syntax(), false).unwrap();
+    let doc = format_node(options, &tree.syntax(), Vec::new()).unwrap();
     let result = doc.print().unwrap();
 
     // With trailing newline enabled (default), should end with newline
@@ -117,7 +117,7 @@ fn test_trailing_newline_disabled() {
     let options =
         JsFormatOptions::new(source_type).with_trailing_newline(TrailingNewline::from(false));
 
-    let doc = format_node(options, &tree.syntax(), false).unwrap();
+    let doc = format_node(options, &tree.syntax(), Vec::new()).unwrap();
     let result = doc.print().unwrap();
 
     // With trailing newline disabled, should NOT end with newline

--- a/crates/biome_js_transform/tests/spec_tests.rs
+++ b/crates/biome_js_transform/tests/spec_tests.rs
@@ -116,7 +116,7 @@ pub(crate) fn analyze_and_snap(
                 let node = transformation.mutation.commit();
 
                 let formatted =
-                    format_node(JsFormatOptions::new(source_type), &node, false).unwrap();
+                    format_node(JsFormatOptions::new(source_type), &node, Vec::new()).unwrap();
 
                 transformations.push(formatted.print().unwrap().as_code().to_string());
             }

--- a/crates/biome_js_type_info/tests/utils.rs
+++ b/crates/biome_js_type_info/tests/utils.rs
@@ -28,7 +28,7 @@ pub fn assert_type_data_snapshot(
 
     let source_type = JsFileSource::ts();
     let tree = parse(source_code, source_type, JsParserOptions::default());
-    let formatted = format_node(JsFormatOptions::default(), tree.tree().syntax(), false)
+    let formatted = format_node(JsFormatOptions::default(), tree.tree().syntax(), Vec::new())
         .unwrap()
         .print()
         .unwrap();
@@ -63,7 +63,7 @@ pub fn assert_typed_bindings_snapshot(
 
     let source_type = JsFileSource::ts();
     let tree = parse(source_code, source_type, JsParserOptions::default());
-    let formatted = format_node(JsFormatOptions::default(), tree.tree().syntax(), false)
+    let formatted = format_node(JsFormatOptions::default(), tree.tree().syntax(), Vec::new())
         .unwrap()
         .print()
         .unwrap();

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -133,7 +133,7 @@ impl<'a> ModuleGraphSnapshot<'a> {
                     JsParserOptions::default(),
                 );
                 let formatted =
-                    format_node(JsFormatOptions::default(), tree.tree().syntax(), false)
+                    format_node(JsFormatOptions::default(), tree.tree().syntax(), Vec::new())
                         .unwrap()
                         .print()
                         .unwrap();

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -100,6 +100,8 @@ use biome_rowan::{AstNode, BatchMutation, BatchMutationExt, Direction, NodeCache
 use biome_workspace_db::WorkspaceDb;
 use camino::Utf8Path;
 use either::Either;
+#[cfg(feature = "js_embeds")]
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -850,7 +852,7 @@ fn debug_formatter_ir(
     let options = settings.format_options::<JsLanguage>(path, document_file_source);
 
     let tree = parse.syntax(&workspace_db);
-    let formatted = format_node(options, &tree, false)?;
+    let formatted = format_node(options, &tree, Vec::new())?;
 
     let root_element = formatted.into_document();
     Ok(root_element.to_string())
@@ -1274,7 +1276,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
                                     &params.document_file_source,
                                 ),
                                 tree.syntax(),
-                                false,
+                                Vec::new(),
                             ))
                         } else {
                             Either::Right(tree.syntax().to_string())
@@ -1371,7 +1373,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
                         &params.document_file_source,
                     ),
                     tree.syntax(),
-                    false,
+                    Vec::new(),
                 ))
             } else {
                 Either::Right(tree.syntax().to_string())
@@ -1391,7 +1393,7 @@ pub(crate) fn format(
     let options = settings.format_options::<JsLanguage>(biome_path, document_file_source);
     debug!("{:?}", &options);
     let tree = parse.syntax(&workspace_db);
-    let formatted = format_node(options, &tree, false)?;
+    let formatted = format_node(options, &tree, Vec::new())?;
     match formatted.print() {
         Ok(printed) => Ok(printed),
         Err(error) => {
@@ -1474,11 +1476,17 @@ fn format_embedded(
     {
         let tree = parse.syntax(&workspace_db);
         let options = settings.format_options::<JsLanguage>(biome_path, document_file_source);
-        let mut formatted = format_node(options, &tree, true)?;
+
+        // Hand the snippet ranges to the formatter, so it only emits embedded
+        // tags for chunks that were actually parsed as embedded languages.
+        let snippets: FxHashMap<TextRange, ParsedSnippet> = embedded_nodes
+            .into_iter()
+            .map(|snippet| (snippet.content_range(&workspace_db), snippet))
+            .collect();
+        let mut formatted = format_node(options, &tree, snippets.keys().copied().collect())?;
 
         formatted.format_embedded(move |range| {
-            let mut iter = embedded_nodes.iter();
-            let snippet = iter.find(|node| node.content_range(&workspace_db) == range)?;
+            let snippet = snippets.get(&range)?;
             let snippet_file_source =
                 workspace_db.source_from_index(snippet.document_source_index(&workspace_db))?;
 

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -187,7 +187,7 @@ fn format(
         0
     };
     let tree = parse.syntax(&workspace_db);
-    let formatted = format_node(options, &tree, false)?;
+    let formatted = format_node(options, &tree, Vec::new())?;
     match formatted.print_with_indent(indent_amount, SourceMapGeneration::Disabled) {
         Ok(printed) => Ok(printed),
         Err(error) => {

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -177,7 +177,7 @@ fn format(
         0
     };
     let tree = parse.syntax(&workspace_db);
-    let formatted = format_node(options, &tree, false)?;
+    let formatted = format_node(options, &tree, Vec::new())?;
     match formatted.print_with_indent(indent_amount, SourceMapGeneration::Disabled) {
         Ok(printed) => Ok(printed),
         Err(error) => {

--- a/crates/biome_wasm/build.rs
+++ b/crates/biome_wasm/build.rs
@@ -69,7 +69,7 @@ fn main() -> io::Result<()> {
     let formatted = format_node(
         JsFormatOptions::new(JsFileSource::ts()),
         module.syntax(),
-        false,
+        Vec::new(),
     )
     .unwrap();
     let printed = formatted.print().unwrap();

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -413,7 +413,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
     let formatted = format_node(
         JsFormatOptions::new(JsFileSource::ts()),
         module.syntax(),
-        false,
+        vec![],
     )
     .unwrap();
     let printed = formatted.print().unwrap();


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR refactors the plumbing of the embedded formatting by giving the formatter the ranges of the embedded nodes. Now that we have a clear data structure, we don't need to iterate every time and `.find` the snippet to format.

Changes were applied using a coding agent, and the new code was checked.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Existing tests must pass. No need for new tests, since it's a refactor.

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
