### PR TITLE
fix(parser): accept argument-less v-bind shorthand `:="props"` in HTML/Vue

### DIFF
--- a/.changeset/fix-vue-v-bind-shorthand-no-argument.md
+++ b/.changeset/fix-vue-v-bind-shorthand-no-argument.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10622](https://github.com/biomejs/biome/issues/10622): the HTML/Vue parser no longer panics on the argument-less `v-bind` shorthand (`:="props"`).
+
+This syntax is valid Vue and equivalent to `v-bind="props"`, so the parser now accepts it (along with the longhand `v-bind:="props"`) instead of crashing while building a diagnostic for a missing argument.

--- a/crates/biome_html_analyze/src/a11y.rs
+++ b/crates/biome_html_analyze/src/a11y.rs
@@ -302,7 +302,7 @@ pub fn has_event_handler(handler_types: &[&str], element: &AnyHtmlTagElement) ->
                         .is_ok_and(|t| t.text_trimmed().eq_ignore_ascii_case("v-on"));
                     is_event_handling
                         && d.arg()
-                            .and_then(|arg| arg.arg().ok())
+                            .and_then(|arg| arg.arg())
                             .and_then(|arg| arg.as_vue_static_argument().cloned())
                             .and_then(|s| s.name_token().ok())
                             .is_some_and(|t| matches_event_handler(handler_types, t.text_trimmed()))

--- a/crates/biome_html_analyze/src/assist/source/use_sorted_attributes.rs
+++ b/crates/biome_html_analyze/src/assist/source/use_sorted_attributes.rs
@@ -364,30 +364,31 @@ impl SortableHtmlAttribute {
                 }
             }
             AnyHtmlAttribute::AnyVueDirective(AnyVueDirective::VueVBindShorthandDirective(dir)) => {
-                if let Some(arg) = dir.arg().ok().and_then(|arg| arg.arg()) {
-                    match arg {
-                        AnyVueDirectiveArgument::VueBogusDirectiveArgument(_) => {
-                            SortCategory::Unknown
-                        }
-                        AnyVueDirectiveArgument::VueDynamicArgument(_) => {
-                            SortCategory::VueOtherAttribute
-                        }
-                        AnyVueDirectiveArgument::VueStaticArgument(arg) => {
-                            if let Ok(arg_name) =
-                                arg.name_token().as_ref().map(|token| token.text_trimmed())
-                            {
-                                match arg_name {
-                                    "is" => SortCategory::VueDefinition,
-                                    "key" => SortCategory::VueUnique,
-                                    _ => SortCategory::VueOtherAttribute,
-                                }
-                            } else {
-                                SortCategory::VueCustomDirective
+                let Ok(directive_arg) = dir.arg() else {
+                    return SortCategory::VueCustomDirective;
+                };
+                // Argument-less `:="props"` is equivalent to `v-bind="props"`.
+                let Some(arg) = directive_arg.arg() else {
+                    return SortCategory::VueOtherAttribute;
+                };
+                match arg {
+                    AnyVueDirectiveArgument::VueBogusDirectiveArgument(_) => SortCategory::Unknown,
+                    AnyVueDirectiveArgument::VueDynamicArgument(_) => {
+                        SortCategory::VueOtherAttribute
+                    }
+                    AnyVueDirectiveArgument::VueStaticArgument(arg) => {
+                        if let Ok(arg_name) =
+                            arg.name_token().as_ref().map(|token| token.text_trimmed())
+                        {
+                            match arg_name {
+                                "is" => SortCategory::VueDefinition,
+                                "key" => SortCategory::VueUnique,
+                                _ => SortCategory::VueOtherAttribute,
                             }
+                        } else {
+                            SortCategory::VueCustomDirective
                         }
                     }
-                } else {
-                    SortCategory::VueCustomDirective
                 }
             }
             AnyHtmlAttribute::AnyVueDirective(AnyVueDirective::VueVOnShorthandDirective(_)) => {

--- a/crates/biome_html_analyze/src/assist/source/use_sorted_attributes.rs
+++ b/crates/biome_html_analyze/src/assist/source/use_sorted_attributes.rs
@@ -364,7 +364,7 @@ impl SortableHtmlAttribute {
                 }
             }
             AnyHtmlAttribute::AnyVueDirective(AnyVueDirective::VueVBindShorthandDirective(dir)) => {
-                if let Ok(arg) = dir.arg().and_then(|arg| arg.arg()) {
+                if let Some(arg) = dir.arg().ok().and_then(|arg| arg.arg()) {
                     match arg {
                         AnyVueDirectiveArgument::VueBogusDirectiveArgument(_) => {
                             SortCategory::Unknown
@@ -485,13 +485,12 @@ impl SortableAttribute for SortableHtmlAttribute {
                     "v-on" | "v-bind" | "v-slot" => dir
                         .arg()?
                         .arg()
-                        .ok()
                         .and_then(|arg| vue_directive_arg_token(&arg)),
                     _ => dir.name_token().ok(),
                 }
             }
             AnyHtmlAttribute::AnyVueDirective(AnyVueDirective::VueVBindShorthandDirective(dir)) => {
-                vue_directive_arg_token(&dir.arg().ok()?.arg().ok()?)
+                vue_directive_arg_token(&dir.arg().ok()?.arg()?)
             }
             AnyHtmlAttribute::AnyVueDirective(AnyVueDirective::VueVSlotShorthandDirective(dir)) => {
                 vue_directive_arg_token(&dir.arg().ok()?)

--- a/crates/biome_html_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
@@ -96,8 +96,7 @@ impl Rule for NoAriaUnsupportedElements {
                         AnyVueDirective::VueVBindShorthandDirective(d) => Some(
                             d.arg()
                                 .ok()?
-                                .arg()
-                                .ok()?
+                                .arg()?
                                 .as_vue_static_argument()?
                                 .name_token()
                                 .ok()?
@@ -109,8 +108,7 @@ impl Rule for NoAriaUnsupportedElements {
                             }
                             Some(
                                 d.arg()?
-                                    .arg()
-                                    .ok()?
+                                    .arg()?
                                     .as_vue_static_argument()?
                                     .name_token()
                                     .ok()?

--- a/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_props.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_valid_aria_props.rs
@@ -109,8 +109,7 @@ fn extract_attribute_name(attr: &AnyHtmlAttribute) -> Option<TokenText> {
             AnyVueDirective::VueVBindShorthandDirective(d) => Some(
                 d.arg()
                     .ok()?
-                    .arg()
-                    .ok()?
+                    .arg()?
                     .as_vue_static_argument()?
                     .name_token()
                     .ok()?
@@ -122,8 +121,7 @@ fn extract_attribute_name(attr: &AnyHtmlAttribute) -> Option<TokenText> {
                 }
                 Some(
                     d.arg()?
-                        .arg()
-                        .ok()?
+                        .arg()?
                         .as_vue_static_argument()?
                         .name_token()
                         .ok()?

--- a/crates/biome_html_analyze/src/lint/correctness/no_duplicate_attributes.rs
+++ b/crates/biome_html_analyze/src/lint/correctness/no_duplicate_attributes.rs
@@ -138,7 +138,7 @@ fn attribute_key(attribute: &AnyHtmlAttribute) -> Option<(TokenText, TextRange)>
             }
 
             let argument = directive.arg()?;
-            let argument = argument.arg().ok()?;
+            let argument = argument.arg()?;
             let static_argument = argument.as_vue_static_argument()?;
             let name_token = static_argument.name_token().ok()?;
 
@@ -153,7 +153,7 @@ fn attribute_key(attribute: &AnyHtmlAttribute) -> Option<(TokenText, TextRange)>
         // Shorthand bind: :foo
         AnyVueDirective::VueVBindShorthandDirective(directive) => {
             let argument = directive.arg().ok()?;
-            let argument = argument.arg().ok()?;
+            let argument = argument.arg()?;
             let static_argument = argument.as_vue_static_argument()?;
             let name_token = static_argument.name_token().ok()?;
 

--- a/crates/biome_html_analyze/src/lint/correctness/use_vue_v_for_key.rs
+++ b/crates/biome_html_analyze/src/lint/correctness/use_vue_v_for_key.rs
@@ -114,7 +114,7 @@ impl Rule for UseVueVForKey {
 }
 
 fn is_v_bind_key_argument(arg: &VueDirectiveArgument) -> bool {
-    let Ok(arg) = arg.arg() else {
+    let Some(arg) = arg.arg() else {
         return false;
     };
     let Some(static_arg) = arg.as_vue_static_argument() else {

--- a/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_bind.rs
+++ b/crates/biome_html_analyze/src/lint/correctness/use_vue_valid_v_bind.rs
@@ -155,7 +155,7 @@ fn find_invalid_modifiers(modifiers: &VueModifierList) -> Option<TextRange> {
 /// See <https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand>.
 fn is_static_arg(arg: &VueDirectiveArgument) -> bool {
     matches!(
-        arg.arg().ok(),
+        arg.arg(),
         Some(AnyVueDirectiveArgument::VueStaticArgument(_))
     )
 }

--- a/crates/biome_html_analyze/src/lint/style/use_vue_consistent_v_on_style.rs
+++ b/crates/biome_html_analyze/src/lint/style/use_vue_consistent_v_on_style.rs
@@ -142,7 +142,7 @@ impl Rule for UseVueConsistentVOnStyle {
                 let initializer = dir.initializer();
                 // Build VueVOnShorthandDirective: at_token '@' + arg + modifiers (+initializer)
                 let at_token = HtmlSyntaxToken::new_detached(T![@], "@", [], []);
-                let inner = dir.arg()?.arg().ok()?;
+                let inner = dir.arg()?.arg()?;
                 let mut builder = make::vue_v_on_shorthand_directive(at_token, inner, modifiers);
                 if let Some(init) = initializer {
                     builder = builder.with_initializer(init);
@@ -168,7 +168,9 @@ impl Rule for UseVueConsistentVOnStyle {
 
                 // Build VueDirectiveArgument with ':' token and same inner arg
                 let colon = HtmlSyntaxToken::new_detached(HtmlSyntaxKind::COLON, ":", [], []);
-                let arg = make::vue_directive_argument(colon, any_arg);
+                let arg = make::vue_directive_argument(colon)
+                    .with_arg(any_arg)
+                    .build();
                 let mut builder = make::vue_directive(name_token, modifiers).with_arg(arg);
                 if let Some(init) = initializer {
                     builder = builder.with_initializer(init);

--- a/crates/biome_html_analyze/src/lint/style/use_vue_hyphenated_attributes.rs
+++ b/crates/biome_html_analyze/src/lint/style/use_vue_hyphenated_attributes.rs
@@ -187,7 +187,7 @@ impl Rule for UseVueHyphenatedAttributes {
             // v-directive with static argument: v-bind:foo
             if let Some(directive) = vue.as_vue_directive() {
                 if let Some(vue_arg) = directive.arg()
-                    && let Ok(any_arg) = vue_arg.arg()
+                    && let Some(any_arg) = vue_arg.arg()
                     && let Some(static_arg) = any_arg.as_vue_static_argument()
                     && let Ok(old_token) = static_arg.name_token()
                 {
@@ -203,7 +203,7 @@ impl Rule for UseVueHyphenatedAttributes {
             // v-bind shorthand: :foo
             } else if let Some(shorthand_bind) = vue.as_vue_v_bind_shorthand_directive()
                 && let Ok(vue_arg) = shorthand_bind.arg()
-                && let Ok(any_arg) = vue_arg.arg()
+                && let Some(any_arg) = vue_arg.arg()
                 && let Some(static_arg) = any_arg.as_vue_static_argument()
                 && let Ok(old_token) = static_arg.name_token()
             {
@@ -248,7 +248,7 @@ fn extract_attribute_name(attr: &AnyHtmlAttribute) -> Option<TokenText> {
                 return None;
             }
             if let Some(vue_arg) = directive.arg()
-                && let Ok(any_arg) = vue_arg.arg()
+                && let Some(any_arg) = vue_arg.arg()
                 && let Some(static_arg) = any_arg.as_vue_static_argument()
                 && let Ok(name_token) = static_arg.name_token()
             {
@@ -261,7 +261,7 @@ fn extract_attribute_name(attr: &AnyHtmlAttribute) -> Option<TokenText> {
         if let Some(shorthand_bind) = vue.as_vue_v_bind_shorthand_directive()
             && let Ok(vue_arg) = shorthand_bind.arg()
         {
-            if let Ok(any_arg) = vue_arg.arg()
+            if let Some(any_arg) = vue_arg.arg()
                 && let Some(static_arg) = any_arg.as_vue_static_argument()
                 && let Ok(name_token) = static_arg.name_token()
             {

--- a/crates/biome_html_analyze/tests/specs/source/useSortedAttributes/vue/unsorted.vue
+++ b/crates/biome_html_analyze/tests/specs/source/useSortedAttributes/vue/unsorted.vue
@@ -61,3 +61,6 @@
 <div @scroll.passive="onScroll" @click.stop="doThis" v-on:click="doThis" @click.prevent="doThis"></div>
 
 <div v-text="msg" v-html="html"></div>
+
+<!-- argument-less v-bind shorthand sorts like v-bind (VueOtherAttribute), not like a custom directive -->
+<div v-mycustomdirective v-if="awesome" :="props" ref="my-ref"></div>

--- a/crates/biome_html_analyze/tests/specs/source/useSortedAttributes/vue/unsorted.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/source/useSortedAttributes/vue/unsorted.vue.snap
@@ -68,6 +68,9 @@ expression: unsorted.vue
 
 <div v-text="msg" v-html="html"></div>
 
+<!-- argument-less v-bind shorthand sorts like v-bind (VueOtherAttribute), not like a custom directive -->
+<div v-mycustomdirective v-if="awesome" :="props" ref="my-ref"></div>
+
 ```
 
 # Diagnostics
@@ -459,6 +462,7 @@ unsorted.vue:63:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━
   > 63 │ <div v-text="msg" v-html="html"></div>
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     64 │ 
+    65 │ <!-- argument-less v-bind shorthand sorts like v-bind (VueOtherAttribute), not like a custom directive -->
   
   i Safe fix: Sort the HTML attributes.
   
@@ -467,6 +471,28 @@ unsorted.vue:63:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━
     63    │ - <div·v-text="msg"·v-html="html"></div>
        63 │ + <div·v-html="html"·v-text="msg"·></div>
     64 64 │   
+    65 65 │   <!-- argument-less v-bind shorthand sorts like v-bind (VueOtherAttribute), not like a custom directive -->
+  
+
+```
+
+```
+unsorted.vue:66:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted.
+  
+    65 │ <!-- argument-less v-bind shorthand sorts like v-bind (VueOtherAttribute), not like a custom directive -->
+  > 66 │ <div v-mycustomdirective v-if="awesome" :="props" ref="my-ref"></div>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    67 │ 
+  
+  i Safe fix: Sort the HTML attributes.
+  
+    64 64 │   
+    65 65 │   <!-- argument-less v-bind shorthand sorts like v-bind (VueOtherAttribute), not like a custom directive -->
+    66    │ - <div·v-mycustomdirective·v-if="awesome"·:="props"·ref="my-ref"></div>
+       66 │ + <div·v-if="awesome"·ref="my-ref"·v-mycustomdirective·:="props"·></div>
+    67 67 │   
   
 
 ```

--- a/crates/biome_html_factory/src/generated/node_factory.rs
+++ b/crates/biome_html_factory/src/generated/node_factory.rs
@@ -1495,17 +1495,31 @@ impl VueDirectiveBuilder {
         ))
     }
 }
-pub fn vue_directive_argument(
+pub fn vue_directive_argument(colon_token: SyntaxToken) -> VueDirectiveArgumentBuilder {
+    VueDirectiveArgumentBuilder {
+        colon_token,
+        arg: None,
+    }
+}
+pub struct VueDirectiveArgumentBuilder {
     colon_token: SyntaxToken,
-    arg: AnyVueDirectiveArgument,
-) -> VueDirectiveArgument {
-    VueDirectiveArgument::unwrap_cast(SyntaxNode::new_detached(
-        HtmlSyntaxKind::VUE_DIRECTIVE_ARGUMENT,
-        [
-            Some(SyntaxElement::Token(colon_token)),
-            Some(SyntaxElement::Node(arg.into_syntax())),
-        ],
-    ))
+    arg: Option<AnyVueDirectiveArgument>,
+}
+impl VueDirectiveArgumentBuilder {
+    pub fn with_arg(mut self, arg: AnyVueDirectiveArgument) -> Self {
+        self.arg = Some(arg);
+        self
+    }
+    pub fn build(self) -> VueDirectiveArgument {
+        VueDirectiveArgument::unwrap_cast(SyntaxNode::new_detached(
+            HtmlSyntaxKind::VUE_DIRECTIVE_ARGUMENT,
+            [
+                Some(SyntaxElement::Token(self.colon_token)),
+                self.arg
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
+            ],
+        ))
+    }
 }
 pub fn vue_dynamic_argument(
     l_brack_token: SyntaxToken,

--- a/crates/biome_html_parser/src/syntax/vue.rs
+++ b/crates/biome_html_parser/src/syntax/vue.rs
@@ -169,9 +169,13 @@ fn parse_vue_directive_argument(p: &mut HtmlParser) -> ParsedSyntax {
         p.error(expected_vue_directive_argument(p, last_trivia.text_range()));
         return Present(m.complete(p, VUE_BOGUS_DIRECTIVE));
     }
-    parse_vue_dynamic_argument(p)
-        .or_else(|| parse_vue_static_argument(p))
-        .ok();
+    // `:="props"` (argument-less v-bind shorthand) is valid Vue syntax, identical
+    // to `v-bind="props"` -- the argument is optional here, unlike in v-on/v-slot.
+    if p.at(T!['[']) || p.at(HTML_LITERAL) {
+        parse_vue_dynamic_argument(p)
+            .or_else(|| parse_vue_static_argument(p))
+            .ok();
+    }
 
     Present(m.complete(p, VUE_DIRECTIVE_ARGUMENT))
 }

--- a/crates/biome_html_parser/src/syntax/vue.rs
+++ b/crates/biome_html_parser/src/syntax/vue.rs
@@ -171,7 +171,7 @@ fn parse_vue_directive_argument(p: &mut HtmlParser) -> ParsedSyntax {
     }
     // `:="props"` (argument-less v-bind shorthand) is valid Vue syntax, identical
     // to `v-bind="props"` -- the argument is optional here, unlike in v-on/v-slot.
-    if p.at(T!['[']) || p.at(HTML_LITERAL) {
+    if p.at_ts(token_set![T!['['], HTML_LITERAL]) {
         parse_vue_dynamic_argument(p)
             .or_else(|| parse_vue_static_argument(p))
             .ok();

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/issue-10622.vue
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/issue-10622.vue
@@ -1,0 +1,2 @@
+<div :="props"></div>
+<div v-bind:="props"></div>

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/issue-10622.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/issue-10622.vue.snap
@@ -1,0 +1,152 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```vue
+<div :="props"></div>
+<div v-bind:="props"></div>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@0..1 "<" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@1..5 "div" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    VueVBindShorthandDirective {
+                        arg: VueDirectiveArgument {
+                            colon_token: COLON@5..6 ":" [] [],
+                            arg: missing (optional),
+                        },
+                        modifiers: VueModifierList [],
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@6..7 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@7..14 "\"props\"" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@14..15 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@15..16 "<" [] [],
+                slash_token: SLASH@16..17 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@17..20 "div" [] [],
+                },
+                r_angle_token: R_ANGLE@20..21 ">" [] [],
+            },
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@21..23 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@23..27 "div" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    VueDirective {
+                        name_token: IDENT@27..33 "v-bind" [] [],
+                        arg: VueDirectiveArgument {
+                            colon_token: COLON@33..34 ":" [] [],
+                            arg: missing (optional),
+                        },
+                        modifiers: VueModifierList [],
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@34..35 "=" [] [],
+                            value: HtmlString {
+                                value_token: HTML_STRING_LITERAL@35..42 "\"props\"" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@42..43 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@43..44 "<" [] [],
+                slash_token: SLASH@44..45 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_LITERAL@45..48 "div" [] [],
+                },
+                r_angle_token: R_ANGLE@48..49 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@49..50 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..50
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..49
+    0: HTML_ELEMENT@0..21
+      0: HTML_OPENING_ELEMENT@0..15
+        0: L_ANGLE@0..1 "<" [] []
+        1: HTML_TAG_NAME@1..5
+          0: HTML_LITERAL@1..5 "div" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@5..14
+          0: VUE_V_BIND_SHORTHAND_DIRECTIVE@5..14
+            0: VUE_DIRECTIVE_ARGUMENT@5..6
+              0: COLON@5..6 ":" [] []
+              1: (empty)
+            1: VUE_MODIFIER_LIST@6..6
+            2: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@6..14
+              0: EQ@6..7 "=" [] []
+              1: HTML_STRING@7..14
+                0: HTML_STRING_LITERAL@7..14 "\"props\"" [] []
+        3: R_ANGLE@14..15 ">" [] []
+      1: HTML_ELEMENT_LIST@15..15
+      2: HTML_CLOSING_ELEMENT@15..21
+        0: L_ANGLE@15..16 "<" [] []
+        1: SLASH@16..17 "/" [] []
+        2: HTML_TAG_NAME@17..20
+          0: HTML_LITERAL@17..20 "div" [] []
+        3: R_ANGLE@20..21 ">" [] []
+    1: HTML_ELEMENT@21..49
+      0: HTML_OPENING_ELEMENT@21..43
+        0: L_ANGLE@21..23 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@23..27
+          0: HTML_LITERAL@23..27 "div" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@27..42
+          0: VUE_DIRECTIVE@27..42
+            0: IDENT@27..33 "v-bind" [] []
+            1: VUE_DIRECTIVE_ARGUMENT@33..34
+              0: COLON@33..34 ":" [] []
+              1: (empty)
+            2: VUE_MODIFIER_LIST@34..34
+            3: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@34..42
+              0: EQ@34..35 "=" [] []
+              1: HTML_STRING@35..42
+                0: HTML_STRING_LITERAL@35..42 "\"props\"" [] []
+        3: R_ANGLE@42..43 ">" [] []
+      1: HTML_ELEMENT_LIST@43..43
+      2: HTML_CLOSING_ELEMENT@43..49
+        0: L_ANGLE@43..44 "<" [] []
+        1: SLASH@44..45 "/" [] []
+        2: HTML_TAG_NAME@45..48
+          0: HTML_LITERAL@45..48 "div" [] []
+        3: R_ANGLE@48..49 ">" [] []
+  4: EOF@49..50 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_syntax/src/attribute_ext.rs
+++ b/crates/biome_html_syntax/src/attribute_ext.rs
@@ -117,14 +117,14 @@ impl AnyHtmlAttribute {
                 AnyVueDirective::VueVBindShorthandDirective(d) => d
                     .arg()
                     .ok()
-                    .and_then(|arg| arg.arg().ok())
+                    .and_then(|arg| arg.arg())
                     .and_then(|arg| arg.as_vue_static_argument().cloned())
                     .and_then(|s| s.name_token().ok())
                     .map(|t| t.token_text_trimmed()),
                 // v-bind:attr="..." — full Vue binding
                 AnyVueDirective::VueDirective(d) if d.is_binding() => d
                     .arg()
-                    .and_then(|arg| arg.arg().ok())
+                    .and_then(|arg| arg.arg())
                     .and_then(|arg| arg.as_vue_static_argument().cloned())
                     .and_then(|s| s.name_token().ok())
                     .map(|t| t.token_text_trimmed()),
@@ -185,7 +185,7 @@ impl AnyHtmlAttribute {
                 AnyVueDirective::VueVBindShorthandDirective(d) => d
                     .arg()
                     .ok()
-                    .and_then(|arg| arg.arg().ok())
+                    .and_then(|arg| arg.arg())
                     .and_then(|arg| arg.as_vue_static_argument().cloned())
                     .and_then(|s| s.name_token().ok())
                     .is_some_and(|t| t.text_trimmed().eq_ignore_ascii_case(name_to_lookup)),
@@ -194,7 +194,7 @@ impl AnyHtmlAttribute {
                 AnyVueDirective::VueDirective(d) => {
                     d.is_binding()
                         && d.arg()
-                            .and_then(|arg| arg.arg().ok())
+                            .and_then(|arg| arg.arg())
                             .and_then(|arg| arg.as_vue_static_argument().cloned())
                             .and_then(|s| s.name_token().ok())
                             .is_some_and(|t| t.text_trimmed().eq_ignore_ascii_case(name_to_lookup))
@@ -244,7 +244,7 @@ impl AnyHtmlAttribute {
                     AnyVueDirective::VueDirective(d) => {
                         d.is_event_listener()
                             && d.arg()
-                                .and_then(|arg| arg.arg().ok())
+                                .and_then(|arg| arg.arg())
                                 .and_then(|arg| arg.as_vue_static_argument().cloned())
                                 .and_then(|s| s.name_token().ok())
                                 .is_some_and(|t| {
@@ -405,7 +405,7 @@ impl HtmlAttributeList {
                 AnyVueDirective::VueDirective(d) => {
                     d.is_event_listener()
                         && d.arg()
-                            .and_then(|arg| arg.arg().ok())
+                            .and_then(|arg| arg.arg())
                             .and_then(|arg| arg.as_vue_static_argument().cloned())
                             .and_then(|s| s.name_token().ok())
                             .is_some_and(|t| t.text_trimmed().eq_ignore_ascii_case(name_to_lookup))
@@ -434,7 +434,7 @@ impl HtmlAttributeList {
                 AnyVueDirective::VueVBindShorthandDirective(d) => d
                     .arg()
                     .ok()
-                    .and_then(|arg| arg.arg().ok())
+                    .and_then(|arg| arg.arg())
                     .and_then(|arg| arg.as_vue_static_argument().cloned())
                     .and_then(|s| s.name_token().ok())
                     .is_some_and(|t| t.text_trimmed() == name_to_lookup),
@@ -443,7 +443,7 @@ impl HtmlAttributeList {
                 AnyVueDirective::VueDirective(d) => {
                     d.is_binding()
                         && d.arg()
-                            .and_then(|arg| arg.arg().ok())
+                            .and_then(|arg| arg.arg())
                             .and_then(|arg| arg.as_vue_static_argument().cloned())
                             .and_then(|s| s.name_token().ok())
                             .is_some_and(|t| t.text_trimmed() == name_to_lookup)

--- a/crates/biome_html_syntax/src/generated/nodes.rs
+++ b/crates/biome_html_syntax/src/generated/nodes.rs
@@ -3807,8 +3807,8 @@ impl VueDirectiveArgument {
     pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
-    pub fn arg(&self) -> SyntaxResult<AnyVueDirectiveArgument> {
-        support::required_node(&self.syntax, 1usize)
+    pub fn arg(&self) -> Option<AnyVueDirectiveArgument> {
+        support::node(&self.syntax, 1usize)
     }
 }
 impl Serialize for VueDirectiveArgument {
@@ -3822,7 +3822,7 @@ impl Serialize for VueDirectiveArgument {
 #[derive(Serialize)]
 pub struct VueDirectiveArgumentFields {
     pub colon_token: SyntaxResult<SyntaxToken>,
-    pub arg: SyntaxResult<AnyVueDirectiveArgument>,
+    pub arg: Option<AnyVueDirectiveArgument>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct VueDynamicArgument {
@@ -9919,7 +9919,7 @@ impl std::fmt::Debug for VueDirectiveArgument {
                     "colon_token",
                     &support::DebugSyntaxResult(self.colon_token()),
                 )
-                .field("arg", &support::DebugSyntaxResult(self.arg()))
+                .field("arg", &support::DebugOptionalElement(self.arg()))
                 .finish()
         } else {
             f.debug_struct("VueDirectiveArgument").finish()

--- a/crates/biome_html_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_html_syntax/src/generated/nodes_mut.rs
@@ -1672,11 +1672,11 @@ impl VueDirectiveArgument {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_arg(self, element: AnyVueDirectiveArgument) -> Self {
-        Self::unwrap_cast(
-            self.syntax
-                .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
-        )
+    pub fn with_arg(self, element: Option<AnyVueDirectiveArgument>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            1usize..=1usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
     }
 }
 impl VueDynamicArgument {

--- a/xtask/codegen/html.ungram
+++ b/xtask/codegen/html.ungram
@@ -713,9 +713,11 @@ VueDirective =
 
 // <div v-bind:href="url" />
 //            ^^^^^
+// <div :="props" />
+//      ^ (arg is absent for the argument-less v-bind shorthand)
 VueDirectiveArgument =
 	':'
-	arg: AnyVueDirectiveArgument
+	arg: AnyVueDirectiveArgument?
 
 // <div :href="url" />
 //      ^^^^^^^^^^^


### PR DESCRIPTION
Fixes #10622.

`:="props"` is the argument-less shorthand for `v-bind`, equivalent to `v-bind="props"`. The [issue thread has a Vue playground](https://github.com/biomejs/biome/issues/10622#issuecomment-4703735316) confirming both forms render identically. The parser panicked on it because it unconditionally tried to parse an argument after the colon and then built a diagnostic for a token kind that has no punctuation/keyword text.

Since this is valid syntax rather than a user error, I made `VueDirectiveArgument.arg` optional in the grammar instead of just turning the panic into a parse error. Both the shorthand (`:="props"`) and the longhand (`v-bind:="props"`) now parse correctly.

Added a test fixture covering both forms.

---

This PR was written primarily by Claude Code. I reviewed the diff and the generated grammar changes before opening this.