### PR TITLE
fix(console): swallow BrokenPipe errors in EnvConsole print/println

### DIFF
--- a/.changeset/fix-8125-broken-pipe.md
+++ b/.changeset/fix-8125-broken-pipe.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8125](https://github.com/biomejs/biome/issues/8125): `EnvConsole` no longer panics with `failed to write markup to console` (or `failed to write to console`) when stdout/stderr is piped to a reader that closes early, e.g. `biome format ... | head`. Write errors with `io::ErrorKind::BrokenPipe` are now treated as a clean termination; other I/O errors still panic to surface unexpected conditions loudly.

--- a/crates/biome_console/src/lib.rs
+++ b/crates/biome_console/src/lib.rs
@@ -3,7 +3,7 @@
 use std::io;
 use std::io::{IsTerminal, Read, Write};
 use std::panic::RefUnwindSafe;
-use termcolor::{ColorChoice, StandardStream, WriteColor};
+use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
 use write::{StringBuffer, Termcolor};
 
 pub mod fmt;
@@ -190,23 +190,25 @@ impl Console for EnvConsole {
 /// and panics, matching the previous behaviour of `.unwrap()` on the write
 /// results.
 fn write_to_console<W: WriteColor>(out: &mut W, args: Markup, with_newline: bool) {
-    let markup = fmt::Formatter::new(&mut Termcolor(out)).write_markup(args);
-    if let Err(e) = markup {
-        if e.kind() == io::ErrorKind::BrokenPipe {
-            return;
-        }
-        panic!("failed to write markup to console: {e}");
+    check_write(
+        fmt::Formatter::new(&mut Termcolor(out)).write_markup(args),
+        "failed to write markup to console",
+    );
+
+    if with_newline {
+        check_write(writeln!(out), "failed to write to console");
     }
-    let trailing = if with_newline {
-        writeln!(out)
-    } else {
-        write!(out, "")
-    };
-    if let Err(e) = trailing {
-        if e.kind() == io::ErrorKind::BrokenPipe {
-            return;
+}
+
+/// Inspect a write result: a `BrokenPipe` error is silently swallowed (the
+/// consumer has closed the pipe, so the partial output we managed to flush is
+/// the final answer); any other I/O error is unexpected and panics with
+/// `"{msg}: {err}"` to surface the failure loudly.
+fn check_write(result: io::Result<()>, msg: &str) {
+    if let Err(e) = result {
+        if e.kind() != io::ErrorKind::BrokenPipe {
+            panic!("{msg}: {e}");
         }
-        panic!("failed to write to console: {e}");
     }
 }
 
@@ -321,7 +323,19 @@ mod tests {
         }
     }
 
-    impl WriteColor for BrokenPipeWriter {}
+    impl WriteColor for BrokenPipeWriter {
+        fn supports_color(&self) -> bool {
+            false
+        }
+
+        fn set_color(&mut self, _spec: &ColorSpec) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn reset(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     /// `Vec<u8>` does not implement `WriteColor` on its own; wrap it so we
     /// can verify the happy path goes through formatter + writeln machinery.
@@ -339,7 +353,19 @@ mod tests {
         }
     }
 
-    impl WriteColor for BufWriteColor {}
+    impl WriteColor for BufWriteColor {
+        fn supports_color(&self) -> bool {
+            false
+        }
+
+        fn set_color(&mut self, _spec: &ColorSpec) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn reset(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn write_to_console_does_not_panic_on_broken_pipe() {

--- a/crates/biome_console/src/lib.rs
+++ b/crates/biome_console/src/lib.rs
@@ -3,7 +3,7 @@
 use std::io;
 use std::io::{IsTerminal, Read, Write};
 use std::panic::RefUnwindSafe;
-use termcolor::{ColorChoice, StandardStream};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
 use write::{StringBuffer, Termcolor};
 
 pub mod fmt;
@@ -153,12 +153,7 @@ impl Console for EnvConsole {
             LogLevel::Error => self.err.lock(),
             LogLevel::Log => self.out.lock(),
         };
-
-        fmt::Formatter::new(&mut Termcolor(&mut out))
-            .write_markup(args)
-            .unwrap();
-
-        writeln!(out).unwrap();
+        write_to_console(&mut out, args, true);
     }
 
     fn print(&mut self, level: LogLevel, args: Markup) {
@@ -166,12 +161,7 @@ impl Console for EnvConsole {
             LogLevel::Error => self.err.lock(),
             LogLevel::Log => self.out.lock(),
         };
-
-        fmt::Formatter::new(&mut Termcolor(&mut out))
-            .write_markup(args)
-            .unwrap();
-
-        write!(out, "").unwrap();
+        write_to_console(&mut out, args, false);
     }
 
     fn read(&mut self) -> Option<String> {
@@ -187,6 +177,36 @@ impl Console for EnvConsole {
         let result = handle.read_to_string(&mut buffer);
         // Skipping the error for now
         if result.is_ok() { Some(buffer) } else { None }
+    }
+}
+
+/// Render `args` as markup into `out`, optionally followed by a newline.
+///
+/// A broken-pipe error from the underlying stream is treated as a clean
+/// termination: when the consumer has closed the pipe (e.g. `biome ... | head`
+/// or a CI step that times out early) writing will fail with
+/// `io::ErrorKind::BrokenPipe`, and panicking would mask the legitimate output
+/// already produced before the pipe closed. Any other I/O error is unexpected
+/// and panics, matching the previous behaviour of `.unwrap()` on the write
+/// results.
+fn write_to_console<W: WriteColor>(out: &mut W, args: Markup, with_newline: bool) {
+    let markup = fmt::Formatter::new(&mut Termcolor(out)).write_markup(args);
+    if let Err(e) = markup {
+        if e.kind() == io::ErrorKind::BrokenPipe {
+            return;
+        }
+        panic!("failed to write markup to console: {e}");
+    }
+    let trailing = if with_newline {
+        writeln!(out)
+    } else {
+        write!(out, "")
+    };
+    if let Err(e) = trailing {
+        if e.kind() == io::ErrorKind::BrokenPipe {
+            return;
+        }
+        panic!("failed to write to console: {e}");
     }
 }
 
@@ -279,5 +299,67 @@ impl Console for FileBufferConsole {
 
     fn clear(&mut self) {
         self.out.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mock writer that fails every write/flush with `BrokenPipe`. Models the
+    /// scenario where stdout/stderr has been redirected to a pipe whose reader
+    /// closed early (e.g. `biome ... | head`).
+    struct BrokenPipeWriter;
+
+    impl io::Write for BrokenPipeWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+    }
+
+    impl WriteColor for BrokenPipeWriter {}
+
+    /// `Vec<u8>` does not implement `WriteColor` on its own; wrap it so we
+    /// can verify the happy path goes through formatter + writeln machinery.
+    struct BufWriteColor {
+        buf: Vec<u8>,
+    }
+
+    impl io::Write for BufWriteColor {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buf.write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl WriteColor for BufWriteColor {}
+
+    #[test]
+    fn write_to_console_does_not_panic_on_broken_pipe() {
+        let mut out = BrokenPipeWriter;
+        // Both calls exercise the markup-write path (the first write into
+        // the broken pipe fails with BrokenPipe). Neither must panic.
+        write_to_console(&mut out, markup!({ "hello" }), true);
+        write_to_console(&mut out, markup!({ "world" }), false);
+    }
+
+    #[test]
+    fn write_to_console_writes_happy_path() {
+        let mut out = BufWriteColor { buf: Vec::new() };
+        write_to_console(&mut out, markup!({ "hi" }), true);
+        write_to_console(&mut out, markup!({ "!" }), false);
+        let rendered = String::from_utf8(out.buf).unwrap();
+        assert!(rendered.contains("hi"));
+        assert!(rendered.contains("!"));
+        // The first call appended a newline; the second did not, so the
+        // output ends with the bang rather than a trailing blank line.
+        assert!(rendered.ends_with("!"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #8125.

`EnvConsole::println` and `EnvConsole::print` panicked via `.unwrap()` whenever the underlying stdout/stderr writer returned `io::ErrorKind::BrokenPipe`. That happens whenever output is piped to a reader that closes early — e.g. `biome format ... | head`, `biome lint ... | grep ... | head`, or any CI step that times out mid-stream. The user-visible failure mode was a Rust panic (the `biome` process crashed with `failed to write markup to console` / `failed to write to console`) instead of a clean exit.

This change routes both methods through a private `write_to_console` helper that treats `BrokenPipe` as a clean termination (returns silently) while still panicking on any other I/O error, preserving the existing failure mode for genuine faults. The behavior of `BufferConsole` and `FileBufferConsole` is unchanged — those implementations already buffered their writes, so no consumer can close their pipe mid-write.

## Test Plan

- New unit test `write_to_console_does_not_panic_on_broken_pipe` in `crates/biome_console/src/lib.rs`: exercises the helper with a `WriteColor` mock whose `write`/`flush` always returns `BrokenPipe`. Before this fix, the call would panic at `fmt::Formatter::new(...).write_markup(args).unwrap()`. After the fix, it returns silently.
- New unit test `write_to_console_writes_happy_path`: exercises the helper against a `Vec<u8>` wrapper and asserts that the rendered output contains both `hi` and `!`, and that the trailing-newline path leaves the buffer ending with `!` rather than `!\n`.
- Reproduction of the original bug (manual, not committed):
  - On `main`, `cargo run --bin biome -- format --write <dir> | head -c 1` exits with a `thread main panicked at ... failed to write markup to console`.
  - On this branch, the same command exits 0 and `head` receives the first byte cleanly.
- CI: `cargo test -p biome_console` and `cargo clippy -p biome_console -- -D warnings` will run on the PR.

## Docs

No user-facing doc change. The fix is a bug-only behavior correction.

> This PR was created with AI assistance (Claude Code). The code change was reviewed and validated by the contributor.