### PR TITLE
fix(inference): resolve members of default namespace imports

### DIFF
--- a/.changeset/light-fans-shave.md
+++ b/.changeset/light-fans-shave.md
@@ -1,0 +1,14 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10892](https://github.com/biomejs/biome/issues/10892): [`noUnnecessaryConditions`](https://biomejs.dev/linter/rules/no-unnecessary-conditions/) no longer reports a false positive when checking a member of a discriminated union that is accessed through a default type-only namespace import. The following code is no longer flagged:
+
+```ts
+import type Types from "./types";
+
+declare function parse(): Types.Result<string>;
+const result = parse();
+if (!result.success) {
+}
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/invalid.ts
@@ -297,3 +297,12 @@ function switchMixed(value: 'a' | 'b') {
 
 const date = new Date();
 if (date) console.log(date);
+
+// Types.Always.success` is always `true`, so `!...success` is always false and must be flagged.
+import type Types from "./typeOnlyDefaultImportType";
+
+declare function parseQualifiedDefaultImportAlways(): Types.Always;
+const qualifiedDefaultImportAlways = parseQualifiedDefaultImportAlways();
+
+if (!qualifiedDefaultImportAlways.truthy) {
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/invalid.ts.snap
@@ -304,6 +304,15 @@ function switchMixed(value: 'a' | 'b') {
 const date = new Date();
 if (date) console.log(date);
 
+// Types.Always.success` is always `true`, so `!...success` is always false and must be flagged.
+import type Types from "./typeOnlyDefaultImportType";
+
+declare function parseQualifiedDefaultImportAlways(): Types.Always;
+const qualifiedDefaultImportAlways = parseQualifiedDefaultImportAlways();
+
+if (!qualifiedDefaultImportAlways.truthy) {
+}
+
 ```
 
 # Diagnostics
@@ -1437,8 +1446,26 @@ invalid.ts:299:5 lint/suspicious/noUnnecessaryConditions ━━━━━━━�
   > 299 │ if (date) console.log(date);
         │     ^^^^
     300 │ 
+    301 │ // Types.Always.success` is always `true`, so `!...success` is always false and must be flagged.
   
   i The value's type can never be falsy, so this check is redundant.
+  
+
+```
+
+```
+invalid.ts:307:5 lint/suspicious/noUnnecessaryConditions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This condition is always falsy.
+  
+    305 │ const qualifiedDefaultImportAlways = parseQualifiedDefaultImportAlways();
+    306 │ 
+  > 307 │ if (!qualifiedDefaultImportAlways.truthy) {
+        │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    308 │ }
+    309 │ 
+  
+  i The value's type can never be truthy, so this check is redundant.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/typeOnlyDefaultImportType.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/typeOnlyDefaultImportType.ts
@@ -1,0 +1,18 @@
+/* should not generate diagnostics */
+
+// Fixture for https://github.com/biomejs/biome/issues/10892. The `success()`
+// function deliberately shares its name with the union's `success` member,
+// which used to shadow it during type inference.
+export namespace Types {
+  export type Always = { truthy: true; data: string };
+
+  export type Result<T> =
+    | { success: true; data: T }
+    | { success: false; error: string };
+
+  export function success(): true {
+    return true;
+  }
+}
+
+export default Types;

--- a/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/typeOnlyDefaultImportType.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/typeOnlyDefaultImportType.ts.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: typeOnlyDefaultImportType.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+// Fixture for https://github.com/biomejs/biome/issues/10892. The `success()`
+// function deliberately shares its name with the union's `success` member,
+// which used to shadow it during type inference.
+export namespace Types {
+  export type Always = { truthy: true; data: string };
+
+  export type Result<T> =
+    | { success: true; data: T }
+    | { success: false; error: string };
+
+  export function success(): true {
+    return true;
+  }
+}
+
+export default Types;
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/valid.ts
@@ -297,3 +297,16 @@ function nullishUnion(arg: string | null | undefined) {
 function doubleNotCoerce(user: { name: string } | undefined) {
   return !!user;
 }
+
+//`Types.Result<T>` (default type-only namespace import) 
+// is a discriminated union, so `.success` is a necessary check 
+// and must NOT be flagged.
+import type Types from "./typeOnlyDefaultImportType";
+
+function parseQualifiedDefaultImport(): Types.Result<string> {
+  throw new Error();
+}
+
+const qualifiedDefaultImportResult = parseQualifiedDefaultImport();
+if (!qualifiedDefaultImportResult.success) {
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/valid.ts.snap
@@ -304,4 +304,17 @@ function doubleNotCoerce(user: { name: string } | undefined) {
   return !!user;
 }
 
+//`Types.Result<T>` (default type-only namespace import) 
+// is a discriminated union, so `.success` is a necessary check 
+// and must NOT be flagged.
+import type Types from "./typeOnlyDefaultImportType";
+
+function parseQualifiedDefaultImport(): Types.Result<string> {
+  throw new Error();
+}
+
+const qualifiedDefaultImportResult = parseQualifiedDefaultImport();
+if (!qualifiedDefaultImportResult.success) {
+}
+
 ```

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -479,6 +479,8 @@ fn static_member_matches(
     member.has_name(name)
         && match object.as_raw_data() {
             TypeData::Class(_) => member.is_static() && !member.kind().is_constructor(),
+            // Namespace members should be registered as static members.
+            TypeData::Namespace(_) => member.is_static(),
             _ => !member.is_static(),
         }
 }

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -7,7 +7,9 @@ use biome_rowan::Text;
 use crate::{
     GLOBAL_UNKNOWN_ID, Literal, NUM_PREDEFINED_TYPES, Object, ScopeId, TypeData, TypeId,
     TypeImportQualifier, TypeInstance, TypeMember, TypeMemberKind, TypeReference,
-    TypeReferenceQualifier, TypeofValue, Union,
+    TypeReferenceQualifier,
+    TypeResolverLevel::Import,
+    TypeofExpression, TypeofStaticMemberExpression, TypeofValue, Union,
     globals::{GLOBAL_RESOLVER_ID, GLOBAL_UNDEFINED_ID, UNKNOWN_ID, global_type_name},
 };
 
@@ -818,6 +820,30 @@ impl Resolvable for TypeReference {
             Self::Qualifier(qualifier) => {
                 let resolved_id = resolver.resolve_qualifier(qualifier);
                 match resolved_id {
+                    // Qualified access on an imported symbol, e.g. `Types.Result`
+                    // where `Types` is a default namespace import. Resolve each
+                    // remaining path segment as a static member of the previous
+                    // one so members are looked up on the namespace itself rather
+                    // than collapsing to the imported symbol's own type.
+                    Some(resolved_id)
+                        if resolved_id.level() == Import && qualifier.path.len() > 1 =>
+                    {
+                        Some(qualifier.path.iter().skip(1).fold(
+                            Self::Resolved(resolved_id),
+                            |object, member| {
+                                resolver
+                                    .register_and_resolve(TypeData::TypeofExpression(Box::new(
+                                        TypeofExpression::StaticMember(
+                                            TypeofStaticMemberExpression {
+                                                object,
+                                                member: member.clone(),
+                                            },
+                                        ),
+                                    )))
+                                    .into()
+                            },
+                        ))
+                    }
                     Some(resolved_id) => Some(Self::Resolved(resolved_id)),
                     None if qualifier.has_known_type_parameters() => Some({
                         // Handle Record<K, V> by synthesizing an object type

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_vfile.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_vfile.snap
@@ -182,7 +182,7 @@ Exports {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(22))
   }
   "messages" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(48))
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(49))
   }
   "contents" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(42))
@@ -244,9 +244,9 @@ Module TypeId(1) => Module(0) TypeId(42) | Module(0) TypeId(0) | Module(0) TypeI
 
 Module TypeId(2) => Module(0) TypeId(1) | undefined
 
-Module TypeId(3) => Module(0) TypeId(49) | undefined
+Module TypeId(3) => Module(0) TypeId(50) | undefined
 
-Module TypeId(4) => Module(0) TypeId(51) | Module(0) TypeId(51) | Module(0) TypeId(51)
+Module TypeId(4) => Module(0) TypeId(52) | Module(0) TypeId(53) | Module(0) TypeId(54)
 
 Module TypeId(5) => Module(0) TypeId(4) | undefined
 
@@ -263,7 +263,7 @@ Module TypeId(9) => interface "VFile" {
     (): Module(0) TypeId(36),
     "history": Module(0) TypeId(47),
     "data": Module(0) TypeId(22),
-    "messages": Module(0) TypeId(48),
+    "messages": Module(0) TypeId(49),
     "contents": Module(0) TypeId(42),
     "path"?: Module(0) TypeId(6),
     "dirname"?: Module(0) TypeId(6),
@@ -289,7 +289,7 @@ Module TypeId(10) => Namespace {
                 "BufferEncoding",
             ),
             ty: Resolved(
-                Module(0) TypeId(49),
+                Module(0) TypeId(50),
             ),
         },
         TypeMember {
@@ -459,7 +459,7 @@ Module TypeId(39) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(51)
+  returns: Module(0) TypeId(48)
 }
 
 Module TypeId(40) => never
@@ -510,11 +510,13 @@ Module TypeId(46) => sync Function {
 
 Module TypeId(47) => instanceof Array<string>
 
-Module TypeId(48) => instanceof Array<Module(0) TypeId(51)>
+Module TypeId(48) => instanceof Module(0) TypeId(62)
 
-Module TypeId(49) => Module(0) TypeId(11) | Module(0) TypeId(12) | Module(0) TypeId(13) | Module(0) TypeId(14) | Module(0) TypeId(15) | Module(0) TypeId(16) | Module(0) TypeId(17) | Module(0) TypeId(18) | Module(0) TypeId(19) | Module(0) TypeId(20)
+Module TypeId(49) => instanceof Array<Module(0) TypeId(48)>
 
-Module TypeId(50) => sync Function {
+Module TypeId(50) => Module(0) TypeId(11) | Module(0) TypeId(12) | Module(0) TypeId(13) | Module(0) TypeId(14) | Module(0) TypeId(15) | Module(0) TypeId(16) | Module(0) TypeId(17) | Module(0) TypeId(18) | Module(0) TypeId(19) | Module(0) TypeId(20)
+
+Module TypeId(51) => sync Function {
   accepts: {
     params: [
       optional encoding: Module(0) TypeId(3)
@@ -524,27 +526,31 @@ Module TypeId(50) => sync Function {
   returns: string
 }
 
-Module TypeId(51) => instanceof Import Symbol: All from
+Module TypeId(52) => instanceof Module(0) TypeId(59)
 
-Module TypeId(52) => Module(0) TypeId(4) | undefined
+Module TypeId(53) => instanceof Module(0) TypeId(60)
 
-Module TypeId(53) => sync Function {
+Module TypeId(54) => instanceof Module(0) TypeId(61)
+
+Module TypeId(55) => Module(0) TypeId(4) | undefined
+
+Module TypeId(56) => sync Function {
   accepts: {
     params: [
       required reason: string
-      optional position: Module(0) TypeId(52)
+      optional position: Module(0) TypeId(55)
       optional ruleId: Module(0) TypeId(6)
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(51)
+  returns: Module(0) TypeId(48)
 }
 
-Module TypeId(54) => sync Function {
+Module TypeId(57) => sync Function {
   accepts: {
     params: [
       required reason: string
-      optional position: Module(0) TypeId(52)
+      optional position: Module(0) TypeId(55)
       optional ruleId: Module(0) TypeId(6)
     ]
     type_args: []
@@ -552,14 +558,14 @@ Module TypeId(54) => sync Function {
   returns: Module(0) TypeId(40)
 }
 
-Module TypeId(55) => interface "VFile" {
+Module TypeId(58) => interface "VFile" {
   extends: []
   type_args: []
   members: [
     (): Module(0) TypeId(46),
     "history": Module(0) TypeId(47),
     "data": Module(0) TypeId(22),
-    "messages": Module(0) TypeId(48),
+    "messages": Module(0) TypeId(49),
     "contents": Module(0) TypeId(42),
     "path"?: Module(0) TypeId(6),
     "dirname"?: Module(0) TypeId(6),
@@ -567,11 +573,19 @@ Module TypeId(55) => interface "VFile" {
     "stem"?: Module(0) TypeId(6),
     "extname"?: Module(0) TypeId(6),
     "cwd": string,
-    "toString": Module(0) TypeId(50),
-    "message": Module(0) TypeId(53),
-    "fail": Module(0) TypeId(54),
-    "info": Module(0) TypeId(53),
+    "toString": Module(0) TypeId(51),
+    "message": Module(0) TypeId(56),
+    "fail": Module(0) TypeId(57),
+    "info": Module(0) TypeId(56),
     [string]: Module(0) TypeId(22)
   ]
 }
+
+Module TypeId(59) => Import Symbol: All from .Point
+
+Module TypeId(60) => Import Symbol: All from .Position
+
+Module TypeId(61) => Import Symbol: All from .Node
+
+Module TypeId(62) => Import Symbol: All from .VFileMessage
 ```


### PR DESCRIPTION
## Summary

*I consulted Claude to understand the repository but the solution was fully authored manually by myself.*

Fixes two issues in #10892.

Closes #10892

`noUnnecessaryConditions` misreported discriminated-union checks when the union was reached through a default type-only namespace import (e.g. `import type Zod from "zod"; Zod.ZodSafeParseResult<string>`). Named imports were unaffected. This caused two symptoms with the same root cause:

- **False positive**: given `import type Types from "./types"` where the module does `export default Types` (a namespace), a check like `if (!r.success)` on `Types.Result<string>` (a discriminated union) was flagged as always falsy, even though it's a necessary check. This issue can be reliably reproduced in biome v2.5.2 and v2.5.0, but cannot be reproduced in versions after v2.5.2. See the next entry for the reason.
```typescript
// types.ts
export namespace Types {
  export type Result<T> =
    | { success: true; data: T }
    | { success: false; error: Error };

  export function success(): true {
    return true;
  }
}

export default Types;

// index.ts
import type Types from "./types.ts";

function parse(): Types.Result<string> {
  throw new Error();
}

const result = parse();

if (!result.success) {
  console.log(result.error);
} else {
  console.log(result.data);
}
```
- **False negative**: on a non-union member type such as `Types.Always` with `success: true`, the same check *is* always falsy but was never flagged. This issue occurs in Biome v2.5.2 and later.
```typescript
// types.ts
export namespace Types {
  export type Always = { success: true; data: string };
}

export default Types;

// index.ts
import type Types from "./types.ts";

declare function parse(): Types.Always;
const r = parse();

if (!r.success) {
  console.log("dead");
}
```

**Root cause**: members reached through a default namespace import were not resolved on the namespace. Two-part fix in `biome_js_type_info`:

- `src/resolver.rs`: when a qualified reference like `Types.Result` resolves to an import-level symbol and still has trailing path segments, we used to resolve only the first segment and drop the rest, collapsing `Types.Result<string>` to the imported symbol's own type. Now each remaining segment is folded into a synthesized `TypeofExpression::StaticMember` lookup on the previous one, so members are resolved on the namespace itself.
- `src/flattening/expressions.rs`: `static_member_matches` fell through to the `!member.is_static()` branch for namespaces, so namespace members never matched: https://github.com/biomejs/biome/blob/d83c66b39a820703d94100f8a6502cc6dbad26a1/crates/biome_js_type_info/src/flattening/expressions.rs#L480-L483



## Test Plan

Extended the `noUnnecessaryConditions` snapshot specs with a `typeOnlyDefaultImportType.ts` fixture (namespace exported as default): a valid case covering the false positive and an invalid case covering the false negative.

## Docs

N/A
