### PR TITLE
feat(plugins): show plugin names in --profile-rules output

### DIFF
--- a/.changeset/profile-rules-split-plugins.md
+++ b/.changeset/profile-rules-split-plugins.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10795](https://github.com/biomejs/biome/issues/10795): `--profile-rules` now reports timings for each plugin separately as `plugin/<pluginName>`, matching the naming used by plugin suppressions, instead of aggregating all plugins under a single `plugin/plugin` entry.

--- a/crates/biome_analyze/src/analyzer_plugin.rs
+++ b/crates/biome_analyze/src/analyzer_plugin.rs
@@ -48,6 +48,9 @@ pub struct PluginEvalResult {
 
 /// Definition of an analyzer plugin.
 pub trait AnalyzerPlugin: Debug + Send + Sync {
+    /// Human readable identifier of the plugin for profiling and logging.
+    fn name(&self) -> &str;
+
     fn language(&self) -> PluginTargetLanguage;
 
     fn query(&self) -> Vec<RawSyntaxKind>;
@@ -167,7 +170,7 @@ where
             return;
         }
 
-        let rule_timer = profiling::start_plugin_rule("plugin");
+        let rule_timer = profiling::start_plugin_rule(self.plugin.name());
         let eval_result = self
             .plugin
             .evaluate(node.clone().into(), ctx.options.file_path.clone());
@@ -310,7 +313,7 @@ where
             }
 
             let plugin = &self.plugins[idx];
-            let rule_timer = profiling::start_plugin_rule("plugin");
+            let rule_timer = profiling::start_plugin_rule(plugin.name());
             let eval_result = plugin.evaluate(node.clone().into(), ctx.options.file_path.clone());
             rule_timer.stop();
 

--- a/crates/biome_js_analyze/tests/plugin_profiling.rs
+++ b/crates/biome_js_analyze/tests/plugin_profiling.rs
@@ -1,0 +1,92 @@
+use std::slice;
+use std::sync::Arc;
+
+use biome_analyze::{
+    AnalysisFilter, AnalyzerOptions, AnalyzerPlugin, ControlFlow, Never, RuleFilter, profiling,
+};
+use biome_fs::MemoryFileSystem;
+use biome_js_analyze::JsAnalyzerServices;
+use biome_js_parser::{JsParserOptions, parse};
+use biome_js_semantic::{SemanticModelOptions, semantic_model};
+use biome_languages::JsFileSource;
+use biome_plugin_loader::AnalyzerGritPlugin;
+use camino::Utf8Path;
+
+/// Rule timings must be attributed to each plugin individually
+/// (`plugin/<name>`) in `--profile-rules` output, instead of being aggregated
+/// under a single `plugin/plugin` label.
+/// See <https://github.com/biomejs/biome/issues/10795>.
+///
+/// This lives in its own integration test binary because the profiler is
+/// process-global state.
+#[test]
+fn profiles_are_split_per_plugin() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/noAssign.grit".into(),
+        r#"`Object.assign($args)` where {
+    register_diagnostic(span = $args, message = "Prefer object spread")
+}"#,
+    );
+    fs.insert(
+        "/noConsoleLog.grit".into(),
+        r#"`console.log($msg)` where {
+    register_diagnostic(span = $msg, message = "No console.log")
+}"#,
+    );
+
+    let plugins: Vec<_> = ["/noAssign.grit", "/noConsoleLog.grit"]
+        .iter()
+        .map(|path| {
+            let plugin = AnalyzerGritPlugin::load(&fs, Utf8Path::new(path), None)
+                .expect("Couldn't load plugin");
+            Arc::new(Box::new(plugin) as Box<dyn AnalyzerPlugin>)
+        })
+        .collect();
+
+    let source = "const a = Object.assign({}, b);\nconsole.log(a);\n";
+    let parsed = parse(
+        source,
+        JsFileSource::js_module(),
+        JsParserOptions::default(),
+    );
+    let root = parsed.tree();
+
+    // Enable at least one rule so that the analyzer phases run.
+    let rule_filter = RuleFilter::Rule("nursery", "noCommonJs");
+    let filter = AnalysisFilter {
+        enabled_rules: Some(slice::from_ref(&rule_filter)),
+        ..AnalysisFilter::default()
+    };
+
+    let options = AnalyzerOptions::default().with_file_path("/test.js");
+    let semantic_model = semantic_model(&root, SemanticModelOptions::default());
+    let services = JsAnalyzerServices::default()
+        .with_source_type(JsFileSource::js_module())
+        .with_semantic_model(&semantic_model);
+
+    profiling::reset();
+    profiling::enable();
+    biome_js_analyze::analyze(&root, filter, &options, &plugins, services, |_| {
+        ControlFlow::<Never>::Continue(())
+    });
+    profiling::disable();
+
+    let labels: Vec<String> = profiling::drain_sorted_by_total(true)
+        .into_iter()
+        .map(|profile| profile.label.to_string())
+        .collect();
+
+    assert!(
+        labels.contains(&"plugin/noAssign".to_string()),
+        "expected a profile for plugin/noAssign, got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"plugin/noConsoleLog".to_string()),
+        "expected a profile for plugin/noConsoleLog, got: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"plugin/plugin".to_string()),
+        "plugin timings should not be aggregated under plugin/plugin: {labels:?}"
+    );
+}

