### PR TITLE
fix(workspace): deadlock on salsa setters 

### DIFF
--- a/.changeset/itchy-cities-say.md
+++ b/.changeset/itchy-cities-say.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10845](https://github.com/biomejs/biome/issues/10845). Biome Language Server no longer goes in deadlock when the scanner is enabled.

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -94,11 +94,11 @@ tokio                = { workspace = true, features = ["io-util"] }
 [target.'cfg(all(target_family="unix", not(all(target_arch = "aarch64", target_env = "musl"))))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
-[target.'cfg(unix)'.dependencies]
+[target."cfg(unix)".dependencies]
 libc  = "0.2.184"
 tokio = { workspace = true, features = ["process"] }
 
-[target.'cfg(windows)'.dependencies]
+[target."cfg(windows)".dependencies]
 mimalloc = { workspace = true }
 
 [features]

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -63,33 +63,41 @@ pub(crate) fn code_actions(
     let Some(doc) = session.document(&url) else {
         return Ok(None);
     };
-    if !session.workspace().file_exists(path.clone().into())? {
+    if !session
+        .workspace_for_request()
+        .file_exists(path.clone().into())?
+    {
         return Ok(None);
     }
 
-    if session.workspace().is_path_ignored(PathIsIgnoredParams {
-        path: path.clone(),
-        is_dir: false,
-        project_key: doc.project_key,
-        features,
-        ignore_kind: IgnoreKind::Ancestors,
-    })? {
+    if session
+        .workspace_for_request()
+        .is_path_ignored(PathIsIgnoredParams {
+            path: path.clone(),
+            is_dir: false,
+            project_key: doc.project_key,
+            features,
+            ignore_kind: IgnoreKind::Ancestors,
+        })?
+    {
         return Ok(Some(Vec::new()));
     }
 
     let FileFeaturesResult {
         features_supported: file_features,
-    } = &session.workspace().file_features(SupportsFeatureParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-        features,
-        inline_config: session.inline_config(),
-        skip_ignore_check: false,
-        not_requested_features: FeaturesBuilder::new()
-            .with_search()
-            .with_formatter()
-            .build(),
-    })?;
+    } = &session
+        .workspace_for_request()
+        .file_features(SupportsFeatureParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+            features,
+            inline_config: session.inline_config(),
+            skip_ignore_check: false,
+            not_requested_features: FeaturesBuilder::new()
+                .with_search()
+                .with_formatter()
+                .build(),
+        })?;
 
     if !file_features.supports_lint() && !file_features.supports_assist() {
         info!("Linter and assist are disabled.");
@@ -103,10 +111,13 @@ pub(crate) fn code_actions(
         categories = categories.with_assist();
     }
 
-    let size_limit_result = session.workspace().check_file_size(CheckFileSizeParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-    })?;
+    let size_limit_result =
+        session
+            .workspace_for_request()
+            .check_file_size(CheckFileSizeParams {
+                project_key: doc.project_key,
+                path: path.clone(),
+            })?;
     if size_limit_result.is_too_large() {
         return Ok(None);
     }
@@ -130,10 +141,12 @@ pub(crate) fn code_actions(
     let position_encoding = session.position_encoding();
 
     let diagnostics = params.context.diagnostics;
-    let content = session.workspace().get_file_content(GetFileContentParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-    })?;
+    let content = session
+        .workspace_for_request()
+        .get_file_content(GetFileContentParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+        })?;
     let offset = match path.extension() {
         Some("vue") => VueFileHandler::start(content.as_str()),
         Some("astro") => AstroFileHandler::start(content.as_str()),
@@ -164,23 +177,25 @@ pub(crate) fn code_actions(
     };
     debug!("Cursor range {:?}", &cursor_range);
     let supports_resolve = session.supports_code_action_resolve();
-    let result = match session.workspace().pull_actions(PullActionsParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-        range: Some(cursor_range),
-        // TODO: compute skip and only based on configuration
-        skip: vec![],
-        only: vec![],
-        suppression_reason: None,
-        enabled_rules: filters
-            .iter()
-            .filter_map(|filter| RuleSelector::from_lsp_filter(filter))
-            .map(AnalyzerSelector::from)
-            .collect(),
-        categories: categories.build(),
-        inline_config: session.inline_config(),
-        compute_actions: !supports_resolve,
-    }) {
+    let result = match session
+        .workspace_for_request()
+        .pull_actions(PullActionsParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+            range: Some(cursor_range),
+            // TODO: compute skip and only based on configuration
+            skip: vec![],
+            only: vec![],
+            suppression_reason: None,
+            enabled_rules: filters
+                .iter()
+                .filter_map(|filter| RuleSelector::from_lsp_filter(filter))
+                .map(AnalyzerSelector::from)
+                .collect(),
+            categories: categories.build(),
+            inline_config: session.inline_config(),
+            compute_actions: !supports_resolve,
+        }) {
         Ok(result) => result,
         Err(err) => {
             return if matches!(
@@ -427,21 +442,23 @@ pub(crate) fn code_action_resolve(
     let rule_selector =
         AnalyzerSelector::Rule(resolve_data.rule.context("The rule doesn't exist")?);
 
-    let result = session.workspace().pull_actions(PullActionsParams {
-        project_key: resolve_data.project_key,
-        path: path.clone(),
-        range: Some(resolve_data.range),
-        suppression_reason: None,
-        only: vec![rule_selector],
-        skip: vec![],
-        enabled_rules: vec![],
-        categories: RuleCategoriesBuilder::default()
-            .with_lint()
-            .with_assist()
-            .build(),
-        inline_config: session.inline_config(),
-        compute_actions: true,
-    })?;
+    let result = session
+        .workspace_for_request()
+        .pull_actions(PullActionsParams {
+            project_key: resolve_data.project_key,
+            path: path.clone(),
+            range: Some(resolve_data.range),
+            suppression_reason: None,
+            only: vec![rule_selector],
+            skip: vec![],
+            enabled_rules: vec![],
+            categories: RuleCategoriesBuilder::default()
+                .with_lint()
+                .with_assist()
+                .build(),
+            inline_config: session.inline_config(),
+            compute_actions: true,
+        })?;
 
     // Find the action matching the requested kind
     let target_action = result.actions.into_iter().find(|action| {
@@ -526,50 +543,64 @@ fn fix_all(
     };
     let analyzer_features = FeaturesBuilder::new().with_linter().with_assist().build();
 
-    if !session.workspace().file_exists(path.clone().into())? {
+    if !session
+        .workspace_for_request()
+        .file_exists(path.clone().into())?
+    {
         return Ok(None);
     }
 
-    if session.workspace().is_path_ignored(PathIsIgnoredParams {
-        path: path.clone(),
-        is_dir: false,
-        project_key: doc.project_key,
-        features: analyzer_features,
-        ignore_kind: IgnoreKind::Ancestors,
-    })? {
+    if session
+        .workspace_for_request()
+        .is_path_ignored(PathIsIgnoredParams {
+            path: path.clone(),
+            is_dir: false,
+            project_key: doc.project_key,
+            features: analyzer_features,
+            ignore_kind: IgnoreKind::Ancestors,
+        })?
+    {
         return Ok(None);
     }
 
     let FileFeaturesResult {
         features_supported: file_features,
-    } = session.workspace().file_features(SupportsFeatureParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-        features: FeaturesBuilder::new()
-            .with_formatter()
-            .with_linter()
-            .with_assist()
-            .build(),
-        inline_config: session.inline_config(),
-        skip_ignore_check: false,
-        not_requested_features: FeaturesBuilder::new().with_search().build(),
-    })?;
+    } = session
+        .workspace_for_request()
+        .file_features(SupportsFeatureParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+            features: FeaturesBuilder::new()
+                .with_formatter()
+                .with_linter()
+                .with_assist()
+                .build(),
+            inline_config: session.inline_config(),
+            skip_ignore_check: false,
+            not_requested_features: FeaturesBuilder::new().with_search().build(),
+        })?;
     let should_format = file_features.supports_format();
 
-    if session.workspace().is_path_ignored(PathIsIgnoredParams {
-        path: path.clone(),
-        is_dir: false,
-        project_key: doc.project_key,
-        features: analyzer_features,
-        ignore_kind: IgnoreKind::Ancestors,
-    })? {
+    if session
+        .workspace_for_request()
+        .is_path_ignored(PathIsIgnoredParams {
+            path: path.clone(),
+            is_dir: false,
+            project_key: doc.project_key,
+            features: analyzer_features,
+            ignore_kind: IgnoreKind::Ancestors,
+        })?
+    {
         return Ok(None);
     }
 
-    let size_limit_result = session.workspace().check_file_size(CheckFileSizeParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-    })?;
+    let size_limit_result =
+        session
+            .workspace_for_request()
+            .check_file_size(CheckFileSizeParams {
+                project_key: doc.project_key,
+                path: path.clone(),
+            })?;
     if size_limit_result.is_too_large() {
         return Ok(None);
     }
@@ -590,7 +621,7 @@ fn fix_all(
         )));
     }
 
-    let fixed = session.workspace().fix_file(FixFileParams {
+    let fixed = session.workspace_for_request().fix_file(FixFileParams {
         project_key: doc.project_key,
         path: path.clone(),
         fix_file_mode: FixFileMode::SafeFixes,
@@ -607,10 +638,13 @@ fn fix_all(
     } else {
         match path.as_path().extension() {
             Some(extension) => {
-                let input = session.workspace().get_file_content(GetFileContentParams {
-                    project_key: doc.project_key,
-                    path: path.clone(),
-                })?;
+                let input =
+                    session
+                        .workspace_for_request()
+                        .get_file_content(GetFileContentParams {
+                            project_key: doc.project_key,
+                            path: path.clone(),
+                        })?;
                 match extension {
                     "astro" => AstroFileHandler::output(input.as_str(), fixed.code.as_str()),
                     "vue" => VueFileHandler::output(input.as_str(), fixed.code.as_str()),

--- a/crates/biome_lsp/src/handlers/formatting.rs
+++ b/crates/biome_lsp/src/handlers/formatting.rs
@@ -28,7 +28,10 @@ pub(crate) fn format(
     let Some(doc) = session.document(&url) else {
         return Ok(None);
     };
-    if !session.workspace().file_exists(path.clone().into())? {
+    if !session
+        .workspace_for_request()
+        .file_exists(path.clone().into())?
+    {
         return Ok(None);
     }
 
@@ -36,37 +39,46 @@ pub(crate) fn format(
 
     let FileFeaturesResult {
         features_supported: file_features,
-    } = session.workspace().file_features(SupportsFeatureParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-        features,
-        inline_config: session.inline_config(),
-        skip_ignore_check: false,
-        not_requested_features: FeaturesBuilder::new().with_search().build(),
-    })?;
+    } = session
+        .workspace_for_request()
+        .file_features(SupportsFeatureParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+            features,
+            inline_config: session.inline_config(),
+            skip_ignore_check: false,
+            not_requested_features: FeaturesBuilder::new().with_search().build(),
+        })?;
     if !file_features.supports_format() {
         return notify_user(file_features, path);
     }
 
-    let size_limit_result = session.workspace().check_file_size(CheckFileSizeParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-    })?;
+    let size_limit_result =
+        session
+            .workspace_for_request()
+            .check_file_size(CheckFileSizeParams {
+                project_key: doc.project_key,
+                path: path.clone(),
+            })?;
     if size_limit_result.is_too_large() {
         return Ok(None);
     }
 
-    let printed = session.workspace().format_file(FormatFileParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-        inline_config: session.inline_config(),
-    })?;
+    let printed = session
+        .workspace_for_request()
+        .format_file(FormatFileParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+            inline_config: session.inline_config(),
+        })?;
 
     let mut output = printed.into_code();
-    let input = session.workspace().get_file_content(GetFileContentParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-    })?;
+    let input = session
+        .workspace_for_request()
+        .get_file_content(GetFileContentParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+        })?;
     if output.is_empty() {
         return Ok(None);
     }
@@ -102,29 +114,37 @@ pub(crate) fn format_range(
     let Some(doc) = session.document(&url) else {
         return Err(extension_error(&path).into());
     };
-    if !session.workspace().file_exists(path.clone().into())? {
+    if !session
+        .workspace_for_request()
+        .file_exists(path.clone().into())?
+    {
         return Ok(None);
     }
 
     let features = FeaturesBuilder::new().with_formatter().build();
     let FileFeaturesResult {
         features_supported: file_features,
-    } = session.workspace().file_features(SupportsFeatureParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-        features,
-        inline_config: session.inline_config(),
-        skip_ignore_check: false,
-        not_requested_features: FeaturesBuilder::new().with_search().build(),
-    })?;
+    } = session
+        .workspace_for_request()
+        .file_features(SupportsFeatureParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+            features,
+            inline_config: session.inline_config(),
+            skip_ignore_check: false,
+            not_requested_features: FeaturesBuilder::new().with_search().build(),
+        })?;
     if !file_features.supports_format() {
         return notify_user(file_features, path);
     }
 
-    let size_limit_result = session.workspace().check_file_size(CheckFileSizeParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-    })?;
+    let size_limit_result =
+        session
+            .workspace_for_request()
+            .check_file_size(CheckFileSizeParams {
+                project_key: doc.project_key,
+                path: path.clone(),
+            })?;
     if size_limit_result.is_too_large() {
         return Ok(None);
     }
@@ -138,10 +158,12 @@ pub(crate) fn format_range(
                 url.as_str()
             )
         })?;
-    let content = session.workspace().get_file_content(GetFileContentParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-    })?;
+    let content = session
+        .workspace_for_request()
+        .get_file_content(GetFileContentParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+        })?;
 
     let offset = match path.extension() {
         Some("vue") => VueFileHandler::start(content.as_str()),
@@ -162,12 +184,14 @@ pub(crate) fn format_range(
         format_range
     };
 
-    let formatted = session.workspace().format_range(FormatRangeParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-        range: format_range,
-        inline_config: session.inline_config(),
-    })?;
+    let formatted = session
+        .workspace_for_request()
+        .format_range(FormatRangeParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+            range: format_range,
+            inline_config: session.inline_config(),
+        })?;
 
     let formatted_range = formatted
         .range()
