### PR TITLE
fix(lint): ignore computed __proto__ in useLiteralKeys 🤖🤖🤖

### DIFF
--- a/.changeset/fix-useliteralkeys-proto-member.md
+++ b/.changeset/fix-useliteralkeys-proto-member.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10769](https://github.com/biomejs/biome/issues/10769): [`useLiteralKeys`](https://biomejs.dev/linter/rules/use-literal-keys/) no longer suggests rewriting computed `["__proto__"]` member accesses to dot syntax.

--- a/crates/biome_js_analyze/src/lint/complexity/use_literal_keys.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_literal_keys.rs
@@ -85,12 +85,10 @@ impl Rule for UseLiteralKeys {
                 }
             StaticValue::String(token) => {
                 let value = inner_string_text(&token);
-                // `{["__proto__"]: null }` and `{"__proto__": null}`/`{"__proto__": null}`
-                // have different semantic.
-                // The first is a regular property.
-                // The second is a special property that changes the object prototype.
+                // Keep computed `["__proto__"]` unchanged because literal or dot
+                // rewrites interact with the legacy prototype accessor.
                 // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto
-                if is_computed_member_name && value == "__proto__" {
+                if value == "__proto__" {
                     return None;
                 }
                 // A computed property `["something"]` can always be simplified to a string literal "something",

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js
@@ -15,6 +15,10 @@ a["a-b"]
 a[`a-b`]
 a[`time range`];
 a[`time${range}`];
+a["__proto__"];
+a[`__proto__`];
+a["__proto__"] = value;
+a?.["__proto__"];
 class C { a = 0 }
 class C { a(){} }
 class C { get a(){} }

--- a/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useLiteralKeys/valid.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 196
 expression: valid.js
 ---
 # Input
@@ -21,6 +22,10 @@ a["a-b"]
 a[`a-b`]
 a[`time range`];
 a[`time${range}`];
+a["__proto__"];
+a[`__proto__`];
+a["__proto__"] = value;
+a?.["__proto__"];
 class C { a = 0 }
 class C { a(){} }
 class C { get a(){} }


### PR DESCRIPTION
## Summary

Fixes #10769

`useLiteralKeys` now leaves computed `["__proto__"]` member accesses unchanged instead of suggesting a dot-access rewrite.

> This PR was created with AI assistance (Codex).

## Test Plan

- `cargo test -p biome_js_analyze -- use_literal_keys --show-output`
- `cargo test -p biome_js_analyze -- no_proto --show-output`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p biome_js_analyze --all-features --all-targets -- --deny warnings`
- `cargo run -p rules_check`

## Docs

No docs update needed. Added a patch changeset for the user-facing lint behavior fix.
