### PR TITLE
refactor(lint): port direct type-aware rules

### DIFF
--- a/.changeset/soft-games-sort.md
+++ b/.changeset/soft-games-sort.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [`useArrayFind`](https://biomejs.dev/linter/rules/use-array-find/) to recognize bigint zero indexes.

--- a/crates/biome_js_analyze/src/lint/complexity/use_array_find.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_array_find.rs
@@ -46,8 +46,8 @@ declare_lint_rule! {
 }
 
 fn is_first_position(ctx: &RuleContext<UseArrayFind>, express: &AnyJsExpression) -> bool {
-    ctx.type_of_expression(express).is_number_literal(0.)
-        || ctx.type_of_expression(express).is_bigint_literal(0)
+    ctx.inferred_type_of_expression(express)
+        .is_some_and(|ty| ty.is_number_literal(0.) || ty.is_bigint_literal(0))
 }
 
 impl Rule for UseArrayFind {

--- a/crates/biome_js_analyze/src/lint/nursery/no_unsafe_plus_operands.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unsafe_plus_operands.rs
@@ -1,15 +1,13 @@
-use std::io;
-
 use crate::services::typed::Typed;
 use biome_analyze::{
     Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext, declare_lint_rule,
 };
-use biome_console::{fmt, markup};
+use biome_console::markup;
 use biome_js_syntax::{
     AnyJsAssignment, AnyJsAssignmentPattern, AnyJsExpression, JsAssignmentExpression,
     JsAssignmentOperator, JsBinaryExpression, JsBinaryOperator, JsParenthesizedExpression,
 };
-use biome_js_type_info::{Literal, Type, TypeData};
+use biome_js_type_info::InferredType;
 use biome_rowan::{AstNode, TextRange, declare_node_union};
 use biome_rule_options::no_unsafe_plus_operands::NoUnsafePlusOperandsOptions;
 
@@ -80,9 +78,9 @@ pub enum NoUnsafePlusOperandsState {
     },
 }
 
-struct OperandInfo {
+struct OperandInfo<'db> {
     range: TextRange,
-    ty: Type,
+    ty: InferredType<'db>,
 }
 
 impl Rule for NoUnsafePlusOperands {
@@ -107,14 +105,14 @@ impl Rule for NoUnsafePlusOperands {
 
         match state {
             NoUnsafePlusOperandsState::InvalidOperand { range } => {
-                let ty = type_for_range(ctx, *range)?;
+                let ty = type_for_range(ctx, *range)?.plus_operand_description();
 
                 Some(
                 RuleDiagnostic::new(
                     rule_category!(),
                     range,
                     markup! {
-                        "Invalid operand for a "<Emphasis>"+"</Emphasis>" operation: "<Emphasis>{TypeDescription(&ty)}</Emphasis>"."
+                        "Invalid operand for a "<Emphasis>"+"</Emphasis>" operation: "<Emphasis>{ty}</Emphasis>"."
                     },
                 )
                 .detail(node.range(), markup! {
@@ -130,8 +128,8 @@ impl Rule for NoUnsafePlusOperands {
                 left_range,
                 right_range,
             } => {
-                let left = type_for_range(ctx, *left_range)?;
-                let right = type_for_range(ctx, *right_range)?;
+                let left = type_for_range(ctx, *left_range)?.plus_operand_description();
+                let right = type_for_range(ctx, *right_range)?.plus_operand_description();
 
                 Some(
                 RuleDiagnostic::new(
@@ -142,7 +140,7 @@ impl Rule for NoUnsafePlusOperands {
                     },
                 )
                 .detail(range, markup! {
-                    "This operation mixes "<Emphasis>{TypeDescription(&left)}</Emphasis>" with "<Emphasis>{TypeDescription(&right)}</Emphasis>"."
+                    "This operation mixes "<Emphasis>{left}</Emphasis>" with "<Emphasis>{right}</Emphasis>"."
                 })
                 .note(markup! {
                     "Convert one side so both operands use the same numeric type before applying "<Emphasis>"+"</Emphasis>" or "<Emphasis>"+="</Emphasis>"."
@@ -179,7 +177,7 @@ fn run_assignment(
     let right = assignment.right().ok()?;
     let left_ty = type_of_assignment_target(ctx, assignment, &left)?;
 
-    let right_ty = ctx.type_of_expression(&right);
+    let right_ty = ctx.inferred_type_of_expression(&right)?;
 
     let left = OperandInfo {
         range: left.range(),
@@ -193,11 +191,11 @@ fn run_assignment(
     Some(analyze_pair(assignment.range(), &left, &right))
 }
 
-fn type_of_assignment_target(
-    ctx: &RuleContext<NoUnsafePlusOperands>,
+fn type_of_assignment_target<'a>(
+    ctx: &'a RuleContext<NoUnsafePlusOperands>,
     assignment: &JsAssignmentExpression,
     left: &AnyJsAssignmentPattern,
-) -> Option<Type> {
+) -> Option<InferredType<'a>> {
     match left {
         AnyJsAssignmentPattern::AnyJsAssignment(assignment_target) => {
             type_of_assignment(ctx, assignment, assignment_target)
@@ -207,15 +205,15 @@ fn type_of_assignment_target(
     }
 }
 
-fn type_of_assignment(
-    ctx: &RuleContext<NoUnsafePlusOperands>,
+fn type_of_assignment<'a>(
+    ctx: &'a RuleContext<NoUnsafePlusOperands>,
     assignment: &JsAssignmentExpression,
     target: &AnyJsAssignment,
-) -> Option<Type> {
+) -> Option<InferredType<'a>> {
     match target {
         AnyJsAssignment::JsIdentifierAssignment(identifier) => {
             let name = identifier.name_token().ok()?;
-            Some(ctx.type_of_named_value(assignment.range(), name.text_trimmed()))
+            ctx.inferred_type_of_named_value(assignment.range(), name.text_trimmed())
         }
         AnyJsAssignment::JsParenthesizedAssignment(parenthesized) => {
             type_of_assignment(ctx, assignment, &parenthesized.assignment().ok()?)
@@ -245,159 +243,6 @@ fn has_parent_plus_expression(node: &JsBinaryExpression) -> bool {
         .find(|ancestor| !JsParenthesizedExpression::can_cast(ancestor.kind()))
         .and_then(JsBinaryExpression::cast)
         .is_some_and(|parent| parent.operator() == Ok(JsBinaryOperator::Plus))
-}
-
-fn has_invalid_variant(ty: &Type) -> bool {
-    if ty.is_union() {
-        ty.flattened_union_variants()
-            .any(|variant| is_invalid_variant(&variant))
-    } else {
-        is_invalid_variant(ty)
-    }
-}
-
-fn is_invalid_variant(ty: &Type) -> bool {
-    let Some(data) = ty.resolved_data().map(|resolved| resolved.as_raw_data()) else {
-        return true;
-    };
-
-    match data {
-        TypeData::NeverKeyword | TypeData::Symbol | TypeData::UnknownKeyword => true,
-        TypeData::Literal(literal) => matches!(literal.as_ref(), Literal::Object(_)),
-        TypeData::Reference(reference) => ty
-            .resolve(reference)
-            .is_some_and(|resolved| is_invalid_variant(&resolved)),
-        TypeData::Intersection(intersection) => intersection.types().iter().all(|reference| {
-            ty.resolve(reference)
-                .is_some_and(|ty| is_object_like_variant(&ty))
-        }),
-        _ => is_object_like_variant(ty),
-    }
-}
-
-fn is_object_like_variant(ty: &Type) -> bool {
-    let Some(data) = ty.resolved_data().map(|resolved| resolved.as_raw_data()) else {
-        return true;
-    };
-
-    match data {
-        TypeData::Class(_)
-        | TypeData::Constructor(_)
-        | TypeData::Function(_)
-        | TypeData::Interface(_)
-        | TypeData::Module(_)
-        | TypeData::Namespace(_)
-        | TypeData::Object(_)
-        | TypeData::ObjectKeyword
-        | TypeData::Tuple(_) => true,
-        TypeData::Reference(reference) => ty
-            .resolve(reference)
-            .is_some_and(|resolved| is_object_like_variant(&resolved)),
-        TypeData::InstanceOf(instance) => ty
-            .resolve(&instance.ty)
-            .is_some_and(|resolved| is_object_like_variant(&resolved)),
-        _ => false,
-    }
-}
-
-fn has_number_like(ty: &Type) -> bool {
-    ty.is_number_or_number_literal()
-        || ty.has_variant(|variant| variant.is_number_or_number_literal())
-}
-
-fn has_bigint_like(ty: &Type) -> bool {
-    is_bigint_like(ty) || ty.has_variant(|variant| is_bigint_like(&variant))
-}
-
-fn is_bigint_like(ty: &Type) -> bool {
-    match ty.resolved_data().map(|resolved| resolved.as_raw_data()) {
-        Some(TypeData::BigInt) => true,
-        Some(TypeData::Literal(literal)) => matches!(literal.as_ref(), Literal::BigInt(_)),
-        _ => false,
-    }
-}
-
-struct TypeDescription<'a>(&'a Type);
-
-impl fmt::Display for TypeDescription<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> io::Result<()> {
-        self.write_type(self.0, fmt)
-    }
-}
-
-impl TypeDescription<'_> {
-    fn write_type(&self, ty: &Type, fmt: &mut fmt::Formatter) -> io::Result<()> {
-        if ty.is_union() {
-            let mut variants = ty.flattened_union_variants();
-            let Some(first) = variants.next() else {
-                return fmt.write_str("unknown");
-            };
-
-            self.write_variant(&first, fmt)?;
-            for variant in variants {
-                fmt.write_str(" | ")?;
-                self.write_variant(&variant, fmt)?;
-            }
-            return Ok(());
-        }
-
-        self.write_variant(ty, fmt)
-    }
-
-    fn write_variant(&self, ty: &Type, fmt: &mut fmt::Formatter) -> io::Result<()> {
-        let Some(data) = ty.resolved_data().map(|resolved| resolved.as_raw_data()) else {
-            return fmt.write_str("unknown");
-        };
-
-        match data {
-            TypeData::Unknown | TypeData::UnknownKeyword => fmt.write_str("unknown"),
-            TypeData::AnyKeyword => fmt.write_str("any"),
-            TypeData::NeverKeyword => fmt.write_str("never"),
-            TypeData::Null => fmt.write_str("null"),
-            TypeData::Undefined => fmt.write_str("undefined"),
-            TypeData::Boolean => fmt.write_str("boolean"),
-            TypeData::Number => fmt.write_str("number"),
-            TypeData::String => fmt.write_str("string"),
-            TypeData::BigInt => fmt.write_str("bigint"),
-            TypeData::Symbol => fmt.write_str("symbol"),
-            TypeData::ObjectKeyword | TypeData::Object(_) => fmt.write_str("object"),
-            TypeData::Interface(_) => fmt.write_str("interface"),
-            TypeData::Class(_) => fmt.write_str("class"),
-            TypeData::Function(_) => fmt.write_str("function"),
-            TypeData::Tuple(_) => fmt.write_str("tuple"),
-            TypeData::Module(_) | TypeData::Namespace(_) => fmt.write_str("namespace"),
-            TypeData::Constructor(_) => fmt.write_str("constructor"),
-            TypeData::InstanceOf(instance) => match ty.resolve(&instance.ty) {
-                Some(resolved) => self.write_variant(&resolved, fmt),
-                None => fmt.write_str("object"),
-            },
-            TypeData::Intersection(intersection) => {
-                let mut resolved = intersection
-                    .types()
-                    .iter()
-                    .filter_map(|reference| ty.resolve(reference));
-                let Some(first) = resolved.next() else {
-                    return fmt.write_str("intersection");
-                };
-
-                self.write_variant(&first, fmt)?;
-                for ty in resolved {
-                    fmt.write_str(" & ")?;
-                    self.write_variant(&ty, fmt)?;
-                }
-                Ok(())
-            }
-            TypeData::Literal(literal) => match literal.as_ref() {
-                Literal::BigInt(_) => fmt.write_str("bigint"),
-                Literal::Boolean(_) => fmt.write_str("boolean"),
-                Literal::Number(_) => fmt.write_str("number"),
-                Literal::String(_) | Literal::Template(_) => fmt.write_str("string"),
-                Literal::Object(_) => fmt.write_str("object"),
-                Literal::RegExp(_) => fmt.write_str("RegExp"),
-            },
-            _ => fmt.write_fmt(format_args!("{ty}")),
-        }
-    }
 }
 
 fn analyze_binary_operands(
@@ -457,19 +302,19 @@ fn analyze_expression(
 
     let operand = OperandInfo {
         range: expression.range(),
-        ty: ctx.type_of_expression(&expression),
+        ty: ctx.inferred_type_of_expression(&expression)?,
     };
 
-    if has_invalid_variant(&operand.ty) {
+    if operand.ty.has_invalid_plus_operand_variant() {
         return Some(Some(NoUnsafePlusOperandsState::InvalidOperand {
             range: operand.range,
         }));
     }
 
-    if has_number_like(&operand.ty) {
+    if operand.ty.has_number_like_variant() {
         first_number_range.get_or_insert(operand.range);
     }
-    if has_bigint_like(&operand.ty) {
+    if operand.ty.has_bigint_like_variant() {
         first_bigint_range.get_or_insert(operand.range);
     }
 
@@ -481,16 +326,16 @@ fn analyze_pair(
     left: &OperandInfo,
     right: &OperandInfo,
 ) -> Option<NoUnsafePlusOperandsState> {
-    if has_invalid_variant(&left.ty) {
+    if left.ty.has_invalid_plus_operand_variant() {
         return Some(NoUnsafePlusOperandsState::InvalidOperand { range: left.range });
     }
 
-    if has_invalid_variant(&right.ty) {
+    if right.ty.has_invalid_plus_operand_variant() {
         return Some(NoUnsafePlusOperandsState::InvalidOperand { range: right.range });
     }
 
-    if (has_number_like(&left.ty) && has_bigint_like(&right.ty))
-        || (has_bigint_like(&left.ty) && has_number_like(&right.ty))
+    if (left.ty.has_number_like_variant() && right.ty.has_bigint_like_variant())
+        || (left.ty.has_bigint_like_variant() && right.ty.has_number_like_variant())
     {
         return Some(NoUnsafePlusOperandsState::MixedBigIntAndNumber {
             range,
@@ -502,7 +347,10 @@ fn analyze_pair(
     None
 }
 
-fn type_for_range(ctx: &RuleContext<NoUnsafePlusOperands>, range: TextRange) -> Option<Type> {
+fn type_for_range<'a>(
+    ctx: &'a RuleContext<NoUnsafePlusOperands>,
+    range: TextRange,
+) -> Option<InferredType<'a>> {
     match ctx.query() {
         NoUnsafePlusOperandsQuery::JsBinaryExpression(binary) => {
             type_for_range_in_binary(ctx, binary, range)
@@ -513,24 +361,24 @@ fn type_for_range(ctx: &RuleContext<NoUnsafePlusOperands>, range: TextRange) -> 
     }
 }
 
-fn type_for_range_in_binary(
-    ctx: &RuleContext<NoUnsafePlusOperands>,
+fn type_for_range_in_binary<'a>(
+    ctx: &'a RuleContext<NoUnsafePlusOperands>,
     binary: &JsBinaryExpression,
     range: TextRange,
-) -> Option<Type> {
+) -> Option<InferredType<'a>> {
     type_for_range_in_expression(ctx, binary.left().ok()?, range)
         .or_else(|| type_for_range_in_expression(ctx, binary.right().ok()?, range))
 }
 
-fn type_for_range_in_expression(
-    ctx: &RuleContext<NoUnsafePlusOperands>,
+fn type_for_range_in_expression<'a>(
+    ctx: &'a RuleContext<NoUnsafePlusOperands>,
     expression: AnyJsExpression,
     range: TextRange,
-) -> Option<Type> {
+) -> Option<InferredType<'a>> {
     let expression = expression.omit_parentheses();
 
     if expression.range() == range {
-        return Some(ctx.type_of_expression(&expression));
+        return ctx.inferred_type_of_expression(&expression);
     }
 
     if let AnyJsExpression::JsBinaryExpression(binary) = &expression
@@ -543,11 +391,11 @@ fn type_for_range_in_expression(
     None
 }
 
-fn type_for_range_in_assignment(
-    ctx: &RuleContext<NoUnsafePlusOperands>,
+fn type_for_range_in_assignment<'a>(
+    ctx: &'a RuleContext<NoUnsafePlusOperands>,
     assignment: &JsAssignmentExpression,
     range: TextRange,
-) -> Option<Type> {
+) -> Option<InferredType<'a>> {
     let left = assignment.left().ok()?;
     let right = assignment.right().ok()?;
 
@@ -556,7 +404,7 @@ fn type_for_range_in_assignment(
     }
 
     if right.range() == range {
-        return Some(ctx.type_of_expression(&right));
+        return ctx.inferred_type_of_expression(&right);
     }
 
     None

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_type_conversion.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_type_conversion.rs
@@ -8,7 +8,7 @@ use biome_js_syntax::{
     JsAssignmentOperator, JsBinaryExpression, JsBinaryOperator, JsCallExpression,
     JsUnaryExpression, JsUnaryOperator, global_identifier,
 };
-use biome_js_type_info::{Literal, ResolvedTypeData, Type, TypeData};
+use biome_js_type_info::InferredType;
 use biome_rowan::{AstNode, AstNodeList, AstSeparatedList, TextRange, declare_node_union};
 use biome_rule_options::no_useless_type_conversion::NoUselessTypeConversionOptions;
 
@@ -242,9 +242,9 @@ fn run_builtin_call(
 
     let first_argument = arguments.first()?.ok()?;
     let argument = first_argument.as_any_js_expression()?;
-    let ty = ctx.type_of_expression(argument);
+    let ty = ctx.inferred_type_of_expression(argument)?;
 
-    matches_primitive_type(&ty, primitive).then_some(RuleState {
+    matches_primitive_type(ty, primitive).then_some(RuleState {
         kind: ConversionKind::BuiltinCall,
         primitive,
         range: callee.range(),
@@ -281,9 +281,9 @@ fn run_to_string_call(
     }
 
     let object = member_expression.object().ok()?;
-    let ty = ctx.type_of_expression(&object);
+    let ty = ctx.inferred_type_of_expression(&object)?;
 
-    matches_primitive_type(&ty, PrimitiveKind::String).then_some(RuleState {
+    matches_primitive_type(ty, PrimitiveKind::String).then_some(RuleState {
         kind: ConversionKind::ToString,
         primitive: PrimitiveKind::String,
         range: member.range(),
@@ -325,8 +325,8 @@ fn run_binary_expression(
         return None;
     };
 
-    let ty = ctx.type_of_expression(&expression);
-    matches_primitive_type(&ty, PrimitiveKind::String).then_some(RuleState {
+    let ty = ctx.inferred_type_of_expression(&expression)?;
+    matches_primitive_type(ty, PrimitiveKind::String).then_some(RuleState {
         kind: ConversionKind::StringConcatenation,
         primitive: PrimitiveKind::String,
         range: node.range(),
@@ -366,12 +366,12 @@ fn run_assignment_expression(
             // `type_of_expression()` works on expressions, but the left-hand side
             // of `+=` is an assignment target. Resolve the named value instead so
             // we can ask for the variable's current type.
-            ctx.type_of_named_value(node.range(), name.text_trimmed())
+            ctx.inferred_type_of_named_value(node.range(), name.text_trimmed())?
         }
         _ => return None,
     };
 
-    matches_primitive_type(&ty, PrimitiveKind::String).then_some(RuleState {
+    matches_primitive_type(ty, PrimitiveKind::String).then_some(RuleState {
         kind: ConversionKind::StringAssignment,
         primitive: PrimitiveKind::String,
         range: node.range(),
@@ -405,8 +405,8 @@ fn run_unary_expression(
 
     match node.operator().ok()? {
         JsUnaryOperator::Plus => {
-            let ty = ctx.type_of_expression(&argument);
-            matches_primitive_type(&ty, PrimitiveKind::Number).then_some(RuleState {
+            let ty = ctx.inferred_type_of_expression(&argument)?;
+            matches_primitive_type(ty, PrimitiveKind::Number).then_some(RuleState {
                 kind: ConversionKind::UnaryPlus,
                 primitive: PrimitiveKind::Number,
                 range: node.range(),
@@ -419,8 +419,8 @@ fn run_unary_expression(
             }
 
             let nested_argument = nested.argument().ok()?;
-            let ty = ctx.type_of_expression(&nested_argument);
-            matches_primitive_type(&ty, PrimitiveKind::Boolean).then_some(RuleState {
+            let ty = ctx.inferred_type_of_expression(&nested_argument)?;
+            matches_primitive_type(ty, PrimitiveKind::Boolean).then_some(RuleState {
                 kind: ConversionKind::DoubleNegation,
                 primitive: PrimitiveKind::Boolean,
                 range: node.range(),
@@ -433,10 +433,10 @@ fn run_unary_expression(
             }
 
             let nested_argument = nested.argument().ok()?;
-            let ty = ctx.type_of_expression(&nested_argument);
-            let primitive = if matches_primitive_type(&ty, PrimitiveKind::BigInt) {
+            let ty = ctx.inferred_type_of_expression(&nested_argument)?;
+            let primitive = if matches_primitive_type(ty, PrimitiveKind::BigInt) {
                 PrimitiveKind::BigInt
-            } else if is_integer_like_type(&ty) {
+            } else if ty.is_all_integer_like() {
                 PrimitiveKind::Number
             } else {
                 return None;
@@ -474,91 +474,11 @@ fn is_empty_string_expression(expression: &AnyJsExpression) -> bool {
 /// the conversion may still change runtime behavior for some inputs.
 /// Generic types only match when their resolved constraint is precise enough to
 /// prove the same property.
-fn matches_primitive_type(ty: &Type, primitive: PrimitiveKind) -> bool {
-    all_type_variants_match(ty, |current, raw| {
-        primitive_matches_non_union_type(current, raw, primitive)
-    })
-}
-
-fn primitive_matches_non_union_type(ty: &Type, raw: &TypeData, primitive: PrimitiveKind) -> bool {
+fn matches_primitive_type(ty: InferredType, primitive: PrimitiveKind) -> bool {
     match primitive {
-        PrimitiveKind::String => ty.is_string_or_string_literal(),
-        PrimitiveKind::Number => ty.is_number_or_number_literal(),
-        PrimitiveKind::Boolean => match raw {
-            TypeData::Boolean => true,
-            TypeData::Literal(literal) => matches!(literal.as_ref(), Literal::Boolean(_)),
-            _ => false,
-        },
-        PrimitiveKind::BigInt => match raw {
-            TypeData::BigInt => true,
-            TypeData::Literal(literal) => matches!(literal.as_ref(), Literal::BigInt(_)),
-            _ => false,
-        },
-    }
-}
-
-/// Returns true when every reachable variant keeps the same value after `~~`.
-///
-/// That is true for bigint values and for number literals that are already
-/// integral. As with `matches_primitive_type()`, unions and constrained
-/// generics only match when every resolved variant satisfies the check.
-fn is_integer_like_type(ty: &Type) -> bool {
-    all_type_variants_match(ty, |_current, raw| integer_like_matches_non_union_type(raw))
-}
-
-/// Evaluates `predicate` against every concrete variant reachable from `ty`.
-///
-/// The traversal expands unions and follows known generic constraints until it
-/// reaches non-union, non-generic types. The check succeeds only when at least
-/// one concrete variant is found and every variant satisfies `predicate`.
-fn all_type_variants_match(ty: &Type, mut predicate: impl FnMut(&Type, &TypeData) -> bool) -> bool {
-    let mut saw_variant = false;
-    let mut pending = vec![ty.clone()];
-
-    while let Some(current) = pending.pop() {
-        if current.is_union() {
-            let mut variants = current.flattened_union_variants().peekable();
-            if variants.peek().is_none() {
-                return false;
-            }
-
-            saw_variant = true;
-            pending.extend(variants);
-            continue;
-        }
-
-        let Some(raw) = current.resolved_data().map(ResolvedTypeData::as_raw_data) else {
-            return false;
-        };
-
-        match raw {
-            TypeData::Generic(generic) if generic.constraint.is_known() => {
-                let Some(constraint) = current.resolve(&generic.constraint) else {
-                    return false;
-                };
-
-                pending.push(constraint);
-            }
-            TypeData::Generic(_) => return false,
-            _ if predicate(&current, raw) => saw_variant = true,
-            _ => return false,
-        }
-    }
-
-    saw_variant
-}
-
-fn integer_like_matches_non_union_type(raw: &TypeData) -> bool {
-    match raw {
-        TypeData::BigInt => true,
-        TypeData::Literal(literal) => match literal.as_ref() {
-            // `fract()` returns the fractional part of the numeric literal. It
-            // is `0.0` exactly when the literal already represents an integer,
-            // which means `~~` cannot truncate it any further.
-            Literal::Number(value) => value.to_f64().is_some_and(|value| value.fract() == 0.0),
-            Literal::BigInt(_) => true,
-            _ => false,
-        },
-        _ => false,
+        PrimitiveKind::String => ty.is_all_string_like(),
+        PrimitiveKind::Number => ty.is_all_number_like(),
+        PrimitiveKind::Boolean => ty.is_all_boolean_like(),
+        PrimitiveKind::BigInt => ty.is_all_bigint_like(),
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/use_disposables.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_disposables.rs
@@ -86,8 +86,7 @@ impl Rule for UseDisposables {
         let decl = ctx.query();
         let initializer = decl.initializer()?;
         let expression = initializer.expression().ok()?;
-        let ty = ctx.type_of_expression(&expression);
-
+        let ty = ctx.inferred_type_of_expression(&expression)?;
         // Lookup the parent declaration which possibly has `await` and/or `using` tokens.
         let parent = decl
             .parent::<JsVariableDeclaratorList>()?

--- a/crates/biome_js_analyze/src/lint/nursery/use_includes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_includes.rs
@@ -1,4 +1,4 @@
-use crate::JsRuleAction;
+use crate::{JsRuleAction, services::typed::Typed};
 use biome_analyze::{
     FixKind, Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext, declare_lint_rule,
 };
@@ -7,9 +7,7 @@ use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, JsBinaryExpression, JsBinaryOperator, JsCallExpression, T,
 };
-use biome_js_type_info::{ResolvedTypeData, Type, TypeData};
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
-use crate::services::typed::Typed;
 
 declare_lint_rule! {
     /// Prefer `Array#includes()` over `Array#indexOf()` checks.
@@ -322,48 +320,11 @@ fn ensure_known_includes_type(ctx: &RuleContext<UseIncludes>, call: &JsCallExpre
     let callee = call.callee().ok();
     let member = callee.as_ref().and_then(|c| c.as_js_static_member_expression());
     let object = member.and_then(|m| m.object().ok());
-    
+
     let Some(object) = object else {
         return false;
     };
 
-    all_type_variants_match(&ctx.type_of_expression(&object), |current, raw| {
-        current.is_string_or_string_literal() || current.is_array_of(|_| true) || matches!(raw, TypeData::Tuple(_))
-    })
+    ctx.inferred_type_of_expression(&object)
+        .is_some_and(|ty| ty.is_all_string_array_or_tuple())
 }
-
-fn all_type_variants_match(ty: &Type, mut predicate: impl FnMut(&Type, &TypeData) -> bool) -> bool {
-    let mut saw_variant = false;
-    let mut pending = vec![ty.clone()];
-
-    while let Some(current) = pending.pop() {
-        if current.is_union() {
-            let mut variants = current.flattened_union_variants().peekable();
-            if variants.peek().is_none() {
-                return false;
-            }
-            saw_variant = true;
-            pending.extend(variants);
-            continue;
-        }
-
-        let Some(raw) = current.resolved_data().map(ResolvedTypeData::as_raw_data) else {
-            return false;
-        };
-
-        match raw {
-            TypeData::Generic(generic) if generic.constraint.is_known() => {
-                let Some(constraint) = current.resolve(&generic.constraint) else {
-                    return false;
-                };
-                pending.push(constraint);
-            }
-            TypeData::Generic(_) => return false,
-            _ if predicate(&current, raw) => saw_variant = true,
-            _ => return false,
-        }
-    }
-
-    saw_variant
-}
-

--- a/crates/biome_js_analyze/src/lint/nursery/use_regexp_exec.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_regexp_exec.rs
@@ -4,7 +4,6 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_js_syntax::JsCallExpression;
-use biome_js_type_info::{Literal, ResolvedTypeData, TypeData};
 use biome_rowan::{AstNode, AstSeparatedList};
 use biome_rule_options::use_regexp_exec::UseRegexpExecOptions;
 
@@ -54,8 +53,8 @@ impl Rule for UseRegexpExec {
 
         let call_object = callee.object().ok()?;
         if !ctx
-            .type_of_expression(&call_object)
-            .is_string_or_string_literal()
+            .inferred_type_of_expression(&call_object)
+            .is_some_and(|ty| ty.is_string_or_string_literal())
         {
             return None;
         }
@@ -69,18 +68,9 @@ impl Rule for UseRegexpExec {
         let first_arg = args.first()?.ok()?;
         let express = first_arg.as_any_js_expression()?;
 
-        let value_type = ctx.type_of_expression(express);
-
-        if value_type
-            .resolved_data()
-            .map(ResolvedTypeData::as_raw_data)
-            .is_some_and(|ty| match ty {
-                TypeData::Literal(literal) => match literal.as_ref() {
-                    Literal::RegExp(literal) => !literal.flags.contains('g'),
-                    _ => false,
-                },
-                _ => false,
-            })
+        if ctx
+            .inferred_type_of_expression(express)
+            .is_some_and(|ty| ty.is_regexp_literal_without_global_flag())
         {
             return Some(());
         }

--- a/crates/biome_js_analyze/src/lint/nursery/use_string_starts_ends_with.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_string_starts_ends_with.rs
@@ -10,7 +10,6 @@ use biome_js_syntax::{
     AnyJsCallArgument, AnyJsExpression, AnyJsLiteralExpression, JsBinaryExpression,
     JsBinaryOperator, JsCallExpression, JsStaticMemberExpression, JsSyntaxToken, T,
 };
-use biome_js_type_info::{Literal, ResolvedTypeData, Type, TypeData};
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TextRange, declare_node_union};
 use biome_rule_options::use_string_starts_ends_with::UseStringStartsEndsWithOptions;
 
@@ -778,57 +777,16 @@ fn ensure_known_string_type(
     ctx: &RuleContext<UseStringStartsEndsWith>,
     expression: &AnyJsExpression,
 ) -> bool {
-    all_type_variants_match(&ctx.type_of_expression(expression), |current, _| {
-        current.is_string_or_string_literal()
-    })
-}
-
-/// Walks a possibly-unioned type and requires every concrete branch to satisfy the predicate.
-///
-/// ```ts
-/// declare const text: string | string[];
-/// declare const suffix: string;
-/// ```
-fn all_type_variants_match(ty: &Type, mut predicate: impl FnMut(&Type, &TypeData) -> bool) -> bool {
-    let mut saw_variant = false;
-    let mut pending = vec![ty.clone()];
-
-    while let Some(current) = pending.pop() {
-        if current.is_union() {
-            let mut variants = current.flattened_union_variants().peekable();
-            if variants.peek().is_none() {
-                return false;
-            }
-            saw_variant = true;
-            pending.extend(variants);
-            continue;
-        }
-
-        let Some(raw) = current.resolved_data().map(ResolvedTypeData::as_raw_data) else {
-            return false;
-        };
-
-        match raw {
-            TypeData::Generic(generic) if generic.constraint.is_known() => {
-                let Some(constraint) = current.resolve(&generic.constraint) else {
-                    return false;
-                };
-                pending.push(constraint);
-            }
-            TypeData::Generic(_) => return false,
-            _ if predicate(&current, raw) => saw_variant = true,
-            _ => return false,
-        }
-    }
-
-    saw_variant
+    ctx.inferred_type_of_expression(expression)
+        .is_some_and(|ty| ty.is_all_string_like())
 }
 
 fn is_zero_number_expression(
     ctx: &RuleContext<UseStringStartsEndsWith>,
     expression: &AnyJsExpression,
 ) -> bool {
-    ctx.type_of_expression(expression).is_number_literal(0.0)
+    ctx.inferred_type_of_expression(expression)
+        .is_some_and(|ty| ty.is_number_literal(0.0))
 }
 
 fn is_length_minus_number(
@@ -979,21 +937,13 @@ fn build_method_call_with_regex_literal(
     method: PreferredMethod,
     negated: bool,
 ) -> Option<AnyJsExpression> {
-    let ty = ctx.type_of_expression(regex);
-    let raw = ty.resolved_data()?.as_raw_data();
-    let regex = match raw {
-        TypeData::Literal(literal) => match literal.as_ref() {
-            Literal::RegExp(regex) => regex,
-            _ => return None,
-        },
-        _ => return None,
-    };
+    let (pattern, flags) = ctx.inferred_type_of_expression(regex)?.regexp_literal()?;
 
-    if !regex.flags.is_empty() {
+    if !flags.text().is_empty() {
         return None;
     }
 
-    let pattern = regex.pattern.text();
+    let pattern = pattern.text();
     // We decode at fix time so the borrowed regex text stays borrowed until we actually need to
     // materialize the replacement string literal.
     let text = match method {
@@ -1084,8 +1034,8 @@ fn matches_length_expression(
     if let Some(expected_len) = compared_string_utf16_len(value) {
         // Literal strings are the easy case: the target length is known up front.
         return ctx
-            .type_of_expression(expression)
-            .is_number_literal(expected_len as f64);
+            .inferred_type_of_expression(expression)
+            .is_some_and(|ty| ty.is_number_literal(expected_len as f64));
     }
 
     // Otherwise we only trust `.length` on the exact same expression, e.g. `needle.length`
@@ -1242,22 +1192,16 @@ fn extract_plain_anchored_regex(
     ctx: &RuleContext<UseStringStartsEndsWith>,
     expression: &AnyJsExpression,
 ) -> Option<PreferredMethod> {
-    let ty = ctx.type_of_expression(expression);
-    let raw = ty.resolved_data()?.as_raw_data();
-    let regex = match raw {
-        TypeData::Literal(literal) => match literal.as_ref() {
-            Literal::RegExp(regex) => regex,
-            _ => return None,
-        },
-        _ => return None,
-    };
+    let (pattern, flags) = ctx
+        .inferred_type_of_expression(expression)?
+        .regexp_literal()?;
 
-    if !regex.flags.is_empty() {
+    if !flags.text().is_empty() {
         // Anchored prefix/suffix rewrites are only obviously safe for plain regexes without flags.
         return None;
     }
 
-    let pattern = regex.pattern.text();
+    let pattern = pattern.text();
     if let Some(body) = pattern.strip_prefix('^') {
         decode_plain_regex_text(body)?;
         return Some(PreferredMethod::StartsWith);

--- a/crates/biome_js_analyze/src/lint/style/use_consistent_enum_value_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_enum_value_type.rs
@@ -100,9 +100,9 @@ impl Rule for UseConsistentEnumValueType {
                 continue;
             };
 
-            let expr_type = ctx.type_of_expression(&expr);
+            let expr_type = ctx.inferred_type_of_expression(&expr);
 
-            if expr_type.is_string_or_string_literal() {
+            if expr_type.is_some_and(|ty| ty.is_string_or_string_literal()) {
                 if let Some(enum_type) = enum_type.clone() {
                     if enum_type != EnumValueType::String {
                         found.push(member.range());
@@ -113,7 +113,7 @@ impl Rule for UseConsistentEnumValueType {
                 continue;
             }
 
-            if expr_type.is_number_or_number_literal() {
+            if expr_type.is_some_and(|ty| ty.is_number_or_number_literal()) {
                 if let Some(enum_type) = enum_type.clone() {
                     if enum_type != EnumValueType::Number {
                         found.push(member.range());

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unnecessary_conditions.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unnecessary_conditions.rs
@@ -11,7 +11,7 @@ use biome_js_syntax::{
     JsIfStatement, JsLogicalExpression, JsLogicalOperator, JsStaticMemberExpression, JsSwitchStatement,
     JsUnaryOperator, JsWhileStatement, inner_string_text,
 };
-use biome_js_type_info::Type;
+use biome_js_type_info::InferredType;
 use biome_rowan::{AstNode, TextRange, TokenText, declare_node_union};
 use biome_rule_options::no_unnecessary_conditions::NoUnnecessaryConditionsOptions;
 
@@ -457,11 +457,10 @@ fn check_condition_necessity(
                 return Some(IssueKind::AlwaysFalsyCondition(expr.range()));
             }
 
-            let ty = ctx.type_of_expression(expr);
-            let conditional = ty.conditional_semantics();
-            if conditional.is_truthy() {
+            let ty = ctx.inferred_type_of_expression(expr)?;
+            if ty.is_always_truthy() {
                 return Some(IssueKind::AlwaysTruthyCondition(expr.range()));
-            } else if conditional.is_falsy() {
+            } else if ty.is_always_falsy() {
                 return Some(IssueKind::AlwaysFalsyCondition(expr.range()));
             }
         }
@@ -492,11 +491,10 @@ fn check_condition_necessity(
                 return None;
             }
 
-            let ty = ctx.type_of_expression(expr);
-            let conditional = ty.conditional_semantics();
-            if conditional.is_truthy() {
+            let ty = ctx.inferred_type_of_expression(expr)?;
+            if ty.is_always_truthy() {
                 return Some(IssueKind::AlwaysTruthyCondition(expr.range()));
-            } else if conditional.is_falsy() {
+            } else if ty.is_always_falsy() {
                 return Some(IssueKind::AlwaysFalsyCondition(expr.range()));
             }
         }
@@ -547,8 +545,8 @@ fn check_nullish_necessity(
     }
 
     // Type-aware path: report when the left-hand side is statically non-nullish.
-    let ty = ctx.type_of_expression(expr);
-    if ty.conditional_semantics().is_non_nullish() {
+    let ty = ctx.inferred_type_of_expression(expr)?;
+    if ty.is_non_nullish() {
         return Some(IssueKind::UnnecessaryCoalescing(
             expr.range(),
             optional_chain_range,
@@ -581,8 +579,8 @@ fn check_optional_chain_necessity(
     }
 
     // Type-aware path: report when the object is statically non-nullish.
-    let ty = ctx.type_of_expression(expr);
-    if ty.conditional_semantics().is_non_nullish() {
+    let ty = ctx.inferred_type_of_expression(expr)?;
+    if ty.is_non_nullish() {
         return Some(IssueKind::UnnecessaryOptionalChain(
             expr.range(),
             optional_chain_range,
@@ -740,13 +738,12 @@ fn check_comparison_necessity(
         _ => return None,
     };
 
-    let ty = ctx.type_of_expression(typed_side);
-    let conditional = ty.conditional_semantics();
+    let ty = ctx.inferred_type_of_expression(typed_side)?;
 
     // Is the non-null side known to be non-nullish? Then the comparison is unnecessary
     // for any equality operator: `x === null`, `x !== undefined`, `x == null` are
     // all statically false/true.
-    if conditional.is_non_nullish() {
+    if ty.is_non_nullish() {
         let range = TextRange::new(left.range().start(), right.range().end());
         return Some(IssueKind::UnnecessaryComparison(range));
     }
@@ -758,7 +755,7 @@ fn check_comparison_necessity(
     // literal, so skip those to avoid false positives.
     // Note: this narrow pass does not detect `void 0` because it's a unary
     // expression, not an identifier.
-    if conditional.is_nullish()
+    if ty.is_nullish()
         && matches!(
             operator,
             JsBinaryOperator::Equality | JsBinaryOperator::Inequality
@@ -803,69 +800,12 @@ fn extract_case_literal(test: &AnyJsExpression) -> Option<CaseLiteral> {
 /// unresolved references, type variables, complex types), it returns `true`.
 /// Used to determine case-clause reachability: if this returns `false`, the
 /// `case` is statically guaranteed to never match.
-fn type_could_equal_literal(ty: &Type, literal: &CaseLiteral) -> bool {
-    if ty.is_union() {
-        return ty
-            .flattened_union_variants()
-            .any(|variant| single_type_could_equal_literal(&variant, literal));
-    }
-    single_type_could_equal_literal(ty, literal)
-}
-
-/// Same predicate as [`type_could_equal_literal`], but for a single non-union
-/// type. Callers from union handling pass each variant through here; direct
-/// callers pass the type as-is.
-fn single_type_could_equal_literal(ty: &Type, literal: &CaseLiteral) -> bool {
-    use biome_js_type_info::TypeData;
-
-    let raw = &**ty;
-
-    // Unknown / any / inference failures: always treat as "possibly equal".
-    if matches!(
-        raw,
-        TypeData::Unknown | TypeData::AnyKeyword | TypeData::UnknownKeyword
-    ) {
-        return true;
-    }
-
+fn type_could_equal_literal(ty: InferredType, literal: &CaseLiteral) -> bool {
     match literal {
-        CaseLiteral::String(s) => {
-            // `string` could be any string.
-            if ty.is_string_or_string_literal() {
-                // A plain `string` (non-literal) could equal any value.
-                if matches!(raw, TypeData::String) {
-                    return true;
-                }
-                // Otherwise it's a string literal: match on exact value.
-                return ty.is_string_literal(s.text());
-            }
-            false
-        }
-        CaseLiteral::Number(n) => {
-            if ty.is_number_or_number_literal() {
-                if matches!(raw, TypeData::Number) {
-                    return true;
-                }
-                return ty.is_number_literal(*n);
-            }
-            false
-        }
-        CaseLiteral::Boolean(b) => {
-            if matches!(raw, TypeData::Boolean) {
-                return true;
-            }
-            ty.is_boolean_literal(*b)
-        }
-        CaseLiteral::Null => {
-            // Conservative: also treat Undefined and VoidKeyword as possible
-            // matches for a null-literal case, to avoid false positives.
-            // Strictly, `null === undefined` is false, so `case null:` inside
-            // `switch (x: undefined)` is unreachable. Detecting that requires
-            // distinguishing strict-equality semantics we do not yet model.
-            // TODO: tighten to only match TypeData::Null when disjointness
-            // becomes reliable.
-            matches!(raw, TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword)
-        }
+        CaseLiteral::String(value) => ty.could_equal_string_literal(value.text()),
+        CaseLiteral::Number(value) => ty.could_equal_number_literal(*value),
+        CaseLiteral::Boolean(value) => ty.could_equal_boolean_literal(*value),
+        CaseLiteral::Null => ty.could_equal_null(),
     }
 }
 
@@ -889,8 +829,8 @@ fn check_case_clause_reachability(
         .find_map(JsSwitchStatement::cast)?;
     let discriminant = switch_stmt.discriminant().ok()?;
 
-    let discriminant_ty = ctx.type_of_expression(&discriminant);
-    if type_could_equal_literal(&discriminant_ty, &case_literal) {
+    let discriminant_ty = ctx.inferred_type_of_expression(&discriminant)?;
+    if type_could_equal_literal(discriminant_ty, &case_literal) {
         None
     } else {
         Some(IssueKind::UnreachableCase(test.range()))

--- a/crates/biome_js_analyze/src/lint/suspicious/use_array_sort_compare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_array_sort_compare.rs
@@ -62,8 +62,10 @@ impl Rule for UseArraySortCompare {
         let callee = binding.as_js_static_member_expression()?;
 
         let call_object = callee.object().ok()?;
-        let ty = ctx.type_of_expression(&call_object);
-        if !ty.is_array_of(|_ty| true) {
+        if !ctx
+            .inferred_type_of_expression(&call_object)
+            .is_some_and(|ty| ty.is_array())
+        {
             return None;
         }
 
@@ -79,8 +81,10 @@ impl Rule for UseArraySortCompare {
 
         let binding = arguments.first()?.ok()?;
         let first_arg = binding.as_any_js_expression()?;
-        let ty = ctx.type_of_expression(first_arg);
-        if ty.is_undefined() || ty.is_null() {
+        if ctx
+            .inferred_type_of_expression(first_arg)
+            .is_some_and(|ty| ty.is_undefined() || ty.is_null())
+        {
             return Some(());
         }
 

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrayFind/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrayFind/invalid.ts
@@ -6,3 +6,4 @@ const found2 = [1, 2, 3].filter(x => x > 1).at(0);
 
 [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1)[0].toString();
 [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1).at(0)?.toString();
+[1, 2, 3].filter(x => x > 1)[0n];

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrayFind/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrayFind/invalid.ts.snap
@@ -12,6 +12,7 @@ const found2 = [1, 2, 3].filter(x => x > 1).at(0);
 
 [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1)[0].toString();
 [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1).at(0)?.toString();
+[1, 2, 3].filter(x => x > 1)[0n];
 
 ```
 
@@ -98,7 +99,7 @@ invalid.ts:7:1 lint/complexity/useArrayFind ━━━━━━━━━━━━
   > 7 │ [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1)[0].toString();
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     8 │ [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1).at(0)?.toString();
-    9 │ 
+    9 │ [1, 2, 3].filter(x => x > 1)[0n];
   
   i Array#find() expresses that intent more clearly and can stop once it finds the first match.
   
@@ -112,10 +113,29 @@ invalid.ts:8:1 lint/complexity/useArrayFind ━━━━━━━━━━━━
 
   i This call uses Array#filter() to retrieve a single matching element.
   
-    7 │ [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1)[0].toString();
-  > 8 │ [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1).at(0)?.toString();
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    9 │ 
+     7 │ [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1)[0].toString();
+   > 8 │ [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1).at(0)?.toString();
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ [1, 2, 3].filter(x => x > 1)[0n];
+    10 │ 
+  
+  i Array#find() expresses that intent more clearly and can stop once it finds the first match.
+  
+  i Use Array#find() instead.
+  
+
+```
+
+```
+invalid.ts:9:1 lint/complexity/useArrayFind ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This call uses Array#filter() to retrieve a single matching element.
+  
+     7 │ [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1)[0].toString();
+     8 │ [1, 2, 3].concat([56, 76, 4543]).filter(x => x > 1).at(0)?.toString();
+   > 9 │ [1, 2, 3].filter(x => x > 1)[0n];
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
   
   i Array#find() expresses that intent more clearly and can stop once it finds the first match.
   

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -41,6 +41,14 @@ pub struct ReturnTypeEvidence {
     pub prefer_inferred_suggestion: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct IgnoredPrimitiveTypes {
+    pub string: bool,
+    pub number: bool,
+    pub boolean: bool,
+    pub bigint: bool,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MisleadingReturnType {
     pub suggestion: Option<String>,
@@ -407,28 +415,22 @@ impl<'db> InferredType<'db> {
         })
     }
 
-    pub fn nullish_union_matches_ignored_primitives(
-        self,
-        ignore_string: bool,
-        ignore_number: bool,
-        ignore_boolean: bool,
-        ignore_bigint: bool,
-    ) -> bool {
+    pub fn nullish_union_matches_ignored_primitives(self, ignored: IgnoredPrimitiveTypes) -> bool {
         let TypeData::Union(_) = self.data else {
             return false;
         };
 
         self.all_variants_match(|data| match data {
             TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword => true,
-            TypeData::String => ignore_string,
-            TypeData::Number => ignore_number,
-            TypeData::Boolean => ignore_boolean,
-            TypeData::BigInt => ignore_bigint,
+            TypeData::String => ignored.string,
+            TypeData::Number => ignored.number,
+            TypeData::Boolean => ignored.boolean,
+            TypeData::BigInt => ignored.bigint,
             TypeData::Literal(literal) => match literal.literal(self.db) {
-                Literal::String(_) => ignore_string,
-                Literal::Number(_) => ignore_number,
-                Literal::Boolean(_) => ignore_boolean,
-                Literal::BigInt(_) => ignore_bigint,
+                Literal::String(_) => ignored.string,
+                Literal::Number(_) => ignored.number,
+                Literal::Boolean(_) => ignored.boolean,
+                Literal::BigInt(_) => ignored.bigint,
                 _ => false,
             },
             _ => false,

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -27,8 +27,8 @@ pub use flattening::MAX_FLATTEN_DEPTH;
 pub use globals::{GLOBAL_RESOLVER, GlobalsResolver};
 pub use globals_ids::{GLOBAL_BOOLEAN_ID, GLOBAL_UNKNOWN_ID, NUM_PREDEFINED_TYPES};
 pub use inferred_type::{
-    InferredSwitchCase, InferredType, MisleadingReturnType, ReturnTypeEvidence,
-    StringificationMode, StringificationUsefulness,
+    IgnoredPrimitiveTypes, InferredSwitchCase, InferredType, MisleadingReturnType,
+    ReturnTypeEvidence, StringificationMode, StringificationUsefulness,
 };
 pub use interned_types::TypeDb;
 pub use resolver::*;

--- a/crates/biome_module_graph/src/db/mod.rs
+++ b/crates/biome_module_graph/src/db/mod.rs
@@ -1,6 +1,10 @@
+//! Salsa database traits and tracked module-graph queries.
+
 use crate::{CssModuleInfo, HtmlModuleInfo, JsModuleInfo, ModuleInfo, ModuleInfoKind};
 pub use biome_js_type_info::TypeDb;
+use biome_js_type_info::interned_types::ModuleKey;
 use camino::{Utf8Path, Utf8PathBuf};
+use salsa::plumbing::{AsId, FromId};
 
 pub mod queries;
 mod type_inference;
@@ -60,4 +64,11 @@ pub trait ModuleDb: TypeDb {
         });
         result
     }
+}
+
+/// Resolves a module key while rejecting stale module handles.
+pub fn module_for_key(db: &dyn ModuleDb, module_key: ModuleKey) -> Option<ModuleInfo> {
+    let module = ModuleInfo::from_id(module_key.as_id());
+    let current = db.module_for_path(module.path(db))?;
+    (ModuleKey::new(current.as_id()) == module_key).then_some(current)
 }

--- a/crates/biome_module_graph/src/db/queries.rs
+++ b/crates/biome_module_graph/src/db/queries.rs
@@ -17,6 +17,7 @@ use crate::db::type_inference::{
     collected_type_result, infer_module_types_cycle_result, normalize_type_cycle_result,
     resolve_raw_types,
 };
+use crate::module_for_key;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
 use crate::{ImportTreeNode, JsExport, JsOwnExport, ModuleDb, ResolvedPath};
 use biome_css_syntax::{TextRange, TextSize};
@@ -35,7 +36,6 @@ use biome_jsdoc_comment::JsdocComment;
 use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::IndexMap;
 use rustc_hash::{FxHashMap, FxHashSet};
-use salsa::plumbing::{AsId, FromId};
 use std::collections::VecDeque;
 
 pub use crate::db::type_inference::InferredModuleTypes;
@@ -215,11 +215,12 @@ pub(crate) fn infer_call_expression_return_type_from_args<'db>(
             union
                 .types(db)
                 .iter()
-                .filter_map(|callee| match callee {
-                    InferredTypeData::Null | InferredTypeData::Undefined => {
+                .filter_map(|callee| {
+                    if matches!(callee, InferredTypeData::Null | InferredTypeData::Undefined) {
                         Some(InferredTypeData::Undefined)
+                    } else {
+                        infer_function_call_type(db, *callee, args)
                     }
-                    callee => infer_function_call_type(db, *callee, args),
                 })
                 .collect(),
         )
@@ -329,11 +330,12 @@ fn infer_function_call_type<'db>(
             union
                 .types(db)
                 .iter()
-                .filter_map(|callee| match callee {
-                    InferredTypeData::Null | InferredTypeData::Undefined => {
+                .filter_map(|callee| {
+                    if matches!(callee, InferredTypeData::Null | InferredTypeData::Undefined) {
                         Some(InferredTypeData::Undefined)
+                    } else {
+                        infer_function_call_type(db, *callee, args)
                     }
-                    callee => infer_function_call_type(db, *callee, args),
                 })
                 .collect(),
         ),
@@ -1199,11 +1201,7 @@ fn raw_local_class_name<'db>(
     local: InferredLocalTypeHandle<'db>,
 ) -> Option<String> {
     let module_key = local.module(db);
-    let module = ModuleInfo::from_id(module_key.as_id());
-    let current = db.module_for_path(module.path(db))?;
-    if InferredModuleKey::new(current.as_id()) != module_key {
-        return None;
-    }
+    let current = module_for_key(db, module_key)?;
     let ModuleInfoKind::Js(js_info) = current.kind(db) else {
         return None;
     };
@@ -1219,11 +1217,7 @@ fn raw_local_class_extends<'db>(
     local: InferredLocalTypeHandle<'db>,
 ) -> Option<InferredLocalTypeHandle<'db>> {
     let module_key = local.module(db);
-    let module = ModuleInfo::from_id(module_key.as_id());
-    let current = db.module_for_path(module.path(db))?;
-    if InferredModuleKey::new(current.as_id()) != module_key {
-        return None;
-    };
+    let current = module_for_key(db, module_key)?;
     let ModuleInfoKind::Js(js_info) = current.kind(db) else {
         return None;
     };

--- a/crates/biome_module_graph/src/lib.rs
+++ b/crates/biome_module_graph/src/lib.rs
@@ -23,7 +23,7 @@ pub use css_module_info::{
     ImportTreeDisplay, ImportTreeNode,
 };
 pub use db::queries::*;
-pub use db::{ModuleDb, TypeDb};
+pub use db::{ModuleDb, TypeDb, module_for_key};
 pub use diagnostics::ModuleDiagnostic;
 pub use html_module_info::{HtmlEmbeddedContent, HtmlModuleInfo, SerializedHtmlModuleInfo};
 pub use js_module_info::{

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -25,7 +25,8 @@ use biome_module_graph::{
     CallExpressionTypeInput, InferredModuleTypes, JsExport, JsOwnExport, ModuleDb, ModuleInfo,
     ModuleInfoKind, NormalizeTypeInput, PathInfoCache,
     infer_call_expression_type as infer_call_expression_type_query, infer_module_types,
-    infer_module_types_bottom_up, normalize_type as normalize_type_query, resolve_js_module,
+    infer_module_types_bottom_up, module_for_key, normalize_type as normalize_type_query,
+    resolve_js_module,
 };
 use biome_package::{Dependencies, PackageJson};
 use biome_project_layout::ProjectLayout;
@@ -40,6 +41,27 @@ struct TestModuleDb {
     modules: BTreeMap<Utf8PathBuf, ModuleInfo>,
     events: Events,
     storage: Storage<Self>,
+}
+
+#[test]
+fn test_module_keys_reject_stale_handles() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), "export const value = 1;");
+
+    let mut db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let path = Utf8PathBuf::from("/src/index.ts");
+    let original = db.module_for_path(&path).expect("module must exist");
+    let replacement = ModuleInfo::new(&db, path.clone(), original.kind(&db).clone());
+    db.modules.insert(path, replacement);
+
+    assert!(
+        module_for_key(&db, InferredModuleKey::new(original.as_id())).is_none(),
+        "stale module handles must be rejected"
+    );
+    assert_eq!(
+        module_for_key(&db, InferredModuleKey::new(replacement.as_id())),
+        Some(replacement)
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
--> 

<!-- What demonstrates that your implementation is correct? -->

## Summary

> [!NOTE]
> Apologies for the automated messages. I have been reviewing things though :) 

This PR migrates the first group of type-aware lint rules from the legacy type inference engine to the new one. These rules can be migrated now because they require only direct information that the new engine already provides, such as primitive types, literals, arrays, regular expressions, nullability, and truthiness.

The name `inferred_type_of_expression` is temporary. It allows the legacy and new engines to coexist while rules are migrated incrementally. After the legacy engine is removed later in the stack, this method is renamed to `type_of_expression`. It is not intended to remain as a separate API.

Common type checks now live on `InferredType`, removing repeated type traversal from individual rules. If type information is unavailable, the migrated rules do not report a diagnostic. Type lookups also reject information associated with an older version of a workspace file.

This PR also fixes `useArrayFind` so that it recognises bigint zero indexes such as `array.filter(callback)[0n]`.

## Test Plan

- Existing specification tests cover the migrated lint rules.
- A new `useArrayFind` regression case covers bigint zero indexes.
- A module graph test verifies that type handles associated with an older version of a file are rejected.
- The `biome_js_type_info` test suite and Clippy checks validate the new shared helpers.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

> This PR was created with AI assistance (OpenCode).