@@ -198,29 +222,37 @@ pub(crate) fn format_on_type(
     let Some(doc) = session.document(&url) else {
         return Err(extension_error(&path).into());
     };
-    if !session.workspace().file_exists(path.clone().into())? {
+    if !session
+        .workspace_for_request()
+        .file_exists(path.clone().into())?
+    {
         return Ok(None);
     }
 
     let features = FeaturesBuilder::new().with_formatter().build();
     let FileFeaturesResult {
         features_supported: file_features,
-    } = session.workspace().file_features(SupportsFeatureParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-        features,
-        inline_config: session.inline_config(),
-        skip_ignore_check: false,
-        not_requested_features: FeaturesBuilder::new().with_search().build(),
-    })?;
+    } = session
+        .workspace_for_request()
+        .file_features(SupportsFeatureParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+            features,
+            inline_config: session.inline_config(),
+            skip_ignore_check: false,
+            not_requested_features: FeaturesBuilder::new().with_search().build(),
+        })?;
     if !file_features.supports_format() {
         return notify_user(file_features, path);
     }
 
-    let size_limit_result = session.workspace().check_file_size(CheckFileSizeParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-    })?;
+    let size_limit_result =
+        session
+            .workspace_for_request()
+            .check_file_size(CheckFileSizeParams {
+                project_key: doc.project_key,
+                path: path.clone(),
+            })?;
     if size_limit_result.is_too_large() {
         return Ok(None);
     }
