### PR TITLE
fix(biome_js_analyze): mark noThisInStatic fix as unsafe

### DIFF
--- a/.changeset/no-this-in-static-unsafe-fix.md
+++ b/.changeset/no-this-in-static-unsafe-fix.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10278](https://github.com/biomejs/biome/issues/10278): The fix of the [`noThisInStatic`](https://biomejs.dev/linter/rules/no-this-in-static/) rule is now unsafe. Replacing `this` with the class name in a static context isn't always safe, for example when a static `[Symbol.hasInstance]` method relies on `this` to resolve the current class through the prototype chain.
+Fixed [#10278](https://github.com/biomejs/biome/issues/10278): The fix of the [`noThisInStatic`](https://biomejs.dev/linter/rules/no-this-in-static/) rule is now unsafe by default. Replacing `this` with the class name in a static context isn't always safe, for example when a static `[Symbol.hasInstance]` method relies on `this` to resolve the current class through the prototype chain.

--- a/.changeset/no-this-in-static-unsafe-fix.md
+++ b/.changeset/no-this-in-static-unsafe-fix.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10278](https://github.com/biomejs/biome/issues/10278): The fix of the [`noThisInStatic`](https://biomejs.dev/linter/rules/no-this-in-static/) rule is now unsafe. Replacing `this` with the class name in a static context isn't always safe, for example when a static `[Symbol.hasInstance]` method relies on `this` to resolve the current class through the prototype chain.

--- a/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
@@ -85,7 +85,7 @@ declare_lint_rule! {
         sources: &[RuleSource::EslintMysticatea("no-this-in-static").same()],
         recommended: true,
         severity: Severity::Warning,
-        fix_kind: FixKind::Safe,
+        fix_kind: FixKind::Unsafe,
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js
@@ -45,3 +45,42 @@ class FactoryCases {
         new this.Factory();
     }
 }
+
+class BaseWithHasInstance {
+    constructor(name) {
+        this.name = name;
+    }
+
+    static [Symbol.hasInstance](instance) {
+        if (
+            instance === null ||
+            instance === undefined ||
+            typeof instance !== "object"
+        ) {
+            return false;
+        }
+
+        if (
+            this.prototype &&
+            Object.prototype.isPrototypeOf.call(this.prototype, instance)
+        ) {
+            return true;
+        }
+
+        let proto = Object.getPrototypeOf(instance);
+        while (proto !== null) {
+            if (proto.constructor?.name === this.name) {
+                return true;
+            }
+            proto = Object.getPrototypeOf(proto);
+        }
+
+        return false;
+    }
+}
+
+class HasInstanceSub1 extends BaseWithHasInstance {}
+class HasInstanceSub2 extends BaseWithHasInstance {}
+
+const hasInstanceSub1 = new HasInstanceSub1("sub1");
+hasInstanceSub1 instanceof HasInstanceSub2;

--- a/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js.snap
@@ -52,6 +52,45 @@ class FactoryCases {
     }
 }
 
+class BaseWithHasInstance {
+    constructor(name) {
+        this.name = name;
+    }
+
+    static [Symbol.hasInstance](instance) {
+        if (
+            instance === null ||
+            instance === undefined ||
+            typeof instance !== "object"
+        ) {
+            return false;
+        }
+
+        if (
+            this.prototype &&
+            Object.prototype.isPrototypeOf.call(this.prototype, instance)
+        ) {
+            return true;
+        }
+
+        let proto = Object.getPrototypeOf(instance);
+        while (proto !== null) {
+            if (proto.constructor?.name === this.name) {
+                return true;
+            }
+            proto = Object.getPrototypeOf(proto);
+        }
+
+        return false;
+    }
+}
+
+class HasInstanceSub1 extends BaseWithHasInstance {}
+class HasInstanceSub2 extends BaseWithHasInstance {}
+
+const hasInstanceSub1 = new HasInstanceSub1("sub1");
+hasInstanceSub1 instanceof HasInstanceSub2;
+
 ```
 
 # Diagnostics
@@ -68,7 +107,7 @@ invalid.js:2:14 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      1  1 │   export default class B extends A {
      2    │ - ····static·{·this.CONSTANT·+=·super.foo();·}
@@ -92,7 +131,7 @@ invalid.js:2:31 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      1  1 │   export default class B extends A {
      2    │ - ····static·{·this.CONSTANT·+=·super.foo();·}
@@ -116,7 +155,7 @@ invalid.js:8:19 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      6  6 │   
      7  7 │       static get property() {
@@ -142,7 +181,7 @@ invalid.js:9:26 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      7  7 │       static get property() {
      8  8 │           /*before*/this/*after*/;
@@ -167,7 +206,7 @@ invalid.js:13:15 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     11 11 │   
     12 12 │       static set property(x) {
@@ -193,7 +232,7 @@ invalid.js:14:15 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     12 12 │       static set property(x) {
     13 13 │           () => this;
@@ -218,7 +257,7 @@ invalid.js:18:16 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     16 16 │   
     17 17 │       static method() {
@@ -243,7 +282,7 @@ invalid.js:18:32 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     16 16 │   
     17 17 │       static method() {
@@ -269,7 +308,7 @@ invalid.js:24:16 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     22 22 │   class C extends A {
     23 23 │       static method() {
@@ -295,7 +334,7 @@ invalid.js:24:32 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     22 22 │   class C extends A {
     23 23 │       static method() {
@@ -321,7 +360,7 @@ invalid.js:30:16 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     28 28 │   const D = class D extends f() {
     29 29 │       static method() {
@@ -398,7 +437,7 @@ invalid.js:43:18 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     41 41 │   class FactoryCases {
     42 42 │       static method() {
@@ -424,7 +463,7 @@ invalid.js:44:17 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     42 42 │       static method() {
     43 43 │           new this(this);
@@ -450,7 +489,7 @@ invalid.js:45:13 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     43 43 │           new this(this);
     44 44 │           new Foo(this);
@@ -458,6 +497,83 @@ invalid.js:45:13 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
        45 │ + ········new·FactoryCases.Factory();
     46 46 │       }
     47 47 │   }
+  
+
+```
+
+```
+invalid.js:64:13 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Using this in a static context can be confusing.
+  
+    63 │         if (
+  > 64 │             this.prototype &&
+       │             ^^^^
+    65 │             Object.prototype.isPrototypeOf.call(this.prototype, instance)
+    66 │         ) {
+  
+  i this refers to the class.
+  
+  i Unsafe fix: Use the class name instead.
+  
+    62 62 │   
+    63 63 │           if (
+    64    │ - ············this.prototype·&&
+       64 │ + ············BaseWithHasInstance.prototype·&&
+    65 65 │               Object.prototype.isPrototypeOf.call(this.prototype, instance)
+    66 66 │           ) {
+  
+
+```
+
+```
+invalid.js:65:49 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Using this in a static context can be confusing.
+  
+    63 │         if (
+    64 │             this.prototype &&
+  > 65 │             Object.prototype.isPrototypeOf.call(this.prototype, instance)
+       │                                                 ^^^^
+    66 │         ) {
+    67 │             return true;
+  
+  i this refers to the class.
+  
+  i Unsafe fix: Use the class name instead.
+  
+    63 63 │           if (
+    64 64 │               this.prototype &&
+    65    │ - ············Object.prototype.isPrototypeOf.call(this.prototype,·instance)
+       65 │ + ············Object.prototype.isPrototypeOf.call(BaseWithHasInstance.prototype,·instance)
+    66 66 │           ) {
+    67 67 │               return true;
+  
+
+```
+
+```
+invalid.js:72:45 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Using this in a static context can be confusing.
+  
+    70 │         let proto = Object.getPrototypeOf(instance);
+    71 │         while (proto !== null) {
+  > 72 │             if (proto.constructor?.name === this.name) {
+       │                                             ^^^^
+    73 │                 return true;
+    74 │             }
+  
+  i this refers to the class.
+  
+  i Unsafe fix: Use the class name instead.
+  
+    70 70 │           let proto = Object.getPrototypeOf(instance);
+    71 71 │           while (proto !== null) {
+    72    │ - ············if·(proto.constructor?.name·===·this.name)·{
+       72 │ + ············if·(proto.constructor?.name·===·BaseWithHasInstance.name)·{
+    73 73 │                   return true;
+    74 74 │               }
   
 
 ```


### PR DESCRIPTION
## Summary

Fixes #10278. The `noThisInStatic` fix rewrites `this` to the class name, but in a static context `this` resolves to the current class, so the two aren't always interchangeable. A static `[Symbol.hasInstance]` that reads `this.prototype`/`this.name` to walk the prototype chain is one case where the rewrite changes behavior, as shown in the issue. Changing the fix from safe to unsafe so it no longer applies automatically.

This follows up on #10588, which made the same change but was closed without a changeset.

## Test Plan

Added the `Symbol.hasInstance` case from the issue to the `noThisInStatic` invalid spec and updated the snapshot, which now reports the fix as unsafe.

## Docs

N/A
