### PR TITLE
fix(markdown): parse whitespace after list markers

### DIFF
--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
@@ -63,7 +63,8 @@ impl FormatNodeRule<MdListMarkerPrefix> for FormatMdListMarkerPrefix {
             }
         }
 
-        let post_marker_len = if is_marker_only_bullet(node) {
+        let is_marker_only_bullet = is_marker_only_bullet(node);
+        let post_marker_len = if is_marker_only_bullet {
             // marker-only bullets have no post-marker space to preserve
             0
         } else {
@@ -89,7 +90,16 @@ impl FormatNodeRule<MdListMarkerPrefix> for FormatMdListMarkerPrefix {
                 write!(f, [token(" ")])?;
             }
         }
-        write!(f, [content_indent.format()])
+        if is_marker_only_bullet {
+            for indent_token in content_indent.iter() {
+                f.context().comments().is_suppressed(indent_token.syntax());
+                write!(f, [format_removed(&indent_token.md_indent_char_token()?)])?;
+            }
+        } else {
+            write!(f, [content_indent.format()])?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
@@ -198,9 +198,7 @@ impl Format<MarkdownFormatContext> for LocatedTargetMarker {
 }
 
 // A marker-only bullet (`-\n`, or `-   \n` before formatting) has no block
-// content besides the newline. Prettier removes the separator and indent
-// padding for those items, so the prefix formatter needs to detect them before
-// deciding how many spaces to print after the marker.
+// content besides the newline.
 fn is_marker_only_bullet(node: &MdListMarkerPrefix) -> bool {
     let Some(bullet) = node.syntax().parent().and_then(MdBullet::cast) else {
         return false;

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
@@ -1,9 +1,7 @@
-use crate::prelude::*;
+use crate::{markdown::lists::indent_token_list::FormatMdIndentTokenListOptions, prelude::*};
 use biome_formatter::{FormatRuleWithOptions, format_args, write};
 use biome_markdown_syntax::list_ext::{ListMarker, OrderedListDelimiter};
-use biome_markdown_syntax::{
-    AnyMdBlock, AnyMdLeafBlock, MdBullet, MdListMarkerPrefix, MdListMarkerPrefixFields,
-};
+use biome_markdown_syntax::{MdBullet, MdListMarkerPrefix, MdListMarkerPrefixFields};
 use biome_rowan::TextSize;
 use std::ops::Add;
 
@@ -91,10 +89,14 @@ impl FormatNodeRule<MdListMarkerPrefix> for FormatMdListMarkerPrefix {
             }
         }
         if is_marker_only_bullet {
-            for indent_token in content_indent.iter() {
-                f.context().comments().is_suppressed(indent_token.syntax());
-                write!(f, [format_removed(&indent_token.md_indent_char_token()?)])?;
-            }
+            write!(
+                f,
+                [content_indent
+                    .format()
+                    .with_options(FormatMdIndentTokenListOptions {
+                        should_remove: true,
+                    })]
+            )?;
         } else {
             write!(f, [content_indent.format()])?;
         }

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
@@ -1,7 +1,9 @@
 use crate::prelude::*;
 use biome_formatter::{FormatRuleWithOptions, format_args, write};
 use biome_markdown_syntax::list_ext::{ListMarker, OrderedListDelimiter};
-use biome_markdown_syntax::{MdListMarkerPrefix, MdListMarkerPrefixFields};
+use biome_markdown_syntax::{
+    AnyMdBlock, AnyMdLeafBlock, MdBullet, MdListMarkerPrefix, MdListMarkerPrefixFields,
+};
 use biome_rowan::TextSize;
 use std::ops::Add;
 
@@ -61,10 +63,16 @@ impl FormatNodeRule<MdListMarkerPrefix> for FormatMdListMarkerPrefix {
             }
         }
 
-        let post_marker_len = post_marker_space_token
-            .as_ref()
-            .map_or(0, |token| token.text_trimmed().len())
-            .max(self.min_post_marker_len);
+        let post_marker_len = if is_marker_only_bullet(node) {
+            // marker-only bullets have no post-marker space to preserve
+            0
+        } else {
+            // this returns the number of spaces to preserve after the marker
+            post_marker_space_token
+                .as_ref()
+                .map_or(0, |token| token.text_trimmed().len())
+                .max(self.min_post_marker_len)
+        };
 
         if let Some(post_marker_space_token) = post_marker_space_token {
             write!(f, [format_removed(&post_marker_space_token)])?;
@@ -175,6 +183,22 @@ impl Format<MarkdownFormatContext> for LocatedTargetMarker {
     fn fmt(&self, f: &mut MarkdownFormatter) -> FormatResult<()> {
         write!(f, [source_position(self.source_position), self.target])
     }
+}
+
+// A marker-only bullet (`-\n`, or `-   \n` before formatting) has no block
+// content besides the newline. Prettier removes the separator and indent
+// padding for those items, so the prefix formatter needs to detect them before
+// deciding how many spaces to print after the marker.
+fn is_marker_only_bullet(node: &MdListMarkerPrefix) -> bool {
+    let Some(bullet) = node.syntax().parent().and_then(MdBullet::cast) else {
+        return false;
+    };
+
+    let mut blocks = bullet.content().iter();
+    matches!(
+        blocks.next(),
+        Some(AnyMdBlock::AnyMdLeafBlock(AnyMdLeafBlock::MdNewline(_)))
+    ) && blocks.next().is_none()
 }
 
 pub(crate) struct FormatMdListMarkerPrefixOptions {

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/list_marker_prefix.rs
@@ -205,10 +205,7 @@ fn is_marker_only_bullet(node: &MdListMarkerPrefix) -> bool {
     };
 
     let mut blocks = bullet.content().iter();
-    matches!(
-        blocks.next(),
-        Some(AnyMdBlock::AnyMdLeafBlock(AnyMdLeafBlock::MdNewline(_)))
-    ) && blocks.next().is_none()
+    blocks.next().is_some_and(|block| block.is_newline()) && blocks.next().is_none()
 }
 
 pub(crate) struct FormatMdListMarkerPrefixOptions {

--- a/crates/biome_markdown_formatter/src/markdown/lists/indent_token_list.rs
+++ b/crates/biome_markdown_formatter/src/markdown/lists/indent_token_list.rs
@@ -1,9 +1,11 @@
-use crate::prelude::*;
-use biome_formatter::write;
+use crate::{markdown::auxiliary::indent_token::FormatMdIndentTokenOptions, prelude::*};
+use biome_formatter::{FormatRuleWithOptions, write};
 use biome_markdown_syntax::{MdHeader, MdIndentTokenList, MdListMarkerPrefix};
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct FormatMdIndentTokenList;
+pub(crate) struct FormatMdIndentTokenList {
+    should_remove: bool,
+}
 impl FormatRule<MdIndentTokenList> for FormatMdIndentTokenList {
     type Context = MarkdownFormatContext;
     fn fmt(&self, node: &MdIndentTokenList, f: &mut MarkdownFormatter) -> FormatResult<()> {
@@ -18,14 +20,32 @@ impl FormatRule<MdIndentTokenList> for FormatMdIndentTokenList {
             .is_some_and(|node| MdHeader::can_cast(node.kind()));
 
         // inside lists, alignment is handled by alignments
-        if inside_list_prefix || inside_header {
+        if self.should_remove || inside_list_prefix || inside_header {
             for token in node.iter() {
-                f.context().comments().is_suppressed(token.syntax());
-                write!(f, [format_removed(&token.md_indent_char_token()?)])?;
+                write!(
+                    f,
+                    [token.format().with_options(FormatMdIndentTokenOptions {
+                        replace_tabs_with_spaces: false,
+                        should_remove: true,
+                    })]
+                )?;
             }
             Ok(())
         } else {
             f.join().entries(node.iter().formatted()).finish()
         }
+    }
+}
+
+pub(crate) struct FormatMdIndentTokenListOptions {
+    pub(crate) should_remove: bool,
+}
+
+impl FormatRuleWithOptions<MdIndentTokenList> for FormatMdIndentTokenList {
+    type Options = FormatMdIndentTokenListOptions;
+
+    fn with_options(mut self, options: Self::Options) -> Self {
+        self.should_remove = options.should_remove;
+        self
     }
 }

--- a/crates/biome_markdown_formatter/tests/specs/markdown/bullet_list.md
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/bullet_list.md
@@ -13,3 +13,7 @@ __bold__
 * - - -
 
 + item after dash thematic break
+
+-   
+
+1.   

--- a/crates/biome_markdown_formatter/tests/specs/markdown/bullet_list.md.snap
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/bullet_list.md.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 249
 info: markdown/bullet_list.md
 ---
 

--- a/crates/biome_markdown_formatter/tests/specs/markdown/bullet_list.md.snap
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/bullet_list.md.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
 info: markdown/bullet_list.md
 ---
 
@@ -22,6 +23,10 @@ __bold__
 
 + item after dash thematic break
 
+-   
+
+1.   
+
 ```
 
 
@@ -42,5 +47,9 @@ __bold__
 + ---
 
 * item after dash thematic break
+
+-
+
+1.
 
 ```

--- a/crates/biome_markdown_parser/src/lexer/mod.rs
+++ b/crates/biome_markdown_parser/src/lexer/mod.rs
@@ -856,6 +856,16 @@ impl<'src> MarkdownLexer<'src> {
         }
 
         let trailing = &prefix[idx..];
+
+        // Padding in marker-only (`-   \n`, `1.   \n`) belongs to the list prefix,
+        // not an inline hard break. Keep it split so the parser can classify the
+        // first space as the list separator and the rest as content indent.
+        if trailing.iter().copied().all(is_space_or_tab_byte)
+            && self.current_whitespace_run_ends_line()
+        {
+            return true;
+        }
+
         if trailing.is_empty() {
             let mut saw_tab = current == b'\t';
             let mut next = self.position + 1;
@@ -949,15 +959,12 @@ impl<'src> MarkdownLexer<'src> {
                 self.advance(1);
                 dash_count += 1;
             }
-            // Allow trailing spaces/tabs
-            while matches!(self.current_byte(), Some(b' ' | b'\t')) {
-                self.advance(1);
-            }
             // 1-2 dashes followed by newline/EOF is a setext underline
             // 3+ dashes goes to thematic break logic below
-            if (1..=2).contains(&dash_count)
-                && matches!(self.current_byte(), Some(b'\n' | b'\r') | None)
-            {
+            if (1..=2).contains(&dash_count) && self.current_whitespace_run_ends_line() {
+                // The trailing whitespace is only peeked to validate the setext
+                // underline. Leave it for the parser instead of including it in
+                // MD_SETEXT_UNDERLINE_LITERAL's span.
                 return MD_SETEXT_UNDERLINE_LITERAL;
             }
             // Not a setext underline - restore and try thematic break
@@ -1573,6 +1580,15 @@ impl<'src> MarkdownLexer<'src> {
         }
 
         false
+    }
+
+    fn current_whitespace_run_ends_line(&self) -> bool {
+        let mut offset = 0;
+        while matches!(self.byte_at(offset), Some(b' ' | b'\t')) {
+            offset += 1;
+        }
+
+        matches!(self.byte_at(offset), Some(b'\n' | b'\r') | None)
     }
 
     /// Bumps the current byte and creates a lexed token of the passed in kind

--- a/crates/biome_markdown_parser/src/lexer/mod.rs
+++ b/crates/biome_markdown_parser/src/lexer/mod.rs
@@ -860,7 +860,7 @@ impl<'src> MarkdownLexer<'src> {
         // Padding in marker-only (`-   \n`, `1.   \n`) belongs to the list prefix,
         // not an inline hard break. Keep it split so the parser can classify the
         // first space as the list separator and the rest as content indent.
-        if trailing.iter().copied().all(is_space_or_tab_byte)
+        if trailing.iter().all(|byte| is_space_or_tab_byte(*byte))
             && self.current_whitespace_run_ends_line()
         {
             return true;

--- a/crates/biome_markdown_parser/src/lexer/tests.rs
+++ b/crates/biome_markdown_parser/src/lexer/tests.rs
@@ -452,6 +452,19 @@ fn ordered_list_marker_dot() {
 }
 
 #[test]
+fn ordered_list_marker_only_padding_is_split() {
+    // Marker-only padding belongs to the list prefix, not an inline hard break.
+    assert_lex! {
+        "1.   \n",
+        MD_ORDERED_LIST_MARKER:2,
+        MD_TEXTUAL_LITERAL:1,
+        MD_TEXTUAL_LITERAL:1,
+        MD_TEXTUAL_LITERAL:1,
+        NEWLINE:1,
+    }
+}
+
+#[test]
 fn ordered_list_marker_paren() {
     // Ordered list marker with parenthesis
     assert_lex! {
@@ -528,6 +541,23 @@ fn setext_underline_dashes() {
         "--\n",
         MD_SETEXT_UNDERLINE_LITERAL:2,
         NEWLINE:1,
+    }
+
+    // Trailing whitespace is allowed for setext underlines, but it must remain
+    // separate so a single-dash line can still be parsed as an empty list item.
+    assert_lex! {
+        "-   \n",
+        MD_SETEXT_UNDERLINE_LITERAL:1,
+        MD_TEXTUAL_LITERAL:1,
+        MD_TEXTUAL_LITERAL:1,
+        MD_TEXTUAL_LITERAL:1,
+        NEWLINE:1,
+    }
+
+    assert_lex! {
+        "--  \n",
+        MD_SETEXT_UNDERLINE_LITERAL:2,
+        MD_HARD_LINE_LITERAL:3,
     }
 
     // Three+ dashes is a thematic break at lexer level

--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -862,9 +862,7 @@ fn parse_bullet(p: &mut MarkdownParser) -> (ParsedSyntax, ListItemBlankInfo) {
     let marker_width = 1;
 
     // Bump the bullet marker
-    let mut setext_marker = false;
     if p.at(MD_SETEXT_UNDERLINE_LITERAL) && is_single_dash_setext_marker(p.cur_text()) {
-        setext_marker = true;
         p.bump_remap(T![-]);
     } else if p.at(MD_TEXTUAL_LITERAL) && is_textual_bullet_marker(p.cur_text()) {
         let text = p.cur_text();
@@ -884,32 +882,23 @@ fn parse_bullet(p: &mut MarkdownParser) -> (ParsedSyntax, ListItemBlankInfo) {
     }
 
     // Count spaces BEFORE consuming (peek from source text)
-    let spaces_after_marker = if setext_marker {
-        0
-    } else {
-        count_spaces_after_marker(p.source_after_current(), marker_indent + marker_width)
-    };
+    let spaces_after_marker =
+        count_spaces_after_marker(p.source_after_current(), marker_indent + marker_width);
 
-    let first_line_empty = if setext_marker {
-        true
-    } else {
-        p.lookahead(|p| {
-            while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
-                p.bump(MD_TEXTUAL_LITERAL);
-            }
-            p.at(NEWLINE) || p.at(T![EOF])
-        })
-    };
+    let first_line_empty = p.lookahead(|p| {
+        while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
+            p.bump(MD_TEXTUAL_LITERAL);
+        }
+        p.at(NEWLINE) || p.at(T![EOF])
+    });
 
     // Post-marker space (first whitespace token after marker)
-    if !setext_marker {
-        emit_list_post_marker_space(p, spaces_after_marker > INDENT_CODE_BLOCK_SPACES);
-    }
+    emit_list_post_marker_space(p, spaces_after_marker > INDENT_CODE_BLOCK_SPACES);
 
     // Content indent (remaining whitespace tokens on first line).
     // For first-line indented code, only the 4-column code indent is consumed
     // here so any additional padding remains in the code content.
-    if !setext_marker && !first_line_empty && spaces_after_marker > 1 {
+    if spaces_after_marker > 1 {
         let max_columns = if spaces_after_marker > INDENT_CODE_BLOCK_SPACES {
             INDENT_CODE_BLOCK_SPACES
         } else {
@@ -928,11 +917,7 @@ fn parse_bullet(p: &mut MarkdownParser) -> (ParsedSyntax, ListItemBlankInfo) {
     let prev_required_indent = p.state().list_item_required_indent;
     let prev_marker_indent = p.state().list_item_marker_indent;
 
-    let effective_spaces = if setext_marker {
-        0
-    } else {
-        spaces_after_marker
-    };
+    let effective_spaces = spaces_after_marker;
 
     p.state_mut().list_item_required_indent =
         if effective_spaces > INDENT_CODE_BLOCK_SPACES || first_line_empty {
@@ -1240,7 +1225,7 @@ fn parse_ordered_bullet(p: &mut MarkdownParser) -> (ParsedSyntax, ListItemBlankI
     // Content indent.
     // For first-line indented code, only the 4-column code indent is consumed
     // here so any additional padding remains in the code content.
-    if !first_line_empty && spaces_after_marker > 1 {
+    if spaces_after_marker > 1 {
         let max_columns = if spaces_after_marker > INDENT_CODE_BLOCK_SPACES {
             INDENT_CODE_BLOCK_SPACES
         } else {

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_continuation_edge_cases.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_continuation_edge_cases.md.snap
@@ -183,8 +183,8 @@ MdDocument {
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@153..155 "- " [] [],
-                        post_marker_space_token: missing (optional),
+                        marker: MINUS@153..154 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@154..155 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
@@ -509,8 +509,8 @@ MdDocument {
         0: MD_BULLET@153..156
           0: MD_LIST_MARKER_PREFIX@153..155
             0: MD_INDENT_TOKEN_LIST@153..153
-            1: MINUS@153..155 "- " [] []
-            2: (empty)
+            1: MINUS@153..154 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@154..155 " " [] []
             3: MD_INDENT_TOKEN_LIST@155..155
           1: MD_BLOCK_LIST@155..156
             0: MD_NEWLINE@155..156

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_marker_trailing_spaces.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_marker_trailing_spaces.md.snap
@@ -77,10 +77,7 @@ MdDocument {
                         post_marker_space_token: MD_LIST_POST_MARKER_SPACE@13..14 " " [] [],
                         content_indent: MdIndentTokenList [
                             MdIndentToken {
-                                md_indent_char_token: MD_INDENT_CHAR@14..15 " " [] [],
-                            },
-                            MdIndentToken {
-                                md_indent_char_token: MD_INDENT_CHAR@15..16 " " [] [],
+                                md_indent_char_token: MD_INDENT_CHAR@14..16 "  " [] [],
                             },
                         ],
                     },
@@ -124,10 +121,7 @@ MdDocument {
                         post_marker_space_token: MD_LIST_POST_MARKER_SPACE@24..25 " " [] [],
                         content_indent: MdIndentTokenList [
                             MdIndentToken {
-                                md_indent_char_token: MD_INDENT_CHAR@25..26 " " [] [],
-                            },
-                            MdIndentToken {
-                                md_indent_char_token: MD_INDENT_CHAR@26..27 " " [] [],
+                                md_indent_char_token: MD_INDENT_CHAR@25..27 "  " [] [],
                             },
                         ],
                     },
@@ -240,10 +234,8 @@ MdDocument {
             1: MD_ORDERED_LIST_MARKER@11..13 "1." [] []
             2: MD_LIST_POST_MARKER_SPACE@13..14 " " [] []
             3: MD_INDENT_TOKEN_LIST@14..16
-              0: MD_INDENT_TOKEN@14..15
-                0: MD_INDENT_CHAR@14..15 " " [] []
-              1: MD_INDENT_TOKEN@15..16
-                0: MD_INDENT_CHAR@15..16 " " [] []
+              0: MD_INDENT_TOKEN@14..16
+                0: MD_INDENT_CHAR@14..16 "  " [] []
           1: MD_BLOCK_LIST@16..17
             0: MD_NEWLINE@16..17
               0: NEWLINE@16..17 "\n" [] []
@@ -270,10 +262,8 @@ MdDocument {
             1: MINUS@23..24 "-" [] []
             2: MD_LIST_POST_MARKER_SPACE@24..25 " " [] []
             3: MD_INDENT_TOKEN_LIST@25..27
-              0: MD_INDENT_TOKEN@25..26
-                0: MD_INDENT_CHAR@25..26 " " [] []
-              1: MD_INDENT_TOKEN@26..27
-                0: MD_INDENT_CHAR@26..27 " " [] []
+              0: MD_INDENT_TOKEN@25..27
+                0: MD_INDENT_CHAR@25..27 "  " [] []
           1: MD_BLOCK_LIST@27..28
             0: MD_NEWLINE@27..28
               0: NEWLINE@27..28 "\n" [] []

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/list_marker_trailing_spaces.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/list_marker_trailing_spaces.md.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_markdown_parser/tests/spec_test.rs
+assertion_line: 190
 expression: snapshot
 ---
 
@@ -33,12 +34,16 @@ MdDocument {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
                         marker: MD_ORDERED_LIST_MARKER@0..2 "1." [] [],
-                        post_marker_space_token: missing (optional),
-                        content_indent: MdIndentTokenList [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@2..3 " " [] [],
+                        content_indent: MdIndentTokenList [
+                            MdIndentToken {
+                                md_indent_char_token: MD_INDENT_CHAR@3..4 " " [] [],
+                            },
+                        ],
                     },
                     content: MdBlockList [
                         MdNewline {
-                            value_token: NEWLINE@2..5 "  \n" [] [],
+                            value_token: NEWLINE@4..5 "\n" [] [],
                         },
                     ],
                 },
@@ -69,12 +74,19 @@ MdDocument {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
                         marker: MD_ORDERED_LIST_MARKER@11..13 "1." [] [],
-                        post_marker_space_token: missing (optional),
-                        content_indent: MdIndentTokenList [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@13..14 " " [] [],
+                        content_indent: MdIndentTokenList [
+                            MdIndentToken {
+                                md_indent_char_token: MD_INDENT_CHAR@14..15 " " [] [],
+                            },
+                            MdIndentToken {
+                                md_indent_char_token: MD_INDENT_CHAR@15..16 " " [] [],
+                            },
+                        ],
                     },
                     content: MdBlockList [
                         MdNewline {
-                            value_token: NEWLINE@13..17 "   \n" [] [],
+                            value_token: NEWLINE@16..17 "\n" [] [],
                         },
                     ],
                 },
@@ -108,9 +120,16 @@ MdDocument {
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@23..27 "-   " [] [],
-                        post_marker_space_token: missing (optional),
-                        content_indent: MdIndentTokenList [],
+                        marker: MINUS@23..24 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@24..25 " " [] [],
+                        content_indent: MdIndentTokenList [
+                            MdIndentToken {
+                                md_indent_char_token: MD_INDENT_CHAR@25..26 " " [] [],
+                            },
+                            MdIndentToken {
+                                md_indent_char_token: MD_INDENT_CHAR@26..27 " " [] [],
+                            },
+                        ],
                     },
                     content: MdBlockList [
                         MdNewline {
@@ -190,14 +209,16 @@ MdDocument {
     0: MD_ORDERED_LIST_ITEM@0..22
       0: MD_BULLET_LIST@0..22
         0: MD_BULLET@0..5
-          0: MD_LIST_MARKER_PREFIX@0..2
+          0: MD_LIST_MARKER_PREFIX@0..4
             0: MD_INDENT_TOKEN_LIST@0..0
             1: MD_ORDERED_LIST_MARKER@0..2 "1." [] []
-            2: (empty)
-            3: MD_INDENT_TOKEN_LIST@2..2
-          1: MD_BLOCK_LIST@2..5
-            0: MD_NEWLINE@2..5
-              0: NEWLINE@2..5 "  \n" [] []
+            2: MD_LIST_POST_MARKER_SPACE@2..3 " " [] []
+            3: MD_INDENT_TOKEN_LIST@3..4
+              0: MD_INDENT_TOKEN@3..4
+                0: MD_INDENT_CHAR@3..4 " " [] []
+          1: MD_BLOCK_LIST@4..5
+            0: MD_NEWLINE@4..5
+              0: NEWLINE@4..5 "\n" [] []
         1: MD_BULLET@5..11
           0: MD_LIST_MARKER_PREFIX@5..8
             0: MD_INDENT_TOKEN_LIST@5..5
@@ -214,14 +235,18 @@ MdDocument {
             1: MD_NEWLINE@10..11
               0: NEWLINE@10..11 "\n" [] []
         2: MD_BULLET@11..17
-          0: MD_LIST_MARKER_PREFIX@11..13
+          0: MD_LIST_MARKER_PREFIX@11..16
             0: MD_INDENT_TOKEN_LIST@11..11
             1: MD_ORDERED_LIST_MARKER@11..13 "1." [] []
-            2: (empty)
-            3: MD_INDENT_TOKEN_LIST@13..13
-          1: MD_BLOCK_LIST@13..17
-            0: MD_NEWLINE@13..17
-              0: NEWLINE@13..17 "   \n" [] []
+            2: MD_LIST_POST_MARKER_SPACE@13..14 " " [] []
+            3: MD_INDENT_TOKEN_LIST@14..16
+              0: MD_INDENT_TOKEN@14..15
+                0: MD_INDENT_CHAR@14..15 " " [] []
+              1: MD_INDENT_TOKEN@15..16
+                0: MD_INDENT_CHAR@15..16 " " [] []
+          1: MD_BLOCK_LIST@16..17
+            0: MD_NEWLINE@16..17
+              0: NEWLINE@16..17 "\n" [] []
         3: MD_BULLET@17..22
           0: MD_LIST_MARKER_PREFIX@17..20
             0: MD_INDENT_TOKEN_LIST@17..17
@@ -242,9 +267,13 @@ MdDocument {
         0: MD_BULLET@23..28
           0: MD_LIST_MARKER_PREFIX@23..27
             0: MD_INDENT_TOKEN_LIST@23..23
-            1: MINUS@23..27 "-   " [] []
-            2: (empty)
-            3: MD_INDENT_TOKEN_LIST@27..27
+            1: MINUS@23..24 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@24..25 " " [] []
+            3: MD_INDENT_TOKEN_LIST@25..27
+              0: MD_INDENT_TOKEN@25..26
+                0: MD_INDENT_CHAR@25..26 " " [] []
+              1: MD_INDENT_TOKEN@26..27
+                0: MD_INDENT_CHAR@26..27 " " [] []
           1: MD_BLOCK_LIST@27..28
             0: MD_NEWLINE@27..28
               0: NEWLINE@27..28 "\n" [] []


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->


Fixes #9770. Fixes Markdown list parsing so whitespace after a list marker is represented as `MdListMarkerPrefix` padding instead of being bundled with the following content token. This lets the formatter normalize cases like `-      1` and marker-only items like `-   ` correctly.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

```
cargo test -p biome_markdown_parser
cargo test -p biome_markdown_formatter
```

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

N/A

Given Markdown isn't released yet, I assume we don't need a changeset just like the other PRs (https://github.com/biomejs/biome/pull/10844). Let me know if we need one.