### PR TITLE
fix(useVueHyphenatedAttributes): don't flag colon-separated attributes

### DIFF
--- a/.changeset/fix-vue-hyphenated-attributes-colon-props.md
+++ b/.changeset/fix-vue-hyphenated-attributes-colon-props.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10776](https://github.com/biomejs/biome/issues/10776): [`useVueHyphenatedAttributes`](https://biomejs.dev/linter/rules/use-vue-hyphenated-attributes/) no longer flags colon-separated attributes such as PrimeVue pass-through props (e.g. `pt:header:data-test-id`). Each colon-separated segment is now checked individually, so an attribute is valid when every segment is already hyphenated.

--- a/crates/biome_html_analyze/src/lint/style/use_vue_hyphenated_attributes.rs
+++ b/crates/biome_html_analyze/src/lint/style/use_vue_hyphenated_attributes.rs
@@ -274,8 +274,12 @@ fn extract_attribute_name(attr: &AnyHtmlAttribute) -> Option<TokenText> {
 }
 
 fn is_hyphenated(name: &str) -> bool {
-    // Treat pure lowercase and kebab-case as valid.
-    matches!(Case::identify(name, true), Case::Kebab | Case::Lower)
+    // Colon-separated names (e.g. PrimeVue pass-through props like `pt:header:data-test-id`)
+    // are valid as long as every segment is itself hyphenated.
+    name.split(':').all(|segment| {
+        // Treat pure lowercase and kebab-case as valid.
+        matches!(Case::identify(segment, true), Case::Kebab | Case::Lower)
+    })
 }
 
 fn is_svg_element(element: &AnyHtmlTagElement) -> bool {

--- a/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/valid.vue
@@ -31,4 +31,7 @@
 
   <!-- Should not apply to other directives -->
   <MyComp v-foo:bar="asdf"></MyComp>
+
+  <!-- PrimeVue pass-through props: colon-separated segments that are each kebab-case/lowercase -->
+  <Panel pt:root:class="border" pt:header:id="headerId" pt:header:data-test-id="testId"></Panel>
 </template>

--- a/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/valid.vue.snap
@@ -37,6 +37,9 @@ expression: valid.vue
 
   <!-- Should not apply to other directives -->
   <MyComp v-foo:bar="asdf"></MyComp>
+
+  <!-- PrimeVue pass-through props: colon-separated segments that are each kebab-case/lowercase -->
+  <Panel pt:root:class="border" pt:header:id="headerId" pt:header:data-test-id="testId"></Panel>
 </template>
 
 ```


### PR DESCRIPTION
## Summary

`useVueHyphenatedAttributes` was flagging colon-separated attributes like PrimeVue pass-through props (e.g. `pt:header:data-test-id`), because the colons made the whole name fail the kebab-case check. The rule now splits the name on `:` and validates each segment on its own, so an attribute is fine when every segment is already hyphenated.

Fixes #10776

## Test Plan

Added the colon-separated case to the `valid.vue` fixture of the rule and updated the snapshot; it no longer produces a diagnostic. The existing `invalid.vue` cases still fail as before.
