### PR TITLE
fix(fmt): don't move comments inside if statement

### DIFF
--- a/.changeset/cute-bats-brake.md
+++ b/.changeset/cute-bats-brake.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6392](https://github.com/biomejs/biome/issues/6392): On-type formatting no longer moves comments before an `if` statement into its body.

--- a/crates/biome_formatter/src/comments/builder.rs
+++ b/crates/biome_formatter/src/comments/builder.rs
@@ -22,6 +22,15 @@ pub(super) struct CommentsBuilderVisitor<'a, Style: CommentStyle> {
     following_node_index: Option<usize>,
     parents: Vec<SyntaxNode<Style::Language>>,
     last_token: Option<SyntaxToken<Style::Language>>,
+    root: Option<SyntaxNode<Style::Language>>,
+    /// Whether the formatted root has a parent, which is the case when only a
+    /// part of a document is formatted (range and on-type formatting).
+    is_sub_tree: bool,
+    /// Whether the formatted root is a list.
+    is_list_root: bool,
+    /// Where the text of the root's first token starts. Comments that come
+    /// before this offset sit in front of the whole formatted sub-tree.
+    root_content_start: TextSize,
 }
 
 impl<'a, Style> CommentsBuilderVisitor<'a, Style>
@@ -39,6 +48,10 @@ where
             following_node_index: Default::default(),
             parents: Default::default(),
             last_token: Default::default(),
+            root: Default::default(),
+            is_sub_tree: false,
+            is_list_root: false,
+            root_content_start: TextSize::default(),
         }
     }
 
