### PR TITLE
docs(useSortedClasses): remove outdated notes about unsupported features

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -48,9 +48,8 @@ declare_lint_rule! {
     /// Notably, keep in mind that the following features are not supported yet:
     ///
     /// - Screen variant sorting (e.g. `md:`, `max-lg:`). Only static, dynamic and arbitrary variants are supported.
-    /// - Custom utilitites and variants (such as ones introduced by Tailwind CSS plugins). Only the default Tailwind CSS configuration is supported.
+    /// - Custom utilities and variants (such as ones introduced by Tailwind CSS plugins). Only the default Tailwind CSS configuration is supported.
     /// - Options such as `prefix` and `separator`.
-    /// - Object properties (e.g. in `clsx` calls).
     ///
     /// Please don't report issues about these features.
     /// :::


### PR DESCRIPTION
## Summary

The docs page is outdated; clsx class sorting in object keys is currently supported.

Disclosure: AI tooling double-checked with me that the bullet was indeed stale; the two-line edit was suggested as a style match for the surrounding docs.

## Test Plan

`cargo t -p biome_js_analyze use_sorted` shows 48 passing 0 failed, including the lines checking `clsx({ "px-2 foo p-4 bar": cond })` -style object keys.
