### PR TITLE
refactor(lint): port behavior-sensitive type rules

### DIFF
--- a/crates/biome_html_parser/tests/html_specs/ok/vue/issue-10622.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/issue-10622.vue.snap
@@ -24,7 +24,7 @@ HtmlRoot {
             opening_element: HtmlOpeningElement {
                 l_angle_token: L_ANGLE@0..1 "<" [] [],
                 name: HtmlTagName {
-                    value_token: HTML_LITERAL@1..5 "div" [] [Whitespace(" ")],
+                    value_token: DIV_KW@1..5 "div" [] [Whitespace(" ")],
                 },
                 attributes: HtmlAttributeList [
                     VueVBindShorthandDirective {
@@ -48,7 +48,7 @@ HtmlRoot {
                 l_angle_token: L_ANGLE@15..16 "<" [] [],
                 slash_token: SLASH@16..17 "/" [] [],
                 name: HtmlTagName {
-                    value_token: HTML_LITERAL@17..20 "div" [] [],
+                    value_token: DIV_KW@17..20 "div" [] [],
                 },
                 r_angle_token: R_ANGLE@20..21 ">" [] [],
             },
@@ -57,7 +57,7 @@ HtmlRoot {
             opening_element: HtmlOpeningElement {
                 l_angle_token: L_ANGLE@21..23 "<" [Newline("\n")] [],
                 name: HtmlTagName {
-                    value_token: HTML_LITERAL@23..27 "div" [] [Whitespace(" ")],
+                    value_token: DIV_KW@23..27 "div" [] [Whitespace(" ")],
                 },
                 attributes: HtmlAttributeList [
                     VueDirective {
@@ -82,7 +82,7 @@ HtmlRoot {
                 l_angle_token: L_ANGLE@43..44 "<" [] [],
                 slash_token: SLASH@44..45 "/" [] [],
                 name: HtmlTagName {
-                    value_token: HTML_LITERAL@45..48 "div" [] [],
+                    value_token: DIV_KW@45..48 "div" [] [],
                 },
                 r_angle_token: R_ANGLE@48..49 ">" [] [],
             },
@@ -104,7 +104,7 @@ HtmlRoot {
       0: HTML_OPENING_ELEMENT@0..15
         0: L_ANGLE@0..1 "<" [] []
         1: HTML_TAG_NAME@1..5
-          0: HTML_LITERAL@1..5 "div" [] [Whitespace(" ")]
+          0: DIV_KW@1..5 "div" [] [Whitespace(" ")]
         2: HTML_ATTRIBUTE_LIST@5..14
           0: VUE_V_BIND_SHORTHAND_DIRECTIVE@5..14
             0: VUE_DIRECTIVE_ARGUMENT@5..6
@@ -121,13 +121,13 @@ HtmlRoot {
         0: L_ANGLE@15..16 "<" [] []
         1: SLASH@16..17 "/" [] []
         2: HTML_TAG_NAME@17..20
-          0: HTML_LITERAL@17..20 "div" [] []
+          0: DIV_KW@17..20 "div" [] []
         3: R_ANGLE@20..21 ">" [] []
     1: HTML_ELEMENT@21..49
       0: HTML_OPENING_ELEMENT@21..43
         0: L_ANGLE@21..23 "<" [Newline("\n")] []
         1: HTML_TAG_NAME@23..27
-          0: HTML_LITERAL@23..27 "div" [] [Whitespace(" ")]
+          0: DIV_KW@23..27 "div" [] [Whitespace(" ")]
         2: HTML_ATTRIBUTE_LIST@27..42
           0: VUE_DIRECTIVE@27..42
             0: IDENT@27..33 "v-bind" [] []
@@ -145,7 +145,7 @@ HtmlRoot {
         0: L_ANGLE@43..44 "<" [] []
         1: SLASH@44..45 "/" [] []
         2: HTML_TAG_NAME@45..48
-          0: HTML_LITERAL@45..48 "div" [] []
+          0: DIV_KW@45..48 "div" [] []
         3: R_ANGLE@48..49 ">" [] []
   4: EOF@49..50 "" [Newline("\n")] []
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
@@ -1,5 +1,4 @@
 use crate::services::typed::Typed;
-use std::collections::HashSet;
 
 use biome_analyze::{
     Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext, declare_lint_rule,
@@ -10,9 +9,7 @@ use biome_js_syntax::{
     JsAssignmentExpression, JsAssignmentOperator, JsBinaryExpression, JsBinaryOperator,
     JsCallExpression, JsTemplateExpression, global_identifier,
 };
-use biome_js_type_info::{
-    ImportSymbol, Literal, ResolvedTypeData, ResolverId, Type, TypeData, TypeId, TypeReference,
-};
+use biome_js_type_info::{InferredType, StringificationMode, StringificationUsefulness};
 use biome_rowan::{AstNode, AstSeparatedList, TextRange, declare_node_union};
 use biome_rule_options::no_base_to_string::NoBaseToStringOptions;
 
@@ -81,7 +78,7 @@ declare_node_union! {
 #[derive(Clone, Copy, Debug)]
 pub struct RuleState {
     kind: DiagnosticKind,
-    certainty: Usefulness,
+    certainty: StringificationUsefulness,
     range: TextRange,
 }
 
@@ -112,9 +109,9 @@ impl Rule for NoBaseToString {
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
         let certainty = match state.certainty {
-            Usefulness::Always => return None,
-            Usefulness::Sometimes => "may",
-            Usefulness::Never => "will",
+            StringificationUsefulness::Always => return None,
+            StringificationUsefulness::Sometimes => "may",
+            StringificationUsefulness::Never => "will",
         };
 
         let diagnostic = match state.kind {
@@ -148,39 +145,6 @@ impl Rule for NoBaseToString {
 enum DiagnosticKind {
     BaseToString,
     BaseArrayJoin,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Usefulness {
-    Always,
-    Sometimes,
-    Never,
-}
-
-type VisitedTypes = HashSet<(ResolverId, TypeId)>;
-
-#[derive(Clone, Copy)]
-enum AnalysisMode {
-    Join,
-    ToString,
-}
-
-/// Worklist entries used by `collect_certainty()` to traverse type graphs.
-enum AnalysisTask {
-    /// Analyze a type under the given stringification mode.
-    Eval(Type, AnalysisMode),
-    /// Combine the next `usize` collected child results using the given strategy.
-    Aggregate(AggregateKind, usize),
-    /// Remove a type from the active traversal set after finishing its children.
-    Leave((ResolverId, TypeId)),
-}
-
-/// Describes how a group of child results should be combined.
-#[derive(Clone, Copy)]
-enum AggregateKind {
-    Intersection,
-    Tuple,
-    Union,
 }
 
 fn run_call_expression(
@@ -249,11 +213,17 @@ fn run_binary_expression(
     let left = node.left().ok()?;
     let right = node.right().ok()?;
 
-    if is_string_like_type(&ctx.type_of_expression(&left)) {
+    if ctx
+        .inferred_type_of_expression(&left)
+        .is_some_and(InferredType::is_all_string_like)
+    {
         return check_expression(ctx, &right, DiagnosticKind::BaseToString);
     }
 
-    if is_string_like_type(&ctx.type_of_expression(&right)) {
+    if ctx
+        .inferred_type_of_expression(&right)
+        .is_some_and(InferredType::is_all_string_like)
+    {
         return check_expression(ctx, &left, DiagnosticKind::BaseToString);
     }
 
@@ -271,7 +241,7 @@ fn run_assignment_expression(
 
     let left = node.left().ok()?;
     let left_ty = type_of_assignment_target(ctx, node, &left)?;
-    if !is_string_like_type(&left_ty) {
+    if !left_ty.is_all_string_like() {
         return None;
     }
 
@@ -299,11 +269,11 @@ fn run_template_expression(
         })
 }
 
-fn type_of_assignment_target(
-    ctx: &RuleContext<NoBaseToString>,
+fn type_of_assignment_target<'a>(
+    ctx: &'a RuleContext<NoBaseToString>,
     assignment: &JsAssignmentExpression,
     left: &AnyJsAssignmentPattern,
-) -> Option<Type> {
+) -> Option<InferredType<'a>> {
     match left {
         AnyJsAssignmentPattern::AnyJsAssignment(assignment_target) => {
             type_of_assignment(ctx, assignment, assignment_target)
@@ -313,19 +283,20 @@ fn type_of_assignment_target(
     }
 }
 
-fn type_of_assignment(
-    ctx: &RuleContext<NoBaseToString>,
+fn type_of_assignment<'a>(
+    ctx: &'a RuleContext<NoBaseToString>,
     _assignment: &JsAssignmentExpression,
     target: &AnyJsAssignment,
-) -> Option<Type> {
+) -> Option<InferredType<'a>> {
     let mut current = target.clone();
 
     loop {
         match current {
             AnyJsAssignment::JsIdentifierAssignment(identifier) => {
                 let name = identifier.name_token().ok()?;
-                return Some(
-                    ctx.type_of_named_value(name.text_trimmed_range(), name.text_trimmed()),
+                return ctx.inferred_type_of_named_value(
+                    name.text_trimmed_range(),
+                    name.text_trimmed(),
                 );
             }
             AnyJsAssignment::JsParenthesizedAssignment(parenthesized) => {
@@ -359,15 +330,27 @@ fn check_expression(
         return None;
     }
 
-    let ty = ctx.type_of_expression(expression);
+    let ty = ctx.inferred_type_of_expression(expression)?;
+    let ignored_type_names = ctx
+        .options()
+        .ignored_type_names
+        .as_deref()
+        .map_or_else(
+            || DEFAULT_IGNORED_TYPE_NAMES.to_vec(),
+            |names| names.iter().map(AsRef::as_ref).collect(),
+        );
     let certainty = match kind {
-        DiagnosticKind::BaseArrayJoin => collect_certainty(&ty, ctx.options(), AnalysisMode::Join),
-        DiagnosticKind::BaseToString => {
-            collect_certainty(&ty, ctx.options(), AnalysisMode::ToString)
-        }
+        DiagnosticKind::BaseArrayJoin => ty.stringification_usefulness(
+            StringificationMode::Join,
+            &ignored_type_names,
+        ),
+        DiagnosticKind::BaseToString => ty.stringification_usefulness(
+            StringificationMode::ToString,
+            &ignored_type_names,
+        ),
     };
 
-    if certainty == Usefulness::Always {
+    if certainty == StringificationUsefulness::Always {
         None
     } else {
         Some(RuleState {
@@ -383,591 +366,4 @@ fn is_literal_expression(expression: &AnyJsExpression) -> bool {
         expression.clone().omit_parentheses(),
         AnyJsExpression::AnyJsLiteralExpression(_) | AnyJsExpression::JsArrayExpression(_)
     )
-}
-
-fn is_string_like_type(ty: &Type) -> bool {
-    let mut saw_variant = false;
-    let mut pending = vec![ty.clone()];
-
-    while let Some(current) = pending.pop() {
-        if current.is_union() {
-            let mut variants = current.flattened_union_variants().peekable();
-            if variants.peek().is_none() {
-                return false;
-            }
-
-            saw_variant = true;
-            pending.extend(variants);
-            continue;
-        }
-
-        let Some(raw) = current.resolved_data().map(ResolvedTypeData::as_raw_data) else {
-            return false;
-        };
-
-        match raw {
-            TypeData::Generic(generic) if generic.constraint.is_known() => {
-                let Some(constraint) = current.resolve(&generic.constraint) else {
-                    return false;
-                };
-
-                pending.push(constraint);
-            }
-            TypeData::Generic(_) => return false,
-            _ if current.is_string_or_string_literal() => saw_variant = true,
-            _ => return false,
-        }
-    }
-
-    saw_variant
-}
-
-/// Computes whether stringification is always useful, sometimes useful, or never useful. The core business logic for the rule.
-fn collect_certainty(ty: &Type, options: &NoBaseToStringOptions, mode: AnalysisMode) -> Usefulness {
-    let mut active_types = HashSet::new();
-    let mut results = Vec::new();
-    let mut tasks = vec![AnalysisTask::Eval(ty.clone(), mode)];
-
-    while let Some(task) = tasks.pop() {
-        match task {
-            AnalysisTask::Eval(ty, mode) => {
-                let Some(key) = visited_type(&ty) else {
-                    results.push(Usefulness::Always);
-                    continue;
-                };
-
-                if active_types.contains(&key) {
-                    results.push(Usefulness::Always);
-                    continue;
-                }
-
-                if let Some(raw) = ty.resolved_data().map(ResolvedTypeData::as_raw_data) {
-                    match raw {
-                        TypeData::Generic(generic) if generic.constraint.is_known() => {
-                            if let Some(constraint) = ty.resolve(&generic.constraint) {
-                                tasks.push(AnalysisTask::Eval(constraint, mode));
-                            } else {
-                                results.push(Usefulness::Always);
-                            }
-                            continue;
-                        }
-                        TypeData::Generic(_) => {
-                            results.push(Usefulness::Always);
-                            continue;
-                        }
-                        _ => {}
-                    }
-                }
-
-                if matches!(mode, AnalysisMode::ToString)
-                    && (is_ignored_type(&ty, options, &mut HashSet::new())
-                        || is_primitive_or_otherwise_safe(&ty))
-                {
-                    results.push(Usefulness::Always);
-                    continue;
-                }
-
-                if push_aggregate_tasks(
-                    &mut tasks,
-                    &mut active_types,
-                    key,
-                    AggregateKind::Union,
-                    ty.flattened_union_variants(),
-                    mode,
-                ) {
-                    continue;
-                }
-
-                let Some(raw) = ty.resolved_data().map(ResolvedTypeData::as_raw_data) else {
-                    results.push(Usefulness::Always);
-                    continue;
-                };
-
-                if let TypeData::Intersection(intersection) = raw {
-                    if !push_aggregate_tasks(
-                        &mut tasks,
-                        &mut active_types,
-                        key,
-                        AggregateKind::Intersection,
-                        intersection
-                            .types()
-                            .iter()
-                            .filter_map(|reference| ty.resolve(reference)),
-                        mode,
-                    ) {
-                        results.push(Usefulness::Never);
-                    }
-                    continue;
-                }
-
-                if let TypeData::Tuple(tuple) = raw {
-                    if !push_aggregate_tasks(
-                        &mut tasks,
-                        &mut active_types,
-                        key,
-                        AggregateKind::Tuple,
-                        tuple
-                            .elements()
-                            .iter()
-                            .filter_map(|element| ty.resolve(&element.ty)),
-                        AnalysisMode::ToString,
-                    ) {
-                        results.push(Usefulness::Always);
-                    }
-                    continue;
-                }
-
-                if let Some(element_ty) = array_element_type(&ty) {
-                    active_types.insert(key);
-                    tasks.push(AnalysisTask::Leave(key));
-                    tasks.push(AnalysisTask::Eval(element_ty, AnalysisMode::ToString));
-                    continue;
-                }
-
-                let certainty = match mode {
-                    AnalysisMode::Join => Usefulness::Always,
-                    AnalysisMode::ToString => {
-                        match is_to_string_like_from_object(&ty, &mut HashSet::new()) {
-                            Some(true) => Usefulness::Never,
-                            Some(false) | None => Usefulness::Always,
-                        }
-                    }
-                };
-                results.push(certainty);
-            }
-            AnalysisTask::Aggregate(kind, count) => {
-                let start = results.len().saturating_sub(count);
-                let combined = match kind {
-                    AggregateKind::Intersection => combine_intersection(results.drain(start..)),
-                    AggregateKind::Tuple => combine_tuple(results.drain(start..)),
-                    AggregateKind::Union => combine_union(results.drain(start..)),
-                };
-                results.push(combined);
-            }
-            AnalysisTask::Leave(key) => {
-                active_types.remove(&key);
-            }
-        }
-    }
-
-    results.pop().unwrap_or(Usefulness::Always)
-}
-
-fn push_aggregate_tasks(
-    tasks: &mut Vec<AnalysisTask>,
-    active_types: &mut VisitedTypes,
-    key: (ResolverId, TypeId),
-    kind: AggregateKind,
-    types: impl Iterator<Item = Type>,
-    mode: AnalysisMode,
-) -> bool {
-    active_types.insert(key);
-    tasks.push(AnalysisTask::Leave(key));
-    let aggregate_index = tasks.len();
-    tasks.push(AnalysisTask::Aggregate(kind, 0));
-
-    let mut count = 0;
-    for ty in types {
-        tasks.push(AnalysisTask::Eval(ty, mode));
-        count += 1;
-    }
-
-    if count == 0 {
-        tasks.pop();
-        tasks.pop();
-        active_types.remove(&key);
-        return false;
-    }
-
-    tasks[aggregate_index] = AnalysisTask::Aggregate(kind, count);
-    true
-}
-
-fn array_element_type(ty: &Type) -> Option<Type> {
-    if !ty.is_array_of(|_| true) {
-        return None;
-    }
-
-    let TypeData::InstanceOf(instance) = ty.resolved_data().map(ResolvedTypeData::as_raw_data)?
-    else {
-        return None;
-    };
-
-    let element_ty = instance
-        .type_parameters
-        .first()
-        .and_then(|reference| ty.resolve(reference))?;
-
-    Some(element_ty)
-}
-
-/// Combine the certainties of union variants. If all variants have the same certainty, that is returned. Otherwise, `Sometimes` is returned.
-fn combine_union(certainties: impl Iterator<Item = Usefulness>) -> Usefulness {
-    let mut combined = None;
-
-    for certainty in certainties {
-        match combined {
-            None => combined = Some(certainty),
-            Some(existing) if existing == certainty => {}
-            Some(_) => return Usefulness::Sometimes,
-        }
-    }
-
-    combined.unwrap_or(Usefulness::Always)
-}
-
-/// Combine the certainties of intersection constituents. If any constituent is `Always`, the result is `Always`. Otherwise, the result is `Never`.
-fn combine_intersection(certainties: impl Iterator<Item = Usefulness>) -> Usefulness {
-    if certainties
-        .into_iter()
-        .any(|certainty| certainty == Usefulness::Always)
-    {
-        Usefulness::Always
-    } else {
-        Usefulness::Never
-    }
-}
-
-/// Combine the certainties of tuple elements. If any element is `Never`, the result is `Never`. Otherwise, if any element is `Sometimes`, the result is `Sometimes`. Otherwise, the result is `Always`.
-fn combine_tuple(certainties: impl Iterator<Item = Usefulness>) -> Usefulness {
-    let mut saw_sometimes = false;
-
-    for certainty in certainties {
-        match certainty {
-            Usefulness::Always => {}
-            Usefulness::Sometimes => saw_sometimes = true,
-            Usefulness::Never => return Usefulness::Never,
-        }
-    }
-
-    if saw_sometimes {
-        Usefulness::Sometimes
-    } else {
-        Usefulness::Always
-    }
-}
-
-fn is_primitive_or_otherwise_safe(ty: &Type) -> bool {
-    if ty.is_string_or_string_literal() || ty.is_number_or_number_literal() {
-        return true;
-    }
-
-    let Some(raw) = ty.resolved_data().map(ResolvedTypeData::as_raw_data) else {
-        // if we can't resolve the type, assume it's safe to avoid false positives
-        return true;
-    };
-
-    match raw {
-        TypeData::AnyKeyword
-        | TypeData::BigInt
-        | TypeData::Boolean
-        | TypeData::Function(_)
-        | TypeData::Null
-        | TypeData::Number
-        | TypeData::String
-        | TypeData::Symbol
-        | TypeData::Undefined
-        | TypeData::Unknown
-        | TypeData::UnknownKeyword
-        | TypeData::NeverKeyword
-        | TypeData::VoidKeyword => true,
-        TypeData::Literal(literal) => matches!(
-            literal.as_ref(),
-            Literal::BigInt(_)
-                | Literal::Boolean(_)
-                | Literal::Number(_)
-                | Literal::String(_)
-                | Literal::Template(_)
-        ),
-        _ => false,
-    }
-}
-
-/// Returns whether `ty` ultimately falls back to object-style stringification
-/// like `[object Object]`, which is what the rule wants to flag.
-///
-/// `Some(true)` means the reachable type graph bottoms out in plain object-like
-/// behavior without a custom `toString`-like member. `Some(false)` means a
-/// custom stringification member was found. `None` means the type shape is not
-/// one this rule can classify with confidence.
-fn is_to_string_like_from_object(ty: &Type, visited: &mut VisitedTypes) -> Option<bool> {
-    let mut stack = vec![ty.clone()];
-    let mut saw_true = false;
-    let mut saw_unknown = false;
-
-    while let Some(current) = stack.pop() {
-        let Some(key) = visited_type(&current) else {
-            saw_unknown = true;
-            continue;
-        };
-
-        if !visited.insert(key) {
-            return Some(false);
-        }
-
-        let Some(raw) = current.resolved_data().map(ResolvedTypeData::as_raw_data) else {
-            saw_unknown = true;
-            continue;
-        };
-
-        if has_custom_stringification_member(raw) {
-            return Some(false);
-        }
-
-        match raw {
-            TypeData::Class(class) => {
-                if let Some(base) = class
-                    .extends
-                    .as_ref()
-                    .and_then(|reference| current.resolve(reference))
-                {
-                    stack.push(base);
-                } else {
-                    saw_true = true;
-                }
-            }
-            TypeData::InstanceOf(instance) => {
-                if let Some(base) = current.resolve(&instance.ty) {
-                    stack.push(base);
-                } else {
-                    saw_true = true;
-                }
-            }
-            TypeData::Interface(interface) => {
-                let mut bases = interface
-                    .extends
-                    .iter()
-                    .filter_map(|reference| current.resolve(reference))
-                    .peekable();
-                if bases.peek().is_none() {
-                    saw_true = true;
-                } else {
-                    stack.extend(bases);
-                }
-            }
-            TypeData::Literal(literal) => match literal.as_ref() {
-                Literal::Object(object) => {
-                    if has_custom_object_literal_member(object.members()) {
-                        return Some(false);
-                    } else {
-                        saw_true = true;
-                    }
-                }
-                Literal::RegExp(_) => saw_true = true,
-                _ => return Some(false),
-            },
-            TypeData::MergedReference(reference) => {
-                if let Some(resolved) = reference
-                    .ty
-                    .as_ref()
-                    .and_then(|reference| current.resolve(reference))
-                {
-                    stack.push(resolved);
-                } else {
-                    saw_unknown = true;
-                }
-            }
-            TypeData::Object(_) | TypeData::ObjectKeyword => saw_true = true,
-            TypeData::Reference(reference) => {
-                if let Some(resolved) = current.resolve(reference) {
-                    stack.push(resolved);
-                } else {
-                    saw_unknown = true;
-                }
-            }
-            TypeData::TypeofValue(value) => {
-                if let Some(resolved) = current.resolve(&value.ty) {
-                    stack.push(resolved);
-                } else {
-                    saw_unknown = true;
-                }
-            }
-            _ => return None,
-        }
-    }
-
-    if saw_true {
-        Some(true)
-    } else {
-        let _ = saw_unknown;
-        None
-    }
-}
-
-fn has_custom_stringification_member(raw: &TypeData) -> bool {
-    raw.own_members().any(|member| {
-        member.has_name("toLocaleString")
-            || member.has_name("toString")
-            || member.has_name("valueOf")
-    })
-}
-
-fn has_custom_object_literal_member(members: &[biome_js_type_info::TypeMember]) -> bool {
-    members.iter().any(|member| {
-        member.has_name("toLocaleString")
-            || member.has_name("toString")
-            || member.has_name("valueOf")
-    })
-}
-
-fn is_ignored_type(ty: &Type, options: &NoBaseToStringOptions, visited: &mut VisitedTypes) -> bool {
-    let mut stack = vec![ty.clone()];
-
-    while let Some(current) = stack.pop() {
-        let Some(raw) = current.resolved_data().map(ResolvedTypeData::as_raw_data) else {
-            continue;
-        };
-        let Some(visited_key) = visited_type(&current) else {
-            continue;
-        };
-
-        if !visited.insert(visited_key) {
-            continue;
-        }
-
-        if matches_ignored_type_name(raw, options) {
-            return true;
-        }
-
-        match raw {
-            TypeData::Class(class) => {
-                if let Some(base) = class
-                    .extends
-                    .as_ref()
-                    .and_then(|reference| current.resolve(reference))
-                {
-                    stack.push(base);
-                }
-            }
-            TypeData::Generic(generic) if generic.constraint.is_known() => {
-                if let Some(constraint) = current.resolve(&generic.constraint) {
-                    stack.push(constraint);
-                }
-            }
-            TypeData::InstanceOf(instance) => {
-                if let Some(base) = current.resolve(&instance.ty) {
-                    stack.push(base);
-                }
-            }
-            TypeData::Interface(interface) => {
-                stack.extend(
-                    interface
-                        .extends
-                        .iter()
-                        .filter_map(|reference| current.resolve(reference)),
-                );
-            }
-            TypeData::MergedReference(reference) => {
-                if let Some(resolved) = reference
-                    .ty
-                    .as_ref()
-                    .and_then(|reference| current.resolve(reference))
-                {
-                    stack.push(resolved);
-                }
-            }
-            TypeData::Reference(reference) => {
-                if let Some(resolved) = current.resolve(reference) {
-                    stack.push(resolved);
-                }
-            }
-            TypeData::TypeofType(reference) => {
-                if let Some(resolved) = current.resolve(reference) {
-                    stack.push(resolved);
-                }
-            }
-            TypeData::TypeOperator(operator) => {
-                if let Some(resolved) = current.resolve(&operator.ty) {
-                    stack.push(resolved);
-                }
-            }
-            TypeData::TypeofValue(value) => {
-                if let Some(resolved) = current.resolve(&value.ty) {
-                    stack.push(resolved);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    false
-}
-
-fn matches_ignored_type_name(raw: &TypeData, options: &NoBaseToStringOptions) -> bool {
-    match raw {
-        TypeData::Class(class) => class
-            .name
-            .as_ref()
-            .is_some_and(|name| is_ignored_type_name(name.text(), options)),
-        TypeData::Generic(generic) => is_ignored_type_name(generic.name.text(), options),
-        TypeData::InstanceOf(instance) => matches_ignored_type_reference(&instance.ty, options),
-        TypeData::Interface(interface) => is_ignored_type_name(interface.name.text(), options),
-        TypeData::Literal(literal) => {
-            matches!(literal.as_ref(), Literal::RegExp(_))
-                && is_ignored_type_name("RegExp", options)
-        }
-        TypeData::MergedReference(reference) => {
-            reference
-                .ty
-                .as_ref()
-                .is_some_and(|reference| matches_ignored_type_reference(reference, options))
-                || reference
-                    .value_ty
-                    .as_ref()
-                    .is_some_and(|reference| matches_ignored_type_reference(reference, options))
-                || reference
-                    .namespace_ty
-                    .as_ref()
-                    .is_some_and(|reference| matches_ignored_type_reference(reference, options))
-        }
-        TypeData::Reference(reference) => matches_ignored_type_reference(reference, options),
-        TypeData::TypeofType(reference) => matches_ignored_type_reference(reference, options),
-        TypeData::TypeOperator(operator) => matches_ignored_type_reference(&operator.ty, options),
-        TypeData::TypeofValue(value) => is_ignored_type_name(value.identifier.text(), options),
-        _ => false,
-    }
-}
-
-fn matches_ignored_type_reference(
-    reference: &TypeReference,
-    options: &NoBaseToStringOptions,
-) -> bool {
-    let mut stack = vec![reference];
-
-    while let Some(reference) = stack.pop() {
-        match reference {
-            TypeReference::Qualifier(qualifier) => {
-                if qualifier
-                    .path
-                    .iter()
-                    .any(|part| is_ignored_type_name(part.text(), options))
-                {
-                    return true;
-                }
-
-                stack.extend(qualifier.type_parameters.iter());
-            }
-            TypeReference::Import(import) => {
-                if let ImportSymbol::Named(name) = &import.symbol
-                    && is_ignored_type_name(name.text(), options)
-                {
-                    return true;
-                }
-            }
-            TypeReference::Resolved(_) => {}
-        }
-    }
-
-    false
-}
-
-fn is_ignored_type_name(name: &str, options: &NoBaseToStringOptions) -> bool {
-    options.ignored_type_names.as_deref().map_or_else(
-        || DEFAULT_IGNORED_TYPE_NAMES.contains(&name),
-        |ignored| ignored.iter().any(|candidate| candidate.as_ref() == name),
-    )
-}
-
-fn visited_type(ty: &Type) -> Option<(ResolverId, TypeId)> {
-    Some((ty.resolved_data()?.resolver_id(), ty.id()))
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -176,16 +176,15 @@ impl Rule for NoFloatingPromises {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let expression = node.expression().ok()?;
-        let ty = ctx.type_of_expression(&expression);
+        let ty = ctx.inferred_type_of_expression(&expression)?;
 
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");
-        if ty.is_array_of(|ty| ty.is_promise_instance()) {
+        if ty.is_array_of_promise() {
             return Some(NoFloatingPromisesState::ArrayOfPromises);
         }
 
-        let is_maybe_promise =
-            ty.is_promise_instance() || ty.has_variant(|ty| ty.is_promise_instance());
+        let is_maybe_promise = ty.is_promise_instance() || ty.has_promise_variant();
         if !is_maybe_promise {
             return None;
         }

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -7,7 +7,7 @@ use biome_js_syntax::{
     AnyJsCallArgument, AnyJsExpression, JsCallArgumentList, JsCallExpression,
     JsConditionalExpression, JsNewExpression, JsSyntaxKind,
 };
-use biome_js_type_info::{Type, TypeMemberKind};
+use biome_js_type_info::InferredType;
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TriviaPieceKind};
 use biome_rule_options::no_misused_promises::NoMisusedPromisesOptions;
 
@@ -108,11 +108,11 @@ impl Rule for NoMisusedPromises {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let expression = ctx.query();
-        let ty = ctx.type_of_expression(expression);
+        let ty = ctx.inferred_type_of_expression(expression)?;
         if ty.is_function() {
-            find_misused_promise_returning_callback(ctx, expression, &ty)
+            find_misused_promise_returning_callback(ctx, expression, ty)
         } else {
-            find_misused_promise_expression(expression, &ty)
+            find_misused_promise_expression(expression, ty)
         }
     }
 
@@ -212,7 +212,7 @@ impl Rule for NoMisusedPromises {
 
 fn find_misused_promise_expression(
     expression: &AnyJsExpression,
-    ty: &Type,
+    ty: InferredType,
 ) -> Option<NoMisusedPromisesState> {
     let parent = expression.syntax().parent()?;
     let state = match parent.kind() {
@@ -231,25 +231,16 @@ fn find_misused_promise_expression(
 
     // Uncomment the following line for debugging convenience:
     //let printed = format!("type of {expression:?} = {ty:?}");
-    let is_promise = ty.is_promise_instance();
-    let is_maybe_promise = ty.has_variant(|ty| ty.is_promise_instance());
-    let should_signal = is_promise || is_maybe_promise;
+    let should_signal = ty.is_promise_instance() || ty.has_promise_variant();
     should_signal.then_some(state)
 }
 
 fn find_misused_promise_returning_callback(
     ctx: &RuleContext<NoMisusedPromises>,
     expression: &AnyJsExpression,
-    ty: &Type,
+    ty: InferredType,
 ) -> Option<NoMisusedPromisesState> {
-    let callback = ty.as_function()?;
-
-    let return_ty = callback.return_type.as_type()?;
-    let return_ty = ty.resolve(return_ty)?;
-
-    let should_signal =
-        return_ty.is_promise_instance() || return_ty.has_variant(|ty| ty.is_promise_instance());
-    if !should_signal {
+    if !ty.function_returns_promise() {
         return None;
     }
 
@@ -268,31 +259,29 @@ fn find_misused_promise_returning_callback(
         .skip(1)
         .find_map(JsCallExpression::cast)
     {
-        let callee_ty = ctx.type_of_expression(&call_expression.callee().ok()?);
-        let function = callee_ty.as_function()?;
-        callee_ty.resolve(function.parameters.get(argument_index)?.ty())?
+        ctx.inferred_expected_argument_type(
+            &call_expression.callee().ok()?,
+            argument_index,
+            false,
+        )?
     } else if let Some(new_expression) = argument_list
         .syntax()
         .ancestors()
         .skip(1)
         .find_map(JsNewExpression::cast)
     {
-        let callee_ty = ctx.type_of_expression(&new_expression.callee().ok()?);
-        let class = callee_ty.as_class()?;
-        let constructor = class
-            .members
-            .iter()
-            .find(|member| member.kind == TypeMemberKind::Constructor)?;
-        let constructor_ty = callee_ty.resolve(&constructor.ty)?;
-        let constructor = constructor_ty.as_function()?;
-        constructor_ty.resolve(constructor.parameters.get(argument_index)?.ty())?
+        ctx.inferred_expected_argument_type(
+            &new_expression.callee().ok()?,
+            argument_index,
+            true,
+        )?
     } else {
         return None;
     };
 
-    if argument_ty.is_function_with_return_type(|ty| ty.is_conditional()) {
+    if argument_ty.function_returns_conditional() {
         Some(NoMisusedPromisesState::ConditionalReturn)
-    } else if argument_ty.is_function_with_return_type(|ty| ty.is_void_keyword()) {
+    } else if argument_ty.function_returns_void() {
         Some(NoMisusedPromisesState::VoidReturn)
     } else {
         None

--- a/crates/biome_js_analyze/src/lint/nursery/use_await_thenable.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_await_thenable.rs
@@ -59,14 +59,14 @@ impl Rule for UseAwaitThenable {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let expression = node.argument().ok()?;
-        let ty = ctx.type_of_expression(&expression);
+        let ty = ctx.inferred_type_of_expression(&expression)?;
 
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");
 
         let is_maybe_promise = ty.is_promise_instance()
-            || ty.is_thenable()
-            || ty.has_variant(|ty| ty.is_promise_instance() || ty.is_thenable());
+            || ty.has_promise_variant()
+            || ctx.inferred_expression_has_callable_member(&expression, "then");
         (ty.is_inferred() && !is_maybe_promise).then_some(())
     }
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
@@ -1,4 +1,4 @@
-use std::{io, ops::Deref};
+use std::io;
 
 use biome_analyze::{
     FixKind, Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext, declare_lint_rule,
@@ -11,7 +11,7 @@ use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsCallArgument, AnyJsExpression, AnyJsStatement, AnyJsSwitchClause, JsSwitchStatement, T,
 };
-use biome_js_type_info::{Literal, Type, TypeData};
+use biome_js_type_info::InferredSwitchCase;
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, TriviaPieceKind};
 use biome_rule_options::use_exhaustive_switch_cases::UseExhaustiveSwitchCasesOptions;
 
@@ -104,10 +104,7 @@ declare_lint_rule! {
     }
 }
 
-pub enum MissingCase {
-    Type(Type),
-    BooleanLiteral(bool),
-}
+pub struct MissingCase(InferredSwitchCase);
 
 impl Rule for UseExhaustiveSwitchCases {
     type Query = Typed<JsSwitchStatement>;
@@ -131,9 +128,13 @@ impl Rule for UseExhaustiveSwitchCases {
             .filter_map(|case| match case {
                 AnyJsSwitchClause::JsCaseClause(case) => {
                     let test = case.test().ok()?;
-                    flatten_type(&ctx.type_of_expression(&test))
-                        .as_deref()
-                        .cloned()
+                    let variants = ctx
+                        .inferred_type_of_expression(&test)?
+                        .switch_case_variants();
+                    match variants.as_slice() {
+                        [variant] => Some(variant.clone()),
+                        _ => None,
+                    }
                 }
                 _ => None,
             })
@@ -144,7 +145,7 @@ impl Rule for UseExhaustiveSwitchCases {
         let discriminant = stmt.discriminant().ok()?;
 
         let is_switch_true_condition_group = is_true_literal_expression(&discriminant)
-            && found_cases.iter().any(|case| matches!(case, TypeData::Boolean));
+            && found_cases.contains(&InferredSwitchCase::Boolean);
         if is_switch_true_condition_group {
             return None;
         }
@@ -152,40 +153,29 @@ impl Rule for UseExhaustiveSwitchCases {
         let has_boolean_case = |value: bool| {
             found_cases
                 .iter()
-                .any(|case| is_boolean_literal_data_with_value(case, value))
+                .any(|case| *case == InferredSwitchCase::BooleanLiteral(value))
         };
 
-        let discriminant_ty = flatten_type(&ctx.type_of_expression(&discriminant))?;
+        let variants = ctx
+            .inferred_type_of_expression(&discriminant)?
+            .switch_case_variants();
 
-        let variants = match discriminant_ty.is_union() {
-            true => Type::normalized_boolean_union_variants(
-                discriminant_ty.flattened_union_variants().collect(),
-            ),
-            false => vec![discriminant_ty],
-        };
-
-        for intersection_part in variants {
-            let intersection_part = flatten_type(&intersection_part)?;
-
-            if matches!(intersection_part.deref(), TypeData::Boolean) {
+        for variant in variants {
+            if variant == InferredSwitchCase::Boolean {
                 if !has_boolean_case(true) {
-                    missing_cases.push(MissingCase::BooleanLiteral(true));
+                    missing_cases.push(MissingCase(InferredSwitchCase::BooleanLiteral(true)));
                 }
                 if !has_boolean_case(false) {
-                    missing_cases.push(MissingCase::BooleanLiteral(false));
+                    missing_cases.push(MissingCase(InferredSwitchCase::BooleanLiteral(false)));
                 }
                 continue;
             }
 
-            if !matches!(
-                intersection_part.deref(),
-                TypeData::Literal(_) | TypeData::Null | TypeData::Undefined | TypeData::Symbol
-            ) || found_cases.contains(&intersection_part)
-            {
+            if found_cases.contains(&variant) {
                 continue;
             }
 
-            missing_cases.push(MissingCase::Type(intersection_part));
+            missing_cases.push(MissingCase(variant));
         }
 
         if missing_cases.is_empty() {
@@ -293,17 +283,6 @@ impl Rule for UseExhaustiveSwitchCases {
     }
 }
 
-/// Unwraps [`TypeInner::InstanceOf`] and [`TypeInner::TypeofType`] to get the inner type.
-// TODO: I am not sure if this should be in the type flattening logic.
-fn flatten_type(ty: &Type) -> Option<Type> {
-    match ty.deref() {
-        TypeData::InstanceOf(instance) => ty.resolve(&instance.ty),
-        TypeData::Reference(reference) => ty.resolve(reference),
-        TypeData::TypeofType(inner) => ty.resolve(inner),
-        _ => Some(ty.clone()),
-    }
-}
-
 // A condition-group switch must use the literal `true`, not a boolean expression.
 fn is_true_literal_expression(expr: &AnyJsExpression) -> bool {
     expr.as_any_js_literal_expression()
@@ -312,84 +291,57 @@ fn is_true_literal_expression(expr: &AnyJsExpression) -> bool {
         .is_some_and(|token| token.kind() == T![true])
 }
 
-// Only boolean literal cases satisfy individual `true`/`false` variants.
-fn is_boolean_literal_data_with_value(ty: &TypeData, value: bool) -> bool {
-    matches!(
-        ty,
-        TypeData::Literal(lit)
-            if matches!(lit.as_ref(), Literal::Boolean(b) if b.as_bool() == value)
-    )
-}
-
 impl Display for MissingCase {
     fn fmt(&self, formatter: &mut Formatter) -> io::Result<()> {
-        match self {
-            Self::Type(case_type) => write_type(case_type, formatter),
-            Self::BooleanLiteral(value) => {
+        match &self.0 {
+            InferredSwitchCase::BooleanLiteral(value) => {
                 formatter.write_str(if *value { "true" } else { "false" })
             }
+            InferredSwitchCase::Number(number) => formatter.write_str(number.text()),
+            InferredSwitchCase::String(string) => {
+                formatter.write_fmt(format_args!("\"{}\"", string.text()))
+            }
+            InferredSwitchCase::Null => formatter.write_str("null"),
+            InferredSwitchCase::Undefined => formatter.write_str("undefined"),
+            InferredSwitchCase::Boolean
+            | InferredSwitchCase::Symbol
+            | InferredSwitchCase::UnsupportedLiteral => formatter.write_str("unknown"),
         }
-    }
-}
-
-// Render directly into the diagnostic formatter to avoid a temporary `String`.
-fn write_type(case_type: &Type, formatter: &mut Formatter) -> io::Result<()> {
-    match case_type.deref() {
-        TypeData::Literal(literal) => match literal.as_ref() {
-            Literal::Boolean(boolean) => {
-                formatter.write_str(if boolean.as_bool() { "true" } else { "false" })
-            }
-            Literal::Number(number) => formatter.write_str(number.as_str()),
-            Literal::String(string) => {
-                formatter.write_fmt(format_args!("\"{}\"", string.as_str()))
-            }
-            _ => formatter.write_str("unknown"),
-        },
-        TypeData::Null => formatter.write_str("null"),
-        TypeData::Undefined => formatter.write_str("undefined"),
-        _ => formatter.write_str("unknown"),
     }
 }
 
 fn missing_case_to_expression(case: &MissingCase) -> Option<AnyJsExpression> {
     match case {
-        MissingCase::Type(ty) => type_to_expression(ty),
-        MissingCase::BooleanLiteral(value) => Some(AnyJsExpression::AnyJsLiteralExpression(
+        MissingCase(InferredSwitchCase::BooleanLiteral(value)) => Some(
+            AnyJsExpression::AnyJsLiteralExpression(
             make::js_boolean_literal_expression(make::token(match value {
                 true => T![true],
                 false => T![false],
             }))
             .into(),
-        )),
-    }
-}
-
-fn type_to_expression(ty: &Type) -> Option<AnyJsExpression> {
-    Some(match ty.deref() {
-        TypeData::Literal(lit) => AnyJsExpression::AnyJsLiteralExpression(match lit.as_ref() {
-            Literal::Boolean(b) => {
-                make::js_boolean_literal_expression(make::token(match b.as_bool() {
-                    true => T![true],
-                    false => T![false],
-                }))
-                .into()
-            }
-            Literal::Number(n) => {
-                let text = n.text();
-                make::js_number_literal_expression(make::js_number_literal(text)).into()
-            }
-            Literal::String(s) => {
-                make::js_string_literal_expression(make::js_string_literal(s.as_str())).into()
-            }
-            _ => return None,
-        }),
-        TypeData::Null => AnyJsExpression::AnyJsLiteralExpression(
-            make::js_null_literal_expression(make::token(T![null])).into(),
+            ),
         ),
-        TypeData::Undefined => {
+        MissingCase(InferredSwitchCase::Number(number)) => Some(
+            AnyJsExpression::AnyJsLiteralExpression(
+                make::js_number_literal_expression(make::js_number_literal(number.text())).into(),
+            ),
+        ),
+        MissingCase(InferredSwitchCase::String(string)) => Some(
+            AnyJsExpression::AnyJsLiteralExpression(
+                make::js_string_literal_expression(make::js_string_literal(string.text())).into(),
+            ),
+        ),
+        MissingCase(InferredSwitchCase::Null) => Some(AnyJsExpression::AnyJsLiteralExpression(
+            make::js_null_literal_expression(make::token(T![null])).into(),
+        )),
+        MissingCase(InferredSwitchCase::Undefined) => Some(
             make::js_identifier_expression(make::js_reference_identifier(make::ident("undefined")))
-                .into()
-        }
-        _ => return None,
-    })
+                .into(),
+        ),
+        MissingCase(
+            InferredSwitchCase::Boolean
+            | InferredSwitchCase::Symbol
+            | InferredSwitchCase::UnsupportedLiteral,
+        ) => None,
+    }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
@@ -12,7 +12,7 @@ use biome_js_syntax::{
     JsLogicalExpression, JsLogicalOperator, JsParenthesizedExpression, JsSyntaxKind,
     JsWhileStatement, OperatorPrecedence, T,
 };
-use biome_js_type_info::{ConditionalType, TypeData};
+use biome_js_type_info::{IgnoredPrimitiveTypes, InferredType};
 use biome_rowan::{
     AstNode, BatchMutationExt, SyntaxResult, TextRange, declare_node_union,
     trim_leading_trivia_pieces,
@@ -94,7 +94,7 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```ts,use_options
+    /// ```ts,expect_diagnostic,use_options
     /// declare const cond: string | null;
     /// if (cond || 'fallback') {}
     /// ```
@@ -472,18 +472,18 @@ fn run_logical_or(
     }
 
     let left = logical.left().ok()?;
-    let left_ty = ctx.type_of_expression(&left);
+    let left_ty = ctx.inferred_type_of_expression(&left)?;
 
-    if !is_possibly_nullish(&left_ty) {
+    if !left_ty.has_nullish_variant() {
         return None;
     }
 
-    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, &left_ty) {
+    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, left_ty) {
         return None;
     }
 
     let can_fix =
-        is_safe_type_for_replacement(&left_ty) && is_safe_syntax_context_for_replacement(logical);
+        left_ty.is_safe_for_nullish_coalescing() && is_safe_syntax_context_for_replacement(logical);
 
     Some(UseNullishCoalescingState::LogicalOr {
         operator_range: logical.operator_token().ok()?.text_trimmed_range(),
@@ -519,50 +519,25 @@ fn run_logical_or_assignment(
         AnyJsAssignmentPattern::AnyJsAssignment(assign) => {
             let id = assign.as_js_identifier_assignment()?;
             let name = id.name_token().ok()?;
-            ctx.type_of_named_value(assignment.range(), name.text_trimmed())
+            ctx.inferred_type_of_named_value(assignment.range(), name.text_trimmed())?
         }
         _ => return None,
     };
 
-    if !is_possibly_nullish(&left_ty) {
+    if !left_ty.has_nullish_variant() {
         return None;
     }
 
-    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, &left_ty) {
+    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, left_ty) {
         return None;
     }
 
-    let can_fix = is_safe_type_for_replacement(&left_ty);
+    let can_fix = left_ty.is_safe_for_nullish_coalescing();
 
     Some(UseNullishCoalescingState::LogicalOrAssignment {
         operator_range: assignment.operator_token().ok()?.text_trimmed_range(),
         can_fix,
     })
-}
-
-fn is_safe_type_for_replacement(ty: &biome_js_type_info::Type) -> bool {
-    if ty.is_union() {
-        ty.flattened_union_variants().all(|variant| {
-            matches!(
-                variant.conditional_semantics(),
-                ConditionalType::Truthy | ConditionalType::Nullish
-            )
-        })
-    } else {
-        matches!(
-            ty.conditional_semantics(),
-            ConditionalType::Truthy | ConditionalType::Nullish
-        )
-    }
-}
-
-fn is_possibly_nullish(ty: &biome_js_type_info::Type) -> bool {
-    if ty.is_union() {
-        ty.flattened_union_variants()
-            .any(|variant| variant.conditional_semantics().is_nullish())
-    } else {
-        ty.conditional_semantics().is_nullish()
-    }
 }
 
 /// Returns `true` when every non-nullish variant of `ty` is a primitive that the
@@ -571,35 +546,13 @@ fn is_possibly_nullish(ty: &biome_js_type_info::Type) -> bool {
 /// union in the first place.
 fn should_ignore_for_primitives(
     options: &UseNullishCoalescingOptions,
-    ty: &biome_js_type_info::Type,
+    ty: InferredType,
 ) -> bool {
-    if !ty.is_union() {
-        return false;
-    }
-    ty.flattened_union_variants()
-        .filter(|variant| !variant.conditional_semantics().is_nullish())
-        .all(|variant| is_ignored_primitive(options, &variant))
-}
-
-/// Maps a resolved primitive (or primitive literal) type to its matching
-/// `ignorePrimitives` selector. Non-primitive types are never ignored.
-fn is_ignored_primitive(
-    options: &UseNullishCoalescingOptions,
-    ty: &biome_js_type_info::Type,
-) -> bool {
-    ty.resolved_data().is_some_and(|data| match data.as_raw_data() {
-        TypeData::String => options.should_ignore_primitive_string(),
-        TypeData::Number => options.should_ignore_primitive_number(),
-        TypeData::Boolean => options.should_ignore_primitive_boolean(),
-        TypeData::BigInt => options.should_ignore_primitive_bigint(),
-        TypeData::Literal(literal) => match literal.as_ref() {
-            biome_js_type_info::Literal::String(_) => options.should_ignore_primitive_string(),
-            biome_js_type_info::Literal::Number(_) => options.should_ignore_primitive_number(),
-            biome_js_type_info::Literal::Boolean(_) => options.should_ignore_primitive_boolean(),
-            biome_js_type_info::Literal::BigInt(_) => options.should_ignore_primitive_bigint(),
-            _ => false,
-        },
-        _ => false,
+    ty.nullish_union_matches_ignored_primitives(IgnoredPrimitiveTypes {
+        string: options.should_ignore_primitive_string(),
+        number: options.should_ignore_primitive_number(),
+        boolean: options.should_ignore_primitive_boolean(),
+        bigint: options.should_ignore_primitive_bigint(),
     })
 }
 
@@ -804,8 +757,8 @@ fn run_ternary(
 
     let options = ctx.options();
     if options.has_any_ignore_primitives() {
-        let checked_ty = ctx.type_of_expression(&checked_expr);
-        if should_ignore_for_primitives(options, &checked_ty) {
+        let checked_ty = ctx.inferred_type_of_expression(&checked_expr)?;
+        if should_ignore_for_primitives(options, checked_ty) {
             return None;
         }
     }
@@ -821,10 +774,10 @@ fn run_ternary(
             // A single strict check only covers one nullish variant. The fix to `??`
             // is safe only if the type cannot be the opposite variant.
             NullishCheckKind::StrictSingle(lit) => {
-                let ty = ctx.type_of_expression(&checked_expr);
+                let ty = ctx.inferred_type_of_expression(&checked_expr)?;
                 match lit {
-                    NullishLiteral::Null => !type_has_undefined(&ty),
-                    NullishLiteral::Undefined => !type_has_null(&ty),
+                    NullishLiteral::Null => !ty.has_undefined_variant(),
+                    NullishLiteral::Undefined => !ty.has_null_variant(),
                 }
             }
         };
@@ -983,30 +936,6 @@ fn contains_call_or_new_expression(expr: &AnyJsExpression) -> bool {
             JsSyntaxKind::JS_CALL_EXPRESSION | JsSyntaxKind::JS_NEW_EXPRESSION
         )
     })
-}
-
-fn type_has_null(ty: &biome_js_type_info::Type) -> bool {
-    let is_null = |t: &biome_js_type_info::Type| {
-        t.resolved_data()
-            .is_some_and(|d| matches!(d.as_raw_data(), TypeData::Null))
-    };
-    if ty.is_union() {
-        ty.flattened_union_variants().any(|v| is_null(&v))
-    } else {
-        is_null(ty)
-    }
-}
-
-fn type_has_undefined(ty: &biome_js_type_info::Type) -> bool {
-    let is_undef = |t: &biome_js_type_info::Type| {
-        t.resolved_data()
-            .is_some_and(|d| matches!(d.as_raw_data(), TypeData::Undefined | TypeData::VoidKeyword))
-    };
-    if ty.is_union() {
-        ty.flattened_union_variants().any(|v| is_undef(&v))
-    } else {
-        is_undef(ty)
-    }
 }
 
 /// Wraps the expression in parentheses if it would be invalid or change meaning

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unnecessary_conditions.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unnecessary_conditions.rs
@@ -30,7 +30,7 @@ declare_lint_rule! {
     ///
     /// A non-nullable value never needs an `if` guard:
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic
     /// function head<T>(items: T[]) {
     ///     if (items) {
     ///         return items[0];
@@ -41,7 +41,7 @@ declare_lint_rule! {
     /// A literal-union type can never be empty, so the truthiness check is
     /// redundant:
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic
     /// function foo(arg: 'bar' | 'baz') {
     ///     if (arg) {}
     /// }
@@ -49,13 +49,13 @@ declare_lint_rule! {
     ///
     /// `?.` and `??` on operands that are guaranteed to be non-nullish:
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic
     /// function bar(arg: string) {
     ///     return arg?.length;
     /// }
     /// ```
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic
     /// function withDefault(name: string) {
     ///     return name ?? "anonymous";
     /// }
@@ -63,7 +63,7 @@ declare_lint_rule! {
     ///
     /// `||` and `&&` on always-truthy operands:
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic
     /// interface Config { items: string[] }
     /// function f(c: Config) {
     ///     return c.items || [];
@@ -72,14 +72,14 @@ declare_lint_rule! {
     ///
     /// `!expr` on a value that is always truthy:
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic
     /// const items = [];
     /// if (!items) {}
     /// ```
     ///
     /// Comparing a non-nullable value against `null` or `undefined`:
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic
     /// function f(x: string) {
     ///     return x === null;
     /// }
@@ -87,7 +87,7 @@ declare_lint_rule! {
     ///
     /// A `case` whose value can never equal the value passed to `switch`:
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic
     /// function f(v: 'a' | 'b') {
     ///     switch (v) {
     ///         case 'c': return 1;

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -403,36 +403,8 @@ fn call_argument_type<'db>(
     ty: InferredTypeData<'db>,
     argument_index: usize,
 ) -> Option<InferredTypeData<'db>> {
-    if let Some(function) = ty.callable_function(db) {
-        return function_parameter_type(function.parameters(db), argument_index);
-    }
-
-    match ty {
-        InferredTypeData::Interface(interface) => interface
-            .members(db)
-            .iter()
-            .filter(|member| member.kind.is_call_signature())
-            .find_map(|member| call_argument_type(db, member.ty, argument_index)),
-        InferredTypeData::Object(object) => object
-            .members(db)
-            .iter()
-            .filter(|member| member.kind.is_call_signature())
-            .find_map(|member| call_argument_type(db, member.ty, argument_index)),
-        InferredTypeData::InstanceOf(instance) => {
-            call_argument_type(db, instance.ty(db), argument_index)
-        }
-        InferredTypeData::TypeofType(typeof_type) => {
-            call_argument_type(db, typeof_type.ty(db), argument_index)
-        }
-        InferredTypeData::TypeofValue(typeof_value) => {
-            call_argument_type(db, typeof_value.ty(db), argument_index)
-        }
-        InferredTypeData::Union(union) => union
-            .types(db)
-            .iter()
-            .find_map(|ty| call_argument_type(db, *ty, argument_index)),
-        _ => None,
-    }
+    let function = ty.callable_function(db)?;
+    function_parameter_type(function.parameters(db), argument_index)
 }
 
 fn constructor_argument_type<'db>(

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validShadowedArray.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validShadowedArray.ts
@@ -1,0 +1,10 @@
+/* should not generate diagnostics */
+
+class Array<T> {
+    join(): string {
+        return "custom";
+    }
+}
+
+declare const values: Array<{}>;
+values.join();

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validShadowedArray.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/validShadowedArray.ts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validShadowedArray.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+class Array<T> {
+    join(): string {
+        return "custom";
+    }
+}
+
+declare const values: Array<{}>;
+values.join();
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/validShadowedPromise.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/validShadowedPromise.ts
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+
+class Promise<T> {}
+declare const value: Promise<void>;
+
+value;

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/validShadowedPromise.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/validShadowedPromise.ts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validShadowedPromise.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+class Promise<T> {}
+declare const value: Promise<void>;
+
+value;
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/validOverloadedCallback.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/validOverloadedCallback.ts
@@ -1,0 +1,9 @@
+/* should not generate diagnostics */
+
+interface Invoke {
+  (kind: number, callback: () => void): void;
+  (kind: string, callback: () => Promise<void>): void;
+}
+
+declare const invoke: Invoke;
+invoke("async", async () => {});

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/validOverloadedCallback.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/validOverloadedCallback.ts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validOverloadedCallback.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+interface Invoke {
+  (kind: number, callback: () => void): void;
+  (kind: string, callback: () => Promise<void>): void;
+}
+
+declare const invoke: Invoke;
+invoke("async", async () => {});
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/validShadowedPromise.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/validShadowedPromise.ts
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+
+class Promise<T> {}
+declare const value: Promise<void>;
+
+if (value) {}

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/validShadowedPromise.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/validShadowedPromise.ts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validShadowedPromise.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+class Promise<T> {}
+declare const value: Promise<void>;
+
+if (value) {}
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/invalidShadowedPromise.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/invalidShadowedPromise.ts
@@ -1,0 +1,8 @@
+/* should generate diagnostics */
+
+class Promise<T> {}
+declare const value: Promise<void>;
+
+async function test(): globalThis.Promise<void> {
+    await value;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/invalidShadowedPromise.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/invalidShadowedPromise.ts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidShadowedPromise.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+
+class Promise<T> {}
+declare const value: Promise<void>;
+
+async function test(): globalThis.Promise<void> {
+    await value;
+}
+
+```
+
+# Diagnostics
+```
+invalidShadowedPromise.ts:7:5 lint/nursery/useAwaitThenable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i `await` used on a non-Promise value.
+  
+    6 │ async function test(): globalThis.Promise<void> {
+  > 7 │     await value;
+      │     ^^^^^^^^^^^
+    8 │ }
+    9 │ 
+  
+  i This may happen if you accidentally used `await` on a synchronous value.
+  
+  i Please ensure the value is not a custom "thenable" implementation before removing the `await`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidDynamicCase.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidDynamicCase.ts
@@ -1,0 +1,9 @@
+/* should generate diagnostics */
+
+declare const value: "a" | "b";
+declare const dynamicCase: "a" | "b";
+
+switch (value) {
+    case dynamicCase:
+        break;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidDynamicCase.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidDynamicCase.ts.snap
@@ -1,0 +1,56 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidDynamicCase.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+
+declare const value: "a" | "b";
+declare const dynamicCase: "a" | "b";
+
+switch (value) {
+    case dynamicCase:
+        break;
+}
+
+```
+
+# Diagnostics
+```
+invalidDynamicCase.ts:6:1 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The switch statement is not exhaustive.
+  
+     4 │ declare const dynamicCase: "a" | "b";
+     5 │ 
+   > 6 │ switch (value) {
+       │ ^^^^^^^^^^^^^^^^
+   > 7 │     case dynamicCase:
+   > 8 │         break;
+   > 9 │ }
+       │ ^
+    10 │ 
+  
+  i Some variants of the union type are not handled here.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i These cases are missing:
+  
+  - "a"
+  - "b"
+  
+  i Unsafe fix: Add the missing cases to the switch statement.
+  
+     6  6 │   switch (value) {
+     7  7 │       case dynamicCase:
+     8    │ - ········break;
+        8 │ + ········break;
+        9 │ + ····case·"a":·throw·new·Error("TODO:·Not·implemented·yet");
+       10 │ + ····case·"b":·throw·new·Error("TODO:·Not·implemented·yet");
+     9 11 │   }
+    10 12 │   
+  
+
+```

--- a/crates/biome_js_type_info/src/builders.rs
+++ b/crates/biome_js_type_info/src/builders.rs
@@ -456,6 +456,7 @@ impl<'db> MergedType<'db> {
                     Box::default(),
                     members.into_boxed_slice(),
                     None,
+                    false,
                 )),
                 Box::default(),
             ),

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -493,16 +493,16 @@ impl<'db> TypeData<'db> {
     }
 
     pub fn is_array_class(self, db: &'db dyn TypeDb) -> bool {
-        self.is_class_named(db, "Array")
+        self.is_builtin_class_named(db, "Array")
     }
 
     pub fn is_promise_class(self, db: &'db dyn TypeDb) -> bool {
-        self.is_class_named(db, "Promise")
+        self.is_builtin_class_named(db, "Promise")
     }
 
-    pub fn is_class_named(self, db: &'db dyn TypeDb, expected_name: &str) -> bool {
+    fn is_builtin_class_named(self, db: &'db dyn TypeDb, expected_name: &str) -> bool {
         match self {
-            Self::Class(class) => class
+            Self::Class(class) if class.is_builtin(db) => class
                 .name(db)
                 .as_ref()
                 .is_some_and(|name| name.text() == expected_name),
@@ -676,6 +676,7 @@ impl<'db> TypeData<'db> {
             Box::default(),
             Box::default(),
             Some(Text::new_static(name)),
+            true,
         ))
     }
 
@@ -793,6 +794,7 @@ impl<'db> TypeData<'db> {
                 convert_references(db, &class.implements, resolve_reference),
                 convert_type_members(db, &class.members, resolve_reference),
                 class.name.clone(),
+                false,
             )),
             raw::TypeData::Constructor(constructor) => Self::Constructor(InternedConstructor::new(
                 db,
@@ -1525,6 +1527,7 @@ pub struct InternedClass<'db> {
     pub members: Box<[TypeMember<'db>]>,
     #[returns(ref)]
     pub name: Option<Text>,
+    pub is_builtin: bool,
 }
 
 #[salsa::interned]

--- a/crates/biome_module_graph/src/db/type_inference/globals.rs
+++ b/crates/biome_module_graph/src/db/type_inference/globals.rs
@@ -199,6 +199,7 @@ fn resolve_global_type_id_with_resolver<'db>(
                         implements.into_boxed_slice(),
                         members.into_boxed_slice(),
                         name,
+                        true,
                     ),
                 )));
             }
@@ -468,6 +469,7 @@ fn global_cycle_placeholder<'db>(
             Box::default(),
             Box::default(),
             class.name.clone(),
+            true,
         )),
         RawTypeData::Interface(interface) => {
             InferredTypeData::Interface(InferredInternedInterface::new(

--- a/crates/biome_ruledoc_utils/src/lib.rs
+++ b/crates/biome_ruledoc_utils/src/lib.rs
@@ -12,7 +12,7 @@ use biome_deserialize::json::deserialize_from_json_ast;
 use biome_diagnostics::DiagnosticExt;
 use biome_fs::{BiomePath, MemoryFileSystem};
 use biome_js_analyze::JsAnalyzerServices;
-use biome_js_semantic::semantic_model_from_source;
+use biome_js_semantic::{SemanticModel, semantic_model_from_source};
 use biome_json_factory::make;
 use biome_json_parser::{JsonParserOptions, parse_json};
 use biome_json_syntax::{AnyJsonValue, JsonMember, JsonObjectValue};
@@ -35,7 +35,11 @@ use std::sync::Arc;
 /// for multiple code blocks.
 pub struct AnalyzerServicesBuilder {
     module_db: WorkspaceDb,
+    file_system: MemoryFileSystem,
+    path_info_cache: PathInfoCache,
     project_layout: Arc<ProjectLayout>,
+    semantic_model: Option<Arc<SemanticModel>>,
+    enable_type_inference: bool,
 }
 
 impl AnalyzerServicesBuilder {
@@ -47,12 +51,19 @@ impl AnalyzerServicesBuilder {
     /// # Arguments
     ///
     /// * `files` - A map of file paths to their contents.
-    pub fn from_files<S: BuildHasher>(files: HashMap<String, String, S>) -> Self {
+    pub fn from_files<S: BuildHasher>(
+        files: HashMap<String, String, S>,
+        enable_type_inference: bool,
+    ) -> Self {
         if files.is_empty() {
             let db = WorkspaceDb::default();
             return Self {
                 module_db: db,
+                file_system: MemoryFileSystem::default(),
+                path_info_cache: PathInfoCache::default(),
                 project_layout: Default::default(),
+                semantic_model: None,
+                enable_type_inference,
             };
         }
 
@@ -116,7 +127,7 @@ impl AnalyzerServicesBuilder {
                 &layout,
                 semantic_model,
                 &path_info_cache,
-                true,
+                enable_type_inference,
             );
             let md = biome_module_graph::ModuleInfo::new(
                 &db,
@@ -158,7 +169,11 @@ impl AnalyzerServicesBuilder {
 
         Self {
             module_db: db,
+            file_system: fs,
+            path_info_cache,
             project_layout: Arc::new(layout),
+            semantic_model: None,
+            enable_type_inference,
         }
     }
 
@@ -168,6 +183,7 @@ impl AnalyzerServicesBuilder {
         parse: biome_js_parser::Parse<biome_js_parser::AnyJsRoot>,
         file_source: JsFileSource,
     ) -> JsAnalyzerServices<'_> {
+        let root = parse.tree();
         let source_index = self
             .module_db
             .insert_source(DocumentFileSource::Js(file_source));
@@ -180,13 +196,32 @@ impl AnalyzerServicesBuilder {
         );
         self.module_db.insert_file(&path, parsed_source);
 
+        let semantic_model =
+            Arc::new(semantic_model_from_source(&self.module_db, parsed_source).clone());
+        let (module_info, _, _) = resolve_js_module(
+            root,
+            &BiomePath::new(&path),
+            &self.file_system,
+            &self.project_layout,
+            semantic_model.clone(),
+            &self.path_info_cache,
+            self.enable_type_inference,
+        );
+        self.module_db
+            .update_or_insert_module(path, ModuleInfoKind::Js(module_info));
+        self.semantic_model = Some(semantic_model);
+
         JsAnalyzerServices::from((
             self.module_db.rc_module_db(),
             self.project_layout.clone(),
             file_source,
         ))
         .with_language_db(self.module_db.rc_language_db())
-        .with_semantic_model(semantic_model_from_source(&self.module_db, parsed_source))
+        .with_semantic_model(
+            self.semantic_model
+                .as_deref()
+                .expect("the semantic model was just created"),
+        )
     }
 }
 

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -165,7 +165,8 @@ fn change_file_resumes_module_update_after_cancellation() {
         Utf8PathBuf::from(INDEX_PATH),
         b"import { task } from './base';\ntask();",
     );
-    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/project");
+    let (mut workspace, project_key) = setup_workspace_and_open_project(fs, "/project");
+    workspace.db_state = db::DbState::lsp();
 
     workspace
         .update_settings(UpdateSettingsParams {

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -10,7 +10,7 @@ use std::{mem, slice};
 use anyhow::bail;
 use biome_analyze::{
     ActionFilter, AnalysisFilter, ControlFlow, GroupCategory, Queryable, RegistryVisitor, Rule,
-    RuleCategory, RuleFilter, RuleGroup, RuleMetadata,
+    RuleCategory, RuleDomain, RuleFilter, RuleGroup, RuleMetadata,
 };
 use biome_configuration::Configuration;
 use biome_css_analyze::CssAnalyzerServices;
@@ -552,7 +552,12 @@ fn parse_documentation(
 
     let mut diagnostics_writer = DiagnosticConsoleWriter::default();
 
-    let mut test_runner = TestRunner::new(group, rule_metadata.name, rule_metadata.language);
+    let mut test_runner = TestRunner::new(
+        group,
+        rule_metadata.name,
+        rule_metadata.language,
+        rule_metadata.domains.contains(&RuleDomain::Types),
+    );
 
     // Track the last configuration options block that was encountered
     let mut last_options: Option<Configuration> = None;
@@ -641,6 +646,7 @@ struct TestRunner {
     group: &'static str,
     rule_name: &'static str,
     rule_language: &'static str,
+    enable_type_inference: bool,
 
     /// Code block tests for the current documentation section.
     /// Tests are deferred and run as a batch when the section ends.
@@ -654,11 +660,17 @@ struct TestRunner {
 }
 
 impl TestRunner {
-    pub fn new(group: &'static str, rule_name: &'static str, rule_language: &'static str) -> Self {
+    pub fn new(
+        group: &'static str,
+        rule_name: &'static str,
+        rule_language: &'static str,
+        enable_type_inference: bool,
+    ) -> Self {
         Self {
             group,
             rule_name,
             rule_language,
+            enable_type_inference,
             pending_tests: Vec::new(),
             file_system: HashMap::new(),
         }
@@ -668,8 +680,10 @@ impl TestRunner {
     ///
     /// Resets state for the next section.
     pub fn run_pending_tests(&mut self) -> anyhow::Result<()> {
-        let mut services_builder =
-            AnalyzerServicesBuilder::from_files(mem::take(&mut self.file_system));
+        let mut services_builder = AnalyzerServicesBuilder::from_files(
+            mem::take(&mut self.file_system),
+            self.enable_type_inference,
+        );
 
         for test in self.pending_tests.drain(..) {
             assert_lint(


### PR DESCRIPTION
## Summary

Continues #10933 by migrating six behavior-sensitive type-aware lint rules to the Salsa-backed inference APIs:

- `noBaseToString`
- `noFloatingPromises`
- `noMisusedPromises`
- `useAwaitThenable`
- `useExhaustiveSwitchCases`
- `useNullishCoalescing`

The migration removes duplicated legacy type traversal while preserving existing behavior for shadowed `Promise` and `Array` classes, dynamic union-valued switch cases, and callback overload selection.

This is an internal migration with no intended user-facing behavior change, so no changeset is required.

## Test Plan

Added regression coverage for shadowed built-ins, dynamic switch cases, and overloaded callbacks.

Green CI

## Docs

N/A

> This PR was created with AI assistance (OpenCode).