### PR TITLE
fix: allow named forwardRef components with ref params

### DIFF
--- a/.changeset/fix-forward-ref-hook-component.md
+++ b/.changeset/fix-forward-ref-hook-component.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#9195](https://github.com/biomejs/biome/issues/9195): [`useHookAtTopLevel`](https://biomejs.dev/linter/rules/use-hook-at-top-level/) no longer reports hooks in named `forwardRef` components that receive a `ref` parameter.

--- a/crates/biome_js_analyze/src/react/components.rs
+++ b/crates/biome_js_analyze/src/react/components.rs
@@ -559,8 +559,8 @@ fn has_valid_react_component_params(
     parameters: impl Iterator<Item = SyntaxResult<AnyJsParameter>>,
 ) -> Option<bool> {
     let mut parameters = parameters;
-    let first = parameters.next().transpose()?;
-    let second = parameters.next().transpose()?;
+    let first = parameters.next().transpose().ok()?;
+    let second = parameters.next().transpose().ok()?;
 
     if parameters.next().is_some() {
         return Some(false);

--- a/crates/biome_js_analyze/src/react/components.rs
+++ b/crates/biome_js_analyze/src/react/components.rs
@@ -1,12 +1,12 @@
 use biome_js_syntax::export_ext::{AnyJsExported, ExportedItem};
 use biome_js_syntax::{
-    AnyJsBinding, AnyJsExpression, AnyJsFormalParameter, AnyJsParameter,
-    JsArrowFunctionExpression, JsAssignmentExpression, JsCallArgumentList, JsCallArguments,
-    JsCallExpression, JsClassDeclaration, JsClassExportDefaultDeclaration,
-    JsExportDefaultExpressionClause, JsExtendsClause, JsFunctionDeclaration,
-    JsFunctionExportDefaultDeclaration, JsFunctionExpression, JsInitializerClause, JsLanguage,
-    JsMethodClassMember, JsMethodObjectMember, JsPropertyClassMember, JsPropertyObjectMember,
-    JsSyntaxToken, JsVariableDeclarator,
+    AnyJsBinding, AnyJsExpression, AnyJsFormalParameter, AnyJsParameter, JsArrowFunctionExpression,
+    JsAssignmentExpression, JsCallArgumentList, JsCallArguments, JsCallExpression,
+    JsClassDeclaration, JsClassExportDefaultDeclaration, JsExportDefaultExpressionClause,
+    JsExtendsClause, JsFunctionDeclaration, JsFunctionExportDefaultDeclaration,
+    JsFunctionExpression, JsInitializerClause, JsLanguage, JsMethodClassMember,
+    JsMethodObjectMember, JsPropertyClassMember, JsPropertyObjectMember, JsSyntaxToken,
+    JsVariableDeclarator,
 };
 use biome_rowan::{
     AstNode, AstSeparatedList, SyntaxNode, SyntaxResult, TextRange, declare_node_union,
@@ -577,16 +577,13 @@ fn is_ref_parameter(parameter: &AnyJsParameter) -> bool {
     let name = match parameter {
         AnyJsParameter::AnyJsFormalParameter(AnyJsFormalParameter::JsFormalParameter(
             parameter,
-        )) => parameter
-            .binding()
-            .ok()
-            .and_then(|binding| {
-                binding
-                    .as_any_js_binding()?
-                    .as_js_identifier_binding()?
-                    .name_token()
-                    .ok()
-            }),
+        )) => parameter.binding().ok().and_then(|binding| {
+            binding
+                .as_any_js_binding()?
+                .as_js_identifier_binding()?
+                .name_token()
+                .ok()
+        }),
         AnyJsParameter::AnyJsFormalParameter(
             AnyJsFormalParameter::JsBogusParameter(_) | AnyJsFormalParameter::JsMetavariable(_),
         )

--- a/crates/biome_js_analyze/src/react/components.rs
+++ b/crates/biome_js_analyze/src/react/components.rs
@@ -1,13 +1,16 @@
 use biome_js_syntax::export_ext::{AnyJsExported, ExportedItem};
 use biome_js_syntax::{
-    AnyJsBinding, AnyJsExpression, JsArrowFunctionExpression, JsAssignmentExpression,
-    JsCallArgumentList, JsCallArguments, JsCallExpression, JsClassDeclaration,
-    JsClassExportDefaultDeclaration, JsExportDefaultExpressionClause, JsExtendsClause,
-    JsFunctionDeclaration, JsFunctionExportDefaultDeclaration, JsFunctionExpression,
-    JsInitializerClause, JsLanguage, JsMethodClassMember, JsMethodObjectMember,
-    JsPropertyClassMember, JsPropertyObjectMember, JsSyntaxToken, JsVariableDeclarator,
+    AnyJsBinding, AnyJsExpression, AnyJsFormalParameter, AnyJsParameter,
+    JsArrowFunctionExpression, JsAssignmentExpression, JsCallArgumentList, JsCallArguments,
+    JsCallExpression, JsClassDeclaration, JsClassExportDefaultDeclaration,
+    JsExportDefaultExpressionClause, JsExtendsClause, JsFunctionDeclaration,
+    JsFunctionExportDefaultDeclaration, JsFunctionExpression, JsInitializerClause, JsLanguage,
+    JsMethodClassMember, JsMethodObjectMember, JsPropertyClassMember, JsPropertyObjectMember,
+    JsSyntaxToken, JsVariableDeclarator,
 };
-use biome_rowan::{AstNode, AstSeparatedList, SyntaxNode, TextRange, declare_node_union};
+use biome_rowan::{
+    AstNode, AstSeparatedList, SyntaxNode, SyntaxResult, TextRange, declare_node_union,
+};
 
 // This module provides utilities for analyzing React components in JavaScript/JSX code.
 // It is mainly useful for identifying React components, their names,
@@ -47,10 +50,6 @@ use biome_rowan::{AstNode, AstSeparatedList, SyntaxNode, TextRange, declare_node
 // class MyComponent extends PureComponent { ... } // class component extending a pure component imported from React-like library
 // ```
 
-/// React Function components may have no more than one parameter (props).
-/// Parameter count in case of wrapped components (in memo or forwardRef) is not checked.
-const REACT_COMPONENT_PARAMS_LIMIT: usize = 1;
-
 /// Represents information about a React component.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ReactComponentInfo {
@@ -84,7 +83,7 @@ impl ReactComponentInfo {
     ) -> Option<Self> {
         let name = function_declaration.name()?;
 
-        if function_declaration.param_count()? > REACT_COMPONENT_PARAMS_LIMIT {
+        if !function_declaration.has_valid_react_component_params()? {
             return None;
         }
 
@@ -250,7 +249,7 @@ impl ReactComponentInfo {
         // check if it's a function expression.
         if wrappers.is_empty() {
             let function_expression = function_expression?;
-            if function_expression.param_count()? > REACT_COMPONENT_PARAMS_LIMIT {
+            if !function_expression.has_valid_react_component_params()? {
                 return None;
             }
             name_hint = function_expression.name();
@@ -433,13 +432,14 @@ impl AnyJsFunctionExpression {
         }
     }
 
-    fn param_count(&self) -> Option<usize> {
-        match self {
-            Self::JsFunctionExpression(expr) => Some(expr.parameters().ok()?.items().len()),
+    fn has_valid_react_component_params(&self) -> Option<bool> {
+        let parameters = match self {
+            Self::JsFunctionExpression(expr) => expr.parameters().ok()?.items(),
             Self::JsArrowFunctionExpression(expr) => {
-                Some(expr.parameters().ok()?.as_js_parameters()?.items().len())
+                expr.parameters().ok()?.as_js_parameters()?.items()
             }
-        }
+        };
+        has_valid_react_component_params(parameters.into_iter())
     }
 
     fn as_any_js_expression(&self) -> AnyJsExpression {
@@ -487,14 +487,14 @@ impl AnyJsFunctionOrMethodDeclaration {
         }
     }
 
-    fn param_count(&self) -> Option<usize> {
+    fn has_valid_react_component_params(&self) -> Option<bool> {
         let parameters = match self {
             Self::JsFunctionExportDefaultDeclaration(decl) => decl.parameters(),
             Self::JsFunctionDeclaration(decl) => decl.parameters(),
             Self::JsMethodClassMember(method) => method.parameters(),
             Self::JsMethodObjectMember(method) => method.parameters(),
         };
-        parameters.ok().map(|params| params.items().len())
+        has_valid_react_component_params(parameters.ok()?.items().into_iter())
     }
 
     fn start_range(&self) -> TextRange {
@@ -550,6 +550,54 @@ impl AnyJsProperty {
             Self::JsPropertyClassMember(property) => property.value()?.expression().ok(),
         }
     }
+}
+
+/// React function components may have zero or one parameter (`props`).
+/// They may also have a second `ref`-like parameter for named components
+/// passed to `forwardRef()`, for example `forwardRef(MyComponent)`.
+fn has_valid_react_component_params(
+    parameters: impl Iterator<Item = SyntaxResult<AnyJsParameter>>,
+) -> Option<bool> {
+    let mut parameters = parameters;
+    let first = parameters.next().transpose()?;
+    let second = parameters.next().transpose()?;
+
+    if parameters.next().is_some() {
+        return Some(false);
+    }
+
+    Some(match (first, second) {
+        (None, None) | (Some(_), None) => true,
+        (Some(_), Some(second)) => is_ref_parameter(&second),
+        (None, Some(_)) => false,
+    })
+}
+
+fn is_ref_parameter(parameter: &AnyJsParameter) -> bool {
+    let name = match parameter {
+        AnyJsParameter::AnyJsFormalParameter(AnyJsFormalParameter::JsFormalParameter(
+            parameter,
+        )) => parameter
+            .binding()
+            .ok()
+            .and_then(|binding| {
+                binding
+                    .as_any_js_binding()?
+                    .as_js_identifier_binding()?
+                    .name_token()
+                    .ok()
+            }),
+        AnyJsParameter::AnyJsFormalParameter(
+            AnyJsFormalParameter::JsBogusParameter(_) | AnyJsFormalParameter::JsMetavariable(_),
+        )
+        | AnyJsParameter::JsRestParameter(_)
+        | AnyJsParameter::TsThisParameter(_) => None,
+    };
+
+    name.is_some_and(|name| {
+        let name = name.text_trimmed();
+        name == "ref" || name.ends_with("Ref") || name.ends_with("ref")
+    })
 }
 
 /// Checks whether the given function name belongs to a React component, based

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js
@@ -190,3 +190,7 @@ function useRecursiveHookA() {
 function useRecursiveHookB() {
     useRecursiveHookA();
 }
+
+function NotForwardRefComponent(props, value) {
+    useState();
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js.snap
@@ -197,6 +197,10 @@ function useRecursiveHookB() {
     useRecursiveHookA();
 }
 
+function NotForwardRefComponent(props, value) {
+    useState();
+}
+
 ```
 
 _Note: The parser emitted 3 diagnostics which are not shown here._
@@ -914,5 +918,23 @@ invalid.js:191:5 lint/correctness/useHookAtTopLevel ━━━━━━━━━�
   
   i See https://react.dev/reference/rules/rules-of-hooks
   
+
+```
+
+```
+invalid.js:195:5 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This hook is being called from within a function or method that is not a hook or component.
+
+    193 │
+    194 │ function NotForwardRefComponent(props, value) {
+  > 195 │     useState();
+        │     ^^^^^^^^
+    196 │ }
+
+  i Move the hook call into the top level of a hook or component in order to use it.
+
+  i See https://react.dev/reference/rules/rules-of-hooks
+
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
@@ -139,3 +139,24 @@ class DemoProperty {
         return useMemo(() => "string", []);
     }
 }
+
+function ForwardRefComponent(props, ref) {
+    const inputRef = useRef(null);
+    useEffect(() => {
+        ref.current = inputRef.current;
+    }, [ref]);
+
+    return <input ref={inputRef} {...props} />;
+}
+
+forwardRef(ForwardRefComponent);
+
+function ForwardedInput(props, forwardedRef) {
+    useImperativeHandle(forwardedRef, () => ({
+        focus() {},
+    }));
+
+    return <input {...props} />;
+}
+
+forwardRef(ForwardedInput);

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
@@ -146,6 +146,27 @@ class DemoProperty {
     }
 }
 
+function ForwardRefComponent(props, ref) {
+    const inputRef = useRef(null);
+    useEffect(() => {
+        ref.current = inputRef.current;
+    }, [ref]);
+
+    return <input ref={inputRef} {...props} />;
+}
+
+forwardRef(ForwardRefComponent);
+
+function ForwardedInput(props, forwardedRef) {
+    useImperativeHandle(forwardedRef, () => ({
+        focus() {},
+    }));
+
+    return <input {...props} />;
+}
+
+forwardRef(ForwardedInput);
+
 ```
 
 _Note: The parser emitted 6 diagnostics which are not shown here._


### PR DESCRIPTION
## Summary

Fixes #9195.

Updates React component detection so named function declarations with a second ref-like parameter are accepted as function components, covering `forwardRef(MyComponent)`. Functions with a non-ref second parameter are still rejected as components, so hooks inside those functions continue to report as not being inside a component.

Added a patch changeset for the user-facing lint fix.

AI assistance notice: I used OpenAI Codex to help implement this PR.

## Test Plan

- Added and updated `useHookAtTopLevel` valid/invalid fixtures and snapshots.
- `git diff --check`
- `cargo fmt --check` was attempted, but local Rustup reports `Missing manifest in toolchain 'stable-x86_64-pc-windows-msvc'`.
- `cargo test -p biome_js_analyze use_hook_at_top_level --no-fail-fast` was attempted, but is blocked by the same local Rust toolchain issue.

## Docs

No docs changes. This fixes existing rule behavior and includes a changeset.
