### PR TITLE
fix(inference): harden Salsa type inference

### DIFF
--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -7,8 +7,17 @@ use biome_js_syntax::{
     AnyJsBinding, AnyJsExpression, AnyJsFunction, AnyJsRoot, JsClassDeclaration, JsClassExpression,
     JsLanguage, JsObjectExpression, JsReferenceIdentifier, JsSyntaxNode,
 };
-use biome_js_type_info::Type;
-use biome_module_graph::{ModuleDb, ModuleInfo, ModuleInfoKind, ModuleResolver};
+use biome_js_type_info::{
+    InferredType, Type, TypeResolverLevel,
+    interned_types::{
+        FunctionParameter as InferredFunctionParameter, LocalTypeHandle, LocalTypeId,
+        ReturnType as InferredReturnType, TypeData as InferredTypeData,
+    },
+};
+use biome_module_graph::{
+    JsOwnExport, ModuleDb, ModuleInfo, ModuleInfoKind, ModuleResolver, NormalizeTypeInput,
+    infer_module_types_bottom_up, normalize_type,
+};
 use biome_rowan::{AstNode, TextRange};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -36,6 +45,244 @@ pub struct TypedService {
 }
 
 impl TypedService {
+    fn normalized_inferred_type<'db>(
+        &'db self,
+        ty: InferredTypeData<'db>,
+    ) -> Option<InferredType<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
+        Some(InferredType::new(db, ty))
+    }
+
+    /// Returns the Salsa-inferred type for an expression.
+    pub fn inferred_type_of_expression<'db>(
+        &'db self,
+        expression: &AnyJsExpression,
+    ) -> Option<InferredType<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        let inferred = infer_module_types_bottom_up(db, typed_module.module)?;
+        let ty = inferred.expressions.get(&expression.range()).copied()?;
+        let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
+
+        Some(InferredType::new(db, ty))
+    }
+
+    /// Returns the Salsa-inferred type for a named value visible at `range`.
+    pub fn inferred_type_of_named_value<'db>(
+        &'db self,
+        range: TextRange,
+        name: &str,
+    ) -> Option<InferredType<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let model = self.model.as_ref()?;
+        let mut scope = model.scope_for_range(range);
+        let binding = loop {
+            if let Some(binding) = scope.get_binding(name) {
+                break binding;
+            }
+            scope = scope.parent()?;
+        };
+
+        let db = typed_module.db.as_ref();
+        let inferred = infer_module_types_bottom_up(db, typed_module.module)?;
+        let ty = inferred
+            .binding_type_data
+            .get(&binding.tree().syntax().text_trimmed_range())?
+            .ty;
+        let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
+
+        Some(InferredType::new(db, ty))
+    }
+
+    /// Returns the normalized Salsa-inferred return type for a function.
+    pub fn inferred_return_type_of_function<'db>(
+        &'db self,
+        function: &AnyJsFunction,
+    ) -> Option<InferredType<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        let inferred = infer_module_types_bottom_up(db, typed_module.module)?;
+        let function_ty = match function {
+            AnyJsFunction::JsArrowFunctionExpression(expression) => {
+                inferred.expressions.get(&expression.range()).copied()
+            }
+            AnyJsFunction::JsFunctionDeclaration(declaration) => declaration
+                .id()
+                .ok()
+                .as_ref()
+                .and_then(AnyJsBinding::as_js_identifier_binding)
+                .and_then(|identifier| identifier.name_token().ok())
+                .and_then(|name| {
+                    self.inferred_named_value_data(function.range(), name.text_trimmed())
+                }),
+            AnyJsFunction::JsFunctionExportDefaultDeclaration(declaration) => {
+                if let Some(name) = declaration
+                    .id()
+                    .and_then(|id| id.as_js_identifier_binding().cloned())
+                    .and_then(|identifier| identifier.name_token().ok())
+                {
+                    self.inferred_named_value_data(function.range(), name.text_trimmed())
+                } else {
+                    self.inferred_default_export_data()
+                }
+            }
+            AnyJsFunction::JsFunctionExpression(expression) => {
+                inferred.expressions.get(&expression.range()).copied()
+            }
+        }?;
+        let function = function_ty.callable_function(db)?;
+        let InferredReturnType::Type(return_ty) = function.return_type(db) else {
+            return None;
+        };
+        self.normalized_inferred_type(*return_ty)
+    }
+
+    /// Returns the normalized Salsa-inferred return type for a class or object member.
+    pub fn inferred_return_type_of_member<'db>(
+        &'db self,
+        member_syntax: &JsSyntaxNode,
+        member_name: &str,
+    ) -> Option<InferredType<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        let inferred = infer_module_types_bottom_up(db, typed_module.module)?;
+        let parent_ty = member_syntax.ancestors().find_map(|ancestor| {
+            if let Some(class) = JsClassDeclaration::cast(ancestor.clone()) {
+                let binding_range = class
+                    .id()
+                    .ok()?
+                    .as_js_identifier_binding()?
+                    .name_token()
+                    .ok()?
+                    .text_trimmed_range();
+                return inferred
+                    .binding_type_data
+                    .get(&binding_range)
+                    .map(|data| data.ty);
+            }
+            if let Some(class) = JsClassExpression::cast(ancestor.clone()) {
+                return inferred.expressions.get(&class.range()).copied();
+            }
+            if let Some(object) = JsObjectExpression::cast(ancestor) {
+                return inferred.expressions.get(&object.range()).copied();
+            }
+            None
+        })?;
+        let parent_ty = normalize_type(
+            db,
+            NormalizeTypeInput::new(db, typed_module.module, parent_ty),
+        );
+        let member_ty = inferred.find_member_type(db, parent_ty, member_name)?;
+        let return_ty = member_ty.callable_function(db).and_then(|function| {
+            let InferredReturnType::Type(return_ty) = function.return_type(db) else {
+                return None;
+            };
+            Some(*return_ty)
+        });
+        self.normalized_inferred_type(return_ty.unwrap_or(member_ty))
+    }
+
+    fn inferred_default_export_data<'db>(&'db self) -> Option<InferredTypeData<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        let inferred = infer_module_types_bottom_up(db, typed_module.module)?;
+        let ModuleInfoKind::Js(js_info) = typed_module.module.kind(db) else {
+            return None;
+        };
+        let own_export = js_info.exports.get("default")?.as_own_export()?;
+        let ty = match own_export {
+            JsOwnExport::Binding(range) => inferred.binding_type_data.get(range)?.ty,
+            JsOwnExport::Type(resolved) if resolved.level() == TypeResolverLevel::Thin => {
+                let type_id = LocalTypeId::new(resolved.index());
+                if inferred.named_type_ids.contains(&type_id) {
+                    InferredTypeData::Local(LocalTypeHandle::new(db, inferred.module_key, type_id))
+                } else {
+                    *inferred.types.get(resolved.index())?
+                }
+            }
+            JsOwnExport::Type(_) | JsOwnExport::Namespace(_) => return None,
+        };
+        Some(ty)
+    }
+
+    fn inferred_named_value_data<'db>(
+        &'db self,
+        range: TextRange,
+        name: &str,
+    ) -> Option<InferredTypeData<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let model = self.model.as_ref()?;
+        let mut scope = model.scope_for_range(range);
+        let binding = loop {
+            if let Some(binding) = scope.get_binding(name) {
+                break binding;
+            }
+            scope = scope.parent()?;
+        };
+        infer_module_types_bottom_up(typed_module.db.as_ref(), typed_module.module)?
+            .binding_type_data
+            .get(&binding.tree().syntax().text_trimmed_range())
+            .map(|data| data.ty)
+    }
+
+    /// Returns whether an expression has a callable member with the given name.
+    pub fn inferred_expression_has_callable_member(
+        &self,
+        expression: &AnyJsExpression,
+        name: &str,
+    ) -> bool {
+        let Some(typed_module) = self.module.as_ref() else {
+            return false;
+        };
+        let db = typed_module.db.as_ref();
+        let Some(inferred) = infer_module_types_bottom_up(db, typed_module.module) else {
+            return false;
+        };
+        let Some(ty) = inferred.expressions.get(&expression.range()).copied() else {
+            return false;
+        };
+        let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
+        let Some(member_ty) = inferred.find_member_type(db, ty, name) else {
+            return false;
+        };
+        let member_ty = normalize_type(
+            db,
+            NormalizeTypeInput::new(db, typed_module.module, member_ty),
+        );
+
+        is_callable_inferred_type(db, member_ty)
+    }
+
+    /// Returns the expected type for a call or constructor argument.
+    pub fn inferred_expected_argument_type<'db>(
+        &'db self,
+        callee: &AnyJsExpression,
+        argument_index: usize,
+        is_constructor: bool,
+    ) -> Option<InferredType<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        let inferred = infer_module_types_bottom_up(db, typed_module.module)?;
+        let callee_ty = inferred.expressions.get(&callee.range()).copied()?;
+        let callee_ty = normalize_type(
+            db,
+            NormalizeTypeInput::new(db, typed_module.module, callee_ty),
+        );
+        let argument_ty = if is_constructor {
+            constructor_argument_type(db, callee_ty, argument_index)?
+        } else {
+            call_argument_type(db, callee_ty, argument_index)?
+        };
+        let argument_ty = normalize_type(
+            db,
+            NormalizeTypeInput::new(db, typed_module.module, argument_ty),
+        );
+
+        Some(InferredType::new(db, argument_ty))
+    }
+
     #[expect(
         clippy::arc_with_non_send_sync,
         reason = "The legacy ModuleResolver and Type APIs require Arc while this migration keeps them in place."
@@ -139,6 +386,90 @@ impl TypedService {
             .as_ref()
             .is_some_and(|model| model.binding(reference).is_some())
     }
+}
+
+fn is_callable_inferred_type(db: &dyn ModuleDb, ty: InferredTypeData) -> bool {
+    match ty {
+        InferredTypeData::Union(union) => union
+            .types(db)
+            .iter()
+            .any(|ty| is_callable_inferred_type(db, *ty)),
+        ty => ty.callable_function(db).is_some(),
+    }
+}
+
+fn call_argument_type<'db>(
+    db: &'db dyn ModuleDb,
+    ty: InferredTypeData<'db>,
+    argument_index: usize,
+) -> Option<InferredTypeData<'db>> {
+    if let Some(function) = ty.callable_function(db) {
+        return function_parameter_type(function.parameters(db), argument_index);
+    }
+
+    match ty {
+        InferredTypeData::Interface(interface) => interface
+            .members(db)
+            .iter()
+            .filter(|member| member.kind.is_call_signature())
+            .find_map(|member| call_argument_type(db, member.ty, argument_index)),
+        InferredTypeData::Object(object) => object
+            .members(db)
+            .iter()
+            .filter(|member| member.kind.is_call_signature())
+            .find_map(|member| call_argument_type(db, member.ty, argument_index)),
+        InferredTypeData::InstanceOf(instance) => {
+            call_argument_type(db, instance.ty(db), argument_index)
+        }
+        InferredTypeData::TypeofType(typeof_type) => {
+            call_argument_type(db, typeof_type.ty(db), argument_index)
+        }
+        InferredTypeData::TypeofValue(typeof_value) => {
+            call_argument_type(db, typeof_value.ty(db), argument_index)
+        }
+        InferredTypeData::Union(union) => union
+            .types(db)
+            .iter()
+            .find_map(|ty| call_argument_type(db, *ty, argument_index)),
+        _ => None,
+    }
+}
+
+fn constructor_argument_type<'db>(
+    db: &'db dyn ModuleDb,
+    ty: InferredTypeData<'db>,
+    argument_index: usize,
+) -> Option<InferredTypeData<'db>> {
+    let ty = match ty {
+        InferredTypeData::InstanceOf(instance) => instance.ty(db),
+        ty => ty,
+    };
+    let InferredTypeData::Class(class) = ty else {
+        return None;
+    };
+
+    class.members(db).iter().find_map(|member| {
+        if !member.kind.is_constructor() {
+            return None;
+        }
+        match member.ty {
+            InferredTypeData::Constructor(constructor) => constructor
+                .parameters(db)
+                .get(argument_index)
+                .map(|parameter| parameter.parameter.ty()),
+            ty => call_argument_type(db, ty, argument_index),
+        }
+    })
+}
+
+fn function_parameter_type<'db>(
+    parameters: &[InferredFunctionParameter<'db>],
+    argument_index: usize,
+) -> Option<InferredTypeData<'db>> {
+    parameters
+        .get(argument_index)
+        .or_else(|| parameters.last().filter(|parameter| parameter.is_rest()))
+        .map(InferredFunctionParameter::ty)
 }
 
 impl FromServices for TypedService {

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -344,6 +344,13 @@ impl SemanticModel {
             })
     }
 
+    pub fn binding_by_id(&self, id: BindingId) -> Option<Binding> {
+        self.data.bindings.get(id.index()).map(|_| Binding {
+            data: self.data.clone(),
+            id,
+        })
+    }
+
     pub fn all_exported_bindings(&self) -> impl Iterator<Item = Binding> + '_ {
         self.data.exported.iter().map(|&id| Binding {
             data: self.data.clone(),

--- a/crates/biome_js_type_info/src/builders.rs
+++ b/crates/biome_js_type_info/src/builders.rs
@@ -343,6 +343,11 @@ impl<'db> MergedType<'db> {
         if types.len() < 2 {
             return None;
         }
+        if types.iter().any(|ty| ty.is_primitive(db))
+            && types.iter().any(|ty| is_structural_object_type(db, *ty))
+        {
+            return None;
+        }
 
         let mut types = types.iter().copied();
         let mut merged = Self::from_type(db, types.next()?)?;
@@ -477,6 +482,23 @@ impl<'db> MergedType<'db> {
     }
 }
 
+fn is_structural_object_type<'db>(db: &'db dyn TypeDb, ty: TypeData<'db>) -> bool {
+    match ty {
+        TypeData::Class(_)
+        | TypeData::Constructor(_)
+        | TypeData::Function(_)
+        | TypeData::Interface(_)
+        | TypeData::Module(_)
+        | TypeData::Namespace(_)
+        | TypeData::Object(_)
+        | TypeData::Tuple(_)
+        | TypeData::ObjectKeyword => true,
+        TypeData::InstanceOf(instance) => is_structural_object_type(db, instance.ty(db)),
+        TypeData::Literal(literal) => matches!(literal.literal(db), Literal::Object(_)),
+        _ => false,
+    }
+}
+
 fn class_instance_members<'db>(members: &[TypeMember<'db>]) -> Vec<TypeMember<'db>> {
     members
         .iter()
