### PR TITLE
fix(lsp): guard format on type using the right characters

### DIFF
--- a/.changeset/strong-clowns-yawn.md
+++ b/.changeset/strong-clowns-yawn.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [biome-zed#164](https://github.com/biomejs/biome-zed/issues/164): Biome no longer inserts stray whitespace when format-on-type runs after closing delimiters such as `)`, `]`, and `}`.

--- a/crates/biome_formatter/src/source_map.rs
+++ b/crates/biome_formatter/src/source_map.rs
@@ -77,11 +77,12 @@ impl TransformSourceMap {
             self.source_offset(transformed_range.end(), RangePosition::End),
         );
 
+        let source_text_end = self.source_text.offset + self.source_text.text.text_len();
         debug_assert!(
-            range.end() <= self.source_text.text.text_len() - self.source_text.offset,
+            range.end() <= source_text_end,
             "Mapped range {:?} exceeds the length of the source document {:?}. Please check if the passed `transformed_range` is a range of the transformed tree and not of the source tree, and that it belongs to the tree for which the source map was created for.",
             range,
-            self.source_text.text.text_len() - self.source_text.offset
+            source_text_end
         );
         range
     }

--- a/crates/biome_js_formatter/tests/quick_test.rs
+++ b/crates/biome_js_formatter/tests/quick_test.rs
@@ -91,6 +91,58 @@ const c = [
     );
 }
 
+#[ignore]
+#[test]
+// temporary repro for biome-zed#164 — mimics workspace format_on_type
+fn on_type_repro() {
+    use biome_js_formatter::format_sub_tree;
+    use biome_rowan::TokenAtOffset;
+
+    // Valid code: the user just typed the `}` closing the inner function body.
+    let src = "class A {\n  foo() {\n    return 1;\n  }\n}\n";
+    // offset right after the inner `}` (line 3 `  }`)
+    let offset =
+        biome_rowan::TextSize::from(u32::try_from(src.find("  }").unwrap() + "  }".len()).unwrap());
+
+    let source_type = JsFileSource::ts();
+    let parsed = parse(src, source_type, JsParserOptions::default());
+    let tree = parsed.syntax();
+    eprintln!("has errors: {}", parsed.has_errors());
+
+    let token = match tree.token_at_offset(offset) {
+        TokenAtOffset::None => panic!("empty file"),
+        TokenAtOffset::Single(token) => token,
+        TokenAtOffset::Between(token, _) => token,
+    };
+    eprintln!("token at offset: {:?} {:?}", token.kind(), token.text());
+    let root_node = token.parent().unwrap();
+    eprintln!(
+        "formatting subtree: {:?} range {:?}",
+        root_node.kind(),
+        root_node.text_range_with_trivia()
+    );
+
+    let printed = format_sub_tree(JsFormatOptions::new(source_type), &root_node).unwrap();
+    eprintln!("printed range: {:?}", printed.range());
+    eprintln!("--- input slice ---");
+    eprintln!("{}", &src[printed.range().unwrap()]);
+    eprintln!("--- formatted ---");
+    eprintln!("{}", printed.as_code());
+
+    // Alternative: what format_range would produce for the same spot
+    let ranged = biome_js_formatter::format_range(
+        JsFormatOptions::new(source_type),
+        &tree,
+        root_node.text_trimmed_range(),
+    )
+    .unwrap();
+    eprintln!("format_range printed range: {:?}", ranged.range());
+    eprintln!("--- format_range input slice ---");
+    eprintln!("{}", &src[ranged.range().unwrap()]);
+    eprintln!("--- format_range formatted ---");
+    eprintln!("{}", ranged.as_code());
+}
+
 #[test]
 fn test_trailing_newline_enabled() {
     let src = r#"const a = 1;"#;

--- a/crates/biome_js_formatter/tests/quick_test.rs
+++ b/crates/biome_js_formatter/tests/quick_test.rs
@@ -91,58 +91,6 @@ const c = [
     );
 }
 