@@ -49,6 +62,25 @@ where
         CommentsMap<SyntaxElementKey, SourceComment<Style::Language>>,
         FxHashSet<SyntaxElementKey>,
     ) {
+        // A root with a parent means that only a part of a document is
+        // formatted (range and on-type formatting). Full documents always
+        // start at a parentless root and take none of the subtree paths
+        // below.
+        self.is_sub_tree = root.parent().is_some();
+        self.is_list_root = root.kind().is_list();
+        self.root = Some(root.clone());
+        self.root_content_start = root.text_trimmed_range().start();
+
+        // Lists are normally skipped because comments belong to the parent or
+        // to a child. When the formatted root is itself a list, there is no
+        // parent to take that role, so the list goes onto the stack: comments
+        // between its children are then enclosed by the list instead of by
+        // the child that follows them.
+        let push_list_root = self.is_sub_tree && self.is_list_root;
+        if push_list_root {
+            self.parents.push(root.clone());
+        }
+
         for event in root.preorder_with_tokens(Direction::Next) {
             match event {
                 WalkEvent::Enter(SyntaxElement::Node(node)) => {
@@ -64,6 +96,10 @@ where
                     // Handled as part of enter
                 }
             }
+        }
+
+        if push_list_root {
+            self.parents.pop();
         }
 
         assert!(
@@ -248,8 +284,99 @@ where
         for mut comment in self.pending_comments.drain(..) {
             comment.following = following.cloned();
 
+            // A comment that comes before the formatted root itself always
+            // becomes a leading comment of the root, printed before
+            // everything else. The placement rules are skipped because they
+            // need to see the code around the comment, and here everything
+            // before the comment is outside of the formatted root.
+            //
+            // Lists don't print their own comments, so a comment before a
+            // list root goes through the normal placement instead and ends up
+            // on the list's first child.
+            if self.is_sub_tree
+                && !self.is_list_root
+                && comment.piece().text_range().end() <= self.root_content_start
+            {
+                let root = self
+                    .root
+                    .clone()
+                    .expect("Expected the root to be set before visiting comments.");
+                self.builder.push_leading_comment(&root, comment);
+                continue;
+            }
+
             let placement = self.style.place_comment(comment);
+            let placement = Self::normalize_placement_into_formatted_tree(&self.root, placement);
             self.builder.add_comment(placement);
+        }
+    }
+
+    /// Makes sure that every comment ends up on a node that is part of the
+    /// formatted tree. The formatter only prints comments attached to nodes
+    /// it visits; a comment attached to any other node is silently lost.
+    ///
+    /// When only a part of a document is formatted, a placement rule can pick
+    /// a node that lies outside of that part. Take `for (;;) continue; /* a */`:
+    /// when only the `continue` statement is formatted, the rule for the
+    /// comment picks the surrounding `for` loop, and the loop is not part of
+    /// what gets printed.
+    ///
+    /// In that case the comment is moved back onto the formatted tree itself:
+    /// a comment written before the tree becomes a leading comment of it, and
+    /// a comment written after it becomes a trailing comment. When the tree
+    /// is a list, the comment goes on the first or last child instead,
+    /// because lists don't print their own comments.
+    fn normalize_placement_into_formatted_tree(
+        root: &Option<SyntaxNode<Style::Language>>,
+        placement: CommentPlacement<Style::Language>,
+    ) -> CommentPlacement<Style::Language> {
+        let Some(root) = root else {
+            return placement;
+        };
+
+        match placement {
+            CommentPlacement::Leading { node, comment }
+            | CommentPlacement::Trailing { node, comment }
+            | CommentPlacement::Dangling { node, comment }
+                if !node.ancestors().any(|ancestor| &ancestor == root) =>
+            {
+                let root_content = root.text_trimmed_range();
+                let comment_range = comment.piece().text_range();
+
+                // Only comments before or after the whole formatted tree can
+                // legitimately end up on an outside node. An inner comment
+                // placed outside means a placement rule resolved a wrong node.
+                debug_assert!(
+                    comment_range.end() <= root_content.start()
+                        || comment_range.start() >= root_content.end(),
+                    "A comment inside of the formatted tree was placed on a node outside of it.\nComment: {comment:#?}\nNode: {node:#?}"
+                );
+
+                // The anchor must be a node whose format rule prints comments,
+                // which excludes lists: use the closest child instead.
+                if comment_range.start() >= root_content.end() {
+                    let anchor = if root.kind().is_list() {
+                        root.last_child()
+                    } else {
+                        Some(root.clone())
+                    };
+                    match anchor {
+                        Some(anchor) => CommentPlacement::trailing(anchor, comment),
+                        None => CommentPlacement::dangling(root.clone(), comment),
+                    }
+                } else {
+                    let anchor = if root.kind().is_list() {
+                        root.first_child()
+                    } else {
+                        Some(root.clone())
+                    };
+                    match anchor {
+                        Some(anchor) => CommentPlacement::leading(anchor, comment),
+                        None => CommentPlacement::dangling(root.clone(), comment),
+                    }
+                }
+            }
+            placement => placement,
         }
     }
 
@@ -1018,6 +1145,108 @@ b;"#;
             .unwrap();
 
         assert!(!comments.trailing(&sequence.syntax().key()).is_empty());
+    }
+
+    /// Comments between the children of a list that is the formatted root are
+    /// enclosed by the list itself, and the surrounding children are siblings.
+    #[test]
+    fn list_as_sub_tree_root() {
+        let root = parse_module(
+            "function test() {\n\tfirst();\n\n\t// comment\n\tsecond();\n}",
+            JsParserOptions::default(),
+        )
+        .syntax();
+
+        let list = root
+            .descendants()
+            .find(|node| node.kind() == JsSyntaxKind::JS_STATEMENT_LIST)
+            .unwrap();
+
+        let (decorated, _) = extract_comments_from_node(&list);
+
+        assert_eq!(decorated.len(), 1);
+        let comment = &decorated[0];
+        assert_eq!(comment.enclosing_node(), &list);
+        assert_eq!(
+            comment.preceding_node().and_then(|node| node.parent()),
+            Some(list.clone())
+        );
+        assert_eq!(
+            comment.following_node().and_then(|node| node.parent()),
+            Some(list)
+        );
+    }
+
+    /// Comments before the first token of a sub-tree root become leading
+    /// comments of the root without going through the placement rules.
+    #[test]
+    fn sub_tree_root_leading_comments() {
+        let root = parse_module(
+            "// comment\nif (a) {\n\tb();\n}",
+            JsParserOptions::default(),
+        )
+        .syntax();
+
+        let if_statement = root
+            .descendants()
+            .find(|node| node.kind() == JsSyntaxKind::JS_IF_STATEMENT)
+            .unwrap();
+
+        let (decorated, comments) = extract_comments_from_node(&if_statement);
+
+        assert!(decorated.is_empty());
+        assert_eq!(comments.leading(&if_statement.key()).len(), 1);
+    }
+
+    /// Comments before the first child of a list root are attached to that
+    /// child, because list format rules never print their own comments.
+    #[test]
+    fn list_root_leading_comments() {
+        let root = parse_module(
+            "function test() {\n\t// comment\n\tfirst();\n\tsecond();\n}",
+            JsParserOptions::default(),
+        )
+        .syntax();
+
+        let list = root
+            .descendants()
+            .find(|node| node.kind() == JsSyntaxKind::JS_STATEMENT_LIST)
+            .unwrap();
+        let first_statement = list.first_child().unwrap();
+
+        let (decorated, comments) = extract_comments_from_node(&list);
+
+        assert_eq!(decorated.len(), 1);
+        assert!(comments.leading(&list.key()).is_empty());
+        assert_eq!(comments.leading(&first_statement.key()).len(), 1);
+    }
+
+    /// A parentless root keeps the full-document behavior: its leading
+    /// comments still go through the placement rules.
+    #[test]
+    fn parentless_root_leading_comments() {
+        let root = parse_module(
+            "// comment\nif (a) {\n\tb();\n}",
+            JsParserOptions::default(),
+        )
+        .syntax();
+
+        let (decorated, comments) = extract_comments_from_node(&root);
+
+        assert_eq!(decorated.len(), 1);
+        assert!(comments.leading(&root.key()).is_empty());
+    }
+
+    fn extract_comments_from_node(
+        root: &JsSyntaxNode,
+    ) -> (
+        Vec<DecoratedComment<JsLanguage>>,
+        CommentsMap<SyntaxElementKey, SourceComment<JsLanguage>>,
+    ) {
+        let style = TestCommentStyle::default();
+        let builder = CommentsBuilderVisitor::new(&style, None);
+        let (comments, _) = builder.visit(root);
+        (style.finish(), comments)
     }
 
     fn extract_comments(

--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -851,8 +851,11 @@ fn handle_if_statement_comment(
             // ```javascript
             // if (cond1)  /* test */ if (other) { a }
             // ```
-            if let Some(if_statement) = JsIfStatement::cast_ref(following)
-                && let Ok(nested_consequent) = if_statement.consequent()
+            if let Some(nested_if) = JsIfStatement::cast_ref(following)
+                && if_statement
+                    .consequent()
+                    .is_ok_and(|consequent| consequent.syntax() == following)
+                && let Ok(nested_consequent) = nested_if.consequent()
             {
                 return place_leading_statement_comment(nested_consequent, comment);
             }

--- a/crates/biome_js_formatter/src/lib.rs
+++ b/crates/biome_js_formatter/src/lib.rs
@@ -851,6 +851,78 @@ function() {
         )
     }
 
+    fn assert_range_formatting_preserves_leading_comments(input: &str, closing_paren: &str) {
+        let tree = parse_script(input, JsParserOptions::default());
+        let root = tree.syntax();
+        let offset =
+            TextSize::try_from(input.find(closing_paren).unwrap() + closing_paren.len()).unwrap();
+        let token = root.token_at_offset(offset).left_biased().unwrap();
+        let parent = token.parent().unwrap();
+        let printed = format_range(
+            JsFormatOptions::new(JsFileSource::js_script()).with_indent_style(IndentStyle::Tab),
+            &root,
+            parent.text_trimmed_range(),
+        )
+        .expect("range formatting failed");
+
+        let range = printed.range().unwrap();
+        let mut output = input.to_string();
+        output.replace_range(
+            usize::from(range.start())..usize::from(range.end()),
+            printed.as_code(),
+        );
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn range_formatting_preserves_if_statement_leading_comments() {
+        assert_range_formatting_preserves_leading_comments(
+            r#"function test() {
+	const num = Math.random();
+
+	// Add a new check
+	// TODO: try removing and re-adding closing paren
+	if (num < 0.5 && num < 0.4) {
+		console.log("Less than 0.5");
+	}
+}
+"#,
+            "num < 0.4)",
+        );
+    }
+
+    #[test]
+    fn range_formatting_preserves_while_statement_leading_comments() {
+        assert_range_formatting_preserves_leading_comments(
+            r#"function test() {
+	const num = Math.random();
+
+	// A loop
+	while (num < 0.5) {
+		console.log("Less than 0.5");
+	}
+}
+"#,
+            "num < 0.5)",
+        );
+    }
+
+    #[test]
+    fn range_formatting_preserves_for_statement_leading_comments() {
+        assert_range_formatting_preserves_leading_comments(
+            r#"function test() {
+	const num = Math.random();
+
+	// A loop
+	for (let index = 0; index < num; index++) {
+		console.log(index);
+	}
+}
+"#,
+            "index++)",
+        );
+    }
+
     #[test]
     fn format_range_out_of_bounds() {
         let src = "statement();";

--- a/crates/biome_js_formatter/src/lib.rs
+++ b/crates/biome_js_formatter/src/lib.rs
@@ -923,6 +923,177 @@ function() {
         );
     }
 
