### PR TITLE
fix: include plugin path in read errors

### DIFF
--- a/.changeset/fix-plugin-read-error-path.md
+++ b/.changeset/fix-plugin-read-error-path.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Improved plugin loading diagnostics reported in [#10846](https://github.com/biomejs/biome/issues/10846): Biome now includes the plugin file path when a `.grit` plugin file cannot be read.
+Fixed [#10846](https://github.com/biomejs/biome/issues/10846): Biome now includes the plugin file path when a `.grit` plugin file cannot be read.

--- a/.changeset/fix-plugin-read-error-path.md
+++ b/.changeset/fix-plugin-read-error-path.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved plugin loading diagnostics reported in [#10846](https://github.com/biomejs/biome/issues/10846): Biome now includes the plugin file path when a `.grit` plugin file cannot be read.

--- a/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
@@ -40,7 +40,7 @@ impl AnalyzerGritPlugin {
     ) -> Result<Self, PluginDiagnostic> {
         let source = fs
             .read_file_from_path(path)
-            .map_err(|source| PluginDiagnostic::cant_read_file(path.to_path_buf(), source))?;
+            .map_err(|error| PluginDiagnostic::cant_read_file(path.to_path_buf(), error))?;
         let options = CompilePatternOptions::default()
             .with_extra_built_ins(vec![
                 BuiltInFunction::new(

--- a/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
@@ -38,7 +38,9 @@ impl AnalyzerGritPlugin {
         path: &Utf8Path,
         includes: Option<&[NormalizedGlob]>,
     ) -> Result<Self, PluginDiagnostic> {
-        let source = fs.read_file_from_path(path)?;
+        let source = fs
+            .read_file_from_path(path)
+            .map_err(|source| PluginDiagnostic::cant_read_file(path.to_path_buf(), source))?;
         let options = CompilePatternOptions::default()
             .with_extra_built_ins(vec![
                 BuiltInFunction::new(

--- a/crates/biome_plugin_loader/src/diagnostics.rs
+++ b/crates/biome_plugin_loader/src/diagnostics.rs
@@ -113,13 +113,8 @@ impl PluginDiagnostic {
 
     pub fn cant_read_file(path: Utf8PathBuf, source: FileSystemDiagnostic) -> Self {
         Self::CantReadFile(CantReadFile {
-            message: MessageAndDescription::from(
-                markup! {
-                    "Cannot read plugin file "
-                    <Emphasis>{path.to_string()}</Emphasis>
-                }
-                .to_owned(),
-            ),
+            message: MessageAndDescription::from(markup! {"Cannot read plugin file"}.to_owned()),
+            path: path.to_string(),
             source: Some(Error::from(source)),
         })
     }
@@ -220,6 +215,9 @@ pub struct CantReadFile {
     #[message]
     #[description]
     message: MessageAndDescription,
+
+    #[location(resource)]
+    path: String,
 
     #[serde(skip)]
     #[source]

--- a/crates/biome_plugin_loader/src/diagnostics.rs
+++ b/crates/biome_plugin_loader/src/diagnostics.rs
@@ -30,6 +30,9 @@ pub enum PluginDiagnostic {
     /// Error loading the plugin from the file system.
     FileSystem(FileSystemDiagnostic),
 
+    /// Error reading a plugin file from the file system.
+    CantReadFile(CantReadFile),
+
     /// When something is wrong with the manifest.
     InvalidManifest(InvalidManifest),
 
@@ -105,6 +108,19 @@ impl PluginDiagnostic {
     pub fn unsupported_rule_format(message: impl Display) -> Self {
         Self::UnsupportedRuleFormat(UnsupportedRuleFormat {
             message: MessageAndDescription::from(markup! {{message}}.to_owned()),
+        })
+    }
+
+    pub fn cant_read_file(path: Utf8PathBuf, source: FileSystemDiagnostic) -> Self {
+        Self::CantReadFile(CantReadFile {
+            message: MessageAndDescription::from(
+                markup! {
+                    "Cannot read plugin file "
+                    <Emphasis>{path.to_string()}</Emphasis>
+                }
+                .to_owned(),
+            ),
+            source: Some(Error::from(source)),
         })
     }
 
@@ -193,6 +209,21 @@ pub struct UnsupportedRuleFormat {
     #[message]
     #[description]
     pub message: MessageAndDescription,
+}
+
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+#[diagnostic(
+    category = "plugin",
+    severity = Error,
+)]
+pub struct CantReadFile {
+    #[message]
+    #[description]
+    pub message: MessageAndDescription,
+
+    #[serde(skip)]
+    #[source]
+    source: Option<Error>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]

--- a/crates/biome_plugin_loader/src/diagnostics.rs
+++ b/crates/biome_plugin_loader/src/diagnostics.rs
@@ -7,7 +7,7 @@ use biome_console::fmt::Display;
 use biome_console::markup;
 use biome_deserialize::DeserializationDiagnostic;
 use biome_diagnostics::{Diagnostic, Error, MessageAndDescription};
-use biome_fs::FileSystemDiagnostic;
+use biome_fs::{FileSystemDiagnostic, FsErrorKind};
 use biome_grit_patterns::CompileError;
 use biome_resolver::{ResolveError, ResolveErrorDiagnostic};
 use biome_rowan::SyntaxError;
@@ -112,10 +112,13 @@ impl PluginDiagnostic {
     }
 
     pub fn cant_read_file(path: Utf8PathBuf, source: FileSystemDiagnostic) -> Self {
+        let FileSystemDiagnostic {
+            error_kind, source, ..
+        } = source;
         Self::CantReadFile(CantReadFile {
-            message: MessageAndDescription::from(markup! {"Cannot read plugin file"}.to_owned()),
+            error_kind,
             path: path.to_string(),
-            source: Some(Error::from(source)),
+            source,
         })
     }
 
@@ -214,7 +217,7 @@ pub struct UnsupportedRuleFormat {
 pub struct CantReadFile {
     #[message]
     #[description]
-    message: MessageAndDescription,
+    error_kind: FsErrorKind,
 
     #[location(resource)]
     path: String,

--- a/crates/biome_plugin_loader/src/diagnostics.rs
+++ b/crates/biome_plugin_loader/src/diagnostics.rs
@@ -219,7 +219,7 @@ pub struct UnsupportedRuleFormat {
 pub struct CantReadFile {
     #[message]
     #[description]
-    pub message: MessageAndDescription,
+    message: MessageAndDescription,
 
     #[serde(skip)]
     #[source]

--- a/crates/biome_plugin_loader/src/lib.rs
+++ b/crates/biome_plugin_loader/src/lib.rs
@@ -150,6 +150,8 @@ mod test {
 
         // Normalize Windows paths...
         let content = content.replace('\\', "/");
+        #[cfg(windows)]
+        let content = content.replace("//", "/");
 
         insta::with_settings!({
             prepend_module_to_snapshot => false,

--- a/crates/biome_plugin_loader/src/lib.rs
+++ b/crates/biome_plugin_loader/src/lib.rs
@@ -148,10 +148,8 @@ mod test {
     fn snap_diagnostic(test_name: &str, diagnostic: Error) {
         let content = print_diagnostic_to_string(&diagnostic);
 
-        // Normalize Windows paths...
-        let content = content.replace('\\', "/");
-        #[cfg(windows)]
-        let content = content.replace("//", "/");
+        // Normalize Windows paths, including separators escaped by Debug output.
+        let content = content.replace("\\\\", "/").replace('\\', "/");
 
         insta::with_settings!({
             prepend_module_to_snapshot => false,

--- a/crates/biome_plugin_loader/src/lib.rs
+++ b/crates/biome_plugin_loader/src/lib.rs
@@ -189,6 +189,31 @@ mod test {
     }
 
     #[test]
+    fn load_missing_single_rule_plugin() {
+        let fs = Arc::new(MemoryFileSystem::default()) as Arc<dyn FsWithResolverProxy>;
+        let error = BiomePlugin::load(fs, "./missing.grit", Utf8Path::new("/"), None)
+            .expect_err("Plugin loading should've failed");
+        snap_diagnostic("load_missing_single_rule_plugin", error.into());
+    }
+
+    #[test]
+    fn load_plugin_with_missing_rule_file() {
+        let fs = MemoryFileSystem::default();
+        fs.insert(
+            "/my-plugin/biome-manifest.jsonc".into(),
+            r#"{
+    "version": 1,
+    "rules": ["rules/missing.grit"]
+}"#,
+        );
+
+        let fs = Arc::new(fs) as Arc<dyn FsWithResolverProxy>;
+        let error = BiomePlugin::load(fs, "./my-plugin", Utf8Path::new("/"), None)
+            .expect_err("Plugin loading should've failed");
+        snap_diagnostic("load_plugin_with_missing_rule_file", error.into());
+    }
+
+    #[test]
     fn load_plugin_with_wrong_version() {
         let fs = MemoryFileSystem::default();
         fs.insert(

--- a/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
@@ -2,9 +2,9 @@
 source: crates/biome_plugin_loader/src/lib.rs
 expression: content
 ---
-plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+/missing.grit plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Cannot read plugin file /missing.grit
+  × Cannot read plugin file
     
     Caused by:
       Cannot read file.

--- a/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
@@ -4,10 +4,7 @@ expression: content
 ---
 /missing.grit plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Cannot read plugin file
-    
-    Caused by:
-      Cannot read file.
+  × Cannot read file.
     
     Caused by:
       path "/missing.grit" does not exists in memory filesystem

--- a/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
@@ -5,6 +5,9 @@ expression: content
 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Cannot read plugin file /missing.grit
-
+    
     Caused by:
       Cannot read file.
+    
+    Caused by:
+      path "/missing.grit" does not exists in memory filesystem

--- a/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_plugin_loader/src/lib.rs
+expression: content
+---
+plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Cannot read plugin file /missing.grit
+
+    Caused by:
+      Cannot read file.

--- a/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
@@ -4,10 +4,7 @@ expression: content
 ---
 /my-plugin/rules/missing.grit plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Cannot read plugin file
-    
-    Caused by:
-      Cannot read file.
+  × Cannot read file.
     
     Caused by:
       path "/my-plugin/rules/missing.grit" does not exists in memory filesystem

--- a/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_plugin_loader/src/lib.rs
+expression: content
+---
+plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Cannot read plugin file /my-plugin/rules/missing.grit
+
+    Caused by:
+      Cannot read file.

--- a/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
@@ -5,6 +5,9 @@ expression: content
 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Cannot read plugin file /my-plugin/rules/missing.grit
-
+    
     Caused by:
       Cannot read file.
+    
+    Caused by:
+      path "/my-plugin/rules/missing.grit" does not exists in memory filesystem

--- a/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
@@ -2,9 +2,9 @@
 source: crates/biome_plugin_loader/src/lib.rs
 expression: content
 ---
-plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+/my-plugin/rules/missing.grit plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Cannot read plugin file /my-plugin/rules/missing.grit
+  × Cannot read plugin file
     
     Caused by:
       Cannot read file.


### PR DESCRIPTION
AI assistance notice: this PR was prepared with Codex assistance.

## Summary

Fixes #10846.

This adds the plugin file path to diagnostics produced when Biome cannot read a .grit plugin file, so configurations with multiple plugins identify which plugin path failed. It covers missing direct .grit plugins and missing manifest rule files with snapshot tests.

## Test Plan

- git diff --check HEAD~1..HEAD
- Local Rust tests could not run because the workspace-local rustup toolchain fails while downloading components (ust-std-wasm32-unknown-unknown rename error).

## Docs

No documentation changes are needed; this only improves an existing plugin loading diagnostic.