### PR TITLE
fix(inference): use correct function when cloning data

### DIFF
--- a/.changeset/forty-items-fall.md
+++ b/.changeset/forty-items-fall.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10885](https://github.com/biomejs/biome/issues/10885). Fixed a regression in the module inference introduced by a house-keeping change.
+Fixed [`#10885`](https://github.com/biomejs/biome/issues/10885): prevented a module-inference regression introduced by a housekeeping change.

--- a/.changeset/forty-items-fall.md
+++ b/.changeset/forty-items-fall.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10885](https://github.com/biomejs/biome/issues/10885). Fixed a regression in the module inference introduced by a house-keeping change.

--- a/crates/biome_cli/tests/cases/regression_tests.rs
+++ b/crates/biome_cli/tests/cases/regression_tests.rs
@@ -2,10 +2,10 @@ use bpaf::Args;
 use camino::Utf8Path;
 
 use biome_console::BufferConsole;
-use biome_fs::MemoryFileSystem;
+use biome_fs::{MemoryFileSystem, TemporaryFs};
 
-use crate::run_cli;
 use crate::snap_test::{SnapshotPayload, assert_cli_snapshot};
+use crate::{run_cli, run_cli_with_dyn_fs};
 
 /// Regression test for https://github.com/biomejs/biome/issues/9180
 ///
@@ -110,6 +110,65 @@ fn issue_9300() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "issue_9300",
+        fs,
+        console,
+        result,
+    ));
+}
+
+/// Regression test for https://github.com/biomejs/biome/issues/10885
+#[test]
+fn issue_10885() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+    let mut temp_fs = TemporaryFs::new("issue_10885");
+
+    for (path, content) in [
+        (
+            "biome.json",
+            r#"{
+    "linter": {
+        "domains": {
+            "types": "recommended"
+        },
+        "rules": {
+            "nursery": {
+                "noFloatingPromises": "error"
+            }
+        }
+    }
+}
+"#,
+        ),
+        (
+            "router.ts",
+            r#"import { protectedProcedure } from "./procedures";
+
+export const routerProcedure = protectedProcedure.mutation;
+"#,
+        ),
+        (
+            "procedures.ts",
+            r#"declare const trpc: unknown;
+
+export const protectedProcedure = trpc.baseProcedure.use;
+"#,
+        ),
+    ] {
+        temp_fs.create_file(path, content);
+    }
+
+    let result = run_cli_with_dyn_fs(
+        Box::new(temp_fs.create_os()),
+        &mut console,
+        Args::from(["check", temp_fs.cli_path(), "--formatter-enabled=false"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "issue_10885",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_regression_tests/issue_10885.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_regression_tests/issue_10885.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+# Emitted Messages
+
+```block
+Checked 3 files in <TIME>. No fixes applied.
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/crossModuleMemberChain/procedures.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/crossModuleMemberChain/procedures.ts
@@ -1,0 +1,3 @@
+declare const trpc: unknown;
+
+export const protectedProcedure = trpc.baseProcedure.use;

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/crossModuleMemberChain/procedures.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/crossModuleMemberChain/procedures.ts.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: procedures.ts
+---
+# Input
+```ts
+declare const trpc: unknown;
+
+export const protectedProcedure = trpc.baseProcedure.use;
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/crossModuleMemberChain/router.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/crossModuleMemberChain/router.ts
@@ -1,0 +1,3 @@
+import { protectedProcedure } from "./procedures";
+
+export const routerProcedure = protectedProcedure.mutation;

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/crossModuleMemberChain/router.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/crossModuleMemberChain/router.ts.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: router.ts
+---
+# Input
+```ts
+import { protectedProcedure } from "./procedures";
+
+export const routerProcedure = protectedProcedure.mutation;
+
+```

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -209,8 +209,8 @@ pub(super) fn flattened_expression(
         }
         TypeofExpression::StaticMember(expr) => {
             let object = resolver.resolve_and_get(&expr.object)?;
-            if let TypeData::TypeofExpression(object_expr) = object.as_raw_data()
-                && should_flatten_static_member_object(object_expr)
+            if let TypeData::TypeofExpression(object_expr) = object.to_data()
+                && should_flatten_static_member_object(&object_expr)
             {
                 let object = flattened_static_member_object_expression(
                     object_expr.as_ref().clone(),
@@ -312,31 +312,31 @@ fn flattened_static_member_object_expression(
     while remaining_depth > 0 {
         remaining_depth -= 1;
 
-        match expr {
+        return match expr {
             TypeofExpression::Call(expr) => {
                 let callee = resolver.resolve_and_get(&expr.callee)?;
                 let object = flattened_call(&expr, callee.to_data(), resolver)?;
-                return apply_static_member_chain(object, pending_members, resolver);
+                apply_static_member_chain(object, pending_members, resolver)
             }
             TypeofExpression::New(expr) => {
                 let object = flattened_new(&expr, resolver)?;
-                return apply_static_member_chain(object, pending_members, resolver);
+                apply_static_member_chain(object, pending_members, resolver)
             }
-            TypeofExpression::StaticMember(member_expr) => {
+            TypeofExpression::StaticMember(ref member_expr) => {
                 let object = resolver.resolve_and_get(&member_expr.object)?;
-                if let TypeData::TypeofExpression(object_expr) = object.as_raw_data()
-                    && should_flatten_static_member_object(object_expr)
+                if let TypeData::TypeofExpression(object_expr) = object.to_data()
+                    && should_flatten_static_member_object(&object_expr)
                 {
-                    pending_members.push(member_expr.member)?;
+                    pending_members.push(member_expr.member.clone())?;
                     expr = object_expr.as_ref().clone();
                     continue;
                 }
 
                 let object = flattened_static_member(object, &member_expr.member, resolver)?;
-                return apply_static_member_chain(object, pending_members, resolver);
+                apply_static_member_chain(object, pending_members, resolver)
             }
-            _ => return None,
-        }
+            _ => None,
+        };
     }
 
     None

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -359,7 +359,9 @@ impl<'a> ResolvedTypeData<'a> {
 
     /// Returns a reference to the raw data.
     ///
-    /// **Be careful:** If you intend to invoke the resolver on the data, it may
+    /// ## Warning
+    ///
+    /// If you intend to invoke the resolver on the data, it may
     /// not be aware of the context in which the data was resolved, and further
     /// references may be resolved from the wrong context. If you wish to call
     /// the resolver on the data, use [`Self::to_data()`] instead.


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/10885

Fixes a bug introduced by https://github.com/biomejs/biome/pull/10721

The PR used `as_raw_data` incorrectly; this PR switches to `to_data` when it needs to close the data.

I helped myself with a could of agents in identifying where the issue is. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added two new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