+    /// A leading comment of `continue` must not become a trailing comment.
+    #[test]
+    fn range_formatting_preserves_continue_leading_comments() {
+        assert_range_formatting_preserves_leading_comments(
+            r#"while (true) {
+	// continue to the next iteration
+	continue;
+}
+"#,
+            "continue;",
+        );
+    }
+
+    #[test]
+    fn range_formatting_preserves_break_leading_comments() {
+        assert_range_formatting_preserves_leading_comments(
+            r#"while (true) {
+	// stop the loop
+	break;
+}
+"#,
+            "break;",
+        );
+    }
+
+    /// A trailing comment whose placement rule resolves the loop around the
+    /// formatted statement must not be dropped.
+    #[test]
+    fn range_formatting_preserves_continue_trailing_comments_in_braceless_body() {
+        assert_range_formatting_preserves_leading_comments(
+            r#"for (;;) continue; /* comment */
+"#,
+            "continue;",
+        );
+    }
+
+    /// The comment must not be dropped when the loop body has no braces.
+    #[test]
+    fn range_formatting_preserves_continue_leading_comments_in_braceless_body() {
+        assert_range_formatting_preserves_leading_comments(
+            r#"for (;;)
+	// note
+	continue;
+"#,
+            "continue;",
+        );
+    }
+
+    /// An inline block comment before the `if` keyword must stay in place.
+    #[test]
+    fn range_formatting_preserves_if_statement_inline_leading_comments() {
+        assert_range_formatting_preserves_leading_comments(
+            r#"function test() {
+	const num = Math.random();
+
+	/* check */ if (num < 0.5) {
+		console.log("Less than 0.5");
+	}
+}
+"#,
+            "num < 0.5)",
+        );
+    }
+
+    /// Simulates on-type formatting after typing `]`.
+    #[test]
+    fn range_formatting_preserves_variable_statement_leading_comments() {
+        assert_range_formatting_preserves_leading_comments(
+            r#"function test() {
+	const num = Math.random();
+
+	// the list
+	const x = [1, 2];
+}
+"#,
+            "[1, 2]",
+        );
+    }
+
+    /// Simulates on-type formatting after typing `}` of an import specifier.
+    #[test]
+    fn range_formatting_preserves_import_leading_comments() {
+        let input = r#"// external dependencies
+import { a } from "b";
+console.log(a);
+"#;
+        let source = JsFileSource::js_module();
+        let tree = parse(input, source, JsParserOptions::default());
+        let root = tree.syntax();
+        let offset = TextSize::try_from(input.find("{ a }").unwrap() + "{ a }".len()).unwrap();
+        let token = root.token_at_offset(offset).left_biased().unwrap();
+        let parent = token.parent().unwrap();
+        let printed = format_range(
+            JsFormatOptions::new(source).with_indent_style(IndentStyle::Tab),
+            &root,
+            parent.text_trimmed_range(),
+        )
+        .expect("range formatting failed");
+
+        let range = printed.range().unwrap();
+        let mut output = input.to_string();
+        output.replace_range(
+            usize::from(range.start())..usize::from(range.end()),
+            printed.as_code(),
+        );
+        assert_eq!(output, input);
+    }
+
+    /// Simulates formatting a selection that covers only the `if` header,
+    /// which makes the if statement itself the formatting root.
+    #[test]
+    fn range_formatting_preserves_leading_comments_of_selected_if_header() {
+        let input = r#"function test() {
+	const num = Math.random();
+
+	// Add a new check
+	if (num < 0.5 && num < 0.4) {
+		console.log("Less than 0.5");
+	}
+}
+"#;
+        let tree = parse_script(input, JsParserOptions::default());
+        let start = TextSize::try_from(input.find("if (").unwrap()).unwrap();
+        let end =
+            TextSize::try_from(input.find("num < 0.4)").unwrap() + "num < 0.4)".len()).unwrap();
+        let printed = format_range(
+            JsFormatOptions::new(JsFileSource::js_script()).with_indent_style(IndentStyle::Tab),
+            &tree.syntax(),
+            TextRange::new(start, end),
+        )
+        .expect("range formatting failed");
+
+        let range = printed.range().unwrap();
+        let mut output = input.to_string();
+        output.replace_range(
+            usize::from(range.start())..usize::from(range.end()),
+            printed.as_code(),
+        );
+        assert_eq!(output, input);
+    }
+
+    /// Selecting two sibling statements must preserve the leading comment of
+    /// the first one and the own-line and inline comments between them.
+    #[test]
+    fn range_formatting_preserves_comments_between_selected_statements() {
+        let input = r#"function test() {
+	// leading comment
+	first(); /* inline */
+	// own line
+	second();
+}
+"#;
+        let tree = parse_script(input, JsParserOptions::default());
+        let start = TextSize::try_from(input.find("first").unwrap()).unwrap();
+        let end = TextSize::try_from(input.find("second();").unwrap() + "second();".len()).unwrap();
+        let printed = format_range(
+            JsFormatOptions::new(JsFileSource::js_script()).with_indent_style(IndentStyle::Tab),
+            &tree.syntax(),
+            TextRange::new(start, end),
+        )
+        .expect("range formatting failed");
+
+        let range = printed.range().unwrap();
+        let mut output = input.to_string();
+        output.replace_range(
+            usize::from(range.start())..usize::from(range.end()),
+            printed.as_code(),
+        );
+        assert_eq!(output, input);
+    }
+
     #[test]
     fn format_range_out_of_bounds() {
         let src = "statement();";

--- a/crates/biome_lsp/src/server_type_on_format.tests.rs
+++ b/crates/biome_lsp/src/server_type_on_format.tests.rs
@@ -529,6 +529,50 @@ async fn on_type_formatting_still_formats_closing_curly() -> Result<()> {
 }
 
 #[tokio::test]
+async fn on_type_formatting_does_not_edit_if_statement_with_leading_comments() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.js");
+    let text = r#"function test() {
+	const num = Math.random();
+
+	// Add a new check
+	// TODO: try removing and re-adding closing paren
+	if (num < 0.5 && num < 0.4) {
+		console.log("Less than 0.5");
+	}
+}
+"#;
+    server
+        .open_named_document(text, uri.clone(), "javascript")
+        .await?;
+
+    let edits = request_on_type_formatting(
+        &mut server,
+        uri,
+        position_after(text, "num < 0.5 && num < 0.4)"),
+        ")",
+    )
+    .await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn on_type_formatting_does_not_edit_formatted_method_body() -> Result<()> {
     let factory = ServerFactory::default();
     let (service, client) = factory.create().into_inner();

--- a/crates/biome_lsp/src/server_type_on_format.tests.rs
+++ b/crates/biome_lsp/src/server_type_on_format.tests.rs
@@ -394,6 +394,39 @@ async fn on_type_formatting_does_not_edit_formatted_css_block() -> Result<()> {
 }
 
 #[tokio::test]
+async fn on_type_formatting_does_not_edit_css_block_with_leading_comment() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    let uri = uri!("document.css");
+    let text = "a {\n\tcolor: blue;\n}\n\n/* heading */\nb {\n\tcolor: red;\n}\n";
+    server.open_named_document(text, uri.clone(), "css").await?;
+
+    let edits = request_on_type_formatting(
+        &mut server,
+        uri,
+        position_after(text, "\tcolor: red;\n}"),
+        "}",
+    )
+    .await?;
+
+    assert_no_edits(edits);
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn on_type_formatting_formats_css_closing_curly() -> Result<()> {
     let factory = ServerFactory::default();
     let (service, client) = factory.create().into_inner();


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/6392

I used an agent to find the bug and implement the solution. 

UPDATE: the second commit improves the placement of comments as a whole: when the piece of code that is being formatted is a list, comments are flushed because lists are nodes that don't emit comments. This makes sure that the placement is consistent across the board.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a few tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
