### PR TITLE
feat(useSortedClasses): sort important-suffix classes in sort_v4

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
@@ -54,6 +54,7 @@ enum SortKey {
         property_idx: u16,
         property_count: u8,
         registration_idx: u16,
+        important: bool,
     },
 }
 
@@ -70,17 +71,16 @@ impl SortKey {
         if !node.variants().is_empty() {
             return Self::Unknown;
         }
-        // TODO: important suffix (`flex!`).
-        if node.excl_token().is_some() {
-            return Self::Unknown;
-        }
 
         let is_negative = node.negative_token().is_some();
+        // An important candidate (`flex!`) sorts exactly where its plain
+        // twin does; `compare` breaks exact-key ties plain-first.
+        let is_important = node.excl_token().is_some();
 
         let Ok(inner) = node.candidate() else {
             return Self::Unknown;
         };
-        match inner {
+        let base = match inner {
             AnyTwCandidate::TwArbitraryCandidate(a) => {
                 let Ok(property_token) = a.property_token() else {
                     return Self::Unknown;
@@ -93,6 +93,7 @@ impl SortKey {
                     property_idx,
                     property_count: 1,
                     registration_idx: 0,
+                    important: false,
                 }
             }
             AnyTwCandidate::TwBogusCandidate(_) => Self::Unknown,
@@ -116,6 +117,7 @@ impl SortKey {
                     property_idx: entry.property_idx,
                     property_count: entry.property_count,
                     registration_idx,
+                    important: false,
                 }
             }
 
@@ -154,19 +156,34 @@ impl SortKey {
                 };
 
                 if let AnyTwValue::TwArbitraryValue(arb) = &value {
-                    return resolve_arbitrary_branch(arbitrary_branches, &arb.value(), registration_idx)
-                        .unwrap_or(Self::Unknown);
+                    resolve_arbitrary_branch(arbitrary_branches, &arb.value(), registration_idx)
+                        .unwrap_or(Self::Unknown)
+                } else {
+                    let modifier = f.modifier();
+                    resolve_named_branch(
+                        named_branches,
+                        &value,
+                        modifier.as_ref(),
+                        registration_idx,
+                    )
+                    .unwrap_or(Self::Unknown)
                 }
-
-                let modifier = f.modifier();
-                resolve_named_branch(
-                    named_branches,
-                    &value,
-                    modifier.as_ref(),
-                    registration_idx,
-                )
-                .unwrap_or(Self::Unknown)
             }
+        };
+
+        match base {
+            Self::Unknown => Self::Unknown,
+            Self::Known {
+                property_idx,
+                property_count,
+                registration_idx,
+                ..
+            } => Self::Known {
+                property_idx,
+                property_count,
+                registration_idx,
+                important: is_important,
+            },
         }
     }
 }
@@ -183,11 +200,13 @@ fn compare(a: &SortKey, b: &SortKey) -> Ordering {
                 property_idx: p1,
                 property_count: c1,
                 registration_idx: r1,
+                important: i1,
             },
             SortKey::Known {
                 property_idx: p2,
                 property_count: c2,
                 registration_idx: r2,
+                important: i2,
             },
         ) => p1
             .cmp(&p2)
@@ -195,7 +214,9 @@ fn compare(a: &SortKey, b: &SortKey) -> Ordering {
             // their property bucket so they sort before single-property
             // utilities in the same bucket.
             .then_with(|| c2.cmp(&c1))
-            .then_with(|| r1.cmp(&r2)),
+            .then_with(|| r1.cmp(&r2))
+            // A plain utility precedes its important twin (`flex flex!`).
+            .then_with(|| i1.cmp(&i2)),
     }
 }
 
@@ -265,7 +286,8 @@ fn named_value_type_matches(
 }
 
 /// Walk a basename's named branch list and return the first matching
-/// branch as a complete `SortKey::Known`. Branch order in the preset
+/// branch as a `SortKey::Known` (importance is stamped by
+/// `SortKey::from_candidate`). Branch order in the preset
 /// already reflects the resolution precedence we want
 /// (Keyword → Theme → Typed).
 fn resolve_named_branch(
@@ -319,13 +341,15 @@ fn resolve_named_branch(
             property_idx,
             property_count,
             registration_idx,
+            important: false,
         });
     }
     None
 }
 
 /// Walk a basename's arbitrary branch list and return the first matching
-/// branch as a complete `SortKey::Known`. Typed branches precede the
+/// branch as a `SortKey::Known` (importance is stamped by
+/// `SortKey::from_candidate`). Typed branches precede the
 /// type-blind fallback in generated preset order.
 fn resolve_arbitrary_branch(
     branches: &[ArbitraryBranch],
@@ -346,6 +370,7 @@ fn resolve_arbitrary_branch(
             property_idx,
             property_count,
             registration_idx,
+            important: false,
         });
     }
     None
@@ -361,7 +386,14 @@ mod tests {
             property_idx,
             property_count,
             registration_idx,
+            important: false,
         }