@@ -547,6 +569,11 @@ impl<'db> UnionBuilder<'db> {
                 TypeData::AnyKeyword => {
                     self.types.clear();
                     self.types.push(TypeData::AnyKeyword);
+                }
+                _ if self.types.as_slice() == [TypeData::Unknown] => {}
+                TypeData::Unknown => {
+                    self.types.clear();
+                    self.types.push(TypeData::Unknown);
                 }
                 TypeData::NeverKeyword => {}
                 ty => {

--- a/crates/biome_js_type_info/src/format_inferred_type_info.rs
+++ b/crates/biome_js_type_info/src/format_inferred_type_info.rs
@@ -376,6 +376,9 @@ impl<'db> Format<FormatInferredTypeContext<'db>> for TypeMemberKind<'db> {
             Self::ComputedValue(ty) | Self::ConstAssertedComputedValue(ty) => {
                 write!(f, [token("computed"), space(), token("["), ty, token("]")])
             }
+            Self::ComputedValueNamed(name, _) | Self::ConstAssertedComputedValueNamed(name, _) => {
+                write!(f, [text(&std::format!("computed [{name}]"), None)])
+            }
             Self::Named(name) | Self::ConstAssertedNamed(name) => {
                 write!(f, [text(&std::format!("\"{name}\""), None)])
             }

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -1,0 +1,1932 @@
+use crate::TypeDb;
+use crate::interned_types::{
+    ConditionalType, Literal, ReturnType, TypeData, TypeMember, TypeMemberKind,
+};
+use biome_rowan::Text;
+use rustc_hash::FxHashSet;
+
+const MAX_TYPE_VARIANT_STEPS: usize = 1024;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum InferredSwitchCase {
+    Boolean,
+    BooleanLiteral(bool),
+    Number(Text),
+    String(Text),
+    Null,
+    Undefined,
+    Symbol,
+    UnsupportedLiteral,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StringificationMode {
+    Join,
+    ToString,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StringificationUsefulness {
+    Always,
+    Sometimes,
+    Never,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReturnTypeEvidence {
+    pub has_any_const: bool,
+    pub object_wide_casts: usize,
+    pub has_narrower_than_object: bool,
+    pub has_pinning_assertion: bool,
+    pub prefer_inferred_suggestion: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MisleadingReturnType {
+    pub suggestion: Option<String>,
+}
+
+/// A Salsa-backed type value returned by type inference.
+#[derive(Clone, Copy)]
+pub struct InferredType<'db> {
+    db: &'db dyn TypeDb,
+    data: TypeData<'db>,
+}
+
+impl<'db> InferredType<'db> {
+    pub const fn new(db: &'db dyn TypeDb, data: TypeData<'db>) -> Self {
+        Self { db, data }
+    }
+
+    pub fn is_number_literal(self, value: f64) -> bool {
+        matches!(
+            self.data,
+            TypeData::Literal(literal)
+                if matches!(literal.literal(self.db), Literal::Number(number) if number.to_f64() == Some(value))
+        )
+    }
+
+    pub fn is_number_or_number_literal(self) -> bool {
+        matches!(self.data, TypeData::Number)
+            || matches!(
+                self.data,
+                TypeData::Literal(literal)
+                    if matches!(literal.literal(self.db), Literal::Number(_))
+            )
+    }
+
+    pub fn is_bigint_literal(self, value: i64) -> bool {
+        matches!(
+            self.data,
+            TypeData::Literal(literal)
+                if matches!(literal.literal(self.db), Literal::BigInt(number) if number.text().trim_end_matches('n').parse() == Ok(value))
+        )
+    }
+
+    pub fn is_string_or_string_literal(self) -> bool {
+        matches!(self.data, TypeData::String)
+            || matches!(
+                self.data,
+                TypeData::Literal(literal)
+                    if matches!(literal.literal(self.db), Literal::String(_))
+            )
+    }
+
+    pub fn is_all_string_like(self) -> bool {
+        self.all_variants_match(|data| {
+            matches!(data, TypeData::String)
+                || matches!(
+                    data,
+                    TypeData::Literal(literal)
+                        if matches!(literal.literal(self.db), Literal::String(_))
+                )
+        })
+    }
+
+    pub fn is_all_number_like(self) -> bool {
+        self.all_variants_match(|data| {
+            matches!(data, TypeData::Number)
+                || matches!(
+                    data,
+                    TypeData::Literal(literal)
+                        if matches!(literal.literal(self.db), Literal::Number(_))
+                )
+        })
+    }
+
+    pub fn is_all_boolean_like(self) -> bool {
+        self.all_variants_match(|data| {
+            matches!(data, TypeData::Boolean)
+                || matches!(
+                    data,
+                    TypeData::Literal(literal)
+                        if matches!(literal.literal(self.db), Literal::Boolean(_))
+                )
+        })
+    }
+
+    pub fn is_all_bigint_like(self) -> bool {
+        self.all_variants_match(|data| {
+            matches!(data, TypeData::BigInt)
+                || matches!(
+                    data,
+                    TypeData::Literal(literal)
+                        if matches!(literal.literal(self.db), Literal::BigInt(_))
+                )
+        })
+    }
+
+    pub fn is_all_integer_like(self) -> bool {
+        self.all_variants_match(|data| match data {
+            TypeData::BigInt => true,
+            TypeData::Literal(literal) => match literal.literal(self.db) {
+                Literal::BigInt(_) => true,
+                Literal::Number(number) => {
+                    number.to_f64().is_some_and(|number| number.fract() == 0.0)
+                }
+                _ => false,
+            },
+            _ => false,
+        })
+    }
+
+    pub fn is_all_string_array_or_tuple(self) -> bool {
+        self.all_variants_match(|data| {
+            matches!(data, TypeData::String | TypeData::Tuple(_))
+                || matches!(
+                    data,
+                    TypeData::Literal(literal)
+                        if matches!(literal.literal(self.db), Literal::String(_))
+                )
+                || matches!(
+                    data,
+                    TypeData::InstanceOf(instance)
+                        if instance.ty(self.db).is_array_class(self.db)
+                )
+        })
+    }
+
+    pub fn is_regexp_literal_without_global_flag(self) -> bool {
+        matches!(
+        self.data,
+        TypeData::Literal(literal)
+            if matches!(literal.literal(self.db), Literal::RegExp(regexp) if !regexp.flags.contains('g'))
+        )
+    }
+
+    pub fn regexp_literal(self) -> Option<(Text, Text)> {
+        let TypeData::Literal(literal) = self.data else {
+            return None;
+        };
+        let Literal::RegExp(regexp) = literal.literal(self.db) else {
+            return None;
+        };
+        Some((regexp.pattern.clone(), regexp.flags.clone()))
+    }
+
+    pub fn is_array(self) -> bool {
+        matches!(self.data, TypeData::InstanceOf(instance) if instance.ty(self.db).is_array_class(self.db))
+    }
+
+    pub fn is_array_of_promise(self) -> bool {
+        let TypeData::InstanceOf(instance) = self.data else {
+            return false;
+        };
+
+        instance.ty(self.db).is_array_class(self.db)
+            && instance
+                .type_parameters(self.db)
+                .first()
+                .is_some_and(|ty| is_promise_instance(self.db, *ty))
+    }
+
+    pub fn is_disposable(self) -> bool {
+        self.has_computed_member("Symbol.dispose")
+    }
+
+    pub fn is_async_disposable(self) -> bool {
+        self.has_computed_member("Symbol.asyncDispose")
+    }
+
+    pub fn is_promise_instance(self) -> bool {
+        is_promise_instance(self.db, self.data)
+    }
+
+    pub fn is_function(self) -> bool {
+        self.data.callable_function(self.db).is_some()
+    }
+
+    pub fn is_at_least_as_wide_as_object(self) -> bool {
+        is_at_least_as_wide_as_object(self.db, self.data, &mut FxHashSet::default(), 0)
+    }
+
+    pub fn check_misleading_return_type(
+        self,
+        returns: &[Self],
+        evidence: ReturnTypeEvidence,
+        is_async: bool,
+    ) -> Option<MisleadingReturnType> {
+        let mut annotation = self.data;
+        if is_escape_hatch(annotation) {
+            return None;
+        }
+        if is_async {
+            annotation = promise_inner(self.db, annotation).unwrap_or(annotation);
+        }
+        annotation =
+            collapse_union_absorbed_by_primitive(self.db, annotation).unwrap_or(annotation);
+
+        let return_types = normalize_boolean_return_types(
+            self.db,
+            returns.iter().map(|ty| ty.data).collect::<Vec<_>>(),
+        );
+        if return_types.is_empty() {
+            return None;
+        }
+        if return_types.len() == 1
+            && !evidence.has_any_const
+            && !evidence.has_pinning_assertion
+            && is_literal_of_primitive(self.db, return_types[0])
+            && !matches!(annotation, TypeData::Union(_))
+        {
+            return None;
+        }
+        if !evidence.has_any_const
+            && evidence.object_wide_casts == return_types.len()
+            && matches!(annotation, TypeData::ObjectKeyword)
+        {
+            return None;
+        }
+        if matches!(annotation, TypeData::Boolean)
+            && return_types
+                .iter()
+                .any(|ty| ty.is_boolean_literal(self.db, true))
+            && return_types
+                .iter()
+                .any(|ty| ty.is_boolean_literal(self.db, false))
+        {
+            return None;
+        }
+        if return_types
+            .iter()
+            .any(|ty| is_any_contaminated(self.db, *ty))
+        {
+            return None;
+        }
+        if matches!(annotation, TypeData::Union(_))
+            && union_variants(self.db, annotation)
+                .iter()
+                .any(|ty| matches!(ty, TypeData::UnknownKeyword | TypeData::Unknown))
+        {
+            return None;
+        }
+        if includes_undefined(self.db, annotation)
+            && !return_types
+                .iter()
+                .any(|ty| includes_undefined(self.db, *ty))
+        {
+            return None;
+        }
+        if return_types
+            .iter()
+            .any(|ty| is_intersection_with_type_param(self.db, *ty))
+        {
+            return None;
+        }
+        if !evidence.has_any_const
+            && is_only_property_literal_widening(self.db, annotation, &return_types)
+        {
+            return None;
+        }
+
+        let is_misleading = if matches!(annotation, TypeData::Union(_)) {
+            is_union_wider_than_returns(self.db, annotation, &return_types)
+        } else if matches!(annotation, TypeData::ObjectKeyword) {
+            !return_types
+                .iter()
+                .any(|ty| includes_object_keyword(self.db, *ty))
+                && evidence.object_wide_casts == 0
+                && (evidence.has_narrower_than_object
+                    || return_types
+                        .iter()
+                        .any(|ty| is_wider_than(self.db, annotation, *ty)))
+        } else {
+            return_types
+                .iter()
+                .all(|ty| is_wider_than(self.db, annotation, *ty))
+        };
+        if !is_misleading {
+            return None;
+        }
+
+        let suggestion = if evidence.has_any_const || evidence.prefer_inferred_suggestion {
+            render_inferred(self.db, &return_types)
+        } else {
+            render_narrowed(self.db, annotation, &return_types)
+                .or_else(|| render_inferred(self.db, &return_types))
+        };
+        Some(MisleadingReturnType { suggestion })
+    }
+
+    pub fn function_returns_promise(self) -> bool {
+        let Some(function) = self.data.callable_function(self.db) else {
+            return false;
+        };
+        let ReturnType::Type(return_ty) = function.return_type(self.db) else {
+            return false;
+        };
+        contains_promise(self.db, *return_ty)
+    }
+
+    pub fn function_returns_conditional(self) -> bool {
+        self.function_return_matches(|ty| matches!(ty, TypeData::Conditional))
+    }
+
+    pub fn function_returns_void(self) -> bool {
+        self.function_return_matches(|ty| matches!(ty, TypeData::VoidKeyword))
+    }
+
+    pub fn has_promise_variant(self) -> bool {
+        match self.data {
+            TypeData::Union(union) => union
+                .types(self.db)
+                .iter()
+                .any(|ty| is_promise_instance(self.db, *ty)),
+            _ => false,
+        }
+    }
+
+    /// Returns whether the top-level type was successfully inferred.
+    ///
+    /// Internal `Unknown` variants poison unions in `UnionBuilder`, while the
+    /// explicit TypeScript `unknown` keyword remains an inferred type.
+    pub const fn is_inferred(self) -> bool {
+        !matches!(
+            self.data,
+            TypeData::Unknown
+                | TypeData::Divergent(_)
+                | TypeData::Local(_)
+                | TypeData::TypeofExpression(_)
+        )
+    }
+
+    pub fn is_always_truthy(self) -> bool {
+        self.conditional_type().is_truthy()
+    }
+
+    pub fn is_always_falsy(self) -> bool {
+        self.conditional_type().is_falsy()
+    }
+
+    pub fn is_non_nullish(self) -> bool {
+        self.conditional_type().is_non_nullish()
+    }
+
+    pub fn is_nullish(self) -> bool {
+        self.conditional_type().is_nullish()
+    }
+
+    pub fn has_nullish_variant(self) -> bool {
+        self.any_variant_matches(|data| {
+            matches!(
+                data,
+                TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword
+            )
+        })
+    }
+
+    pub fn is_safe_for_nullish_coalescing(self) -> bool {
+        self.all_variants_match(|data| {
+            if matches!(data, TypeData::InstanceOf(_)) {
+                return true;
+            }
+            matches!(
+                data.conditional_type_shallow(self.db),
+                Some(ConditionalType::Truthy | ConditionalType::Nullish)
+            )
+        })
+    }
+
+    pub fn nullish_union_matches_ignored_primitives(
+        self,
+        ignore_string: bool,
+        ignore_number: bool,
+        ignore_boolean: bool,
+        ignore_bigint: bool,
+    ) -> bool {
+        let TypeData::Union(_) = self.data else {
+            return false;
+        };
+
+        self.all_variants_match(|data| match data {
+            TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword => true,
+            TypeData::String => ignore_string,
+            TypeData::Number => ignore_number,
+            TypeData::Boolean => ignore_boolean,
+            TypeData::BigInt => ignore_bigint,
+            TypeData::Literal(literal) => match literal.literal(self.db) {
+                Literal::String(_) => ignore_string,
+                Literal::Number(_) => ignore_number,
+                Literal::Boolean(_) => ignore_boolean,
+                Literal::BigInt(_) => ignore_bigint,
+                _ => false,
+            },
+            _ => false,
+        })
+    }
+
+    pub fn has_null_variant(self) -> bool {
+        self.any_variant_matches(|data| matches!(data, TypeData::Null))
+    }
+
+    pub fn has_undefined_variant(self) -> bool {
+        self.any_variant_matches(|data| matches!(data, TypeData::Undefined | TypeData::VoidKeyword))
+    }
+
+    pub fn has_invalid_plus_operand_variant(self) -> bool {
+        self.any_variant_matches(|data| match data {
+            TypeData::NeverKeyword | TypeData::Symbol | TypeData::UnknownKeyword => true,
+            TypeData::Literal(literal) => {
+                matches!(literal.literal(self.db), Literal::Object(_))
+            }
+            TypeData::Intersection(intersection) => intersection
+                .types(self.db)
+                .iter()
+                .all(|ty| is_object_like(self.db, *ty)),
+            data => is_object_like(self.db, data),
+        })
+    }
+
+    pub fn has_number_like_variant(self) -> bool {
+        self.any_variant_matches(|data| {
+            matches!(data, TypeData::Number)
+                || matches!(
+                    data,
+                    TypeData::Literal(literal)
+                        if matches!(literal.literal(self.db), Literal::Number(_))
+                )
+        })
+    }
+
+    pub fn has_bigint_like_variant(self) -> bool {
+        self.any_variant_matches(|data| {
+            matches!(data, TypeData::BigInt)
+                || matches!(
+                    data,
+                    TypeData::Literal(literal)
+                        if matches!(literal.literal(self.db), Literal::BigInt(_))
+                )
+        })
+    }
+
+    pub fn plus_operand_description(self) -> String {
+        type_description(self.db, self.data)
+    }
+
+    pub fn switch_case_variants(self) -> Vec<InferredSwitchCase> {
+        let mut cases = Vec::new();
+        let mut seen = FxHashSet::default();
+        let mut pending = vec![self.data];
+
+        for _ in 0..MAX_TYPE_VARIANT_STEPS {
+            let Some(data) = pending.pop() else {
+                break;
+            };
+            if !seen.insert(data) {
+                continue;
+            }
+
+            match data {
+                TypeData::Boolean => cases.push(InferredSwitchCase::Boolean),
+                TypeData::Literal(literal) => cases.push(match literal.literal(self.db) {
+                    Literal::Boolean(boolean) => {
+                        InferredSwitchCase::BooleanLiteral(boolean.as_bool())
+                    }
+                    Literal::Number(number) => InferredSwitchCase::Number(number.text().clone()),
+                    Literal::String(string) => {
+                        InferredSwitchCase::String(Text::new_owned(string.as_str().into()))
+                    }
+                    Literal::BigInt(_)
+                    | Literal::Object(_)
+                    | Literal::RegExp(_)
+                    | Literal::Template(_) => InferredSwitchCase::UnsupportedLiteral,
+                }),
+                TypeData::Null => cases.push(InferredSwitchCase::Null),
+                TypeData::Undefined => cases.push(InferredSwitchCase::Undefined),
+                TypeData::Symbol => cases.push(InferredSwitchCase::Symbol),
+                TypeData::InstanceOf(instance) => pending.push(instance.ty(self.db)),
+                TypeData::Intersection(intersection) => pending.extend(
+                    intersection
+                        .types(self.db)
+                        .iter()
+                        .filter(|ty| ty.is_primitive(self.db))
+                        .rev()
+                        .copied(),
+                ),
+                TypeData::TypeofType(typeof_type) => pending.push(typeof_type.ty(self.db)),
+                TypeData::TypeofValue(typeof_value) => pending.push(typeof_value.ty(self.db)),
+                TypeData::Union(union) => {
+                    pending.extend(union.types(self.db).iter().rev().copied());
+                }
+                _ => {}
+            }
+        }
+
+        cases.dedup();
+        cases
+    }
+
+    pub fn stringification_usefulness(
+        self,
+        mode: StringificationMode,
+        ignored_type_names: &[&str],
+    ) -> StringificationUsefulness {
+        let mut active = FxHashSet::default();
+        stringification_usefulness(self.db, self.data, mode, ignored_type_names, &mut active, 0)
+    }
+
+    pub fn could_equal_string_literal(self, value: &str) -> bool {
+        self.could_equal_literal(|data| match data {
+            TypeData::String => Some(true),
+            TypeData::Literal(literal) => Some(matches!(
+                literal.literal(self.db),
+                Literal::String(string) if string.as_str() == value
+            )),
+            _ => Some(false),
+        })
+    }
+
+    pub fn could_equal_number_literal(self, value: f64) -> bool {
+        self.could_equal_literal(|data| match data {
+            TypeData::Number => Some(true),
+            TypeData::Literal(literal) => Some(matches!(
+                literal.literal(self.db),
+                Literal::Number(number) if number.to_f64() == Some(value)
+            )),
+            _ => Some(false),
+        })
+    }
+
+    pub fn could_equal_boolean_literal(self, value: bool) -> bool {
+        self.could_equal_literal(|data| match data {
+            TypeData::Boolean => Some(true),
+            TypeData::Literal(literal) => Some(matches!(
+                literal.literal(self.db),
+                Literal::Boolean(boolean) if boolean.as_bool() == value
+            )),
+            _ => Some(false),
+        })
+    }
+
+    pub fn could_equal_null(self) -> bool {
+        self.could_equal_literal(|data| {
+            Some(matches!(
+                data,
+                TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword
+            ))
+        })
+    }
+
+    pub const fn is_null(self) -> bool {
+        matches!(self.data, TypeData::Null)
+    }
+
+    pub const fn is_undefined(self) -> bool {
+        matches!(self.data, TypeData::Undefined)
+    }
+
+    fn all_variants_match(self, mut predicate: impl FnMut(TypeData<'db>) -> bool) -> bool {
+        let mut saw_variant = false;
+        let mut seen = FxHashSet::default();
+        let mut pending = vec![self.data];
+
+        for _ in 0..MAX_TYPE_VARIANT_STEPS {
+            let Some(data) = pending.pop() else {
+                return saw_variant;
+            };
+            if !seen.insert(data) {
+                continue;
+            }
+
+            match data {
+                TypeData::Union(union) => {
+                    if union.types(self.db).is_empty() {
+                        return false;
+                    }
+                    pending.extend(union.types(self.db).iter().copied());
+                }
+                TypeData::Generic(generic) => {
+                    let Some(constraint) = generic.constraint(self.db) else {
+                        return false;
+                    };
+                    pending.push(constraint);
+                }
+                _ if predicate(data) => saw_variant = true,
+                _ => return false,
+            }
+        }
+
+        false
+    }
+
+    fn conditional_type(self) -> ConditionalType {
+        let mut conditional = ConditionalType::Unknown;
+        let mut seen = FxHashSet::default();
+        let mut pending = vec![self.data];
+
+        for _ in 0..MAX_TYPE_VARIANT_STEPS {
+            let Some(data) = pending.pop() else {
+                return conditional;
+            };
+            if !seen.insert(data) {
+                continue;
+            }
+
+            if let Some(next) = data.conditional_type_shallow(self.db) {
+                conditional = if conditional == ConditionalType::Unknown {
+                    next
+                } else {
+                    conditional.merged_with(next)
+                };
+            } else {
+                match data {
+                    TypeData::Generic(generic) => {
+                        let Some(constraint) = generic.constraint(self.db) else {
+                            return ConditionalType::Unknown;
+                        };
+                        pending.push(constraint);
+                    }
+                    TypeData::InstanceOf(instance) => pending.push(instance.ty(self.db)),
+                    TypeData::Intersection(intersection) => {
+                        pending.extend(intersection.types(self.db).iter().copied());
+                    }
+                    TypeData::MergedReference(reference) => pending.extend(
+                        [
+                            reference.ty(self.db),
+                            reference.value_ty(self.db),
+                            reference.namespace_ty(self.db),
+                        ]
+                        .into_iter()
+                        .flatten(),
+                    ),
+                    TypeData::TypeofType(typeof_type) => pending.push(typeof_type.ty(self.db)),
+                    TypeData::TypeofValue(typeof_value) => pending.push(typeof_value.ty(self.db)),
+                    TypeData::Union(union) => {
+                        pending.extend(union.types(self.db).iter().copied());
+                    }
+                    _ => return ConditionalType::Unknown,
+                }
+            }
+
+            if conditional != ConditionalType::Unknown && !conditional.is_mergeable() {
+                return conditional;
+            }
+        }
+
+        ConditionalType::Unknown
+    }
+
+    fn could_equal_literal(self, mut predicate: impl FnMut(TypeData<'db>) -> Option<bool>) -> bool {
+        let mut seen = FxHashSet::default();
+        let mut pending = vec![self.data];
+
+        for _ in 0..MAX_TYPE_VARIANT_STEPS {
+            let Some(data) = pending.pop() else {
+                return false;
+            };
+            if !seen.insert(data) {
+                continue;
+            }
+
+            match data {
+                TypeData::Unknown
+                | TypeData::Divergent(_)
+                | TypeData::AnyKeyword
+                | TypeData::UnknownKeyword
+                | TypeData::Local(_)
+                | TypeData::TypeofExpression(_) => return true,
+                TypeData::Generic(generic) => {
+                    let Some(constraint) = generic.constraint(self.db) else {
+                        return true;
+                    };
+                    pending.push(constraint);
+                }
+                TypeData::InstanceOf(instance) => pending.push(instance.ty(self.db)),
+                TypeData::TypeofType(typeof_type) => pending.push(typeof_type.ty(self.db)),
+                TypeData::TypeofValue(typeof_value) => pending.push(typeof_value.ty(self.db)),
+                TypeData::Union(union) => {
+                    pending.extend(union.types(self.db).iter().copied());
+                }
+                data => match predicate(data) {
+                    Some(true) => return true,
+                    Some(false) => {}
+                    None => return true,
+                },
+            }
+        }
+
+        true
+    }
+
+    fn any_variant_matches(self, mut predicate: impl FnMut(TypeData<'db>) -> bool) -> bool {
+        let mut seen = FxHashSet::default();
+        let mut pending = vec![self.data];
+
+        for _ in 0..MAX_TYPE_VARIANT_STEPS {
+            let Some(data) = pending.pop() else {
+                return false;
+            };
+            if !seen.insert(data) {
+                continue;
+            }
+
+            match data {
+                TypeData::Generic(generic) => {
+                    if let Some(constraint) = generic.constraint(self.db) {
+                        pending.push(constraint);
+                    }
+                }
+                TypeData::InstanceOf(instance) => pending.push(instance.ty(self.db)),
+                TypeData::TypeofType(typeof_type) => pending.push(typeof_type.ty(self.db)),
+                TypeData::TypeofValue(typeof_value) => pending.push(typeof_value.ty(self.db)),
+                TypeData::Union(union) => {
+                    pending.extend(union.types(self.db).iter().copied());
+                }
+                data if predicate(data) => return true,
+                _ => {}
+            }
+        }
+
+        false
+    }
+
+    fn function_return_matches(self, predicate: impl Fn(TypeData<'db>) -> bool) -> bool {
+        let Some(function) = self.data.callable_function(self.db) else {
+            return false;
+        };
+        let ReturnType::Type(return_ty) = function.return_type(self.db) else {
+            return false;
+        };
+        predicate(*return_ty)
+    }
+
+    fn has_computed_member(self, name: &str) -> bool {
+        let mut seen = FxHashSet::default();
+        let mut pending = vec![self.data];
+
+        for _ in 0..MAX_TYPE_VARIANT_STEPS {
+            let Some(data) = pending.pop() else {
+                return false;
+            };
+            if !seen.insert(data) {
+                continue;
+            }
+
+            match data {
+                TypeData::Class(class) => {
+                    if class.members(self.db).iter().any(|member| {
+                        !member.kind.is_static() && member.kind.computed_name() == Some(name)
+                    }) {
+                        return true;
+                    }
+                    pending.extend(class.extends(self.db));
+                    pending.extend(class.implements(self.db).iter().copied());
+                }
+                TypeData::Interface(interface) => {
+                    if interface
+                        .members(self.db)
+                        .iter()
+                        .any(|member| member.kind.computed_name() == Some(name))
+                    {
+                        return true;
+                    }
+                    pending.extend(interface.extends(self.db).iter().copied());
+                }
+                TypeData::Literal(literal) => {
+                    if let Literal::Object(members) = literal.literal(self.db)
+                        && members
+                            .iter()
+                            .any(|member| member.kind.computed_name() == Some(name))
+                    {
+                        return true;
+                    }
+                }
+                TypeData::Object(object) => {
+                    if object
+                        .members(self.db)
+                        .iter()
+                        .any(|member| member.kind.computed_name() == Some(name))
+                    {
+                        return true;
+                    }
+                    pending.extend(object.prototype(self.db));
+                }
+                TypeData::Generic(generic) => pending.extend(generic.constraint(self.db)),
+                TypeData::InstanceOf(instance) => pending.push(instance.ty(self.db)),
+                TypeData::Intersection(intersection) => {
+                    pending.extend(intersection.types(self.db).iter().copied());
+                }
+                TypeData::MergedReference(reference) => pending.extend(reference.targets(self.db)),
+                TypeData::TypeofType(typeof_type) => pending.push(typeof_type.ty(self.db)),
+                TypeData::TypeofValue(typeof_value) => pending.push(typeof_value.ty(self.db)),
+                TypeData::Union(union) => {
+                    pending.extend(union.types(self.db).iter().copied());
+                }
+                _ => {}
+            }
+        }
+
+        false
+    }
+}
+
+const MAX_RETURN_TYPE_STEPS: usize = 50;
+const MAX_RETURN_TYPE_DESCRIPTION_LENGTH: usize = 80;
+const RETURN_TYPE_SEPARATOR: &str = " | ";
+
+fn is_escape_hatch(ty: TypeData<'_>) -> bool {
+    matches!(
+        ty,
+        TypeData::AnyKeyword
+            | TypeData::VoidKeyword
+            | TypeData::UnknownKeyword
+            | TypeData::NeverKeyword
+            | TypeData::Unknown
+            | TypeData::ThisKeyword
+    )
+}
+
+fn normalize_boolean_return_types<'db>(
+    db: &'db dyn TypeDb,
+    mut types: Vec<TypeData<'db>>,
+) -> Vec<TypeData<'db>> {
+    let has_boolean = types.contains(&TypeData::Boolean);
+    let has_true = types.iter().any(|ty| ty.is_boolean_literal(db, true));
+    let has_false = types.iter().any(|ty| ty.is_boolean_literal(db, false));
+    if !(has_boolean || has_true && has_false) {
+        return types;
+    }
+
+    let mut seen_boolean = false;
+    types.retain(|ty| {
+        if matches!(ty, TypeData::Boolean) {
+            if seen_boolean {
+                return false;
+            }
+            seen_boolean = true;
+            return true;
+        }
+        !ty.is_boolean_literal(db, true) && !ty.is_boolean_literal(db, false)
+    });
+    if !seen_boolean {
+        types.push(TypeData::Boolean);
+    }
+    types
+}
+
+fn promise_inner<'db>(db: &'db dyn TypeDb, ty: TypeData<'db>) -> Option<TypeData<'db>> {
+    let TypeData::InstanceOf(instance) = ty else {
+        return None;
+    };
+    if !instance.ty(db).is_promise_class(db) {
+        return None;
+    }
+    instance
+        .type_parameters(db)
+        .first()
+        .copied()
+        .filter(|ty| !is_escape_hatch(*ty))
+}
+
+fn union_variants<'db>(db: &'db dyn TypeDb, ty: TypeData<'db>) -> Vec<TypeData<'db>> {
+    match ty {
+        TypeData::Union(union) => union.types(db).to_vec(),
+        ty => Vec::from([ty]),
+    }
+}
+
+fn collapse_union_absorbed_by_primitive<'db>(
+    db: &'db dyn TypeDb,
+    ty: TypeData<'db>,
+) -> Option<TypeData<'db>> {
+    let TypeData::Union(_) = ty else {
+        return None;
+    };
+    let variants = union_variants(db, ty);
+    let mut primitive = None;
+    for variant in &variants {
+        if matches!(
+            variant,
+            TypeData::String | TypeData::Number | TypeData::Boolean | TypeData::BigInt
+        ) {
+            if primitive.is_some() {
+                return None;
+            }
+            primitive = Some(*variant);
+        }
+    }
+    let primitive = primitive?;
+    variants
+        .iter()
+        .all(|variant| {
+            types_match(db, *variant, primitive) || is_nonunion_wider(db, primitive, *variant)
+        })
+        .then_some(primitive)
+}
+
+fn includes_object_keyword(db: &dyn TypeDb, ty: TypeData<'_>) -> bool {
+    matches!(ty, TypeData::ObjectKeyword)
+        || matches!(ty, TypeData::Union(_))
+            && union_variants(db, ty)
+                .iter()
+                .any(|variant| matches!(variant, TypeData::ObjectKeyword))
+}
+
+fn includes_undefined(db: &dyn TypeDb, ty: TypeData<'_>) -> bool {
+    matches!(ty, TypeData::Undefined | TypeData::VoidKeyword)
+        || matches!(ty, TypeData::Union(_))
+            && union_variants(db, ty)
+                .iter()
+                .any(|variant| matches!(variant, TypeData::Undefined | TypeData::VoidKeyword))
+}
+
+fn is_any_contaminated(db: &dyn TypeDb, ty: TypeData<'_>) -> bool {
+    match ty {
+        TypeData::AnyKeyword => true,
+        TypeData::Union(union) => union
+            .types(db)
+            .iter()
+            .any(|ty| matches!(ty, TypeData::AnyKeyword)),
+        TypeData::Intersection(intersection) => intersection
+            .types(db)
+            .iter()
+            .any(|ty| matches!(ty, TypeData::AnyKeyword)),
+        _ => false,
+    }
+}
+
+fn is_intersection_with_type_param(db: &dyn TypeDb, ty: TypeData<'_>) -> bool {
+    matches!(ty, TypeData::Intersection(intersection) if intersection.types(db).iter().any(|ty| matches!(ty, TypeData::Generic(_))))
+}
+
+fn is_literal_of_primitive(db: &dyn TypeDb, ty: TypeData<'_>) -> bool {
+    match ty {
+        TypeData::Literal(literal) => matches!(
+            literal.literal(db),
+            Literal::BigInt(_)
+                | Literal::Boolean(_)
+                | Literal::Number(_)
+                | Literal::String(_)
+                | Literal::Template(_)
+        ),
+        TypeData::Union(union) if union.types(db).len() == 1 => {
+            is_literal_of_primitive(db, union.types(db)[0])
+        }
+        _ => false,
+    }
+}
+
+fn is_base_type_of_literal(db: &dyn TypeDb, base: TypeData<'_>, literal: TypeData<'_>) -> bool {
+    matches!(literal.literal_base_type(db), Some(literal_base) if literal_base == base)
+}
+
+fn is_only_property_literal_widening(
+    db: &dyn TypeDb,
+    annotation: TypeData<'_>,
+    returns: &[TypeData<'_>],
+) -> bool {
+    returns.iter().all(|inferred| {
+        let mut stack = vec![(annotation, *inferred)];
+        let mut has_widening = false;
+        let mut iterations = 0;
+
+        while let Some((annotated, inferred)) = stack.pop() {
+            iterations += 1;
+            if iterations > MAX_RETURN_TYPE_STEPS {
+                return false;
+            }
+
+            if let TypeData::Tuple(annotated_tuple) = annotated {
+                let TypeData::Tuple(inferred_tuple) = inferred else {
+                    return false;
+                };
+                let annotated_elements = annotated_tuple.elements(db);
+                let inferred_elements = inferred_tuple.elements(db);
+                if annotated_elements.len() != inferred_elements.len()
+                    || annotated_elements.is_empty()
+                {
+                    return false;
+                }
+                for (annotated_element, inferred_element) in
+                    annotated_elements.iter().zip(inferred_elements)
+                {
+                    if types_match(db, annotated_element.ty, inferred_element.ty) {
+                        continue;
+                    }
+                    if is_base_type_of_literal(db, annotated_element.ty, inferred_element.ty) {
+                        has_widening = true;
+                    } else {
+                        stack.push((annotated_element.ty, inferred_element.ty));
+                    }
+                }
+                continue;
+            }
+
+            let TypeData::Object(annotated_object) = annotated else {
+                return false;
+            };
+            let annotated_members = annotated_object.members(db);
+            if annotated_members.is_empty() {
+                return false;
+            }
+            let inferred_members = match inferred {
+                TypeData::Object(object) => object.members(db),
+                TypeData::Literal(literal) => match literal.literal(db) {
+                    Literal::Object(members) => members,
+                    _ => return false,
+                },
+                _ => return false,
+            };
+            if inferred_members.is_empty() {
+                return false;
+            }
+
+            if let Some(index_signature) = annotated_members
+                .iter()
+                .find_map(|member| member.kind.index_signature_type().map(|_| member))
+            {
+                let mut index_has_widening = false;
+                let all_covered = inferred_members.iter().all(|member| {
+                    if member.kind.is_const_asserted() {
+                        return false;
+                    }
+                    if types_match(db, index_signature.ty, member.ty) {
+                        return true;
+                    }
+                    if is_base_type_of_literal(db, index_signature.ty, member.ty) {
+                        index_has_widening = true;
+                        return true;
+                    }
+                    false
+                });
+                if !(all_covered && index_has_widening) {
+                    return false;
+                }
+                has_widening = true;
+                continue;
+            }
+
+            for annotated_member in annotated_members {
+                let Some(name) = annotated_member.kind.name() else {
+                    continue;
+                };
+                let Some(inferred_member) = inferred_members
+                    .iter()
+                    .find(|member| member.kind.has_name(name.text()))
+                else {
+                    return false;
+                };
+                if inferred_member.kind.is_const_asserted() {
+                    return false;
+                }
+                if types_match(db, annotated_member.ty, inferred_member.ty) {
+                    continue;
+                }
+                if is_base_type_of_literal(db, annotated_member.ty, inferred_member.ty) {
+                    has_widening = true;
+                } else {
+                    stack.push((annotated_member.ty, inferred_member.ty));
+                }
+            }
+        }
+
+        has_widening
+    })
+}
+
+fn resolve_generic_chain<'db>(db: &'db dyn TypeDb, mut ty: TypeData<'db>) -> TypeData<'db> {
+    for _ in 0..6 {
+        let TypeData::Generic(generic) = ty else {
+            break;
+        };
+        let Some(constraint) = generic.constraint(db) else {
+            break;
+        };
+        ty = constraint;
+    }
+    ty
+}
+
+fn type_members<'db>(db: &'db dyn TypeDb, ty: TypeData<'db>) -> Option<&'db [TypeMember<'db>]> {
+    match ty {
+        TypeData::Object(object) => Some(object.members(db)),
+        TypeData::Literal(literal) => match literal.literal(db) {
+            Literal::Object(members) => Some(members),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn is_strictly_narrower_than_object_keyword(db: &dyn TypeDb, ty: TypeData<'_>) -> bool {
+    match ty {
+        TypeData::Object(object) => !object.members(db).is_empty(),
+        TypeData::InstanceOf(instance) => match instance.ty(db) {
+            TypeData::Class(class) => {
+                class_has_instance_shape(db, class, &mut FxHashSet::default(), 0)
+            }
+            _ => true,
+        },
+        TypeData::Tuple(_) | TypeData::Function(_) => true,
+        TypeData::Literal(literal) => match literal.literal(db) {
+            Literal::RegExp(_) => true,
+            Literal::Object(members) => !members.is_empty(),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn class_has_instance_shape<'db>(
+    db: &'db dyn TypeDb,
+    class: crate::interned_types::InternedClass<'db>,
+    seen: &mut FxHashSet<TypeData<'db>>,
+    depth: usize,
+) -> bool {
+    let ty = TypeData::Class(class);
+    if depth >= MAX_RETURN_TYPE_STEPS || !seen.insert(ty) {
+        return false;
+    }
+    if class
+        .members(db)
+        .iter()
+        .any(|member| !member.kind.is_static())
+    {
+        return true;
+    }
+    class.extends(db).is_some_and(|base| match base {
+        TypeData::Class(base) => class_has_instance_shape(db, base, seen, depth + 1),
+        TypeData::InstanceOf(instance) => match instance.ty(db) {
+            TypeData::Class(base) => class_has_instance_shape(db, base, seen, depth + 1),
+            _ => true,
+        },
+        _ => true,
+    })
+}
+
+fn is_nonunion_wider<'db>(
+    db: &'db dyn TypeDb,
+    annotated: TypeData<'db>,
+    inferred: TypeData<'db>,
+) -> bool {
+    let mut stack = vec![(annotated, resolve_generic_chain(db, inferred))];
+    let mut found_wider = false;
+    let mut iterations = 0;
+
+    while let Some((annotated, inferred)) = stack.pop() {
+        iterations += 1;
+        if iterations > MAX_RETURN_TYPE_STEPS {
+            return false;
+        }
+        if is_base_type_of_literal(db, annotated, inferred) {
+            found_wider = true;
+            continue;
+        }
+        if types_match(db, annotated, inferred) {
+            continue;
+        }
+
+        match (annotated, inferred) {
+            (TypeData::ObjectKeyword, TypeData::InstanceOf(_)) => found_wider = true,
+            (TypeData::InstanceOf(annotated), TypeData::InstanceOf(inferred)) => {
+                if !types_match(db, annotated.ty(db), inferred.ty(db)) {
+                    return false;
+                }
+                let annotated_parameters = annotated.type_parameters(db);
+                let inferred_parameters = inferred.type_parameters(db);
+                if annotated_parameters.len() != inferred_parameters.len()
+                    || annotated_parameters.is_empty()
+                {
+                    return false;
+                }
+                stack.extend(annotated_parameters.iter().zip(inferred_parameters).map(
+                    |(annotated, inferred)| (*annotated, resolve_generic_chain(db, *inferred)),
+                ));
+            }
+            (TypeData::Object(_), TypeData::Object(_) | TypeData::Literal(_)) => {
+                if !push_object_pairs(db, annotated, inferred, &mut stack) {
+                    return false;
+                }
+            }
+            (TypeData::ObjectKeyword, inferred)
+                if is_strictly_narrower_than_object_keyword(db, inferred) =>
+            {
+                found_wider = true;
+            }
+            (TypeData::Tuple(annotated), TypeData::Tuple(inferred)) => {
+                let annotated_elements = annotated.elements(db);
+                let inferred_elements = inferred.elements(db);
+                if annotated_elements.len() != inferred_elements.len()
+                    || annotated_elements.is_empty()
+                {
+                    return false;
+                }
+                stack.extend(annotated_elements.iter().zip(inferred_elements).map(
+                    |(annotated, inferred)| (annotated.ty, resolve_generic_chain(db, inferred.ty)),
+                ));
+            }
+            _ => return false,
+        }
+    }
+
+    found_wider
+}
+
+fn push_object_pairs<'db>(
+    db: &'db dyn TypeDb,
+    annotated: TypeData<'db>,
+    inferred: TypeData<'db>,
+    stack: &mut Vec<(TypeData<'db>, TypeData<'db>)>,
+) -> bool {
+    let Some(annotated_members) = type_members(db, annotated) else {
+        return false;
+    };
+    let Some(inferred_members) = type_members(db, inferred) else {
+        return false;
+    };
+    if annotated_members.is_empty() || inferred_members.is_empty() {
+        return false;
+    }
+
+    if let Some(index_signature) = annotated_members.iter().find(|member| {
+        matches!(
+            member.kind,
+            TypeMemberKind::IndexSignature(_) | TypeMemberKind::ConstAssertedIndexSignature(_)
+        )
+    }) {
+        stack.extend(
+            inferred_members
+                .iter()
+                .map(|member| (index_signature.ty, resolve_generic_chain(db, member.ty))),
+        );
+        return true;
+    }
+
+    for annotated_member in annotated_members {
+        let Some(name) = annotated_member.kind.name() else {
+            continue;
+        };
+        let Some(inferred_member) = inferred_members
+            .iter()
+            .find(|member| member.kind.has_name(name.text()))
+        else {
+            return false;
+        };
+        stack.push((
+            annotated_member.ty,
+            resolve_generic_chain(db, inferred_member.ty),
+        ));
+    }
+    true
+}
+
+fn is_wider_than<'db>(
+    db: &'db dyn TypeDb,
+    annotated: TypeData<'db>,
+    inferred: TypeData<'db>,
+) -> bool {
+    let inferred = resolve_generic_chain(db, inferred);
+    match (annotated, inferred) {
+        (TypeData::String, TypeData::String)
+        | (TypeData::Number, TypeData::Number)
+        | (TypeData::Boolean, TypeData::Boolean)
+        | (TypeData::BigInt, TypeData::BigInt) => false,
+        (TypeData::Union(_), _) => is_union_wider(db, annotated, inferred),
+        (_, TypeData::Union(_)) => {
+            let variants = union_variants(db, inferred);
+            let has_base = variants
+                .iter()
+                .any(|variant| types_match(db, annotated, *variant));
+            let all_subsumed = variants.iter().all(|variant| {
+                types_match(db, annotated, *variant)
+                    || is_base_type_of_literal(db, annotated, *variant)
+            });
+            if has_base && all_subsumed {
+                return false;
+            }
+            variants.iter().all(|variant| {
+                types_match(db, annotated, *variant) || is_nonunion_wider(db, annotated, *variant)
+            }) && variants
+                .iter()
+                .any(|variant| is_nonunion_wider(db, annotated, *variant))
+        }
+        _ => is_nonunion_wider(db, annotated, inferred),
+    }
+}
+
+fn is_union_wider_than_returns<'db>(
+    db: &'db dyn TypeDb,
+    annotated: TypeData<'db>,
+    returns: &[TypeData<'db>],
+) -> bool {
+    let variants = union_variants(db, annotated);
+    if !returns.iter().all(|return_ty| {
+        variants.iter().any(|variant| {
+            types_match(db, *variant, *return_ty) || is_nonunion_wider(db, *variant, *return_ty)
+        })
+    }) {
+        return false;
+    }
+    let has_extra = variants.iter().any(|variant| {
+        !returns.iter().any(|return_ty| {
+            types_match(db, *variant, *return_ty) || is_nonunion_wider(db, *variant, *return_ty)
+        })
+    });
+    let has_wider = returns.iter().any(|return_ty| {
+        !variants
+            .iter()
+            .any(|variant| types_match(db, *variant, *return_ty))
+            && variants
+                .iter()
+                .any(|variant| is_nonunion_wider(db, *variant, *return_ty))
+    });
+    has_extra || has_wider
+}
+
+fn is_union_wider<'db>(
+    db: &'db dyn TypeDb,
+    annotated: TypeData<'db>,
+    inferred: TypeData<'db>,
+) -> bool {
+    let annotated_variants = union_variants(db, annotated);
+    let inferred_variants = union_variants(db, inferred);
+    if !inferred_variants.iter().all(|inferred| {
+        annotated_variants.iter().any(|annotated| {
+            types_match(db, *annotated, *inferred) || is_nonunion_wider(db, *annotated, *inferred)
+        })
+    }) {
+        return false;
+    }
+
+    annotated_variants
+        .iter()
+        .filter(|variant| {
+            let TypeData::Generic(generic) = variant else {
+                return true;
+            };
+            let Some(constraint) = generic.constraint(db) else {
+                return true;
+            };
+            !annotated_variants.iter().any(|other| {
+                other != *variant
+                    && (types_match(db, *other, constraint)
+                        || is_nonunion_wider(db, *other, constraint))
+            })
+        })
+        .any(|annotated| {
+            !inferred_variants.iter().any(|inferred| {
+                types_match(db, *annotated, *inferred)
+                    || is_nonunion_wider(db, *annotated, *inferred)
+            })
+        })
+}
+
+fn types_match<'db>(
+    db: &'db dyn TypeDb,
+    mut left: TypeData<'db>,
+    mut right: TypeData<'db>,
+) -> bool {
+    for _ in 0..MAX_RETURN_TYPE_STEPS {
+        if left == right {
+            return true;
+        }
+        match (left, right) {
+            (TypeData::Generic(left_generic), TypeData::Generic(right_generic)) => {
+                return left_generic.name(db) == right_generic.name(db);
+            }
+            (TypeData::InstanceOf(left_instance), TypeData::InstanceOf(right_instance))
+                if left_instance.type_parameters(db).is_empty()
+                    && right_instance.type_parameters(db).is_empty() =>
+            {
+                left = left_instance.ty(db);
+                right = right_instance.ty(db);
+            }
+            (TypeData::Generic(generic), TypeData::InstanceOf(instance))
+                if instance.type_parameters(db).is_empty() =>
+            {
+                return matches!(instance.ty(db), TypeData::Generic(other) if generic.name(db) == other.name(db));
+            }
+            (TypeData::InstanceOf(instance), TypeData::Generic(generic))
+                if instance.type_parameters(db).is_empty() =>
+            {
+                return matches!(instance.ty(db), TypeData::Generic(other) if generic.name(db) == other.name(db));
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn is_at_least_as_wide_as_object<'db>(
+    db: &'db dyn TypeDb,
+    ty: TypeData<'db>,
+    seen: &mut FxHashSet<TypeData<'db>>,
+    depth: usize,
+) -> bool {
+    if depth >= MAX_RETURN_TYPE_STEPS || !seen.insert(ty) {
+        return true;
+    }
+    let result = match ty {
+        TypeData::AnyKeyword
+        | TypeData::Unknown
+        | TypeData::UnknownKeyword
+        | TypeData::ObjectKeyword
+        | TypeData::Conditional
+        | TypeData::TypeofExpression(_)
+        | TypeData::TypeofType(_)
+        | TypeData::TypeofValue(_) => true,
+        TypeData::Object(object) => object.members(db).is_empty(),
+        TypeData::Interface(interface) => interface.members(db).is_empty(),
+        TypeData::Class(class) => class
+            .members(db)
+            .iter()
+            .all(|member| member.kind.is_static()),
+        TypeData::Generic(generic) => generic
+            .constraint(db)
+            .is_none_or(|ty| is_at_least_as_wide_as_object(db, ty, seen, depth + 1)),
+        TypeData::InstanceOf(instance) => {
+            is_at_least_as_wide_as_object(db, instance.ty(db), seen, depth + 1)
+        }
+        TypeData::Intersection(intersection) => {
+            intersection
+                .types(db)
+                .iter()
+                .any(|ty| matches!(ty, TypeData::AnyKeyword))
+                || intersection
+                    .types(db)
+                    .iter()
+                    .all(|ty| is_at_least_as_wide_as_object(db, *ty, seen, depth + 1))
+        }
+        TypeData::Union(union) => union
+            .types(db)
+            .iter()
+            .any(|ty| is_at_least_as_wide_as_object(db, *ty, seen, depth + 1)),
+        TypeData::MergedReference(reference) => reference
+            .targets(db)
+            .any(|ty| is_at_least_as_wide_as_object(db, ty, seen, depth + 1)),
+        _ => false,
+    };
+    seen.remove(&ty);
+    result
+}
+
+fn literal_text(db: &dyn TypeDb, ty: TypeData<'_>) -> Option<String> {
+    let TypeData::Literal(literal) = ty else {
+        return None;
+    };
+    match literal.literal(db) {
+        Literal::String(value) => Some(format!("\"{}\"", value.as_str())),
+        Literal::Number(value) => Some(value.as_str().to_string()),
+        Literal::Boolean(value) => Some(value.as_bool().to_string()),
+        _ => None,
+    }
+}
+
+fn renderable_variant(db: &dyn TypeDb, ty: TypeData<'_>) -> Option<String> {
+    match ty {
+        TypeData::String => Some("string".into()),
+        TypeData::Number => Some("number".into()),
+        TypeData::Boolean => Some("boolean".into()),
+        TypeData::BigInt => Some("bigint".into()),
+        _ => literal_text(db, ty),
+    }
+}
+
+fn clean_literal_text(text: &str) -> bool {
+    !text.contains("...") && !text.contains("__internal") && !text.contains("typeof import(")
+}
+
+fn join_description(parts: Vec<String>) -> Option<String> {
+    if parts.is_empty() || parts.iter().any(|part| !clean_literal_text(part)) {
+        return None;
+    }
+    let description = parts.join(RETURN_TYPE_SEPARATOR);
+    (description.len() <= MAX_RETURN_TYPE_DESCRIPTION_LENGTH).then_some(description)
+}
+
+fn render_inferred(db: &dyn TypeDb, returns: &[TypeData<'_>]) -> Option<String> {
+    join_description(
+        returns
+            .iter()
+            .map(|ty| literal_text(db, *ty))
+            .collect::<Option<Vec<_>>>()?,
+    )
+}
+
+fn render_narrowed<'db>(
+    db: &'db dyn TypeDb,
+    annotation: TypeData<'db>,
+    returns: &[TypeData<'db>],
+) -> Option<String> {
+    let variants = union_variants(db, annotation);
+    let covered = variants
+        .iter()
+        .filter(|variant| {
+            returns.iter().any(|return_ty| {
+                types_match(db, **variant, *return_ty)
+                    || is_nonunion_wider(db, **variant, *return_ty)
+            })
+        })
+        .copied()
+        .collect::<Vec<_>>();
+    if covered.is_empty() || covered.len() == variants.len() {
+        return None;
+    }
+    let has_widening = covered.iter().any(|variant| {
+        returns.iter().any(|return_ty| {
+            !types_match(db, *variant, *return_ty) && is_nonunion_wider(db, *variant, *return_ty)
+        })
+    });
+    if has_widening
+        && !(covered.len() == 1 && returns.len() == 1 && is_literal_of_primitive(db, returns[0]))
+    {
+        return None;
+    }
+    join_description(
+        covered
+            .iter()
+            .map(|ty| renderable_variant(db, *ty))
+            .collect::<Option<Vec<_>>>()?,
+    )
+}
+
+fn stringification_usefulness<'db>(
+    db: &'db dyn TypeDb,
+    data: TypeData<'db>,
+    mode: StringificationMode,
+    ignored_type_names: &[&str],
+    active: &mut FxHashSet<TypeData<'db>>,
+    depth: usize,
+) -> StringificationUsefulness {
+    use StringificationUsefulness::{Always, Never};
+
+    if depth >= MAX_TYPE_VARIANT_STEPS || !active.insert(data) {
+        return Always;
+    }
+
+    let result = if let TypeData::Generic(generic) = data {
+        generic.constraint(db).map_or(Always, |constraint| {
+            stringification_usefulness(db, constraint, mode, ignored_type_names, active, depth + 1)
+        })
+    } else if matches!(mode, StringificationMode::ToString)
+        && (is_ignored_stringification_type(db, data, ignored_type_names)
+            || is_safe_stringification_type(db, data))
+    {
+        Always
+    } else {
+        match data {
+            TypeData::Union(union) => {
+                combine_stringification_union(union.types(db).iter().map(|ty| {
+                    stringification_usefulness(db, *ty, mode, ignored_type_names, active, depth + 1)
+                }))
+            }
+            TypeData::Intersection(intersection) => {
+                combine_stringification_intersection(intersection.types(db).iter().map(|ty| {
+                    stringification_usefulness(db, *ty, mode, ignored_type_names, active, depth + 1)
+                }))
+            }
+            TypeData::Tuple(tuple) => {
+                combine_stringification_tuple(tuple.elements(db).iter().map(|element| {
+                    stringification_usefulness(
+                        db,
+                        element.ty,
+                        StringificationMode::ToString,
+                        ignored_type_names,
+                        active,
+                        depth + 1,
+                    )
+                }))
+            }
+            TypeData::InstanceOf(instance) if instance.ty(db).is_array_class(db) => instance
+                .type_parameters(db)
+                .first()
+                .map_or(Always, |element| {
+                    stringification_usefulness(
+                        db,
+                        *element,
+                        StringificationMode::ToString,
+                        ignored_type_names,
+                        active,
+                        depth + 1,
+                    )
+                }),
+            TypeData::InstanceOf(instance) => stringification_usefulness(
+                db,
+                instance.ty(db),
+                mode,
+                ignored_type_names,
+                active,
+                depth + 1,
+            ),
+            _ if matches!(mode, StringificationMode::Join) => Always,
+            _ => match uses_base_object_stringification(
+                db,
+                data,
+                &mut FxHashSet::default(),
+                depth + 1,
+            ) {
+                Some(true) => Never,
+                Some(false) | None => Always,
+            },
+        }
+    };
+
+    active.remove(&data);
+    result
+}
+
+fn combine_stringification_union(
+    usefulness: impl Iterator<Item = StringificationUsefulness>,
+) -> StringificationUsefulness {
+    let mut combined = None;
+    for usefulness in usefulness {
+        match combined {
+            None => combined = Some(usefulness),
+            Some(existing) if existing == usefulness => {}
+            Some(_) => return StringificationUsefulness::Sometimes,
+        }
+    }
+    combined.unwrap_or(StringificationUsefulness::Always)
+}
+
+fn combine_stringification_intersection(
+    usefulness: impl Iterator<Item = StringificationUsefulness>,
+) -> StringificationUsefulness {
+    if usefulness
+        .into_iter()
+        .any(|usefulness| usefulness == StringificationUsefulness::Always)
+    {
+        StringificationUsefulness::Always
+    } else {
+        StringificationUsefulness::Never
+    }
+}
+
+fn combine_stringification_tuple(
+    usefulness: impl Iterator<Item = StringificationUsefulness>,
+) -> StringificationUsefulness {
+    let mut saw_sometimes = false;
+    for usefulness in usefulness {
+        match usefulness {
+            StringificationUsefulness::Always => {}
+            StringificationUsefulness::Sometimes => saw_sometimes = true,
+            StringificationUsefulness::Never => return StringificationUsefulness::Never,
+        }
+    }
+    if saw_sometimes {
+        StringificationUsefulness::Sometimes
+    } else {
+        StringificationUsefulness::Always
+    }
+}
+
+fn is_safe_stringification_type<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> bool {
+    match data {
+        TypeData::AnyKeyword
+        | TypeData::BigInt
+        | TypeData::Boolean
+        | TypeData::Function(_)
+        | TypeData::Null
+        | TypeData::Number
+        | TypeData::String
+        | TypeData::Symbol
+        | TypeData::Undefined
+        | TypeData::Unknown
+        | TypeData::UnknownKeyword
+        | TypeData::NeverKeyword
+        | TypeData::VoidKeyword => true,
+        TypeData::Literal(literal) => matches!(
+            literal.literal(db),
+            Literal::BigInt(_)
+                | Literal::Boolean(_)
+                | Literal::Number(_)
+                | Literal::String(_)
+                | Literal::Template(_)
+        ),
+        _ => false,
+    }
+}
+
+fn is_ignored_stringification_type<'db>(
+    db: &'db dyn TypeDb,
+    data: TypeData<'db>,
+    ignored_type_names: &[&str],
+) -> bool {
+    let mut seen = FxHashSet::default();
+    let mut pending = vec![data];
+
+    for _ in 0..MAX_TYPE_VARIANT_STEPS {
+        let Some(data) = pending.pop() else {
+            return false;
+        };
+        if !seen.insert(data) {
+            continue;
+        }
+
+        let name = match data {
+            TypeData::Class(class) => class.name(db).as_ref().map(Text::text),
+            TypeData::Generic(generic) => Some(generic.name(db).text()),
+            TypeData::Interface(interface) => Some(interface.name(db).text()),
+            TypeData::Literal(literal) if matches!(literal.literal(db), Literal::RegExp(_)) => {
+                Some("RegExp")
+            }
+            TypeData::TypeofValue(value) => Some(value.identifier(db).text()),
+            _ => None,
+        };
+        if name.is_some_and(|name| ignored_type_names.contains(&name)) {
+            return true;
+        }
+
+        match data {
+            TypeData::Class(class) => pending.extend(class.extends(db)),
+            TypeData::Generic(generic) => pending.extend(generic.constraint(db)),
+            TypeData::InstanceOf(instance) => pending.push(instance.ty(db)),
+            TypeData::Interface(interface) => {
+                pending.extend(interface.extends(db).iter().copied());
+            }
+            TypeData::MergedReference(reference) => pending.extend(reference.targets(db)),
+            TypeData::TypeOperator(operator) => pending.push(operator.ty(db)),
+            TypeData::TypeofType(typeof_type) => pending.push(typeof_type.ty(db)),
+            TypeData::TypeofValue(typeof_value) => pending.push(typeof_value.ty(db)),
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn uses_base_object_stringification<'db>(
+    db: &'db dyn TypeDb,
+    data: TypeData<'db>,
+    active: &mut FxHashSet<TypeData<'db>>,
+    depth: usize,
+) -> Option<bool> {
+    if depth >= MAX_TYPE_VARIANT_STEPS || !active.insert(data) {
+        return Some(false);
+    }
+
+    let result = match data {
+        TypeData::Class(class) => {
+            if has_custom_stringification_member(class.members(db)) {
+                Some(false)
+            } else if let Some(base) = class.extends(db) {
+                uses_base_object_stringification(db, base, active, depth + 1)
+            } else {
+                Some(true)
+            }
+        }
+        TypeData::InstanceOf(instance) => {
+            uses_base_object_stringification(db, instance.ty(db), active, depth + 1)
+        }
+        TypeData::Interface(interface) => {
+            if has_custom_stringification_member(interface.members(db)) {
+                Some(false)
+            } else if interface.extends(db).is_empty() {
+                Some(true)
+            } else {
+                combine_base_stringification(
+                    interface
+                        .extends(db)
+                        .iter()
+                        .map(|base| uses_base_object_stringification(db, *base, active, depth + 1)),
+                )
+            }
+        }
+        TypeData::Literal(literal) => match literal.literal(db) {
+            Literal::Object(members) => Some(!has_custom_stringification_member(members)),
+            Literal::RegExp(_) => Some(true),
+            _ => Some(false),
+        },
+        TypeData::MergedReference(reference) => combine_base_stringification(
+            reference
+                .targets(db)
+                .map(|target| uses_base_object_stringification(db, target, active, depth + 1)),
+        ),
+        TypeData::Object(object) => Some(!has_custom_stringification_member(object.members(db))),
+        TypeData::ObjectKeyword => Some(true),
+        TypeData::TypeofValue(value) => {
+            uses_base_object_stringification(db, value.ty(db), active, depth + 1)
+        }
+        _ => None,
+    };
+
+    active.remove(&data);
+    result
+}
+
+fn combine_base_stringification(results: impl Iterator<Item = Option<bool>>) -> Option<bool> {
+    let mut saw_true = false;
+    for result in results {
+        match result {
+            Some(false) => return Some(false),
+            Some(true) => saw_true = true,
+            None => {}
+        }
+    }
+    saw_true.then_some(true)
+}
+
+fn has_custom_stringification_member(members: &[crate::interned_types::TypeMember<'_>]) -> bool {
+    members.iter().any(|member| {
+        ["toLocaleString", "toString", "valueOf"]
+            .iter()
+            .any(|name| member.kind.has_name(name))
+    })
+}
+
+fn is_promise_instance<'db>(db: &'db dyn TypeDb, mut data: TypeData<'db>) -> bool {
+    while let TypeData::InstanceOf(instance) = data {
+        data = instance.ty(db);
+        if data.is_promise_class(db) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn contains_promise<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> bool {
+    match data {
+        TypeData::Union(union) => union.types(db).iter().any(|ty| contains_promise(db, *ty)),
+        data => is_promise_instance(db, data),
+    }
+}
+
+fn is_object_like<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> bool {
+    match data {
+        TypeData::Class(_)
+        | TypeData::Constructor(_)
+        | TypeData::Function(_)
+        | TypeData::Interface(_)
+        | TypeData::Module(_)
+        | TypeData::Namespace(_)
+        | TypeData::Object(_)
+        | TypeData::ObjectKeyword
+        | TypeData::Tuple(_) => true,
+        TypeData::InstanceOf(instance) => is_object_like(db, instance.ty(db)),
+        _ => false,
+    }
+}
+
+fn type_description<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> String {
+    match data {
+        TypeData::Unknown | TypeData::UnknownKeyword | TypeData::Divergent(_) => "unknown".into(),
+        TypeData::AnyKeyword => "any".into(),
+        TypeData::NeverKeyword => "never".into(),
+        TypeData::Null => "null".into(),
+        TypeData::Undefined | TypeData::VoidKeyword => "undefined".into(),
+        TypeData::Boolean => "boolean".into(),
+        TypeData::Number => "number".into(),
+        TypeData::String => "string".into(),
+        TypeData::BigInt => "bigint".into(),
+        TypeData::Symbol => "symbol".into(),
+        TypeData::ObjectKeyword | TypeData::Object(_) => "object".into(),
+        TypeData::Interface(_) => "interface".into(),
+        TypeData::Class(_) => "class".into(),
+        TypeData::Function(_) => "function".into(),
+        TypeData::Tuple(_) => "tuple".into(),
+        TypeData::Module(_) | TypeData::Namespace(_) => "namespace".into(),
+        TypeData::Constructor(_) => "constructor".into(),
+        TypeData::InstanceOf(instance) => type_description(db, instance.ty(db)),
+        TypeData::Intersection(intersection) => intersection
+            .types(db)
+            .iter()
+            .map(|ty| type_description(db, *ty))
+            .collect::<Vec<_>>()
+            .join(" & "),
+        TypeData::Union(union) => union
+            .types(db)
+            .iter()
+            .map(|ty| type_description(db, *ty))
+            .collect::<Vec<_>>()
+            .join(" | "),
+        TypeData::Literal(literal) => match literal.literal(db) {
+            Literal::BigInt(_) => "bigint".into(),
+            Literal::Boolean(_) => "boolean".into(),
+            Literal::Number(_) => "number".into(),
+            Literal::String(_) | Literal::Template(_) => "string".into(),
+            Literal::Object(_) => "object".into(),
+            Literal::RegExp(_) => "RegExp".into(),
+        },
+        TypeData::Generic(_)
+        | TypeData::Local(_)
+        | TypeData::MergedReference(_)
+        | TypeData::TypeOperator(_)
+        | TypeData::TypeofExpression(_)
+        | TypeData::TypeofType(_)
+        | TypeData::TypeofValue(_)
+        | TypeData::Conditional
+        | TypeData::Global
+        | TypeData::ThisKeyword => format!("{data:?}"),
+    }
+}

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -14,8 +14,8 @@ use crate::{
         GLOBAL_ARRAY_ID, GLOBAL_ASYNC_DISPOSABLE_ID, GLOBAL_BOOLEAN_ID, GLOBAL_CONDITIONAL_ID,
         GLOBAL_DATE_ID, GLOBAL_DISPOSABLE_ID, GLOBAL_ERROR_ID, GLOBAL_GLOBAL_ID, GLOBAL_MAP_ID,
         GLOBAL_NUMBER_ID, GLOBAL_PROMISE_ID, GLOBAL_REGEXP_ID, GLOBAL_SET_ID, GLOBAL_STRING_ID,
-        GLOBAL_SYMBOL_ID, GLOBAL_UNDEFINED_ID, GLOBAL_UNKNOWN_ID, GLOBAL_VOID_ID,
-        GLOBAL_WEAK_MAP_ID,
+        GLOBAL_SYMBOL_ASYNC_DISPOSE_ID, GLOBAL_SYMBOL_DISPOSE_ID, GLOBAL_SYMBOL_ID,
+        GLOBAL_UNDEFINED_ID, GLOBAL_UNKNOWN_ID, GLOBAL_VOID_ID, GLOBAL_WEAK_MAP_ID,
     },
     literal::{BooleanLiteral, NumberLiteral, RegexpLiteral, StringLiteral},
     type_data as raw,
@@ -26,6 +26,30 @@ pub type ReferenceResolver<'db, 'resolver> =
     dyn FnMut(&raw::TypeReference) -> TypeData<'db> + 'resolver;
 const MAX_GENERIC_REPLACEMENT_STEPS: usize = 64;
 const MAX_TYPE_SUBSTITUTION_STEPS: usize = 1024;
+
+pub fn well_known_symbol_name(reference: &raw::TypeReference) -> Option<Text> {
+    match reference {
+        raw::TypeReference::Resolved(id) if *id == GLOBAL_SYMBOL_DISPOSE_ID => {
+            Some(Text::new_static("Symbol.dispose"))
+        }
+        raw::TypeReference::Resolved(id) if *id == GLOBAL_SYMBOL_ASYNC_DISPOSE_ID => {
+            Some(Text::new_static("Symbol.asyncDispose"))
+        }
+        raw::TypeReference::Qualifier(qualifier) => {
+            let mut parts = qualifier.path.iter();
+            match (parts.next(), parts.next(), parts.next()) {
+                (Some(symbol), Some(member), None)
+                    if symbol.text() == "Symbol"
+                        && matches!(member.text(), "dispose" | "asyncDispose") =>
+                {
+                    Some(Text::new_owned(format!("Symbol.{}", member.text()).into()))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update)]
 pub struct TypeSubstitution<'db> {
@@ -1189,8 +1213,10 @@ impl TypeMember<'_> {
 pub enum TypeMemberKind<'db> {
     CallSignature,
     ComputedValue(TypeData<'db>),
+    ComputedValueNamed(Text, TypeData<'db>),
     ConstAssertedCallSignature,
     ConstAssertedComputedValue(TypeData<'db>),
+    ConstAssertedComputedValueNamed(Text, TypeData<'db>),
     ConstAssertedConstructor,
     ConstAssertedGetter(Text),
     ConstAssertedIndexSignature(TypeData<'db>),
@@ -1211,6 +1237,8 @@ impl<'db> TypeMemberKind<'db> {
             Self::Constructor | Self::ConstAssertedConstructor => name == "constructor",
             Self::Getter(own_name)
             | Self::ConstAssertedGetter(own_name)
+            | Self::ComputedValueNamed(own_name, _)
+            | Self::ConstAssertedComputedValueNamed(own_name, _)
             | Self::Named(own_name)
             | Self::ConstAssertedNamed(own_name)
             | Self::NamedOptional(own_name)
@@ -1254,6 +1282,21 @@ impl<'db> TypeMemberKind<'db> {
         )
     }
 
+    pub fn is_const_asserted(&self) -> bool {
+        matches!(
+            self,
+            Self::ConstAssertedCallSignature
+                | Self::ConstAssertedComputedValue(_)
+                | Self::ConstAssertedComputedValueNamed(_, _)
+                | Self::ConstAssertedConstructor
+                | Self::ConstAssertedGetter(_)
+                | Self::ConstAssertedIndexSignature(_)
+                | Self::ConstAssertedNamed(_)
+                | Self::ConstAssertedNamedOptional(_)
+                | Self::ConstAssertedNamedStatic(_)
+        )
+    }
+
     pub fn with_optional(self) -> Self {
         match self {
             Self::Named(name) => Self::NamedOptional(name),
@@ -1286,13 +1329,34 @@ impl<'db> TypeMemberKind<'db> {
                 Some(Text::new_static("constructor"))
             }
             Self::ConstAssertedGetter(name)
+            | Self::ConstAssertedComputedValueNamed(name, _)
             | Self::ConstAssertedNamed(name)
             | Self::ConstAssertedNamedOptional(name)
             | Self::ConstAssertedNamedStatic(name)
             | Self::Getter(name)
+            | Self::ComputedValueNamed(name, _)
             | Self::Named(name)
             | Self::NamedOptional(name)
             | Self::NamedStatic(name) => Some(name.clone()),
+        }
+    }
+
+    pub fn computed_name(&self) -> Option<&str> {
+        match self {
+            Self::ComputedValueNamed(name, _) | Self::ConstAssertedComputedValueNamed(name, _) => {
+                Some(name.text())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn computed_value_type(&self) -> Option<TypeData<'db>> {
+        match self {
+            Self::ComputedValue(ty)
+            | Self::ComputedValueNamed(_, ty)
+            | Self::ConstAssertedComputedValue(ty)
+            | Self::ConstAssertedComputedValueNamed(_, ty) => Some(*ty),
+            _ => None,
         }
     }
 }
@@ -1663,13 +1727,20 @@ fn convert_type_member_kind<'db>(
     match kind {
         raw::TypeMemberKind::CallSignature => TypeMemberKind::CallSignature,
         raw::TypeMemberKind::ComputedValue(ty) => {
-            TypeMemberKind::ComputedValue(resolve_reference(ty))
+            let resolved = resolve_reference(ty);
+            well_known_symbol_name(ty).map_or(TypeMemberKind::ComputedValue(resolved), |name| {
+                TypeMemberKind::ComputedValueNamed(name, resolved)
+            })
         }
         raw::TypeMemberKind::ConstAssertedCallSignature => {
             TypeMemberKind::ConstAssertedCallSignature
         }
         raw::TypeMemberKind::ConstAssertedComputedValue(ty) => {
-            TypeMemberKind::ConstAssertedComputedValue(resolve_reference(ty))
+            let resolved = resolve_reference(ty);
+            well_known_symbol_name(ty).map_or(
+                TypeMemberKind::ConstAssertedComputedValue(resolved),
+                |name| TypeMemberKind::ConstAssertedComputedValueNamed(name, resolved),
+            )
         }
         raw::TypeMemberKind::ConstAssertedConstructor => TypeMemberKind::ConstAssertedConstructor,
         raw::TypeMemberKind::ConstAssertedGetter(name) => {
@@ -1941,10 +2012,16 @@ fn raw_type_member_kind_from_type<'db>(
         TypeMemberKind::ComputedValue(ty) => {
             raw::TypeMemberKind::ComputedValue(ty.to_raw_reference_lossy())
         }
+        TypeMemberKind::ComputedValueNamed(_, ty) => {
+            raw::TypeMemberKind::ComputedValue(ty.to_raw_reference_lossy())
+        }
         TypeMemberKind::ConstAssertedCallSignature => {
             raw::TypeMemberKind::ConstAssertedCallSignature
         }
         TypeMemberKind::ConstAssertedComputedValue(ty) => {
+            raw::TypeMemberKind::ConstAssertedComputedValue(ty.to_raw_reference_lossy())
+        }
+        TypeMemberKind::ConstAssertedComputedValueNamed(_, ty) => {
             raw::TypeMemberKind::ConstAssertedComputedValue(ty.to_raw_reference_lossy())
         }
         TypeMemberKind::ConstAssertedConstructor => raw::TypeMemberKind::ConstAssertedConstructor,

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -14,6 +14,7 @@ mod globals;
 mod globals_builder;
 pub(crate) mod globals_ids;
 mod helpers;
+mod inferred_type;
 pub mod interned_types;
 mod local_inference;
 mod resolver;
@@ -25,6 +26,10 @@ pub use conditionals::*;
 pub use flattening::MAX_FLATTEN_DEPTH;
 pub use globals::{GLOBAL_RESOLVER, GlobalsResolver};
 pub use globals_ids::{GLOBAL_BOOLEAN_ID, GLOBAL_UNKNOWN_ID, NUM_PREDEFINED_TYPES};
+pub use inferred_type::{
+    InferredSwitchCase, InferredType, MisleadingReturnType, ReturnTypeEvidence,
+    StringificationMode, StringificationUsefulness,
+};
 pub use interned_types::TypeDb;
 pub use resolver::*;
 pub use r#type::Type;

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -29,6 +29,7 @@ use biome_rowan::{AstNode, SyntaxResult, Text, TextRange, TokenText};
 
 use crate::globals::{
     GLOBAL_GLOBAL_ID, GLOBAL_INSTANCEOF_PROMISE_ID, GLOBAL_NUMBER_ID, GLOBAL_STRING_ID,
+    GLOBAL_SYMBOL_ASYNC_DISPOSE_ID, GLOBAL_SYMBOL_DISPOSE_ID, GLOBAL_SYMBOL_ID,
     GLOBAL_UNDEFINED_ID,
 };
 use crate::literal::{BooleanLiteral, NumberLiteral, RegexpLiteral, StringLiteral};
@@ -2058,7 +2059,7 @@ impl TypeMember {
                 .and_then(|name| match name {
                     AnyJsObjectMemberName::JsComputedMemberName(name) => {
                         name.expression().ok().map(|expr| {
-                            TypeMemberKind::IndexSignature(TypeReference::from_any_js_expression(
+                            TypeMemberKind::ComputedValue(computed_member_reference(
                                 resolver, scope_id, &expr,
                             ))
                         })
@@ -2106,7 +2107,7 @@ impl TypeMember {
                 .and_then(|name| match name {
                     AnyJsObjectMemberName::JsComputedMemberName(name) => {
                         name.expression().ok().map(|expr| {
-                            TypeMemberKind::IndexSignature(TypeReference::from_any_js_expression(
+                            TypeMemberKind::ComputedValue(computed_member_reference(
                                 resolver, scope_id, &expr,
                             ))
                         })
@@ -2303,8 +2304,8 @@ impl TypeMember {
         is_optional: bool,
     ) -> Option<Self> {
         let kind = match name {
-            AnyJsClassMemberName::JsComputedMemberName(name) => TypeMemberKind::IndexSignature(
-                TypeReference::from_any_js_expression(resolver, scope_id, &name.expression().ok()?),
+            AnyJsClassMemberName::JsComputedMemberName(name) => TypeMemberKind::ComputedValue(
+                computed_member_reference(resolver, scope_id, &name.expression().ok()?),
             ),
             _ => {
                 let name = text_from_class_member_name(name.name()?);
@@ -2389,6 +2390,37 @@ impl TypeMember {
 
         members.into()
     }
+}
+
+fn computed_member_reference(
+    resolver: &mut dyn TypeResolver,
+    scope_id: ScopeId,
+    expression: &AnyJsExpression,
+) -> TypeReference {
+    if let Some(member) = expression.as_js_static_member_expression()
+        && let Ok(object) = member.object()
+        && let Some(identifier) = object.as_js_identifier_expression()
+        && let (Some(object_name), Some(member_name)) = (
+            identifier
+                .name()
+                .ok()
+                .and_then(|name| text_from_token(name.value_token())),
+            member.member().ok().and_then(text_from_any_js_name),
+        )
+    {
+        let symbol_qualifier = TypeReferenceQualifier::from_path(scope_id, object_name.clone());
+        if resolver.resolve_qualifier(&symbol_qualifier) == Some(GLOBAL_SYMBOL_ID) {
+            match member_name.text() {
+                "dispose" => return TypeReference::Resolved(GLOBAL_SYMBOL_DISPOSE_ID),
+                "asyncDispose" => {
+                    return TypeReference::Resolved(GLOBAL_SYMBOL_ASYNC_DISPOSE_ID);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    TypeReference::from_any_js_expression(resolver, scope_id, expression)
 }
 
 impl TypeReference {

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_async_disposable_object.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_async_disposable_object.snap
@@ -18,7 +18,7 @@ const a = {
 ```
 a => Object {
   prototype: No prototype
-  members: [[Global TypeId(0)]: Disposable[Symbol.dispose]]
+  members: [computed [Symbol.asyncDispose]: Disposable[Symbol.dispose]]
 }
 
 ```
@@ -26,10 +26,8 @@ a => Object {
 ## Registered types
 
 ```
-Global TypeId(0) => Symbol.asyncDispose
-
-Global TypeId(1) => Object {
+Global TypeId(0) => Object {
   prototype: No prototype
-  members: [[Global TypeId(0)]: Disposable[Symbol.dispose]]
+  members: [computed [Symbol.asyncDispose]: Disposable[Symbol.dispose]]
 }
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_disposable_object.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_disposable_object.snap
@@ -18,7 +18,7 @@ const a = {
 ```
 a => Object {
   prototype: No prototype
-  members: [[Global TypeId(0)]: Disposable[Symbol.dispose]]
+  members: [computed [Symbol.dispose]: Disposable[Symbol.dispose]]
 }
 
 ```
@@ -26,10 +26,8 @@ a => Object {
 ## Registered types
 
 ```
-Global TypeId(0) => Symbol.dispose
-
-Global TypeId(1) => Object {
+Global TypeId(0) => Object {
   prototype: No prototype
-  members: [[Global TypeId(0)]: Disposable[Symbol.dispose]]
+  members: [computed [Symbol.dispose]: Disposable[Symbol.dispose]]
 }
 ```

--- a/crates/biome_module_graph/src/db/queries.rs
+++ b/crates/biome_module_graph/src/db/queries.rs
@@ -24,10 +24,11 @@ use biome_js_type_info::{
     ImportSymbol, RawTypeData, TypeReference, TypeResolverLevel,
     interned_types::{
         FunctionParameter as InferredFunctionParameter, InternedFunction as InferredFunction,
-        InternedMergedReference as InferredMergedReference, Literal as InferredLiteral,
-        LocalTypeHandle as InferredLocalTypeHandle, LocalTypeId as InferredLocalTypeId,
-        ModuleKey as InferredModuleKey, ReturnType, TypeData as InferredTypeData,
-        TypeMember as InferredTypeMember, TypeSubstitution as InferredTypeSubstitution,
+        InternedMergedReference as InferredMergedReference, InternedTuple as InferredTuple,
+        Literal as InferredLiteral, LocalTypeHandle as InferredLocalTypeHandle,
+        LocalTypeId as InferredLocalTypeId, ModuleKey as InferredModuleKey, ReturnType,
+        TypeData as InferredTypeData, TypeMember as InferredTypeMember,
+        TypeSubstitution as InferredTypeSubstitution,
     },
 };
 use biome_jsdoc_comment::JsdocComment;
@@ -214,7 +215,12 @@ pub(crate) fn infer_call_expression_return_type_from_args<'db>(
             union
                 .types(db)
                 .iter()
-                .filter_map(|callee| infer_function_call_type(db, *callee, args))
+                .filter_map(|callee| match callee {
+                    InferredTypeData::Null | InferredTypeData::Undefined => {
+                        Some(InferredTypeData::Undefined)
+                    }
+                    callee => infer_function_call_type(db, *callee, args),
+                })
                 .collect(),
         )
         .unwrap_or(InferredTypeData::Unknown),
@@ -274,6 +280,15 @@ fn infer_function_call_type<'db>(
             InferredTypeData::Object(object) => {
                 infer_call_signature_type(db, object.members(db), args)
             }
+            InferredTypeData::Union(union) => {
+                infer_function_call_type(db, InferredTypeData::Union(union), args)
+            }
+            InferredTypeData::TypeofType(typeof_type) => {
+                infer_function_call_type(db, typeof_type.ty(db), args)
+            }
+            InferredTypeData::TypeofValue(typeof_value) => {
+                infer_function_call_type(db, typeof_value.ty(db), args)
+            }
             InferredTypeData::Unknown
             | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
@@ -293,14 +308,11 @@ fn infer_function_call_type<'db>(
             | InferredTypeData::Generic(_)
             | InferredTypeData::Local(_)
             | InferredTypeData::Intersection(_)
-            | InferredTypeData::Union(_)
             | InferredTypeData::TypeOperator(_)
             | InferredTypeData::Literal(_)
             | InferredTypeData::InstanceOf(_)
             | InferredTypeData::MergedReference(_)
             | InferredTypeData::TypeofExpression(_)
-            | InferredTypeData::TypeofType(_)
-            | InferredTypeData::TypeofValue(_)
             | InferredTypeData::AnyKeyword
             | InferredTypeData::NeverKeyword
             | InferredTypeData::ObjectKeyword
@@ -312,6 +324,25 @@ fn infer_function_call_type<'db>(
             infer_call_signature_type(db, interface.members(db), args)
         }
         InferredTypeData::Object(object) => infer_call_signature_type(db, object.members(db), args),
+        InferredTypeData::Union(union) => collected_type_result(
+            db,
+            union
+                .types(db)
+                .iter()
+                .filter_map(|callee| match callee {
+                    InferredTypeData::Null | InferredTypeData::Undefined => {
+                        Some(InferredTypeData::Undefined)
+                    }
+                    callee => infer_function_call_type(db, *callee, args),
+                })
+                .collect(),
+        ),
+        InferredTypeData::TypeofType(typeof_type) => {
+            infer_function_call_type(db, typeof_type.ty(db), args)
+        }
+        InferredTypeData::TypeofValue(typeof_value) => {
+            infer_function_call_type(db, typeof_value.ty(db), args)
+        }
         InferredTypeData::Unknown
         | InferredTypeData::Divergent(_)
         | InferredTypeData::Global
@@ -331,13 +362,10 @@ fn infer_function_call_type<'db>(
         | InferredTypeData::Generic(_)
         | InferredTypeData::Local(_)
         | InferredTypeData::Intersection(_)
-        | InferredTypeData::Union(_)
         | InferredTypeData::TypeOperator(_)
         | InferredTypeData::Literal(_)
         | InferredTypeData::MergedReference(_)
         | InferredTypeData::TypeofExpression(_)
-        | InferredTypeData::TypeofType(_)
-        | InferredTypeData::TypeofValue(_)
         | InferredTypeData::AnyKeyword
         | InferredTypeData::NeverKeyword
         | InferredTypeData::ObjectKeyword
@@ -1316,6 +1344,7 @@ enum TypeNormalizationItem<'db> {
         has_value_ty: bool,
         has_namespace_ty: bool,
     },
+    RebuildTuple(InferredTuple<'db>),
     RebuildUnion(usize),
 }
 
@@ -1453,6 +1482,12 @@ pub fn normalize_type<'db>(
                             stack.push(TypeNormalizationItem::Type(ty));
                         }
                     }
+                    InferredTypeData::Tuple(tuple) => {
+                        stack.push(TypeNormalizationItem::RebuildTuple(tuple));
+                        for element in tuple.elements(db).iter().rev() {
+                            stack.push(TypeNormalizationItem::Type(element.ty));
+                        }
+                    }
                     InferredTypeData::Union(union) => {
                         stack.push(TypeNormalizationItem::RebuildUnion(union.types(db).len()));
                         for ty in union.types(db).iter().rev() {
@@ -1477,7 +1512,6 @@ pub fn normalize_type<'db>(
                     | InferredTypeData::Module(_)
                     | InferredTypeData::Namespace(_)
                     | InferredTypeData::Object(_)
-                    | InferredTypeData::Tuple(_)
                     | InferredTypeData::Generic(_)
                     | InferredTypeData::Local(_)
                     | InferredTypeData::TypeOperator(_)
@@ -1548,6 +1582,26 @@ pub fn normalize_type<'db>(
                         InferredMergedReference::new(db, ty, value_ty, namespace_ty),
                     ));
                 }
+            }
+            TypeNormalizationItem::RebuildTuple(tuple) => {
+                let Some(start) = results.len().checked_sub(tuple.elements(db).len()) else {
+                    return original;
+                };
+                let types = results.split_off(start);
+                let elements = tuple
+                    .elements(db)
+                    .iter()
+                    .zip(types)
+                    .map(|(element, ty)| {
+                        let mut element = element.clone();
+                        element.ty = ty;
+                        element
+                    })
+                    .collect::<Vec<_>>();
+                results.push(InferredTypeData::Tuple(InferredTuple::new(
+                    db,
+                    elements.into_boxed_slice(),
+                )));
             }
             TypeNormalizationItem::RebuildUnion(type_count) => {
                 let Some(start) = results.len().checked_sub(type_count) else {

--- a/crates/biome_module_graph/src/db/type_inference/expressions.rs
+++ b/crates/biome_module_graph/src/db/type_inference/expressions.rs
@@ -7,16 +7,19 @@ use super::{
     resolver::ResolutionCtx,
 };
 use crate::db::queries::{ResolvedCallArgument, infer_call_expression_return_type_from_args};
+use biome_js_semantic::ScopeId;
 use biome_js_type_info::{
     CallArgumentType as RawCallArgumentType, DestructureField as RawDestructureField,
+    GLOBAL_RESOLVER, Path, TypeReferenceQualifier, TypeResolver,
     TypeofExpression as RawTypeofExpression,
     interned_types::{
         CallArgumentType as InferredCallArgumentType, ConditionalSubset, ConditionalType,
         InternedClass as InferredClass, InternedConstructor as InferredConstructor,
-        InternedLiteral as InferredInternedLiteral, InternedTuple as InferredTuple,
-        Literal as InferredLiteral, ReturnType as InferredReturnType,
-        TupleElementType as InferredTupleElementType, TypeData as InferredTypeData,
-        TypeMember as InferredTypeMember, TypeofExpression as InferredTypeofExpression,
+        InternedFunction as InferredFunction, InternedLiteral as InferredInternedLiteral,
+        InternedTuple as InferredTuple, Literal as InferredLiteral,
+        ReturnType as InferredReturnType, TupleElementType as InferredTupleElementType,
+        TypeData as InferredTypeData, TypeMember as InferredTypeMember,
+        TypeofExpression as InferredTypeofExpression,
     },
     literal::NumberLiteral,
 };
@@ -698,10 +701,14 @@ impl<'db> ResolutionCtx<'db, '_> {
             };
             let target = self.resolve_inferred_type(instance.ty(self.db));
             if self.is_promise_like_target(target) {
-                return instance
-                    .type_parameters(self.db)
-                    .first()
-                    .map(|ty| self.resolve_inferred_type(*ty));
+                return Some(
+                    instance
+                        .type_parameters(self.db)
+                        .first()
+                        .map_or(InferredTypeData::Unknown, |ty| {
+                            self.resolve_inferred_type(*ty)
+                        }),
+                );
             }
 
             if let InferredTypeData::Class(class) = target
@@ -827,12 +834,19 @@ impl<'db> ResolutionCtx<'db, '_> {
             .map(|(ty, is_optional)| self.member_type(ty, is_optional)),
             InferredTypeData::InstanceOf(instance) => {
                 let target = self.resolve_inferred_type(instance.ty(self.db));
+                if let Some((ty, is_optional)) = self.promise_member_type(target, member_name) {
+                    return Some(self.member_type(ty, is_optional));
+                }
                 let substitutions = substitutions_for_instance(
                     self.db,
                     target,
                     instance.type_parameters(self.db),
                     &[],
                 );
+                if matches!(target, InferredTypeData::Union(_)) {
+                    let ty = self.resolve_static_member_expression(target, member_name)?;
+                    return Some(apply_substitutions(self.db, ty, &substitutions));
+                }
                 self.find_static_member_on_resolved_type(target, member_name)
                     .map(|(ty, is_optional)| {
                         let ty = apply_substitutions(self.db, ty, &substitutions);
@@ -889,9 +903,26 @@ impl<'db> ResolutionCtx<'db, '_> {
                 }
                 collected_type_result(self.db, types).or(Some(InferredTypeData::Unknown))
             }
+            InferredTypeData::Global => self.resolve_global_name(member_name),
+            InferredTypeData::Tuple(tuple) => {
+                let element_ty = InferredTypeData::union_from_types(
+                    self.db,
+                    tuple
+                        .elements(self.db)
+                        .iter()
+                        .map(|element| element.ty)
+                        .collect(),
+                );
+                let target = self.resolve_global_name("Array")?;
+                let substitutions = substitutions_for_instance(self.db, target, &[element_ty], &[]);
+                self.find_static_member_on_resolved_type(target, member_name)
+                    .map(|(ty, is_optional)| {
+                        let ty = apply_substitutions(self.db, ty, &substitutions);
+                        self.member_type(ty, is_optional)
+                    })
+            }
             ty @ (InferredTypeData::Unknown
             | InferredTypeData::Divergent(_)
-            | InferredTypeData::Global
             | InferredTypeData::BigInt
             | InferredTypeData::Boolean
             | InferredTypeData::Null
@@ -906,7 +937,6 @@ impl<'db> ResolutionCtx<'db, '_> {
             | InferredTypeData::Module(_)
             | InferredTypeData::Namespace(_)
             | InferredTypeData::Object(_)
-            | InferredTypeData::Tuple(_)
             | InferredTypeData::Generic(_)
             | InferredTypeData::Local(_)
             | InferredTypeData::Intersection(_)
@@ -987,22 +1017,32 @@ impl<'db> ResolutionCtx<'db, '_> {
                     }
                 }
                 InferredTypeData::Module(module) => {
-                    if let Some(member) = find_member_in_members_for_mode(
-                        self.db,
-                        module.members(self.db),
-                        member_name,
-                        StaticMemberMode::Instance,
-                    ) {
+                    if let Some(member) = [StaticMemberMode::Instance, StaticMemberMode::Class]
+                        .into_iter()
+                        .find_map(|mode| {
+                            find_member_in_members_for_mode(
+                                self.db,
+                                module.members(self.db),
+                                member_name,
+                                mode,
+                            )
+                        })
+                    {
                         return Some(member);
                     }
                 }
                 InferredTypeData::Namespace(namespace) => {
-                    if let Some(member) = find_member_in_members_for_mode(
-                        self.db,
-                        namespace.members(self.db),
-                        member_name,
-                        StaticMemberMode::Instance,
-                    ) {
+                    if let Some(member) = [StaticMemberMode::Instance, StaticMemberMode::Class]
+                        .into_iter()
+                        .find_map(|mode| {
+                            find_member_in_members_for_mode(
+                                self.db,
+                                namespace.members(self.db),
+                                member_name,
+                                mode,
+                            )
+                        })
+                    {
                         return Some(member);
                     }
                 }
@@ -1051,6 +1091,39 @@ impl<'db> ResolutionCtx<'db, '_> {
         }
 
         None
+    }
+
+    fn promise_member_type(
+        &self,
+        target: InferredTypeData<'db>,
+        member_name: &str,
+    ) -> Option<(InferredTypeData<'db>, bool)> {
+        if !target.is_promise_class(self.db) || !matches!(member_name, "catch" | "finally" | "then")
+        {
+            return None;
+        }
+
+        let return_type = InferredTypeData::instance_of(self.db, target, Box::default());
+        Some((
+            InferredTypeData::Function(InferredFunction::new(
+                self.db,
+                Box::default(),
+                Box::default(),
+                InferredReturnType::Type(return_type),
+                false,
+                None,
+            )),
+            false,
+        ))
+    }
+
+    fn resolve_global_name(&mut self, name: &str) -> Option<InferredTypeData<'db>> {
+        GLOBAL_RESOLVER
+            .resolve_qualifier(&TypeReferenceQualifier::from_path(
+                ScopeId::GLOBAL,
+                Path::from(Text::new_owned(name.into())),
+            ))
+            .map(|resolved_id| self.resolve_resolved_id(resolved_id))
     }
 
     fn member_type(

--- a/crates/biome_module_graph/src/db/type_inference/globals.rs
+++ b/crates/biome_module_graph/src/db/type_inference/globals.rs
@@ -24,6 +24,7 @@ use biome_js_type_info::{
         PredicateReturnType as InferredPredicateReturnType, ReturnType as InferredReturnType,
         TupleElementType as InferredTupleElementType, TypeData as InferredTypeData,
         TypeMember as InferredTypeMember, TypeMemberKind as InferredTypeMemberKind,
+        well_known_symbol_name,
     },
 };
 use biome_rowan::Text;
@@ -867,15 +868,29 @@ fn global_member_kind_from_raw<'db>(
 ) -> InferredTypeMemberKind<'db> {
     match kind {
         RawTypeMemberKind::CallSignature => InferredTypeMemberKind::CallSignature,
-        RawTypeMemberKind::ComputedValue(_) => {
-            InferredTypeMemberKind::ComputedValue(key_ty.unwrap_or(InferredTypeData::Unknown))
-        }
+        RawTypeMemberKind::ComputedValue(reference) => well_known_symbol_name(reference).map_or(
+            InferredTypeMemberKind::ComputedValue(key_ty.unwrap_or(InferredTypeData::Unknown)),
+            |name| {
+                InferredTypeMemberKind::ComputedValueNamed(
+                    name,
+                    key_ty.unwrap_or(InferredTypeData::Unknown),
+                )
+            },
+        ),
         RawTypeMemberKind::ConstAssertedCallSignature => {
             InferredTypeMemberKind::ConstAssertedCallSignature
         }
-        RawTypeMemberKind::ConstAssertedComputedValue(_) => {
-            InferredTypeMemberKind::ConstAssertedComputedValue(
-                key_ty.unwrap_or(InferredTypeData::Unknown),
+        RawTypeMemberKind::ConstAssertedComputedValue(reference) => {
+            well_known_symbol_name(reference).map_or(
+                InferredTypeMemberKind::ConstAssertedComputedValue(
+                    key_ty.unwrap_or(InferredTypeData::Unknown),
+                ),
+                |name| {
+                    InferredTypeMemberKind::ConstAssertedComputedValueNamed(
+                        name,
+                        key_ty.unwrap_or(InferredTypeData::Unknown),
+                    )
+                },
             )
         }
         RawTypeMemberKind::ConstAssertedConstructor => {

--- a/crates/biome_module_graph/src/db/type_inference/imports.rs
+++ b/crates/biome_module_graph/src/db/type_inference/imports.rs
@@ -95,13 +95,11 @@ impl<'db> ResolutionCtx<'db, '_> {
     ) -> InferredTypeData<'db> {
         let mut collection = NamespaceExportCollection::new();
 
-        if !self.collect_namespace_members(module, inferred_types, true, &mut collection) {
-            return InferredTypeData::Unknown;
-        }
+        self.collect_namespace_members(module, inferred_types, true, &mut collection);
 
         while let Some((module, include_default)) = collection.stack.pop() {
             if collection.remaining_steps == 0 {
-                return InferredTypeData::Unknown;
+                break;
             }
             collection.remaining_steps -= 1;
 
@@ -109,14 +107,12 @@ impl<'db> ResolutionCtx<'db, '_> {
                 continue;
             };
 
-            if !self.collect_namespace_members(
+            self.collect_namespace_members(
                 module,
                 &inferred_types,
                 include_default,
                 &mut collection,
-            ) {
-                return InferredTypeData::Unknown;
-            }
+            );
         }
 
         InferredTypeData::Namespace(InferredNamespace::new(
@@ -132,14 +128,14 @@ impl<'db> ResolutionCtx<'db, '_> {
         inferred_types: &InferredModuleTypes<'db>,
         include_default: bool,
         collection: &mut NamespaceExportCollection<'db>,
-    ) -> bool {
+    ) {
         let module_key = ModuleKey::new(module.as_id());
         if !collection.seen_modules.insert(module_key) {
-            return true;
+            return;
         }
 
         let ModuleInfoKind::Js(js_info) = module.kind(self.db) else {
-            return true;
+            return;
         };
 
         for (name, _) in js_info.exports.iter() {
@@ -150,11 +146,6 @@ impl<'db> ResolutionCtx<'db, '_> {
             if !collection.seen_names.insert(name.text().to_string()) {
                 continue;
             }
-
-            if collection.remaining_steps == 0 {
-                return false;
-            }
-            collection.remaining_steps -= 1;
 
             collection.members.push(InferredTypeMember {
                 kind: InferredTypeMemberKind::Named(name.clone()),
@@ -167,8 +158,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 collection.stack.push((module, false));
             }
         }
-
-        true
     }
 
     fn resolve_export_name(

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -3,9 +3,9 @@ use crate::ModuleDb;
 use crate::db::queries::infer_module_types;
 use crate::module_graph::ModuleInfo;
 use biome_js_type_info::interned_types::{
-    Literal as InferredLiteral, LocalTypeHandle, ModuleKey, TypeData as InferredTypeData,
-    TypeMember as InferredTypeMember, TypeMemberKind as InferredTypeMemberKind,
-    TypeSubstitution as InferredTypeSubstitution,
+    Literal as InferredLiteral, LocalTypeHandle, ModuleKey, ReturnType as InferredReturnType,
+    TypeData as InferredTypeData, TypeMember as InferredTypeMember,
+    TypeMemberKind as InferredTypeMemberKind, TypeSubstitution as InferredTypeSubstitution,
 };
 use rustc_hash::FxHashSet;
 use salsa::plumbing::{AsId, FromId};
@@ -526,9 +526,20 @@ fn find_member_in_members<'db>(
     let named_member = members
         .iter()
         .find(|member| allows_named_member(&member.kind) && member.kind.has_name(name))
-        .map(|member| (member.ty, member.kind.is_optional()));
+        .map(|member| (member_value_type(db, member), member.kind.is_optional()));
     if named_member.is_some() {
         return named_member;
+    }
+
+    let computed_member = members.iter().find_map(|member| {
+        member
+            .kind
+            .computed_value_type()
+            .is_some_and(|ty| ty.is_string_literal_key(db, name))
+            .then_some((member.ty, false))
+    });
+    if computed_member.is_some() {
+        return computed_member;
     }
 
     allow_index_signature.then(|| {
@@ -540,6 +551,22 @@ fn find_member_in_members<'db>(
                 .then_some((member.ty, false))
         })
     })?
+}
+
+fn member_value_type<'db>(
+    db: &'db dyn ModuleDb,
+    member: &InferredTypeMember<'db>,
+) -> InferredTypeData<'db> {
+    if matches!(
+        member.kind,
+        InferredTypeMemberKind::Getter(_) | InferredTypeMemberKind::ConstAssertedGetter(_)
+    ) && let InferredTypeData::Function(function) = member.ty
+        && let InferredReturnType::Type(return_ty) = function.return_type(db)
+    {
+        *return_ty
+    } else {
+        member.ty
+    }
 }
 
 pub(in crate::db::type_inference) fn find_member_in_members_for_mode<'db>(

--- a/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
+++ b/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
@@ -1,4 +1,5 @@
 use super::resolver::ResolutionCtx;
+use crate::js_module_info::TsBindingReferenceExt;
 use biome_js_type_info::{
     GLOBAL_RESOLVER, Path, TypeImportQualifier, TypeReferenceQualifier, TypeResolver,
     interned_types::{
@@ -16,9 +17,11 @@ impl<'db> ResolutionCtx<'db, '_> {
         &mut self,
         qualifier: &TypeReferenceQualifier,
     ) -> InferredTypeData<'db> {
-        let Some(identifier) = qualifier.path.iter().next() else {
+        let mut path = qualifier.path.iter();
+        let Some(identifier) = path.next() else {
             return InferredTypeData::Unknown;
         };
+        let members = path.collect::<Vec<_>>();
 
         let mut scope = self
             .js_info
@@ -26,26 +29,38 @@ impl<'db> ResolutionCtx<'db, '_> {
             .scope_from_id(qualifier.scope_id);
         let mut reached_root_scope = false;
         for _ in 0..MAX_SCOPE_RESOLUTION_STEPS {
-            if let Some(binding) = scope.get_binding(identifier.text()) {
-                if binding.is_imported()
+            let binding = scope
+                .get_binding_reference(identifier.text())
+                .and_then(|reference| reference.get_binding_id_for_qualifier(qualifier))
+                .and_then(|id| self.js_info.semantic_model.binding_by_id(id));
+            if let Some(binding) = binding {
+                let mut target = if binding.is_imported()
                     && let Some(import) = self.js_info.static_imports.get(identifier.text())
                 {
-                    let target = self.resolve_import(&TypeImportQualifier {
+                    self.resolve_import(&TypeImportQualifier {
                         symbol: import.symbol.clone(),
                         resolved_path: import.resolved_path.clone(),
                         type_only: qualifier.type_only,
-                    });
-                    return self.apply_qualifier_type_parameters(target, qualifier);
+                    })
+                } else {
+                    self.js_info
+                        .raw_binding_types
+                        .get(&binding.syntax().text_trimmed_range())
+                        .cloned()
+                        .map_or(InferredTypeData::Unknown, |reference| {
+                            self.resolve(&reference)
+                        })
+                };
+
+                for member in &members {
+                    let Some(member_ty) =
+                        self.resolve_static_member_expression(target, member.text())
+                    else {
+                        return InferredTypeData::Unknown;
+                    };
+                    target = member_ty;
                 }
 
-                let target = self
-                    .js_info
-                    .raw_binding_types
-                    .get(&binding.syntax().text_trimmed_range())
-                    .cloned()
-                    .map_or(InferredTypeData::Unknown, |reference| {
-                        self.resolve(&reference)
-                    });
                 return self.apply_qualifier_type_parameters(target, qualifier);
             }
 

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -6,8 +6,11 @@ use crate::module_graph::ModuleInfo;
 use crate::{JsModuleInfo, ModuleDb, ResolvedPath};
 use biome_js_semantic::JsDeclarationKind;
 use biome_js_type_info::{
-    RawTypeData, ResolvedTypeId, TypeId, TypeReference, TypeResolverLevel,
-    interned_types::{LocalTypeHandle, LocalTypeId, ModuleKey, TypeData as InferredTypeData},
+    RawTypeData, ResolvedTypeId, ScopeId, TypeId, TypeReference, TypeReferenceQualifier,
+    TypeResolverLevel,
+    interned_types::{
+        InternedTypeofValue, LocalTypeHandle, LocalTypeId, ModuleKey, TypeData as InferredTypeData,
+    },
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::plumbing::AsId;
@@ -197,6 +200,23 @@ impl<'db> ResolutionCtx<'db, '_> {
             && let Some(ty) = self.resolve_typeof_expression(expression)
         {
             return ty;
+        }
+
+        if let RawTypeData::TypeofValue(value) = raw {
+            let ty = if value.ty.is_unknown() {
+                self.resolve_qualifier(&TypeReferenceQualifier::from_path(
+                    value.scope_id.unwrap_or(ScopeId::GLOBAL),
+                    value.identifier.clone(),
+                ))
+            } else {
+                self.resolve(&value.ty)
+            };
+            return InferredTypeData::TypeofValue(InternedTypeofValue::new(
+                self.db,
+                ty,
+                value.identifier.clone(),
+                value.scope_id,
+            ));
         }
 
         let db = self.db;

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -3,6 +3,7 @@ mod collector;
 mod diagnostics;
 mod module_resolver;
 mod scope;
+pub(crate) use scope::TsBindingReferenceExt;
 mod utils;
 mod visitor;
 

--- a/crates/biome_module_graph/tests/snapshots/test_infer_module_types_merges_mixed_intersections_on_build.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_infer_module_types_merges_mixed_intersections_on_build.snap
@@ -54,13 +54,31 @@ Binding readPrimitive "readPrimitive" => sync Function "readPrimitive" {
   accepts: {
     params: [
       required value: string
+      & Object {
+        prototype: No prototype
+        members: ["value": number]
+      }
     ]
     type_args: []
   }
   returns: string
+  & Object {
+    prototype: No prototype
+    members: ["value": number]
+  }
 }
 
-Binding value "value" => string
+Binding value "value" =>
+  string
+  & Object {
+    prototype: No prototype
+    members: ["value": number]
+  }
 
-Expression "value" => string
+Expression "value" =>
+  string
+  & Object {
+    prototype: No prototype
+    members: ["value": number]
+  }
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_infer_module_types_preserves_floating_promise_shapes.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_infer_module_types_preserves_floating_promise_shapes.snap
@@ -1,0 +1,434 @@
+---
+source: crates/biome_module_graph/tests/spec_tests_v2.rs
+expression: content
+---
+
+# `/src/index.ts`
+
+## Source
+
+```ts
+type Cheating<T extends 1> = T extends 1 ? Promise<string> : Promise<string>;
+
+async function promiseLike(): Cheating<1> {
+	return "value";
+}
+
+const sneakyObject = {
+	get something() {
+		return new Promise((_, reject) => reject("value"));
+	},
+};
+
+function wrapper<F extends (...args: any) => any>(fn: F): F {
+	return fn;
+}
+
+async function doWork(): Promise<void> {}
+
+export const mappedAsync = [1, 2, 3].map(async (value) => value + 1);
+export const mappedPromise = [1, 2, 3].map((value) =>
+	Promise.resolve(value + 1),
+);
+export const conditional = promiseLike();
+export const getter = sneakyObject.something;
+export const wrapped = wrapper(doWork)();
+export const maybeDoWork: typeof doWork | undefined = doWork;
+export const optional = maybeDoWork?.();
+export const globalChain = globalThis.Promise.reject("value").finally();
+
+await new Promise((resolve) => resolve("value"));
+```
+
+## Inferred types
+
+```
+Binding Cheating "Cheating" => instanceof instanceof Promise<string><T extends number: 1>
+
+Binding T "T" => T extends number: 1
+
+Binding promiseLike "promiseLike" => async Function "promiseLike" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Cheating<number: 1>
+}
+
+Expression "\"value\"" => string: value
+
+Binding sneakyObject "sneakyObject" => Object {
+  prototype: No prototype
+  members: [
+    get "something":
+      sync Function "something" {
+        accepts: {
+          params: []
+          type_args: []
+        }
+        returns: instanceof Promise
+      }
+  ]
+}
+
+Expression "{ get something() { return new Promise((_, reject) => reject(\"value\")); }, }" => Object {
+  prototype: No prototype
+  members: [
+    get "something":
+      sync Function "something" {
+        accepts: {
+          params: []
+          type_args: []
+        }
+        returns: instanceof Promise
+      }
+  ]
+}
+
+Expression "new Promise((_, reject) => reject(\"value\"))" => instanceof Promise
+
+Expression "Promise" => class "Promise" {
+  extends: none
+  implements: []
+  type_args: [T]
+}
+
+Expression "(_, reject) => reject(\"value\")" => sync Function {
+  accepts: {
+    params: [
+      required _: unknown
+      required reject: unknown
+    ]
+    type_args: []
+  }
+  returns: unknown
+}
+
+Binding _ "_" => unknown
+
+Binding reject "reject" => unknown
+
+Expression "reject" => unknown
+
+Expression "reject(\"value\")" => unknown
+
+Expression "\"value\"" => string: value
+
+Binding wrapper "wrapper" => sync Function "wrapper" {
+  accepts: {
+    params: [
+      required fn: instanceof F
+    ]
+    type_args: [
+      F extends sync Function {
+        accepts: {
+          params: [
+            required ...args: any
+          ]
+          type_args: []
+        }
+        returns: any
+      }
+    ]
+  }
+  returns: instanceof F
+}
+
+Binding F "F" => F extends sync Function {
+  accepts: {
+    params: [
+      required ...args: any
+    ]
+    type_args: []
+  }
+  returns: any
+}
+
+Binding args "args" => any
+
+Binding fn "fn" => instanceof F
+
+Expression "fn" => instanceof F
+
+Binding doWork "doWork" => async Function "doWork" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise<void>
+}
+
+Binding mappedAsync "mappedAsync" => instanceof Array<instanceof Promise<unknown>>
+
+Expression "[1, 2, 3]" => [number: 1,
+number: 2,
+number: 3]
+
+Expression "[1, 2, 3].map" => sync Function "Array.prototype.map" {
+  accepts: {
+    params: [
+      : sync Function "<U>(item: T) => U" {
+        accepts: {
+          params: [
+            : U
+          ]
+          type_args: []
+        }
+        returns: U
+      }
+    ]
+    type_args: [U]
+  }
+  returns: instanceof Array<U>
+}
+
+Expression "[1, 2, 3].map(async (value) => value + 1)" => instanceof Array<instanceof Promise<unknown>>
+
+Expression "1" => number: 1
+
+Expression "2" => number: 2
+
+Expression "3" => number: 3
+
+Expression "async (value) => value + 1" => async Function {
+  accepts: {
+    params: [
+      required value: unknown
+    ]
+    type_args: []
+  }
+  returns: instanceof Promise<unknown>
+}
+
+Binding value "value" => unknown
+
+Expression "value" => unknown
+
+Expression "value + 1" => unknown
+
+Expression "1" => number: 1
+
+Binding mappedPromise "mappedPromise" => instanceof Array<instanceof Promise>
+
+Expression "[1, 2, 3]" => [number: 1,
+number: 2,
+number: 3]
+
+Expression "[1, 2, 3].map" => sync Function "Array.prototype.map" {
+  accepts: {
+    params: [
+      : sync Function "<U>(item: T) => U" {
+        accepts: {
+          params: [
+            : U
+          ]
+          type_args: []
+        }
+        returns: U
+      }
+    ]
+    type_args: [U]
+  }
+  returns: instanceof Array<U>
+}
+
+Expression "[1, 2, 3].map((value) => Promise.resolve(value + 1))" => instanceof Array<instanceof Promise>
+
+Expression "1" => number: 1
+
+Expression "2" => number: 2
+
+Expression "3" => number: 3
+
+Expression "(value) => Promise.resolve(value + 1)" => sync Function {
+  accepts: {
+    params: [
+      required value: unknown
+    ]
+    type_args: []
+  }
+  returns: instanceof Promise
+}
+
+Binding value "value" => unknown
+
+Expression "Promise" => class "Promise" {
+  extends: none
+  implements: []
+  type_args: [T]
+}
+
+Expression "Promise.resolve" => sync Function "Promise.resolve" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise
+}
+
+Expression "Promise.resolve(value + 1)" => instanceof Promise
+
+Expression "value" => unknown
+
+Expression "value + 1" => unknown
+
+Expression "1" => number: 1
+
+Binding conditional "conditional" => instanceof Cheating<number: 1>
+
+Expression "promiseLike" => async Function "promiseLike" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Cheating<number: 1>
+}
+
+Expression "promiseLike()" => instanceof Cheating<number: 1>
+
+Binding getter "getter" => instanceof Promise
+
+Expression "sneakyObject" => Object {
+  prototype: No prototype
+  members: [
+    get "something":
+      sync Function "something" {
+        accepts: {
+          params: []
+          type_args: []
+        }
+        returns: instanceof Promise
+      }
+  ]
+}
+
+Expression "sneakyObject.something" => instanceof Promise
+
+Binding wrapped "wrapped" => instanceof Promise<void>
+
+Expression "wrapper" => sync Function "wrapper" {
+  accepts: {
+    params: [
+      required fn: instanceof F
+    ]
+    type_args: [
+      F extends sync Function {
+        accepts: {
+          params: [
+            required ...args: any
+          ]
+          type_args: []
+        }
+        returns: any
+      }
+    ]
+  }
+  returns: instanceof F
+}
+
+Expression "wrapper(doWork)" => async Function "doWork" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise<void>
+}
+
+Expression "wrapper(doWork)()" => instanceof Promise<void>
+
+Expression "doWork" => async Function "doWork" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise<void>
+}
+
+Binding maybeDoWork "maybeDoWork" => instanceof typeof async Function "doWork" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise<void>
+} | undefined
+
+Expression "doWork" => async Function "doWork" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise<void>
+}
+
+Binding optional "optional" => instanceof Promise<void> | undefined
+
+Expression "maybeDoWork" => instanceof typeof async Function "doWork" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise<void>
+} | undefined
+
+Expression "maybeDoWork?.()" => instanceof Promise<void> | undefined
+
+Binding globalChain "globalChain" => instanceof Promise
+
+Expression "globalThis" => globalThis
+
+Expression "globalThis.Promise" => class "Promise" {
+  extends: none
+  implements: []
+  type_args: [T]
+}
+
+Expression "globalThis.Promise.reject" => sync Function "Promise.reject" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise
+}
+
+Expression "globalThis.Promise.reject(\"value\")" => instanceof Promise
+
+Expression "globalThis.Promise.reject(\"value\").finally" => sync Function {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise
+}
+
+Expression "globalThis.Promise.reject(\"value\").finally()" => instanceof Promise
+
+Expression "\"value\"" => string: value
+
+Expression "await new Promise((resolve) => resolve(\"value\"))" => unknown
+
+Expression "new Promise((resolve) => resolve(\"value\"))" => instanceof Promise
+
+Expression "Promise" => class "Promise" {
+  extends: none
+  implements: []
+  type_args: [T]
+}
+
+Expression "(resolve) => resolve(\"value\")" => sync Function {
+  accepts: {
+    params: [
+      required resolve: unknown
+    ]
+    type_args: []
+  }
+  returns: unknown
+}
+
+Binding resolve "resolve" => unknown
+
+Expression "resolve" => unknown
+
+Expression "resolve(\"value\")" => unknown
+
+Expression "\"value\"" => string: value
+```

--- a/crates/biome_module_graph/tests/snapshots/test_infer_module_types_resolves_promise_member_chain.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_infer_module_types_resolves_promise_member_chain.snap
@@ -1,0 +1,110 @@
+---
+source: crates/biome_module_graph/tests/spec_tests_v2.rs
+expression: content
+---
+
+# `/src/index.ts`
+
+## Source
+
+```ts
+export class Parent {
+	async returnsPromise(): Promise<string> {
+		return "value";
+	}
+}
+
+export class Child extends Parent {}
+
+export const direct = new Child().returnsPromise();
+export const then = direct.then(() => {});
+export const finalResult = then.finally(() => {});
+```
+
+## Inferred types
+
+```
+Binding Parent "Parent" => class "Parent" {
+  extends: none
+  implements: []
+  type_args: []
+}
+
+Expression "\"value\"" => string: value
+
+Binding Child "Child" => class "Child" {
+  extends: Parent
+  implements: []
+  type_args: []
+}
+
+Expression "Parent" => class "Parent" {
+  extends: none
+  implements: []
+  type_args: []
+}
+
+Binding direct "direct" => instanceof Promise<string>
+
+Expression "new Child()" => instanceof Child
+
+Expression "new Child().returnsPromise" => async Function "returnsPromise" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise<string>
+}
+
+Expression "new Child().returnsPromise()" => instanceof Promise<string>
+
+Expression "Child" => class "Child" {
+  extends: Parent
+  implements: []
+  type_args: []
+}
+
+Binding then "then" => instanceof Promise
+
+Expression "direct" => instanceof Promise<string>
+
+Expression "direct.then" => sync Function {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise
+}
+
+Expression "direct.then(() => {})" => instanceof Promise
+
+Expression "() => {}" => sync Function {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: void
+}
+
+Binding finalResult "finalResult" => instanceof Promise
+
+Expression "then" => instanceof Promise
+
+Expression "then.finally" => sync Function {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise
+}
+
+Expression "then.finally(() => {})" => instanceof Promise
+
+Expression "() => {}" => sync Function {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: void
+}
+```

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -10,7 +10,7 @@ use biome_js_formatter::context::JsFormatOptions;
 use biome_js_formatter::format_node;
 use biome_js_parser::{JsParserOptions, parse};
 use biome_js_type_info::{
-    format_inferred_type,
+    InferredType, format_inferred_type,
     interned_types::{
         FunctionParameter as InferredFunctionParameter, InternedInterface as InferredInterface,
         InternedMergedReference as InferredMergedReference, InternedUnion as InferredUnion,
@@ -40,6 +40,118 @@ struct TestModuleDb {
     modules: BTreeMap<Utf8PathBuf, ModuleInfo>,
     events: Events,
     storage: Storage<Self>,
+}
+
+#[test]
+fn test_infer_module_types_poison_unresolved_union_variants() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            type Failed = "known" | MissingType;
+            type Explicit = "known" | unknown;
+
+            export function failed(value: Failed): Failed { return value; }
+            export function explicit(value: Explicit): Explicit { return value; }
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+
+    let failed = inferred_function_return_ty_by_name(&db, module, &inferred, "failed")
+        .expect("failed return type must be inferred");
+    let failed = normalize_type(&db, module, failed);
+    assert_eq!(failed, InferredTypeData::Unknown);
+    assert!(!InferredType::new(&db, failed).is_inferred());
+
+    let explicit = inferred_function_return_ty_by_name(&db, module, &inferred, "explicit")
+        .expect("explicit return type must be inferred");
+    let explicit = normalize_type(&db, module, explicit);
+    assert_ne!(explicit, InferredTypeData::Unknown);
+    assert!(InferredType::new(&db, explicit).is_inferred());
+}
+
+#[test]
+fn test_infer_module_types_resolves_shorthand_value_members() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            const job = () => Promise.resolve("done");
+            const api = { job };
+            export const result = api.job();
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+    let result = inferred_binding_ty_by_name(&db, module, &inferred, "result")
+        .expect("result type must be inferred");
+    let result = normalize_type(&db, module, result);
+    assert!(is_inferred_promise_instance(&db, result));
+}
+
+#[test]
+fn test_infer_module_types_resolves_local_multisegment_qualifiers() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            namespace Outer {
+                export namespace Inner {
+                    export interface Value { field: string; }
+                }
+            }
+
+            declare const value: Outer.Inner.Value;
+            export const result = value.field;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+    let result = inferred_binding_ty_by_name(&db, module, &inferred, "result")
+        .expect("result type must be inferred");
+    assert!(is_inferred_string(&db, normalize_type(&db, module, result)));
+}
+
+#[test]
+fn test_namespace_import_preserves_members_above_export_step_limit() {
+    let fs = MemoryFileSystem::default();
+    let exports = (0..1025)
+        .map(|index| format!("export const member{index} = {index};\n"))
+        .collect::<String>();
+    fs.insert("/src/source.ts".into(), exports);
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import * as source from "./source";
+            export const first = source.member0;
+            export const last = source.member1024;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/source.ts", "/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+
+    for name in ["first", "last"] {
+        let ty = inferred_binding_ty_by_name(&db, module, &inferred, name)
+            .expect("namespace member type must be inferred");
+        assert!(is_inferred_number(&db, normalize_type(&db, module, ty)));
+    }
 }
 
 impl TestModuleDb {
@@ -133,6 +245,29 @@ fn is_inferred_boolean<'db>(db: &'db dyn ModuleDb, ty: InferredTypeData<'db>) ->
     ty == InferredTypeData::Boolean
         || is_inferred_instance_of(db, ty, InferredTypeData::Boolean)
         || matches!(ty, InferredTypeData::Literal(literal) if matches!(literal.literal(db), InferredLiteral::Boolean(_)))
+}
+
+fn is_inferred_array_of_promises<'db>(db: &'db dyn ModuleDb, ty: InferredTypeData<'db>) -> bool {
+    let InferredTypeData::InstanceOf(instance) = ty else {
+        return false;
+    };
+
+    instance.ty(db).is_array_class(db)
+        && instance
+            .type_parameters(db)
+            .first()
+            .is_some_and(|ty| is_inferred_promise_instance(db, *ty))
+}
+
+fn is_inferred_promise_instance<'db>(db: &'db dyn ModuleDb, mut ty: InferredTypeData<'db>) -> bool {
+    while let InferredTypeData::InstanceOf(instance) = ty {
+        ty = instance.ty(db);
+        if ty.is_promise_class(db) {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn is_inferred_string_literal<'db>(
@@ -1627,6 +1762,7 @@ fn test_infer_module_types_uses_local_handle_for_recursive_class_type() {
 
     assert_eq!(local.module(&db), inferred.module_key);
     assert_eq!(local.type_id(&db).index(), class_index);
+    assert!(!InferredType::new(&db, InferredTypeData::Local(local)).is_inferred());
 
     let name_ty = inferred
         .find_member_type(&db, return_ty, "name")
@@ -2952,6 +3088,162 @@ fn test_infer_module_types_infers_new_expression_nested_generic_instances_on_bui
 
     assert_inferred_type_snapshot(
         "test_infer_module_types_infers_new_expression_nested_generic_instances_on_build",
+        &db,
+        &fs,
+    );
+}
+
+#[test]
+fn test_infer_module_types_resolves_promise_member_chain() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            export class Parent {
+                async returnsPromise(): Promise<string> {
+                    return "value";
+                }
+            }
+
+            export class Child extends Parent {}
+
+            export const direct = new Child().returnsPromise();
+            export const then = direct.then(() => {});
+            export const finalResult = then.finally(() => {});
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, index_module).expect("types must be inferred");
+
+    for name in ["direct", "then", "finalResult"] {
+        let ty = inferred_binding_ty_by_name(&db, index_module, &inferred, name)
+            .expect("binding type must be inferred");
+        let ty = inferred.resolve_type(&db, ty);
+        assert!(
+            is_inferred_promise_instance(&db, ty),
+            "{name} must be a Promise, got {}",
+            format_inferred_type(&db, ty)
+        );
+    }
+
+    assert_inferred_type_snapshot(
+        "test_infer_module_types_resolves_promise_member_chain",
+        &db,
+        &fs,
+    );
+}
+
+#[test]
+fn test_infer_module_types_preserves_floating_promise_shapes() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            type Cheating<T extends 1> = T extends 1 ? Promise<string> : Promise<string>;
+
+            async function promiseLike(): Cheating<1> {
+                return "value";
+            }
+
+            const sneakyObject = {
+                get something() {
+                    return new Promise((_, reject) => reject("value"));
+                },
+            };
+
+            function wrapper<F extends (...args: any) => any>(fn: F): F {
+                return fn;
+            }
+
+            async function doWork(): Promise<void> {}
+
+            export const mappedAsync = [1, 2, 3].map(async (value) => value + 1);
+            export const mappedPromise = [1, 2, 3].map((value) => Promise.resolve(value + 1));
+            export const conditional = promiseLike();
+            export const getter = sneakyObject.something;
+            export const wrapped = wrapper(doWork)();
+            export const maybeDoWork: typeof doWork | undefined = doWork;
+            export const optional = maybeDoWork?.();
+            export const globalChain = globalThis.Promise.reject("value").finally();
+
+            await new Promise((resolve) => resolve("value"));
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, index_module).expect("types must be inferred");
+
+    for name in ["mappedAsync", "mappedPromise"] {
+        let ty = inferred_binding_ty_by_name(&db, index_module, &inferred, name)
+            .expect("array binding type must be inferred");
+        let ty = normalize_type(&db, index_module, ty);
+        assert!(
+            is_inferred_array_of_promises(&db, ty),
+            "{name} must be an array of Promises, got {}",
+            format_inferred_type(&db, ty)
+        );
+    }
+
+    for name in ["conditional", "getter", "wrapped", "globalChain"] {
+        let ty = inferred_binding_ty_by_name(&db, index_module, &inferred, name)
+            .expect("Promise binding type must be inferred");
+        let ty = normalize_type(&db, index_module, ty);
+        assert!(
+            is_inferred_promise_instance(&db, ty),
+            "{name} must be a Promise, got {}",
+            format_inferred_type(&db, ty)
+        );
+    }
+
+    let optional = inferred_binding_ty_by_name(&db, index_module, &inferred, "optional")
+        .expect("optional binding type must be inferred");
+    let optional = normalize_type(&db, index_module, optional);
+    let InferredTypeData::Union(optional) = optional else {
+        panic!("optional call must preserve a Promise | undefined union, got {optional:?}");
+    };
+    assert!(
+        optional
+            .types(&db)
+            .iter()
+            .any(|ty| is_inferred_promise_instance(&db, *ty))
+    );
+    assert!(optional.types(&db).contains(&InferredTypeData::Undefined));
+
+    let maybe_do_work = inferred_binding_ty_by_name(&db, index_module, &inferred, "maybeDoWork")
+        .expect("maybeDoWork binding type must be inferred");
+    let optional_call = infer_call_expression_type(
+        &db,
+        index_module,
+        inferred.resolve_type(&db, maybe_do_work),
+        Vec::new(),
+    );
+    let InferredTypeData::Union(optional_call) = optional_call else {
+        panic!(
+            "optional call query must preserve Promise | undefined, got {}",
+            format_inferred_type(&db, optional_call)
+        );
+    };
+    assert!(
+        optional_call
+            .types(&db)
+            .iter()
+            .any(|ty| is_inferred_promise_instance(&db, *ty))
+    );
+    assert!(
+        optional_call
+            .types(&db)
+            .contains(&InferredTypeData::Undefined)
+    );
+
+    assert_inferred_type_snapshot(
+        "test_infer_module_types_preserves_floating_promise_shapes",
         &db,
         &fs,
     );
@@ -4944,7 +5236,16 @@ fn test_infer_module_types_merges_mixed_intersections_on_build() {
     let primitive_ty =
         inferred_function_return_ty_by_name(&db, index_module, &inferred, "readPrimitive")
             .expect("readPrimitive return type must be inferred");
-    assert_eq!(primitive_ty, InferredTypeData::String);
+    let InferredTypeData::Intersection(primitive) = primitive_ty else {
+        panic!("readPrimitive must preserve its branded intersection, got {primitive_ty:?}");
+    };
+    assert!(primitive.types(&db).contains(&InferredTypeData::String));
+    assert!(
+        primitive
+            .types(&db)
+            .iter()
+            .any(|ty| matches!(ty, InferredTypeData::Object(_)))
+    );
 
     assert_inferred_type_snapshot(
         "test_infer_module_types_merges_mixed_intersections_on_build",


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Harden the Salsa-backed type-inference layer before migrating type-aware lint rules in the following PRs.

This introduces `InferredType` as a query API over interned Salsa types and adds normalised inference queries to `TypedService` for expressions, bindings, function and member return types, callable members, and call arguments. It also fixes resolution and normalisation gaps involving Promise chains, optional calls, tuples, unions, qualified names, computed well-known symbols, getter members, namespace exports, and branded primitive intersections.

## Test Plan

Added module-graph regression tests for unresolved unions, shorthand members, multi-segment qualifiers, large namespace exports, Promise member chains, floating Promise shapes, optional calls, and branded intersections. Updated the affected inference snapshots.


## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

> This PR was created with AI assistance (OpenCode).