### PR TITLE
fix: astro shorthand syntax embedded nodes

### DIFF
--- a/.changeset/nasty-spies-begin.md
+++ b/.changeset/nasty-spies-begin.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10840](https://github.com/biomejs/biome/issues/10840): Astro shorthand attribute syntax is now correctly being parsed from embedded nodes.

--- a/crates/biome_html_analyze/tests/specs/a11y/noAccessKey/astro/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAccessKey/astro/invalid.astro
@@ -3,3 +3,4 @@
 <a href="https://webaim.org/" accesskey="w">WebAIM.org</a>
 <button accesskey="n">Next</button>
 <button accesskey={accesskeyValue}>Next</button>
+<button {accesskey}>Next</button>

--- a/crates/biome_html_analyze/tests/specs/a11y/noAccessKey/astro/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAccessKey/astro/invalid.astro.snap
@@ -9,6 +9,7 @@ expression: invalid.astro
 <a href="https://webaim.org/" accesskey="w">WebAIM.org</a>
 <button accesskey="n">Next</button>
 <button accesskey={accesskeyValue}>Next</button>
+<button {accesskey}>Next</button>
 
 ```
 
@@ -64,7 +65,7 @@ invalid.astro:4:9 lint/a11y/noAccessKey  FIXABLE  ━━━━━━━━━━
   > 4 │ <button accesskey="n">Next</button>
       │         ^^^^^^^^^^^^^
     5 │ <button accesskey={accesskeyValue}>Next</button>
-    6 │ 
+    6 │ <button {accesskey}>Next</button>
   
   i Assigning keyboard shortcuts using the accesskey attribute leads to inconsistent keyboard actions across applications.
   
@@ -84,7 +85,8 @@ invalid.astro:5:9 lint/a11y/noAccessKey  FIXABLE  ━━━━━━━━━━
     4 │ <button accesskey="n">Next</button>
   > 5 │ <button accesskey={accesskeyValue}>Next</button>
       │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    6 │ 
+    6 │ <button {accesskey}>Next</button>
+    7 │ 
   
   i Assigning keyboard shortcuts using the accesskey attribute leads to inconsistent keyboard actions across applications.
   
@@ -92,5 +94,25 @@ invalid.astro:5:9 lint/a11y/noAccessKey  FIXABLE  ━━━━━━━━━━
   
     5 │ <button·accesskey={accesskeyValue}>Next</button>
       │         --------------------------              
+
+```
+
+```
+invalid.astro:6:9 lint/a11y/noAccessKey  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Avoid the accesskey attribute to reduce inconsistencies between keyboard shortcuts and screen reader keyboard commands.
+  
+    4 │ <button accesskey="n">Next</button>
+    5 │ <button accesskey={accesskeyValue}>Next</button>
+  > 6 │ <button {accesskey}>Next</button>
+      │         ^^^^^^^^^^^
+    7 │ 
+  
+  i Assigning keyboard shortcuts using the accesskey attribute leads to inconsistent keyboard actions across applications.
+  
+  i Unsafe fix: Remove the accesskey attribute.
+  
+    6 │ <button·{accesskey}>Next</button>
+      │         -----------              
 
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/noAutofocus/astro/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAutofocus/astro/invalid.astro
@@ -2,6 +2,7 @@
 <input autofocus />
 <input autofocus="true" />
 <input autofocus={autofocusValue} />
+<input {autofocus} />
 <textarea autofocus>content</textarea>
 <button autofocus>Submit</button>
 <select autofocus><option>a</option></select>

--- a/crates/biome_html_analyze/tests/specs/a11y/noAutofocus/astro/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAutofocus/astro/invalid.astro.snap
@@ -8,6 +8,7 @@ expression: invalid.astro
 <input autofocus />
 <input autofocus="true" />
 <input autofocus={autofocusValue} />
+<input {autofocus} />
 <textarea autofocus>content</textarea>
 <button autofocus>Submit</button>
 <select autofocus><option>a</option></select>
@@ -49,7 +50,7 @@ invalid.astro:3:8 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━
   > 3 │ <input autofocus="true" />
       │        ^^^^^^^^^^^^^^^^
     4 │ <input autofocus={autofocusValue} />
-    5 │ <textarea autofocus>content</textarea>
+    5 │ <input {autofocus} />
   
   i Autofocusing elements can disrupt navigation and confuse screen reader and keyboard users.
   
@@ -69,8 +70,8 @@ invalid.astro:4:8 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━
     3 │ <input autofocus="true" />
   > 4 │ <input autofocus={autofocusValue} />
       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    5 │ <textarea autofocus>content</textarea>
-    6 │ <button autofocus>Submit</button>
+    5 │ <input {autofocus} />
+    6 │ <textarea autofocus>content</textarea>
   
   i Autofocusing elements can disrupt navigation and confuse screen reader and keyboard users.
   
@@ -82,44 +83,44 @@ invalid.astro:4:8 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━
 ```
 
 ```
-invalid.astro:5:11 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.astro:5:8 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This element uses the autofocus attribute outside an allowed modal context.
   
     3 │ <input autofocus="true" />
     4 │ <input autofocus={autofocusValue} />
-  > 5 │ <textarea autofocus>content</textarea>
-      │           ^^^^^^^^^
-    6 │ <button autofocus>Submit</button>
-    7 │ <select autofocus><option>a</option></select>
+  > 5 │ <input {autofocus} />
+      │        ^^^^^^^^^^^
+    6 │ <textarea autofocus>content</textarea>
+    7 │ <button autofocus>Submit</button>
   
   i Autofocusing elements can disrupt navigation and confuse screen reader and keyboard users.
   
   i Unsafe fix: Remove the autofocus attribute.
   
-    5 │ <textarea·autofocus>content</textarea>
-      │           ---------                   
+    5 │ <input·{autofocus}·/>
+      │        ------------  
 
 ```
 
 ```
-invalid.astro:6:9 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.astro:6:11 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This element uses the autofocus attribute outside an allowed modal context.
   
     4 │ <input autofocus={autofocusValue} />
-    5 │ <textarea autofocus>content</textarea>
-  > 6 │ <button autofocus>Submit</button>
-      │         ^^^^^^^^^
-    7 │ <select autofocus><option>a</option></select>
-    8 │ 
+    5 │ <input {autofocus} />
+  > 6 │ <textarea autofocus>content</textarea>
+      │           ^^^^^^^^^
+    7 │ <button autofocus>Submit</button>
+    8 │ <select autofocus><option>a</option></select>
   
   i Autofocusing elements can disrupt navigation and confuse screen reader and keyboard users.
   
   i Unsafe fix: Remove the autofocus attribute.
   
-    6 │ <button·autofocus>Submit</button>
-      │         ---------                
+    6 │ <textarea·autofocus>content</textarea>
+      │           ---------                   
 
 ```
 
@@ -128,58 +129,79 @@ invalid.astro:7:9 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━
 
   × This element uses the autofocus attribute outside an allowed modal context.
   
-    5 │ <textarea autofocus>content</textarea>
-    6 │ <button autofocus>Submit</button>
-  > 7 │ <select autofocus><option>a</option></select>
+    5 │ <input {autofocus} />
+    6 │ <textarea autofocus>content</textarea>
+  > 7 │ <button autofocus>Submit</button>
       │         ^^^^^^^^^
-    8 │ 
-    9 │ <!-- autofocus on dialog/popover container itself is invalid -->
+    8 │ <select autofocus><option>a</option></select>
+    9 │ 
   
   i Autofocusing elements can disrupt navigation and confuse screen reader and keyboard users.
   
   i Unsafe fix: Remove the autofocus attribute.
   
-    7 │ <select·autofocus><option>a</option></select>
+    7 │ <button·autofocus>Submit</button>
+      │         ---------                
+
+```
+
+```
+invalid.astro:8:9 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This element uses the autofocus attribute outside an allowed modal context.
+  
+     6 │ <textarea autofocus>content</textarea>
+     7 │ <button autofocus>Submit</button>
+   > 8 │ <select autofocus><option>a</option></select>
+       │         ^^^^^^^^^
+     9 │ 
+    10 │ <!-- autofocus on dialog/popover container itself is invalid -->
+  
+  i Autofocusing elements can disrupt navigation and confuse screen reader and keyboard users.
+  
+  i Unsafe fix: Remove the autofocus attribute.
+  
+    8 │ <select·autofocus><option>a</option></select>
       │         ---------                            
 
 ```
 
 ```
-invalid.astro:10:9 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.astro:11:9 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This element uses the autofocus attribute outside an allowed modal context.
   
-     9 │ <!-- autofocus on dialog/popover container itself is invalid -->
-  > 10 │ <dialog autofocus>content</dialog>
+    10 │ <!-- autofocus on dialog/popover container itself is invalid -->
+  > 11 │ <dialog autofocus>content</dialog>
        │         ^^^^^^^^^
-    11 │ <div popover autofocus>content</div>
-    12 │ 
+    12 │ <div popover autofocus>content</div>
+    13 │ 
   
   i Autofocusing elements can disrupt navigation and confuse screen reader and keyboard users.
   
   i Unsafe fix: Remove the autofocus attribute.
   
-    10 │ <dialog·autofocus>content</dialog>
+    11 │ <dialog·autofocus>content</dialog>
        │         ---------                 
 
 ```
 
 ```
-invalid.astro:11:14 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.astro:12:14 lint/a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This element uses the autofocus attribute outside an allowed modal context.
   
-     9 │ <!-- autofocus on dialog/popover container itself is invalid -->
-    10 │ <dialog autofocus>content</dialog>
-  > 11 │ <div popover autofocus>content</div>
+    10 │ <!-- autofocus on dialog/popover container itself is invalid -->
+    11 │ <dialog autofocus>content</dialog>
+  > 12 │ <div popover autofocus>content</div>
        │              ^^^^^^^^^
-    12 │ 
+    13 │ 
   
   i Autofocusing elements can disrupt navigation and confuse screen reader and keyboard users.
   
   i Unsafe fix: Remove the autofocus attribute.
   
-    11 │ <div·popover·autofocus>content</div>
+    12 │ <div·popover·autofocus>content</div>
        │              ---------              
 
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/noRedundantAlt/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noRedundantAlt/astro/valid.astro
@@ -1,6 +1,7 @@
 <!-- should not generate diagnostics -->
 <img alt="foo" />
 <img alt={altValue} />
+<img {alt} />
 <img alt="picture of me taking a photo of an image" aria-hidden />
 <img aria-hidden alt="photo of image" />
 <img aria-hidden="true" alt="photo of image" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noRedundantAlt/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noRedundantAlt/astro/valid.astro.snap
@@ -7,6 +7,7 @@ expression: valid.astro
 <!-- should not generate diagnostics -->
 <img alt="foo" />
 <img alt={altValue} />
+<img {alt} />
 <img alt="picture of me taking a photo of an image" aria-hidden />
 <img aria-hidden alt="photo of image" />
 <img aria-hidden="true" alt="photo of image" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useAltText/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAltText/astro/valid.astro
@@ -4,6 +4,7 @@
 <img src="image.png" alt="A beautiful landscape" />
 <img src="photo.jpg" alt="Profile picture" />
 <img src="photo.jpg" alt={altValue} />
+<img src="photo.jpg" {alt} />
 
 <!-- img with empty alt (decorative) -->
 <img src="decorative.png" alt="" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useAltText/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAltText/astro/valid.astro.snap
@@ -10,6 +10,7 @@ expression: valid.astro
 <img src="image.png" alt="A beautiful landscape" />
 <img src="photo.jpg" alt="Profile picture" />
 <img src="photo.jpg" alt={altValue} />
+<img src="photo.jpg" {alt} />
 
 <!-- img with empty alt (decorative) -->
 <img src="decorative.png" alt="" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useButtonType/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useButtonType/astro/valid.astro
@@ -6,5 +6,6 @@
 <button type="submit"></button>
 <button type="reset"></button>
 <button type={typeValue}></button>
+<button {type}></button>
 <BUTTON type="button">Do something</BUTTON>
 <Button type="reset" />

--- a/crates/biome_html_analyze/tests/specs/a11y/useButtonType/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useButtonType/astro/valid.astro.snap
@@ -12,6 +12,7 @@ expression: valid.astro
 <button type="submit"></button>
 <button type="reset"></button>
 <button type={typeValue}></button>
+<button {type}></button>
 <BUTTON type="button">Do something</BUTTON>
 <Button type="reset" />
 

--- a/crates/biome_html_analyze/tests/specs/a11y/useHtmlLang/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHtmlLang/astro/valid.astro
@@ -1,3 +1,4 @@
 <!-- should not generate diagnostics -->
 <html lang="en"></html>
 <html lang={langValue}></html>
+<html {lang}></html>

--- a/crates/biome_html_analyze/tests/specs/a11y/useHtmlLang/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHtmlLang/astro/valid.astro.snap
@@ -7,5 +7,6 @@ expression: valid.astro
 <!-- should not generate diagnostics -->
 <html lang="en"></html>
 <html lang={langValue}></html>
+<html {lang}></html>
 
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidLang/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidLang/astro/valid.astro
@@ -6,3 +6,4 @@
 <html lang="zh-Hant"></html>
 <html lang="zh-Hans-CN"></html>
 <html lang={langValue}></html>
+<html {lang}></html>

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidLang/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidLang/astro/valid.astro.snap
@@ -12,5 +12,6 @@ expression: valid.astro
 <html lang="zh-Hant"></html>
 <html lang="zh-Hans-CN"></html>
 <html lang={langValue}></html>
+<html {lang}></html>
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid_issue_10840.astro
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid_issue_10840.astro
@@ -1,0 +1,8 @@
+<!-- should not generate diagnostics -->
+---
+import MyComponent from "./my-component.astro";
+
+const text = "abc";
+---
+
+<MyComponent {text} />

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid_issue_10840.astro.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid_issue_10840.astro.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid_issue_10840.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+---
+import MyComponent from "./my-component.astro";
+
+const text = "abc";
+---
+
+<MyComponent {text} />
+
+```

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
@@ -130,6 +130,17 @@ pub(crate) fn parse_embedded_nodes(params: ParseEmbeddedParams) -> ParseEmbedRes
                     ctx.parse_and_push(&candidate, &doc_file_source, None, &mut nodes);
                 }
 
+                // Shorthand attributes: <MyComponent {text} /> (Astro shorthand syntax)
+                if let Some(attr) = HtmlAttributeSingleTextExpression::cast_ref(&element)
+                    && !attr.syntax().parent().is_some_and(|parent| {
+                        HtmlAttributeInitializerClause::can_cast(parent.kind())
+                    })
+                    && let Ok(expression) = attr.expression()
+                    && let Some(candidate) = build_text_expression_candidate(&expression)
+                {
+                    ctx.parse_and_push(&candidate, &doc_file_source, None, &mut nodes);
+                }
+
                 // Spread attributes: <input {...props}>
                 if let Some(spread) = HtmlSpreadAttribute::cast_ref(&element)
                     && let Ok(expression) = spread.argument()
@@ -339,6 +350,7 @@ pub(crate) fn parse_embedded_nodes(params: ParseEmbeddedParams) -> ParseEmbedRes
                     );
                 }
 
+                // Shorthand attributes: <MyComponent {text} /> (Svelte shorthand syntax)
                 if let Some(attr) = HtmlAttributeSingleTextExpression::cast_ref(&element)
                     && !attr.syntax().parent().is_some_and(|parent| {
                         HtmlAttributeInitializerClause::can_cast(parent.kind())


### PR DESCRIPTION
## Summary

Support Astro shorthand syntax from embedded nodes & added some shorthand Astro test cases in some HTML rules

Closes #10840

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
