### PR TITLE
fix(format/js): wrap curried test each calls

### DIFF
--- a/.changeset/public-pants-beg.md
+++ b/.changeset/public-pants-beg.md
@@ -1,0 +1,17 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10727](https://github.com/biomejs/biome/issues/10727): Biome now breaks the arguments of curried `test.each`, `it.each`, `describe.each`, and `test.for` calls when they exceed the configured line width.
+
+```diff
+- test.each([[1, 2]])("a description that is long enough to push the hugged opening line beyond the print width", (a, b) => {
+-   expect(a).toBe(b);
+- });
++ test.each([[1, 2]])(
++   "a description that is long enough to push the hugged opening line beyond the print width",
++   (a, b) => {
++     expect(a).toBe(b);
++   },
++ );
+```

--- a/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
@@ -43,15 +43,15 @@ impl FormatNodeRule<JsCallArguments> for FormatJsCallArguments {
 
         let call_expression = node.parent::<JsCallExpression>();
 
-        let (is_commonjs_or_amd_call, is_test_call) =
-            call_expression
-                .as_ref()
-                .map_or((Ok(false), Ok(false)), |call| {
-                    (
-                        is_commonjs_or_amd_call(node, call),
-                        call.is_test_call_expression(),
-                    )
-                });
+        let (is_commonjs_or_amd_call, is_test_call, is_curried_test_each_call) = call_expression
+            .as_ref()
+            .map_or((Ok(false), Ok(false), Ok(false)), |call| {
+                (
+                    is_commonjs_or_amd_call(node, call),
+                    call.is_test_call_expression(),
+                    is_curried_test_each_call(call),
+                )
+            });
 
         let is_first_arg_string_literal_or_template = if args.len() != 2 {
             true
@@ -69,7 +69,9 @@ impl FormatNodeRule<JsCallArguments> for FormatJsCallArguments {
         if is_commonjs_or_amd_call?
             || is_multiline_template_only_args(node)
             || is_react_hook_with_deps_array(node, f.comments())
-            || (is_test_call? && is_first_arg_string_literal_or_template)
+            || (is_test_call?
+                && !is_curried_test_each_call?
+                && is_first_arg_string_literal_or_template)
         {
             let l_paren = format_with(|f: &mut JsFormatter| {
                 if f.options().delimiter_spacing().value() {
@@ -1262,6 +1264,17 @@ fn can_group_expression_argument(
     };
 
     Ok(result)
+}
+
+fn is_curried_test_each_call(call: &JsCallExpression) -> SyntaxResult<bool> {
+    // Matches `test.each([...])("name", callback)`: the outer call is applied to
+    // the result of the inner `test.each(...)` call, so it should use the normal
+    // breakable argument layout instead of the direct test-call single-line layout.
+    let AnyJsExpression::JsCallExpression(inner_call) = call.callee()? else {
+        return Ok(false);
+    };
+
+    Ok(inner_call.callee()?.contains_a_test_each_pattern())
 }
 
 /// Tests if this is a call to commonjs [`require`](https://nodejs.org/api/modules.html#requireid)

--- a/crates/biome_js_formatter/tests/specs/js/module/each/each.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/each/each.js
@@ -64,3 +64,34 @@ ${11111111111} | ${2} | ${2}
 ${1} | ${2} | ${3}
 ${2} | ${1} | ${3}`
 
+test.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);
+
+test.each([[1,2]])("a description that is long enough to push the hugged opening line beyond the print width",(a,b)=>{expect(a).toBe(b);});
+
+it.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);
+
+describe.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		test("adds", () => {
+			expect(a).toBe(b);
+		});
+	},
+);
+
+test.for([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);

--- a/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
@@ -72,6 +72,37 @@ ${11111111111} | ${2} | ${2}
 ${1} | ${2} | ${3}
 ${2} | ${1} | ${3}`
 
+test.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);
+
+test.each([[1,2]])("a description that is long enough to push the hugged opening line beyond the print width",(a,b)=>{expect(a).toBe(b);});
+
+it.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);
+
+describe.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		test("adds", () => {
+			expect(a).toBe(b);
+		});
+	},
+);
+
+test.for([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);
 
 ```
 
@@ -150,6 +181,43 @@ ${11111111111} | ${2} | ${2}
 ${1} | ${2} | ${3}
 ${2} | ${1} | ${3}`;
 
+test.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);
+
+test.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);
+
+it.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);
+
+describe.each([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		test("adds", () => {
+			expect(a).toBe(b);
+		});
+	},
+);
+
+test.for([[1, 2]])(
+	"a description that is long enough to push the hugged opening line beyond the print width",
+	(a, b) => {
+		expect(a).toBe(b);
+	},
+);
+
 ```
 
 # Lines exceeding max width of 80 characters
@@ -158,4 +226,9 @@ ${2} | ${1} | ${3}`;
    29: 	${11}        | ${1}     | ${222}  | ${"unknown column 1"}   | ${"unknown column 2"}
    54: 	${1} | ${[{ start: 5, end: 15 }]}                        | ${[1, 2, 3, 4, 5, 6, 7, 8]}
    55: 	${1} | ${[{ start: 5, end: 15 }]}                        | ${["test", "string", "for", "prettier"]}
+   73: 	"a description that is long enough to push the hugged opening line beyond the print width",
+   80: 	"a description that is long enough to push the hugged opening line beyond the print width",
+   87: 	"a description that is long enough to push the hugged opening line beyond the print width",
+   94: 	"a description that is long enough to push the hugged opening line beyond the print width",
+  103: 	"a description that is long enough to push the hugged opening line beyond the print width",
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
fixes the linked formatting issue. i had the clanker verify against prettier. its a small and simple fix.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #10727

generated by gpt 5.5. 
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
