### PR TITLE
docs(noDuplicateProperties): note that @keyframes declarations are ignored

### DIFF
--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_properties.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_properties.rs
@@ -12,7 +12,7 @@ use crate::services::semantic::Semantic;
 declare_lint_rule! {
     /// Disallow duplicate properties within declaration blocks.
     ///
-    /// This rule checks the declaration blocks for duplicate properties. It ignores custom properties.
+    /// This rule checks the declaration blocks for duplicate properties. It ignores custom properties and declarations inside `@keyframes` blocks.
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
`noDuplicateProperties` skips declarations inside `@keyframes` blocks as well as custom properties (a `@keyframes` selector legitimately repeats the same property across frames), but the rule description only mentions custom properties. This notes the `@keyframes` exclusion in the description.
