### PR TITLE
docs(noMissingVarFunction): list container-name in ignored properties

### DIFF
--- a/crates/biome_css_analyze/src/lint/correctness/no_missing_var_function.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_missing_var_function.rs
@@ -16,6 +16,7 @@ declare_lint_rule! {
     /// - It ignores the following properties:
     ///   - `animation`
     ///   - `animation-name`
+    ///   - `container-name`
     ///   - `counter-increment`
     ///   - `counter-reset`
     ///   - `counter-set`


### PR DESCRIPTION
The `noMissingVarFunction` rule ignores `container-name` (it's in `IGNORED_PROPERTIES`), but the rule's documentation leaves it out of the "It ignores the following properties" list. This adds the missing entry so the docs match the rule.