+    }
+
+    fn classify(input: &str) -> SortKey {
+        let parsed = parse_tailwind(input);
+        let full = parsed.tree().candidates().iter().next().unwrap();
+        SortKey::from_candidate(&full)
     }
 
     fn functional_parts(input: &str) -> (AnyTwValue, Option<AnyTwModifier>) {
@@ -417,6 +449,19 @@ mod tests {
     #[test]
     fn compare_returns_equal_for_identical_known_keys() {
         assert_eq!(compare(&known(5, 1, 0), &known(5, 1, 0)), Ordering::Equal);
+    }
+
+    #[test]
+    fn compare_breaks_exact_key_tie_plain_before_important() {
+        let plain = known(5, 1, 0);
+        let important = SortKey::Known {
+            property_idx: 5,
+            property_count: 1,
+            registration_idx: 0,
+            important: true,
+        };
+        assert_eq!(compare(&plain, &important), Ordering::Less);
+        assert_eq!(compare(&important, &plain), Ordering::Greater);
     }
 
     // endregion: compare
@@ -559,6 +604,52 @@ mod tests {
         let full = parsed.tree().candidates().iter().next().unwrap();
         let display_idx = *PROPERTY_INDEX.get("display").unwrap();
         assert_eq!(SortKey::from_candidate(&full), known(display_idx, 1, 0));
+    }
+
+    #[test]
+    fn important_suffix_is_position_neutral_in_the_key() {
+        let SortKey::Known {
+            property_idx,
+            property_count,
+            registration_idx,
+            important: false,
+        } = classify("flex")
+        else {
+            panic!("expected `flex` to classify as a plain known key");
+        };
+        assert_eq!(
+            classify("flex!"),
+            SortKey::Known {
+                property_idx,
+                property_count,
+                registration_idx,
+                important: true,
+            }
+        );
+    }
+
+    #[test]
+    fn important_suffix_classifies_functional_and_arbitrary_candidates() {
+        assert!(matches!(
+            classify("p-4!"),
+            SortKey::Known {
+                important: true,
+                ..
+            }
+        ));
+        assert!(matches!(
+            classify("[display:block]!"),
+            SortKey::Known {
+                important: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn important_with_variants_is_still_unknown() {
+        // Variant weight is the remaining TODO; `!` must not bypass it.
+        assert_eq!(classify("hover:flex!"), SortKey::Unknown);
     }
 
     // endregion: sort key classification

--- a/crates/biome_js_analyze/tests/sort_v4/cases.jsonc
+++ b/crates/biome_js_analyze/tests/sort_v4/cases.jsonc
@@ -112,6 +112,22 @@
 	"p-4 bg-linear-to-r from-blue-500 to-purple-500 m-2",         // linear gradient with surrounding spacing
 	"mask-linear-to-75% mask-linear-from-25%",                    // mask gradient stops
 
+	// ─── important suffix ──────────────────────────────────────────
+	// `flex!` sorts exactly where `flex` does; an exact-key tie breaks
+	// plain-first. Expected order cross-checked against
+	// prettier-plugin-tailwindcss.
+
+	"px-2! flex p-4",               // position-neutral: sorts as px-2
+	"underline flex!",              // jumps ahead with its utility
+	"flex! flex",                   // twin tie: plain first
+	"p-4! p-4",                     // twin tie: plain first even from behind
+	"w-1/2! flex",                  // ratio value + important
+	"bg-red-500! flex p-4",         // theme value + important
+	"flex! block",                  // static bucket + important
+	"[display:block]! [color:red]", // arbitrary candidate + important
+	"mt-4 -mt-2!",                  // negative + important
+	"not-a-class! flex",            // unknown base stays front even with `!`
+
 	// ─── real-world strings (shadcn/ui v4, MIT) ─────────────────────
 	// Inputs scrambled; output captured by snapshot.
 	// Source: github.com/shadcn-ui/ui registry/new-york-v4.

--- a/crates/biome_js_analyze/tests/sort_v4/cases.snap
+++ b/crates/biome_js_analyze/tests/sort_v4/cases.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/sort_v4_test.rs
+assertion_line: 25
 expression: rendered
 input_file: crates/biome_js_analyze/tests/sort_v4/cases.jsonc
 ---
@@ -173,6 +174,36 @@ sorted: m-2 bg-linear-to-r from-blue-500 to-purple-500 p-4
 ---
 input:  mask-linear-to-75% mask-linear-from-25%
 sorted: mask-linear-from-25% mask-linear-to-75%
+---
+input:  px-2! flex p-4
+sorted: flex p-4 px-2!
+---
+input:  underline flex!
+sorted: flex! underline
+---
+input:  flex! flex
+sorted: flex flex!
+---
+input:  p-4! p-4
+sorted: p-4 p-4!
+---
+input:  w-1/2! flex
+sorted: flex w-1/2!
+---
+input:  bg-red-500! flex p-4
+sorted: flex bg-red-500! p-4
+---
+input:  flex! block
+sorted: block flex!
+---
+input:  [display:block]! [color:red]
+sorted: [display:block]! [color:red]
+---
+input:  mt-4 -mt-2!
+sorted: -mt-2! mt-4
+---
+input:  not-a-class! flex
+sorted: not-a-class! flex
 ---
 input:  shadow-sm text-card-foreground border bg-card gap-6 py-6 rounded-xl flex flex-col
 sorted: text-card-foreground border bg-card flex-col flex gap-6 rounded-xl py-6 shadow-sm


### PR DESCRIPTION
## Summary

Moves #1274.

sort_v4 previously bailed to `Unknown` on any class with Tailwind's !important notation (the ! suffix). It now classifies them; `important` itself is position neutral, but an exact-key tie sorts the plain twin first (`flex flex!`).

AI tools were used to identify the next unclaimed step in useSortedClasses nursery promotion; implementation plans were drafted and considered, with this being the winning candidate for its adherence to repo conventions and inclusion of correct additional tests.

No changesets as `sort_v4` is not yet wired to user-side behavior.

## Test Plan

- `cargo t -p biome_js_analyze --lib sort_v4` has 20 passing (4 of which are new). 
- The `sort_v4_test` snapshot is green with 10 new cases. 
- Full `biome_js_analyze` lib suite 265 passed. 
- Old-engine `use_sorted` specs still 48 passing. 
- Clippy clean.

## Docs

No docs as no user-visible behavior change yet.