### PR TITLE
feat(languages): support Google Apps Script (.gs) files

### DIFF
--- a/.changeset/support-google-apps-script.md
+++ b/.changeset/support-google-apps-script.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": minor
+---
+
+Added support for Google Apps Script (`.gs`) files.
+
+They are parsed as JavaScript scripts, so ES module `import`/`export` statements are reported as errors (Apps Script has no module system). Common Apps Script service globals (e.g. `SpreadsheetApp`, `DriveApp`, `Logger`) are recognized by `noUndeclaredVariables` and `noGlobalAssign`, and the list can be extended through the `javascript.globals` option.

--- a/crates/biome_cli/tests/cases/handle_gs_files.rs
+++ b/crates/biome_cli/tests/cases/handle_gs_files.rs
@@ -1,0 +1,229 @@
+use crate::run_cli;
+use crate::snap_test::{SnapshotPayload, assert_cli_snapshot, assert_file_contents};
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+use bpaf::Args;
+use camino::Utf8Path;
+
+// Google Apps Script uses the `.gs` extension and is plain JavaScript running in
+// Google's runtime (no module system, extra service globals).
+
+const GS_UNFORMATTED: &str = "  statement(  )  ";
+const GS_FORMATTED: &str = "statement();\n";
+
+// `noUndeclaredVariables` is not recommended, so it must be enabled explicitly.
+const NO_UNDECLARED_CONFIG: &str = r#"{
+    "linter": {
+        "rules": {
+            "correctness": {
+                "noUndeclaredVariables": "error"
+            }
+        }
+    }
+}"#;
+
+const GS_GLOBALS_CODE: &str = r#"SpreadsheetApp.getActiveSpreadsheet();
+Logger.log("hello");
+notAGlobal();
+"#;
+
+const GS_REASSIGN_CODE: &str = r#"SpreadsheetApp = null;
+Logger = 1;
+localVar = 2;
+"#;
+
+const GS_MODULE_SYNTAX_CODE: &str = r#"import { x } from "./y";
+export const z = 1;
+"#;
+
+const GS_CHECK_CODE: &str = "SpreadsheetApp   =   null ;\n";
+
+#[test]
+fn format_gs_file() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new("Code.gs");
+    fs.insert(file_path.into(), GS_UNFORMATTED.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--write", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, file_path, GS_FORMATTED);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_gs_file",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn lint_gs_globals_are_recognized() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert("biome.json".into(), NO_UNDECLARED_CONFIG.as_bytes());
+
+    let file_path = Utf8Path::new("Code.gs");
+    fs.insert(file_path.into(), GS_GLOBALS_CODE.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", file_path.as_str()].as_slice()),
+    );
+
+    // Only `notAGlobal` is reported; `SpreadsheetApp`/`Logger` are recognized.
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "lint_gs_globals_are_recognized",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn lint_gs_globals_are_not_leaked_to_cjs() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert("biome.json".into(), NO_UNDECLARED_CONFIG.as_bytes());
+
+    // The same code in a `.cjs` file: the Apps Script globals must be reported,
+    // proving they are scoped to `.gs` files only.
+    let file_path = Utf8Path::new("code.cjs");
+    fs.insert(file_path.into(), GS_GLOBALS_CODE.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "lint_gs_globals_are_not_leaked_to_cjs",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn lint_gs_flags_global_reassignment() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // `noGlobalAssign` is recommended: reassigning a service global is reported,
+    // while assigning to a non-global identifier is not.
+    let file_path = Utf8Path::new("Code.gs");
+    fs.insert(file_path.into(), GS_REASSIGN_CODE.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "lint_gs_flags_global_reassignment",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn lint_gs_rejects_module_syntax() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // Apps Script has no module system, so `import`/`export` are parse errors.
+    let file_path = Utf8Path::new("Code.gs");
+    fs.insert(file_path.into(), GS_MODULE_SYNTAX_CODE.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "lint_gs_rejects_module_syntax",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn check_gs_file() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // `check` runs the formatter and the linter: the file is both misformatted
+    // and reassigns a service global.
+    let file_path = Utf8Path::new("Code.gs");
+    fs.insert(file_path.into(), GS_CHECK_CODE.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "check_gs_file",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn search_gs_file() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // `.gs` files are searchable as JavaScript.
+    let file_path = Utf8Path::new("Code.gs");
+    fs.insert(file_path.into(), GS_GLOBALS_CODE.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["search", "`SpreadsheetApp`", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "search_gs_file",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -14,6 +14,7 @@ mod format_with_errors;
 mod graphql;
 mod handle_astro_files;
 mod handle_css_files;
+mod handle_gs_files;
 mod handle_svelte_files;
 mod handle_vue_files;
 mod help;

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/check_gs_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/check_gs_file.snap
@@ -1,0 +1,54 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `Code.gs`
+
+```gs
+SpreadsheetApp   =   null ;
+
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Code.gs:1:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A global variable should not be reassigned.
+  
+  > 1 │ SpreadsheetApp   =   null ;
+      │ ^^^^^^^^^^^^^^
+    2 │ 
+  
+  i Assigning to a global variable can override essential functionality.
+  
+
+```
+
+```block
+Code.gs format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - SpreadsheetApp···=···null·;
+      1 │ + SpreadsheetApp·=·null;
+    2 2 │   
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 2 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/format_gs_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/format_gs_file.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `Code.gs`
+
+```gs
+statement();
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/lint_gs_flags_global_reassignment.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/lint_gs_flags_global_reassignment.snap
@@ -1,0 +1,61 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `Code.gs`
+
+```gs
+SpreadsheetApp = null;
+Logger = 1;
+localVar = 2;
+
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Code.gs:1:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A global variable should not be reassigned.
+  
+  > 1 │ SpreadsheetApp = null;
+      │ ^^^^^^^^^^^^^^
+    2 │ Logger = 1;
+    3 │ localVar = 2;
+  
+  i Assigning to a global variable can override essential functionality.
+  
+
+```
+
+```block
+Code.gs:2:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A global variable should not be reassigned.
+  
+    1 │ SpreadsheetApp = null;
+  > 2 │ Logger = 1;
+      │ ^^^^^^
+    3 │ localVar = 2;
+    4 │ 
+  
+  i Assigning to a global variable can override essential functionality.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 2 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/lint_gs_globals_are_not_leaked_to_cjs.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/lint_gs_globals_are_not_leaked_to_cjs.snap
@@ -1,0 +1,94 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUndeclaredVariables": "error"
+      }
+    }
+  }
+}
+```
+
+## `code.cjs`
+
+```cjs
+SpreadsheetApp.getActiveSpreadsheet();
+Logger.log("hello");
+notAGlobal();
+
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+code.cjs:1:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The SpreadsheetApp variable is undeclared.
+  
+  > 1 │ SpreadsheetApp.getActiveSpreadsheet();
+      │ ^^^^^^^^^^^^^^
+    2 │ Logger.log("hello");
+    3 │ notAGlobal();
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```
+
+```block
+code.cjs:2:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The Logger variable is undeclared.
+  
+    1 │ SpreadsheetApp.getActiveSpreadsheet();
+  > 2 │ Logger.log("hello");
+      │ ^^^^^^
+    3 │ notAGlobal();
+    4 │ 
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```
+
+```block
+code.cjs:3:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The notAGlobal variable is undeclared.
+  
+    1 │ SpreadsheetApp.getActiveSpreadsheet();
+    2 │ Logger.log("hello");
+  > 3 │ notAGlobal();
+      │ ^^^^^^^^^^
+    4 │ 
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 3 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/lint_gs_globals_are_recognized.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/lint_gs_globals_are_recognized.snap
@@ -1,0 +1,61 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUndeclaredVariables": "error"
+      }
+    }
+  }
+}
+```
+
+## `Code.gs`
+
+```gs
+SpreadsheetApp.getActiveSpreadsheet();
+Logger.log("hello");
+notAGlobal();
+
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Code.gs:3:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The notAGlobal variable is undeclared.
+  
+    1 │ SpreadsheetApp.getActiveSpreadsheet();
+    2 │ Logger.log("hello");
+  > 3 │ notAGlobal();
+      │ ^^^^^^^^^^
+    4 │ 
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/lint_gs_rejects_module_syntax.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/lint_gs_rejects_module_syntax.snap
@@ -1,0 +1,101 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `Code.gs`
+
+```gs
+import { x } from "./y";
+export const z = 1;
+
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Code.gs:1:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+  > 1 │ import { x } from "./y";
+      │        ^^^^^
+    2 │ export const z = 1;
+    3 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Unsafe fix: Remove the unused imports.
+  
+    1 │ import·{·x·}·from·"./y";
+      │ ------------------------
+
+```
+
+```block
+Code.gs:2:14 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable z is unused.
+  
+    1 │ import { x } from "./y";
+  > 2 │ export const z = 1;
+      │              ^
+    3 │ 
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend z with an underscore.
+  
+    1 1 │   import { x } from "./y";
+    2   │ - export·const·z·=·1;
+      2 │ + export·const·_z·=·1;
+    3 3 │   
+  
+
+```
+
+```block
+Code.gs:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Illegal use of an import declaration outside of a module
+  
+  > 1 │ import { x } from "./y";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ export const z = 1;
+    3 │ 
+  
+  i not allowed inside scripts
+  
+
+```
+
+```block
+Code.gs:2:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Illegal use of an export declaration outside of a module
+  
+    1 │ import { x } from "./y";
+  > 2 │ export const z = 1;
+      │ ^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i not allowed inside scripts
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 2 errors.
+Found 2 warnings.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/search_gs_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_gs_files/search_gs_file.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `Code.gs`
+
+```gs
+SpreadsheetApp.getActiveSpreadsheet();
+Logger.log("hello");
+notAGlobal();
+
+```
+
+# Emitted Messages
+
+```block
+Code.gs:1:1 search ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  1 │ SpreadsheetApp.getActiveSpreadsheet();
+
+```
+
+```block
+Searched 1 file in <TIME>. Found 1 match.
+```

--- a/crates/biome_js_analyze/src/globals/google_apps_script.rs
+++ b/crates/biome_js_analyze/src/globals/google_apps_script.rs
@@ -1,0 +1,58 @@
+/// Sorted array of core Google Apps Script service globals.
+///
+/// These are the top-level service objects exposed by the Apps Script runtime.
+/// The list intentionally covers the core built-in services only; projects using
+/// advanced services or additional globals can extend it through the
+/// `javascript.globals` configuration option.
+///
+/// Source: <https://developers.google.com/apps-script/reference>
+pub const GOOGLE_APPS_SCRIPT: &[&str] = &[
+    "Browser",
+    "CacheService",
+    "CalendarApp",
+    "Charts",
+    "ContactsApp",
+    "ContentService",
+    "DataStudioApp",
+    "DocumentApp",
+    "DriveApp",
+    "FormApp",
+    "GmailApp",
+    "GroupsApp",
+    "HtmlService",
+    "LanguageApp",
+    "LinearOptimizationService",
+    "LockService",
+    "Logger",
+    "MailApp",
+    "Maps",
+    "PropertiesService",
+    "ScriptApp",
+    "Session",
+    "SitesApp",
+    "SlidesApp",
+    "SpreadsheetApp",
+    "UrlFetchApp",
+    "Utilities",
+    "XmlService",
+];
+
+/// Returns `true` if `name` is a built-in Google Apps Script service global.
+pub fn is_google_apps_script_global(name: &str) -> bool {
+    GOOGLE_APPS_SCRIPT.binary_search(&name).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GOOGLE_APPS_SCRIPT;
+
+    #[test]
+    fn list_is_sorted() {
+        // `is_google_apps_script_global` relies on a binary search, so the list
+        // must stay sorted.
+        assert!(
+            GOOGLE_APPS_SCRIPT.is_sorted(),
+            "GOOGLE_APPS_SCRIPT must be sorted"
+        );
+    }
+}

--- a/crates/biome_js_analyze/src/globals/mod.rs
+++ b/crates/biome_js_analyze/src/globals/mod.rs
@@ -1,5 +1,8 @@
 //! This module tracks all globals variables
 
+pub mod google_apps_script;
+pub use google_apps_script::{GOOGLE_APPS_SCRIPT, is_google_apps_script_global};
+
 pub mod javascript;
 pub use javascript::is_global as is_js_global;
 pub use javascript::is_language_global as is_js_language_global;

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
@@ -1,4 +1,4 @@
-use crate::globals::{is_js_global, is_ts_global};
+use crate::globals::{is_google_apps_script_global, is_js_global, is_ts_global};
 use crate::services::embedded_bindings::EmbeddedBindings;
 use crate::services::semantic::SemanticServices;
 use biome_analyze::context::RuleContext;
@@ -150,8 +150,14 @@ impl Rule for NoUndeclaredVariables {
 }
 
 fn is_global(reference_name: &str, source_type: &JsFileSource) -> bool {
+    // Google Apps Script runs plain JavaScript in Google's runtime, which exposes
+    // extra service globals (e.g. `SpreadsheetApp`) on top of the language ones.
+    let is_gas_global =
+        source_type.is_google_apps_script() && is_google_apps_script_global(reference_name);
     match source_type.language() {
-        Language::JavaScript => is_js_global(reference_name),
-        Language::TypeScript { .. } => is_js_global(reference_name) || is_ts_global(reference_name),
+        Language::JavaScript => is_js_global(reference_name) || is_gas_global,
+        Language::TypeScript { .. } => {
+            is_js_global(reference_name) || is_ts_global(reference_name) || is_gas_global
+        }
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
@@ -1,4 +1,4 @@
-use crate::globals::{is_js_global, is_ts_global};
+use crate::globals::{is_google_apps_script_global, is_js_global, is_ts_global};
 use crate::services::embedded::EmbeddedService;
 use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
@@ -148,8 +148,14 @@ impl Rule for NoUndeclaredVariables {
 }
 
 fn is_global(reference_name: &str, source_type: &JsFileSource) -> bool {
+    // Google Apps Script runs plain JavaScript in Google's runtime, which exposes
+    // extra service globals (e.g. `SpreadsheetApp`) on top of the language ones.
+    let is_gas_global =
+        source_type.is_google_apps_script() && is_google_apps_script_global(reference_name);
     match source_type.language() {
-        Language::JavaScript => is_js_global(reference_name),
-        Language::TypeScript { .. } => is_js_global(reference_name) || is_ts_global(reference_name),
+        Language::JavaScript => is_js_global(reference_name) || is_gas_global,
+        Language::TypeScript { .. } => {
+            is_js_global(reference_name) || is_ts_global(reference_name) || is_gas_global
+        }
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -1,11 +1,11 @@
-use crate::globals::is_js_global;
+use crate::globals::{is_google_apps_script_global, is_js_global};
 
 use crate::services::semantic::SemanticServices;
 use biome_analyze::RuleSource;
 use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{JsSyntaxKind, TextRange};
+use biome_js_syntax::{JsFileSource, JsSyntaxKind, TextRange};
 use biome_rule_options::no_global_assign::NoGlobalAssignOptions;
 
 declare_lint_rule! {
@@ -57,13 +57,19 @@ impl Rule for NoGlobalAssign {
     type Options = NoGlobalAssignOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let source_type = ctx.source_type::<JsFileSource>();
         let global_refs = ctx.query().all_unresolved_references();
         let mut result = Vec::new();
         for global_ref in global_refs {
             let is_write = global_ref.syntax().kind() == JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT;
             if is_write {
                 let identifier = global_ref.syntax().text_trimmed();
-                let is_global_var = is_js_global(identifier.into_text().text());
+                let name = identifier.into_text();
+                let name = name.text();
+                // Apps Script service globals (e.g. `SpreadsheetApp`) are read-only
+                // globals too, so reassigning them in a `.gs` file is reported.
+                let is_global_var = is_js_global(name)
+                    || (source_type.is_google_apps_script() && is_google_apps_script_global(name));
                 if is_global_var {
                     result.push(global_ref.range());
                 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -1,4 +1,4 @@
-use crate::globals::is_js_global;
+use crate::globals::{is_google_apps_script_global, is_js_global};
 
 use crate::services::semantic::Semantic;
 use biome_analyze::RuleSource;
@@ -6,6 +6,7 @@ use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rul
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{JsIdentifierAssignment, TextRange};
+use biome_languages::JsFileSource;
 use biome_rule_options::no_global_assign::NoGlobalAssignOptions;
 
 declare_lint_rule! {
@@ -62,7 +63,13 @@ impl Rule for NoGlobalAssign {
             return None;
         }
         let token = assignment.name_token().ok()?;
-        is_js_global(token.text_trimmed()).then(|| token.text_trimmed_range())
+        let name = token.text_trimmed();
+        // Apps Script service globals (e.g. `SpreadsheetApp`) are read-only
+        // globals too, so reassigning them in a `.gs` file is reported.
+        let source_type = ctx.source_type::<JsFileSource>();
+        let is_global_var = is_js_global(name)
+            || (source_type.is_google_apps_script() && is_google_apps_script_global(name));
+        is_global_var.then(|| token.text_trimmed_range())
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -23,7 +23,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::{fs::read_to_string, slice};
 
-tests_macros::gen_tests! {"tests/specs/**/*.{cjs,cts,js,mjs,jsx,tsx,ts,json,jsonc,svelte,vue,html,astro}", crate::run_test, "module"}
+tests_macros::gen_tests! {"tests/specs/**/*.{cjs,cts,js,mjs,jsx,tsx,ts,json,jsonc,svelte,vue,html,astro,gs}", crate::run_test, "module"}
 tests_macros::gen_tests! {"tests/suppression/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte,vue}", crate::run_suppression_test, "module"}
 tests_macros::gen_tests! {"tests/multiple_rules/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte,vue}", crate::run_multi_rule_test, "module"}
 tests_macros::gen_tests! {"tests/plugin/*.grit", crate::run_plugin_test, "module"}

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::{fs::read_to_string, slice};
 
 // Spec cases are discovered from the filesystem during macro expansion.
-tests_macros::gen_tests! {"tests/specs/**/*.{cjs,cts,js,mjs,jsx,tsx,ts,json,jsonc,svelte,vue,html,astro}", crate::run_test, "module"}
+tests_macros::gen_tests! {"tests/specs/**/*.{cjs,cts,js,mjs,jsx,tsx,ts,json,jsonc,svelte,vue,html,astro,gs}", crate::run_test, "module"}
 tests_macros::gen_tests! {"tests/suppression/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte,vue}", crate::run_suppression_test, "module"}
 tests_macros::gen_tests! {"tests/multiple_rules/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte,vue}", crate::run_multi_rule_test, "module"}
 tests_macros::gen_tests! {"tests/plugin/*.grit", crate::run_plugin_test, "module"}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/googleAppsScript.gs
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/googleAppsScript.gs
@@ -1,0 +1,7 @@
+// Google Apps Script service globals must be recognized (no diagnostics).
+SpreadsheetApp.getActiveSpreadsheet();
+Logger.log("hello");
+DriveApp.getFiles();
+
+// A genuinely undeclared variable must still be reported.
+notAGlobal();

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/googleAppsScript.gs.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/googleAppsScript.gs.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: googleAppsScript.gs
+---
+# Input
+```cjs
+// Google Apps Script service globals must be recognized (no diagnostics).
+SpreadsheetApp.getActiveSpreadsheet();
+Logger.log("hello");
+DriveApp.getFiles();
+
+// A genuinely undeclared variable must still be reported.
+notAGlobal();
+
+```
+
+# Diagnostics
+```
+googleAppsScript.gs:7:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The notAGlobal variable is undeclared.
+  
+    6 │ // A genuinely undeclared variable must still be reported.
+  > 7 │ notAGlobal();
+      │ ^^^^^^^^^^
+    8 │ 
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/googleAppsScript.gs
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/googleAppsScript.gs
@@ -1,0 +1,6 @@
+// Reassigning Google Apps Script service globals is reported.
+SpreadsheetApp = null;
+Logger = 1;
+
+// Assigning to a non-global identifier is fine.
+localVar = 2;

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/googleAppsScript.gs.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/googleAppsScript.gs.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: googleAppsScript.gs
+---
+# Input
+```cjs
+// Reassigning Google Apps Script service globals is reported.
+SpreadsheetApp = null;
+Logger = 1;
+
+// Assigning to a non-global identifier is fine.
+localVar = 2;
+
+```
+
+# Diagnostics
+```
+googleAppsScript.gs:2:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A global variable should not be reassigned.
+  
+    1 │ // Reassigning Google Apps Script service globals is reported.
+  > 2 │ SpreadsheetApp = null;
+      │ ^^^^^^^^^^^^^^
+    3 │ Logger = 1;
+    4 │ 
+  
+  i Assigning to a global variable can override essential functionality.
+  
+
+```
+
+```
+googleAppsScript.gs:3:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A global variable should not be reassigned.
+  
+    1 │ // Reassigning Google Apps Script service globals is reported.
+    2 │ SpreadsheetApp = null;
+  > 3 │ Logger = 1;
+      │ ^^^^^^
+    4 │ 
+    5 │ // Assigning to a non-global identifier is fine.
+  
+  i Assigning to a global variable can override essential functionality.
+  
+
+```

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -266,6 +266,10 @@ pub struct JsFileSource {
     /// Used to mark if the JavaScript is embedded inside some particular files. This affects the parsing.
     /// For example, if inside an Astro file, a top-level return statement is allowed.
     embedding_kind: EmbeddingKind,
+    /// Marks a Google Apps Script file (detected via the `.gs` extension).
+    /// Apps Script is plain JavaScript running in Google's runtime, so it
+    /// exposes extra service globals (e.g. `SpreadsheetApp`).
+    is_google_apps_script: bool,
 }
 
 impl JsFileSource {
@@ -380,6 +384,11 @@ impl JsFileSource {
         self
     }
 
+    pub const fn with_google_apps_script(mut self, is_google_apps_script: bool) -> Self {
+        self.is_google_apps_script = is_google_apps_script;
+        self
+    }
+
     pub const fn language(&self) -> Language {
         self.language
     }
@@ -406,6 +415,10 @@ impl JsFileSource {
 
     pub const fn is_typescript(&self) -> bool {
         self.language.is_typescript()
+    }
+
+    pub const fn is_google_apps_script(&self) -> bool {
+        self.is_google_apps_script
     }
 
     pub const fn is_jsx(&self) -> bool {
@@ -572,6 +585,7 @@ impl JsFileSource {
             "js" | "mjs" => Ok(Self::js_module()),
             "jsx" => Ok(Self::jsx()),
             "cjs" => Ok(Self::js_script()),
+            "gs" => Ok(Self::js_script().with_google_apps_script(true)),
             "ts" => Ok(Self::ts()),
             "mts" | "cts" => Ok(Self::ts_restricted()),
             "tsx" => Ok(Self::tsx()),
@@ -690,5 +704,15 @@ mod tests {
 
         assert!(source.is_svelte_source_module());
         assert!(!source.is_typescript());
+    }
+
+    #[test]
+    fn detects_google_apps_script_by_extension() {
+        // `.gs` files are parsed as scripts so module syntax is rejected.
+        let source = JsFileSource::try_from(Utf8Path::new("Code.GS")).unwrap();
+
+        assert!(source.is_script());
+        assert!(!source.is_typescript());
+        assert!(source.is_google_apps_script());
     }
 }

--- a/crates/biome_languages/src/javascript.rs
+++ b/crates/biome_languages/src/javascript.rs
@@ -299,6 +299,10 @@ pub struct JsFileSource {
     /// Used to mark if the JavaScript is embedded inside some particular files. This affects the parsing.
     /// For example, if inside an Astro file, a top-level return statement is allowed.
     embedding_kind: JsEmbeddingKind,
+    /// Marks a Google Apps Script file (detected via the `.gs` extension).
+    /// Apps Script is plain JavaScript running in Google's runtime, so it
+    /// exposes extra service globals (e.g. `SpreadsheetApp`).
+    is_google_apps_script: bool,
 }
 
 impl JsFileSource {
@@ -411,6 +415,11 @@ impl JsFileSource {
         self
     }
 
+    pub const fn with_google_apps_script(mut self, is_google_apps_script: bool) -> Self {
+        self.is_google_apps_script = is_google_apps_script;
+        self
+    }
+
     pub const fn language(&self) -> Language {
         self.language
     }
@@ -437,6 +446,10 @@ impl JsFileSource {
 
     pub const fn is_typescript(&self) -> bool {
         self.language.is_typescript()
+    }
+
+    pub const fn is_google_apps_script(&self) -> bool {
+        self.is_google_apps_script
     }
 
     pub const fn is_jsx(&self) -> bool {
@@ -614,6 +627,7 @@ impl JsFileSource {
             "js" | "mjs" => Ok(Self::js_module()),
             "jsx" => Ok(Self::jsx()),
             "cjs" => Ok(Self::js_script()),
+            "gs" => Ok(Self::js_script().with_google_apps_script(true)),
             "ts" => Ok(Self::ts()),
             "mts" | "cts" => Ok(Self::ts_restricted()),
             "tsx" => Ok(Self::tsx()),
@@ -732,5 +746,15 @@ mod tests {
 
         assert!(source.is_svelte_source_module());
         assert!(!source.is_typescript());
+    }
+
+    #[test]
+    fn detects_google_apps_script_by_extension() {
+        // `.gs` files are parsed as scripts so module syntax is rejected.
+        let source = JsFileSource::try_from(Utf8Path::new("Code.GS")).unwrap();
+
+        assert!(source.is_script());
+        assert!(!source.is_typescript());
+        assert!(source.is_google_apps_script());
     }
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -10186,6 +10186,12 @@ export interface JsFileSource {
 For example, if inside an Astro file, a top-level return statement is allowed. 
 	 */
 	embedding_kind: EmbeddingKind;
+	/**
+	* Marks a Google Apps Script file (detected via the `.gs` extension).
+Apps Script is plain JavaScript running in Google's runtime, so it
+exposes extra service globals (e.g. `SpreadsheetApp`). 
+	 */
+	is_google_apps_script: boolean;
 	language: Language;
 	module_kind: ModuleKind;
 	variant: LanguageVariant;

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -10548,6 +10548,12 @@ export interface JsFileSource {
 For example, if inside an Astro file, a top-level return statement is allowed. 
 	 */
 	embedding_kind: JsEmbeddingKind;
+	/**
+	* Marks a Google Apps Script file (detected via the `.gs` extension).
+Apps Script is plain JavaScript running in Google's runtime, so it
+exposes extra service globals (e.g. `SpreadsheetApp`). 
+	 */
+	is_google_apps_script: boolean;
 	language: Language;
 	module_kind: ModuleKind;
 	variant: LanguageVariant;


### PR DESCRIPTION
## Summary

Adds support for Google Apps Script (`.gs`) files (#8267). This is a follow-up to #10834 that addresses the review feedback there.

Apps Script is plain JavaScript running in Google's runtime: it has no module system and exposes a set of built-in service globals. This PR models that:

- **First-class source signal.** `JsFileSource` carries an `is_google_apps_script` flag, set when a file resolves through the `.gs` extension. Apps Script is therefore identified via `source_type` (used by the analyzer) rather than by an ad-hoc file-extension check in the service layer.
- **No module syntax.** `.gs` is parsed as a script (`ModuleKind::Script`), so top-level `import`/`export` are reported as parse errors, matching Apps Script (which has no modules).
- **Service globals.** The analyzer resolves a curated set of Apps Script service globals (`SpreadsheetApp`, `DriveApp`, `Logger`, …) from the source type, so `noUndeclaredVariables` no longer flags them and `noGlobalAssign` reports reassigning them. The list is a conservative starter set and is extensible per project via `javascript.globals`.

On the earlier review's point about scope: Apps Script's implicit cross-file single global scope is not representable in Biome's per-file semantic model, so it is intentionally out of scope; per-file analysis with the curated globals list is the pragmatic approximation.

A changeset is included (`minor`), so this PR targets `next`.

## Test Plan

- **Unit** — the `.gs` extension resolves to a script source with the Apps Script flag set; the globals list is asserted to stay sorted (the lookup uses a binary search).
- **Analyzer spec tests** — `.gs` fixtures for `noUndeclaredVariables` (service globals recognized, a genuinely undeclared identifier still reported) and `noGlobalAssign` (reassigning service globals reported); the spec-test glob now includes `gs`.
- **CLI** — `crates/biome_cli/tests/cases/handle_gs_files.rs` (following the astro/svelte pattern) covers the `format`, `lint`, `check`, and `search` commands on `.gs` files, including the service-globals behaviour and a `.cjs` companion proving the globals do not leak to plain scripts.

## Docs

Documentation PR: biomejs/website#4365 (targets the `next` branch) — documents Google Apps Script (`.gs`) support on the Language support page.

---

**AI assistance disclosure:** This PR was written primarily by Claude Code (Anthropic), directed and reviewed by me.

