### PR TITLE
ci: ignore Bot PRs in AgentScan workflow

### DIFF
--- a/.github/workflows/agent_scan.yml
+++ b/.github/workflows/agent_scan.yml
@@ -10,7 +10,8 @@ permissions: { }
 
 jobs:
   agentscan:
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Summary

Bots like Renovate may create PRs in this repository, and it is not needed to scan these PRs using AgentScan.

## Test Plan

YOLO. At least AgentScan should be still working in this PR.