-#[ignore]
-#[test]
-// temporary repro for biome-zed#164 — mimics workspace format_on_type
-fn on_type_repro() {
-    use biome_js_formatter::format_sub_tree;
-    use biome_rowan::TokenAtOffset;
-
-    // Valid code: the user just typed the `}` closing the inner function body.
-    let src = "class A {\n  foo() {\n    return 1;\n  }\n}\n";
-    // offset right after the inner `}` (line 3 `  }`)
-    let offset =
-        biome_rowan::TextSize::from(u32::try_from(src.find("  }").unwrap() + "  }".len()).unwrap());
-
-    let source_type = JsFileSource::ts();
-    let parsed = parse(src, source_type, JsParserOptions::default());
-    let tree = parsed.syntax();
-    eprintln!("has errors: {}", parsed.has_errors());
-
-    let token = match tree.token_at_offset(offset) {
-        TokenAtOffset::None => panic!("empty file"),
-        TokenAtOffset::Single(token) => token,
-        TokenAtOffset::Between(token, _) => token,
-    };
-    eprintln!("token at offset: {:?} {:?}", token.kind(), token.text());
-    let root_node = token.parent().unwrap();
-    eprintln!(
-        "formatting subtree: {:?} range {:?}",
-        root_node.kind(),
-        root_node.text_range_with_trivia()
-    );
-
-    let printed = format_sub_tree(JsFormatOptions::new(source_type), &root_node).unwrap();
-    eprintln!("printed range: {:?}", printed.range());
-    eprintln!("--- input slice ---");
-    eprintln!("{}", &src[printed.range().unwrap()]);
-    eprintln!("--- formatted ---");
-    eprintln!("{}", printed.as_code());
-
-    // Alternative: what format_range would produce for the same spot
-    let ranged = biome_js_formatter::format_range(
-        JsFormatOptions::new(source_type),
-        &tree,
-        root_node.text_trimmed_range(),
-    )
-    .unwrap();
-    eprintln!("format_range printed range: {:?}", ranged.range());
-    eprintln!("--- format_range input slice ---");
-    eprintln!("{}", &src[ranged.range().unwrap()]);
-    eprintln!("--- format_range formatted ---");
-    eprintln!("{}", ranged.as_code());
-}
-
 #[test]
 fn test_trailing_newline_enabled() {
     let src = r#"const a = 1;"#;

--- a/crates/biome_lsp/src/capabilities.rs
+++ b/crates/biome_lsp/src/capabilities.rs
@@ -1,6 +1,7 @@
 use biome_analyze::{SUPPRESSION_INLINE_ACTION_CATEGORY, SUPPRESSION_TOP_LEVEL_ACTION_CATEGORY};
 use biome_line_index::WideEncoding;
 use biome_lsp_converters::{PositionEncoding, negotiated_encoding};
+use biome_service::file_handlers::ON_TYPE_CHARS;
 use tower_lsp_server::ls_types::{
     ClientCapabilities, CodeActionKind, CodeActionOptions, CodeActionProviderCapability,
     DocumentOnTypeFormattingOptions, OneOf, PositionEncodingKind, ServerCapabilities,
@@ -67,7 +68,12 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
             } else {
                 Some(DocumentOnTypeFormattingOptions {
                     first_trigger_character: String::from("}"),
-                    more_trigger_character: Some(vec![String::from("]"), String::from(")")]),
+                    more_trigger_character: Some(
+                        ON_TYPE_CHARS
+                            .iter()
+                            .map(|c| c.to_string())
+                            .collect::<Vec<_>>(),
+                    ),
                 })
             }
         });

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -872,3 +872,7 @@ mod tests;
 #[cfg(test)]
 #[path = "server_goto.tests.rs"]
 mod server_goto;
+
+#[cfg(test)]
+#[path = "server_type_on_format.tests.rs"]
+mod server_type_on_format;

