### PR TITLE
feat(type-info): preserve readonly type members

### DIFF
--- a/.changeset/calm-otters-report.md
+++ b/.changeset/calm-otters-report.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": patch
+---
+
+[`noMisleadingReturnType`](https://biomejs.dev/linter/rules/no-misleading-return-type/) now analyzes return annotations with `readonly` members, so a wider annotation like `Readonly<Record<string, string>>` is reported when the function returns a narrower value.
+
+```ts
+export function createRecord(): Readonly<Record<string, string>> {
+  return { key: "value" } as const;
+}
+```

--- a/.changeset/calm-otters-report.md
+++ b/.changeset/calm-otters-report.md
@@ -2,7 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-[`noMisleadingReturnType`](https://biomejs.dev/linter/rules/no-misleading-return-type/) now analyzes return annotations with `readonly` members, so a wider annotation like `Readonly<Record<string, string>>` is reported when the function returns a narrower value.
+[`noMisleadingReturnType`](https://biomejs.dev/linter/rules/no-misleading-return-type/) now recognizes `readonly` index signatures when comparing return annotations, so a wider annotation like `Readonly<Record<string, string>>` is reported when the function returns a narrower value.
 
 ```ts
 export function createRecord(): Readonly<Record<string, string>> {

--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
@@ -16,9 +16,7 @@ use biome_js_syntax::{
     TsReferenceType, TsTypeAliasDeclaration, TsTypeAssertionExpression,
 };
 use biome_js_semantic::ScopeId;
-use biome_js_type_info::{
-    Class, Literal, Type, TypeData, TypeMemberKind, TypeReferenceQualifier,
-};
+use biome_js_type_info::{Class, Literal, Type, TypeData, TypeMemberKind, TypeReferenceQualifier};
 use biome_rowan::{AstNode, Text, TextRange, declare_node_union};
 use biome_rule_options::no_misleading_return_type::NoMisleadingReturnTypeOptions;
 use smallvec::{SmallVec, smallvec};
@@ -797,12 +795,10 @@ fn is_only_property_literal_widening(annotation: &Type, returns: &[Type]) -> boo
                 return false;
             }
 
-            let annotated_index_signature = annotated_object.members.iter().find(|member| {
-                matches!(
-                    member.kind,
-                    TypeMemberKind::IndexSignature(_)
-                )
-            });
+            let annotated_index_signature = annotated_object
+                .members
+                .iter()
+                .find(|member| member.is_index_signature_with_ty(|_| true));
             if let Some(index_signature_member) = annotated_index_signature
                 && let Some(index_signature_value_type) =
                     annotated.resolve(&index_signature_member.ty)
@@ -831,10 +827,9 @@ fn is_only_property_literal_widening(annotation: &Type, returns: &[Type]) -> boo
             }
 
             for annotated_member in annotated_object.members.iter() {
-                let annotated_name = match &annotated_member.kind {
-                    TypeMemberKind::Named(name)
-                    | TypeMemberKind::NamedOptional(name) => name,
-                    _ => continue,
+                let Some(annotated_name) = named_property_member_name(&annotated_member.kind)
+                else {
+                    continue;
                 };
                 let Some(inferred_member) = inferred_members
                     .iter()
@@ -1765,7 +1760,7 @@ fn is_nonunion_wider(annotated: &Type, inferred: &Type) -> bool {
 
             (TypeData::Object(ann_obj), TypeData::Literal(lit)) => match lit.as_ref() {
                 Literal::Object(inf_lit) => {
-                    if !push_object_literal_pairs(&ann, ann_obj, inf_lit, &mut stack) {
+                    if !push_object_literal_pairs(&ann, ann_obj, &inf, inf_lit, &mut stack) {
                         return false;
                     }
                 }
@@ -1811,9 +1806,10 @@ fn push_object_pairs(
         return false;
     }
 
-    let ann_index_sig = ann_obj.members.iter().find(|m| {
-        matches!(m.kind, TypeMemberKind::IndexSignature(_))
-    });
+    let ann_index_sig = ann_obj
+        .members
+        .iter()
+        .find(|m| m.is_index_signature_with_ty(|_| true));
     if let Some(sig_member) = ann_index_sig
         && let Some(sig_value_ty) = annotated.resolve(&sig_member.ty)
     {
@@ -1827,10 +1823,8 @@ fn push_object_pairs(
     }
 
     for ann_member in ann_obj.members.iter() {
-        let ann_name = match &ann_member.kind {
-            TypeMemberKind::Named(name)
-            | TypeMemberKind::NamedOptional(name) => name,
-            _ => continue,
+        let Some(ann_name) = named_property_member_name(&ann_member.kind) else {
+            continue;
         };
         let inf_member = inf_obj.members.iter().find(|m| m.kind.has_name(ann_name));
         let Some(inf_member) = inf_member else {
@@ -1848,30 +1842,66 @@ fn push_object_pairs(
 fn push_object_literal_pairs(
     annotated: &Type,
     ann_obj: &biome_js_type_info::Object,
-    inf_lit: &biome_js_type_info::ObjectLiteral,
+    inferred: &Type,
+    inferred_literal: &biome_js_type_info::ObjectLiteral,
     stack: &mut Vec<(Type, Type)>,
 ) -> bool {
-    if ann_obj.members.is_empty() || inf_lit.members().is_empty() {
+    if ann_obj.members.is_empty() || inferred_literal.members().is_empty() {
         return false;
     }
 
+    let annotated_index_signature = ann_obj
+        .members
+        .iter()
+        .find(|member| member.is_index_signature_with_ty(|_| true));
+    if let Some(index_signature_member) = annotated_index_signature
+        && let Some(index_signature_value_type) = annotated.resolve(&index_signature_member.ty)
+    {
+        for inferred_member in inferred_literal.members() {
+            match inferred.resolve(&inferred_member.ty) {
+                Some(inferred_type) => stack.push((
+                    index_signature_value_type.clone(),
+                    resolve_generic_chain(&inferred_type),
+                )),
+                None => return false,
+            }
+        }
+        return true;
+    }
+
     for ann_member in ann_obj.members.iter() {
-        let ann_name = match &ann_member.kind {
-            TypeMemberKind::Named(name)
-            | TypeMemberKind::NamedOptional(name) => name,
-            _ => continue,
+        let Some(ann_name) = named_property_member_name(&ann_member.kind) else {
+            continue;
         };
-        let inf_member = inf_lit.members().iter().find(|m| m.kind.has_name(ann_name));
+        let inf_member = inferred_literal
+            .members()
+            .iter()
+            .find(|m| m.kind.has_name(ann_name));
         let Some(inf_member) = inf_member else {
             return false;
         };
-        match (annotated.resolve(&ann_member.ty), annotated.resolve(&inf_member.ty)) {
+        match (
+            annotated.resolve(&ann_member.ty),
+            inferred.resolve(&inf_member.ty),
+        ) {
             (Some(a), Some(b)) => stack.push((a, resolve_generic_chain(&b))),
             _ => return false,
         }
     }
 
     true
+}
+
+fn named_property_member_name(kind: &TypeMemberKind) -> Option<&Text> {
+    match kind {
+        TypeMemberKind::Named(name)
+        | TypeMemberKind::NamedOptional(name)
+        | TypeMemberKind::ReadonlyNamed(name)
+        | TypeMemberKind::ReadonlyNamedOptional(name)
+        | TypeMemberKind::ConstAssertedReadonlyNamed(name)
+        | TypeMemberKind::ConstAssertedReadonlyNamedOptional(name) => Some(name),
+        _ => None,
+    }
 }
 
 /// Checks whether `annotated` is strictly wider than `inferred`.

--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
@@ -1896,10 +1896,22 @@ fn named_property_member_name(kind: &TypeMemberKind) -> Option<&Text> {
     match kind {
         TypeMemberKind::Named(name)
         | TypeMemberKind::NamedOptional(name)
+        | TypeMemberKind::NamedStatic(name)
+        | TypeMemberKind::NamedStaticOptional(name)
+        | TypeMemberKind::Getter(name)
+        | TypeMemberKind::ConstAssertedGetter(name)
+        | TypeMemberKind::ConstAssertedNamed(name)
+        | TypeMemberKind::ConstAssertedNamedOptional(name)
+        | TypeMemberKind::ConstAssertedNamedStatic(name)
+        | TypeMemberKind::ConstAssertedNamedStaticOptional(name)
         | TypeMemberKind::ReadonlyNamed(name)
         | TypeMemberKind::ReadonlyNamedOptional(name)
+        | TypeMemberKind::ReadonlyNamedStatic(name)
+        | TypeMemberKind::ReadonlyNamedStaticOptional(name)
         | TypeMemberKind::ConstAssertedReadonlyNamed(name)
-        | TypeMemberKind::ConstAssertedReadonlyNamedOptional(name) => Some(name),
+        | TypeMemberKind::ConstAssertedReadonlyNamedOptional(name)
+        | TypeMemberKind::ConstAssertedReadonlyNamedStatic(name)
+        | TypeMemberKind::ConstAssertedReadonlyNamedStaticOptional(name) => Some(name),
         _ => None,
     }
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts
@@ -209,3 +209,7 @@ function literalAssertionNarrows(b: boolean): string { if (b) return "a" as "a";
 function satisfiesDoesNotWiden(b: boolean): string { if (b) return "a" satisfies string; return "b" satisfies string; }
 function doubleCastNarrows(b: boolean): string { if (b) return "a" as unknown as "a"; return "b" as unknown as "b"; }
 function singleAssertedBooleanLiteral(): boolean { return false as false; }
+
+function readonlyRecordWider(): Readonly<Record<string, string>> {
+    return { key: "value" } as const;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/invalid.ts.snap
@@ -216,6 +216,10 @@ function satisfiesDoesNotWiden(b: boolean): string { if (b) return "a" satisfies
 function doubleCastNarrows(b: boolean): string { if (b) return "a" as unknown as "a"; return "b" as unknown as "b"; }
 function singleAssertedBooleanLiteral(): boolean { return false as false; }
 
+function readonlyRecordWider(): Readonly<Record<string, string>> {
+    return { key: "value" } as const;
+}
+
 ```
 
 # Diagnostics
@@ -2490,10 +2494,34 @@ invalid.ts:211:40 lint/nursery/noMisleadingReturnType ━━━━━━━━�
   > 211 │ function singleAssertedBooleanLiteral(): boolean { return false as false; }
         │                                        ^^^^^^^^^
     212 │ 
+    213 │ function readonlyRecordWider(): Readonly<Record<string, string>> {
   
   i A wider return type hides the precise types that callers could rely on.
   
   i Consider using false as the return type.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:213:31 lint/nursery/noMisleadingReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The return type annotation is wider than what the function actually returns.
+  
+    211 │ function singleAssertedBooleanLiteral(): boolean { return false as false; }
+    212 │ 
+  > 213 │ function readonlyRecordWider(): Readonly<Record<string, string>> {
+        │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    214 │     return { key: "value" } as const;
+    215 │ }
+  
+  i A wider return type hides the precise types that callers could rely on.
+  
+  i Narrow the return type to match what the function actually returns.
   
   i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/9810 for more information or to report possible bugs.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts
@@ -99,6 +99,8 @@ function overloaded(x: "b"): "b";
 function overloaded(x: "a" | "b"): string { if (x === "a") return "a"; return "b"; }
 
 function complexAnnotation(): Record<string, string> { return { a: "b" }; }
+function exactReadonlyProperty(): Readonly<{ key: "value" }> { return { key: "value" } as const; }
+function exactReadonlyRecord(): Readonly<Record<string, "value">> { return { key: "value" } as const; }
 function arrayAnnotation(): string[] { return ["a", "b"]; }
 
 function booleanExhaustive(b: boolean): boolean { if (b) return true; return false; }

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisleadingReturnType/valid.ts.snap
@@ -105,6 +105,8 @@ function overloaded(x: "b"): "b";
 function overloaded(x: "a" | "b"): string { if (x === "a") return "a"; return "b"; }
 
 function complexAnnotation(): Record<string, string> { return { a: "b" }; }
+function exactReadonlyProperty(): Readonly<{ key: "value" }> { return { key: "value" } as const; }
+function exactReadonlyRecord(): Readonly<Record<string, "value">> { return { key: "value" } as const; }
 function arrayAnnotation(): string[] { return ["a", "b"]; }
 
 function booleanExhaustive(b: boolean): boolean { if (b) return true; return false; }

--- a/crates/biome_js_type_info/src/builders.rs
+++ b/crates/biome_js_type_info/src/builders.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use crate::Path;
 use crate::interned_types::{
     InternedClass, InternedFunction, InternedInterface, InternedIntersection, InternedNamespace,
-    InternedObject, InternedUnion, Literal, TypeData, TypeDb, TypeMember, TypeMemberKind,
+    InternedObject, InternedUnion, Literal, TypeData, TypeDb, TypeMember,
 };
 use biome_rowan::Text;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -511,16 +511,15 @@ fn class_instance_members<'db>(members: &[TypeMember<'db>]) -> Vec<TypeMember<'d
 fn class_static_members<'db>(members: &[TypeMember<'db>]) -> Vec<TypeMember<'db>> {
     members
         .iter()
-        .filter_map(|member| match &member.kind {
-            TypeMemberKind::NamedStatic(name) => Some(TypeMember {
-                kind: TypeMemberKind::Named(name.clone()),
-                ty: member.ty,
-            }),
-            TypeMemberKind::ConstAssertedNamedStatic(name) => Some(TypeMember {
-                kind: TypeMemberKind::ConstAssertedNamed(name.clone()),
-                ty: member.ty,
-            }),
-            _ => None,
+        .filter_map(|member| {
+            member
+                .kind
+                .clone()
+                .into_non_static()
+                .map(|kind| TypeMember {
+                    kind,
+                    ty: member.ty,
+                })
         })
         .collect()
 }
@@ -538,10 +537,15 @@ fn merge_members<'db>(
         });
 
         match existing {
-            Some(existing) if existing.ty != member.ty => {
-                existing.ty = TypeData::union_from_types(db, Vec::from([existing.ty, member.ty]));
+            Some(existing) => {
+                if existing.kind.is_readonly() && !member.kind.is_readonly() {
+                    existing.kind = existing.kind.without_readonly();
+                }
+                if existing.ty != member.ty {
+                    existing.ty =
+                        TypeData::union_from_types(db, Vec::from([existing.ty, member.ty]));
+                }
             }
-            Some(_) => {}
             None => merged.push(member.clone()),
         }
     }

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -1259,6 +1259,7 @@ mod tests {
                 is_rest,
             }),
             accessibility: None,
+            is_readonly: false,
         }
     }
 

