### PR TITLE
chore(xtask): migrate disposable global types

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/useDisposables/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useDisposables/invalid.ts
@@ -46,3 +46,15 @@ class AsyncDisposableClass implements AsyncDisposable {
 }
 
 const asyncDisposableInstance = new AsyncDisposableClass();
+
+const valueReturningDisposable = {
+  [Symbol.dispose]() {
+    return 1;
+  }
+};
+
+const promiseLikeDisposable = {
+  [Symbol.asyncDispose](): PromiseLike<void> {
+    return Promise.resolve();
+  }
+};

--- a/crates/biome_js_analyze/tests/specs/nursery/useDisposables/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useDisposables/invalid.ts.snap
@@ -53,6 +53,18 @@ class AsyncDisposableClass implements AsyncDisposable {
 
 const asyncDisposableInstance = new AsyncDisposableClass();
 
+const valueReturningDisposable = {
+  [Symbol.dispose]() {
+    return 1;
+  }
+};
+
+const promiseLikeDisposable = {
+  [Symbol.asyncDispose](): PromiseLike<void> {
+    return Promise.resolve();
+  }
+};
+
 ```
 
 # Diagnostics
@@ -224,6 +236,7 @@ invalid.ts:48:7 lint/nursery/useDisposables  FIXABLE  ━━━━━━━━�
   > 48 │ const asyncDisposableInstance = new AsyncDisposableClass();
        │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     49 │ 
+    50 │ const valueReturningDisposable = {
   
   i The object implements the AsyncDisposable interface, which is intended to be disposed after use with await using syntax.
   
@@ -238,6 +251,76 @@ invalid.ts:48:7 lint/nursery/useDisposables  FIXABLE  ━━━━━━━━�
     48    │ - const·asyncDisposableInstance·=·new·AsyncDisposableClass();
        48 │ + await·using·asyncDisposableInstance·=·new·AsyncDisposableClass();
     49 49 │   
+    50 50 │   const valueReturningDisposable = {
+  
+
+```
+
+```
+invalid.ts:50:7 lint/nursery/useDisposables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Disposable object is assigned here but never disposed.
+  
+    48 │ const asyncDisposableInstance = new AsyncDisposableClass();
+    49 │ 
+  > 50 │ const valueReturningDisposable = {
+       │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 51 │   [Symbol.dispose]() {
+  > 52 │     return 1;
+  > 53 │   }
+  > 54 │ };
+       │ ^
+    55 │ 
+    56 │ const promiseLikeDisposable = {
+  
+  i The object implements the Disposable interface, which is intended to be disposed after use with using syntax.
+  
+  i Not disposing the object properly can lead some resource or memory leak.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Add the using keyword to dispose the object when leaving the scope.
+  
+    48 48 │   const asyncDisposableInstance = new AsyncDisposableClass();
+    49 49 │   
+    50    │ - const·valueReturningDisposable·=·{
+       50 │ + using·valueReturningDisposable·=·{
+    51 51 │     [Symbol.dispose]() {
+    52 52 │       return 1;
+  
+
+```
+
+```
+invalid.ts:56:7 lint/nursery/useDisposables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Disposable object is assigned here but never disposed.
+  
+    54 │ };
+    55 │ 
+  > 56 │ const promiseLikeDisposable = {
+       │       ^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 57 │   [Symbol.asyncDispose](): PromiseLike<void> {
+  > 58 │     return Promise.resolve();
+  > 59 │   }
+  > 60 │ };
+       │ ^
+    61 │ 
+  
+  i The object implements the AsyncDisposable interface, which is intended to be disposed after use with await using syntax.
+  
+  i Not disposing the object properly can lead some resource or memory leak.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Add the using keyword to dispose the object when leaving the scope.
+  
+    54 54 │   };
+    55 55 │   
+    56    │ - const·promiseLikeDisposable·=·{
+       56 │ + await·using·promiseLikeDisposable·=·{
+    57 57 │     [Symbol.asyncDispose](): PromiseLike<void> {
+    58 58 │       return Promise.resolve();
   
 
 ```

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -352,6 +352,12 @@ impl Format<FormatTypeContext> for TypeMemberKind {
             | Self::ConstAssertedIndexSignature(index_signature_type) => {
                 write!(formatter, [token("["), index_signature_type, token("]")])
             }
+            Self::ComputedValue(key_type) | Self::ConstAssertedComputedValue(key_type) => {
+                write!(
+                    formatter,
+                    [token("computed"), space(), token("["), key_type, token("]")]
+                )
+            }
             Self::Named(name) | Self::ConstAssertedNamed(name) => {
                 let quoted = std::format!("\"{name}\"");
                 write!(formatter, [text(&quoted, None)])

--- a/crates/biome_js_type_info/src/generated/global_types.rs
+++ b/crates/biome_js_type_info/src/generated/global_types.rs
@@ -4,6 +4,10 @@
 
 /// Predefined global IDs whose `TypeData` is supplied by this generated module.
 pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
+    crate::globals::DISPOSABLE_ID_GLOBAL_TYPE_ID,
+    crate::globals::DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID,
+    crate::globals::ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID,
+    crate::globals::ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID,
     crate::globals::ERROR_ID_GLOBAL_TYPE_ID,
     crate::globals::ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID,
     crate::globals::ERROR_CALL_ID_GLOBAL_TYPE_ID,
@@ -13,6 +17,49 @@ pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
 pub(crate) fn set_generated_global_type_data(
     builder: &mut crate::globals_builder::GlobalsResolverBuilder,
 ) {
+    let data = crate::TypeData::Interface(Box::new(crate::Interface {
+        name: biome_rowan::Text::new_static("Disposable"),
+        type_parameters: Box::default(),
+        extends: Box::default(),
+        members: Box::new([crate::TypeMember {
+            kind: crate::TypeMemberKind::ComputedValue(
+                crate::globals::GLOBAL_SYMBOL_DISPOSE_ID.into(),
+            ),
+            ty: crate::globals::GLOBAL_DISPOSABLE_DISPOSE_ID.into(),
+        }]),
+    }));
+    builder.set_type_data(crate::globals::DISPOSABLE_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Function(Box::new(crate::Function {
+        is_async: false,
+        type_parameters: Box::default(),
+        name: None,
+        parameters: Box::new([]),
+        return_type: crate::ReturnType::Type(crate::globals::GLOBAL_VOID_ID.into()),
+    }));
+    builder.set_type_data(crate::globals::DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Interface(Box::new(crate::Interface {
+        name: biome_rowan::Text::new_static("AsyncDisposable"),
+        type_parameters: Box::default(),
+        extends: Box::default(),
+        members: Box::new([crate::TypeMember {
+            kind: crate::TypeMemberKind::ComputedValue(
+                crate::globals::GLOBAL_SYMBOL_ASYNC_DISPOSE_ID.into(),
+            ),
+            ty: crate::globals::GLOBAL_ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID.into(),
+        }]),
+    }));
+    builder.set_type_data(crate::globals::ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Function(Box::new(crate::Function {
+        is_async: true,
+        type_parameters: Box::default(),
+        name: None,
+        parameters: Box::new([]),
+        return_type: crate::ReturnType::Type(crate::globals::GLOBAL_INSTANCEOF_PROMISE_ID.into()),
+    }));
+    builder.set_type_data(
+        crate::globals::ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID,
+        data,
+    );
     let data = crate::TypeData::Class(Box::new(crate::Class {
         name: Some(biome_rowan::Text::new_static("Error")),
         type_parameters: Box::default(),

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -7,11 +7,10 @@ use biome_js_syntax::AnyJsExpression;
 use biome_rowan::Text;
 
 use crate::{
-    Class, Function, FunctionParameter, GenericTypeParameter, Interface, Literal,
-    PatternFunctionParameter, Resolvable, ResolvedTypeData, ResolvedTypeId, ResolverId, ReturnType,
-    ScopeId, TypeData, TypeId, TypeInstance, TypeMember, TypeMemberKind, TypeReference,
-    TypeReferenceQualifier, TypeResolver, TypeResolverLevel, TypeStore, Union,
-    flattening::MAX_FLATTEN_DEPTH,
+    Class, Function, FunctionParameter, GenericTypeParameter, Literal, PatternFunctionParameter,
+    Resolvable, ResolvedTypeData, ResolvedTypeId, ResolverId, ReturnType, ScopeId, TypeData,
+    TypeId, TypeInstance, TypeMember, TypeMemberKind, TypeReference, TypeReferenceQualifier,
+    TypeResolver, TypeResolverLevel, TypeStore, Union, flattening::MAX_FLATTEN_DEPTH,
 };
 
 use super::globals_builder::GlobalsResolverBuilder;
@@ -408,55 +407,9 @@ impl Default for GlobalsResolver {
         });
         builder.set_manual_type_data(SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID, || TypeData::Symbol);
         builder.set_manual_type_data(SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID, || TypeData::Symbol);
-        builder.set_manual_type_data(DISPOSABLE_ID_GLOBAL_TYPE_ID, || {
-            TypeData::Interface(Box::new(Interface {
-                name: Text::new_static(DISPOSABLE_ID_NAME),
-                type_parameters: Box::default(),
-                extends: Box::default(),
-                members: Box::new([TypeMember {
-                    kind: TypeMemberKind::IndexSignature(TypeReference::Resolved(
-                        GLOBAL_SYMBOL_DISPOSE_ID,
-                    )),
-                    ty: ResolvedTypeId::new(TypeResolverLevel::Global, DISPOSABLE_DISPOSE_ID)
-                        .into(),
-                }]),
-            }))
-        });
-        builder.set_manual_type_data(DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID, || {
-            TypeData::Function(Box::new(Function {
-                is_async: false,
-                type_parameters: Default::default(),
-                name: None,
-                parameters: Default::default(),
-                return_type: ReturnType::Type(GLOBAL_VOID_ID.into()),
-            }))
-        });
-        builder.set_manual_type_data(ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID, || {
-            TypeData::Interface(Box::new(Interface {
-                name: Text::new_static(ASYNC_DISPOSABLE_ID_NAME),
-                type_parameters: Box::default(),
-                extends: Box::default(),
-                members: Box::new([TypeMember {
-                    kind: TypeMemberKind::IndexSignature(TypeReference::Resolved(
-                        GLOBAL_SYMBOL_ASYNC_DISPOSE_ID,
-                    )),
-                    ty: ResolvedTypeId::new(
-                        TypeResolverLevel::Global,
-                        ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID,
-                    )
-                    .into(),
-                }]),
-            }))
-        });
-        builder.set_manual_type_data(ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID, || {
-            TypeData::Function(Box::new(Function {
-                is_async: true,
-                type_parameters: Default::default(),
-                name: None,
-                parameters: Default::default(),
-                return_type: ReturnType::Type(GLOBAL_INSTANCEOF_PROMISE_ID.into()),
-            }))
-        });
+        // `Disposable`, `AsyncDisposable`, and their `[Symbol.(async)Dispose]` helpers are
+        // supplied by the generated global types (see `MIGRATED_PREDEFINED_IDS`), which encode
+        // the members as computed keys instead of the index-signature hack this used to carry.
 
         builder.build()
     }

--- a/crates/biome_js_type_info/src/globals_ids.rs
+++ b/crates/biome_js_type_info/src/globals_ids.rs
@@ -461,11 +461,15 @@ mod tests {
     }
 
     #[test]
-    fn error_global_is_migrated() {
+    fn error_and_disposable_globals_are_migrated() {
         let migrated = crate::generated::global_types::MIGRATED_PREDEFINED_IDS;
         assert_eq!(
             migrated,
             &[
+                DISPOSABLE_ID_GLOBAL_TYPE_ID,
+                DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID,
+                ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID,
+                ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID,
                 ERROR_ID_GLOBAL_TYPE_ID,
                 ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID,
                 ERROR_CALL_ID_GLOBAL_TYPE_ID,

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -489,6 +489,15 @@ impl<'a> ResolvedTypeMember<'a> {
         })
     }
 
+    /// Returns whether this member is keyed by a type reference that, with the
+    /// module context applied, matches `predicate`. The key may be spelled as
+    /// an index signature or as a computed value.
+    pub fn is_keyed_member_with_ty(&self, predicate: impl Fn(&TypeReference) -> bool) -> bool {
+        self.member.is_keyed_member_with_ty(|reference| {
+            predicate(&self.apply_module_id_to_reference(reference))
+        })
+    }
+
     #[inline]
     pub fn is_static(&self) -> bool {
         self.member.is_static()
@@ -522,6 +531,37 @@ impl<'a> ResolvedTypeMember<'a> {
     pub fn ty(&self) -> Cow<'_, TypeReference> {
         self.apply_module_id_to_reference(&self.member.ty)
     }
+}
+
+/// Applies the module ID of `resolved` to the key reference of index signature
+/// and computed value member kinds. Returns `None` for other kinds.
+fn keyed_member_kind_with_resolved_reference(
+    resolved: ResolvedTypeData,
+    member_kind: &TypeMemberKind,
+) -> Option<TypeMemberKind> {
+    let (key_reference, constructor): (&TypeReference, fn(TypeReference) -> TypeMemberKind) =
+        match member_kind {
+            TypeMemberKind::IndexSignature(key_reference)
+            | TypeMemberKind::ConstAssertedIndexSignature(key_reference) => {
+                (key_reference, TypeMemberKind::IndexSignature)
+            }
+            TypeMemberKind::ComputedValue(key_reference)
+            | TypeMemberKind::ConstAssertedComputedValue(key_reference) => {
+                (key_reference, TypeMemberKind::ComputedValue)
+            }
+            _ => return None,
+        };
+
+    let kind = constructor(
+        resolved
+            .apply_module_id_to_reference(key_reference)
+            .into_owned(),
+    );
+    Some(if member_kind.is_const_asserted() {
+        kind.with_const_asserted()
+    } else {
+        kind
+    })
 }
 
 /// Trait for implementing type resolution.
@@ -874,34 +914,17 @@ impl Resolvable for TypeReference {
                                         .own_members()
                                         .map(|member| {
                                             let was_optional = member.is_optional();
-                                            let kind = match &member.kind {
-                                                TypeMemberKind::IndexSignature(key_reference)
-                                                | TypeMemberKind::ConstAssertedIndexSignature(
-                                                    key_reference,
-                                                ) => {
-                                                    let resolved_index_signature_kind =
-                                                        TypeMemberKind::IndexSignature(
-                                                            resolved
-                                                                .apply_module_id_to_reference(
-                                                                    key_reference,
-                                                                )
-                                                                .into_owned(),
-                                                        );
-                                                    if member.kind.is_const_asserted() {
-                                                        resolved_index_signature_kind
-                                                            .with_const_asserted()
-                                                    } else {
-                                                        resolved_index_signature_kind
-                                                    }
+                                            let kind = keyed_member_kind_with_resolved_reference(
+                                                resolved,
+                                                &member.kind,
+                                            )
+                                            .unwrap_or_else(|| {
+                                                if is_partial {
+                                                    member.kind.clone().with_optional()
+                                                } else {
+                                                    member.kind.clone().without_optional()
                                                 }
-                                                other => {
-                                                    if is_partial {
-                                                        other.clone().with_optional()
-                                                    } else {
-                                                        other.clone().without_optional()
-                                                    }
-                                                }
-                                            };
+                                            });
                                             (
                                                 TypeMember {
                                                     kind,
@@ -953,28 +976,11 @@ impl Resolvable for TypeReference {
                                         .as_raw_data()
                                         .own_members()
                                         .map(|member| {
-                                            let kind = match &member.kind {
-                                                TypeMemberKind::IndexSignature(key_reference)
-                                                | TypeMemberKind::ConstAssertedIndexSignature(
-                                                    key_reference,
-                                                ) => {
-                                                    let resolved_index_signature_kind =
-                                                        TypeMemberKind::IndexSignature(
-                                                            resolved
-                                                                .apply_module_id_to_reference(
-                                                                    key_reference,
-                                                                )
-                                                                .into_owned(),
-                                                        );
-                                                    if member.kind.is_const_asserted() {
-                                                        resolved_index_signature_kind
-                                                            .with_const_asserted()
-                                                    } else {
-                                                        resolved_index_signature_kind
-                                                    }
-                                                }
-                                                other => other.clone(),
-                                            };
+                                            let kind = keyed_member_kind_with_resolved_reference(
+                                                resolved,
+                                                &member.kind,
+                                            )
+                                            .unwrap_or_else(|| member.kind.clone());
                                             TypeMember {
                                                 kind,
                                                 ty: resolved

--- a/crates/biome_js_type_info/src/type.rs
+++ b/crates/biome_js_type_info/src/type.rs
@@ -333,12 +333,9 @@ impl Type {
             return true;
         }
 
-        self.resolved_data().is_some_and(|ty| {
-            ty.find_member(self.resolver.as_ref(), |member| {
-                member.is_index_signature_with_ty(|ty| {
-                    self.resolve(ty)
-                        .is_some_and(|ty| ty.id == GLOBAL_SYMBOL_DISPOSE_ID)
-                })
+        self.resolved_data().is_some_and(|data| {
+            data.find_member(self.resolver.as_ref(), |member| {
+                self.has_symbol_keyed_member(member, GLOBAL_SYMBOL_DISPOSE_ID)
             })
             .is_some()
         })
@@ -349,14 +346,28 @@ impl Type {
             return true;
         }
 
-        self.resolved_data().is_some_and(|ty| {
-            ty.find_member(self.resolver.as_ref(), |member| {
-                member.is_index_signature_with_ty(|ty| {
-                    self.resolve(ty)
-                        .is_some_and(|ty| ty.id == GLOBAL_SYMBOL_ASYNC_DISPOSE_ID)
-                })
+        self.resolved_data().is_some_and(|data| {
+            data.find_member(self.resolver.as_ref(), |member| {
+                self.has_symbol_keyed_member(member, GLOBAL_SYMBOL_ASYNC_DISPOSE_ID)
             })
             .is_some()
+        })
+    }
+
+    /// Returns whether `member` is keyed by the well-known symbol `symbol_id`.
+    ///
+    /// The key is accepted whether it is spelled as an index signature (how
+    /// object and class members are inferred from source) or as a computed
+    /// value (how the generated `Disposable`/`AsyncDisposable` globals encode
+    /// it).
+    fn has_symbol_keyed_member(
+        &self,
+        member: &ResolvedTypeMember,
+        symbol_id: ResolvedTypeId,
+    ) -> bool {
+        member.is_keyed_member_with_ty(|reference| {
+            self.resolve(reference)
+                .is_some_and(|resolved| resolved.id == symbol_id)
         })
     }
 

--- a/crates/biome_js_type_info/src/type_data.rs
+++ b/crates/biome_js_type_info/src/type_data.rs
@@ -1005,6 +1005,19 @@ impl TypeMember {
         }
     }
 
+    /// Returns whether this member is keyed by a type reference matching
+    /// `predicate`, whether the key is spelled as an index signature or as a
+    /// computed value.
+    pub fn is_keyed_member_with_ty(&self, predicate: impl Fn(&TypeReference) -> bool) -> bool {
+        match &self.kind {
+            TypeMemberKind::IndexSignature(key_type)
+            | TypeMemberKind::ConstAssertedIndexSignature(key_type)
+            | TypeMemberKind::ComputedValue(key_type)
+            | TypeMemberKind::ConstAssertedComputedValue(key_type) => predicate(key_type),
+            _ => false,
+        }
+    }
+
     #[inline]
     pub fn is_getter(&self) -> bool {
         self.kind.is_getter()
@@ -1025,7 +1038,14 @@ impl TypeMember {
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Resolvable)]
 pub enum TypeMemberKind {
     CallSignature,
+    /// A member keyed by a computed value, such as `[Symbol.dispose]`. The reference is the key's
+    /// type. Currently produced by the generated global types; local inference of source objects
+    /// still spells computed keys as [`Self::IndexSignature`], so the two spellings coexist and
+    /// [`TypeMember::is_keyed_member_with_ty`] accepts either.
+    ComputedValue(TypeReference),
     ConstAssertedCallSignature,
+    /// A [`Self::ComputedValue`] carried through an `as const` assertion.
+    ConstAssertedComputedValue(TypeReference),
     ConstAssertedConstructor,
     ConstAssertedGetter(Text),
     ConstAssertedIndexSignature(TypeReference),
@@ -1045,6 +1065,8 @@ impl TypeMemberKind {
         match self {
             Self::CallSignature
             | Self::ConstAssertedCallSignature
+            | Self::ComputedValue(_)
+            | Self::ConstAssertedComputedValue(_)
             | Self::IndexSignature(_)
             | Self::ConstAssertedIndexSignature(_) => false,
             Self::Constructor | Self::ConstAssertedConstructor => name == "constructor",
@@ -1099,6 +1121,7 @@ impl TypeMemberKind {
         matches!(
             self,
             Self::ConstAssertedCallSignature
+                | Self::ConstAssertedComputedValue(_)
                 | Self::ConstAssertedConstructor
                 | Self::ConstAssertedGetter(_)
                 | Self::ConstAssertedIndexSignature(_)
@@ -1113,6 +1136,9 @@ impl TypeMemberKind {
         match self {
             Self::CallSignature | Self::ConstAssertedCallSignature => {
                 Self::ConstAssertedCallSignature
+            }
+            Self::ComputedValue(key_type) | Self::ConstAssertedComputedValue(key_type) => {
+                Self::ConstAssertedComputedValue(key_type)
             }
             Self::Constructor | Self::ConstAssertedConstructor => Self::ConstAssertedConstructor,
             Self::Getter(name) | Self::ConstAssertedGetter(name) => Self::ConstAssertedGetter(name),
@@ -1134,6 +1160,7 @@ impl TypeMemberKind {
     pub fn without_const_asserted(&self) -> Self {
         match self {
             Self::ConstAssertedCallSignature => Self::CallSignature,
+            Self::ConstAssertedComputedValue(key_type) => Self::ComputedValue(key_type.clone()),
             Self::ConstAssertedConstructor => Self::Constructor,
             Self::ConstAssertedGetter(name) => Self::Getter(name.clone()),
             Self::ConstAssertedIndexSignature(index_signature_type) => {
@@ -1168,6 +1195,8 @@ impl TypeMemberKind {
         match self {
             Self::CallSignature
             | Self::ConstAssertedCallSignature
+            | Self::ComputedValue(_)
+            | Self::ConstAssertedComputedValue(_)
             | Self::IndexSignature(_)
             | Self::ConstAssertedIndexSignature(_) => None,
             Self::Constructor | Self::ConstAssertedConstructor => {

--- a/crates/biome_js_type_info/tests/resolver.rs
+++ b/crates/biome_js_type_info/tests/resolver.rs
@@ -1,8 +1,14 @@
 mod utils;
 
+use std::sync::Arc;
+
 use biome_js_semantic::ScopeId;
 use biome_js_syntax::{AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsExpressionStatement};
-use biome_js_type_info::{GlobalsResolver, Resolvable, TypeData};
+use biome_js_type_info::{
+    GlobalsResolver, Resolvable, Type, TypeData, TypeMemberKind, TypeReference,
+    TypeReferenceQualifier, TypeResolver,
+};
+use biome_rowan::Text;
 
 use utils::{
     HardcodedSymbolResolver, assert_type_data_snapshot, assert_typed_bindings_snapshot,
@@ -265,6 +271,34 @@ fn infer_resolved_type_of_async_disposable_object() {
 }
 
 #[test]
+fn disposable_detection_relies_on_the_symbol_key() {
+    // A value-returning `[Symbol.dispose]` is still disposable: TypeScript
+    // accepts any return type through void assignability.
+    let ty = inferred_variable_type(
+        r#"const a = {
+            [Symbol.dispose]() { return 1; }
+        };"#,
+    );
+    assert!(ty.is_disposable());
+
+    // `[Symbol.asyncDispose]` marks an async disposable regardless of how the
+    // return type is spelled, including the `PromiseLike<void>` lib signature.
+    let ty = inferred_variable_type(
+        r#"const a = {
+            [Symbol.asyncDispose](): PromiseLike<void> { throw 0; }
+        };"#,
+    );
+    assert!(ty.is_async_disposable());
+
+    let ty = inferred_variable_type(
+        r#"const a = {
+            async [Symbol.asyncDispose]() {}
+        };"#,
+    );
+    assert!(ty.is_async_disposable());
+}
+
+#[test]
 fn infer_resolved_type_of_disposable_returning_function() {
     const CODE: &str = r#"function returnsDisposable(): Disposable {
     return {};
@@ -302,6 +336,54 @@ fn infer_resolved_type_of_async_disposable_returning_function() {
         &resolver,
         "infer_resolved_type_of_async_disposable_returning_function",
     )
+}
+
+#[test]
+fn generated_disposable_globals_use_computed_symbol_members() {
+    let resolver = GlobalsResolver::default();
+
+    assert_global_has_computed_member(&resolver, "Disposable");
+    assert_global_has_computed_member(&resolver, "AsyncDisposable");
+}
+
+fn assert_global_has_computed_member(resolver: &GlobalsResolver, name: &'static str) {
+    let reference = TypeReference::from(
+        TypeReferenceQualifier::from_path(ScopeId::GLOBAL, Text::new_static(name)).with_type_only(),
+    );
+    let resolved = resolver
+        .resolve_and_get(&reference)
+        .expect("global should resolve");
+    let TypeData::Interface(interface) = resolved.as_raw_data() else {
+        panic!("{name} should resolve to generated interface data");
+    };
+    let [member] = interface.members.as_ref() else {
+        panic!("{name} should have exactly one generated member");
+    };
+    assert!(matches!(member.kind, TypeMemberKind::ComputedValue(_)));
+}
+
+fn inferred_variable_type(code: &str) -> Type {
+    let root = parse_ts(code);
+    let decl = get_variable_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let bindings = TypeData::typed_bindings_from_js_variable_declaration(
+        &mut resolver,
+        ScopeId::GLOBAL,
+        &decl,
+    );
+    resolver.run_inference();
+
+    let [(name, reference)] = bindings.as_ref() else {
+        panic!("expected exactly one binding");
+    };
+    assert_eq!(name.text(), "a");
+
+    let reference = reference.clone();
+    let resolver = Arc::new(resolver);
+    let id = resolver
+        .resolve_reference(&reference)
+        .expect("binding should resolve");
+    Type::from_id(resolver, id)
 }
 
 pub fn get_expression_statement(root: &AnyJsRoot) -> JsExpressionStatement {

--- a/xtask/codegen/src/generate_global_types/compare.rs
+++ b/xtask/codegen/src/generate_global_types/compare.rs
@@ -4,21 +4,35 @@ use anyhow::{Result, bail};
 
 use super::lower::{
     LoweredClass, LoweredConstructor, LoweredFunction, LoweredFunctionParameter,
-    LoweredGlobalTypes, LoweredMemberKind, LoweredTypeData, LoweredTypeReference,
+    LoweredGlobalTypes, LoweredInterface, LoweredMemberKind, LoweredTypeData, LoweredTypeReference,
 };
 
 /// Number of `Error` class members expected in generated output.
 const ERROR_MEMBER_COUNT: usize = 6;
-/// Number of generated globals expected for `Error`.
-const ERROR_GLOBAL_COUNT: usize = 3;
+/// Expected number of lowered generated globals.
+const GENERATED_GLOBAL_COUNT: usize = 7;
+
+/// Expected shape of one lowered disposable pair (interface + dispose helper), checked by
+/// [`assert_disposable_shape`] against the generated model.
+struct DisposableShape<'a> {
+    interface_name: &'a str,
+    interface_id_constant: &'a str,
+    member_name: &'a str,
+    symbol_id: &'static str,
+    helper_type_id: &'static str,
+    helper_name: &'a str,
+    helper_id_constant: &'a str,
+    helper_is_async: bool,
+    return_type_id: &'static str,
+}
 
 /// Validates lowered generated globals before they are emitted.
 pub fn compare_lowered_globals(lowered: &LoweredGlobalTypes) -> Result<()> {
-    if lowered.globals().len() != ERROR_GLOBAL_COUNT {
+    if lowered.globals().len() != GENERATED_GLOBAL_COUNT {
         bail!(
-            "generated Error global has {} globals, expected {}",
+            "generated globals contain {} entries, expected {}",
             lowered.globals().len(),
-            ERROR_GLOBAL_COUNT
+            GENERATED_GLOBAL_COUNT
         );
     }
 
@@ -60,8 +74,37 @@ pub fn compare_lowered_globals(lowered: &LoweredGlobalTypes) -> Result<()> {
     let constructor = generated_constructor(lowered)?;
     assert_error_constructor_shape(constructor)?;
 
-    let call = generated_call(lowered)?;
+    let call = generated_function(lowered, "Error.call", "ERROR_CALL_ID_GLOBAL_TYPE_ID")?;
     assert_error_call_shape(call)?;
+
+    assert_disposable_shape(
+        lowered,
+        DisposableShape {
+            interface_name: "Disposable",
+            interface_id_constant: "DISPOSABLE_ID_GLOBAL_TYPE_ID",
+            member_name: "[Symbol.dispose]",
+            symbol_id: "GLOBAL_SYMBOL_DISPOSE_ID",
+            helper_type_id: "GLOBAL_DISPOSABLE_DISPOSE_ID",
+            helper_name: "Disposable[Symbol.dispose]",
+            helper_id_constant: "DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID",
+            helper_is_async: false,
+            return_type_id: "GLOBAL_VOID_ID",
+        },
+    )?;
+    assert_disposable_shape(
+        lowered,
+        DisposableShape {
+            interface_name: "AsyncDisposable",
+            interface_id_constant: "ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID",
+            member_name: "[Symbol.asyncDispose]",
+            symbol_id: "GLOBAL_SYMBOL_ASYNC_DISPOSE_ID",
+            helper_type_id: "GLOBAL_ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID",
+            helper_name: "AsyncDisposable[Symbol.asyncDispose]",
+            helper_id_constant: "ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",
+            helper_is_async: true,
+            return_type_id: "GLOBAL_INSTANCEOF_PROMISE_ID",
+        },
+    )?;
 
     Ok(())
 }
@@ -94,21 +137,114 @@ fn generated_constructor(lowered: &LoweredGlobalTypes) -> Result<&LoweredConstru
     Ok(constructor)
 }
 
-/// Returns the generated call helper for `Error(...)`.
-fn generated_call(lowered: &LoweredGlobalTypes) -> Result<&LoweredFunction> {
-    let Some(call) = lowered.global("Error.call") else {
-        bail!("generated globals are missing the Error call helper");
+/// Returns the lowered interface named `name`, checking it targets `id_constant`.
+fn generated_interface<'a>(
+    lowered: &'a LoweredGlobalTypes,
+    name: &str,
+    id_constant: &str,
+) -> Result<&'a LoweredInterface> {
+    let Some(global) = lowered.global(name) else {
+        bail!("generated globals are missing {name}");
     };
-    if call.id_constant() != "ERROR_CALL_ID_GLOBAL_TYPE_ID" {
+    if global.id_constant() != id_constant {
         bail!(
-            "generated Error call targets {}, expected ERROR_CALL_ID_GLOBAL_TYPE_ID",
-            call.id_constant()
+            "generated {name} targets {}, expected {id_constant}",
+            global.id_constant()
         );
     }
-    let LoweredTypeData::Function(call) = call.data() else {
-        bail!("generated Error call helper is not function data");
+    let LoweredTypeData::Interface(interface) = global.data() else {
+        bail!("generated {name} global is not an interface");
     };
-    Ok(call)
+    if interface.name() != name {
+        bail!(
+            "generated {name} interface has unexpected name {}",
+            interface.name()
+        );
+    }
+    Ok(interface)
+}
+
+/// Returns the lowered function named `name`, checking it targets `id_constant`.
+fn generated_function<'a>(
+    lowered: &'a LoweredGlobalTypes,
+    name: &str,
+    id_constant: &str,
+) -> Result<&'a LoweredFunction> {
+    let Some(global) = lowered.global(name) else {
+        bail!("generated globals are missing {name}");
+    };
+    if global.id_constant() != id_constant {
+        bail!(
+            "generated {name} targets {}, expected {id_constant}",
+            global.id_constant()
+        );
+    }
+    let LoweredTypeData::Function(function) = global.data() else {
+        bail!("generated {name} helper is not function data");
+    };
+    Ok(function)
+}
+
+/// Validates that the generated interface and dispose helper match the expected [`DisposableShape`]:
+/// the single computed member keyed by the well-known symbol, and the helper's async flag and return.
+fn assert_disposable_shape(lowered: &LoweredGlobalTypes, shape: DisposableShape) -> Result<()> {
+    let interface =
+        generated_interface(lowered, shape.interface_name, shape.interface_id_constant)?;
+    let [member] = interface.members() else {
+        bail!(
+            "generated {} has {} members, expected one",
+            shape.interface_name,
+            interface.members().len()
+        );
+    };
+    if member.name() != shape.member_name {
+        bail!(
+            "generated {} member has unexpected name {}",
+            shape.interface_name,
+            member.name()
+        );
+    }
+    if member.kind()
+        != &(LoweredMemberKind::ComputedValue {
+            key_reference: LoweredTypeReference::Predefined(shape.symbol_id),
+        })
+    {
+        bail!(
+            "generated {} member has unexpected kind",
+            shape.interface_name
+        );
+    }
+    if member.type_reference() != &LoweredTypeReference::Predefined(shape.helper_type_id) {
+        bail!(
+            "generated {} member has unexpected type",
+            shape.interface_name
+        );
+    }
+
+    let helper = generated_function(lowered, shape.helper_name, shape.helper_id_constant)?;
+    if helper.is_async() != shape.helper_is_async {
+        bail!(
+            "generated {} helper has unexpected async flag",
+            shape.helper_name
+        );
+    }
+    if helper.name().is_some() {
+        bail!("generated {} helper should be anonymous", shape.helper_name);
+    }
+    if !helper.parameters().is_empty() {
+        bail!(
+            "generated {} helper should not have parameters",
+            shape.helper_name
+        );
+    }
+    if helper.return_type() != &LoweredTypeReference::Predefined(shape.return_type_id) {
+        bail!(
+            "generated {} helper has unexpected return type",
+            shape.helper_name
+        );
+    }
+
+    Ok(())
 }
 
 /// Validates a required `Error` string field such as `name` or `message`.
@@ -210,6 +346,9 @@ fn assert_error_constructor_shape(constructor: &LoweredConstructor) -> Result<()
 
 /// Validates the generated call helper shape.
 fn assert_error_call_shape(call: &LoweredFunction) -> Result<()> {
+    if call.is_async() {
+        bail!("generated Error call helper should not be async");
+    }
     if call.name() != Some("Error") {
         bail!("generated Error call helper has unexpected function name");
     }

--- a/xtask/codegen/src/generate_global_types/emit.rs
+++ b/xtask/codegen/src/generate_global_types/emit.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, bail};
 
 use super::lower::{
     LoweredClass, LoweredConstructor, LoweredFunction, LoweredFunctionParameter, LoweredGlobal,
-    LoweredGlobalTypes, LoweredMemberKind, LoweredTypeData, LoweredTypeMember,
+    LoweredGlobalTypes, LoweredInterface, LoweredMemberKind, LoweredTypeData, LoweredTypeMember,
     LoweredTypeReference,
 };
 
@@ -12,7 +12,14 @@ use super::lower::{
 const OUTPUT_RELATIVE_PATH: &str = "crates/biome_js_type_info/src/generated/global_types.rs";
 
 /// Stable generated global emission order for generated globals with fixed IDs.
-const GLOBAL_ID_EMIT_ORDER: [&str; 3] = [
+///
+/// Must stay ordered by ascending `GlobalTypeId` index so the emitted
+/// `MIGRATED_PREDEFINED_IDS` stays sorted for the runtime `binary_search`.
+const GLOBAL_ID_EMIT_ORDER: [&str; 7] = [
+    "DISPOSABLE_ID_GLOBAL_TYPE_ID",
+    "DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID",
+    "ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID",
+    "ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",
     "ERROR_ID_GLOBAL_TYPE_ID",
     "ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID",
     "ERROR_CALL_ID_GLOBAL_TYPE_ID",
@@ -85,6 +92,7 @@ fn render_type_data(data: &LoweredTypeData) -> String {
         LoweredTypeData::Class(class) => render_class(class),
         LoweredTypeData::Constructor(constructor) => render_constructor(constructor),
         LoweredTypeData::Function(function) => render_function(function),
+        LoweredTypeData::Interface(interface) => render_interface(interface),
     }
 }
 
@@ -100,6 +108,20 @@ fn render_class(class: &LoweredClass) -> String {
         }}))",
         name = rust_string_literal(class.name()),
         members = render_members(class.members()),
+    )
+}
+
+/// Builds a `TypeData::Interface` expression.
+fn render_interface(interface: &LoweredInterface) -> String {
+    format!(
+        "crate::TypeData::Interface(Box::new(crate::Interface {{
+            name: biome_rowan::Text::new_static({name}),
+            type_parameters: Box::default(),
+            extends: Box::default(),
+            members: Box::new([{members}]),
+        }}))",
+        name = rust_string_literal(interface.name()),
+        members = render_members(interface.members()),
     )
 }
 
@@ -134,12 +156,13 @@ fn render_function(function: &LoweredFunction) -> String {
 
     format!(
         "crate::TypeData::Function(Box::new(crate::Function {{
-            is_async: false,
+            is_async: {is_async},
             type_parameters: Box::default(),
             name: {name},
             parameters: Box::new([{parameters}]),
             return_type: crate::ReturnType::Type({return_type}),
         }}))",
+        is_async = function.is_async(),
         parameters = render_function_parameters(function.parameters()),
         return_type = render_type_reference(function.return_type()),
     )
@@ -190,6 +213,12 @@ fn render_member_kind(member: &LoweredTypeMember) -> String {
         }
         LoweredMemberKind::Constructor => "crate::TypeMemberKind::Constructor".to_string(),
         LoweredMemberKind::CallSignature => "crate::TypeMemberKind::CallSignature".to_string(),
+        LoweredMemberKind::ComputedValue { key_reference } => {
+            format!(
+                "crate::TypeMemberKind::ComputedValue({})",
+                render_type_reference(key_reference)
+            )
+        }
     }
 }
 
@@ -258,7 +287,7 @@ fn global_with_id_constant<'a>(
 }
 
 /// Returns generated globals in the sorted predefined-ID order.
-fn sorted_globals(lowered: &LoweredGlobalTypes) -> Result<[&LoweredGlobal; 3]> {
+fn sorted_globals(lowered: &LoweredGlobalTypes) -> Result<[&LoweredGlobal; 7]> {
     for global in lowered.globals() {
         if !GLOBAL_ID_EMIT_ORDER.contains(&global.id_constant()) {
             bail!(
@@ -273,5 +302,9 @@ fn sorted_globals(lowered: &LoweredGlobalTypes) -> Result<[&LoweredGlobal; 3]> {
         global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[0])?,
         global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[1])?,
         global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[2])?,
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[3])?,
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[4])?,
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[5])?,
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[6])?,
     ])
 }

--- a/xtask/codegen/src/generate_global_types/lower.rs
+++ b/xtask/codegen/src/generate_global_types/lower.rs
@@ -3,10 +3,11 @@
 use anyhow::{Context, Result, bail};
 use biome_js_parser::{JsParserOptions, parse};
 use biome_js_syntax::{
-    AnyJsBindingPattern, AnyJsFormalParameter, AnyJsObjectMemberName, AnyJsParameter, AnyJsRoot,
-    AnyTsReturnType, AnyTsType, AnyTsTypeMember, AnyTsVariableAnnotation, JsParameters,
-    JsVariableDeclarator, TsCallSignatureTypeMember, TsConstructSignatureTypeMember,
-    TsDeclarationModule, TsInterfaceDeclaration, TsPropertySignatureTypeMember,
+    AnyJsBindingPattern, AnyJsExpression, AnyJsFormalParameter, AnyJsName, AnyJsObjectMemberName,
+    AnyJsParameter, AnyJsRoot, AnyTsReturnType, AnyTsType, AnyTsTypeMember,
+    AnyTsVariableAnnotation, JsParameters, JsVariableDeclarator, TsCallSignatureTypeMember,
+    TsConstructSignatureTypeMember, TsDeclarationModule, TsInterfaceDeclaration,
+    TsMethodSignatureTypeMember, TsPropertySignatureTypeMember,
 };
 use biome_languages::JsFileSource;
 use biome_rowan::{AstNode, Text};
@@ -66,6 +67,7 @@ pub enum LoweredTypeData {
     Class(LoweredClass),
     Constructor(LoweredConstructor),
     Function(LoweredFunction),
+    Interface(LoweredInterface),
 }
 
 /// Lowered class-like global.
@@ -82,6 +84,32 @@ impl LoweredClass {
     }
 
     /// Class members in declaration order.
+    pub fn members(&self) -> &[LoweredTypeMember] {
+        &self.members
+    }
+
+    /// Returns the first member with `name`.
+    pub fn member(&self, name: &str) -> Option<&LoweredTypeMember> {
+        self.members
+            .iter()
+            .find(|member| member.name.text() == name)
+    }
+}
+
+/// Lowered interface data.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoweredInterface {
+    name: Text,
+    members: Box<[LoweredTypeMember]>,
+}
+
+impl LoweredInterface {
+    /// Interface name.
+    pub fn name(&self) -> &str {
+        self.name.text()
+    }
+
+    /// Interface members in declaration order.
     pub fn members(&self) -> &[LoweredTypeMember] {
         &self.members
     }
@@ -116,12 +144,18 @@ impl LoweredConstructor {
 /// Lowered function helper data.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LoweredFunction {
+    is_async: bool,
     name: Option<Text>,
     parameters: Box<[LoweredFunctionParameter]>,
     return_type: LoweredTypeReference,
 }
 
 impl LoweredFunction {
+    /// Returns whether this function is `async`.
+    pub fn is_async(&self) -> bool {
+        self.is_async
+    }
+
     /// Function name, if present.
     pub fn name(&self) -> Option<&str> {
         self.name.as_ref().map(Text::text)
@@ -201,6 +235,7 @@ pub enum LoweredMemberKind {
     NamedStatic,
     Constructor,
     CallSignature,
+    ComputedValue { key_reference: LoweredTypeReference },
 }
 
 /// Lowered type reference.
@@ -289,27 +324,39 @@ pub fn lower_global_types(
         members.push(prototype);
     }
 
+    let mut globals = Vec::new();
+    globals.push(LoweredGlobal {
+        name: Text::from("Error"),
+        id_constant: "ERROR_ID_GLOBAL_TYPE_ID",
+        data: LoweredTypeData::Class(LoweredClass {
+            name: Text::from("Error"),
+            members: members.into_boxed_slice(),
+        }),
+    });
+    globals.push(LoweredGlobal {
+        name: Text::from("Error.constructor"),
+        id_constant: "ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID",
+        data: LoweredTypeData::Constructor(constructor),
+    });
+    globals.push(LoweredGlobal {
+        name: Text::from("Error.call"),
+        id_constant: "ERROR_CALL_ID_GLOBAL_TYPE_ID",
+        data: LoweredTypeData::Function(call),
+    });
+
+    if let Some(disposable_globals) =
+        lower_disposable_global(manifest, &mut source_cache, DISPOSABLE_GLOBAL)?
+    {
+        globals.extend(disposable_globals);
+    }
+    if let Some(async_disposable_globals) =
+        lower_disposable_global(manifest, &mut source_cache, ASYNC_DISPOSABLE_GLOBAL)?
+    {
+        globals.extend(async_disposable_globals);
+    }
+
     Ok(LoweredGlobalTypes {
-        globals: Box::new([
-            LoweredGlobal {
-                name: Text::from("Error"),
-                id_constant: "ERROR_ID_GLOBAL_TYPE_ID",
-                data: LoweredTypeData::Class(LoweredClass {
-                    name: Text::from("Error"),
-                    members: members.into_boxed_slice(),
-                }),
-            },
-            LoweredGlobal {
-                name: Text::from("Error.constructor"),
-                id_constant: "ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID",
-                data: LoweredTypeData::Constructor(constructor),
-            },
-            LoweredGlobal {
-                name: Text::from("Error.call"),
-                id_constant: "ERROR_CALL_ID_GLOBAL_TYPE_ID",
-                data: LoweredTypeData::Function(call),
-            },
-        ]),
+        globals: globals.into_boxed_slice(),
     })
 }
 
@@ -319,6 +366,74 @@ struct ErrorConstructorSignatures {
     call: LoweredFunction,
     prototype: Option<LoweredTypeMember>,
 }
+
+/// Describes how one disposable interface (`Disposable`/`AsyncDisposable`) and its dispose
+/// helper are lowered. Every field is a static string because it feeds generated Rust source.
+#[derive(Clone, Copy)]
+struct DisposableGlobalSpec {
+    /// Interface name in the `.d.ts` source and the manifest group key.
+    interface_name: &'static str,
+    /// `GlobalTypeId` constant the lowered interface registers into.
+    global_id_constant: &'static str,
+    /// Display name of the single computed member (e.g. `[Symbol.dispose]`).
+    member_name: &'static str,
+    /// `GLOBAL_*` reference the computed member key must resolve to.
+    symbol_id: &'static str,
+    /// Display name of the synthesized dispose helper global.
+    helper_name: &'static str,
+    /// `GlobalTypeId` constant the dispose helper registers into.
+    helper_id_constant: &'static str,
+    /// `GLOBAL_*` reference the member's value type points at (the helper).
+    helper_type_id: &'static str,
+    /// Whether the helper returns `void` or `PromiseLike<void>`.
+    return_kind: DisposableReturnKind,
+}
+
+/// Return shape of a dispose helper, mapping the `.d.ts` signature to the lowered return type.
+#[derive(Clone, Copy)]
+enum DisposableReturnKind {
+    Void,
+    PromiseLikeVoid,
+}
+
+impl DisposableReturnKind {
+    /// Whether the lowered dispose helper is an `async` function.
+    fn helper_is_async(self) -> bool {
+        matches!(self, Self::PromiseLikeVoid)
+    }
+
+    /// Predefined ID constant the lowered return type must resolve to.
+    fn return_type_id(self) -> &'static str {
+        match self {
+            Self::Void => "GLOBAL_VOID_ID",
+            Self::PromiseLikeVoid => "GLOBAL_INSTANCEOF_PROMISE_ID",
+        }
+    }
+}
+
+/// Lowering spec for the `Disposable` interface and its `[Symbol.dispose](): void` helper.
+const DISPOSABLE_GLOBAL: DisposableGlobalSpec = DisposableGlobalSpec {
+    interface_name: "Disposable",
+    global_id_constant: "DISPOSABLE_ID_GLOBAL_TYPE_ID",
+    member_name: "[Symbol.dispose]",
+    symbol_id: "GLOBAL_SYMBOL_DISPOSE_ID",
+    helper_name: "Disposable[Symbol.dispose]",
+    helper_id_constant: "DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID",
+    helper_type_id: "GLOBAL_DISPOSABLE_DISPOSE_ID",
+    return_kind: DisposableReturnKind::Void,
+};
+
+/// Lowering spec for `AsyncDisposable` and its `[Symbol.asyncDispose](): PromiseLike<void>` helper.
+const ASYNC_DISPOSABLE_GLOBAL: DisposableGlobalSpec = DisposableGlobalSpec {
+    interface_name: "AsyncDisposable",
+    global_id_constant: "ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID",
+    member_name: "[Symbol.asyncDispose]",
+    symbol_id: "GLOBAL_SYMBOL_ASYNC_DISPOSE_ID",
+    helper_name: "AsyncDisposable[Symbol.asyncDispose]",
+    helper_id_constant: "ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",
+    helper_type_id: "GLOBAL_ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID",
+    return_kind: DisposableReturnKind::PromiseLikeVoid,
+};
 
 struct ParsedSource<'a> {
     repo_relative: &'a str,
@@ -405,6 +520,299 @@ impl<'a> ParsedSourceCache<'a> {
 
         Ok(None)
     }
+}
+
+/// Lowers a disposable interface into its interface global plus the dispose helper global.
+/// Returns `None` when the manifest has no group for `spec.interface_name`.
+fn lower_disposable_global(
+    manifest: &GlobalManifest,
+    source_cache: &mut ParsedSourceCache,
+    spec: DisposableGlobalSpec,
+) -> Result<Option<[LoweredGlobal; 2]>> {
+    let Some(group) = manifest.global_group(spec.interface_name) else {
+        return Ok(None);
+    };
+    if !group.has_role(GlobalDeclarationRole::Type) {
+        bail!(
+            "{} global must have a type-side declaration",
+            spec.interface_name
+        );
+    }
+
+    let mut lowered_member = None;
+    let mut saw_interface = false;
+    for record in group.declarations() {
+        match &record.kind {
+            DeclarationKind::Interface => {
+                saw_interface = true;
+            }
+            DeclarationKind::TypeAlias => {
+                bail!("type aliases are not supported in {}", spec.interface_name)
+            }
+            DeclarationKind::DeclareFunction
+            | DeclarationKind::VariableDeclarator { .. }
+            | DeclarationKind::ImportEquals => {
+                bail!(
+                    "value-side {} declarations are not supported",
+                    spec.interface_name
+                )
+            }
+        }
+
+        let declaration = source_cache
+            .find_interface_declaration(record)?
+            .with_context(|| {
+                format!(
+                    "failed to find interface declaration {} at {:?}",
+                    record.declared_name.text(),
+                    record.text_range
+                )
+            })?;
+        if declaration.extends_clause().is_some() {
+            bail!("{} extends clauses are not supported", spec.interface_name);
+        }
+        if declaration.type_parameters().is_some() {
+            bail!("{} type parameters are not supported", spec.interface_name);
+        }
+
+        for member in declaration.members() {
+            let lowered = lower_disposable_type_member(member, spec)?;
+            if lowered_member.replace(lowered).is_some() {
+                bail!("{} has multiple computed members", spec.interface_name);
+            }
+        }
+    }
+    if !saw_interface {
+        bail!(
+            "{} global must include an interface declaration",
+            spec.interface_name
+        );
+    }
+
+    let lowered_member = lowered_member
+        .with_context(|| format!("{} is missing {}", spec.interface_name, spec.member_name))?;
+
+    Ok(Some([
+        LoweredGlobal {
+            name: Text::from(spec.interface_name),
+            id_constant: spec.global_id_constant,
+            data: LoweredTypeData::Interface(LoweredInterface {
+                name: Text::from(spec.interface_name),
+                members: Box::new([lowered_member]),
+            }),
+        },
+        LoweredGlobal {
+            name: Text::from(spec.helper_name),
+            id_constant: spec.helper_id_constant,
+            data: LoweredTypeData::Function(LoweredFunction {
+                is_async: spec.return_kind.helper_is_async(),
+                name: None,
+                parameters: Box::default(),
+                return_type: LoweredTypeReference::Predefined(spec.return_kind.return_type_id()),
+            }),
+        },
+    ]))
+}
+
+/// Lowers the single member of a disposable interface. Only a computed method signature
+/// (`[Symbol.dispose](): void`) is supported; every other member shape bails.
+fn lower_disposable_type_member(
+    member: AnyTsTypeMember,
+    spec: DisposableGlobalSpec,
+) -> Result<LoweredTypeMember> {
+    match member {
+        AnyTsTypeMember::TsMethodSignatureTypeMember(member) => {
+            lower_disposable_method_signature(&member, spec)
+        }
+        AnyTsTypeMember::TsPropertySignatureTypeMember(_) => {
+            bail!("properties are not supported in {}", spec.interface_name)
+        }
+        AnyTsTypeMember::TsCallSignatureTypeMember(_)
+        | AnyTsTypeMember::TsConstructSignatureTypeMember(_) => {
+            bail!("signatures are not supported in {}", spec.interface_name)
+        }
+        AnyTsTypeMember::JsBogusMember(_) => {
+            bail!("bogus members are not supported in {}", spec.interface_name)
+        }
+        AnyTsTypeMember::TsGetterSignatureTypeMember(_) => {
+            bail!(
+                "getter signatures are not supported in {}",
+                spec.interface_name
+            )
+        }
+        AnyTsTypeMember::TsIndexSignatureTypeMember(_) => {
+            bail!(
+                "index signatures are not supported in {}",
+                spec.interface_name
+            )
+        }
+        AnyTsTypeMember::TsSetterSignatureTypeMember(_) => {
+            bail!(
+                "setter signatures are not supported in {}",
+                spec.interface_name
+            )
+        }
+    }
+}
+
+/// Lowers a `[Symbol.(async)Dispose](): <return>` method into a computed-value member whose
+/// key is the well-known symbol and whose value type is the dispose helper. Bails on any
+/// deviation from that exact shape (optional, generic, parameterized, wrong key, wrong return).
+fn lower_disposable_method_signature(
+    member: &TsMethodSignatureTypeMember,
+    spec: DisposableGlobalSpec,
+) -> Result<LoweredTypeMember> {
+    if member.optional_token().is_some() {
+        bail!("{} must not be optional", spec.member_name);
+    }
+    if member.type_parameters().is_some() {
+        bail!("{} must not be generic", spec.member_name);
+    }
+    if member.parameters()?.items().into_iter().next().is_some() {
+        bail!("{} must not declare parameters", spec.member_name);
+    }
+
+    let computed_member = lower_symbol_computed_member_name(member.name()?)?;
+    if computed_member.name.text() != spec.member_name {
+        bail!(
+            "{} has unsupported computed member {}",
+            spec.interface_name,
+            computed_member.name
+        );
+    }
+    if computed_member.key_reference != LoweredTypeReference::Predefined(spec.symbol_id) {
+        bail!(
+            "{} has unsupported computed key for {}",
+            spec.interface_name,
+            spec.member_name
+        );
+    }
+
+    let return_type = member
+        .return_type_annotation()
+        .with_context(|| format!("{} is missing a return type", spec.member_name))?
+        .ty()
+        .with_context(|| format!("{} has malformed return type", spec.member_name))
+        .and_then(|return_type_node| lower_disposable_return_type(&return_type_node, spec))?;
+    if return_type != LoweredTypeReference::Predefined(spec.return_kind.return_type_id()) {
+        bail!("{} has unsupported return type", spec.member_name);
+    }
+
+    Ok(LoweredTypeMember {
+        name: computed_member.name,
+        kind: LoweredMemberKind::ComputedValue {
+            key_reference: computed_member.key_reference,
+        },
+        type_reference: LoweredTypeReference::Predefined(spec.helper_type_id),
+    })
+}
+
+/// A lowered `[Symbol.<name>]` computed key: its display name and the `GLOBAL_*` symbol reference.
+struct ComputedMemberName {
+    name: Text,
+    key_reference: LoweredTypeReference,
+}
+
+/// Lowers a `[Symbol.dispose]` / `[Symbol.asyncDispose]` computed member name into its display
+/// name and well-known-symbol key reference. Bails on any non-well-known or non-`Symbol` key.
+fn lower_symbol_computed_member_name(name: AnyJsObjectMemberName) -> Result<ComputedMemberName> {
+    let AnyJsObjectMemberName::JsComputedMemberName(name) = name else {
+        bail!("expected computed symbol member name")
+    };
+    let AnyJsExpression::JsStaticMemberExpression(expression) = name.expression()? else {
+        bail!("computed member name must be a static member expression")
+    };
+    let AnyJsExpression::JsIdentifierExpression(object) = expression.object()? else {
+        bail!("computed member object must be Symbol")
+    };
+    if object.name()?.value_token()?.token_text_trimmed().text() != "Symbol" {
+        bail!("computed member object must be Symbol");
+    }
+
+    let AnyJsName::JsName(member_name) = expression.member()? else {
+        bail!("computed Symbol member must be a public name")
+    };
+    let member_name = member_name.value_token()?.token_text_trimmed();
+    match member_name.text() {
+        "dispose" => Ok(ComputedMemberName {
+            name: Text::from("[Symbol.dispose]"),
+            key_reference: LoweredTypeReference::Predefined("GLOBAL_SYMBOL_DISPOSE_ID"),
+        }),
+        "asyncDispose" => Ok(ComputedMemberName {
+            name: Text::from("[Symbol.asyncDispose]"),
+            key_reference: LoweredTypeReference::Predefined("GLOBAL_SYMBOL_ASYNC_DISPOSE_ID"),
+        }),
+        name => bail!("unsupported Symbol computed member {name}"),
+    }
+}
+
+/// Lowers a dispose helper's return type according to `spec.return_kind`: a plain `void`, or
+/// the `PromiseLike<void>` special case handled by [`lower_promise_like_void_reference`].
+fn lower_disposable_return_type(
+    return_type_node: &AnyTsReturnType,
+    spec: DisposableGlobalSpec,
+) -> Result<LoweredTypeReference> {
+    match return_type_node {
+        AnyTsReturnType::AnyTsType(type_node) => match spec.return_kind {
+            DisposableReturnKind::Void => lower_void_reference(type_node, spec),
+            DisposableReturnKind::PromiseLikeVoid => lower_promise_like_void_reference(type_node),
+        },
+        AnyTsReturnType::TsAssertsReturnType(_) | AnyTsReturnType::TsPredicateReturnType(_) => {
+            bail!(
+                "predicate return types are not supported in {}",
+                spec.member_name
+            )
+        }
+    }
+}
+
+/// Lowers the `Disposable` dispose helper's `void` return type to `GLOBAL_VOID_ID`.
+fn lower_void_reference(
+    type_node: &AnyTsType,
+    spec: DisposableGlobalSpec,
+) -> Result<LoweredTypeReference> {
+    if !matches!(type_node, AnyTsType::TsVoidType(_)) {
+        bail!("{} return type must be void", spec.member_name);
+    }
+    Ok(LoweredTypeReference::Predefined("GLOBAL_VOID_ID"))
+}
+
+/// Lowers the `AsyncDisposable` dispose helper's `PromiseLike<void>` return type to
+/// `GLOBAL_INSTANCEOF_PROMISE_ID`. This is a deliberate approximation: `PromiseLike` is not a
+/// migrated global yet, so the helper resolves to `instanceof Promise` exactly like the previous
+/// hand-written data did; the exact-shape check keeps any other return type from being lowered.
+fn lower_promise_like_void_reference(type_node: &AnyTsType) -> Result<LoweredTypeReference> {
+    let AnyTsType::TsReferenceType(reference) = type_node else {
+        bail!("AsyncDisposable return type must be PromiseLike<void>");
+    };
+    let name = reference
+        .name()
+        .context("missing AsyncDisposable return type name")?;
+    let biome_js_syntax::AnyTsName::JsReferenceIdentifier(identifier) = name else {
+        bail!("qualified AsyncDisposable return types are not supported");
+    };
+    if identifier.value_token()?.token_text_trimmed().text() != "PromiseLike" {
+        bail!("AsyncDisposable return type must be PromiseLike<void>");
+    }
+
+    let type_arguments = reference
+        .type_arguments()
+        .context("PromiseLike return type is missing type arguments")?;
+    let mut arguments = type_arguments.ts_type_argument_list().into_iter();
+    let Some(argument) = arguments.next() else {
+        bail!("PromiseLike return type is missing void type argument");
+    };
+    let argument = argument?;
+    if arguments.next().is_some() {
+        bail!("PromiseLike return type must have one type argument");
+    }
+    if !matches!(argument, AnyTsType::TsVoidType(_)) {
+        bail!("PromiseLike return type must be PromiseLike<void>");
+    }
+
+    Ok(LoweredTypeReference::Predefined(
+        "GLOBAL_INSTANCEOF_PROMISE_ID",
+    ))
 }
 
 /// Lowers supported members from `interface Error`.
@@ -668,6 +1076,7 @@ fn lower_call_signature(member: &TsCallSignatureTypeMember) -> Result<LoweredFun
         .and_then(|return_type_node| lower_return_type_reference(&return_type_node))?;
 
     Ok(LoweredFunction {
+        is_async: false,
         name: Some(Text::from("Error")),
         parameters: lower_parameters(member.parameters()?)?,
         return_type: instance_return_reference(return_type),

--- a/xtask/codegen/tests/fixtures/global-types/manifest.disposables.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.disposables.d.ts
@@ -1,5 +1,6 @@
 interface Error {
     name: string;
+    message: string;
     stack?: string;
 }
 

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-wrong-constructor-return.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-wrong-constructor-return.d.ts
@@ -14,3 +14,11 @@ interface ErrorConstructor {
 }
 
 declare var Error: ErrorConstructor;
+
+interface Disposable {
+    [Symbol.dispose](): void;
+}
+
+interface AsyncDisposable {
+    [Symbol.asyncDispose](): PromiseLike<void>;
+}

--- a/xtask/codegen/tests/global_types_codegen.rs
+++ b/xtask/codegen/tests/global_types_codegen.rs
@@ -528,18 +528,17 @@ fn fixture_git_repo_with_malformed_lib() -> Result<FixtureRepo> {
     })
 }
 
-/// Builds a fixture whose selected lib contains the Error global declarations
-/// used by the generated globals output.
-fn fixture_git_repo_with_error_global() -> Result<FixtureRepo> {
+/// Builds a fixture repo with Error, Disposable, and AsyncDisposable declarations.
+fn fixture_git_repo_with_generated_globals() -> Result<FixtureRepo> {
     let repo = fixture_git_repo(SINGLE_LIB_ENTRY)?;
     write_profile_root_placeholders(repo.path())?;
     let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join(COLLECTOR_FIXTURE_DIR)
-        .join("manifest.error.d.ts");
+        .join("manifest.disposables.d.ts");
     fs::copy(&fixture_path, repo.path().join("lib/lib.es5.d.ts"))
         .with_context(|| format!("failed to copy {}", fixture_path.display()))?;
     run_git(repo.path(), &["add", "."])?;
-    run_git(repo.path(), &["commit", "-m", "add error global"])?;
+    run_git(repo.path(), &["commit", "-m", "add generated globals"])?;
     let head = git_stdout_trimmed(repo.path(), &["rev-parse", "HEAD"])?;
     run_git(repo.path(), &["tag", "-f", repo.tag.as_str()])?;
 
@@ -979,8 +978,8 @@ mod tests {
     }
 
     #[test]
-    fn run_emits_error_global_registration() -> Result<()> {
-        let repo = fixture_git_repo_with_error_global()?;
+    fn run_emits_generated_global_registration() -> Result<()> {
+        let repo = fixture_git_repo_with_generated_globals()?;
         let pin = repo.source_pin();
         let _cache_cleanup = seed_cache_from_repo(&pin, repo.path())?;
         let workspace = TempDir::new("bgt-workspace")?;
@@ -998,9 +997,24 @@ mod tests {
         assert!(generated.contains("crate::globals::ERROR_ID_GLOBAL_TYPE_ID"));
         assert!(generated.contains("crate::globals::ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID"));
         assert!(generated.contains("crate::globals::ERROR_CALL_ID_GLOBAL_TYPE_ID"));
+        assert!(generated.contains("crate::globals::DISPOSABLE_ID_GLOBAL_TYPE_ID"));
+        assert!(generated.contains("crate::globals::DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID"));
+        assert!(generated.contains("crate::globals::ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID"));
+        assert!(
+            generated.contains("crate::globals::ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID")
+        );
         assert!(generated.contains("builder.set_type_data("));
+        assert!(generated.contains("crate::TypeData::Interface("));
         assert!(generated.contains("crate::TypeData::Constructor("));
         assert!(generated.contains("crate::TypeData::Function("));
+        assert!(generated.contains("crate::TypeMemberKind::ComputedValue("));
+        // Pin the async flag at the rendered-source level: the `AsyncDisposable` helper must emit
+        // `is_async: true` and the synchronous helpers `is_async: false`, so a regression back to a
+        // hardcoded flag in `render_function` fails here, not only at the lowered-model layer.
+        assert!(generated.contains("is_async: true,"));
+        assert!(generated.contains("is_async: false,"));
+        assert!(generated.contains("crate::globals::GLOBAL_SYMBOL_DISPOSE_ID.into()"));
+        assert!(generated.contains("crate::globals::GLOBAL_SYMBOL_ASYNC_DISPOSE_ID.into()"));
         assert!(generated.contains("biome_rowan::Text::new_static(\"name\")"));
         assert!(generated.contains("biome_rowan::Text::new_static(\"message\")"));
         assert!(generated.contains("crate::TypeMemberKind::NamedOptional("));
@@ -1188,6 +1202,90 @@ mod tests {
     }
 
     #[test]
+    fn lowerer_lowers_disposable_computed_members() -> Result<()> {
+        let lowered = lowered_from_fixture("manifest.disposables.d.ts")?;
+
+        let disposable = lowered
+            .global("Disposable")
+            .expect("Disposable should be lowered");
+        assert_eq!(disposable.id_constant(), "DISPOSABLE_ID_GLOBAL_TYPE_ID");
+        let LoweredTypeData::Interface(disposable_interface) = disposable.data() else {
+            bail!("Disposable should lower to interface data");
+        };
+        let dispose = disposable_interface
+            .member("[Symbol.dispose]")
+            .expect("Disposable computed member should be lowered");
+        assert_eq!(
+            dispose.kind(),
+            &LoweredMemberKind::ComputedValue {
+                key_reference: LoweredTypeReference::Predefined("GLOBAL_SYMBOL_DISPOSE_ID")
+            }
+        );
+        assert_eq!(
+            dispose.type_reference(),
+            &LoweredTypeReference::Predefined("GLOBAL_DISPOSABLE_DISPOSE_ID")
+        );
+
+        let async_disposable = lowered
+            .global("AsyncDisposable")
+            .expect("AsyncDisposable should be lowered");
+        assert_eq!(
+            async_disposable.id_constant(),
+            "ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID"
+        );
+        let LoweredTypeData::Interface(async_disposable_interface) = async_disposable.data() else {
+            bail!("AsyncDisposable should lower to interface data");
+        };
+        let async_dispose = async_disposable_interface
+            .member("[Symbol.asyncDispose]")
+            .expect("AsyncDisposable computed member should be lowered");
+        assert_eq!(
+            async_dispose.kind(),
+            &LoweredMemberKind::ComputedValue {
+                key_reference: LoweredTypeReference::Predefined("GLOBAL_SYMBOL_ASYNC_DISPOSE_ID")
+            }
+        );
+        assert_eq!(
+            async_dispose.type_reference(),
+            &LoweredTypeReference::Predefined("GLOBAL_ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID")
+        );
+
+        let dispose_helper = lowered
+            .global("Disposable[Symbol.dispose]")
+            .expect("Disposable dispose helper should be lowered");
+        assert_eq!(
+            dispose_helper.id_constant(),
+            "DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID"
+        );
+        let LoweredTypeData::Function(dispose_function) = dispose_helper.data() else {
+            bail!("Disposable dispose helper should lower to function data");
+        };
+        assert!(!dispose_function.is_async());
+        assert_eq!(
+            dispose_function.return_type(),
+            &LoweredTypeReference::Predefined("GLOBAL_VOID_ID")
+        );
+
+        let async_dispose_helper = lowered
+            .global("AsyncDisposable[Symbol.asyncDispose]")
+            .expect("AsyncDisposable dispose helper should be lowered");
+        assert_eq!(
+            async_dispose_helper.id_constant(),
+            "ASYNC_DISPOSABLE_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID"
+        );
+        let LoweredTypeData::Function(async_dispose_function) = async_dispose_helper.data() else {
+            bail!("AsyncDisposable dispose helper should lower to function data");
+        };
+        assert!(async_dispose_function.is_async());
+        assert_eq!(
+            async_dispose_function.return_type(),
+            &LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_PROMISE_ID")
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn lowerer_rejects_error_interface_extends_clause() -> Result<()> {
         expect_error_contains(
             lowered_from_fixture("manifest.error-extends.d.ts"),
@@ -1220,12 +1318,22 @@ mod tests {
     }
 
     #[test]
-    fn comparator_accepts_error_member_divergence() -> Result<()> {
-        let lowered = lowered_from_fixture("manifest.error.d.ts")?;
+    fn comparator_accepts_generated_global_shapes() -> Result<()> {
+        let lowered = lowered_from_fixture("manifest.disposables.d.ts")?;
 
         compare_lowered_globals(&lowered)?;
 
         Ok(())
+    }
+
+    #[test]
+    fn comparator_rejects_missing_disposable_globals() -> Result<()> {
+        let lowered = lowered_from_fixture("manifest.error.d.ts")?;
+
+        expect_error_contains(
+            compare_lowered_globals(&lowered),
+            "generated globals contain 3 entries, expected 7",
+        )
     }
 
     #[test]


### PR DESCRIPTION
This PR was implemented with AI assistance from Codex.

## Summary

Foundation for #5977. Migrates `Disposable` and `AsyncDisposable` through the generated global-types pipeline, including computed symbol member schema, lowering/comparison/emission, and generated resolver registration.

## Test Plan

Added global-types codegen coverage for computed symbol members, `Disposable`/`AsyncDisposable` lowering, comparator checks, and generated registration output.

Added type-info coverage for generated disposable globals and verified the `useDisposables` rule keeps recognizing disposable types.

Ran:
- `just gen-global-types`
- `cargo test -p xtask_codegen --features=global_types --test global_types_codegen`
- `cargo test -p biome_js_type_info --test resolver`
- `cargo test -p biome_js_analyze use_disposables`
- `cargo fmt --all --check`
- `git diff --check`

## Docs

Not applicable; this migrates existing type-info globals to generated data.