--- a/crates/biome_lsp/src/server_type_on_format.tests.rs
+++ b/crates/biome_lsp/src/server_type_on_format.tests.rs
@@ -1,0 +1,564 @@
+use crate::WorkspaceSettings;
+use crate::server_test_utils::*;
+use anyhow::{Context, Result};
+use biome_configuration::{Configuration, FormatterConfiguration};
+use futures::channel::mpsc::channel;
+use std::collections::HashMap;
+use std::str::FromStr;
+use tower_lsp_server::ls_types::{
+    self as lsp, DocumentOnTypeFormattingParams, FormattingOptions, Position,
+    TextDocumentIdentifier, TextDocumentPositionParams, TextEdit, Uri,
+};
+
+fn position_after(source: &str, needle: &str) -> Position {
+    let offset = source.find(needle).expect("needle should exist") + needle.len();
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let character = prefix.rsplit('\n').next().unwrap_or(prefix).chars().count() as u32;
+
+    Position::new(line, character)
+}
+
+fn formatting_options() -> FormattingOptions {
+    FormattingOptions {
+        tab_size: 2,
+        insert_spaces: true,
+        properties: HashMap::default(),
+        trim_trailing_whitespace: None,
+        insert_final_newline: None,
+        trim_final_newlines: None,
+    }
+}
+
+async fn request_on_type_formatting(
+    server: &mut Server,
+    uri: Uri,
+    position: Position,
+    ch: &str,
+) -> Result<Option<Vec<TextEdit>>> {
+    server
+        .request(
+            "textDocument/onTypeFormatting",
+            "on_type_formatting",
+            DocumentOnTypeFormattingParams {
+                text_document_position: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri },
+                    position,
+                },
+                ch: ch.to_string(),
+                options: formatting_options(),
+            },
+        )
+        .await?
+        .context("on type formatting returned no response")
+}
+
+fn assert_no_edits(edits: Option<Vec<TextEdit>>) {
+    assert_eq!(edits.unwrap_or_default(), Vec::<TextEdit>::new());
+}
+
+#[tokio::test]
+async fn on_type_formatting_ignores_closing_bracket_inside_string() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server
+        .load_configuration_with_settings(WorkspaceSettings {
+            inline_config: Some(Configuration {
+                formatter: Some(FormatterConfiguration {
+                    format_with_errors: Some(true.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await?;
+
+    let uri = uri!("document.ts");
+    let text = "async function main() {\n  const a = 1;\n}\n\nfunction nice() {\n  console.log(\"    [session]\n}\n";
+    server
+        .open_named_document(text, uri.clone(), "typescript")
+        .await?;
+
+    let edits =
+        request_on_type_formatting(&mut server, uri, position_after(text, "[session]"), "]")
+            .await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_does_not_edit_formatted_function_parameters() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.js");
+    let text = "if (condition) {\n  function x() {}\n}\n";
+    server
+        .open_named_document(text, uri.clone(), "javascript")
+        .await?;
+
+    let edits =
+        request_on_type_formatting(&mut server, uri, position_after(text, "function x()"), ")")
+            .await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_does_not_edit_formatted_array_type() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.ts");
+    let text =
+        "type MyType = string;\nconst x = [];\nif (condition) {\n  const y = x as MyType[];\n}\n";
+    server
+        .open_named_document(text, uri.clone(), "typescript")
+        .await?;
+
+    let edits =
+        request_on_type_formatting(&mut server, uri, position_after(text, "MyType[]"), "]").await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_formats_closing_paren() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.js");
+    let text = "foo(1,2)\n";
+    server
+        .open_named_document(text, uri.clone(), "javascript")
+        .await?;
+
+    let edits = request_on_type_formatting(&mut server, uri, position_after(text, "foo(1,2)"), ")")
+        .await?
+        .context("expected closing paren to return edits")?;
+
+    assert!(
+        !edits.is_empty(),
+        "expected closing paren to format the call"
+    );
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_formats_closing_bracket() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.js");
+    let text = "const x = [1,2]\n";
+    server
+        .open_named_document(text, uri.clone(), "javascript")
+        .await?;
+
+    let edits = request_on_type_formatting(&mut server, uri, position_after(text, "[1,2]"), "]")
+        .await?
+        .context("expected closing bracket to return edits")?;
+
+    assert!(
+        !edits.is_empty(),
+        "expected closing bracket to format the array"
+    );
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_does_not_edit_formatted_json_array() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.json");
+    let text = "{\n\t\"values\": [1, 2]\n}\n";
+    server
+        .open_named_document(text, uri.clone(), "json")
+        .await?;
+
+    let edits =
+        request_on_type_formatting(&mut server, uri, position_after(text, "[1, 2]"), "]").await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_formats_json_closing_bracket() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.json");
+    let text = "{\"values\":[1,2]}\n";
+    server
+        .open_named_document(text, uri.clone(), "json")
+        .await?;
+
+    let edits = request_on_type_formatting(&mut server, uri, position_after(text, "[1,2]"), "]")
+        .await?
+        .context("expected JSON closing bracket to return edits")?;
+
+    assert!(
+        !edits.is_empty(),
+        "expected JSON closing bracket to format the array"
+    );
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_does_not_edit_formatted_graphql_selection() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.graphql");
+    let text = "query {\n\tfield\n}\n";
+    server
+        .open_named_document(text, uri.clone(), "graphql")
+        .await?;
+
+    let edits =
+        request_on_type_formatting(&mut server, uri, position_after(text, "\tfield\n}"), "}")
+            .await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_formats_graphql_closing_curly() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.graphql");
+    let text = "query{field}\n";
+    server
+        .open_named_document(text, uri.clone(), "graphql")
+        .await?;
+
+    let edits = request_on_type_formatting(&mut server, uri, position_after(text, "}"), "}")
+        .await?
+        .context("expected GraphQL closing curly to return edits")?;
+
+    assert!(
+        !edits.is_empty(),
+        "expected GraphQL closing curly to format the selection"
+    );
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_does_not_edit_formatted_css_block() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.css");
+    let text = "a {\n\tcolor: red;\n}\n";
+    server.open_named_document(text, uri.clone(), "css").await?;
+
+    let edits = request_on_type_formatting(
+        &mut server,
+        uri,
+        position_after(text, "\tcolor: red;\n}"),
+        "}",
+    )
+    .await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_formats_css_closing_curly() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.css");
+    let text = "a{color:red}\n";
+    server.open_named_document(text, uri.clone(), "css").await?;
+
+    let edits = request_on_type_formatting(&mut server, uri, position_after(text, "}"), "}")
+        .await?
+        .context("expected CSS closing curly to return edits")?;
+
+    assert!(
+        !edits.is_empty(),
+        "expected CSS closing curly to format the block"
+    );
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_does_not_edit_formatted_grit_definition() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.grit");
+    let text = "pattern console_method_to_info($method) {\n\t`console.$method($message)` => `console.info($message)`\n}\n";
+    server
+        .open_named_document(text, uri.clone(), "grit")
+        .await?;
+
+    let edits = request_on_type_formatting(
+        &mut server,
+        uri,
+        position_after(text, "`console.info($message)`\n}"),
+        "}",
+    )
+    .await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_formats_grit_closing_curly() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.grit");
+    let text = "pattern console_method_to_info($method) {`console.$method($message)` => `console.info($message)`}\n";
+    server
+        .open_named_document(text, uri.clone(), "grit")
+        .await?;
+
+    let edits = request_on_type_formatting(&mut server, uri, position_after(text, "}"), "}")
+        .await?
+        .context("expected Grit closing curly to return edits")?;
+
+    assert!(
+        !edits.is_empty(),
+        "expected Grit closing curly to format the definition"
+    );
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_still_formats_closing_curly() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.js");
+    let text = "if (condition) {\nfoo()\n}\n";
+    server
+        .open_named_document(text, uri.clone(), "javascript")
+        .await?;
+
+    let edits =
+        request_on_type_formatting(&mut server, uri, position_after(text, "}"), "}").await?;
+    let edits = edits.context("expected closing curly to return edits")?;
+
+    assert!(
+        !edits.is_empty(),
+        "expected closing curly to format the block"
+    );
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_type_formatting_does_not_edit_formatted_method_body() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.js");
+    let text = "class A {\n\tfoo() {\n\t\treturn 1;\n\t}\n}\n";
+    server
+        .open_named_document(text, uri.clone(), "javascript")
+        .await?;
+
+    let edits = request_on_type_formatting(
+        &mut server,
+        uri,
+        position_after(text, "\t\treturn 1;\n\t}"),
+        "}",
+    )
+    .await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -3,7 +3,7 @@ mod go_to;
 use super::{
     AnalyzerVisitorBuilder, AnalyzerVisitorResult, CodeActionsParams, EditorCapabilities,
     EnabledForPath, ExtensionHandler, FixAllParams, LintParams, LintResults, ParseResult,
-    ProcessFixAll, ProcessLint, SearchCapabilities,
+    ProcessFixAll, ProcessLint, SearchCapabilities, format_on_type_noop, matches_on_type_char,
 };
 use crate::WorkspaceError;
 use crate::configuration::to_analyzer_rules;
@@ -43,7 +43,7 @@ use biome_formatter::{
 };
 use biome_fs::BiomePath;
 use biome_languages::DocumentFileSource;
-use biome_rowan::{AstNode, NodeCache};
+use biome_rowan::{AstNode, NodeCache, SyntaxKind};
 use biome_rowan::{TextRange, TextSize, TokenAtOffset};
 use biome_workspace_db::WorkspaceDb;
 use camino::Utf8Path;
@@ -557,12 +557,28 @@ fn format_on_type(
         TokenAtOffset::Between(token, _) => token,
     };
 
+    if token.text_trimmed_range().end() != offset {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    if !matches_on_type_char(token.text_trimmed()) {
+        return Ok(format_on_type_noop(offset));
+    }
+
     let root_node = match token.parent() {
         Some(node) => node,
         None => panic!("found a token with no parent"),
     };
 
-    let printed = biome_css_formatter::format_sub_tree(options, &root_node)?;
+    if root_node
+        .ancestors()
+        .any(|node: CssSyntaxNode| node.kind().is_bogus())
+    {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    let printed =
+        biome_css_formatter::format_range(options, &tree, root_node.text_trimmed_range())?;
     Ok(printed)
 }
 

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -1,7 +1,8 @@
 use super::{
     AnalyzerVisitorBuilder, AnalyzerVisitorResult, CodeActionsParams, DocumentFileSource,
     EditorCapabilities, EnabledForPath, ExtensionHandler, FixAllParams, LintParams, LintResults,
-    ParseResult, ProcessFixAll, ProcessLint, SearchCapabilities,
+    ParseResult, ProcessFixAll, ProcessLint, SearchCapabilities, format_on_type_noop,
+    matches_on_type_char,
 };
 use crate::WorkspaceError;
 use crate::configuration::to_analyzer_rules;
@@ -32,8 +33,10 @@ use biome_graphql_analyze::analyze;
 use biome_graphql_formatter::context::GraphqlFormatOptions;
 use biome_graphql_formatter::format_node;
 use biome_graphql_parser::parse_graphql_with_cache;
-use biome_graphql_syntax::{GraphqlLanguage, GraphqlRoot, GraphqlSyntaxNode, TextRange, TextSize};
-use biome_rowan::{AstNode, NodeCache, TokenAtOffset};
+use biome_graphql_syntax::{
+    GraphqlLanguage, GraphqlRoot, GraphqlSyntaxKind, GraphqlSyntaxNode, TextRange, TextSize,
+};
+use biome_rowan::{AstNode, NodeCache, SyntaxKind, TokenAtOffset};
 use biome_workspace_db::WorkspaceDb;
 use camino::Utf8Path;
 use either::Either;
@@ -438,12 +441,39 @@ fn format_on_type(
         TokenAtOffset::Between(token, _) => token,
     };
 
+    if token.text_trimmed_range().end() != offset {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    if !matches_on_type_char(token.text_trimmed()) {
+        return Ok(format_on_type_noop(offset));
+    }
+
     let root_node = match token.parent() {
         Some(node) => node,
         None => panic!("found a token with no parent"),
     };
 
-    let printed = biome_graphql_formatter::format_sub_tree(options, &root_node)?;
+    if root_node
+        .ancestors()
+        .any(|node: GraphqlSyntaxNode| node.kind().is_bogus())
+    {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    let formatting_root = root_node
+        .ancestors()
+        .find(|node: &GraphqlSyntaxNode| {
+            node.parent()
+                .is_some_and(|parent| parent.kind() == GraphqlSyntaxKind::GRAPHQL_ROOT)
+        })
+        .unwrap_or(root_node);
+
+    let printed = biome_graphql_formatter::format_range(
+        options,
+        &tree,
+        formatting_root.text_trimmed_range(),
+    )?;
     Ok(printed)
 }
 

--- a/crates/biome_service/src/file_handlers/grit.rs
+++ b/crates/biome_service/src/file_handlers/grit.rs
@@ -1,7 +1,7 @@
 use super::{
     AnalyzerCapabilities, Capabilities, DebugCapabilities, DocumentFileSource, EditorCapabilities,
     EnabledForPath, ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults,
-    ParseResult, ParserCapabilities, SearchCapabilities,
+    ParseResult, ParserCapabilities, SearchCapabilities, format_on_type_noop, matches_on_type_char,
 };
 use crate::settings::{
     OverrideSettings, SettingsWithEditor, check_feature_activity, check_override_feature_activity,
@@ -22,10 +22,10 @@ use biome_formatter::{
     FormatError, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed, TrailingNewline,
 };
 use biome_fs::BiomePath;
-use biome_grit_formatter::{context::GritFormatOptions, format_node, format_sub_tree};
+use biome_grit_formatter::{context::GritFormatOptions, format_node};
 use biome_grit_parser::parse_grit_with_cache;
-use biome_grit_syntax::{GritLanguage, GritRoot, GritSyntaxNode};
-use biome_rowan::{AstNode, NodeCache, TextRange, TextSize, TokenAtOffset};
+use biome_grit_syntax::{GritLanguage, GritRoot, GritSyntaxKind, GritSyntaxNode};
+use biome_rowan::{AstNode, NodeCache, SyntaxKind, TextRange, TextSize, TokenAtOffset};
 use biome_workspace_db::WorkspaceDb;
 use camino::Utf8Path;
 use tracing::debug_span;
@@ -419,12 +419,36 @@ fn format_on_type(
         TokenAtOffset::Between(token, _) => token,
     };
 
+    if token.text_trimmed_range().end() != offset {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    if !matches_on_type_char(token.text_trimmed()) {
+        return Ok(format_on_type_noop(offset));
+    }
+
     let root_node = match token.parent() {
         Some(node) => node,
         None => panic!("found a token with no parent"),
     };
 
-    let printed = format_sub_tree(options, &root_node)?;
+    if root_node
+        .ancestors()
+        .any(|node: GritSyntaxNode| node.kind().is_bogus())
+    {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    let formatting_root = root_node
+        .ancestors()
+        .find(|node: &GritSyntaxNode| {
+            node.parent()
+                .is_some_and(|parent| parent.kind() == GritSyntaxKind::GRIT_ROOT)
+        })
+        .unwrap_or(root_node);
+
+    let printed =
+        biome_grit_formatter::format_range(options, &tree, formatting_root.text_trimmed_range())?;
     Ok(printed)
 }
 

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -5,7 +5,8 @@ use super::{
     DebugCapabilities, DiagnosticsAndActionsParams, EditorCapabilities, EnabledForPath,
     ExtensionHandler, FormatterCapabilities, LintParams, LintResults, ParseEmbedResult,
     ParseEmbeddedParams, ParseResult, ParserCapabilities, ProcessDiagnosticsAndActions,
-    ProcessFixAll, ProcessLint, SearchCapabilities, UpdateSnippetsNodes,
+    ProcessFixAll, ProcessLint, SearchCapabilities, UpdateSnippetsNodes, format_on_type_noop,
+    matches_on_type_char,
 };
 use crate::configuration::to_analyzer_rules;
 #[cfg(feature = "js_embeds")]
@@ -94,6 +95,7 @@ use biome_parser::AnyParse;
 use biome_project_layout::ProjectLayout;
 #[cfg(feature = "js_embeds")]
 use biome_rowan::AstNodeList;
+use biome_rowan::SyntaxKind;
 #[cfg(feature = "type_inference")]
 use biome_rowan::WalkEvent;
 use biome_rowan::{AstNode, BatchMutation, BatchMutationExt, Direction, NodeCache, SendNode};
@@ -1455,12 +1457,27 @@ pub(crate) fn format_on_type(
         TokenAtOffset::Between(token, _) => token,
     };
 
+    if token.text_trimmed_range().end() != offset {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    if !matches_on_type_char(token.text_trimmed()) {
+        return Ok(format_on_type_noop(offset));
+    }
+
     let root_node = match token.parent() {
         Some(node) => node,
         None => panic!("found a token with no parent"),
     };
 
-    let printed = biome_js_formatter::format_sub_tree(options, &root_node)?;
+    if root_node
+        .ancestors()
+        .any(|node: JsSyntaxNode| node.kind().is_bogus())
+    {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    let printed = biome_js_formatter::format_range(options, &tree, root_node.text_trimmed_range())?;
     Ok(printed)
 }
 

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -1,7 +1,7 @@
 use super::{
     AnalyzerVisitorBuilder, AnalyzerVisitorResult, CodeActionsParams, DocumentFileSource,
     EditorCapabilities, EnabledForPath, ExtensionHandler, ParseResult, ProcessFixAll, ProcessLint,
-    SearchCapabilities,
+    SearchCapabilities, format_on_type_noop, matches_on_type_char,
 };
 use crate::configuration::to_analyzer_rules;
 use crate::file_handlers::DebugCapabilities;
@@ -41,7 +41,7 @@ use biome_json_formatter::format_node;
 use biome_json_parser::JsonParserOptions;
 use biome_json_syntax::{JsonLanguage, JsonRoot, JsonSyntaxNode};
 use biome_languages::JsonFileSource;
-use biome_rowan::{AstNode, NodeCache};
+use biome_rowan::{AstNode, NodeCache, SyntaxKind};
 use biome_rowan::{TextRange, TextSize, TokenAtOffset};
 use biome_workspace_db::WorkspaceDb;
 use camino::Utf8Path;
@@ -516,12 +516,28 @@ fn format_on_type(
         TokenAtOffset::Between(token, _) => token,
     };
 
+    if token.text_trimmed_range().end() != offset {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    if !matches_on_type_char(token.text_trimmed()) {
+        return Ok(format_on_type_noop(offset));
+    }
+
     let root_node = match token.parent() {
         Some(node) => node,
         None => panic!("found a token with no parent"),
     };
 
-    let printed = biome_json_formatter::format_sub_tree(options, &root_node)?;
+    if root_node
+        .ancestors()
+        .any(|node: JsonSyntaxNode| node.kind().is_bogus())
+    {
+        return Ok(format_on_type_noop(offset));
+    }
+
+    let printed =
+        biome_json_formatter::format_range(options, &tree, root_node.text_trimmed_range())?;
     Ok(printed)
 }
 

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -106,6 +106,18 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use tracing::trace;
 
+/// Characters that will enable the format on type
+pub const ON_TYPE_CHARS: &[char] = &['}', ']', ')'];
+
+pub(crate) fn matches_on_type_char(value: &str) -> bool {
+    if value.len() != 1 || value.is_empty() {
+        return false;
+    }
+
+    // SATEFY: we checked that we have exactly one character.
+    ON_TYPE_CHARS.contains(&value.chars().next().unwrap())
+}
+
 pub struct FixAllParams<'a> {
     pub(crate) parsed_source: AnyParsedSource,
     pub(crate) fix_file_mode: FixFileMode,
@@ -840,6 +852,16 @@ type FormatOnType = fn(
     TextSize,
     WorkspaceDb,
 ) -> Result<Printed, WorkspaceError>;
+
+pub(crate) fn format_on_type_noop(offset: TextSize) -> Printed {
+    // The LSP layer treats `range: None` as a whole-file replacement.
+    Printed::new(
+        String::new(),
+        Some(TextRange::at(offset, TextSize::from(0))),
+        Vec::new(),
+        Vec::new(),
+    )
+}
 
 type FormatEmbedded = fn(
     &BiomePath,


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary


Closes https://github.com/biomejs/biome-zed/issues/164

Our type format was utterly broken. The logic didn't protect us from the "known characters" and offset ranges. This PR adds more guards on official languages, which means I left out YAML and MD on purpose. 

PR implemented partially using coding agents. Mostly for discovery and possible solutions. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

I moved all tests inside dedicated files. Added new tests via coding agent. 

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