--- a/crates/biome_js_type_info/src/flattening/intersections.rs
+++ b/crates/biome_js_type_info/src/flattening/intersections.rs
@@ -2,7 +2,7 @@ use biome_rowan::Text;
 
 use crate::{
     Class, Function, Interface, Intersection, Literal, Namespace, Object, Path, ResolvedTypeData,
-    ReturnType, TypeData, TypeMember, TypeMemberKind, TypeResolver,
+    ReturnType, TypeData, TypeMember, TypeResolver,
 };
 
 pub(super) fn flattened_intersection(
@@ -139,18 +139,11 @@ impl MergedType {
                             class
                                 .members
                                 .into_iter()
-                                .filter_map(|member| match member.kind {
-                                    TypeMemberKind::NamedStatic(name) => Some(TypeMember {
-                                        kind: TypeMemberKind::Named(name),
+                                .filter_map(|member| {
+                                    member.kind.into_non_static().map(|kind| TypeMember {
+                                        kind,
                                         ty: member.ty,
-                                    }),
-                                    TypeMemberKind::ConstAssertedNamedStatic(name) => {
-                                        Some(TypeMember {
-                                            kind: TypeMemberKind::ConstAssertedNamed(name),
-                                            ty: member.ty,
-                                        })
-                                    }
-                                    _ => None,
+                                    })
                                 })
                                 .collect(),
                         )
@@ -332,6 +325,9 @@ fn member_intersection(
                 .is_some_and(|name| merged_member.has_name(&name))
         }) {
             Some(merged_member) => {
+                if merged_member.is_readonly() && !member.is_readonly() {
+                    merged_member.kind = merged_member.kind.without_readonly();
+                }
                 if member.ty != merged_member.ty {
                     let ty = std::mem::take(&mut merged_member.ty);
                     merged_member.ty = resolver
@@ -346,4 +342,41 @@ fn member_intersection(
     }
 
     merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::member_intersection;
+    use crate::{GlobalsResolver, TypeMember, TypeMemberKind, TypeReference};
+    use biome_rowan::Text;
+
+    #[test]
+    fn intersection_combines_readonly_independently_of_order() {
+        for (left_is_readonly, right_is_readonly, expected) in [
+            (true, false, false),
+            (false, true, false),
+            (true, true, true),
+        ] {
+            let mut resolver = GlobalsResolver::default();
+            let merged = member_intersection(
+                vec![member(left_is_readonly)],
+                vec![member(right_is_readonly)],
+                &mut resolver,
+            );
+
+            assert_eq!(merged[0].is_readonly(), expected);
+        }
+    }
+
+    fn member(is_readonly: bool) -> TypeMember {
+        let kind = TypeMemberKind::Named(Text::new_static("value"));
+        TypeMember {
+            kind: if is_readonly {
+                kind.with_readonly()
+            } else {
+                kind
+            },
+            ty: TypeReference::unknown(),
+        }
+    }
 }

--- a/crates/biome_js_type_info/src/format_inferred_type_info.rs
+++ b/crates/biome_js_type_info/src/format_inferred_type_info.rs
@@ -350,9 +350,17 @@ impl<'db> Format<FormatInferredTypeContext<'db>> for PatternFunctionParameter<'d
 
 impl<'db> Format<FormatInferredTypeContext<'db>> for TypeMember<'db> {
     fn fmt(&self, f: &mut Formatter<FormatInferredTypeContext<'db>>) -> FormatResult<()> {
+        let readonly = format_with(|formatter| {
+            if self.is_readonly() {
+                write!(formatter, [token("readonly"), space()])
+            } else {
+                Ok(())
+            }
+        });
         write!(
             f,
             [&format_args![
+                readonly,
                 &self.kind,
                 token(":"),
                 space(),
@@ -370,23 +378,117 @@ impl<'db> Format<FormatInferredTypeContext<'db>> for TypeMemberKind<'db> {
             Self::Getter(name) | Self::ConstAssertedGetter(name) => {
                 write!(f, [text(&std::format!("get \"{name}\""), None)])
             }
-            Self::IndexSignature(ty) | Self::ConstAssertedIndexSignature(ty) => {
-                write!(f, [token("["), ty, token("]")])
+            Self::IndexSignature(index_signature_type)
+            | Self::ConstAssertedIndexSignature(index_signature_type)
+            | Self::ReadonlyIndexSignature(index_signature_type)
+            | Self::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
+                write!(f, [token("["), index_signature_type, token("]")])
             }
-            Self::ComputedValue(ty) | Self::ConstAssertedComputedValue(ty) => {
-                write!(f, [token("computed"), space(), token("["), ty, token("]")])
-            }
-            Self::ComputedValueNamed(name, _) | Self::ConstAssertedComputedValueNamed(name, _) => {
+            Self::ComputedValueNamed(name, _)
+            | Self::ConstAssertedComputedValueNamed(name, _)
+            | Self::ReadonlyComputedValueNamed(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamed(name, _) => {
                 write!(f, [text(&std::format!("computed [{name}]"), None)])
             }
-            Self::Named(name) | Self::ConstAssertedNamed(name) => {
+            Self::ComputedValue(key_type)
+            | Self::ConstAssertedComputedValue(key_type)
+            | Self::ReadonlyComputedValue(key_type)
+            | Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                write!(
+                    f,
+                    [token("computed"), space(), token("["), key_type, token("]")]
+                )
+            }
+            Self::ComputedValueNamedOptional(name, _)
+            | Self::ConstAssertedComputedValueNamedOptional(name, _)
+            | Self::ReadonlyComputedValueNamedOptional(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedOptional(name, _) => {
+                write!(f, [text(&std::format!("computed [{name}]?"), None)])
+            }
+            Self::ComputedValueOptional(key_type)
+            | Self::ConstAssertedComputedValueOptional(key_type)
+            | Self::ReadonlyComputedValueOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                write!(
+                    f,
+                    [
+                        token("computed"),
+                        space(),
+                        token("["),
+                        key_type,
+                        token("]?")
+                    ]
+                )
+            }
+            Self::ComputedValueNamedStatic(name, _)
+            | Self::ConstAssertedComputedValueNamedStatic(name, _)
+            | Self::ReadonlyComputedValueNamedStatic(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedStatic(name, _) => {
+                write!(f, [text(&std::format!("static computed [{name}]"), None)])
+            }
+            Self::ComputedValueStatic(key_type)
+            | Self::ConstAssertedComputedValueStatic(key_type)
+            | Self::ReadonlyComputedValueStatic(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                write!(
+                    f,
+                    [
+                        token("static"),
+                        space(),
+                        token("computed"),
+                        space(),
+                        token("["),
+                        key_type,
+                        token("]")
+                    ]
+                )
+            }
+            Self::ComputedValueNamedStaticOptional(name, _)
+            | Self::ConstAssertedComputedValueNamedStaticOptional(name, _)
+            | Self::ReadonlyComputedValueNamedStaticOptional(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, _) => {
+                write!(f, [text(&std::format!("static computed [{name}]?"), None)])
+            }
+            Self::ComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedComputedValueStaticOptional(key_type)
+            | Self::ReadonlyComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                write!(
+                    f,
+                    [
+                        token("static"),
+                        space(),
+                        token("computed"),
+                        space(),
+                        token("["),
+                        key_type,
+                        token("]?")
+                    ]
+                )
+            }
+            Self::Named(name)
+            | Self::ConstAssertedNamed(name)
+            | Self::ReadonlyNamed(name)
+            | Self::ConstAssertedReadonlyNamed(name) => {
                 write!(f, [text(&std::format!("\"{name}\""), None)])
             }
-            Self::NamedOptional(name) | Self::ConstAssertedNamedOptional(name) => {
+            Self::NamedOptional(name)
+            | Self::ConstAssertedNamedOptional(name)
+            | Self::ReadonlyNamedOptional(name)
+            | Self::ConstAssertedReadonlyNamedOptional(name) => {
                 write!(f, [text(&std::format!("\"{name}\"?"), None)])
             }
-            Self::NamedStatic(name) | Self::ConstAssertedNamedStatic(name) => {
+            Self::NamedStatic(name)
+            | Self::ConstAssertedNamedStatic(name)
+            | Self::ReadonlyNamedStatic(name)
+            | Self::ConstAssertedReadonlyNamedStatic(name) => {
                 write!(f, [text(&std::format!("static \"{name}\""), None)])
+            }
+            Self::NamedStaticOptional(name)
+            | Self::ConstAssertedNamedStaticOptional(name)
+            | Self::ReadonlyNamedStaticOptional(name)
+            | Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                write!(f, [text(&std::format!("static \"{name}\"?"), None)])
             }
         }
     }

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -323,9 +323,17 @@ impl Format<FormatTypeContext> for PatternFunctionParameter {
 
 impl Format<FormatTypeContext> for TypeMember {
     fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
+        let readonly = format_with(|formatter| {
+            if self.is_readonly() {
+                write!(formatter, [token("readonly"), space()])
+            } else {
+                Ok(())
+            }
+        });
         write!(
             f,
             [&format_args![
+                readonly,
                 &self.kind,
                 token(":"),
                 space(),
@@ -349,25 +357,95 @@ impl Format<FormatTypeContext> for TypeMemberKind {
                 write!(formatter, [text(&quoted, None)])
             }
             Self::IndexSignature(index_signature_type)
-            | Self::ConstAssertedIndexSignature(index_signature_type) => {
+            | Self::ConstAssertedIndexSignature(index_signature_type)
+            | Self::ReadonlyIndexSignature(index_signature_type)
+            | Self::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
                 write!(formatter, [token("["), index_signature_type, token("]")])
             }
-            Self::ComputedValue(key_type) | Self::ConstAssertedComputedValue(key_type) => {
+            Self::ComputedValue(key_type)
+            | Self::ConstAssertedComputedValue(key_type)
+            | Self::ReadonlyComputedValue(key_type)
+            | Self::ConstAssertedReadonlyComputedValue(key_type) => {
                 write!(
                     formatter,
                     [token("computed"), space(), token("["), key_type, token("]")]
                 )
             }
-            Self::Named(name) | Self::ConstAssertedNamed(name) => {
+            Self::ComputedValueOptional(key_type)
+            | Self::ConstAssertedComputedValueOptional(key_type)
+            | Self::ReadonlyComputedValueOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                write!(
+                    formatter,
+                    [
+                        token("computed"),
+                        space(),
+                        token("["),
+                        key_type,
+                        token("]?")
+                    ]
+                )
+            }
+            Self::ComputedValueStatic(key_type)
+            | Self::ConstAssertedComputedValueStatic(key_type)
+            | Self::ReadonlyComputedValueStatic(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                write!(
+                    formatter,
+                    [
+                        token("static"),
+                        space(),
+                        token("computed"),
+                        space(),
+                        token("["),
+                        key_type,
+                        token("]")
+                    ]
+                )
+            }
+            Self::ComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedComputedValueStaticOptional(key_type)
+            | Self::ReadonlyComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                write!(
+                    formatter,
+                    [
+                        token("static"),
+                        space(),
+                        token("computed"),
+                        space(),
+                        token("["),
+                        key_type,
+                        token("]?")
+                    ]
+                )
+            }
+            Self::Named(name)
+            | Self::ConstAssertedNamed(name)
+            | Self::ReadonlyNamed(name)
+            | Self::ConstAssertedReadonlyNamed(name) => {
                 let quoted = std::format!("\"{name}\"");
                 write!(formatter, [text(&quoted, None)])
             }
-            Self::NamedOptional(name) | Self::ConstAssertedNamedOptional(name) => {
+            Self::NamedOptional(name)
+            | Self::ConstAssertedNamedOptional(name)
+            | Self::ReadonlyNamedOptional(name)
+            | Self::ConstAssertedReadonlyNamedOptional(name) => {
                 let quoted = std::format!("\"{name}\"?");
                 write!(formatter, [text(&quoted, None)])
             }
-            Self::NamedStatic(name) | Self::ConstAssertedNamedStatic(name) => {
+            Self::NamedStatic(name)
+            | Self::ConstAssertedNamedStatic(name)
+            | Self::ReadonlyNamedStatic(name)
+            | Self::ConstAssertedReadonlyNamedStatic(name) => {
                 let quoted = std::format!("static \"{name}\"");
+                write!(formatter, [text(&quoted, None)])
+            }
+            Self::NamedStaticOptional(name)
+            | Self::ConstAssertedNamedStaticOptional(name)
+            | Self::ReadonlyNamedStaticOptional(name)
+            | Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                let quoted = std::format!("static \"{name}\"?");
                 write!(formatter, [text(&quoted, None)])
             }
         }

--- a/crates/biome_js_type_info/src/generated/global_types.rs
+++ b/crates/biome_js_type_info/src/generated/global_types.rs
@@ -87,7 +87,7 @@ pub(crate) fn set_generated_global_type_data(
                 ty: crate::globals::GLOBAL_ERROR_CALL_ID.into(),
             },
             crate::TypeMember {
-                kind: crate::TypeMemberKind::NamedStatic(biome_rowan::Text::new_static(
+                kind: crate::TypeMemberKind::ReadonlyNamedStatic(biome_rowan::Text::new_static(
                     "prototype",
                 )),
                 ty: crate::globals::GLOBAL_INSTANCEOF_ERROR_ID.into(),
@@ -105,6 +105,7 @@ pub(crate) fn set_generated_global_type_data(
                 is_rest: false,
             }),
             accessibility: None,
+            is_readonly: false,
         }]),
         return_type: Some(crate::globals::GLOBAL_ERROR_ID.into()),
     }));

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -1,7 +1,5 @@
 use crate::TypeDb;
-use crate::interned_types::{
-    ConditionalType, Literal, ReturnType, TypeData, TypeMember, TypeMemberKind,
-};
+use crate::interned_types::{ConditionalType, Literal, ReturnType, TypeData, TypeMember};
 use biome_rowan::Text;
 use rustc_hash::FxHashSet;
 
@@ -1260,12 +1258,10 @@ fn push_object_pairs<'db>(
         return false;
     }
 
-    if let Some(index_signature) = annotated_members.iter().find(|member| {
-        matches!(
-            member.kind,
-            TypeMemberKind::IndexSignature(_) | TypeMemberKind::ConstAssertedIndexSignature(_)
-        )
-    }) {
+    if let Some(index_signature) = annotated_members
+        .iter()
+        .find(|member| member.kind.index_signature_type().is_some())
+    {
         stack.extend(
             inferred_members
                 .iter()

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -38,11 +38,12 @@ pub fn well_known_symbol_name(reference: &raw::TypeReference) -> Option<Text> {
         raw::TypeReference::Qualifier(qualifier) => {
             let mut parts = qualifier.path.iter();
             match (parts.next(), parts.next(), parts.next()) {
-                (Some(symbol), Some(member), None)
-                    if symbol.text() == "Symbol"
-                        && matches!(member.text(), "dispose" | "asyncDispose") =>
-                {
-                    Some(Text::new_owned(format!("Symbol.{}", member.text()).into()))
+                (Some(symbol), Some(member), None) if symbol.text() == "Symbol" => {
+                    match member.text() {
+                        "dispose" => Some(Text::new_static("Symbol.dispose")),
+                        "asyncDispose" => Some(Text::new_static("Symbol.asyncDispose")),
+                        _ => None,
+                    }
                 }
                 _ => None,
             }
@@ -667,7 +668,7 @@ impl<'db> TypeData<'db> {
                 convert_references(db, &class.type_parameters, resolve_reference),
                 class.extends.as_ref().map(&mut *resolve_reference),
                 convert_references(db, &class.implements, resolve_reference),
-                convert_type_members(db, &class.members, resolve_reference),
+                convert_type_members(&class.members, resolve_reference),
                 class.name.clone(),
                 false,
             )),
@@ -692,23 +693,23 @@ impl<'db> TypeData<'db> {
                 db,
                 convert_references(db, &interface.type_parameters, resolve_reference),
                 convert_references(db, &interface.extends, resolve_reference),
-                convert_type_members(db, &interface.members, resolve_reference),
+                convert_type_members(&interface.members, resolve_reference),
                 interface.name.clone(),
             )),
             raw::TypeData::Module(module) => Self::Module(InternedModule::new(
                 db,
-                convert_type_members(db, &module.members, resolve_reference),
+                convert_type_members(&module.members, resolve_reference),
                 module.name.clone(),
             )),
             raw::TypeData::Namespace(namespace) => Self::Namespace(InternedNamespace::new(
                 db,
-                convert_type_members(db, &namespace.members, resolve_reference),
+                convert_type_members(&namespace.members, resolve_reference),
                 namespace.path.clone(),
             )),
             raw::TypeData::Object(object) => Self::Object(InternedObject::new(
                 db,
                 object.prototype.as_ref().map(&mut *resolve_reference),
-                convert_type_members(db, &object.members, resolve_reference),
+                convert_type_members(&object.members, resolve_reference),
             )),
             raw::TypeData::Tuple(tuple) => Self::Tuple(InternedTuple::new(
                 db,
@@ -752,7 +753,7 @@ impl<'db> TypeData<'db> {
             }
             raw::TypeData::Literal(literal) => Self::Literal(InternedLiteral::new(
                 db,
-                convert_literal(db, literal.as_ref(), resolve_reference),
+                convert_literal(literal.as_ref(), resolve_reference),
             )),
             raw::TypeData::InstanceOf(instance) => Self::instance_of(
                 db,
@@ -1212,6 +1213,7 @@ pub struct AssertsReturnType<'db> {
 pub struct ConstructorParameter<'db> {
     pub parameter: FunctionParameter<'db>,
     pub accessibility: Option<raw::TypeMemberAccessibility>,
+    pub is_readonly: bool,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update)]
@@ -1283,6 +1285,11 @@ impl TypeMember<'_> {
     pub(crate) fn name(&self) -> Option<Text> {
         self.kind.name()
     }
+
+    /// Returns whether this member is readonly.
+    pub fn is_readonly(&self) -> bool {
+        self.kind.is_readonly()
+    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update)]
@@ -1290,49 +1297,140 @@ pub enum TypeMemberKind<'db> {
     CallSignature,
     ComputedValue(TypeData<'db>),
     ComputedValueNamed(Text, TypeData<'db>),
+    ComputedValueNamedOptional(Text, TypeData<'db>),
+    ComputedValueNamedStatic(Text, TypeData<'db>),
+    ComputedValueNamedStaticOptional(Text, TypeData<'db>),
     ConstAssertedCallSignature,
     ConstAssertedComputedValue(TypeData<'db>),
     ConstAssertedComputedValueNamed(Text, TypeData<'db>),
+    ConstAssertedComputedValueNamedOptional(Text, TypeData<'db>),
+    ConstAssertedComputedValueNamedStatic(Text, TypeData<'db>),
+    ConstAssertedComputedValueNamedStaticOptional(Text, TypeData<'db>),
+    ConstAssertedComputedValueOptional(TypeData<'db>),
+    ConstAssertedComputedValueStatic(TypeData<'db>),
+    ConstAssertedComputedValueStaticOptional(TypeData<'db>),
     ConstAssertedConstructor,
     ConstAssertedGetter(Text),
     ConstAssertedIndexSignature(TypeData<'db>),
     ConstAssertedNamed(Text),
     ConstAssertedNamedOptional(Text),
     ConstAssertedNamedStatic(Text),
+    ConstAssertedNamedStaticOptional(Text),
     Constructor,
+    ComputedValueOptional(TypeData<'db>),
+    ComputedValueStatic(TypeData<'db>),
+    ComputedValueStaticOptional(TypeData<'db>),
     Getter(Text),
     IndexSignature(TypeData<'db>),
     Named(Text),
     NamedOptional(Text),
     NamedStatic(Text),
+    NamedStaticOptional(Text),
+    ReadonlyComputedValue(TypeData<'db>),
+    ReadonlyComputedValueNamed(Text, TypeData<'db>),
+    ReadonlyComputedValueNamedOptional(Text, TypeData<'db>),
+    ReadonlyComputedValueNamedStatic(Text, TypeData<'db>),
+    ReadonlyComputedValueNamedStaticOptional(Text, TypeData<'db>),
+    ReadonlyComputedValueOptional(TypeData<'db>),
+    ReadonlyComputedValueStatic(TypeData<'db>),
+    ReadonlyComputedValueStaticOptional(TypeData<'db>),
+    ReadonlyIndexSignature(TypeData<'db>),
+    ReadonlyNamed(Text),
+    ReadonlyNamedOptional(Text),
+    ReadonlyNamedStatic(Text),
+    ReadonlyNamedStaticOptional(Text),
+    ConstAssertedReadonlyComputedValue(TypeData<'db>),
+    ConstAssertedReadonlyComputedValueNamed(Text, TypeData<'db>),
+    ConstAssertedReadonlyComputedValueNamedOptional(Text, TypeData<'db>),
+    ConstAssertedReadonlyComputedValueNamedStatic(Text, TypeData<'db>),
+    ConstAssertedReadonlyComputedValueNamedStaticOptional(Text, TypeData<'db>),
+    ConstAssertedReadonlyComputedValueOptional(TypeData<'db>),
+    ConstAssertedReadonlyComputedValueStatic(TypeData<'db>),
+    ConstAssertedReadonlyComputedValueStaticOptional(TypeData<'db>),
+    ConstAssertedReadonlyIndexSignature(TypeData<'db>),
+    ConstAssertedReadonlyNamed(Text),
+    ConstAssertedReadonlyNamedOptional(Text),
+    ConstAssertedReadonlyNamedStatic(Text),
+    ConstAssertedReadonlyNamedStaticOptional(Text),
 }
 
 impl<'db> TypeMemberKind<'db> {
+    /// Converts a raw member kind while resolving its key type.
+    pub fn from_raw(
+        kind: &raw::TypeMemberKind,
+        resolve_reference: &mut ReferenceResolver<'db, '_>,
+    ) -> Self {
+        convert_type_member_kind(kind, resolve_reference)
+    }
+
     pub fn has_name(&self, name: &str) -> bool {
         match self {
+            Self::CallSignature
+            | Self::ConstAssertedCallSignature
+            | Self::ComputedValue(_)
+            | Self::ConstAssertedComputedValue(_)
+            | Self::ComputedValueOptional(_)
+            | Self::ConstAssertedComputedValueOptional(_)
+            | Self::ComputedValueStatic(_)
+            | Self::ConstAssertedComputedValueStatic(_)
+            | Self::ComputedValueStaticOptional(_)
+            | Self::ConstAssertedComputedValueStaticOptional(_)
+            | Self::ReadonlyComputedValue(_)
+            | Self::ReadonlyComputedValueOptional(_)
+            | Self::ReadonlyComputedValueStatic(_)
+            | Self::ReadonlyComputedValueStaticOptional(_)
+            | Self::ConstAssertedReadonlyComputedValue(_)
+            | Self::ConstAssertedReadonlyComputedValueOptional(_)
+            | Self::ConstAssertedReadonlyComputedValueStatic(_)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
+            | Self::ConstAssertedIndexSignature(_)
+            | Self::IndexSignature(_)
+            | Self::ReadonlyIndexSignature(_)
+            | Self::ConstAssertedReadonlyIndexSignature(_) => false,
             Self::Constructor | Self::ConstAssertedConstructor => name == "constructor",
             Self::Getter(own_name)
             | Self::ConstAssertedGetter(own_name)
             | Self::ComputedValueNamed(own_name, _)
+            | Self::ComputedValueNamedOptional(own_name, _)
+            | Self::ComputedValueNamedStatic(own_name, _)
+            | Self::ComputedValueNamedStaticOptional(own_name, _)
             | Self::ConstAssertedComputedValueNamed(own_name, _)
+            | Self::ConstAssertedComputedValueNamedOptional(own_name, _)
+            | Self::ConstAssertedComputedValueNamedStatic(own_name, _)
+            | Self::ConstAssertedComputedValueNamedStaticOptional(own_name, _)
+            | Self::ReadonlyComputedValueNamed(own_name, _)
+            | Self::ReadonlyComputedValueNamedOptional(own_name, _)
+            | Self::ReadonlyComputedValueNamedStatic(own_name, _)
+            | Self::ReadonlyComputedValueNamedStaticOptional(own_name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamed(own_name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedOptional(own_name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedStatic(own_name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(own_name, _)
             | Self::Named(own_name)
             | Self::ConstAssertedNamed(own_name)
             | Self::NamedOptional(own_name)
             | Self::ConstAssertedNamedOptional(own_name)
             | Self::NamedStatic(own_name)
-            | Self::ConstAssertedNamedStatic(own_name) => own_name.text() == name,
-            Self::CallSignature
-            | Self::ComputedValue(_)
-            | Self::ConstAssertedCallSignature
-            | Self::ConstAssertedComputedValue(_)
-            | Self::ConstAssertedIndexSignature(_)
-            | Self::IndexSignature(_) => false,
+            | Self::ConstAssertedNamedStatic(own_name)
+            | Self::NamedStaticOptional(own_name)
+            | Self::ConstAssertedNamedStaticOptional(own_name)
+            | Self::ReadonlyNamed(own_name)
+            | Self::ConstAssertedReadonlyNamed(own_name)
+            | Self::ReadonlyNamedOptional(own_name)
+            | Self::ConstAssertedReadonlyNamedOptional(own_name)
+            | Self::ReadonlyNamedStatic(own_name)
+            | Self::ConstAssertedReadonlyNamedStatic(own_name)
+            | Self::ReadonlyNamedStaticOptional(own_name)
+            | Self::ConstAssertedReadonlyNamedStaticOptional(own_name) => own_name.text() == name,
         }
     }
 
     pub fn index_signature_type(&self) -> Option<TypeData<'db>> {
         match self {
-            Self::IndexSignature(ty) | Self::ConstAssertedIndexSignature(ty) => Some(*ty),
+            Self::IndexSignature(ty)
+            | Self::ConstAssertedIndexSignature(ty)
+            | Self::ReadonlyIndexSignature(ty)
+            | Self::ConstAssertedReadonlyIndexSignature(ty) => Some(*ty),
             _ => None,
         }
     }
@@ -1342,8 +1440,30 @@ impl<'db> TypeMemberKind<'db> {
             self,
             Self::Constructor
                 | Self::ConstAssertedConstructor
+                | Self::ComputedValueStatic(_)
+                | Self::ComputedValueNamedStatic(_, _)
+                | Self::ConstAssertedComputedValueStatic(_)
+                | Self::ConstAssertedComputedValueNamedStatic(_, _)
+                | Self::ComputedValueStaticOptional(_)
+                | Self::ComputedValueNamedStaticOptional(_, _)
+                | Self::ConstAssertedComputedValueStaticOptional(_)
+                | Self::ConstAssertedComputedValueNamedStaticOptional(_, _)
+                | Self::ReadonlyComputedValueStatic(_)
+                | Self::ReadonlyComputedValueNamedStatic(_, _)
+                | Self::ConstAssertedReadonlyComputedValueStatic(_)
+                | Self::ConstAssertedReadonlyComputedValueNamedStatic(_, _)
+                | Self::ReadonlyComputedValueStaticOptional(_)
+                | Self::ReadonlyComputedValueNamedStaticOptional(_, _)
+                | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(_, _)
                 | Self::NamedStatic(_)
                 | Self::ConstAssertedNamedStatic(_)
+                | Self::NamedStaticOptional(_)
+                | Self::ConstAssertedNamedStaticOptional(_)
+                | Self::ReadonlyNamedStatic(_)
+                | Self::ConstAssertedReadonlyNamedStatic(_)
+                | Self::ReadonlyNamedStaticOptional(_)
+                | Self::ConstAssertedReadonlyNamedStaticOptional(_)
         )
     }
 
@@ -1354,37 +1474,185 @@ impl<'db> TypeMemberKind<'db> {
     pub fn is_optional(&self) -> bool {
         matches!(
             self,
-            Self::NamedOptional(_) | Self::ConstAssertedNamedOptional(_)
+            Self::NamedOptional(_)
+                | Self::ConstAssertedNamedOptional(_)
+                | Self::ComputedValueOptional(_)
+                | Self::ComputedValueNamedOptional(_, _)
+                | Self::ConstAssertedComputedValueOptional(_)
+                | Self::ConstAssertedComputedValueNamedOptional(_, _)
+                | Self::ReadonlyComputedValueOptional(_)
+                | Self::ReadonlyComputedValueNamedOptional(_, _)
+                | Self::ConstAssertedReadonlyComputedValueOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueNamedOptional(_, _)
+                | Self::ComputedValueStaticOptional(_)
+                | Self::ComputedValueNamedStaticOptional(_, _)
+                | Self::ConstAssertedComputedValueStaticOptional(_)
+                | Self::ConstAssertedComputedValueNamedStaticOptional(_, _)
+                | Self::ReadonlyComputedValueStaticOptional(_)
+                | Self::ReadonlyComputedValueNamedStaticOptional(_, _)
+                | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(_, _)
+                | Self::ReadonlyNamedOptional(_)
+                | Self::ConstAssertedReadonlyNamedOptional(_)
+                | Self::NamedStaticOptional(_)
+                | Self::ConstAssertedNamedStaticOptional(_)
+                | Self::ReadonlyNamedStaticOptional(_)
+                | Self::ConstAssertedReadonlyNamedStaticOptional(_)
         )
     }
 
+    /// Returns whether this member carries `as const` provenance.
     pub fn is_const_asserted(&self) -> bool {
         matches!(
             self,
             Self::ConstAssertedCallSignature
                 | Self::ConstAssertedComputedValue(_)
                 | Self::ConstAssertedComputedValueNamed(_, _)
+                | Self::ConstAssertedComputedValueNamedOptional(_, _)
+                | Self::ConstAssertedComputedValueNamedStatic(_, _)
+                | Self::ConstAssertedComputedValueNamedStaticOptional(_, _)
+                | Self::ConstAssertedComputedValueOptional(_)
+                | Self::ConstAssertedComputedValueStatic(_)
+                | Self::ConstAssertedComputedValueStaticOptional(_)
                 | Self::ConstAssertedConstructor
                 | Self::ConstAssertedGetter(_)
                 | Self::ConstAssertedIndexSignature(_)
                 | Self::ConstAssertedNamed(_)
                 | Self::ConstAssertedNamedOptional(_)
                 | Self::ConstAssertedNamedStatic(_)
+                | Self::ConstAssertedNamedStaticOptional(_)
+                | Self::ConstAssertedReadonlyComputedValue(_)
+                | Self::ConstAssertedReadonlyComputedValueNamed(_, _)
+                | Self::ConstAssertedReadonlyComputedValueNamedOptional(_, _)
+                | Self::ConstAssertedReadonlyComputedValueNamedStatic(_, _)
+                | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(_, _)
+                | Self::ConstAssertedReadonlyComputedValueOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueStatic(_)
+                | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
+                | Self::ConstAssertedReadonlyIndexSignature(_)
+                | Self::ConstAssertedReadonlyNamed(_)
+                | Self::ConstAssertedReadonlyNamedOptional(_)
+                | Self::ConstAssertedReadonlyNamedStatic(_)
+                | Self::ConstAssertedReadonlyNamedStaticOptional(_)
         )
     }
 
     pub fn with_optional(self) -> Self {
         match self {
+            Self::ComputedValue(key_type) => Self::ComputedValueOptional(key_type),
+            Self::ComputedValueNamed(name, key_type) => {
+                Self::ComputedValueNamedOptional(name, key_type)
+            }
+            Self::ConstAssertedComputedValue(key_type) => {
+                Self::ConstAssertedComputedValueOptional(key_type)
+            }
+            Self::ConstAssertedComputedValueNamed(name, key_type) => {
+                Self::ConstAssertedComputedValueNamedOptional(name, key_type)
+            }
+            Self::ReadonlyComputedValue(key_type) => Self::ReadonlyComputedValueOptional(key_type),
+            Self::ReadonlyComputedValueNamed(name, key_type) => {
+                Self::ReadonlyComputedValueNamedOptional(name, key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueOptional(key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueNamed(name, key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamedOptional(name, key_type)
+            }
+            Self::ComputedValueStatic(key_type) => Self::ComputedValueStaticOptional(key_type),
+            Self::ComputedValueNamedStatic(name, key_type) => {
+                Self::ComputedValueNamedStaticOptional(name, key_type)
+            }
+            Self::ConstAssertedComputedValueStatic(key_type) => {
+                Self::ConstAssertedComputedValueStaticOptional(key_type)
+            }
+            Self::ConstAssertedComputedValueNamedStatic(name, key_type) => {
+                Self::ConstAssertedComputedValueNamedStaticOptional(name, key_type)
+            }
+            Self::ReadonlyComputedValueStatic(key_type) => {
+                Self::ReadonlyComputedValueStaticOptional(key_type)
+            }
+            Self::ReadonlyComputedValueNamedStatic(name, key_type) => {
+                Self::ReadonlyComputedValueNamedStaticOptional(name, key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueNamedStatic(name, key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, key_type)
+            }
             Self::Named(name) => Self::NamedOptional(name),
             Self::ConstAssertedNamed(name) => Self::ConstAssertedNamedOptional(name),
+            Self::ReadonlyNamed(name) => Self::ReadonlyNamedOptional(name),
+            Self::ConstAssertedReadonlyNamed(name) => {
+                Self::ConstAssertedReadonlyNamedOptional(name)
+            }
+            Self::NamedStatic(name) => Self::NamedStaticOptional(name),
+            Self::ConstAssertedNamedStatic(name) => Self::ConstAssertedNamedStaticOptional(name),
+            Self::ReadonlyNamedStatic(name) => Self::ReadonlyNamedStaticOptional(name),
+            Self::ConstAssertedReadonlyNamedStatic(name) => {
+                Self::ConstAssertedReadonlyNamedStaticOptional(name)
+            }
             other => other,
         }
     }
 
     pub fn without_optional(self) -> Self {
         match self {
+            Self::ComputedValueOptional(key_type) => Self::ComputedValue(key_type),
+            Self::ComputedValueNamedOptional(name, key_type) => {
+                Self::ComputedValueNamed(name, key_type)
+            }
+            Self::ConstAssertedComputedValueOptional(key_type) => {
+                Self::ConstAssertedComputedValue(key_type)
+            }
+            Self::ConstAssertedComputedValueNamedOptional(name, key_type) => {
+                Self::ConstAssertedComputedValueNamed(name, key_type)
+            }
+            Self::ReadonlyComputedValueOptional(key_type) => Self::ReadonlyComputedValue(key_type),
+            Self::ReadonlyComputedValueNamedOptional(name, key_type) => {
+                Self::ReadonlyComputedValueNamed(name, key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValue(key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueNamedOptional(name, key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamed(name, key_type)
+            }
+            Self::ComputedValueStaticOptional(key_type) => Self::ComputedValueStatic(key_type),
+            Self::ComputedValueNamedStaticOptional(name, key_type) => {
+                Self::ComputedValueNamedStatic(name, key_type)
+            }
+            Self::ConstAssertedComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedComputedValueStatic(key_type)
+            }
+            Self::ConstAssertedComputedValueNamedStaticOptional(name, key_type) => {
+                Self::ConstAssertedComputedValueNamedStatic(name, key_type)
+            }
+            Self::ReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ReadonlyComputedValueStatic(key_type)
+            }
+            Self::ReadonlyComputedValueNamedStaticOptional(name, key_type) => {
+                Self::ReadonlyComputedValueNamedStatic(name, key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStatic(key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamedStatic(name, key_type)
+            }
             Self::NamedOptional(name) => Self::Named(name),
             Self::ConstAssertedNamedOptional(name) => Self::ConstAssertedNamed(name),
+            Self::ReadonlyNamedOptional(name) => Self::ReadonlyNamed(name),
+            Self::ConstAssertedReadonlyNamedOptional(name) => {
+                Self::ConstAssertedReadonlyNamed(name)
+            }
+            Self::NamedStaticOptional(name) => Self::NamedStatic(name),
+            Self::ConstAssertedNamedStaticOptional(name) => Self::ConstAssertedNamedStatic(name),
+            Self::ReadonlyNamedStaticOptional(name) => Self::ReadonlyNamedStatic(name),
+            Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Self::ConstAssertedReadonlyNamedStatic(name)
+            }
             other => other,
         }
     }
@@ -1393,33 +1661,357 @@ impl<'db> TypeMemberKind<'db> {
         matches!(self, Self::CallSignature | Self::ConstAssertedCallSignature)
     }
 
+    /// Returns whether this member kind represents a readonly member.
+    pub fn is_readonly(&self) -> bool {
+        matches!(
+            self,
+            Self::ReadonlyComputedValue(_)
+                | Self::ReadonlyComputedValueNamed(_, _)
+                | Self::ReadonlyComputedValueNamedOptional(_, _)
+                | Self::ReadonlyComputedValueNamedStatic(_, _)
+                | Self::ReadonlyComputedValueNamedStaticOptional(_, _)
+                | Self::ReadonlyComputedValueOptional(_)
+                | Self::ReadonlyComputedValueStatic(_)
+                | Self::ReadonlyComputedValueStaticOptional(_)
+                | Self::ReadonlyIndexSignature(_)
+                | Self::ReadonlyNamed(_)
+                | Self::ReadonlyNamedOptional(_)
+                | Self::ReadonlyNamedStatic(_)
+                | Self::ReadonlyNamedStaticOptional(_)
+                | Self::ConstAssertedReadonlyComputedValue(_)
+                | Self::ConstAssertedReadonlyComputedValueNamed(_, _)
+                | Self::ConstAssertedReadonlyComputedValueNamedOptional(_, _)
+                | Self::ConstAssertedReadonlyComputedValueNamedStatic(_, _)
+                | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(_, _)
+                | Self::ConstAssertedReadonlyComputedValueOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueStatic(_)
+                | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
+                | Self::ConstAssertedReadonlyIndexSignature(_)
+                | Self::ConstAssertedReadonlyNamed(_)
+                | Self::ConstAssertedReadonlyNamedOptional(_)
+                | Self::ConstAssertedReadonlyNamedStatic(_)
+                | Self::ConstAssertedReadonlyNamedStaticOptional(_)
+        )
+    }
+
+    /// Marks the member kind as readonly.
+    pub fn with_readonly(self) -> Self {
+        match self {
+            Self::ComputedValue(key_type) | Self::ReadonlyComputedValue(key_type) => {
+                Self::ReadonlyComputedValue(key_type)
+            }
+            Self::ComputedValueNamed(name, key_type)
+            | Self::ReadonlyComputedValueNamed(name, key_type) => {
+                Self::ReadonlyComputedValueNamed(name, key_type)
+            }
+            Self::ComputedValueOptional(key_type)
+            | Self::ReadonlyComputedValueOptional(key_type) => {
+                Self::ReadonlyComputedValueOptional(key_type)
+            }
+            Self::ComputedValueNamedOptional(name, key_type)
+            | Self::ReadonlyComputedValueNamedOptional(name, key_type) => {
+                Self::ReadonlyComputedValueNamedOptional(name, key_type)
+            }
+            Self::ComputedValueStatic(key_type) | Self::ReadonlyComputedValueStatic(key_type) => {
+                Self::ReadonlyComputedValueStatic(key_type)
+            }
+            Self::ComputedValueNamedStatic(name, key_type)
+            | Self::ReadonlyComputedValueNamedStatic(name, key_type) => {
+                Self::ReadonlyComputedValueNamedStatic(name, key_type)
+            }
+            Self::ComputedValueStaticOptional(key_type)
+            | Self::ReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ReadonlyComputedValueStaticOptional(key_type)
+            }
+            Self::ComputedValueNamedStaticOptional(name, key_type)
+            | Self::ReadonlyComputedValueNamedStaticOptional(name, key_type) => {
+                Self::ReadonlyComputedValueNamedStaticOptional(name, key_type)
+            }
+            Self::ConstAssertedComputedValue(key_type)
+            | Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                Self::ConstAssertedReadonlyComputedValue(key_type)
+            }
+            Self::ConstAssertedComputedValueNamed(name, key_type)
+            | Self::ConstAssertedReadonlyComputedValueNamed(name, key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamed(name, key_type)
+            }
+            Self::ConstAssertedComputedValueOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueOptional(key_type)
+            }
+            Self::ConstAssertedComputedValueNamedOptional(name, key_type)
+            | Self::ConstAssertedReadonlyComputedValueNamedOptional(name, key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamedOptional(name, key_type)
+            }
+            Self::ConstAssertedComputedValueStatic(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStatic(key_type)
+            }
+            Self::ConstAssertedComputedValueNamedStatic(name, key_type)
+            | Self::ConstAssertedReadonlyComputedValueNamedStatic(name, key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamedStatic(name, key_type)
+            }
+            Self::ConstAssertedComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type)
+            }
+            Self::ConstAssertedComputedValueNamedStaticOptional(name, key_type)
+            | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, key_type)
+            }
+            Self::IndexSignature(key_type) | Self::ReadonlyIndexSignature(key_type) => {
+                Self::ReadonlyIndexSignature(key_type)
+            }
+            Self::ConstAssertedIndexSignature(key_type)
+            | Self::ConstAssertedReadonlyIndexSignature(key_type) => {
+                Self::ConstAssertedReadonlyIndexSignature(key_type)
+            }
+            Self::Named(name) | Self::ReadonlyNamed(name) => Self::ReadonlyNamed(name),
+            Self::ConstAssertedNamed(name) | Self::ConstAssertedReadonlyNamed(name) => {
+                Self::ConstAssertedReadonlyNamed(name)
+            }
+            Self::NamedOptional(name) | Self::ReadonlyNamedOptional(name) => {
+                Self::ReadonlyNamedOptional(name)
+            }
+            Self::ConstAssertedNamedOptional(name)
+            | Self::ConstAssertedReadonlyNamedOptional(name) => {
+                Self::ConstAssertedReadonlyNamedOptional(name)
+            }
+            Self::NamedStatic(name) | Self::ReadonlyNamedStatic(name) => {
+                Self::ReadonlyNamedStatic(name)
+            }
+            Self::ConstAssertedNamedStatic(name) | Self::ConstAssertedReadonlyNamedStatic(name) => {
+                Self::ConstAssertedReadonlyNamedStatic(name)
+            }
+            Self::NamedStaticOptional(name) | Self::ReadonlyNamedStaticOptional(name) => {
+                Self::ReadonlyNamedStaticOptional(name)
+            }
+            Self::ConstAssertedNamedStaticOptional(name)
+            | Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Self::ConstAssertedReadonlyNamedStaticOptional(name)
+            }
+            other => other,
+        }
+    }
+
+    /// Returns the structural member kind without readonly provenance.
+    pub fn without_readonly(&self) -> Self {
+        match self {
+            Self::ReadonlyComputedValue(key_type) => Self::ComputedValue(*key_type),
+            Self::ReadonlyComputedValueNamed(name, key_type) => {
+                Self::ComputedValueNamed(name.clone(), *key_type)
+            }
+            Self::ReadonlyComputedValueOptional(key_type) => Self::ComputedValueOptional(*key_type),
+            Self::ReadonlyComputedValueNamedOptional(name, key_type) => {
+                Self::ComputedValueNamedOptional(name.clone(), *key_type)
+            }
+            Self::ReadonlyComputedValueStatic(key_type) => Self::ComputedValueStatic(*key_type),
+            Self::ReadonlyComputedValueNamedStatic(name, key_type) => {
+                Self::ComputedValueNamedStatic(name.clone(), *key_type)
+            }
+            Self::ReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ComputedValueStaticOptional(*key_type)
+            }
+            Self::ReadonlyComputedValueNamedStaticOptional(name, key_type) => {
+                Self::ComputedValueNamedStaticOptional(name.clone(), *key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                Self::ConstAssertedComputedValue(*key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueNamed(name, key_type) => {
+                Self::ConstAssertedComputedValueNamed(name.clone(), *key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                Self::ConstAssertedComputedValueOptional(*key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueNamedOptional(name, key_type) => {
+                Self::ConstAssertedComputedValueNamedOptional(name.clone(), *key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Self::ConstAssertedComputedValueStatic(*key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueNamedStatic(name, key_type) => {
+                Self::ConstAssertedComputedValueNamedStatic(name.clone(), *key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedComputedValueStaticOptional(*key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, key_type) => {
+                Self::ConstAssertedComputedValueNamedStaticOptional(name.clone(), *key_type)
+            }
+            Self::ReadonlyIndexSignature(index_signature_type) => {
+                Self::IndexSignature(*index_signature_type)
+            }
+            Self::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
+                Self::ConstAssertedIndexSignature(*index_signature_type)
+            }
+            Self::ReadonlyNamed(name) => Self::Named(name.clone()),
+            Self::ReadonlyNamedOptional(name) => Self::NamedOptional(name.clone()),
+            Self::ReadonlyNamedStatic(name) => Self::NamedStatic(name.clone()),
+            Self::ReadonlyNamedStaticOptional(name) => Self::NamedStaticOptional(name.clone()),
+            Self::ConstAssertedReadonlyNamed(name) => Self::ConstAssertedNamed(name.clone()),
+            Self::ConstAssertedReadonlyNamedOptional(name) => {
+                Self::ConstAssertedNamedOptional(name.clone())
+            }
+            Self::ConstAssertedReadonlyNamedStatic(name) => {
+                Self::ConstAssertedNamedStatic(name.clone())
+            }
+            Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Self::ConstAssertedNamedStaticOptional(name.clone())
+            }
+            other => other.clone(),
+        }
+    }
+
+    /// Converts a class-side member kind to its object-side form.
+    pub fn into_non_static(self) -> Option<Self> {
+        match self {
+            Self::ComputedValueStatic(key_type) => Some(Self::ComputedValue(key_type)),
+            Self::ComputedValueNamedStatic(name, key_type) => {
+                Some(Self::ComputedValueNamed(name, key_type))
+            }
+            Self::ComputedValueStaticOptional(key_type) => {
+                Some(Self::ComputedValueOptional(key_type))
+            }
+            Self::ComputedValueNamedStaticOptional(name, key_type) => {
+                Some(Self::ComputedValueNamedOptional(name, key_type))
+            }
+            Self::ConstAssertedComputedValueStatic(key_type) => {
+                Some(Self::ConstAssertedComputedValue(key_type))
+            }
+            Self::ConstAssertedComputedValueNamedStatic(name, key_type) => {
+                Some(Self::ConstAssertedComputedValueNamed(name, key_type))
+            }
+            Self::ConstAssertedComputedValueStaticOptional(key_type) => {
+                Some(Self::ConstAssertedComputedValueOptional(key_type))
+            }
+            Self::ConstAssertedComputedValueNamedStaticOptional(name, key_type) => Some(
+                Self::ConstAssertedComputedValueNamedOptional(name, key_type),
+            ),
+            Self::ReadonlyComputedValueStatic(key_type) => {
+                Some(Self::ReadonlyComputedValue(key_type))
+            }
+            Self::ReadonlyComputedValueNamedStatic(name, key_type) => {
+                Some(Self::ReadonlyComputedValueNamed(name, key_type))
+            }
+            Self::ReadonlyComputedValueStaticOptional(key_type) => {
+                Some(Self::ReadonlyComputedValueOptional(key_type))
+            }
+            Self::ReadonlyComputedValueNamedStaticOptional(name, key_type) => {
+                Some(Self::ReadonlyComputedValueNamedOptional(name, key_type))
+            }
+            Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Some(Self::ConstAssertedReadonlyComputedValue(key_type))
+            }
+            Self::ConstAssertedReadonlyComputedValueNamedStatic(name, key_type) => Some(
+                Self::ConstAssertedReadonlyComputedValueNamed(name, key_type),
+            ),
+            Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Some(Self::ConstAssertedReadonlyComputedValueOptional(key_type))
+            }
+            Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, key_type) => Some(
+                Self::ConstAssertedReadonlyComputedValueNamedOptional(name, key_type),
+            ),
+            Self::NamedStatic(name) => Some(Self::Named(name)),
+            Self::ConstAssertedNamedStatic(name) => Some(Self::ConstAssertedNamed(name)),
+            Self::NamedStaticOptional(name) => Some(Self::NamedOptional(name)),
+            Self::ConstAssertedNamedStaticOptional(name) => {
+                Some(Self::ConstAssertedNamedOptional(name))
+            }
+            Self::ReadonlyNamedStatic(name) => Some(Self::ReadonlyNamed(name)),
+            Self::ConstAssertedReadonlyNamedStatic(name) => {
+                Some(Self::ConstAssertedReadonlyNamed(name))
+            }
+            Self::ReadonlyNamedStaticOptional(name) => Some(Self::ReadonlyNamedOptional(name)),
+            Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Some(Self::ConstAssertedReadonlyNamedOptional(name))
+            }
+            _ => None,
+        }
+    }
+
     pub fn name(&self) -> Option<Text> {
         match self {
             Self::CallSignature
             | Self::ComputedValue(_)
             | Self::ConstAssertedCallSignature
             | Self::ConstAssertedComputedValue(_)
+            | Self::ComputedValueOptional(_)
+            | Self::ConstAssertedComputedValueOptional(_)
+            | Self::ComputedValueStatic(_)
+            | Self::ConstAssertedComputedValueStatic(_)
+            | Self::ComputedValueStaticOptional(_)
+            | Self::ConstAssertedComputedValueStaticOptional(_)
+            | Self::ReadonlyComputedValue(_)
+            | Self::ReadonlyComputedValueOptional(_)
+            | Self::ReadonlyComputedValueStatic(_)
+            | Self::ReadonlyComputedValueStaticOptional(_)
+            | Self::ConstAssertedReadonlyComputedValue(_)
+            | Self::ConstAssertedReadonlyComputedValueOptional(_)
+            | Self::ConstAssertedReadonlyComputedValueStatic(_)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
             | Self::ConstAssertedIndexSignature(_)
-            | Self::IndexSignature(_) => None,
+            | Self::IndexSignature(_)
+            | Self::ReadonlyIndexSignature(_)
+            | Self::ConstAssertedReadonlyIndexSignature(_) => None,
             Self::ConstAssertedConstructor | Self::Constructor => {
                 Some(Text::new_static("constructor"))
             }
             Self::ConstAssertedGetter(name)
             | Self::ConstAssertedComputedValueNamed(name, _)
+            | Self::ConstAssertedComputedValueNamedOptional(name, _)
+            | Self::ConstAssertedComputedValueNamedStatic(name, _)
+            | Self::ConstAssertedComputedValueNamedStaticOptional(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamed(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedOptional(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedStatic(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, _)
             | Self::ConstAssertedNamed(name)
             | Self::ConstAssertedNamedOptional(name)
             | Self::ConstAssertedNamedStatic(name)
             | Self::Getter(name)
             | Self::ComputedValueNamed(name, _)
+            | Self::ComputedValueNamedOptional(name, _)
+            | Self::ComputedValueNamedStatic(name, _)
+            | Self::ComputedValueNamedStaticOptional(name, _)
+            | Self::ReadonlyComputedValueNamed(name, _)
+            | Self::ReadonlyComputedValueNamedOptional(name, _)
+            | Self::ReadonlyComputedValueNamedStatic(name, _)
+            | Self::ReadonlyComputedValueNamedStaticOptional(name, _)
             | Self::Named(name)
             | Self::NamedOptional(name)
-            | Self::NamedStatic(name) => Some(name.clone()),
+            | Self::NamedStatic(name)
+            | Self::NamedStaticOptional(name)
+            | Self::ConstAssertedNamedStaticOptional(name)
+            | Self::ReadonlyNamed(name)
+            | Self::ConstAssertedReadonlyNamed(name)
+            | Self::ReadonlyNamedOptional(name)
+            | Self::ConstAssertedReadonlyNamedOptional(name)
+            | Self::ReadonlyNamedStatic(name)
+            | Self::ConstAssertedReadonlyNamedStatic(name)
+            | Self::ReadonlyNamedStaticOptional(name)
+            | Self::ConstAssertedReadonlyNamedStaticOptional(name) => Some(name.clone()),
         }
     }
 
     pub fn computed_name(&self) -> Option<&str> {
         match self {
-            Self::ComputedValueNamed(name, _) | Self::ConstAssertedComputedValueNamed(name, _) => {
+            Self::ComputedValueNamed(name, _)
+            | Self::ComputedValueNamedOptional(name, _)
+            | Self::ComputedValueNamedStatic(name, _)
+            | Self::ComputedValueNamedStaticOptional(name, _)
+            | Self::ConstAssertedComputedValueNamed(name, _)
+            | Self::ConstAssertedComputedValueNamedOptional(name, _)
+            | Self::ConstAssertedComputedValueNamedStatic(name, _)
+            | Self::ConstAssertedComputedValueNamedStaticOptional(name, _)
+            | Self::ReadonlyComputedValueNamed(name, _)
+            | Self::ReadonlyComputedValueNamedOptional(name, _)
+            | Self::ReadonlyComputedValueNamedStatic(name, _)
+            | Self::ReadonlyComputedValueNamedStaticOptional(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamed(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedOptional(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedStatic(name, _)
+            | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, _) => {
                 Some(name.text())
             }
             _ => None,
@@ -1430,9 +2022,92 @@ impl<'db> TypeMemberKind<'db> {
         match self {
             Self::ComputedValue(ty)
             | Self::ComputedValueNamed(_, ty)
+            | Self::ComputedValueOptional(ty)
+            | Self::ComputedValueNamedOptional(_, ty)
+            | Self::ComputedValueStatic(ty)
+            | Self::ComputedValueNamedStatic(_, ty)
+            | Self::ComputedValueStaticOptional(ty)
+            | Self::ComputedValueNamedStaticOptional(_, ty)
             | Self::ConstAssertedComputedValue(ty)
-            | Self::ConstAssertedComputedValueNamed(_, ty) => Some(*ty),
+            | Self::ConstAssertedComputedValueNamed(_, ty)
+            | Self::ConstAssertedComputedValueOptional(ty)
+            | Self::ConstAssertedComputedValueNamedOptional(_, ty)
+            | Self::ConstAssertedComputedValueStatic(ty)
+            | Self::ConstAssertedComputedValueNamedStatic(_, ty)
+            | Self::ConstAssertedComputedValueStaticOptional(ty)
+            | Self::ConstAssertedComputedValueNamedStaticOptional(_, ty)
+            | Self::ReadonlyComputedValue(ty)
+            | Self::ReadonlyComputedValueNamed(_, ty)
+            | Self::ReadonlyComputedValueOptional(ty)
+            | Self::ReadonlyComputedValueNamedOptional(_, ty)
+            | Self::ReadonlyComputedValueStatic(ty)
+            | Self::ReadonlyComputedValueNamedStatic(_, ty)
+            | Self::ReadonlyComputedValueStaticOptional(ty)
+            | Self::ReadonlyComputedValueNamedStaticOptional(_, ty)
+            | Self::ConstAssertedReadonlyComputedValue(ty)
+            | Self::ConstAssertedReadonlyComputedValueNamed(_, ty)
+            | Self::ConstAssertedReadonlyComputedValueOptional(ty)
+            | Self::ConstAssertedReadonlyComputedValueNamedOptional(_, ty)
+            | Self::ConstAssertedReadonlyComputedValueStatic(ty)
+            | Self::ConstAssertedReadonlyComputedValueNamedStatic(_, ty)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(ty)
+            | Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(_, ty) => Some(*ty),
             _ => None,
+        }
+    }
+
+    /// Preserves a resolved name for a computed member.
+    fn with_computed_name(self, name: Option<Text>) -> Self {
+        let Some(name) = name else {
+            return self;
+        };
+
+        match self {
+            Self::ComputedValue(key_type) => Self::ComputedValueNamed(name, key_type),
+            Self::ComputedValueOptional(key_type) => {
+                Self::ComputedValueNamedOptional(name, key_type)
+            }
+            Self::ComputedValueStatic(key_type) => Self::ComputedValueNamedStatic(name, key_type),
+            Self::ComputedValueStaticOptional(key_type) => {
+                Self::ComputedValueNamedStaticOptional(name, key_type)
+            }
+            Self::ConstAssertedComputedValue(key_type) => {
+                Self::ConstAssertedComputedValueNamed(name, key_type)
+            }
+            Self::ConstAssertedComputedValueOptional(key_type) => {
+                Self::ConstAssertedComputedValueNamedOptional(name, key_type)
+            }
+            Self::ConstAssertedComputedValueStatic(key_type) => {
+                Self::ConstAssertedComputedValueNamedStatic(name, key_type)
+            }
+            Self::ConstAssertedComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedComputedValueNamedStaticOptional(name, key_type)
+            }
+            Self::ReadonlyComputedValue(key_type) => {
+                Self::ReadonlyComputedValueNamed(name, key_type)
+            }
+            Self::ReadonlyComputedValueOptional(key_type) => {
+                Self::ReadonlyComputedValueNamedOptional(name, key_type)
+            }
+            Self::ReadonlyComputedValueStatic(key_type) => {
+                Self::ReadonlyComputedValueNamedStatic(name, key_type)
+            }
+            Self::ReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ReadonlyComputedValueNamedStaticOptional(name, key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamed(name, key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamedOptional(name, key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamedStatic(name, key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueNamedStaticOptional(name, key_type)
+            }
+            other => other,
         }
     }
 }
@@ -1782,49 +2457,66 @@ fn convert_references<'db>(
 }
 
 fn convert_type_members<'db>(
-    db: &'db dyn TypeDb,
     members: &[raw::TypeMember],
     resolve_reference: &mut ReferenceResolver<'db, '_>,
 ) -> Box<[TypeMember<'db>]> {
     members
         .iter()
         .map(|member| TypeMember {
-            kind: convert_type_member_kind(db, &member.kind, resolve_reference),
+            kind: TypeMemberKind::from_raw(&member.kind, resolve_reference),
             ty: resolve_reference(&member.ty),
         })
         .collect()
 }
 
 fn convert_type_member_kind<'db>(
-    db: &'db dyn TypeDb,
     kind: &raw::TypeMemberKind,
     resolve_reference: &mut ReferenceResolver<'db, '_>,
 ) -> TypeMemberKind<'db> {
-    let _ = db;
     match kind {
         raw::TypeMemberKind::CallSignature => TypeMemberKind::CallSignature,
-        raw::TypeMemberKind::ComputedValue(ty) => {
-            let resolved = resolve_reference(ty);
-            well_known_symbol_name(ty).map_or(TypeMemberKind::ComputedValue(resolved), |name| {
-                TypeMemberKind::ComputedValueNamed(name, resolved)
-            })
-        }
+        raw::TypeMemberKind::ComputedValue(key_type) => convert_computed_type_member_kind(
+            key_type,
+            resolve_reference,
+            TypeMemberKind::ComputedValue,
+        ),
         raw::TypeMemberKind::ConstAssertedCallSignature => {
             TypeMemberKind::ConstAssertedCallSignature
         }
-        raw::TypeMemberKind::ConstAssertedComputedValue(ty) => {
-            let resolved = resolve_reference(ty);
-            well_known_symbol_name(ty).map_or(
-                TypeMemberKind::ConstAssertedComputedValue(resolved),
-                |name| TypeMemberKind::ConstAssertedComputedValueNamed(name, resolved),
+        raw::TypeMemberKind::ConstAssertedComputedValue(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ConstAssertedComputedValue,
+            )
+        }
+        raw::TypeMemberKind::ConstAssertedComputedValueOptional(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ConstAssertedComputedValueOptional,
+            )
+        }
+        raw::TypeMemberKind::ConstAssertedComputedValueStatic(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ConstAssertedComputedValueStatic,
+            )
+        }
+        raw::TypeMemberKind::ConstAssertedComputedValueStaticOptional(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ConstAssertedComputedValueStaticOptional,
             )
         }
         raw::TypeMemberKind::ConstAssertedConstructor => TypeMemberKind::ConstAssertedConstructor,
         raw::TypeMemberKind::ConstAssertedGetter(name) => {
             TypeMemberKind::ConstAssertedGetter(name.clone())
         }
-        raw::TypeMemberKind::ConstAssertedIndexSignature(ty) => {
-            TypeMemberKind::ConstAssertedIndexSignature(resolve_reference(ty))
+        raw::TypeMemberKind::ConstAssertedIndexSignature(index_signature_type) => {
+            TypeMemberKind::ConstAssertedIndexSignature(resolve_reference(index_signature_type))
         }
         raw::TypeMemberKind::ConstAssertedNamed(name) => {
             TypeMemberKind::ConstAssertedNamed(name.clone())
@@ -1835,15 +2527,130 @@ fn convert_type_member_kind<'db>(
         raw::TypeMemberKind::ConstAssertedNamedStatic(name) => {
             TypeMemberKind::ConstAssertedNamedStatic(name.clone())
         }
+        raw::TypeMemberKind::ConstAssertedNamedStaticOptional(name) => {
+            TypeMemberKind::ConstAssertedNamedStaticOptional(name.clone())
+        }
         raw::TypeMemberKind::Constructor => TypeMemberKind::Constructor,
+        raw::TypeMemberKind::ComputedValueOptional(key_type) => convert_computed_type_member_kind(
+            key_type,
+            resolve_reference,
+            TypeMemberKind::ComputedValueOptional,
+        ),
+        raw::TypeMemberKind::ComputedValueStatic(key_type) => convert_computed_type_member_kind(
+            key_type,
+            resolve_reference,
+            TypeMemberKind::ComputedValueStatic,
+        ),
+        raw::TypeMemberKind::ComputedValueStaticOptional(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ComputedValueStaticOptional,
+            )
+        }
         raw::TypeMemberKind::Getter(name) => TypeMemberKind::Getter(name.clone()),
-        raw::TypeMemberKind::IndexSignature(ty) => {
-            TypeMemberKind::IndexSignature(resolve_reference(ty))
+        raw::TypeMemberKind::IndexSignature(index_signature_type) => {
+            TypeMemberKind::IndexSignature(resolve_reference(index_signature_type))
         }
         raw::TypeMemberKind::Named(name) => TypeMemberKind::Named(name.clone()),
         raw::TypeMemberKind::NamedOptional(name) => TypeMemberKind::NamedOptional(name.clone()),
         raw::TypeMemberKind::NamedStatic(name) => TypeMemberKind::NamedStatic(name.clone()),
+        raw::TypeMemberKind::NamedStaticOptional(name) => {
+            TypeMemberKind::NamedStaticOptional(name.clone())
+        }
+        raw::TypeMemberKind::ReadonlyComputedValue(key_type) => convert_computed_type_member_kind(
+            key_type,
+            resolve_reference,
+            TypeMemberKind::ReadonlyComputedValue,
+        ),
+        raw::TypeMemberKind::ReadonlyComputedValueOptional(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ReadonlyComputedValueOptional,
+            )
+        }
+        raw::TypeMemberKind::ReadonlyComputedValueStatic(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ReadonlyComputedValueStatic,
+            )
+        }
+        raw::TypeMemberKind::ReadonlyComputedValueStaticOptional(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ReadonlyComputedValueStaticOptional,
+            )
+        }
+        raw::TypeMemberKind::ReadonlyIndexSignature(index_signature_type) => {
+            TypeMemberKind::ReadonlyIndexSignature(resolve_reference(index_signature_type))
+        }
+        raw::TypeMemberKind::ReadonlyNamed(name) => TypeMemberKind::ReadonlyNamed(name.clone()),
+        raw::TypeMemberKind::ReadonlyNamedOptional(name) => {
+            TypeMemberKind::ReadonlyNamedOptional(name.clone())
+        }
+        raw::TypeMemberKind::ReadonlyNamedStatic(name) => {
+            TypeMemberKind::ReadonlyNamedStatic(name.clone())
+        }
+        raw::TypeMemberKind::ReadonlyNamedStaticOptional(name) => {
+            TypeMemberKind::ReadonlyNamedStaticOptional(name.clone())
+        }
+        raw::TypeMemberKind::ConstAssertedReadonlyComputedValue(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ConstAssertedReadonlyComputedValue,
+            )
+        }
+        raw::TypeMemberKind::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ConstAssertedReadonlyComputedValueOptional,
+            )
+        }
+        raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ConstAssertedReadonlyComputedValueStatic,
+            )
+        }
+        raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+            convert_computed_type_member_kind(
+                key_type,
+                resolve_reference,
+                TypeMemberKind::ConstAssertedReadonlyComputedValueStaticOptional,
+            )
+        }
+        raw::TypeMemberKind::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
+            TypeMemberKind::ConstAssertedReadonlyIndexSignature(resolve_reference(
+                index_signature_type,
+            ))
+        }
+        raw::TypeMemberKind::ConstAssertedReadonlyNamed(name) => {
+            TypeMemberKind::ConstAssertedReadonlyNamed(name.clone())
+        }
+        raw::TypeMemberKind::ConstAssertedReadonlyNamedOptional(name) => {
+            TypeMemberKind::ConstAssertedReadonlyNamedOptional(name.clone())
+        }
+        raw::TypeMemberKind::ConstAssertedReadonlyNamedStatic(name) => {
+            TypeMemberKind::ConstAssertedReadonlyNamedStatic(name.clone())
+        }
+        raw::TypeMemberKind::ConstAssertedReadonlyNamedStaticOptional(name) => {
+            TypeMemberKind::ConstAssertedReadonlyNamedStaticOptional(name.clone())
+        }
     }
+}
+
+fn convert_computed_type_member_kind<'db>(
+    key_type: &raw::TypeReference,
+    resolve_reference: &mut ReferenceResolver<'db, '_>,
+    make_kind: impl FnOnce(TypeData<'db>) -> TypeMemberKind<'db>,
+) -> TypeMemberKind<'db> {
+    make_kind(resolve_reference(key_type)).with_computed_name(well_known_symbol_name(key_type))
 }
 
 fn convert_constructor_parameters<'db>(
@@ -1856,6 +2663,7 @@ fn convert_constructor_parameters<'db>(
         .map(|parameter| ConstructorParameter {
             parameter: convert_function_parameter(db, &parameter.parameter, resolve_reference),
             accessibility: parameter.accessibility,
+            is_readonly: parameter.is_readonly,
         })
         .collect()
 }
@@ -1922,7 +2730,6 @@ fn convert_return_type<'db>(
 }
 
 fn convert_literal<'db>(
-    db: &'db dyn TypeDb,
     literal: &raw::Literal,
     resolve_reference: &mut ReferenceResolver<'db, '_>,
 ) -> Literal<'db> {
@@ -1930,11 +2737,9 @@ fn convert_literal<'db>(
         raw::Literal::BigInt(text) => Literal::BigInt(text.clone()),
         raw::Literal::Boolean(boolean) => Literal::Boolean(boolean.clone()),
         raw::Literal::Number(number) => Literal::Number(number.clone()),
-        raw::Literal::Object(object) => Literal::Object(convert_type_members(
-            db,
-            object.members(),
-            resolve_reference,
-        )),
+        raw::Literal::Object(object) => {
+            Literal::Object(convert_type_members(object.members(), resolve_reference))
+        }
         raw::Literal::RegExp(regexp) => Literal::RegExp(regexp.clone()),
         raw::Literal::String(string) => Literal::String(string.clone()),
         raw::Literal::Template(text) => Literal::Template(text.clone()),
@@ -2086,27 +2891,55 @@ fn raw_type_member_kind_from_type<'db>(
 ) -> raw::TypeMemberKind {
     match kind {
         TypeMemberKind::CallSignature => raw::TypeMemberKind::CallSignature,
-        TypeMemberKind::ComputedValue(ty) => {
-            raw::TypeMemberKind::ComputedValue(ty.to_raw_reference_lossy())
+        TypeMemberKind::ComputedValue(key_type) => {
+            raw::TypeMemberKind::ComputedValue(key_type.to_raw_reference_lossy())
         }
-        TypeMemberKind::ComputedValueNamed(_, ty) => {
-            raw::TypeMemberKind::ComputedValue(ty.to_raw_reference_lossy())
+        TypeMemberKind::ComputedValueNamed(_, key_type) => {
+            raw::TypeMemberKind::ComputedValue(key_type.to_raw_reference_lossy())
         }
         TypeMemberKind::ConstAssertedCallSignature => {
             raw::TypeMemberKind::ConstAssertedCallSignature
         }
-        TypeMemberKind::ConstAssertedComputedValue(ty) => {
-            raw::TypeMemberKind::ConstAssertedComputedValue(ty.to_raw_reference_lossy())
+        TypeMemberKind::ConstAssertedComputedValue(key_type) => {
+            raw::TypeMemberKind::ConstAssertedComputedValue(key_type.to_raw_reference_lossy())
         }
-        TypeMemberKind::ConstAssertedComputedValueNamed(_, ty) => {
-            raw::TypeMemberKind::ConstAssertedComputedValue(ty.to_raw_reference_lossy())
+        TypeMemberKind::ConstAssertedComputedValueOptional(key_type) => {
+            raw::TypeMemberKind::ConstAssertedComputedValueOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedComputedValueNamedOptional(_, key_type) => {
+            raw::TypeMemberKind::ConstAssertedComputedValueOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedComputedValueStatic(key_type) => {
+            raw::TypeMemberKind::ConstAssertedComputedValueStatic(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ConstAssertedComputedValueNamedStatic(_, key_type) => {
+            raw::TypeMemberKind::ConstAssertedComputedValueStatic(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ConstAssertedComputedValueStaticOptional(key_type) => {
+            raw::TypeMemberKind::ConstAssertedComputedValueStaticOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedComputedValueNamedStaticOptional(_, key_type) => {
+            raw::TypeMemberKind::ConstAssertedComputedValueStaticOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedComputedValueNamed(_, key_type) => {
+            raw::TypeMemberKind::ConstAssertedComputedValue(key_type.to_raw_reference_lossy())
         }
         TypeMemberKind::ConstAssertedConstructor => raw::TypeMemberKind::ConstAssertedConstructor,
         TypeMemberKind::ConstAssertedGetter(name) => {
             raw::TypeMemberKind::ConstAssertedGetter(name.clone())
         }
-        TypeMemberKind::ConstAssertedIndexSignature(ty) => {
-            raw::TypeMemberKind::ConstAssertedIndexSignature(ty.to_raw_reference_lossy())
+        TypeMemberKind::ConstAssertedIndexSignature(index_signature_type) => {
+            raw::TypeMemberKind::ConstAssertedIndexSignature(
+                index_signature_type.to_raw_reference_lossy(),
+            )
         }
         TypeMemberKind::ConstAssertedNamed(name) => {
             raw::TypeMemberKind::ConstAssertedNamed(name.clone())
@@ -2117,14 +2950,138 @@ fn raw_type_member_kind_from_type<'db>(
         TypeMemberKind::ConstAssertedNamedStatic(name) => {
             raw::TypeMemberKind::ConstAssertedNamedStatic(name.clone())
         }
+        TypeMemberKind::ConstAssertedNamedStaticOptional(name) => {
+            raw::TypeMemberKind::ConstAssertedNamedStaticOptional(name.clone())
+        }
         TypeMemberKind::Constructor => raw::TypeMemberKind::Constructor,
+        TypeMemberKind::ComputedValueOptional(key_type) => {
+            raw::TypeMemberKind::ComputedValueOptional(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ComputedValueNamedOptional(_, key_type) => {
+            raw::TypeMemberKind::ComputedValueOptional(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ComputedValueStatic(key_type) => {
+            raw::TypeMemberKind::ComputedValueStatic(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ComputedValueNamedStatic(_, key_type) => {
+            raw::TypeMemberKind::ComputedValueStatic(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ComputedValueStaticOptional(key_type) => {
+            raw::TypeMemberKind::ComputedValueStaticOptional(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ComputedValueNamedStaticOptional(_, key_type) => {
+            raw::TypeMemberKind::ComputedValueStaticOptional(key_type.to_raw_reference_lossy())
+        }
         TypeMemberKind::Getter(name) => raw::TypeMemberKind::Getter(name.clone()),
-        TypeMemberKind::IndexSignature(ty) => {
-            raw::TypeMemberKind::IndexSignature(ty.to_raw_reference_lossy())
+        TypeMemberKind::IndexSignature(index_signature_type) => {
+            raw::TypeMemberKind::IndexSignature(index_signature_type.to_raw_reference_lossy())
         }
         TypeMemberKind::Named(name) => raw::TypeMemberKind::Named(name.clone()),
         TypeMemberKind::NamedOptional(name) => raw::TypeMemberKind::NamedOptional(name.clone()),
         TypeMemberKind::NamedStatic(name) => raw::TypeMemberKind::NamedStatic(name.clone()),
+        TypeMemberKind::NamedStaticOptional(name) => {
+            raw::TypeMemberKind::NamedStaticOptional(name.clone())
+        }
+        TypeMemberKind::ReadonlyComputedValue(key_type) => {
+            raw::TypeMemberKind::ReadonlyComputedValue(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ReadonlyComputedValueNamed(_, key_type) => {
+            raw::TypeMemberKind::ReadonlyComputedValue(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ReadonlyComputedValueOptional(key_type) => {
+            raw::TypeMemberKind::ReadonlyComputedValueOptional(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ReadonlyComputedValueNamedOptional(_, key_type) => {
+            raw::TypeMemberKind::ReadonlyComputedValueOptional(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ReadonlyComputedValueStatic(key_type) => {
+            raw::TypeMemberKind::ReadonlyComputedValueStatic(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ReadonlyComputedValueNamedStatic(_, key_type) => {
+            raw::TypeMemberKind::ReadonlyComputedValueStatic(key_type.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ReadonlyComputedValueStaticOptional(key_type) => {
+            raw::TypeMemberKind::ReadonlyComputedValueStaticOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ReadonlyComputedValueNamedStaticOptional(_, key_type) => {
+            raw::TypeMemberKind::ReadonlyComputedValueStaticOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ReadonlyIndexSignature(index_signature_type) => {
+            raw::TypeMemberKind::ReadonlyIndexSignature(
+                index_signature_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ReadonlyNamed(name) => raw::TypeMemberKind::ReadonlyNamed(name.clone()),
+        TypeMemberKind::ReadonlyNamedOptional(name) => {
+            raw::TypeMemberKind::ReadonlyNamedOptional(name.clone())
+        }
+        TypeMemberKind::ReadonlyNamedStatic(name) => {
+            raw::TypeMemberKind::ReadonlyNamedStatic(name.clone())
+        }
+        TypeMemberKind::ReadonlyNamedStaticOptional(name) => {
+            raw::TypeMemberKind::ReadonlyNamedStaticOptional(name.clone())
+        }
+        TypeMemberKind::ConstAssertedReadonlyComputedValue(key_type) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValue(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedReadonlyComputedValueNamed(_, key_type) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValue(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedReadonlyComputedValueNamedOptional(_, key_type) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStatic(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedReadonlyComputedValueNamedStatic(_, key_type) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStatic(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStaticOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedReadonlyComputedValueNamedStaticOptional(_, key_type) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStaticOptional(
+                key_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyIndexSignature(
+                index_signature_type.to_raw_reference_lossy(),
+            )
+        }
+        TypeMemberKind::ConstAssertedReadonlyNamed(name) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyNamed(name.clone())
+        }
+        TypeMemberKind::ConstAssertedReadonlyNamedOptional(name) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyNamedOptional(name.clone())
+        }
+        TypeMemberKind::ConstAssertedReadonlyNamedStatic(name) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyNamedStatic(name.clone())
+        }
+        TypeMemberKind::ConstAssertedReadonlyNamedStaticOptional(name) => {
+            raw::TypeMemberKind::ConstAssertedReadonlyNamedStaticOptional(name.clone())
+        }
     }
 }
 
@@ -2137,6 +3094,7 @@ fn raw_constructor_parameters_from_types<'db>(
         .map(|parameter| raw::ConstructorParameter {
             parameter: raw_function_parameter_from_type(db, &parameter.parameter),
             accessibility: parameter.accessibility,
+            is_readonly: parameter.is_readonly,
         })
         .collect()
 }
@@ -2334,4 +3292,166 @@ fn raw_call_arguments_from_types<'db>(
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use biome_db::ParsedSource;
+    use camino::Utf8Path;
+    use salsa::Storage;
+
+    #[salsa::db]
+    #[derive(Default)]
+    struct TestDb {
+        storage: Storage<Self>,
+    }
+
+    #[salsa::db]
+    impl salsa::Database for TestDb {}
+
+    #[salsa::db]
+    impl biome_db::Db for TestDb {
+        fn parsed_source_for_path(&self, _path: &Utf8Path) -> Option<ParsedSource> {
+            None
+        }
+    }
+
+    #[salsa::db]
+    impl TypeDb for TestDb {}
+
+    #[test]
+    fn raw_type_member_kinds_round_trip_through_interning() {
+        let db = TestDb::default();
+        let name = Text::new_static("member");
+        let key_type = raw::TypeReference::Resolved(GLOBAL_NUMBER_ID);
+        let kinds = [
+            raw::TypeMemberKind::CallSignature,
+            raw::TypeMemberKind::ComputedValue(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedCallSignature,
+            raw::TypeMemberKind::ConstAssertedComputedValue(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedComputedValueOptional(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedComputedValueStatic(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedComputedValueStaticOptional(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedConstructor,
+            raw::TypeMemberKind::ConstAssertedGetter(name.clone()),
+            raw::TypeMemberKind::ConstAssertedIndexSignature(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedNamed(name.clone()),
+            raw::TypeMemberKind::ConstAssertedNamedOptional(name.clone()),
+            raw::TypeMemberKind::ConstAssertedNamedStatic(name.clone()),
+            raw::TypeMemberKind::ConstAssertedNamedStaticOptional(name.clone()),
+            raw::TypeMemberKind::Constructor,
+            raw::TypeMemberKind::ComputedValueOptional(key_type.clone()),
+            raw::TypeMemberKind::ComputedValueStatic(key_type.clone()),
+            raw::TypeMemberKind::ComputedValueStaticOptional(key_type.clone()),
+            raw::TypeMemberKind::Getter(name.clone()),
+            raw::TypeMemberKind::IndexSignature(key_type.clone()),
+            raw::TypeMemberKind::Named(name.clone()),
+            raw::TypeMemberKind::NamedOptional(name.clone()),
+            raw::TypeMemberKind::NamedStatic(name.clone()),
+            raw::TypeMemberKind::NamedStaticOptional(name.clone()),
+            raw::TypeMemberKind::ReadonlyComputedValue(key_type.clone()),
+            raw::TypeMemberKind::ReadonlyComputedValueOptional(key_type.clone()),
+            raw::TypeMemberKind::ReadonlyComputedValueStatic(key_type.clone()),
+            raw::TypeMemberKind::ReadonlyComputedValueStaticOptional(key_type.clone()),
+            raw::TypeMemberKind::ReadonlyIndexSignature(key_type.clone()),
+            raw::TypeMemberKind::ReadonlyNamed(name.clone()),
+            raw::TypeMemberKind::ReadonlyNamedOptional(name.clone()),
+            raw::TypeMemberKind::ReadonlyNamedStatic(name.clone()),
+            raw::TypeMemberKind::ReadonlyNamedStaticOptional(name.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValue(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueOptional(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStatic(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStaticOptional(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyIndexSignature(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyNamed(name.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyNamedOptional(name.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyNamedStatic(name.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyNamedStaticOptional(name),
+        ];
+
+        for kind in kinds {
+            let raw_type = raw::TypeData::Object(Box::new(raw::Object {
+                prototype: None,
+                members: Box::new([raw::TypeMember {
+                    kind: kind.clone(),
+                    ty: key_type.clone(),
+                }]),
+            }));
+            let round_tripped = TypeData::from_raw_lossy(&db, &raw_type).to_raw_lossy(&db);
+            let raw::TypeData::Object(object) = round_tripped else {
+                panic!("object type should remain an object")
+            };
+
+            assert_eq!(object.members[0].kind, kind);
+        }
+    }
+
+    #[test]
+    fn well_known_computed_member_names_survive_interning() {
+        let db = TestDb::default();
+        let key_type = raw::TypeReference::Resolved(GLOBAL_SYMBOL_DISPOSE_ID);
+        let kinds = [
+            raw::TypeMemberKind::ComputedValue(key_type.clone()),
+            raw::TypeMemberKind::ComputedValueOptional(key_type.clone()),
+            raw::TypeMemberKind::ComputedValueStatic(key_type.clone()),
+            raw::TypeMemberKind::ComputedValueStaticOptional(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedComputedValue(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedComputedValueOptional(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedComputedValueStatic(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedComputedValueStaticOptional(key_type.clone()),
+            raw::TypeMemberKind::ReadonlyComputedValue(key_type.clone()),
+            raw::TypeMemberKind::ReadonlyComputedValueOptional(key_type.clone()),
+            raw::TypeMemberKind::ReadonlyComputedValueStatic(key_type.clone()),
+            raw::TypeMemberKind::ReadonlyComputedValueStaticOptional(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValue(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueOptional(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStatic(key_type.clone()),
+            raw::TypeMemberKind::ConstAssertedReadonlyComputedValueStaticOptional(key_type.clone()),
+        ];
+
+        for kind in kinds {
+            let raw_type = raw::TypeData::Object(Box::new(raw::Object {
+                prototype: None,
+                members: Box::new([raw::TypeMember {
+                    kind: kind.clone(),
+                    ty: key_type.clone(),
+                }]),
+            }));
+            let TypeData::Object(object) = TypeData::from_raw_lossy(&db, &raw_type) else {
+                panic!("object type should remain an object")
+            };
+            let interned_kind = &object.members(&db)[0].kind;
+
+            assert_eq!(interned_kind.computed_name(), Some("Symbol.dispose"));
+            assert_eq!(interned_kind.is_optional(), kind.is_optional());
+            assert_eq!(interned_kind.is_static(), kind.is_static());
+            assert_eq!(interned_kind.is_readonly(), kind.is_readonly());
+            assert_eq!(interned_kind.is_const_asserted(), kind.is_const_asserted());
+        }
+    }
+
+    #[test]
+    fn readonly_constructor_parameter_round_trips_through_interning() {
+        let db = TestDb::default();
+        let raw_type = raw::TypeData::Constructor(Box::new(raw::Constructor {
+            type_parameters: Box::default(),
+            parameters: Box::new([raw::ConstructorParameter {
+                parameter: raw::FunctionParameter::Named(raw::NamedFunctionParameter {
+                    name: Text::new_static("value"),
+                    ty: raw::TypeReference::Resolved(GLOBAL_NUMBER_ID),
+                    is_optional: false,
+                    is_rest: false,
+                }),
+                accessibility: Some(raw::TypeMemberAccessibility::Public),
+                is_readonly: true,
+            }]),
+            return_type: Some(raw::TypeReference::Resolved(GLOBAL_NUMBER_ID)),
+        }));
+
+        let round_tripped = TypeData::from_raw_lossy(&db, &raw_type).to_raw_lossy(&db);
+
+        assert_eq!(round_tripped, raw_type);
+    }
 }

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -1795,7 +1795,7 @@ impl<'db> TypeMemberKind<'db> {
     }
 
     /// Returns the structural member kind without readonly provenance.
-    pub fn without_readonly(&self) -> Self {
+    pub(crate) fn without_readonly(&self) -> Self {
         match self {
             Self::ReadonlyComputedValue(key_type) => Self::ComputedValue(*key_type),
             Self::ReadonlyComputedValueNamed(name, key_type) => {
@@ -1864,7 +1864,7 @@ impl<'db> TypeMemberKind<'db> {
     }
 
     /// Converts a class-side member kind to its object-side form.
-    pub fn into_non_static(self) -> Option<Self> {
+    pub(crate) fn into_non_static(self) -> Option<Self> {
         match self {
             Self::ComputedValueStatic(key_type) => Some(Self::ComputedValue(key_type)),
             Self::ComputedValueNamedStatic(name, key_type) => {

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -1512,10 +1512,12 @@ impl ConstructorParameter {
                     resolver, scope_id, param,
                 ),
                 accessibility: None,
+                is_readonly: false,
             },
             AnyJsConstructorParameter::JsRestParameter(param) => Self {
                 parameter: FunctionParameter::from_js_rest_parameter(resolver, scope_id, param),
                 accessibility: None,
+                is_readonly: false,
             },
             AnyJsConstructorParameter::TsPropertyParameter(param) => param
                 .formal_parameter()
@@ -1528,6 +1530,10 @@ impl ConstructorParameter {
                     accessibility: Some(TypeMemberAccessibility::from_modifier_list(
                         param.modifiers(),
                     )),
+                    is_readonly: param
+                        .modifiers()
+                        .into_iter()
+                        .any(|modifier| modifier.as_ts_readonly_modifier().is_some()),
                 })
                 .unwrap_or_default(),
         }
@@ -1929,7 +1935,15 @@ impl TypeMember {
                     .modifiers()
                     .into_iter()
                     .any(|modifier| modifier.as_js_static_modifier().is_some());
-                Self::from_class_member_info(resolver, scope_id, name, ty.into(), is_static, false)
+                Self::from_class_member_info(
+                    resolver,
+                    scope_id,
+                    name,
+                    ty.into(),
+                    is_static,
+                    false,
+                    false,
+                )
             }),
             AnyJsClassMember::JsPropertyClassMember(member) => {
                 member.name().ok().and_then(|name| {
@@ -1950,6 +1964,10 @@ impl TypeMember {
                         .modifiers()
                         .into_iter()
                         .any(|modifier| modifier.as_js_static_modifier().is_some());
+                    let is_readonly = member
+                        .modifiers()
+                        .into_iter()
+                        .any(|modifier| modifier.as_ts_readonly_modifier().is_some());
                     let is_optional = member
                         .property_annotation()
                         .as_ref()
@@ -1961,6 +1979,7 @@ impl TypeMember {
                         name,
                         ty,
                         is_static,
+                        is_readonly,
                         is_optional,
                     )
                 })
@@ -1996,6 +2015,10 @@ impl TypeMember {
                         .modifiers()
                         .into_iter()
                         .any(|modifier| modifier.as_js_static_modifier().is_some());
+                    let is_readonly = member
+                        .modifiers()
+                        .into_iter()
+                        .any(|modifier| modifier.as_ts_readonly_modifier().is_some());
                     let is_optional = member.question_mark_token().is_some();
                     Self::from_class_member_info(
                         resolver,
@@ -2003,6 +2026,7 @@ impl TypeMember {
                         name,
                         ty,
                         is_static,
+                        is_readonly,
                         is_optional,
                     )
                 })
@@ -2020,6 +2044,10 @@ impl TypeMember {
                         .modifiers()
                         .into_iter()
                         .any(|modifier| modifier.as_js_static_modifier().is_some());
+                    let is_readonly = member
+                        .modifiers()
+                        .into_iter()
+                        .any(|modifier| modifier.as_ts_readonly_modifier().is_some());
                     let is_optional = member
                         .property_annotation()
                         .as_ref()
@@ -2031,6 +2059,7 @@ impl TypeMember {
                         name,
                         ty,
                         is_static,
+                        is_readonly,
                         is_optional,
                     )
                 })
@@ -2252,55 +2281,116 @@ impl TypeMember {
                 })
             }
             AnyTsTypeMember::TsIndexSignatureTypeMember(member) => {
-                let key_ty = member
+                let key_type = member
                     .parameter()
                     .and_then(|parameter| parameter.type_annotation())
                     .and_then(|annotation| annotation.ty())
                     .map(|ty| TypeReference::from_any_ts_type(resolver, scope_id, &ty))
                     .ok()?;
-                let value_ty = member
+                let value_type = member
                     .type_annotation()
                     .and_then(|annotation| annotation.ty())
                     .map(|ty| TypeReference::from_any_ts_type(resolver, scope_id, &ty))
                     .ok()?;
+                let kind = if member.readonly_token().is_some() {
+                    TypeMemberKind::IndexSignature(key_type).with_readonly()
+                } else {
+                    TypeMemberKind::IndexSignature(key_type)
+                };
                 Some(Self {
-                    kind: TypeMemberKind::IndexSignature(key_ty),
-                    ty: value_ty,
+                    kind,
+                    ty: value_type,
                 })
             }
             AnyTsTypeMember::TsMethodSignatureTypeMember(member) => {
-                member.name().ok().and_then(|name| name.name()).map(|name| {
-                    let function = Function {
-                        is_async: false,
-                        type_parameters: generic_params_from_ts_type_params(
+                let name = member.name().ok()?;
+                let is_optional = member.optional_token().is_some();
+                let (kind, function_name) = match name {
+                    AnyJsObjectMemberName::JsComputedMemberName(name) => (
+                        TypeMemberKind::ComputedValue(computed_member_reference(
                             resolver,
                             scope_id,
-                            member.type_parameters(),
-                        ),
-                        name: Some(name.clone().into()),
-                        parameters: function_params_from_js_params(
-                            resolver,
-                            scope_id,
-                            member.parameters(),
-                        ),
-                        return_type: return_type_from_annotation(
-                            resolver,
-                            scope_id,
-                            member.return_type_annotation(),
-                        )
-                        .unwrap_or_default(),
-                    };
-                    let ty = resolver.register_and_resolve(function.into()).into();
-                    let is_optional = member.optional_token().is_some();
-                    Self::from_name_and_optional_type(resolver, name, ty, is_optional)
+                            &name.expression().ok()?,
+                        )),
+                        None,
+                    ),
+                    _ => {
+                        let name = Text::from(name.name()?);
+                        (TypeMemberKind::Named(name.clone()), Some(name))
+                    }
+                };
+                let kind = if is_optional {
+                    kind.with_optional()
+                } else {
+                    kind
+                };
+                let function = Function {
+                    is_async: false,
+                    type_parameters: generic_params_from_ts_type_params(
+                        resolver,
+                        scope_id,
+                        member.type_parameters(),
+                    ),
+                    name: function_name,
+                    parameters: function_params_from_js_params(
+                        resolver,
+                        scope_id,
+                        member.parameters(),
+                    ),
+                    return_type: return_type_from_annotation(
+                        resolver,
+                        scope_id,
+                        member.return_type_annotation(),
+                    )
+                    .unwrap_or_default(),
+                };
+                let type_reference = resolver.register_and_resolve(function.into()).into();
+                Some(Self {
+                    kind,
+                    ty: if is_optional {
+                        ResolvedTypeId::new(resolver.level(), resolver.optional(type_reference))
+                            .into()
+                    } else {
+                        type_reference
+                    },
                 })
             }
             AnyTsTypeMember::TsPropertySignatureTypeMember(member) => {
-                member.name().ok().and_then(|name| name.name()).map(|name| {
-                    let ty = type_from_annotation(resolver, scope_id, member.type_annotation())
+                let name = member.name().ok()?;
+                let type_reference =
+                    type_from_annotation(resolver, scope_id, member.type_annotation())
                         .unwrap_or_default();
-                    let is_optional = member.optional_token().is_some();
-                    Self::from_name_and_optional_type(resolver, name, ty, is_optional)
+                let is_readonly = member.readonly_token().is_some();
+                let is_optional = member.optional_token().is_some();
+                let kind = match name {
+                    AnyJsObjectMemberName::JsComputedMemberName(name) => {
+                        TypeMemberKind::ComputedValue(computed_member_reference(
+                            resolver,
+                            scope_id,
+                            &name.expression().ok()?,
+                        ))
+                    }
+                    other => TypeMemberKind::Named(other.name()?.into()),
+                };
+                let kind = if is_optional {
+                    kind.with_optional()
+                } else {
+                    kind
+                };
+                let kind = if is_readonly {
+                    kind.with_readonly()
+                } else {
+                    kind
+                };
+                Some(Self {
+                    kind,
+                    ty: match is_optional {
+                        true => {
+                            ResolvedTypeId::new(resolver.level(), resolver.optional(type_reference))
+                                .into()
+                        }
+                        false => type_reference,
+                    },
                 })
             }
             AnyTsTypeMember::TsSetterSignatureTypeMember(_member) => {
@@ -2315,57 +2405,50 @@ impl TypeMember {
         resolver: &mut dyn TypeResolver,
         scope_id: ScopeId,
         name: AnyJsClassMemberName,
-        ty: TypeReference,
+        type_reference: TypeReference,
         is_static: bool,
+        is_readonly: bool,
         is_optional: bool,
     ) -> Option<Self> {
         let kind = match name {
-            AnyJsClassMemberName::JsComputedMemberName(name) => TypeMemberKind::ComputedValue(
-                computed_member_reference(resolver, scope_id, &name.expression().ok()?),
-            ),
+            AnyJsClassMemberName::JsComputedMemberName(name) => {
+                let key = computed_member_reference(resolver, scope_id, &name.expression().ok()?);
+                if is_static {
+                    TypeMemberKind::ComputedValueStatic(key)
+                } else {
+                    TypeMemberKind::ComputedValue(key)
+                }
+            }
             _ => {
                 let name = text_from_class_member_name(name.name()?);
                 if is_static {
                     TypeMemberKind::NamedStatic(name)
-                } else if is_optional {
-                    TypeMemberKind::NamedOptional(name)
                 } else {
                     TypeMemberKind::Named(name)
                 }
             }
+        };
+        let kind = if is_optional {
+            kind.with_optional()
+        } else {
+            kind
+        };
+        let kind = if is_readonly {
+            kind.with_readonly()
+        } else {
+            kind
         };
 
         Some(Self {
             kind,
             ty: match is_optional {
                 true => {
-                    let id = resolver.optional(ty);
+                    let id = resolver.optional(type_reference);
                     resolver.reference_to_id(id)
                 }
-                false => ty,
+                false => type_reference,
             },
         })
-    }
-
-    #[inline]
-    fn from_name_and_optional_type(
-        resolver: &mut dyn TypeResolver,
-        name: TokenText,
-        ty: TypeReference,
-        is_optional: bool,
-    ) -> Self {
-        let name: Text = name.into();
-        Self {
-            kind: if is_optional {
-                TypeMemberKind::NamedOptional(name)
-            } else {
-                TypeMemberKind::Named(name)
-            },
-            ty: match is_optional {
-                true => ResolvedTypeId::new(resolver.level(), resolver.optional(ty)).into(),
-                false => ty,
-            },
-        }
     }
 
     fn members_from_class_member_list(
@@ -2391,12 +2474,18 @@ impl TypeMember {
                         && let FunctionParameter::Named(named_param) = &param.parameter
                     {
                         // TODO: Assign accessibility to type members.
+                        let kind = if named_param.is_optional {
+                            TypeMemberKind::NamedOptional(named_param.name.clone())
+                        } else {
+                            TypeMemberKind::Named(named_param.name.clone())
+                        };
+                        let kind = if param.is_readonly {
+                            kind.with_readonly()
+                        } else {
+                            kind
+                        };
                         members.push(Self {
-                            kind: if named_param.is_optional {
-                                TypeMemberKind::NamedOptional(named_param.name.clone())
-                            } else {
-                                TypeMemberKind::Named(named_param.name.clone())
-                            },
+                            kind,
                             ty: param.parameter.ty().clone(),
                         });
                     }
@@ -2762,6 +2851,7 @@ fn constructor_params_from_js_params(
                 .map(|param| ConstructorParameter {
                     parameter: FunctionParameter::from_any_js_parameter(resolver, scope_id, &param),
                     accessibility: None,
+                    is_readonly: false,
                 })
                 .collect()
         })

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -537,35 +537,36 @@ impl<'a> ResolvedTypeMember<'a> {
     }
 }
 
-/// Applies the module ID of `resolved` to the key reference of index signature
-/// and computed value member kinds. Returns `None` for other kinds.
-fn keyed_member_kind_with_resolved_reference(
-    resolved: ResolvedTypeData,
-    member_kind: &TypeMemberKind,
-) -> Option<TypeMemberKind> {
-    let (key_reference, constructor): (&TypeReference, fn(TypeReference) -> TypeMemberKind) =
-        match member_kind {
-            TypeMemberKind::IndexSignature(key_reference)
-            | TypeMemberKind::ConstAssertedIndexSignature(key_reference) => {
-                (key_reference, TypeMemberKind::IndexSignature)
-            }
-            TypeMemberKind::ComputedValue(key_reference)
-            | TypeMemberKind::ConstAssertedComputedValue(key_reference) => {
-                (key_reference, TypeMemberKind::ComputedValue)
-            }
-            _ => return None,
-        };
-
-    let kind = constructor(
-        resolved
-            .apply_module_id_to_reference(key_reference)
-            .into_owned(),
-    );
-    Some(if member_kind.is_const_asserted() {
-        kind.with_const_asserted()
-    } else {
-        kind
-    })
+/// Collects mapped-type members with their module context applied.
+fn collect_mapped_type_members(
+    resolver: &mut dyn TypeResolver,
+    type_reference: &TypeReference,
+) -> Option<Vec<TypeMember>> {
+    let resolved = resolver.resolve_and_get(type_reference)?;
+    let resolver_id = resolved.resolver_id();
+    match resolved.as_raw_data() {
+        TypeData::Class(_) | TypeData::Global | TypeData::Interface(_) | TypeData::Object(_) => {
+            Some(
+                resolved
+                    .as_raw_data()
+                    .own_members()
+                    .map(|member| ResolvedTypeMember::from((resolver_id, member)).to_member())
+                    .collect(),
+            )
+        }
+        TypeData::InstanceOf(instance) if instance.type_parameters.is_empty() => {
+            let materialized = resolved.to_data().inferred(resolver);
+            matches!(
+                materialized,
+                TypeData::Class(_)
+                    | TypeData::Global
+                    | TypeData::Interface(_)
+                    | TypeData::Object(_)
+            )
+            .then(|| materialized.own_members().cloned().collect())
+        }
+        _ => None,
+    }
 }
 
 /// Trait for implementing type resolution.
@@ -933,52 +934,23 @@ impl Resolvable for TypeReference {
                             let params = self.resolved_params(resolver);
                             let inner_ref = &params[0];
                             let is_partial = qualifier.is_partial();
-                            // Collect members while borrowing resolver immutably,
-                            // then modify them afterwards to avoid borrow conflicts.
-                            let collected: Option<Vec<(TypeMember, bool)>> =
-                                resolver.resolve_and_get(inner_ref).map(|resolved| {
-                                    resolved
-                                        .as_raw_data()
-                                        .own_members()
-                                        .map(|member| {
-                                            let was_optional = member.is_optional();
-                                            let kind = keyed_member_kind_with_resolved_reference(
-                                                resolved,
-                                                &member.kind,
-                                            )
-                                            .unwrap_or_else(|| {
-                                                if is_partial {
-                                                    member.kind.clone().with_optional()
-                                                } else {
-                                                    member.kind.clone().without_optional()
-                                                }
-                                            });
-                                            (
-                                                TypeMember {
-                                                    kind,
-                                                    ty: resolved
-                                                        .apply_module_id_to_reference(&member.ty)
-                                                        .into_owned(),
-                                                },
-                                                was_optional,
-                                            )
-                                        })
-                                        .collect()
-                                });
-                            if let Some(collected_members) = collected {
-                                let members: Vec<TypeMember> = collected_members
-                                    .into_iter()
-                                    .map(|(mut member, was_optional)| {
-                                        if is_partial && !was_optional {
-                                            let optional_type_id =
-                                                resolver.optional(member.ty.clone());
-                                            member.ty = resolver.reference_to_id(optional_type_id);
-                                        } else if !is_partial && was_optional {
-                                            strip_undefined_from_member(resolver, &mut member);
-                                        }
-                                        member
-                                    })
-                                    .collect();
+                            if let Some(mut members) =
+                                collect_mapped_type_members(resolver, inner_ref)
+                            {
+                                for member in &mut members {
+                                    let was_optional = member.is_optional();
+                                    member.kind = if is_partial {
+                                        member.kind.clone().with_optional()
+                                    } else {
+                                        member.kind.clone().without_optional()
+                                    };
+                                    if is_partial && !was_optional {
+                                        let optional_type_id = resolver.optional(member.ty.clone());
+                                        member.ty = resolver.reference_to_id(optional_type_id);
+                                    } else if !is_partial && was_optional {
+                                        strip_undefined_from_member(resolver, member);
+                                    }
+                                }
                                 let resolved_id: ResolvedTypeId = resolver.register_and_resolve(
                                     TypeData::Object(Box::new(Object {
                                         prototype: None,
@@ -998,27 +970,12 @@ impl Resolvable for TypeReference {
                         } else if qualifier.is_readonly() && qualifier.type_parameters.len() == 1 {
                             let params = self.resolved_params(resolver);
                             let inner_ref = &params[0];
-                            let collected: Option<Vec<TypeMember>> =
-                                resolver.resolve_and_get(inner_ref).map(|resolved| {
-                                    resolved
-                                        .as_raw_data()
-                                        .own_members()
-                                        .map(|member| {
-                                            let kind = keyed_member_kind_with_resolved_reference(
-                                                resolved,
-                                                &member.kind,
-                                            )
-                                            .unwrap_or_else(|| member.kind.clone());
-                                            TypeMember {
-                                                kind,
-                                                ty: resolved
-                                                    .apply_module_id_to_reference(&member.ty)
-                                                    .into_owned(),
-                                            }
-                                        })
-                                        .collect()
-                                });
-                            if let Some(members) = collected {
+                            if let Some(mut members) =
+                                collect_mapped_type_members(resolver, inner_ref)
+                            {
+                                for member in &mut members {
+                                    member.kind = member.kind.clone().with_readonly();
+                                }
                                 let resolved_id: ResolvedTypeId = resolver.register_and_resolve(
                                     TypeData::Object(Box::new(Object {
                                         prototype: None,
@@ -1168,19 +1125,16 @@ fn strip_undefined_from_member(resolver: &mut dyn TypeResolver, member: &mut Typ
     let Some(resolved) = resolver.resolve_and_get(&member.ty) else {
         return;
     };
-    let TypeData::Union(union) = resolved.as_raw_data() else {
+    let TypeData::Union(union) = resolved.to_data() else {
         return;
     };
-    let filtered: Vec<_> = union
-        .0
-        .iter()
-        .filter(|v| **v != TypeReference::from(GLOBAL_UNDEFINED_ID))
-        .cloned()
-        .collect();
-    if filtered.len() == 1 {
-        member.ty = filtered[0].clone();
-    } else if filtered.len() < union.0.len() {
-        let id = resolver.register_and_resolve(TypeData::Union(Box::new(Union(filtered.into()))));
+    let original_variant_count = union.0.len();
+    let mut variants = union.0.into_vec();
+    variants.retain(|variant| *variant != TypeReference::from(GLOBAL_UNDEFINED_ID));
+    if variants.len() == 1 {
+        member.ty = variants.remove(0);
+    } else if variants.len() < original_variant_count {
+        let id = resolver.register_and_resolve(TypeData::Union(Box::new(Union(variants.into()))));
         member.ty = TypeReference::from(id);
     }
 }

--- a/crates/biome_js_type_info/src/type_data.rs
+++ b/crates/biome_js_type_info/src/type_data.rs
@@ -463,12 +463,28 @@ pub struct Constructor {
 }
 
 /// A constructor parameter.
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Resolvable)]
+#[derive(Clone, Default, Eq, Hash, PartialEq, Resolvable)]
 pub struct ConstructorParameter {
     pub parameter: FunctionParameter,
 
     /// Optional visibility, if the parameter declares a class field.
     pub accessibility: Option<TypeMemberAccessibility>,
+
+    /// Whether this parameter declares a readonly class field.
+    pub is_readonly: bool,
+}
+
+impl Debug for ConstructorParameter {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FormatResult {
+        let mut debug_struct = formatter.debug_struct("ConstructorParameter");
+        debug_struct
+            .field("parameter", &self.parameter)
+            .field("accessibility", &self.accessibility);
+        if self.is_readonly {
+            debug_struct.field("is_readonly", &true);
+        }
+        debug_struct.finish()
+    }
 }
 
 /// Tracks two types that are associated with the same name.
@@ -943,10 +959,16 @@ impl Debug for TypeMember {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> FormatResult {
         let mut debug_struct = formatter.debug_struct("TypeMember");
         debug_struct
-            .field("kind", &self.kind.without_const_asserted())
+            .field(
+                "kind",
+                &self.kind.without_const_asserted().without_readonly(),
+            )
             .field("ty", &self.ty);
         if self.is_const_asserted() {
             debug_struct.field("is_const_asserted", &true);
+        }
+        if self.is_readonly() {
+            debug_struct.field("is_readonly", &true);
         }
         debug_struct.finish()
     }
@@ -963,6 +985,12 @@ impl TypeMember {
     #[inline]
     pub fn is_const_asserted(&self) -> bool {
         self.kind.is_const_asserted()
+    }
+
+    /// Returns whether this member is readonly.
+    #[inline]
+    pub fn is_readonly(&self) -> bool {
+        self.kind.is_readonly()
     }
 
     /// Returns a reference to the type of the member if we dereference it.
@@ -998,7 +1026,9 @@ impl TypeMember {
     pub fn is_index_signature_with_ty(&self, predicate: impl Fn(&TypeReference) -> bool) -> bool {
         match &self.kind {
             TypeMemberKind::IndexSignature(index_signature_type)
-            | TypeMemberKind::ConstAssertedIndexSignature(index_signature_type) => {
+            | TypeMemberKind::ConstAssertedIndexSignature(index_signature_type)
+            | TypeMemberKind::ReadonlyIndexSignature(index_signature_type)
+            | TypeMemberKind::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
                 predicate(index_signature_type)
             }
             _ => false,
@@ -1012,8 +1042,26 @@ impl TypeMember {
         match &self.kind {
             TypeMemberKind::IndexSignature(key_type)
             | TypeMemberKind::ConstAssertedIndexSignature(key_type)
+            | TypeMemberKind::ReadonlyIndexSignature(key_type)
+            | TypeMemberKind::ConstAssertedReadonlyIndexSignature(key_type)
             | TypeMemberKind::ComputedValue(key_type)
-            | TypeMemberKind::ConstAssertedComputedValue(key_type) => predicate(key_type),
+            | TypeMemberKind::ComputedValueOptional(key_type)
+            | TypeMemberKind::ComputedValueStatic(key_type)
+            | TypeMemberKind::ComputedValueStaticOptional(key_type)
+            | TypeMemberKind::ConstAssertedComputedValue(key_type)
+            | TypeMemberKind::ConstAssertedComputedValueOptional(key_type)
+            | TypeMemberKind::ConstAssertedComputedValueStatic(key_type)
+            | TypeMemberKind::ConstAssertedComputedValueStaticOptional(key_type)
+            | TypeMemberKind::ReadonlyComputedValue(key_type)
+            | TypeMemberKind::ReadonlyComputedValueOptional(key_type)
+            | TypeMemberKind::ReadonlyComputedValueStatic(key_type)
+            | TypeMemberKind::ReadonlyComputedValueStaticOptional(key_type)
+            | TypeMemberKind::ConstAssertedReadonlyComputedValue(key_type)
+            | TypeMemberKind::ConstAssertedReadonlyComputedValueOptional(key_type)
+            | TypeMemberKind::ConstAssertedReadonlyComputedValueStatic(key_type)
+            | TypeMemberKind::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                predicate(key_type)
+            }
             _ => false,
         }
     }
@@ -1038,37 +1086,105 @@ impl TypeMember {
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Resolvable)]
 pub enum TypeMemberKind {
     CallSignature,
-    /// A member keyed by a computed value, such as `[Symbol.dispose]`. The reference is the key's
-    /// type. Currently produced by the generated global types; local inference of source objects
-    /// still spells computed keys as [`Self::IndexSignature`], so the two spellings coexist and
-    /// [`TypeMember::is_keyed_member_with_ty`] accepts either.
+    /// A member keyed by a computed value, such as `[Symbol.dispose]`.
+    ///
+    /// Index signatures use separate variants; keyed-member queries accept both.
     ComputedValue(TypeReference),
     ConstAssertedCallSignature,
     /// A [`Self::ComputedValue`] carried through an `as const` assertion.
     ConstAssertedComputedValue(TypeReference),
+    ConstAssertedComputedValueOptional(TypeReference),
+    ConstAssertedComputedValueStatic(TypeReference),
+    ConstAssertedComputedValueStaticOptional(TypeReference),
     ConstAssertedConstructor,
     ConstAssertedGetter(Text),
     ConstAssertedIndexSignature(TypeReference),
     ConstAssertedNamed(Text),
     ConstAssertedNamedOptional(Text),
     ConstAssertedNamedStatic(Text),
+    ConstAssertedNamedStaticOptional(Text),
     Constructor,
+    ComputedValueOptional(TypeReference),
+    ComputedValueStatic(TypeReference),
+    ComputedValueStaticOptional(TypeReference),
     Getter(Text),
     IndexSignature(TypeReference),
     Named(Text),
     NamedOptional(Text),
     NamedStatic(Text),
+    NamedStaticOptional(Text),
+    ReadonlyComputedValue(TypeReference),
+    ReadonlyComputedValueOptional(TypeReference),
+    ReadonlyComputedValueStatic(TypeReference),
+    ReadonlyComputedValueStaticOptional(TypeReference),
+    ReadonlyIndexSignature(TypeReference),
+    ReadonlyNamed(Text),
+    ReadonlyNamedOptional(Text),
+    ReadonlyNamedStatic(Text),
+    ReadonlyNamedStaticOptional(Text),
+    ConstAssertedReadonlyComputedValue(TypeReference),
+    ConstAssertedReadonlyComputedValueOptional(TypeReference),
+    ConstAssertedReadonlyComputedValueStatic(TypeReference),
+    ConstAssertedReadonlyComputedValueStaticOptional(TypeReference),
+    ConstAssertedReadonlyIndexSignature(TypeReference),
+    ConstAssertedReadonlyNamed(Text),
+    ConstAssertedReadonlyNamedOptional(Text),
+    ConstAssertedReadonlyNamedStatic(Text),
+    ConstAssertedReadonlyNamedStaticOptional(Text),
 }
 
 impl TypeMemberKind {
+    /// Returns the type reference used by an index signature or computed member.
+    pub fn key_type(&self) -> Option<&TypeReference> {
+        match self {
+            Self::ComputedValue(key_type)
+            | Self::ComputedValueOptional(key_type)
+            | Self::ComputedValueStatic(key_type)
+            | Self::ComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedComputedValue(key_type)
+            | Self::ConstAssertedComputedValueOptional(key_type)
+            | Self::ConstAssertedComputedValueStatic(key_type)
+            | Self::ConstAssertedComputedValueStaticOptional(key_type)
+            | Self::ReadonlyComputedValue(key_type)
+            | Self::ReadonlyComputedValueOptional(key_type)
+            | Self::ReadonlyComputedValueStatic(key_type)
+            | Self::ReadonlyComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValue(key_type)
+            | Self::ConstAssertedReadonlyComputedValueOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStatic(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type)
+            | Self::IndexSignature(key_type)
+            | Self::ConstAssertedIndexSignature(key_type)
+            | Self::ReadonlyIndexSignature(key_type)
+            | Self::ConstAssertedReadonlyIndexSignature(key_type) => Some(key_type),
+            _ => None,
+        }
+    }
+
     pub fn has_name(&self, name: &str) -> bool {
         match self {
             Self::CallSignature
             | Self::ConstAssertedCallSignature
             | Self::ComputedValue(_)
             | Self::ConstAssertedComputedValue(_)
+            | Self::ComputedValueOptional(_)
+            | Self::ConstAssertedComputedValueOptional(_)
+            | Self::ComputedValueStatic(_)
+            | Self::ConstAssertedComputedValueStatic(_)
+            | Self::ComputedValueStaticOptional(_)
+            | Self::ConstAssertedComputedValueStaticOptional(_)
+            | Self::ReadonlyComputedValue(_)
+            | Self::ReadonlyComputedValueOptional(_)
+            | Self::ReadonlyComputedValueStatic(_)
+            | Self::ReadonlyComputedValueStaticOptional(_)
+            | Self::ConstAssertedReadonlyComputedValue(_)
+            | Self::ConstAssertedReadonlyComputedValueOptional(_)
+            | Self::ConstAssertedReadonlyComputedValueStatic(_)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
             | Self::IndexSignature(_)
-            | Self::ConstAssertedIndexSignature(_) => false,
+            | Self::ConstAssertedIndexSignature(_)
+            | Self::ReadonlyIndexSignature(_)
+            | Self::ConstAssertedReadonlyIndexSignature(_) => false,
             Self::Constructor | Self::ConstAssertedConstructor => name == "constructor",
             Self::Getter(own_name)
             | Self::ConstAssertedGetter(own_name)
@@ -1077,7 +1193,17 @@ impl TypeMemberKind {
             | Self::NamedOptional(own_name)
             | Self::ConstAssertedNamedOptional(own_name)
             | Self::NamedStatic(own_name)
-            | Self::ConstAssertedNamedStatic(own_name) => *own_name == name,
+            | Self::ConstAssertedNamedStatic(own_name)
+            | Self::NamedStaticOptional(own_name)
+            | Self::ConstAssertedNamedStaticOptional(own_name)
+            | Self::ReadonlyNamed(own_name)
+            | Self::ConstAssertedReadonlyNamed(own_name)
+            | Self::ReadonlyNamedOptional(own_name)
+            | Self::ConstAssertedReadonlyNamedOptional(own_name)
+            | Self::ReadonlyNamedStatic(own_name)
+            | Self::ConstAssertedReadonlyNamedStatic(own_name)
+            | Self::ReadonlyNamedStaticOptional(own_name)
+            | Self::ConstAssertedReadonlyNamedStaticOptional(own_name) => *own_name == name,
         }
     }
 
@@ -1086,7 +1212,22 @@ impl TypeMemberKind {
     pub fn is_optional(&self) -> bool {
         matches!(
             self,
-            Self::NamedOptional(_) | Self::ConstAssertedNamedOptional(_)
+            Self::NamedOptional(_)
+                | Self::ConstAssertedNamedOptional(_)
+                | Self::ComputedValueOptional(_)
+                | Self::ConstAssertedComputedValueOptional(_)
+                | Self::ReadonlyComputedValueOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueOptional(_)
+                | Self::ComputedValueStaticOptional(_)
+                | Self::ConstAssertedComputedValueStaticOptional(_)
+                | Self::ReadonlyComputedValueStaticOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
+                | Self::ReadonlyNamedOptional(_)
+                | Self::ConstAssertedReadonlyNamedOptional(_)
+                | Self::NamedStaticOptional(_)
+                | Self::ConstAssertedNamedStaticOptional(_)
+                | Self::ReadonlyNamedStaticOptional(_)
+                | Self::ConstAssertedReadonlyNamedStaticOptional(_)
         )
     }
 
@@ -1111,8 +1252,48 @@ impl TypeMemberKind {
             self,
             Self::Constructor
                 | Self::ConstAssertedConstructor
+                | Self::ComputedValueStatic(_)
+                | Self::ConstAssertedComputedValueStatic(_)
+                | Self::ComputedValueStaticOptional(_)
+                | Self::ConstAssertedComputedValueStaticOptional(_)
+                | Self::ReadonlyComputedValueStatic(_)
+                | Self::ConstAssertedReadonlyComputedValueStatic(_)
+                | Self::ReadonlyComputedValueStaticOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
                 | Self::NamedStatic(_)
                 | Self::ConstAssertedNamedStatic(_)
+                | Self::NamedStaticOptional(_)
+                | Self::ConstAssertedNamedStaticOptional(_)
+                | Self::ReadonlyNamedStatic(_)
+                | Self::ConstAssertedReadonlyNamedStatic(_)
+                | Self::ReadonlyNamedStaticOptional(_)
+                | Self::ConstAssertedReadonlyNamedStaticOptional(_)
+        )
+    }
+
+    /// Returns whether this member kind represents a readonly member.
+    #[inline]
+    pub fn is_readonly(&self) -> bool {
+        matches!(
+            self,
+            Self::ReadonlyComputedValue(_)
+                | Self::ReadonlyComputedValueOptional(_)
+                | Self::ReadonlyComputedValueStatic(_)
+                | Self::ReadonlyComputedValueStaticOptional(_)
+                | Self::ReadonlyIndexSignature(_)
+                | Self::ReadonlyNamed(_)
+                | Self::ReadonlyNamedOptional(_)
+                | Self::ReadonlyNamedStatic(_)
+                | Self::ReadonlyNamedStaticOptional(_)
+                | Self::ConstAssertedReadonlyComputedValue(_)
+                | Self::ConstAssertedReadonlyComputedValueOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueStatic(_)
+                | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
+                | Self::ConstAssertedReadonlyIndexSignature(_)
+                | Self::ConstAssertedReadonlyNamed(_)
+                | Self::ConstAssertedReadonlyNamedOptional(_)
+                | Self::ConstAssertedReadonlyNamedStatic(_)
+                | Self::ConstAssertedReadonlyNamedStaticOptional(_)
         )
     }
 
@@ -1122,12 +1303,25 @@ impl TypeMemberKind {
             self,
             Self::ConstAssertedCallSignature
                 | Self::ConstAssertedComputedValue(_)
+                | Self::ConstAssertedComputedValueOptional(_)
+                | Self::ConstAssertedComputedValueStatic(_)
+                | Self::ConstAssertedComputedValueStaticOptional(_)
                 | Self::ConstAssertedConstructor
                 | Self::ConstAssertedGetter(_)
                 | Self::ConstAssertedIndexSignature(_)
                 | Self::ConstAssertedNamed(_)
                 | Self::ConstAssertedNamedOptional(_)
                 | Self::ConstAssertedNamedStatic(_)
+                | Self::ConstAssertedNamedStaticOptional(_)
+                | Self::ConstAssertedReadonlyComputedValue(_)
+                | Self::ConstAssertedReadonlyComputedValueOptional(_)
+                | Self::ConstAssertedReadonlyComputedValueStatic(_)
+                | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
+                | Self::ConstAssertedReadonlyIndexSignature(_)
+                | Self::ConstAssertedReadonlyNamed(_)
+                | Self::ConstAssertedReadonlyNamedOptional(_)
+                | Self::ConstAssertedReadonlyNamedStatic(_)
+                | Self::ConstAssertedReadonlyNamedStaticOptional(_)
         )
     }
 
@@ -1140,18 +1334,66 @@ impl TypeMemberKind {
             Self::ComputedValue(key_type) | Self::ConstAssertedComputedValue(key_type) => {
                 Self::ConstAssertedComputedValue(key_type)
             }
+            Self::ComputedValueOptional(key_type)
+            | Self::ConstAssertedComputedValueOptional(key_type) => {
+                Self::ConstAssertedComputedValueOptional(key_type)
+            }
+            Self::ComputedValueStatic(key_type)
+            | Self::ConstAssertedComputedValueStatic(key_type) => {
+                Self::ConstAssertedComputedValueStatic(key_type)
+            }
+            Self::ComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedComputedValueStaticOptional(key_type)
+            }
+            Self::ReadonlyComputedValue(key_type)
+            | Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                Self::ConstAssertedReadonlyComputedValue(key_type)
+            }
+            Self::ReadonlyComputedValueOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueOptional(key_type)
+            }
+            Self::ReadonlyComputedValueStatic(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStatic(key_type)
+            }
+            Self::ReadonlyComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type)
+            }
             Self::Constructor | Self::ConstAssertedConstructor => Self::ConstAssertedConstructor,
             Self::Getter(name) | Self::ConstAssertedGetter(name) => Self::ConstAssertedGetter(name),
             Self::IndexSignature(index_signature_type)
             | Self::ConstAssertedIndexSignature(index_signature_type) => {
                 Self::ConstAssertedIndexSignature(index_signature_type)
             }
+            Self::ReadonlyIndexSignature(index_signature_type)
+            | Self::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
+                Self::ConstAssertedReadonlyIndexSignature(index_signature_type)
+            }
             Self::Named(name) | Self::ConstAssertedNamed(name) => Self::ConstAssertedNamed(name),
+            Self::ReadonlyNamed(name) | Self::ConstAssertedReadonlyNamed(name) => {
+                Self::ConstAssertedReadonlyNamed(name)
+            }
             Self::NamedOptional(name) | Self::ConstAssertedNamedOptional(name) => {
                 Self::ConstAssertedNamedOptional(name)
             }
+            Self::ReadonlyNamedOptional(name) | Self::ConstAssertedReadonlyNamedOptional(name) => {
+                Self::ConstAssertedReadonlyNamedOptional(name)
+            }
             Self::NamedStatic(name) | Self::ConstAssertedNamedStatic(name) => {
                 Self::ConstAssertedNamedStatic(name)
+            }
+            Self::NamedStaticOptional(name) | Self::ConstAssertedNamedStaticOptional(name) => {
+                Self::ConstAssertedNamedStaticOptional(name)
+            }
+            Self::ReadonlyNamedStatic(name) | Self::ConstAssertedReadonlyNamedStatic(name) => {
+                Self::ConstAssertedReadonlyNamedStatic(name)
+            }
+            Self::ReadonlyNamedStaticOptional(name)
+            | Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Self::ConstAssertedReadonlyNamedStaticOptional(name)
             }
         }
     }
@@ -1161,33 +1403,283 @@ impl TypeMemberKind {
         match self {
             Self::ConstAssertedCallSignature => Self::CallSignature,
             Self::ConstAssertedComputedValue(key_type) => Self::ComputedValue(key_type.clone()),
+            Self::ConstAssertedComputedValueOptional(key_type) => {
+                Self::ComputedValueOptional(key_type.clone())
+            }
+            Self::ConstAssertedComputedValueStatic(key_type) => {
+                Self::ComputedValueStatic(key_type.clone())
+            }
+            Self::ConstAssertedComputedValueStaticOptional(key_type) => {
+                Self::ComputedValueStaticOptional(key_type.clone())
+            }
+            Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                Self::ReadonlyComputedValue(key_type.clone())
+            }
+            Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                Self::ReadonlyComputedValueOptional(key_type.clone())
+            }
+            Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Self::ReadonlyComputedValueStatic(key_type.clone())
+            }
+            Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ReadonlyComputedValueStaticOptional(key_type.clone())
+            }
             Self::ConstAssertedConstructor => Self::Constructor,
             Self::ConstAssertedGetter(name) => Self::Getter(name.clone()),
             Self::ConstAssertedIndexSignature(index_signature_type) => {
                 Self::IndexSignature(index_signature_type.clone())
             }
+            Self::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
+                Self::ReadonlyIndexSignature(index_signature_type.clone())
+            }
             Self::ConstAssertedNamed(name) => Self::Named(name.clone()),
             Self::ConstAssertedNamedOptional(name) => Self::NamedOptional(name.clone()),
             Self::ConstAssertedNamedStatic(name) => Self::NamedStatic(name.clone()),
+            Self::ConstAssertedNamedStaticOptional(name) => Self::NamedStaticOptional(name.clone()),
+            Self::ConstAssertedReadonlyNamed(name) => Self::ReadonlyNamed(name.clone()),
+            Self::ConstAssertedReadonlyNamedOptional(name) => {
+                Self::ReadonlyNamedOptional(name.clone())
+            }
+            Self::ConstAssertedReadonlyNamedStatic(name) => Self::ReadonlyNamedStatic(name.clone()),
+            Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Self::ReadonlyNamedStaticOptional(name.clone())
+            }
             other => other.clone(),
         }
     }
 
-    /// Makes named properties optional while preserving `as const` provenance.
-    pub fn with_optional(self) -> Self {
+    /// Marks the member kind as readonly without growing `TypeMember`.
+    pub fn with_readonly(self) -> Self {
         match self {
-            Self::Named(name) => Self::NamedOptional(name),
-            Self::ConstAssertedNamed(name) => Self::ConstAssertedNamedOptional(name),
+            Self::ComputedValue(key_type) | Self::ReadonlyComputedValue(key_type) => {
+                Self::ReadonlyComputedValue(key_type)
+            }
+            Self::ComputedValueOptional(key_type)
+            | Self::ReadonlyComputedValueOptional(key_type) => {
+                Self::ReadonlyComputedValueOptional(key_type)
+            }
+            Self::ComputedValueStatic(key_type) | Self::ReadonlyComputedValueStatic(key_type) => {
+                Self::ReadonlyComputedValueStatic(key_type)
+            }
+            Self::ComputedValueStaticOptional(key_type)
+            | Self::ReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ReadonlyComputedValueStaticOptional(key_type)
+            }
+            Self::ConstAssertedComputedValue(key_type)
+            | Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                Self::ConstAssertedReadonlyComputedValue(key_type)
+            }
+            Self::ConstAssertedComputedValueOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueOptional(key_type)
+            }
+            Self::ConstAssertedComputedValueStatic(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStatic(key_type)
+            }
+            Self::ConstAssertedComputedValueStaticOptional(key_type)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type)
+            }
+            Self::IndexSignature(index_signature_type)
+            | Self::ReadonlyIndexSignature(index_signature_type) => {
+                Self::ReadonlyIndexSignature(index_signature_type)
+            }
+            Self::ConstAssertedIndexSignature(index_signature_type)
+            | Self::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
+                Self::ConstAssertedReadonlyIndexSignature(index_signature_type)
+            }
+            Self::Named(name) | Self::ReadonlyNamed(name) => Self::ReadonlyNamed(name),
+            Self::ConstAssertedNamed(name) | Self::ConstAssertedReadonlyNamed(name) => {
+                Self::ConstAssertedReadonlyNamed(name)
+            }
+            Self::NamedOptional(name) | Self::ReadonlyNamedOptional(name) => {
+                Self::ReadonlyNamedOptional(name)
+            }
+            Self::ConstAssertedNamedOptional(name)
+            | Self::ConstAssertedReadonlyNamedOptional(name) => {
+                Self::ConstAssertedReadonlyNamedOptional(name)
+            }
+            Self::NamedStatic(name) | Self::ReadonlyNamedStatic(name) => {
+                Self::ReadonlyNamedStatic(name)
+            }
+            Self::ConstAssertedNamedStatic(name) | Self::ConstAssertedReadonlyNamedStatic(name) => {
+                Self::ConstAssertedReadonlyNamedStatic(name)
+            }
+            Self::NamedStaticOptional(name) | Self::ReadonlyNamedStaticOptional(name) => {
+                Self::ReadonlyNamedStaticOptional(name)
+            }
+            Self::ConstAssertedNamedStaticOptional(name)
+            | Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Self::ConstAssertedReadonlyNamedStaticOptional(name)
+            }
             other => other,
         }
     }
 
-    /// Makes optional named properties required while preserving `as const` provenance.
+    /// Returns the structural member kind without readonly provenance.
+    pub fn without_readonly(&self) -> Self {
+        match self {
+            Self::ReadonlyComputedValue(key_type) => Self::ComputedValue(key_type.clone()),
+            Self::ReadonlyComputedValueOptional(key_type) => {
+                Self::ComputedValueOptional(key_type.clone())
+            }
+            Self::ReadonlyComputedValueStatic(key_type) => {
+                Self::ComputedValueStatic(key_type.clone())
+            }
+            Self::ReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ComputedValueStaticOptional(key_type.clone())
+            }
+            Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                Self::ConstAssertedComputedValue(key_type.clone())
+            }
+            Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                Self::ConstAssertedComputedValueOptional(key_type.clone())
+            }
+            Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Self::ConstAssertedComputedValueStatic(key_type.clone())
+            }
+            Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedComputedValueStaticOptional(key_type.clone())
+            }
+            Self::ReadonlyIndexSignature(index_signature_type) => {
+                Self::IndexSignature(index_signature_type.clone())
+            }
+            Self::ConstAssertedReadonlyIndexSignature(index_signature_type) => {
+                Self::ConstAssertedIndexSignature(index_signature_type.clone())
+            }
+            Self::ReadonlyNamed(name) => Self::Named(name.clone()),
+            Self::ConstAssertedReadonlyNamed(name) => Self::ConstAssertedNamed(name.clone()),
+            Self::ReadonlyNamedOptional(name) => Self::NamedOptional(name.clone()),
+            Self::ConstAssertedReadonlyNamedOptional(name) => {
+                Self::ConstAssertedNamedOptional(name.clone())
+            }
+            Self::ReadonlyNamedStatic(name) => Self::NamedStatic(name.clone()),
+            Self::ConstAssertedReadonlyNamedStatic(name) => {
+                Self::ConstAssertedNamedStatic(name.clone())
+            }
+            Self::ReadonlyNamedStaticOptional(name) => Self::NamedStaticOptional(name.clone()),
+            Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Self::ConstAssertedNamedStaticOptional(name.clone())
+            }
+            other => other.clone(),
+        }
+    }
+
+    /// Makes property members optional while preserving member provenance.
+    pub fn with_optional(self) -> Self {
+        match self {
+            Self::ComputedValue(key_type) => Self::ComputedValueOptional(key_type),
+            Self::ConstAssertedComputedValue(key_type) => {
+                Self::ConstAssertedComputedValueOptional(key_type)
+            }
+            Self::ReadonlyComputedValue(key_type) => Self::ReadonlyComputedValueOptional(key_type),
+            Self::ConstAssertedReadonlyComputedValue(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueOptional(key_type)
+            }
+            Self::ComputedValueStatic(key_type) => Self::ComputedValueStaticOptional(key_type),
+            Self::ConstAssertedComputedValueStatic(key_type) => {
+                Self::ConstAssertedComputedValueStaticOptional(key_type)
+            }
+            Self::ReadonlyComputedValueStatic(key_type) => {
+                Self::ReadonlyComputedValueStaticOptional(key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type)
+            }
+            Self::Named(name) => Self::NamedOptional(name),
+            Self::ConstAssertedNamed(name) => Self::ConstAssertedNamedOptional(name),
+            Self::ReadonlyNamed(name) => Self::ReadonlyNamedOptional(name),
+            Self::ConstAssertedReadonlyNamed(name) => {
+                Self::ConstAssertedReadonlyNamedOptional(name)
+            }
+            Self::NamedStatic(name) => Self::NamedStaticOptional(name),
+            Self::ConstAssertedNamedStatic(name) => Self::ConstAssertedNamedStaticOptional(name),
+            Self::ReadonlyNamedStatic(name) => Self::ReadonlyNamedStaticOptional(name),
+            Self::ConstAssertedReadonlyNamedStatic(name) => {
+                Self::ConstAssertedReadonlyNamedStaticOptional(name)
+            }
+            other => other,
+        }
+    }
+
+    /// Makes optional property members required while preserving member provenance.
     pub fn without_optional(self) -> Self {
         match self {
+            Self::ComputedValueOptional(key_type) => Self::ComputedValue(key_type),
+            Self::ConstAssertedComputedValueOptional(key_type) => {
+                Self::ConstAssertedComputedValue(key_type)
+            }
+            Self::ReadonlyComputedValueOptional(key_type) => Self::ReadonlyComputedValue(key_type),
+            Self::ConstAssertedReadonlyComputedValueOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValue(key_type)
+            }
+            Self::ComputedValueStaticOptional(key_type) => Self::ComputedValueStatic(key_type),
+            Self::ConstAssertedComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedComputedValueStatic(key_type)
+            }
+            Self::ReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ReadonlyComputedValueStatic(key_type)
+            }
+            Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Self::ConstAssertedReadonlyComputedValueStatic(key_type)
+            }
             Self::NamedOptional(name) => Self::Named(name),
             Self::ConstAssertedNamedOptional(name) => Self::ConstAssertedNamed(name),
+            Self::ReadonlyNamedOptional(name) => Self::ReadonlyNamed(name),
+            Self::ConstAssertedReadonlyNamedOptional(name) => {
+                Self::ConstAssertedReadonlyNamed(name)
+            }
+            Self::NamedStaticOptional(name) => Self::NamedStatic(name),
+            Self::ConstAssertedNamedStaticOptional(name) => Self::ConstAssertedNamedStatic(name),
+            Self::ReadonlyNamedStaticOptional(name) => Self::ReadonlyNamedStatic(name),
+            Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Self::ConstAssertedReadonlyNamedStatic(name)
+            }
             other => other,
+        }
+    }
+
+    /// Converts a class-side member kind to its object-side form.
+    pub fn into_non_static(self) -> Option<Self> {
+        match self {
+            Self::ComputedValueStatic(key_type) => Some(Self::ComputedValue(key_type)),
+            Self::ComputedValueStaticOptional(key_type) => {
+                Some(Self::ComputedValueOptional(key_type))
+            }
+            Self::ConstAssertedComputedValueStatic(key_type) => {
+                Some(Self::ConstAssertedComputedValue(key_type))
+            }
+            Self::ConstAssertedComputedValueStaticOptional(key_type) => {
+                Some(Self::ConstAssertedComputedValueOptional(key_type))
+            }
+            Self::ReadonlyComputedValueStatic(key_type) => {
+                Some(Self::ReadonlyComputedValue(key_type))
+            }
+            Self::ReadonlyComputedValueStaticOptional(key_type) => {
+                Some(Self::ReadonlyComputedValueOptional(key_type))
+            }
+            Self::ConstAssertedReadonlyComputedValueStatic(key_type) => {
+                Some(Self::ConstAssertedReadonlyComputedValue(key_type))
+            }
+            Self::ConstAssertedReadonlyComputedValueStaticOptional(key_type) => {
+                Some(Self::ConstAssertedReadonlyComputedValueOptional(key_type))
+            }
+            Self::NamedStatic(name) => Some(Self::Named(name)),
+            Self::ConstAssertedNamedStatic(name) => Some(Self::ConstAssertedNamed(name)),
+            Self::NamedStaticOptional(name) => Some(Self::NamedOptional(name)),
+            Self::ConstAssertedNamedStaticOptional(name) => {
+                Some(Self::ConstAssertedNamedOptional(name))
+            }
+            Self::ReadonlyNamedStatic(name) => Some(Self::ReadonlyNamed(name)),
+            Self::ConstAssertedReadonlyNamedStatic(name) => {
+                Some(Self::ConstAssertedReadonlyNamed(name))
+            }
+            Self::ReadonlyNamedStaticOptional(name) => Some(Self::ReadonlyNamedOptional(name)),
+            Self::ConstAssertedReadonlyNamedStaticOptional(name) => {
+                Some(Self::ConstAssertedReadonlyNamedOptional(name))
+            }
+            _ => None,
         }
     }
 
@@ -1197,8 +1689,24 @@ impl TypeMemberKind {
             | Self::ConstAssertedCallSignature
             | Self::ComputedValue(_)
             | Self::ConstAssertedComputedValue(_)
+            | Self::ComputedValueOptional(_)
+            | Self::ConstAssertedComputedValueOptional(_)
+            | Self::ComputedValueStatic(_)
+            | Self::ConstAssertedComputedValueStatic(_)
+            | Self::ComputedValueStaticOptional(_)
+            | Self::ConstAssertedComputedValueStaticOptional(_)
+            | Self::ReadonlyComputedValue(_)
+            | Self::ReadonlyComputedValueOptional(_)
+            | Self::ReadonlyComputedValueStatic(_)
+            | Self::ReadonlyComputedValueStaticOptional(_)
+            | Self::ConstAssertedReadonlyComputedValue(_)
+            | Self::ConstAssertedReadonlyComputedValueOptional(_)
+            | Self::ConstAssertedReadonlyComputedValueStatic(_)
+            | Self::ConstAssertedReadonlyComputedValueStaticOptional(_)
             | Self::IndexSignature(_)
-            | Self::ConstAssertedIndexSignature(_) => None,
+            | Self::ConstAssertedIndexSignature(_)
+            | Self::ReadonlyIndexSignature(_)
+            | Self::ConstAssertedReadonlyIndexSignature(_) => None,
             Self::Constructor | Self::ConstAssertedConstructor => {
                 Some(Text::new_static("constructor"))
             }
@@ -1209,7 +1717,17 @@ impl TypeMemberKind {
             | Self::NamedOptional(name)
             | Self::ConstAssertedNamedOptional(name)
             | Self::NamedStatic(name)
-            | Self::ConstAssertedNamedStatic(name) => Some(name.clone()),
+            | Self::ConstAssertedNamedStatic(name)
+            | Self::NamedStaticOptional(name)
+            | Self::ConstAssertedNamedStaticOptional(name)
+            | Self::ReadonlyNamed(name)
+            | Self::ConstAssertedReadonlyNamed(name)
+            | Self::ReadonlyNamedOptional(name)
+            | Self::ConstAssertedReadonlyNamedOptional(name)
+            | Self::ReadonlyNamedStatic(name)
+            | Self::ConstAssertedReadonlyNamedStatic(name)
+            | Self::ReadonlyNamedStaticOptional(name)
+            | Self::ConstAssertedReadonlyNamedStaticOptional(name) => Some(name.clone()),
         }
     }
 }

--- a/crates/biome_js_type_info/tests/local_inference.rs
+++ b/crates/biome_js_type_info/tests/local_inference.rs
@@ -1,11 +1,14 @@
 mod utils;
 
 use biome_js_semantic::ScopeId;
-use biome_js_type_info::{GlobalsResolver, TypeData, TypeResolver};
+use biome_js_type_info::{
+    GlobalsResolver, TypeData, TypeMemberKind, TypeResolver, interned_types::well_known_symbol_name,
+};
 
 use utils::{
-    assert_type_data_snapshot, assert_typed_bindings_snapshot, get_expression,
-    get_function_declaration, get_variable_declaration, parse_ts,
+    assert_type_data_snapshot, assert_typed_bindings_snapshot, get_class_declaration,
+    get_expression, get_function_declaration, get_type_alias_declaration, get_variable_declaration,
+    parse_ts,
 };
 
 #[test]
@@ -249,6 +252,165 @@ fn infer_type_of_destructured_array_element() {
         &resolver,
         "infer_type_of_destructured_array_element",
     );
+}
+
+#[test]
+fn infer_readonly_type_members() {
+    const CODE: &str = r#"type Value = { readonly name: string; readonly [key: string]: number };"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_type_alias_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let data = TypeData::from_ts_type_alias_declaration(&mut resolver, ScopeId::GLOBAL, &decl)
+        .expect("type alias should resolve");
+    let TypeData::Object(object) = data else {
+        panic!("expected object type");
+    };
+    let name = object
+        .members
+        .iter()
+        .find(|member| member.has_name("name"))
+        .expect("name member");
+    assert!(name.is_readonly());
+    let index = object
+        .members
+        .iter()
+        .find(|member| matches!(member.kind, TypeMemberKind::ReadonlyIndexSignature(_)))
+        .expect("index signature member");
+    assert!(index.is_readonly());
+}
+
+#[test]
+fn infer_readonly_class_property() {
+    const CODE: &str = r#"class Example { readonly value: string; }"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_class_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let class_data = TypeData::from_js_class_declaration(&mut resolver, ScopeId::GLOBAL, &decl);
+    let TypeData::Class(class) = class_data else {
+        panic!("expected class type");
+    };
+    let value = class
+        .members
+        .iter()
+        .find(|member| member.has_name("value"))
+        .expect("value member");
+    assert!(value.is_readonly());
+}
+
+#[test]
+fn infer_readonly_constructor_parameter_property() {
+    const CODE: &str = r#"class Example { constructor(readonly value: string) {} }"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_class_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let class_data = TypeData::from_js_class_declaration(&mut resolver, ScopeId::GLOBAL, &decl);
+    let TypeData::Class(class) = class_data else {
+        panic!("expected class type");
+    };
+    let value = class
+        .members
+        .iter()
+        .find(|member| member.has_name("value"))
+        .expect("value member");
+    assert!(value.is_readonly());
+}
+
+#[test]
+fn infer_readonly_static_optional_class_property() {
+    const CODE: &str = r#"class Example { static readonly value?: string; }"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_class_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let class_data = TypeData::from_js_class_declaration(&mut resolver, ScopeId::GLOBAL, &decl);
+    let TypeData::Class(class) = class_data else {
+        panic!("expected class type");
+    };
+    let value = class
+        .members
+        .iter()
+        .find(|member| member.has_name("value"))
+        .expect("value member");
+    assert!(value.is_static());
+    assert!(value.is_readonly());
+    assert!(value.is_optional());
+}
+
+#[test]
+fn infer_readonly_static_computed_class_property() {
+    const CODE: &str = r#"class Example { static readonly [Symbol.iterator]: string; }"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_class_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let class_data = TypeData::from_js_class_declaration(&mut resolver, ScopeId::GLOBAL, &decl);
+    let TypeData::Class(class) = class_data else {
+        panic!("expected class type");
+    };
+    let member = class.members.first().expect("computed member");
+    assert!(member.is_static());
+    assert!(member.is_readonly());
+    assert!(member.is_keyed_member_with_ty(|_| true));
+}
+
+#[test]
+fn infer_readonly_computed_type_member() {
+    const CODE: &str = r#"type Value = { readonly [Symbol.iterator]: string; }"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_type_alias_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let data = TypeData::from_ts_type_alias_declaration(&mut resolver, ScopeId::GLOBAL, &decl)
+        .expect("type alias should resolve");
+    let TypeData::Object(object) = data else {
+        panic!("expected object type");
+    };
+    let member = object.members.first().expect("computed member");
+    assert!(member.is_readonly());
+    assert!(member.is_keyed_member_with_ty(|_| true));
+}
+
+#[test]
+fn infer_optional_computed_type_members() {
+    const CODE: &str =
+        r#"type Value = { readonly [Symbol.asyncDispose]?: string; [Symbol.dispose]?(): void; };"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_type_alias_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let data = TypeData::from_ts_type_alias_declaration(&mut resolver, ScopeId::GLOBAL, &decl)
+        .expect("type alias should resolve");
+    let TypeData::Object(object) = data else {
+        panic!("expected object type");
+    };
+    let [property, method] = object.members.as_ref() else {
+        panic!("expected two computed members");
+    };
+
+    assert!(property.is_optional());
+    assert!(property.is_readonly());
+    assert!(method.is_optional());
+    assert!(property.is_keyed_member_with_ty(|key_type| {
+        well_known_symbol_name(key_type).is_some_and(|name| name.text() == "Symbol.asyncDispose")
+    }));
+    assert!(method.is_keyed_member_with_ty(|key_type| {
+        well_known_symbol_name(key_type).is_some_and(|name| name.text() == "Symbol.dispose")
+    }));
+
+    let method_type = resolver
+        .resolve_and_get(&method.ty)
+        .expect("optional method type should resolve");
+    let TypeData::Union(method_type) = method_type.as_raw_data() else {
+        panic!("optional method type should include undefined");
+    };
+    assert!(method_type.types().iter().any(|variant| {
+        resolver
+            .resolve_and_get(variant)
+            .is_some_and(|variant| matches!(variant.as_raw_data(), TypeData::Undefined))
+    }));
 }
 
 #[test]

--- a/crates/biome_js_type_info/tests/resolver.rs
+++ b/crates/biome_js_type_info/tests/resolver.rs
@@ -5,14 +5,14 @@ use std::sync::Arc;
 use biome_js_semantic::ScopeId;
 use biome_js_syntax::{AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsExpressionStatement};
 use biome_js_type_info::{
-    GlobalsResolver, Resolvable, Type, TypeData, TypeMemberKind, TypeReference,
-    TypeReferenceQualifier, TypeResolver,
+    GlobalsResolver, ModuleId, Resolvable, ResolvedTypeId, Type, TypeData, TypeId, TypeMember,
+    TypeMemberKind, TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
 };
 use biome_rowan::Text;
 
 use utils::{
     HardcodedSymbolResolver, assert_type_data_snapshot, assert_typed_bindings_snapshot,
-    get_function_declaration, get_variable_declaration, parse_ts,
+    get_function_declaration, get_interface_declaration, get_variable_declaration, parse_ts,
 };
 
 #[test]
@@ -219,6 +219,234 @@ fn infer_resolved_type_of_destructured_array_element() {
 }
 
 #[test]
+fn readonly_utility_marks_members_readonly() {
+    let data = resolved_variable_data(
+        r#"const value: Readonly<{ name: string; [key: string]: number }> = {};"#,
+    );
+    let TypeData::Object(object) = data else {
+        panic!("expected object type");
+    };
+    let name = object
+        .members
+        .iter()
+        .find(|member| member.has_name("name"))
+        .expect("name member");
+    assert!(name.is_readonly());
+    let index = object
+        .members
+        .iter()
+        .find(|member| matches!(member.kind, TypeMemberKind::ReadonlyIndexSignature(_)))
+        .expect("index signature member");
+    assert!(index.is_readonly());
+
+    let data = resolved_variable_data(r#"const value: Readonly<Record<string, string>> = {};"#);
+    let TypeData::Object(object) = data else {
+        panic!("expected object type");
+    };
+    let index = object
+        .members
+        .iter()
+        .find(|member| member.is_index_signature_with_ty(|_| true))
+        .expect("index signature member");
+    assert!(index.is_readonly());
+}
+
+#[test]
+fn readonly_utility_marks_named_type_members_readonly() {
+    const CODE: &str = r#"interface Foo { name: string; }"#;
+
+    let root = parse_ts(CODE);
+    let mut globals = GlobalsResolver::default();
+    let interface = TypeData::from_ts_interface_declaration(
+        &mut globals,
+        ScopeId::GLOBAL,
+        &get_interface_declaration(&root),
+    )
+    .expect("interface should resolve");
+    let mut resolver = HardcodedSymbolResolver::new("Foo", interface, globals);
+    let reference = TypeReference::from(
+        TypeReferenceQualifier::from_path(ScopeId::GLOBAL, Text::new_static("Readonly"))
+            .with_type_parameters([TypeReference::from(TypeReferenceQualifier::from_path(
+                ScopeId::GLOBAL,
+                Text::new_static("Foo"),
+            ))]),
+    );
+    let reference = reference
+        .resolved(&mut resolver)
+        .expect("Readonly<Foo> should resolve");
+    let data = resolver
+        .resolve_and_get(&reference)
+        .expect("resolved Readonly<Foo> should resolve")
+        .to_data();
+    let TypeData::Object(object) = data else {
+        panic!("expected object type");
+    };
+    let name = object
+        .members
+        .iter()
+        .find(|member| member.has_name("name"))
+        .expect("name member");
+    assert!(name.is_readonly());
+}
+
+#[test]
+fn readonly_utility_preserves_foreign_member_context() {
+    let module_id = ModuleId::new(7);
+    let local_reference =
+        TypeReference::Resolved(ResolvedTypeId::new(TypeResolverLevel::Thin, TypeId::new(1)));
+    let object = TypeData::object_with_members(
+        [TypeMember {
+            kind: TypeMemberKind::ComputedValue(local_reference.clone()),
+            ty: local_reference,
+        }]
+        .into(),
+    );
+    let globals = GlobalsResolver::default();
+    let mut resolver =
+        HardcodedSymbolResolver::new("Foo", object, globals).with_foreign_symbol_module(module_id);
+    let reference = TypeReference::from(
+        TypeReferenceQualifier::from_path(ScopeId::GLOBAL, Text::new_static("Readonly"))
+            .with_type_parameters([TypeReference::from(TypeReferenceQualifier::from_path(
+                ScopeId::GLOBAL,
+                Text::new_static("Foo"),
+            ))]),
+    );
+    let reference = reference
+        .resolved(&mut resolver)
+        .expect("Readonly<Foo> should resolve");
+    let data = resolver
+        .resolve_and_get(&reference)
+        .expect("resolved Readonly<Foo> should resolve")
+        .to_data();
+    let TypeData::Object(object) = data else {
+        panic!("expected object type");
+    };
+    let [member] = object.members.as_ref() else {
+        panic!("expected one member");
+    };
+
+    let TypeMemberKind::ReadonlyComputedValue(TypeReference::Resolved(key_type_id)) = &member.kind
+    else {
+        panic!("expected readonly computed member");
+    };
+    let TypeReference::Resolved(value_type_id) = &member.ty else {
+        panic!("expected resolved member type");
+    };
+
+    assert_eq!(key_type_id.module_id(), module_id);
+    assert_eq!(value_type_id.module_id(), module_id);
+}
+
+#[test]
+fn required_utility_preserves_readonly_foreign_union_member_context() {
+    let module_id = ModuleId::new(7);
+    let optional_type_id = TypeId::new(1);
+    let local_reference =
+        TypeReference::Resolved(ResolvedTypeId::new(TypeResolverLevel::Thin, TypeId::new(2)));
+    let object = TypeData::object_with_members(
+        [TypeMember {
+            kind: TypeMemberKind::ReadonlyComputedValueOptional(local_reference.clone()),
+            ty: TypeReference::Resolved(ResolvedTypeId::new(
+                TypeResolverLevel::Thin,
+                optional_type_id,
+            )),
+        }]
+        .into(),
+    );
+    let globals = GlobalsResolver::default();
+    let mut resolver = HardcodedSymbolResolver::new("Foo", object, globals);
+    assert_eq!(resolver.optional(local_reference), optional_type_id);
+    let mut resolver = resolver.with_foreign_symbol_module(module_id);
+    let reference = TypeReference::from(
+        TypeReferenceQualifier::from_path(ScopeId::GLOBAL, Text::new_static("Required"))
+            .with_type_parameters([TypeReference::from(TypeReferenceQualifier::from_path(
+                ScopeId::GLOBAL,
+                Text::new_static("Foo"),
+            ))]),
+    );
+    let reference = reference
+        .resolved(&mut resolver)
+        .expect("Required<Foo> should resolve");
+    let data = resolver
+        .resolve_and_get(&reference)
+        .expect("resolved Required<Foo> should resolve")
+        .to_data();
+    let TypeData::Object(object) = data else {
+        panic!("expected object type");
+    };
+    let [member] = object.members.as_ref() else {
+        panic!("expected one member");
+    };
+
+    let TypeMemberKind::ReadonlyComputedValue(TypeReference::Resolved(key_type_id)) = &member.kind
+    else {
+        panic!("expected required computed member");
+    };
+    let TypeReference::Resolved(value_type_id) = &member.ty else {
+        panic!("expected resolved member type");
+    };
+
+    assert_eq!(key_type_id.module_id(), module_id);
+    assert_eq!(value_type_id.module_id(), module_id);
+}
+
+#[test]
+fn mapped_utilities_preserve_readonly_members() {
+    let data = resolved_variable_data(
+        r#"const value: Partial<{ readonly name: string; readonly [key: string]: number; readonly [Symbol.iterator]: () => string }> = {};"#,
+    );
+    let TypeData::Object(object) = data else {
+        panic!("expected partial object type");
+    };
+    let name = object
+        .members
+        .iter()
+        .find(|member| member.has_name("name"))
+        .expect("name member");
+    assert!(name.is_readonly());
+    assert!(name.is_optional());
+    let index = object
+        .members
+        .iter()
+        .find(|member| matches!(member.kind, TypeMemberKind::ReadonlyIndexSignature(_)))
+        .expect("index signature member");
+    assert!(index.is_readonly());
+    let computed = object
+        .members
+        .iter()
+        .find(|member| {
+            matches!(
+                member.kind,
+                TypeMemberKind::ReadonlyComputedValueOptional(_)
+            )
+        })
+        .expect("computed member");
+    assert!(computed.is_readonly());
+    assert!(computed.is_optional());
+
+    let data = resolved_variable_data(
+        r#"const value: Required<{ readonly name?: string; readonly [Symbol.iterator]?: () => string }> = {};"#,
+    );
+    let TypeData::Object(object) = data else {
+        panic!("expected required object type");
+    };
+    let name = object
+        .members
+        .iter()
+        .find(|member| member.has_name("name"))
+        .expect("name member");
+    assert!(name.is_readonly());
+    assert!(!name.is_optional());
+    let computed = object
+        .members
+        .iter()
+        .find(|member| matches!(member.kind, TypeMemberKind::ReadonlyComputedValue(_)))
+        .expect("computed member");
+    assert!(computed.is_readonly());
+    assert!(!computed.is_optional());
+}
+
+#[test]
 fn infer_resolved_type_of_disposable_object() {
     const CODE: &str = r#"const a = {
         [Symbol.dispose](): void {
@@ -360,6 +588,50 @@ fn assert_global_has_computed_member(resolver: &GlobalsResolver, name: &'static 
         panic!("{name} should have exactly one generated member");
     };
     assert!(matches!(member.kind, TypeMemberKind::ComputedValue(_)));
+}
+
+#[test]
+fn generated_error_prototype_is_readonly() {
+    let resolver = GlobalsResolver::default();
+    let reference = TypeReference::from(
+        TypeReferenceQualifier::from_path(ScopeId::GLOBAL, Text::new_static("Error"))
+            .with_type_only(),
+    );
+    let resolved = resolver
+        .resolve_and_get(&reference)
+        .expect("Error should resolve");
+    let TypeData::Class(class) = resolved.as_raw_data() else {
+        panic!("Error should resolve to generated class data");
+    };
+    let prototype = class
+        .members
+        .iter()
+        .find(|member| member.has_name("prototype"))
+        .expect("prototype member");
+    assert!(prototype.is_static());
+    assert!(prototype.is_readonly());
+}
+
+fn resolved_variable_data(code: &str) -> TypeData {
+    let root = parse_ts(code);
+    let decl = get_variable_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let bindings = TypeData::typed_bindings_from_js_variable_declaration(
+        &mut resolver,
+        ScopeId::GLOBAL,
+        &decl,
+    );
+
+    let [(name, reference)] = bindings.as_ref() else {
+        panic!("expected exactly one binding");
+    };
+    assert_eq!(name.text(), "value");
+
+    resolver
+        .resolve_and_get(reference)
+        .expect("resolved binding should resolve")
+        .to_data()
+        .inferred(&mut resolver)
 }
 
 fn inferred_variable_type(code: &str) -> Type {

--- a/crates/biome_js_type_info/tests/type_data.rs
+++ b/crates/biome_js_type_info/tests/type_data.rs
@@ -1,4 +1,5 @@
 use biome_js_type_info::*;
+use biome_rowan::Text;
 
 #[test]
 fn test_resolved_type_id() {
@@ -163,5 +164,57 @@ fn verify_type_sizes() {
         std::mem::size_of::<TypeInstance>(),
         32,
         "The size shouldn't go higher"
+    );
+}
+
+#[test]
+fn readonly_member_kind_preserves_other_provenance() {
+    let kind = TypeMemberKind::Named(Text::new_static("value"))
+        .with_readonly()
+        .with_const_asserted()
+        .with_optional();
+
+    assert!(kind.is_readonly());
+    assert!(kind.is_const_asserted());
+    assert!(kind.is_optional());
+    assert_eq!(
+        kind.clone().without_optional().without_const_asserted(),
+        TypeMemberKind::ReadonlyNamed(Text::new_static("value"))
+    );
+    assert_eq!(
+        kind.without_readonly(),
+        TypeMemberKind::ConstAssertedNamedOptional(Text::new_static("value"))
+    );
+}
+
+#[test]
+fn static_member_kind_converts_to_object_member_kind() {
+    let named = TypeMemberKind::NamedStatic(Text::new_static("value"))
+        .with_readonly()
+        .with_optional()
+        .into_non_static()
+        .expect("static named member should convert");
+
+    assert_eq!(
+        named,
+        TypeMemberKind::ReadonlyNamedOptional(Text::new_static("value"))
+    );
+
+    let computed = TypeMemberKind::ComputedValueStatic(TypeReference::unknown())
+        .with_readonly()
+        .with_const_asserted()
+        .with_optional()
+        .into_non_static()
+        .expect("static computed member should convert");
+
+    assert_eq!(
+        computed,
+        TypeMemberKind::ConstAssertedReadonlyComputedValueOptional(TypeReference::unknown())
+    );
+
+    assert!(
+        TypeMemberKind::Named(Text::new_static("value"))
+            .into_non_static()
+            .is_none()
     );
 }

--- a/crates/biome_js_type_info/tests/utils.rs
+++ b/crates/biome_js_type_info/tests/utils.rs
@@ -9,10 +9,13 @@ use biome_js_parser::{JsParserOptions, parse};
 use biome_js_syntax::{
     AnyJsExpression, JsVariableDeclaration, TsInterfaceDeclaration, TsTypeAliasDeclaration,
 };
-use biome_js_syntax::{AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsFunctionDeclaration};
+use biome_js_syntax::{
+    AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsClassDeclaration, JsFunctionDeclaration,
+};
 use biome_js_type_info::{
-    GlobalsResolver, NUM_PREDEFINED_TYPES, Resolvable, ResolvedTypeData, ResolvedTypeId, ScopeId,
-    TypeData, TypeId, TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
+    GlobalsResolver, ModuleId, NUM_PREDEFINED_TYPES, Resolvable, ResolvedTypeData, ResolvedTypeId,
+    ScopeId, TypeData, TypeId, TypeReference, TypeReferenceQualifier, TypeResolver,
+    TypeResolverLevel,
 };
 use biome_languages::JsFileSource;
 use biome_rowan::{AstNode, Text};
@@ -99,6 +102,8 @@ pub fn assert_typed_bindings_snapshot(
 pub struct HardcodedSymbolResolver {
     name: &'static str,
     globals: GlobalsResolver,
+    resolver_level: TypeResolverLevel,
+    symbol_module_id: ModuleId,
     types: Vec<TypeData>,
 }
 
@@ -107,8 +112,16 @@ impl HardcodedSymbolResolver {
         Self {
             name,
             globals,
+            resolver_level: TypeResolverLevel::Thin,
+            symbol_module_id: ModuleId::new(0),
             types: vec![data],
         }
+    }
+
+    pub fn with_foreign_symbol_module(mut self, module_id: ModuleId) -> Self {
+        self.resolver_level = TypeResolverLevel::Full;
+        self.symbol_module_id = module_id;
+        self
     }
 
     pub fn run_inference(&mut self) {
@@ -139,7 +152,7 @@ impl HardcodedSymbolResolver {
 
 impl TypeResolver for HardcodedSymbolResolver {
     fn level(&self) -> TypeResolverLevel {
-        TypeResolverLevel::Thin
+        self.resolver_level
     }
 
     fn find_type(&self, type_data: &TypeData) -> Option<TypeId> {
@@ -155,9 +168,7 @@ impl TypeResolver for HardcodedSymbolResolver {
 
     fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<ResolvedTypeData<'_>> {
         match id.level() {
-            TypeResolverLevel::Full => {
-                panic!("Ad-hoc references unsupported by resolver")
-            }
+            TypeResolverLevel::Full => Some((id, self.get_by_id(id.id())).into()),
             TypeResolverLevel::Thin => Some((id, self.get_by_id(id.id())).into()),
             TypeResolverLevel::Import => {
                 panic!("Import references unsupported by resolver")
@@ -193,7 +204,10 @@ impl TypeResolver for HardcodedSymbolResolver {
 
     fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId> {
         if qualifier.path.is_identifier(self.name) {
-            Some(ResolvedTypeId::new(self.level(), TypeId::new(0)))
+            Some(
+                ResolvedTypeId::new(TypeResolverLevel::Thin, TypeId::new(0))
+                    .with_module_id(self.symbol_module_id),
+            )
         } else {
             self.globals.resolve_qualifier(qualifier)
         }
@@ -252,6 +266,22 @@ pub fn get_function_declaration(root: &AnyJsRoot) -> JsFunctionDeclaration {
         .expect("cannot find function declaration")
 }
 
+pub fn get_class_declaration(root: &AnyJsRoot) -> JsClassDeclaration {
+    let module = root.as_js_module().unwrap();
+    module
+        .items()
+        .into_iter()
+        .filter_map(|item| match item {
+            AnyJsModuleItem::AnyJsStatement(statement) => Some(statement),
+            _ => None,
+        })
+        .find_map(|statement| match statement {
+            AnyJsStatement::JsClassDeclaration(decl) => Some(decl),
+            _ => None,
+        })
+        .expect("cannot find class declaration")
+}
+
 pub fn get_interface_declaration(root: &AnyJsRoot) -> TsInterfaceDeclaration {
     let module = root.as_js_module().unwrap();
     module
@@ -266,6 +296,22 @@ pub fn get_interface_declaration(root: &AnyJsRoot) -> TsInterfaceDeclaration {
             _ => None,
         })
         .expect("cannot find interface declaration")
+}
+
+pub fn get_type_alias_declaration(root: &AnyJsRoot) -> TsTypeAliasDeclaration {
+    let module = root.as_js_module().unwrap();
+    module
+        .items()
+        .into_iter()
+        .filter_map(|item| match item {
+            AnyJsModuleItem::AnyJsStatement(statement) => Some(statement),
+            _ => None,
+        })
+        .find_map(|statement| match statement {
+            AnyJsStatement::TsTypeAliasDeclaration(decl) => Some(decl),
+            _ => None,
+        })
+        .expect("cannot find type alias declaration")
 }
 
 pub fn get_variable_declaration(root: &AnyJsRoot) -> JsVariableDeclaration {

--- a/crates/biome_module_graph/src/db/type_inference/globals.rs
+++ b/crates/biome_module_graph/src/db/type_inference/globals.rs
@@ -24,7 +24,6 @@ use biome_js_type_info::{
         PredicateReturnType as InferredPredicateReturnType, ReturnType as InferredReturnType,
         TupleElementType as InferredTupleElementType, TypeData as InferredTypeData,
         TypeMember as InferredTypeMember, TypeMemberKind as InferredTypeMemberKind,
-        well_known_symbol_name,
     },
 };
 use biome_rowan::Text;
@@ -88,7 +87,10 @@ enum GlobalTypeWork<'a> {
         has_namespace_ty: bool,
     },
     RebuildTypeMember(&'a RawTypeMemberKind),
-    RebuildConstructorParameter(Option<TypeMemberAccessibility>),
+    RebuildConstructorParameter {
+        accessibility: Option<TypeMemberAccessibility>,
+        is_readonly: bool,
+    },
     RebuildFunctionParameter(&'a RawFunctionParameter),
     RebuildFunctionParameterBinding(Text),
     RebuildReturnType(&'a RawReturnType),
@@ -348,18 +350,24 @@ fn resolve_global_type_id_with_resolver<'db>(
             }
             GlobalTypeWork::RebuildTypeMember(kind) => {
                 let member_ty = pop_global_type(&mut values);
-                let key_ty = raw_member_kind_reference(kind).map(|_| pop_global_type(&mut values));
+                let key_type = kind
+                    .key_type()
+                    .map_or(InferredTypeData::Unknown, |_| pop_global_type(&mut values));
                 values.push(GlobalTypeValue::Member(InferredTypeMember {
-                    kind: global_member_kind_from_raw(kind, key_ty),
+                    kind: InferredTypeMemberKind::from_raw(kind, &mut |_| key_type),
                     ty: member_ty,
                 }));
             }
-            GlobalTypeWork::RebuildConstructorParameter(accessibility) => {
+            GlobalTypeWork::RebuildConstructorParameter {
+                accessibility,
+                is_readonly,
+            } => {
                 let parameter = pop_global_function_parameter(&mut values);
                 values.push(GlobalTypeValue::ConstructorParameter(
                     InferredConstructorParameter {
                         parameter,
                         accessibility,
+                        is_readonly,
                     },
                 ));
             }
@@ -765,8 +773,8 @@ fn push_raw_members<'a>(stack: &mut Vec<GlobalTypeWork<'a>>, members: &'a [RawTy
     for member in members.iter().rev() {
         stack.push(GlobalTypeWork::RebuildTypeMember(&member.kind));
         stack.push(GlobalTypeWork::Reference(&member.ty));
-        if let Some(key_ty) = raw_member_kind_reference(&member.kind) {
-            stack.push(GlobalTypeWork::Reference(key_ty));
+        if let Some(key_type) = member.kind.key_type() {
+            stack.push(GlobalTypeWork::Reference(key_type));
         }
     }
 }
@@ -776,9 +784,10 @@ fn push_constructor_parameters<'a>(
     parameters: &'a [RawConstructorParameter],
 ) {
     for parameter in parameters.iter().rev() {
-        stack.push(GlobalTypeWork::RebuildConstructorParameter(
-            parameter.accessibility,
-        ));
+        stack.push(GlobalTypeWork::RebuildConstructorParameter {
+            accessibility: parameter.accessibility,
+            is_readonly: parameter.is_readonly,
+        });
         push_function_parameter(stack, &parameter.parameter);
     }
 }
@@ -840,91 +849,6 @@ fn push_tuple_elements<'a>(
             is_rest: element.is_rest,
         });
         stack.push(GlobalTypeWork::Reference(&element.ty));
-    }
-}
-
-fn raw_member_kind_reference(kind: &RawTypeMemberKind) -> Option<&TypeReference> {
-    match kind {
-        RawTypeMemberKind::ComputedValue(ty)
-        | RawTypeMemberKind::ConstAssertedComputedValue(ty)
-        | RawTypeMemberKind::ConstAssertedIndexSignature(ty)
-        | RawTypeMemberKind::IndexSignature(ty) => Some(ty),
-        RawTypeMemberKind::CallSignature
-        | RawTypeMemberKind::ConstAssertedCallSignature
-        | RawTypeMemberKind::ConstAssertedConstructor
-        | RawTypeMemberKind::ConstAssertedGetter(_)
-        | RawTypeMemberKind::ConstAssertedNamed(_)
-        | RawTypeMemberKind::ConstAssertedNamedOptional(_)
-        | RawTypeMemberKind::ConstAssertedNamedStatic(_)
-        | RawTypeMemberKind::Constructor
-        | RawTypeMemberKind::Getter(_)
-        | RawTypeMemberKind::Named(_)
-        | RawTypeMemberKind::NamedOptional(_)
-        | RawTypeMemberKind::NamedStatic(_) => None,
-    }
-}
-
-fn global_member_kind_from_raw<'db>(
-    kind: &RawTypeMemberKind,
-    key_ty: Option<InferredTypeData<'db>>,
-) -> InferredTypeMemberKind<'db> {
-    match kind {
-        RawTypeMemberKind::CallSignature => InferredTypeMemberKind::CallSignature,
-        RawTypeMemberKind::ComputedValue(reference) => well_known_symbol_name(reference).map_or(
-            InferredTypeMemberKind::ComputedValue(key_ty.unwrap_or(InferredTypeData::Unknown)),
-            |name| {
-                InferredTypeMemberKind::ComputedValueNamed(
-                    name,
-                    key_ty.unwrap_or(InferredTypeData::Unknown),
-                )
-            },
-        ),
-        RawTypeMemberKind::ConstAssertedCallSignature => {
-            InferredTypeMemberKind::ConstAssertedCallSignature
-        }
-        RawTypeMemberKind::ConstAssertedComputedValue(reference) => {
-            well_known_symbol_name(reference).map_or(
-                InferredTypeMemberKind::ConstAssertedComputedValue(
-                    key_ty.unwrap_or(InferredTypeData::Unknown),
-                ),
-                |name| {
-                    InferredTypeMemberKind::ConstAssertedComputedValueNamed(
-                        name,
-                        key_ty.unwrap_or(InferredTypeData::Unknown),
-                    )
-                },
-            )
-        }
-        RawTypeMemberKind::ConstAssertedConstructor => {
-            InferredTypeMemberKind::ConstAssertedConstructor
-        }
-        RawTypeMemberKind::ConstAssertedGetter(name) => {
-            InferredTypeMemberKind::ConstAssertedGetter(name.clone())
-        }
-        RawTypeMemberKind::ConstAssertedIndexSignature(_) => {
-            InferredTypeMemberKind::ConstAssertedIndexSignature(
-                key_ty.unwrap_or(InferredTypeData::Unknown),
-            )
-        }
-        RawTypeMemberKind::ConstAssertedNamed(name) => {
-            InferredTypeMemberKind::ConstAssertedNamed(name.clone())
-        }
-        RawTypeMemberKind::ConstAssertedNamedOptional(name) => {
-            InferredTypeMemberKind::ConstAssertedNamedOptional(name.clone())
-        }
-        RawTypeMemberKind::ConstAssertedNamedStatic(name) => {
-            InferredTypeMemberKind::ConstAssertedNamedStatic(name.clone())
-        }
-        RawTypeMemberKind::Constructor => InferredTypeMemberKind::Constructor,
-        RawTypeMemberKind::Getter(name) => InferredTypeMemberKind::Getter(name.clone()),
-        RawTypeMemberKind::IndexSignature(_) => {
-            InferredTypeMemberKind::IndexSignature(key_ty.unwrap_or(InferredTypeData::Unknown))
-        }
-        RawTypeMemberKind::Named(name) => InferredTypeMemberKind::Named(name.clone()),
-        RawTypeMemberKind::NamedOptional(name) => {
-            InferredTypeMemberKind::NamedOptional(name.clone())
-        }
-        RawTypeMemberKind::NamedStatic(name) => InferredTypeMemberKind::NamedStatic(name.clone()),
     }
 }
 
@@ -991,6 +915,7 @@ fn pop_global_constructor_parameters<'db>(
                         },
                     ),
                     accessibility: None,
+                    is_readonly: false,
                 });
             }
         }

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -531,23 +531,24 @@ fn find_member_in_members<'db>(
     db: &'db dyn ModuleDb,
     members: &[InferredTypeMember<'db>],
     name: &str,
-    allows_named_member: impl Fn(&InferredTypeMemberKind<'db>) -> bool,
+    allows_member: impl Fn(&InferredTypeMemberKind<'db>) -> bool,
     allow_index_signature: bool,
 ) -> Option<(InferredTypeData<'db>, bool)> {
     let named_member = members
         .iter()
-        .find(|member| allows_named_member(&member.kind) && member.kind.has_name(name))
+        .find(|member| allows_member(&member.kind) && member.kind.has_name(name))
         .map(|member| (member_value_type(db, member), member.kind.is_optional()));
     if named_member.is_some() {
         return named_member;
     }
 
     let computed_member = members.iter().find_map(|member| {
-        member
-            .kind
-            .computed_value_type()
-            .is_some_and(|ty| ty.is_string_literal_key(db, name))
-            .then_some((member.ty, false))
+        (allows_member(&member.kind)
+            && member
+                .kind
+                .computed_value_type()
+                .is_some_and(|ty| ty.is_string_literal_key(db, name)))
+        .then_some((member.ty, member.kind.is_optional()))
     });
     if computed_member.is_some() {
         return computed_member;

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -330,7 +330,7 @@ pub(in crate::db::type_inference) enum StaticMemberMode {
 }
 
 impl StaticMemberMode {
-    fn allows_named_member(self, kind: &InferredTypeMemberKind<'_>) -> bool {
+    fn allows_member(self, kind: &InferredTypeMemberKind<'_>) -> bool {
         match self {
             Self::Class => kind.is_static() && !kind.is_constructor(),
             Self::Instance => !kind.is_static(),
@@ -591,7 +591,7 @@ pub(in crate::db::type_inference) fn find_member_in_members_for_mode<'db>(
         db,
         members,
         name,
-        |kind| mode.allows_named_member(kind),
+        |kind| mode.allows_member(kind),
         mode.allows_index_signature(),
     )
 }

--- a/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
+++ b/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
@@ -321,10 +321,15 @@ impl<'db> ResolutionCtx<'db, '_> {
 
     fn resolve_readonly(&mut self, qualifier: &TypeReferenceQualifier) -> InferredTypeData<'db> {
         let target_ty = self.resolve(&qualifier.type_parameters[0]);
-        self.own_members(target_ty)
-            .map_or(InferredTypeData::Unknown, |members| {
-                InferredTypeData::object_from_members(self.db, members)
-            })
+        let Some(mut members) = self.own_members(target_ty) else {
+            return InferredTypeData::Unknown;
+        };
+
+        for member in &mut members {
+            member.kind = member.kind.clone().with_readonly();
+        }
+
+        InferredTypeData::object_from_members(self.db, members)
     }
 
     fn own_members(&mut self, ty: InferredTypeData<'db>) -> Option<Vec<InferredTypeMember<'db>>> {

--- a/crates/biome_module_graph/tests/snapshots/test_infer_module_types_resolves_utility_type_members_on_build.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_infer_module_types_resolves_utility_type_members_on_build.snap
@@ -227,10 +227,10 @@ Binding readReadonly "readReadonly" => sync Function "readReadonly" {
       required value: instanceof Object {
         prototype: No prototype
         members: [
-          [string]: string | number | undefined,
-          "name": string,
-          "value": number,
-          "optional"?: string | undefined
+          readonly [string]: string | number | undefined,
+          readonly "name": string,
+          readonly "value": number,
+          readonly "optional"?: string | undefined
         ]
       }
     ]
@@ -239,10 +239,10 @@ Binding readReadonly "readReadonly" => sync Function "readReadonly" {
   returns: instanceof Object {
     prototype: No prototype
     members: [
-      [string]: string | number | undefined,
-      "name": string,
-      "value": number,
-      "optional"?: string | undefined
+      readonly [string]: string | number | undefined,
+      readonly "name": string,
+      readonly "value": number,
+      readonly "optional"?: string | undefined
     ]
   }
 }
@@ -250,20 +250,20 @@ Binding readReadonly "readReadonly" => sync Function "readReadonly" {
 Binding value "value" => instanceof Object {
   prototype: No prototype
   members: [
-    [string]: string | number | undefined,
-    "name": string,
-    "value": number,
-    "optional"?: string | undefined
+    readonly [string]: string | number | undefined,
+    readonly "name": string,
+    readonly "value": number,
+    readonly "optional"?: string | undefined
   ]
 }
 
 Expression "value" => instanceof Object {
   prototype: No prototype
   members: [
-    [string]: string | number | undefined,
-    "name": string,
-    "value": number,
-    "optional"?: string | undefined
+    readonly [string]: string | number | undefined,
+    readonly "name": string,
+    readonly "value": number,
+    readonly "optional"?: string | undefined
   ]
 }
 ```

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -1138,8 +1138,9 @@ fn test_infer_module_types_resolves_utility_type_members_on_build() {
     let readonly_ty =
         inferred_function_return_ty_by_name(&db, index_module, inferred, "readReadonly")
             .expect("readReadonly return type must be inferred");
-    let (_, readonly_name_ty) = object_member_ty_by_name(&db, readonly_ty, "name")
+    let (readonly_name_kind, readonly_name_ty) = object_member_ty_by_name(&db, readonly_ty, "name")
         .expect("Readonly<Source> must keep name");
+    assert!(readonly_name_kind.is_readonly());
     assert!(is_inferred_string(&db, readonly_name_ty));
 
     assert_inferred_type_snapshot(
@@ -1147,6 +1148,60 @@ fn test_infer_module_types_resolves_utility_type_members_on_build() {
         &db,
         &fs,
     );
+}
+
+#[test]
+fn test_infer_module_types_intersection_readonly_is_order_independent() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            type ReadonlyValue = { readonly value: string };
+            type MutableValue = { value: string };
+
+            export function readReadonlyLeft(
+                value: ReadonlyValue & MutableValue,
+            ): ReadonlyValue & MutableValue {
+                return value;
+            }
+
+            export function readReadonlyRight(
+                value: MutableValue & ReadonlyValue,
+            ): MutableValue & ReadonlyValue {
+                return value;
+            }
+
+            export function readBothReadonly(
+                value: ReadonlyValue & ReadonlyValue,
+            ): ReadonlyValue & ReadonlyValue {
+                return value;
+            }
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, index_module).expect("types must be inferred");
+
+    for function_name in ["readReadonlyLeft", "readReadonlyRight"] {
+        let intersection_type =
+            inferred_function_return_ty_by_name(&db, index_module, &inferred, function_name)
+                .expect("intersection return type must be inferred");
+        let intersection_type = normalize_type(&db, index_module, intersection_type);
+        let (member_kind, _) = object_member_ty_by_name(&db, intersection_type, "value")
+            .expect("intersection must preserve value");
+        assert!(!member_kind.is_readonly());
+    }
+
+    let intersection_type =
+        inferred_function_return_ty_by_name(&db, index_module, &inferred, "readBothReadonly")
+            .expect("intersection return type must be inferred");
+    let intersection_type = normalize_type(&db, index_module, intersection_type);
+    let (member_kind, _) = object_member_ty_by_name(&db, intersection_type, "value")
+        .expect("intersection must preserve value");
+    assert!(member_kind.is_readonly());
 }
 
 #[test]
@@ -2924,6 +2979,53 @@ fn test_infer_module_types_evaluates_static_member_expressions_on_build() {
         &db,
         &fs,
     );
+}
+
+#[test]
+fn test_infer_module_types_preserves_readonly_computed_member_lookup_qualifiers() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            class Box {
+                static readonly ["shared"]: string;
+                readonly ["shared"]: number;
+                readonly ["optional"]?: string;
+            }
+
+            export const staticShared = Box.shared;
+            export const box: Box = {} as Box;
+            export const instanceShared = box.shared;
+            export const optionalValue = box.optional;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, index_module).expect("types must be inferred");
+
+    let static_shared = inferred_binding_ty_by_name(&db, index_module, &inferred, "staticShared")
+        .expect("staticShared binding type must be inferred");
+    assert!(is_inferred_string(
+        &db,
+        inferred.resolve_type(&db, static_shared)
+    ));
+
+    let instance_shared =
+        inferred_binding_ty_by_name(&db, index_module, &inferred, "instanceShared")
+            .expect("instanceShared binding type must be inferred");
+    assert!(is_inferred_number(
+        &db,
+        inferred.resolve_type(&db, instance_shared)
+    ));
+
+    let optional_value = inferred_binding_ty_by_name(&db, index_module, &inferred, "optionalValue")
+        .expect("optionalValue binding type must be inferred");
+    let optional_value = inferred.resolve_type(&db, optional_value);
+    assert!(contains_inferred_string(&db, optional_value));
+    assert!(contains_inferred_undefined(&db, optional_value));
 }
 
 #[test]
@@ -5817,7 +5919,7 @@ fn test_infer_module_types_backdates_equal_output() {
 }
 
 #[test]
-fn test_infer_module_types_documents_react_export_equals_gap() {
+fn test_infer_module_types_documents_react_export_equals_partial_resolution() {
     let fs = MemoryFileSystem::default();
     fs.insert(
         "/node_modules/@types/react/index.d.ts".into(),
@@ -5827,7 +5929,7 @@ fn test_infer_module_types_documents_react_export_equals_gap() {
         "/src/index.ts".into(),
         r#"import { useCallback } from "react";
 
-        const fn = useCallback(async () => {});
+        const fn = useCallback(async () => {}, []);
         const promise = fn();
         "#,
     );
@@ -5855,14 +5957,13 @@ fn test_infer_module_types_documents_react_export_equals_gap() {
         .expect("module must exist");
     let inferred = infer_module_types_bottom_up(&db, index_module).expect("types must be inferred");
 
-    // React types are exposed through `export = React`, which the new engine
-    // does not resolve yet. Once it does, these assertions must be upgraded to
-    // expect a callable `useCallback` and a `Promise` instance for `promise`.
     let use_callback_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "useCallback")
         .expect("useCallback binding type must be inferred");
     let use_callback_ty = inferred.resolve_type(&db, use_callback_ty);
-    assert!(use_callback_ty.callable_function(&db).is_none());
+    assert!(use_callback_ty.callable_function(&db).is_some());
 
+    // The named import resolves, but its generic callback return type is not
+    // propagated through the call yet.
     let promise_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "promise")
         .expect("promise binding type must be inferred");
     let promise_ty = inferred.resolve_type(&db, promise_ty);

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -1187,7 +1187,7 @@ fn test_infer_module_types_intersection_readonly_is_order_independent() {
 
     for function_name in ["readReadonlyLeft", "readReadonlyRight"] {
         let intersection_type =
-            inferred_function_return_ty_by_name(&db, index_module, &inferred, function_name)
+            inferred_function_return_ty_by_name(&db, index_module, inferred, function_name)
                 .expect("intersection return type must be inferred");
         let intersection_type = normalize_type(&db, index_module, intersection_type);
         let (member_kind, _) = object_member_ty_by_name(&db, intersection_type, "value")
@@ -1196,7 +1196,7 @@ fn test_infer_module_types_intersection_readonly_is_order_independent() {
     }
 
     let intersection_type =
-        inferred_function_return_ty_by_name(&db, index_module, &inferred, "readBothReadonly")
+        inferred_function_return_ty_by_name(&db, index_module, inferred, "readBothReadonly")
             .expect("intersection return type must be inferred");
     let intersection_type = normalize_type(&db, index_module, intersection_type);
     let (member_kind, _) = object_member_ty_by_name(&db, intersection_type, "value")
@@ -3006,7 +3006,7 @@ fn test_infer_module_types_preserves_readonly_computed_member_lookup_qualifiers(
         .expect("module must exist");
     let inferred = infer_module_types(&db, index_module).expect("types must be inferred");
 
-    let static_shared = inferred_binding_ty_by_name(&db, index_module, &inferred, "staticShared")
+    let static_shared = inferred_binding_ty_by_name(&db, index_module, inferred, "staticShared")
         .expect("staticShared binding type must be inferred");
     assert!(is_inferred_string(
         &db,
@@ -3014,14 +3014,14 @@ fn test_infer_module_types_preserves_readonly_computed_member_lookup_qualifiers(
     ));
 
     let instance_shared =
-        inferred_binding_ty_by_name(&db, index_module, &inferred, "instanceShared")
+        inferred_binding_ty_by_name(&db, index_module, inferred, "instanceShared")
             .expect("instanceShared binding type must be inferred");
     assert!(is_inferred_number(
         &db,
         inferred.resolve_type(&db, instance_shared)
     ));
 
-    let optional_value = inferred_binding_ty_by_name(&db, index_module, &inferred, "optionalValue")
+    let optional_value = inferred_binding_ty_by_name(&db, index_module, inferred, "optionalValue")
         .expect("optionalValue binding type must be inferred");
     let optional_value = inferred.resolve_type(&db, optional_value);
     assert!(contains_inferred_string(&db, optional_value));

--- a/xtask/codegen/src/generate_global_types/compare.rs
+++ b/xtask/codegen/src/generate_global_types/compare.rs
@@ -257,7 +257,12 @@ fn assert_error_named_string_member(
     let Some(member) = class.member(name) else {
         bail!("missing required Error member {name}");
     };
-    if member.kind() != &(LoweredMemberKind::Named { optional }) {
+    if member.kind()
+        != &(LoweredMemberKind::Named {
+            optional,
+            readonly: false,
+        })
+    {
         bail!(
             "generated Error member {} has unexpected kind",
             member.name()
@@ -278,7 +283,12 @@ fn assert_error_stack_member(lowered: &LoweredGlobalTypes) -> Result<()> {
     let Some(member) = class.member("stack") else {
         bail!("missing required Error member stack");
     };
-    if member.kind() != &(LoweredMemberKind::Named { optional: true }) {
+    if member.kind()
+        != &(LoweredMemberKind::Named {
+            optional: true,
+            readonly: false,
+        })
+    {
         bail!("generated Error member stack has unexpected kind");
     }
     if member.type_reference() != &LoweredTypeReference::Predefined("GLOBAL_STRING_ID") {
@@ -293,7 +303,7 @@ fn assert_error_prototype_member(lowered: &LoweredGlobalTypes) -> Result<()> {
     let Some(member) = class.member("prototype") else {
         bail!("missing required Error prototype member");
     };
-    if member.kind() != &LoweredMemberKind::NamedStatic {
+    if member.kind() != &(LoweredMemberKind::NamedStatic { readonly: true }) {
         bail!("generated Error prototype member has unexpected kind");
     }
     if member.type_reference() != &LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_ERROR_ID") {

--- a/xtask/codegen/src/generate_global_types/emit.rs
+++ b/xtask/codegen/src/generate_global_types/emit.rs
@@ -193,21 +193,51 @@ fn render_member(member: &LoweredTypeMember) -> String {
 /// Builds the `TypeMemberKind` expression for a member.
 fn render_member_kind(member: &LoweredTypeMember) -> String {
     match member.kind() {
-        LoweredMemberKind::Named { optional: false } => {
+        LoweredMemberKind::Named {
+            optional: false,
+            readonly: false,
+        } => {
             format!(
                 "crate::TypeMemberKind::Named(biome_rowan::Text::new_static({}))",
                 rust_string_literal(member.name()),
             )
         }
-        LoweredMemberKind::Named { optional: true } => {
+        LoweredMemberKind::Named {
+            optional: true,
+            readonly: false,
+        } => {
             format!(
                 "crate::TypeMemberKind::NamedOptional(biome_rowan::Text::new_static({}))",
                 rust_string_literal(member.name()),
             )
         }
-        LoweredMemberKind::NamedStatic => {
+        LoweredMemberKind::Named {
+            optional: false,
+            readonly: true,
+        } => {
+            format!(
+                "crate::TypeMemberKind::ReadonlyNamed(biome_rowan::Text::new_static({}))",
+                rust_string_literal(member.name()),
+            )
+        }
+        LoweredMemberKind::Named {
+            optional: true,
+            readonly: true,
+        } => {
+            format!(
+                "crate::TypeMemberKind::ReadonlyNamedOptional(biome_rowan::Text::new_static({}))",
+                rust_string_literal(member.name()),
+            )
+        }
+        LoweredMemberKind::NamedStatic { readonly: false } => {
             format!(
                 "crate::TypeMemberKind::NamedStatic(biome_rowan::Text::new_static({}))",
+                rust_string_literal(member.name()),
+            )
+        }
+        LoweredMemberKind::NamedStatic { readonly: true } => {
+            format!(
+                "crate::TypeMemberKind::ReadonlyNamedStatic(biome_rowan::Text::new_static({}))",
                 rust_string_literal(member.name()),
             )
         }
@@ -228,7 +258,7 @@ fn render_constructor_parameters(parameters: &[LoweredFunctionParameter]) -> Str
     for parameter in parameters {
         rendered.push_str("crate::ConstructorParameter { parameter: ");
         rendered.push_str(&render_function_parameter(parameter));
-        rendered.push_str(", accessibility: None },");
+        rendered.push_str(", accessibility: None, is_readonly: false },");
     }
     rendered
 }

--- a/xtask/codegen/src/generate_global_types/lower.rs
+++ b/xtask/codegen/src/generate_global_types/lower.rs
@@ -231,8 +231,8 @@ impl LoweredTypeMember {
 /// Lowered member kind.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum LoweredMemberKind {
-    Named { optional: bool },
-    NamedStatic,
+    Named { optional: bool, readonly: bool },
+    NamedStatic { readonly: bool },
     Constructor,
     CallSignature,
     ComputedValue { key_reference: LoweredTypeReference },
@@ -838,6 +838,7 @@ fn lower_error_type_member(member: AnyTsTypeMember) -> Result<Option<LoweredType
         AnyTsTypeMember::TsPropertySignatureTypeMember(property) => {
             let name = lower_object_member_name(property.name()?)?;
             let optional = property.optional_token().is_some();
+            let readonly = property.readonly_token().is_some();
             let type_reference = property
                 .type_annotation()
                 .with_context(|| format!("Error member {name} is missing a type annotation"))?
@@ -851,7 +852,7 @@ fn lower_error_type_member(member: AnyTsTypeMember) -> Result<Option<LoweredType
             };
             Ok(Some(LoweredTypeMember {
                 name,
-                kind: LoweredMemberKind::Named { optional },
+                kind: LoweredMemberKind::Named { optional, readonly },
                 type_reference,
             }))
         }
@@ -1038,7 +1039,9 @@ fn lower_error_constructor_property_member(
 
     Ok(LoweredTypeMember {
         name,
-        kind: LoweredMemberKind::NamedStatic,
+        kind: LoweredMemberKind::NamedStatic {
+            readonly: property.readonly_token().is_some(),
+        },
         type_reference,
     })
 }

--- a/xtask/codegen/tests/global_types_codegen.rs
+++ b/xtask/codegen/tests/global_types_codegen.rs
@@ -1019,7 +1019,7 @@ mod tests {
         assert!(generated.contains("biome_rowan::Text::new_static(\"message\")"));
         assert!(generated.contains("crate::TypeMemberKind::NamedOptional("));
         assert!(generated.contains("\"stack\""));
-        assert!(generated.contains("crate::TypeMemberKind::NamedStatic("));
+        assert!(generated.contains("crate::TypeMemberKind::ReadonlyNamedStatic("));
         assert!(generated.contains("\"prototype\""));
 
         Ok(())
@@ -1134,7 +1134,13 @@ mod tests {
         assert_eq!(class.name(), "Error");
 
         let name = class.member("name").expect("name member should be lowered");
-        assert_eq!(name.kind(), &LoweredMemberKind::Named { optional: false });
+        assert_eq!(
+            name.kind(),
+            &LoweredMemberKind::Named {
+                optional: false,
+                readonly: false,
+            }
+        );
         assert_eq!(
             name.type_reference(),
             &LoweredTypeReference::Predefined("GLOBAL_STRING_ID")
@@ -1145,7 +1151,10 @@ mod tests {
             .expect("message member should be lowered");
         assert_eq!(
             message.kind(),
-            &LoweredMemberKind::Named { optional: false }
+            &LoweredMemberKind::Named {
+                optional: false,
+                readonly: false,
+            }
         );
         assert_eq!(
             message.type_reference(),
@@ -1154,7 +1163,13 @@ mod tests {
         let stack = class
             .member("stack")
             .expect("stack member should be lowered");
-        assert_eq!(stack.kind(), &LoweredMemberKind::Named { optional: true });
+        assert_eq!(
+            stack.kind(),
+            &LoweredMemberKind::Named {
+                optional: true,
+                readonly: false,
+            }
+        );
         assert_eq!(
             stack.type_reference(),
             &LoweredTypeReference::Predefined("GLOBAL_STRING_ID")
@@ -1162,7 +1177,10 @@ mod tests {
         let prototype = class
             .member("prototype")
             .expect("prototype member should be lowered");
-        assert_eq!(prototype.kind(), &LoweredMemberKind::NamedStatic);
+        assert_eq!(
+            prototype.kind(),
+            &LoweredMemberKind::NamedStatic { readonly: true }
+        );
         assert_eq!(
             prototype.type_reference(),
             &LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_ERROR_ID")


### PR DESCRIPTION
## Summary

Part of #5977.

Preserves `readonly` on type members through local inference, raw and interned type conversion, module-graph inference, and global-types codegen.

`readonly` is represented by `TypeMemberKind` variants instead of another field on `TypeMember`, keeping `TypeMember` at 40 bytes. The variants preserve optional, static, computed, index-signature, and const-asserted states. `Partial<T>` and `Required<T>` now change optionality without dropping `readonly`, while intersections remain readonly only when every merged declaration is readonly.

Most of the `interned_types.rs` diff is the raw/interned conversion for these variants. Codegen now reads `readonly` from TypeScript declarations and emits the correct `ErrorConstructor.prototype`. `noMisleadingReturnType` also recognizes readonly object members; this behavior change has a patch changeset.

> This PR was implemented with AI assistance from Codex.

## Test Plan

- Added size, modifier, and raw/interned round-trip tests.
- Added inference and resolver tests for readonly members, mapped utility types, and intersections.
- Extended codegen and `noMisleadingReturnType` coverage.
- Updated the existing React regression to record that `useCallback` resolves while generic callback return inference remains unsupported.

## Docs

N/A