@@ -234,17 +266,21 @@ pub(crate) fn format_on_type(
             )
         })?;
 
-    let formatted = session.workspace().format_on_type(FormatOnTypeParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-        offset,
-        inline_config: session.inline_config(),
-    })?;
+    let formatted = session
+        .workspace_for_request()
+        .format_on_type(FormatOnTypeParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+            offset,
+            inline_config: session.inline_config(),
+        })?;
 
-    let content = session.workspace().get_file_content(GetFileContentParams {
-        project_key: doc.project_key,
-        path: path.clone(),
-    })?;
+    let content = session
+        .workspace_for_request()
+        .get_file_content(GetFileContentParams {
+            project_key: doc.project_key,
+            path: path.clone(),
+        })?;
 
     let formatted_range = formatted
         .range()

--- a/crates/biome_lsp/src/handlers/navigation.rs
+++ b/crates/biome_lsp/src/handlers/navigation.rs
@@ -113,7 +113,7 @@ fn to_location(
     let target_range = if definition_path == original_path {
         to_proto::range(&doc.line_index, *definition_range, position_encoding)?
     } else {
-        let content = session.workspace().get_file_content(
+        let content = session.workspace_for_request().get_file_content(
             biome_service::workspace::GetFileContentParams {
                 project_key: doc.project_key,
                 path: definition_path.clone(),

--- a/crates/biome_lsp/src/requests/syntax_tree.rs
+++ b/crates/biome_lsp/src/requests/syntax_tree.rs
@@ -23,18 +23,23 @@ pub(crate) fn syntax_tree(session: &Session, url: &Uri) -> Result<Option<String>
     };
     let features = FeaturesBuilder::new().build();
 
-    if session.workspace().is_path_ignored(PathIsIgnoredParams {
-        path: path.clone(),
-        is_dir: false,
-        project_key: doc.project_key,
-        features,
-        ignore_kind: IgnoreKind::Ancestors,
-    })? {
+    if session
+        .workspace_for_request()
+        .is_path_ignored(PathIsIgnoredParams {
+            path: path.clone(),
+            is_dir: false,
+            project_key: doc.project_key,
+            features,
+            ignore_kind: IgnoreKind::Ancestors,
+        })?
+    {
         return Ok(None);
     }
-    let syntax_tree = session.workspace().get_syntax_tree(GetSyntaxTreeParams {
-        project_key: doc.project_key,
-        path,
-    })?;
+    let syntax_tree = session
+        .workspace_for_request()
+        .get_syntax_tree(GetSyntaxTreeParams {
+            project_key: doc.project_key,
+            path,
+        })?;
     Ok(Some(syntax_tree.ast))
 }

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -71,8 +71,12 @@ impl LSPServer {
 
     async fn syntax_tree_request(&self, params: SyntaxTreePayload) -> LspResult<String> {
         let url = params.text_document.uri;
-        match requests::syntax_tree::syntax_tree(&self.session, &url) {
-            Ok(result) => Ok(result.unwrap_or_default()),
+        let result =
+            catch_lsp_operation(move || requests::syntax_tree::syntax_tree(&self.session, &url));
+        match result {
+            Ok(Ok(Ok(result))) => Ok(result.unwrap_or_default()),
+            Ok(Ok(Err(err))) => Err(into_lsp_error(err)),
+            Ok(Err(cancelled)) => Err(cancelled_to_lsp_error(cancelled)),
             Err(err) => Err(into_lsp_error(err)),
         }
     }
@@ -630,7 +634,7 @@ macro_rules! workspace_method {
                 let session = server.session.clone();
                 let result = spawn_blocking(move || {
                     let _guard = span.entered();
-                    catch_lsp_operation(|| session.workspace().$method(params))
+                    catch_lsp_operation(|| session.workspace_for_request().$method(params))
                 });
 
                 result.map(move |result| {

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -24,7 +24,7 @@ use biome_service::settings::{EditorFeature, ModuleGraphResolutionKind};
 use biome_service::workspace::db::DbState;
 use biome_service::workspace::{
     FeaturesBuilder, GetFileContentParams, OpenProjectParams, OpenProjectResult,
-    PullDiagnosticsParams, SupportsFeatureParams,
+    PullDiagnosticsParams, RetryingWorkspace, SupportsFeatureParams,
 };
 use biome_service::workspace::{FileFeaturesResult, ServiceNotification};
 use biome_service::workspace::{RageEntry, RageParams, RageResult, UpdateSettingsParams};
@@ -277,7 +277,42 @@ impl Session {
         }
     }
 
+    /// Returns the workspace, wrapped so that any call interrupted by a
+    /// concurrent update to the workspace database is automatically retried.
+    ///
+    /// Use this accessor in code where nobody would re-send the work if we
+    /// dropped it:
+    ///
+    /// - **LSP notifications**, i.e. one-way messages from the editor, such
+    ///   as `textDocument/didOpen`, `textDocument/didChange` and
+    ///   `textDocument/didClose`. The editor sends them once and never asks
+    ///   again: dropping a `didChange` would leave our copy of the document
+    ///   permanently out of sync with the editor.
+    /// - **Background tasks** the server starts on its own, such as
+    ///   refreshing the diagnostics of the open documents, loading the
+    ///   configuration file, or scanning the project folder.
+    ///
+    /// LSP request handlers (formatting, code actions, ...) should use
+    /// [Self::workspace_for_request] instead.
     pub(crate) fn workspace(&self) -> impl Workspace + '_ {
+        RetryingWorkspace::new(self.workspace.with_db_state(&self.db_state))
+    }
+
+    /// Returns the workspace without automatic retries.
+    ///
+    /// Use this accessor in **LSP request handlers**, i.e. handlers for
+    /// messages the editor sends and awaits an answer for, such as
+    /// `textDocument/formatting` or `textDocument/codeAction`. These handlers
+    /// run inside `catch_lsp_operation`, which turns an interrupted call into
+    /// a `ContentModified` response.
+    ///
+    /// Requests must not retry on their own, because their positions and
+    /// ranges are only meaningful for the document version the editor sent
+    /// them for. If the user types while we compute code actions for line 10,
+    /// a retry would compute them for whatever moved to line 10 after the
+    /// edit. Answering with `ContentModified` instead makes the editor
+    /// re-send the request with fresh positions, if it still needs it.
+    pub(crate) fn workspace_for_request(&self) -> impl Workspace + '_ {
         self.workspace.with_db_state(&self.db_state)
     }
 
@@ -437,6 +472,7 @@ impl Session {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn schedule_diagnostics(self: &Arc<Self>, url: Uri, version: i32) {
         let entry = self.diagnostics_entry(url.clone(), version);
         entry.closed.store(false, Ordering::Release);
@@ -445,6 +481,7 @@ impl Session {
         self.spawn_delayed_diagnostics(url, entry, version);
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn spawn_delayed_diagnostics(
         self: &Arc<Self>,
         url: Uri,
@@ -458,6 +495,7 @@ impl Session {
         });
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn run_debounced_diagnostics(
         self: Arc<Self>,
         url: Uri,
@@ -578,7 +616,6 @@ impl Session {
                 self.client.show_message(MessageType::WARNING, "The plugin loading has failed. Biome will report only parsing errors until the file is fixed or its usage is disabled.").await
             }
         }
-
         let FileFeaturesResult {
             features_supported: file_features,
         } = self.workspace().file_features(SupportsFeatureParams {
@@ -599,7 +636,6 @@ impl Session {
                 .await;
             return Ok(());
         }
-
         let diagnostics: Vec<Diagnostic> = {
             let mut categories = RuleCategoriesBuilder::default().with_syntax();
             if configuration_status.is_loaded() {
@@ -665,8 +701,6 @@ impl Session {
                 })
                 .collect()
         };
-
-        info!("Diagnostics sent to the client {}", diagnostics.len());
 
         if !self.can_publish_diagnostics(&url, doc.version, entry) {
             return Ok(());
@@ -1440,16 +1474,23 @@ impl Session {
     }
 
     pub(crate) fn failsafe_rage(&self, params: RageParams) -> RageResult {
-        self.workspace().rage(params).unwrap_or_else(|err| {
-            let entries = vec![
-                RageEntry::section("Workspace"),
-                RageEntry::markup(markup! {
-                    <Error>"\u{2716} Rage command failed:"</Error> {&format!("{err}")}
-                }),
-            ];
+        let result = salsa::Cancelled::catch(std::panic::AssertUnwindSafe(|| {
+            self.workspace().rage(params)
+        }));
+        let err = match result {
+            Ok(Ok(result)) => return result,
+            Ok(Err(err)) => err.to_string(),
+            Err(cancelled) => cancelled.to_string(),
+        };
 
-            RageResult { entries }
-        })
+        let entries = vec![
+            RageEntry::section("Workspace"),
+            RageEntry::markup(markup! {
+                <Error>"\u{2716} Rage command failed:"</Error> {&err}
+            }),
+        ];
+
+        RageResult { entries }
     }
 
     /// Retrieves the configuration status of the given project, defaulting to

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -45,10 +45,10 @@ biome_languages = { path = "../biome_languages", features = ["lang_js"] }
 insta           = { workspace = true }
 serde_json      = { workspace = true }
 
-[target.'cfg(unix)'.dependencies]
+[target."cfg(unix)".dependencies]
 libc = { workspace = true, optional = true }
 
-[target.'cfg(windows)'.dependencies]
+[target."cfg(windows)".dependencies]
 windows = { workspace = true, features = ["Win32_System_Threading"], optional = true }
 
 [features]

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -115,7 +115,7 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SupportsFeatureParams {
@@ -785,7 +785,7 @@ impl FeaturesBuilder {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateSettingsParams {
@@ -816,7 +816,7 @@ pub struct ProjectFeaturesParams {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ProjectFeaturesResult {}
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct OpenFileParams {
@@ -847,7 +847,7 @@ pub struct OpenFileResult {
     diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum FileContent {
@@ -876,7 +876,7 @@ impl FileContent {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetSyntaxTreeParams {
@@ -892,7 +892,7 @@ pub struct GetSyntaxTreeResult {
     pub ast: String,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetControlFlowGraphParams {
@@ -901,7 +901,7 @@ pub struct GetControlFlowGraphParams {
     pub cursor: TextSize,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetTypeInfoParams {
@@ -909,7 +909,7 @@ pub struct GetTypeInfoParams {
     pub path: BiomePath,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetRegisteredTypesParams {
@@ -917,7 +917,7 @@ pub struct GetRegisteredTypesParams {
     pub path: BiomePath,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetSemanticModelParams {
@@ -925,12 +925,12 @@ pub struct GetSemanticModelParams {
     pub path: BiomePath,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetModuleGraphParams {}
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetFormatterIRParams {
@@ -938,7 +938,7 @@ pub struct GetFormatterIRParams {
     pub path: BiomePath,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetFileContentParams {
@@ -946,7 +946,7 @@ pub struct GetFileContentParams {
     pub path: BiomePath,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CheckFileSizeParams {
@@ -968,7 +968,7 @@ impl CheckFileSizeResult {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ChangeFileParams {
@@ -992,14 +992,14 @@ pub struct ChangeFileResult {
     diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CloseFileParams {
     pub project_key: ProjectKey,
     pub path: BiomePath,
 }
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateModuleGraphParams {
@@ -1009,7 +1009,7 @@ pub struct UpdateModuleGraphParams {
     pub update_kind: UpdateKind,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum UpdateKind {
@@ -1017,7 +1017,7 @@ pub enum UpdateKind {
     Remove,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct PullDiagnosticsParams {
@@ -1073,7 +1073,7 @@ pub struct PullDiagnosticsResult {
     pub skipped_diagnostics: u64,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct PullActionsParams {
@@ -1101,7 +1101,7 @@ fn default_true() -> bool {
     true
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct PullDiagnosticsAndActionsParams {
@@ -1146,7 +1146,7 @@ pub struct CodeAction {
     pub offset: Option<TextSize>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FormatFileParams {
@@ -1156,7 +1156,7 @@ pub struct FormatFileParams {
     pub inline_config: Option<Configuration>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FormatRangeParams {
@@ -1167,7 +1167,7 @@ pub struct FormatRangeParams {
     pub inline_config: Option<Configuration>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FormatOnTypeParams {
@@ -1191,7 +1191,7 @@ pub enum FixFileMode {
     ApplySuppressions,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FixFileParams {
@@ -1238,7 +1238,7 @@ pub struct FixAction {
     pub range: TextRange,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct RenameParams {
@@ -1258,7 +1258,7 @@ pub struct RenameResult {
     pub indels: TextEdit,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GoToDefinitionParams {
@@ -1397,7 +1397,7 @@ impl RageEntry {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ParsePatternParams {
@@ -1412,7 +1412,7 @@ pub struct ParsePatternResult {
     pub pattern_id: PatternId,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SearchPatternParams {
@@ -1429,7 +1429,7 @@ pub struct SearchResults {
     pub matches: Vec<TextRange>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct DropPatternParams {
@@ -1465,7 +1465,7 @@ impl From<&str> for PatternId {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct PathIsIgnoredParams {
@@ -1483,7 +1483,7 @@ pub struct PathIsIgnoredParams {
     /// Controls how to ignore check should be done
     pub ignore_kind: IgnoreKind,
 }
-#[derive(Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum IgnoreKind {
@@ -1496,7 +1496,7 @@ pub enum IgnoreKind {
     Ancestors,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct OpenProjectParams {
@@ -1516,7 +1516,7 @@ pub struct OpenProjectResult {
     pub project_key: ProjectKey,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ScanProjectParams {
@@ -1536,14 +1536,14 @@ pub struct ScanProjectParams {
     pub verbose: bool,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CloseProjectParams {
     pub project_key: ProjectKey,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FileExistsParams {
@@ -1563,6 +1563,9 @@ pub struct GetModuleGraphResult {
     pub data: FxHashMap<String, SerializedModuleInfo>,
 }
 
+// NOTE: when you add new functions to this trait, you must update:
+// - the macro `delegate_workspace_methods` to include the new function if necessary
+// - the macro `retrying_workspace_methods` to include the new function if necessary
 pub trait Workspace: Send + Sync + RefUnwindSafe {
     // #region PROJECT-LEVEL METHODS
 
@@ -1808,6 +1811,98 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     fn server_info(&self) -> Option<&ServerInfo>;
 
     // #endregion
+}
+
+/// Runs `op` again when it is interrupted by a concurrent update to the
+/// workspace database.
+///
+/// An interrupted operation surfaces as a [salsa::Cancelled] panic with the
+/// [salsa::Cancelled::PendingWrite] cause. Any other cause (a panicked
+/// thread, a local cancellation) is a different problem, so it is re-raised
+/// instead of being hidden behind a retry.
+pub(crate) fn retry_on_pending_write<T>(op: impl Fn() -> T) -> T {
+    loop {
+        match salsa::Cancelled::catch(std::panic::AssertUnwindSafe(&op)) {
+            Ok(result) => return result,
+            // The interrupting update finishes quickly, so retry shortly
+            // after.
+            Err(salsa::Cancelled::PendingWrite) => std::thread::sleep(Duration::from_millis(1)),
+            Err(other) => std::panic::resume_unwind(Box::new(other)),
+        }
+    }
+}
+
+/// Wraps another [Workspace] so that any call interrupted by a concurrent
+/// update to the workspace database is automatically retried.
+///
+/// See [retry_on_pending_write] for what "interrupted" means. Callers that
+/// would rather handle the interruption themselves — for example, LSP request
+/// handlers that answer with `ContentModified` so the editor re-sends the
+/// request — should call the inner workspace directly instead.
+pub struct RetryingWorkspace<W>(W);
+
+impl<W: Workspace> RetryingWorkspace<W> {
+    pub fn new(inner: W) -> Self {
+        Self(inner)
+    }
+}
+
+macro_rules! retrying_workspace_methods {
+    ($(fn $name:ident($params:ident: $params_ty:ty) -> $return_ty:ty;)*) => {
+        $(
+            fn $name(&self, $params: $params_ty) -> $return_ty {
+                retry_on_pending_write(|| self.0.$name($params.clone()))
+            }
+        )*
+    };
+}
+
+impl<W: Workspace> Workspace for RetryingWorkspace<W> {
+    retrying_workspace_methods! {
+        fn open_project(params: OpenProjectParams) -> Result<OpenProjectResult, WorkspaceError>;
+        fn scan_project(params: ScanProjectParams) -> Result<ScanProjectResult, WorkspaceError>;
+        fn update_settings(params: UpdateSettingsParams) -> Result<UpdateSettingsResult, WorkspaceError>;
+        fn close_project(params: CloseProjectParams) -> Result<(), WorkspaceError>;
+        fn open_file(params: OpenFileParams) -> Result<OpenFileResult, WorkspaceError>;
+        fn file_exists(params: FileExistsParams) -> Result<bool, WorkspaceError>;
+        fn file_features(params: SupportsFeatureParams) -> Result<FileFeaturesResult, WorkspaceError>;
+        fn is_path_ignored(params: PathIsIgnoredParams) -> Result<bool, WorkspaceError>;
+        fn get_file_content(params: GetFileContentParams) -> Result<String, WorkspaceError>;
+        fn check_file_size(params: CheckFileSizeParams) -> Result<CheckFileSizeResult, WorkspaceError>;
+        fn change_file(params: ChangeFileParams) -> Result<ChangeFileResult, WorkspaceError>;
+        fn pull_diagnostics(params: PullDiagnosticsParams) -> Result<PullDiagnosticsResult, WorkspaceError>;
+        fn pull_actions(params: PullActionsParams) -> Result<PullActionsResult, WorkspaceError>;
+        fn pull_diagnostics_and_actions(params: PullDiagnosticsAndActionsParams) -> Result<PullDiagnosticsAndActionsResult, WorkspaceError>;
+        fn format_file(params: FormatFileParams) -> Result<Printed, WorkspaceError>;
+        fn format_range(params: FormatRangeParams) -> Result<Printed, WorkspaceError>;
+        fn format_on_type(params: FormatOnTypeParams) -> Result<Printed, WorkspaceError>;
+        fn fix_file(params: FixFileParams) -> Result<FixFileResult, WorkspaceError>;
+        fn rename(params: RenameParams) -> Result<RenameResult, WorkspaceError>;
+        fn go_to_definition(params: GoToDefinitionParams) -> Result<Option<GoToDefinitionResult>, WorkspaceError>;
+        fn close_file(params: CloseFileParams) -> Result<(), WorkspaceError>;
+        fn update_module_graph(params: UpdateModuleGraphParams) -> Result<(), WorkspaceError>;
+        fn parse_pattern(params: ParsePatternParams) -> Result<ParsePatternResult, WorkspaceError>;
+        fn search_pattern(params: SearchPatternParams) -> Result<SearchResults, WorkspaceError>;
+        fn drop_pattern(params: DropPatternParams) -> Result<(), WorkspaceError>;
+        fn get_syntax_tree(params: GetSyntaxTreeParams) -> Result<GetSyntaxTreeResult, WorkspaceError>;
+        fn get_control_flow_graph(params: GetControlFlowGraphParams) -> Result<String, WorkspaceError>;
+        fn get_formatter_ir(params: GetFormatterIRParams) -> Result<String, WorkspaceError>;
+        fn get_type_info(params: GetTypeInfoParams) -> Result<String, WorkspaceError>;
+        fn get_registered_types(params: GetRegisteredTypesParams) -> Result<String, WorkspaceError>;
+        fn get_semantic_model(params: GetSemanticModelParams) -> Result<String, WorkspaceError>;
+        fn get_module_graph(params: GetModuleGraphParams) -> Result<GetModuleGraphResult, WorkspaceError>;
+        fn rage(params: RageParams) -> Result<RageResult, WorkspaceError>;
+    }
+
+    // These two never touch the workspace database, so there is nothing to
+    // retry.
+    fn fs(&self) -> &dyn FsWithResolverProxy {
+        self.0.fs()
+    }
+
+    fn server_info(&self) -> Option<&ServerInfo> {
+        self.0.server_info()
+    }
 }
 
 /// Convenience function for constructing a server instance of [Workspace]

--- a/crates/biome_service/src/workspace/db.rs
+++ b/crates/biome_service/src/workspace/db.rs
@@ -3,9 +3,11 @@ use biome_db::{ParsedSnippet, ParsedSource};
 use biome_languages::DocumentFileSource;
 use biome_parser::AnyParse;
 use biome_rowan::SendNode;
-use biome_workspace_db::{ParsedSourceUpdateMode, SharedWorkspaceDb, WorkspaceDb};
+use biome_workspace_db::{ParsedSourceUpdateMode, SharedWorkspaceDb, WorkspaceDb, WorkspaceDbData};
 use camino::{Utf8Path, Utf8PathBuf};
 use parking_lot::Mutex;
+use std::panic::resume_unwind;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::embed::EmbedContent;
 
@@ -17,7 +19,83 @@ pub struct DbState {
 
 enum DbStorage {
     Shared(SharedWorkspaceDb),
-    Owned(Mutex<WorkspaceDb>),
+    Owned(OwnedDb),
+}
+
+/// Storage for the LSP, where the database is updated through salsa setters
+/// so that salsa can cancel outdated queries.
+///
+/// A salsa setter needs `&mut` access to the database. To get it, salsa waits
+/// until every clone of the database has been dropped. Two rules keep this
+/// from turning into a deadlock:
+///
+/// 1. A thread that holds a clone must be able to finish its work without
+///    taking the lock on [Self::db]. Updates that don't go through salsa use
+///    the shared [Self::data] collections instead, which need no lock.
+/// 2. [Self::fork] must not wait for a setter to finish. The setter is itself
+///    waiting for existing clones to be dropped, so if the thread asking for
+///    a new clone already holds one, both would wait on each other forever.
+///    Instead, while a setter is waiting, [Self::fork] gives up by unwinding
+///    with [salsa::Cancelled] — the same signal a salsa query receives when
+///    it runs during a pending update. Callers catch it and retry.
+///
+/// For the same reason, a thread must never call [Self::with_setter] while it
+/// holds a clone: the setter would wait for the thread's own clone, which is
+/// never dropped.
+struct OwnedDb {
+    /// The database instance itself. The lock is held only briefly to create
+    /// a clone, and for the whole duration of a setter-based update.
+    db: Mutex<WorkspaceDb>,
+    /// The collections shared between the database and all its clones. See
+    /// [WorkspaceDbData].
+    data: WorkspaceDbData,
+    /// How many threads are currently applying, or waiting to apply, a
+    /// setter-based update.
+    pending_setters: AtomicUsize,
+}
+
+impl OwnedDb {
+    fn new(db: WorkspaceDb) -> Self {
+        let data = db.data();
+        Self {
+            db: Mutex::new(db),
+            data,
+            pending_setters: AtomicUsize::new(0),
+        }
+    }
+
+    fn fork(&self) -> WorkspaceDb {
+        loop {
+            if self.pending_setters.load(Ordering::Acquire) > 0 {
+                // A setter is waiting for all clones to be dropped. If we
+                // waited for it here, a thread that already holds a clone
+                // could get stuck forever: see the rules on [OwnedDb].
+                resume_unwind(Box::new(salsa::Cancelled::PendingWrite));
+            }
+            // Normally the lock is only held for the time it takes to create
+            // a clone. A setter may still grab it right after the check
+            // above, so never block on the lock: try it, and if that fails,
+            // check again whether a setter is the reason.
+            if let Some(db) = self.db.try_lock() {
+                return db.clone();
+            }
+            std::thread::yield_now();
+        }
+    }
+
+    fn with_setter<R>(&self, f: impl FnOnce(&mut WorkspaceDb) -> R) -> R {
+        struct PendingSetterGuard<'a>(&'a AtomicUsize);
+        impl Drop for PendingSetterGuard<'_> {
+            fn drop(&mut self) {
+                self.0.fetch_sub(1, Ordering::Release);
+            }
+        }
+
+        self.pending_setters.fetch_add(1, Ordering::Release);
+        let _guard = PendingSetterGuard(&self.pending_setters);
+        let mut db = self.db.lock();
+        f(&mut db)
+    }
 }
 
 impl Default for DbState {
@@ -32,7 +110,7 @@ impl Default for DbState {
 impl DbState {
     pub fn lsp() -> Self {
         Self {
-            storage: DbStorage::Owned(Mutex::new(WorkspaceDb::default())),
+            storage: DbStorage::Owned(OwnedDb::new(WorkspaceDb::default())),
             path_info_cache: PathInfoCache::default(),
         }
     }
@@ -40,14 +118,14 @@ impl DbState {
     pub(crate) fn fork(&self) -> WorkspaceDb {
         match &self.storage {
             DbStorage::Shared(shared_db) => shared_db.fork(),
-            DbStorage::Owned(db) => db.lock().clone(),
+            DbStorage::Owned(db) => db.fork(),
         }
     }
 
     pub(crate) fn insert_source(&self, document_file_source: DocumentFileSource) -> usize {
         match &self.storage {
             DbStorage::Shared(shared_db) => shared_db.fork().insert_source(document_file_source),
-            DbStorage::Owned(db) => db.lock().insert_source(document_file_source),
+            DbStorage::Owned(db) => db.data.insert_source(document_file_source),
         }
     }
 
@@ -58,11 +136,9 @@ impl DbState {
                 new_root,
                 ParsedSourceUpdateMode::Replace,
             ),
-            DbStorage::Owned(db) => db.lock().update_parsed_root_with_mode(
-                path,
-                new_root,
-                ParsedSourceUpdateMode::Setters,
-            ),
+            DbStorage::Owned(db) => db.with_setter(|db| {
+                db.update_parsed_root_with_mode(path, new_root, ParsedSourceUpdateMode::Setters)
+            }),
         }
     }
 
@@ -85,9 +161,8 @@ impl DbState {
                     ParsedSourceUpdateMode::Replace,
                 )
             }
-            DbStorage::Owned(db) => {
-                let mut db = db.lock();
-                let parsed_snippets = create_parsed_snippets(&db, snippets);
+            DbStorage::Owned(db) => db.with_setter(|db| {
+                let parsed_snippets = create_parsed_snippets(db, snippets);
                 db.update_or_insert_file(
                     path,
                     parsed,
@@ -95,14 +170,14 @@ impl DbState {
                     parsed_snippets,
                     ParsedSourceUpdateMode::Setters,
                 )
-            }
+            }),
         }
     }
 
     pub(crate) fn unload_path(&self, path: &Utf8Path) {
         match &self.storage {
             DbStorage::Shared(shared_db) => shared_db.fork().unload_path(path),
-            DbStorage::Owned(db) => db.lock().unload_path(path),
+            DbStorage::Owned(db) => db.data.unload_path(path),
         }
     }
 
@@ -110,7 +185,7 @@ impl DbState {
     pub(crate) fn insert_module(&self, path: Utf8PathBuf, module: biome_module_graph::ModuleInfo) {
         match &self.storage {
             DbStorage::Shared(shared_db) => shared_db.fork().insert_module(path, module),
-            DbStorage::Owned(db) => db.lock().insert_module(path, module),
+            DbStorage::Owned(db) => db.data.insert_module(path, module),
         }
     }
 
@@ -118,7 +193,18 @@ impl DbState {
     pub(crate) fn remove_module(&self, path: &Utf8Path) {
         match &self.storage {
             DbStorage::Shared(shared_db) => shared_db.fork().remove_module(path),
-            DbStorage::Owned(db) => db.lock().remove_module(path),
+            DbStorage::Owned(db) => db.data.remove_module(path),
+        }
+    }
+
+    /// Returns how many setter-based updates are currently running or
+    /// waiting to run. Only used by tests to synchronize with a setter
+    /// without relying on sleeps.
+    #[cfg(test)]
+    fn pending_setters(&self) -> usize {
+        match &self.storage {
+            DbStorage::Shared(_) => 0,
+            DbStorage::Owned(db) => db.pending_setters.load(Ordering::Acquire),
         }
     }
 }
@@ -140,4 +226,121 @@ fn create_parsed_snippets(
             )
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use biome_js_parser::{JsParserOptions, parse};
+    use biome_languages::JsFileSource;
+    use camino::Utf8PathBuf;
+    use std::panic::AssertUnwindSafe;
+    use std::sync::{Arc, Barrier, mpsc};
+    use std::thread;
+    use std::time::Duration;
+
+    fn parse_js(source: &str) -> AnyParse {
+        parse(
+            source,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        )
+        .into()
+    }
+
+    /// Waits until a setter-based update is running or waiting to run.
+    fn wait_for_pending_setter(state: &DbState) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while state.pending_setters() == 0 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "no setter became pending within 5 seconds"
+            );
+            thread::yield_now();
+        }
+    }
+
+    /// A setter-based update waits until all clones of the database are
+    /// dropped. While it waits, a thread holding a clone must still be able
+    /// to update the shared collections: if that update needed the lock held
+    /// by the setter, the two threads would wait on each other forever. This
+    /// is a regression test for exactly that deadlock.
+    #[test]
+    fn owned_storage_shared_data_does_not_wait_for_pending_setters() {
+        let state = Arc::new(DbState::lsp());
+        let path = Utf8PathBuf::from("test.js");
+        // Insert the file first: only updates to files the database already
+        // knows about are applied through salsa setters.
+        state.update_parsed_file(&path, parse_js("let a = 1;"), 0, vec![]);
+
+        let clone_taken = Arc::new(Barrier::new(2));
+        let (done_tx, done_rx) = mpsc::channel();
+
+        let fork_holder = {
+            let state = state.clone();
+            let clone_taken = clone_taken.clone();
+            thread::spawn(move || {
+                let db = state.fork();
+                clone_taken.wait();
+                // Wait for the setter, which in turn waits for our clone to
+                // be dropped.
+                wait_for_pending_setter(&state);
+                // This must complete on its own, without waiting for the
+                // lock held by the setter.
+                state.insert_source(DocumentFileSource::Js(JsFileSource::js_script()));
+                drop(db);
+            })
+        };
+
+        let setter = {
+            let state = state.clone();
+            let path = path.clone();
+            thread::spawn(move || {
+                clone_taken.wait();
+                state.update_parsed_file(&path, parse_js("let b = 2;"), 0, vec![]);
+                done_tx.send(()).unwrap();
+            })
+        };
+
+        assert!(
+            done_rx.recv_timeout(Duration::from_secs(5)).is_ok(),
+            "the setter deadlocked while a thread holding a clone updated the shared collections"
+        );
+        fork_holder.join().unwrap();
+        setter.join().unwrap();
+    }
+
+    /// Asking for a new clone while a setter is waiting must fail with
+    /// [salsa::Cancelled] instead of blocking: the thread asking might
+    /// already hold a clone that the setter is waiting for, and the two
+    /// would wait on each other forever.
+    #[test]
+    fn owned_storage_fork_unwinds_while_setter_is_pending() {
+        let state = Arc::new(DbState::lsp());
+        let path = Utf8PathBuf::from("test.js");
+        state.update_parsed_file(&path, parse_js("let a = 1;"), 0, vec![]);
+
+        // Hold a clone so the setter below has to wait.
+        let db = state.fork();
+
+        let setter = {
+            let state = state.clone();
+            let path = path.clone();
+            thread::spawn(move || {
+                state.update_parsed_file(&path, parse_js("let b = 2;"), 0, vec![]);
+            })
+        };
+
+        // Once the setter is waiting, asking for a clone must fail instead
+        // of blocking.
+        wait_for_pending_setter(&state);
+        let result = salsa::Cancelled::catch(AssertUnwindSafe(|| state.fork()));
+        assert!(
+            matches!(result, Err(salsa::Cancelled::PendingWrite)),
+            "fork should fail with a cancellation instead of waiting for the setter"
+        );
+
+        drop(db);
+        setter.join().unwrap();
+    }
 }

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -3312,19 +3312,26 @@ impl WorkspaceScannerBridge for WorkspaceServerWithDb<'_> {
         path: impl Into<BiomePath>,
         trigger: IndexTrigger,
     ) -> Result<(ModuleDependencies, Vec<Error>), WorkspaceError> {
-        self.open_file_internal(
-            OpenFileReason::Index(trigger),
-            OpenFileParams {
-                project_key,
-                path: path.into(),
-                content: FileContent::FromServer,
-                document_file_source: None,
-                persist_node_cache: false,
-                // TODO: review here, it feels wrong that we can't pass the inline config
-                inline_config: None,
-                editor_features: None,
-            },
-        )
+        let path = path.into();
+        // Indexing this file can be interrupted when another thread updates
+        // the workspace database at the same time (this only happens in the
+        // LSP, see `DbState`). Retry until the file is fully indexed, so its
+        // data is not missing from the module graph.
+        retry_on_pending_write(|| {
+            self.open_file_internal(
+                OpenFileReason::Index(trigger),
+                OpenFileParams {
+                    project_key,
+                    path: path.clone(),
+                    content: FileContent::FromServer,
+                    document_file_source: None,
+                    persist_node_cache: false,
+                    // TODO: review here, it feels wrong that we can't pass the inline config
+                    inline_config: None,
+                    editor_features: None,
+                },
+            )
+        })
         .map(|result| (result.dependencies, result.diagnostics))
     }
 

--- a/crates/biome_workspace_db/src/lib.rs
+++ b/crates/biome_workspace_db/src/lib.rs
@@ -40,12 +40,31 @@ pub struct WorkspaceDb {
     storage: Storage<Self>,
 }
 
-impl WorkspaceDb {
+/// Handles to the collections that a [WorkspaceDb] shares with all its
+/// clones.
+///
+/// The database and its clones all point to the same underlying collections,
+/// so an update made through this type is immediately visible to all of them,
+/// and no lock is needed.
+///
+/// This matters when the database is updated through salsa setters: a setter
+/// can only run once every clone of the database has been dropped. A thread
+/// that still holds a clone must be able to finish its work on its own,
+/// without waiting for the lock that protects the database while the setter
+/// runs. This type is what makes that possible.
+#[derive(Clone)]
+pub struct WorkspaceDbData {
+    #[cfg(feature = "module_graph")]
+    modules: Arc<HashMap<Utf8PathBuf, ModuleInfo>>,
+    file_sources: Arc<boxcar::Vec<DocumentFileSource>>,
+}
+
+impl WorkspaceDbData {
     /// Inserts a file source so that it can be retrieved by index later.
     ///
     /// Returns the index at which the file source can be retrieved using
     /// `get_source()`.
-    pub fn insert_source(&mut self, document_file_source: DocumentFileSource) -> usize {
+    pub fn insert_source(&self, document_file_source: DocumentFileSource) -> usize {
         self.file_sources
             .iter()
             .find(|(_, file_source)| **file_source == document_file_source)
@@ -53,6 +72,55 @@ impl WorkspaceDb {
                 || self.file_sources.push(document_file_source),
                 |(index, _)| index,
             )
+    }
+
+    #[cfg(feature = "module_graph")]
+    pub fn insert_module(&self, path: Utf8PathBuf, module: ModuleInfo) {
+        self.modules.pin().insert(path, module);
+    }
+
+    #[cfg(feature = "module_graph")]
+    pub fn remove_module(&self, path: &Utf8Path) {
+        self.modules.pin().remove(path);
+    }
+
+    /// Removes all modules that start with the given path. That's usually used
+    /// when removing a library or a folder from the project.
+    pub fn unload_path(&self, path: &Utf8Path) {
+        #[cfg(feature = "module_graph")]
+        {
+            let modules = self.modules.pin();
+            let to_remove: Vec<Utf8PathBuf> = modules
+                .keys()
+                .filter(|p| p.starts_with(path))
+                .cloned()
+                .collect();
+            for p in to_remove {
+                modules.remove(&p);
+            }
+        }
+        #[cfg(not(feature = "module_graph"))]
+        let _ = path;
+    }
+}
+
+impl WorkspaceDb {
+    /// Returns handles to the collections that this database shares with all
+    /// its clones.
+    pub fn data(&self) -> WorkspaceDbData {
+        WorkspaceDbData {
+            #[cfg(feature = "module_graph")]
+            modules: self.modules.clone(),
+            file_sources: self.file_sources.clone(),
+        }
+    }
+
+    /// Inserts a file source so that it can be retrieved by index later.
+    ///
+    /// Returns the index at which the file source can be retrieved using
+    /// `get_source()`.
+    pub fn insert_source(&mut self, document_file_source: DocumentFileSource) -> usize {
+        self.data().insert_source(document_file_source)
     }
 
     pub fn insert_file(&mut self, path: &Utf8Path, file: ParsedSource) {
@@ -174,7 +242,7 @@ impl WorkspaceDb {
 
     #[cfg(feature = "module_graph")]
     pub fn insert_module(&self, path: Utf8PathBuf, module: ModuleInfo) {
-        self.modules.pin().insert(path, module);
+        self.data().insert_module(path, module);
     }
 
     /// It updates the CST of an existing parsed source
@@ -210,24 +278,11 @@ impl WorkspaceDb {
 
     #[cfg(feature = "module_graph")]
     pub fn remove_module(&self, path: &Utf8Path) {
-        self.modules.pin().remove(path);
+        self.data().remove_module(path);
     }
 
     pub fn unload_path(&self, path: &Utf8Path) {
-        #[cfg(feature = "module_graph")]
-        {
-            let modules = self.modules.pin();
-            let to_remove: Vec<Utf8PathBuf> = modules
-                .keys()
-                .filter(|p| p.starts_with(path))
-                .cloned()
-                .collect();
-            for p in to_remove {
-                modules.remove(&p);
-            }
-        }
-        #[cfg(not(feature = "module_graph"))]
-        let _ = path;
+        self.data().unload_path(path);
     }
 }
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> [!NOTE]
> PR implemented with the help of two coding agents

Closes https://github.com/biomejs/biome/issues/10845

This PR fixes an issue where a deadlock was occurring when the scanner was launched by the language server.

This was caused by forking the database and attempting to update the database while the fork was still around. This PR refactors the architecture around workspace and language server with the following: 
- `fork` now attempts a lock until it's safe, which means we don't hardlock
- we create a new `OwnedDb`, which holds the mutex, but it also holds the number of setters, so that they might be cancelled if necessary
- Implemented a better mechanism for retries in the language server. We now have two methods:
	- `workspace()` returns the workspace instance wrapped in `RetryingWorkspace`. It a newtype that wraps all functions in a retrying loop. This is needed for LSP operations that don't expect a "retry". For example, a `didChange` is fired once by the client, and forgotten. The protocol doesn't expect anything. Since an internal `change_file` from the workspace might be cancelled in-flight, the `RetryingWorkspace` takes care of it and it will make sure to handle cancellation gracefully.
	- `workspace_for_request` returns the raw workspace. Cancellation is caught by our `catch_unwind`, and then we return the proper signal to the client, which will take care of it. Those are requests such as formatting, code_actions, etc. The protocol takes care of cancellation itself.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests. Manually tested against the reproduction provided. It works as expected now.

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