--- a/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
@@ -303,6 +303,12 @@ mod tests {
     }
 
     #[test]
+    fn name_is_derived_from_the_pattern_file() {
+        let plugin = load_test_plugin(None);
+        assert_eq!(plugin.name(), "test");
+    }
+
+    #[test]
     fn applies_to_all_files_without_includes() {
         let plugin = load_test_plugin(None);
         assert!(plugin.applies_to_file(Utf8Path::new("src/main.ts")));

--- a/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
@@ -59,6 +59,10 @@ impl AnalyzerGritPlugin {
 }
 
 impl AnalyzerPlugin for AnalyzerGritPlugin {
+    fn name(&self) -> &str {
+        self.grit_query.name.as_deref().unwrap_or("anonymous")
+    }
+
     fn language(&self) -> PluginTargetLanguage {
         match &self.grit_query.language {
             GritTargetLanguage::JsTargetLanguage(_) => PluginTargetLanguage::JavaScript,
@@ -88,7 +92,7 @@ impl AnalyzerPlugin for AnalyzerGritPlugin {
     }
 
     fn evaluate(&self, node: AnySyntaxNode, path: Utf8PathBuf) -> PluginEvalResult {
-        let name: &str = self.grit_query.name.as_deref().unwrap_or("anonymous");
+        let name = self.name();
 
         let (root, source_range, original_text) = match self.language() {
             PluginTargetLanguage::JavaScript => node

--- a/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
@@ -84,6 +84,11 @@ impl AnalyzerJsPlugin {
 }
 
 impl AnalyzerPlugin for AnalyzerJsPlugin {
+    fn name(&self) -> &str {
+        // JS plugins don't declare a name; fall back to the plugin file stem.
+        self.path.file_stem().unwrap_or("anonymous")
+    }
+
     fn language(&self) -> PluginTargetLanguage {
         PluginTargetLanguage::JavaScript
     }

--- a/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
@@ -196,6 +196,12 @@ mod tests {
     }
 
     #[test]
+    fn name_is_derived_from_the_plugin_file() {
+        let plugin = load_test_plugin(None);
+        assert_eq!(plugin.name(), "plugin");
+    }
+
+    #[test]
     fn applies_to_all_files_without_includes() {
         let plugin = load_test_plugin(None);
         assert!(plugin.applies_to_file(Utf8Path::new("src/main.ts")));


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Previously, the `--profile-rules` output group all plugins into a single `plugin/plugin` entry. Now, it shows an entry for each plugin.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
closes #10795

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
manually tested.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
