### PR TITLE
refactor(lint): port noMisleadingReturnType

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type.rs
@@ -6,22 +6,17 @@ use biome_console::{
     markup,
 };
 use biome_js_syntax::{
-    AnyJsBinding, AnyJsClass, AnyJsDeclarationClause, AnyJsExpression, AnyJsFunction,
-    AnyJsFunctionBody, AnyJsGetter, AnyTsCastExpression, AnyTsIdentifierBinding, AnyTsType,
-    JsArrowFunctionExpression, JsConstructorClassMember, JsFunctionBody, JsFunctionDeclaration, JsFunctionExpression,
-    JsGetterClassMember, JsGetterObjectMember, JsIdentifierExpression, JsLogicalOperator,
-    JsMethodClassMember, JsMethodObjectMember, JsReturnStatement, JsSetterClassMember,
-    JsSetterObjectMember, JsSyntaxNode, JsVariableStatement, TsAsExpression,
-    TsDeclareFunctionDeclaration, TsInterfaceDeclaration, TsMethodSignatureClassMember,
-    TsReferenceType, TsTypeAliasDeclaration, TsTypeAssertionExpression,
+    AnyJsExpression, AnyJsFunction, AnyJsFunctionBody, AnyJsGetter, AnyTsCastExpression, AnyTsType,
+    JsArrowFunctionExpression, JsConstructorClassMember, JsFunctionBody, JsFunctionDeclaration,
+    JsFunctionExpression, JsGetterClassMember, JsGetterObjectMember, JsIdentifierExpression,
+    JsLogicalOperator, JsMethodClassMember, JsMethodObjectMember, JsReturnStatement,
+    JsSetterClassMember, JsSetterObjectMember, JsSyntaxNode, JsVariableStatement, TsAsExpression,
+    TsDeclareFunctionDeclaration, TsMethodSignatureClassMember, TsTypeAssertionExpression,
 };
-use biome_js_semantic::ScopeId;
-use biome_js_type_info::{
-    Class, Literal, Type, TypeData, TypeMemberKind, TypeReferenceQualifier,
-};
-use biome_rowan::{AstNode, Text, TextRange, declare_node_union};
+use biome_js_type_info::{InferredType, ReturnTypeEvidence};
+use biome_rowan::{AstNode, TextRange, declare_node_union};
 use biome_rule_options::no_misleading_return_type::NoMisleadingReturnTypeOptions;
-use smallvec::{SmallVec, smallvec};
+use smallvec::SmallVec;
 use std::iter::FusedIterator;
 
 use crate::services::typed::Typed;
@@ -105,219 +100,21 @@ declare_node_union! {
 
 pub struct RuleState {
     annotation_range: TextRange,
-    returns: Vec<Type>,
-    effective_return_ty: Type,
-    has_any_const_return: bool,
+    suggestion: Option<String>,
 }
-
-enum DescriptionKind {
-    /// Built from the actual return values (e.g. `"loading" | "idle"`).
-    Inferred,
-    /// Built by narrowing the annotation's union to its covered variants.
-    Narrowed,
-}
-
-/// Maximum iterations for type graph traversal to guard against infinite loops on cyclic types.
-const MAX_TYPE_TRAVERSAL_ITERATIONS: usize = 50;
 
 /// Maximum iterations for expression traversal to guard against infinite loops.
 const MAX_EXPRESSION_TRAVERSAL_ITERATIONS: usize = 200;
 
-// #region display methods
-/// Upper bound on a narrowed return-type suggestion; longer unions fall back
-/// to the generic diagnostic note.
-const MAX_DESCRIPTION_LENGTH: usize = 80;
-
-/// Separator rendered between union members in the suggestion note.
-const SEPARATOR: &str = " | ";
-
-impl RuleState {
-    /// Returns the suggestion kind to render, or `None` to fall back to the
-    /// generic note.
-    fn description_kind(&self) -> Option<DescriptionKind> {
-        if self.has_any_const_return {
-            return can_render_inferred(&self.returns).then_some(DescriptionKind::Inferred);
-        }
-        if can_render_narrowed(&self.effective_return_ty, &self.returns) {
-            return Some(DescriptionKind::Narrowed);
-        }
-        can_render_inferred(&self.returns).then_some(DescriptionKind::Inferred)
-    }
-
-    /// Writes an inferred description like `"loading" | "idle"`.
-    fn write_inferred(&self, formatter: &mut Formatter<'_>) -> io::Result<()> {
-        let mut first = true;
-        for return_type in &self.returns {
-            if let TypeData::Literal(literal) = &**return_type {
-                if !first {
-                    formatter.write_str(SEPARATOR)?;
-                }
-                write_literal(formatter, literal.as_ref())?;
-                first = false;
-            }
-        }
-        Ok(())
-    }
-
-    /// Writes narrowed annotation variants (only those covered by the returns).
-    fn write_narrowed(&self, formatter: &mut Formatter<'_>) -> io::Result<()> {
-        let covers_any = |variant: &Type| {
-            self.returns.iter().any(|return_type| {
-                types_match(variant, return_type) || is_nonunion_wider(variant, return_type)
-            })
-        };
-        let mut first = true;
-        for variant in self.effective_return_ty.flattened_union_variants().filter(covers_any) {
-            if !first {
-                formatter.write_str(SEPARATOR)?;
-            }
-            write_variant(formatter, &variant)?;
-            first = false;
-        }
-        Ok(())
-    }
-}
-
 impl Display for RuleState {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> io::Result<()> {
-        match self.description_kind() {
-            Some(DescriptionKind::Inferred) => self.write_inferred(formatter),
-            Some(DescriptionKind::Narrowed) => self.write_narrowed(formatter),
-            None => Ok(()),
+        if let Some(suggestion) = &self.suggestion {
+            formatter.write_str(suggestion)
+        } else {
+            Ok(())
         }
     }
 }
-
-/// Rendered byte length of a string/number/boolean literal; `None` otherwise.
-fn literal_display_len(literal: &Literal) -> Option<usize> {
-    match literal {
-        Literal::String(value) => Some(value.as_str().len() + 2),
-        Literal::Number(value) => Some(value.as_str().len()),
-        Literal::Boolean(value) => Some(if value.as_bool() { 4 } else { 5 }),
-        _ => None,
-    }
-}
-
-/// Rejects literals whose rendered text contains `...`, `__internal`, or `typeof import(`.
-fn literal_content_ok(literal: &Literal) -> bool {
-    let text = match literal {
-        Literal::String(value) => value.as_str(),
-        Literal::Number(value) => value.as_str(),
-        _ => return true,
-    };
-    !text.contains("...") && !text.contains("__internal") && !text.contains("typeof import(")
-}
-
-/// Writes a string/number/boolean literal; writes nothing for other kinds.
-fn write_literal(formatter: &mut Formatter<'_>, literal: &Literal) -> io::Result<()> {
-    match literal {
-        Literal::String(value) => write!(formatter, "\"{}\"", value.as_str()),
-        Literal::Number(value) => formatter.write_str(value.as_str()),
-        Literal::Boolean(value) => formatter.write_str(if value.as_bool() { "true" } else { "false" }),
-        _ => Ok(()),
-    }
-}
-
-/// Rendered byte length of a primitive keyword or literal variant; `None` otherwise.
-fn variant_display_len(variant: &Type) -> Option<usize> {
-    match &**variant {
-        TypeData::String | TypeData::Number | TypeData::BigInt => Some(6),
-        TypeData::Boolean => Some(7),
-        TypeData::Literal(literal) => literal_display_len(literal.as_ref()),
-        _ => None,
-    }
-}
-
-/// Writes a primitive keyword or literal variant; writes nothing for other kinds.
-fn write_variant(formatter: &mut Formatter<'_>, variant: &Type) -> io::Result<()> {
-    match &**variant {
-        TypeData::String => formatter.write_str("string"),
-        TypeData::Number => formatter.write_str("number"),
-        TypeData::Boolean => formatter.write_str("boolean"),
-        TypeData::BigInt => formatter.write_str("bigint"),
-        TypeData::Literal(literal) => write_literal(formatter, literal.as_ref()),
-        _ => Ok(()),
-    }
-}
-
-/// `true` when every return is a displayable literal with clean content and
-/// the joined output fits within [`MAX_DESCRIPTION_LENGTH`].
-fn can_render_inferred(returns: &[Type]) -> bool {
-    let mut total_len = 0usize;
-    let mut has_any = false;
-    for return_type in returns {
-        let TypeData::Literal(literal) = &**return_type else {
-            return false;
-        };
-        if !literal_content_ok(literal.as_ref()) {
-            return false;
-        }
-        let Some(literal_len) = literal_display_len(literal.as_ref()) else {
-            return false;
-        };
-        if has_any {
-            total_len += SEPARATOR.len();
-        }
-        total_len += literal_len;
-        has_any = true;
-    }
-    has_any && total_len <= MAX_DESCRIPTION_LENGTH
-}
-
-/// Returns `true` when the annotation's union can be safely narrowed to only
-/// its covered variants within [`MAX_DESCRIPTION_LENGTH`].
-fn can_render_narrowed(annotation: &Type, returns: &[Type]) -> bool {
-    let covers_any = |variant: &Type| {
-        returns.iter().any(|return_type| {
-            types_match(variant, return_type) || is_nonunion_wider(variant, return_type)
-        })
-    };
-
-    let mut total = 0usize;
-    let mut covered = 0usize;
-    let mut all_renderable = true;
-    let mut has_widening = false;
-    let mut render_len = 0usize;
-    let mut first = true;
-
-    for variant in annotation.flattened_union_variants() {
-        total += 1;
-        if !covers_any(&variant) {
-            continue;
-        }
-        covered += 1;
-        if returns.iter().any(|return_type| {
-            !types_match(&variant, return_type) && is_nonunion_wider(&variant, return_type)
-        }) {
-            has_widening = true;
-        }
-        match variant_display_len(&variant) {
-            Some(len) => {
-                if !first {
-                    render_len += SEPARATOR.len();
-                }
-                render_len += len;
-                first = false;
-            }
-            None => all_renderable = false,
-        }
-    }
-
-    if covered == 0 || covered == total || !all_renderable {
-        return false;
-    }
-
-    // A widening variant would keep the narrowed annotation misleading, unless
-    // the single-literal-primitive bailout upstream would hide it.
-    let single_literal_bailout =
-        covered == 1 && is_single_literal_primitive_return(returns);
-    if has_widening && !single_literal_bailout {
-        return false;
-    }
-
-    render_len <= MAX_DESCRIPTION_LENGTH
-}
-// #endregion
 
 impl Rule for NoMisleadingReturnType {
     type Query = Typed<AnyFunctionLikeWithReturnType>;
@@ -329,9 +126,7 @@ impl Rule for NoMisleadingReturnType {
         let node = ctx.query();
 
         match node {
-            AnyFunctionLikeWithReturnType::AnyJsFunction(func) => {
-                run_for_function(ctx, func)
-            }
+            AnyFunctionLikeWithReturnType::AnyJsFunction(func) => run_for_function(ctx, func),
             AnyFunctionLikeWithReturnType::JsMethodClassMember(method) => {
                 if method.star_token().is_some() {
                     return None;
@@ -340,18 +135,44 @@ impl Rule for NoMisleadingReturnType {
                     return None;
                 }
                 let annotation = method.return_type_annotation()?;
-                let name = method.name().ok()?.as_js_literal_member_name()?.name().ok()?;
-                let func_type = ctx.type_of_member(method.syntax(), name.text());
-                run_for_member(ctx, annotation.range(), &func_type, method.async_token().is_some(), &method.body().ok()?)
+                let name = method
+                    .name()
+                    .ok()?
+                    .as_js_literal_member_name()?
+                    .name()
+                    .ok()?;
+                let return_type =
+                    ctx.inferred_return_type_of_member(method.syntax(), name.text())?;
+                run_for_member(
+                    ctx,
+                    annotation.range(),
+                    return_type,
+                    method.async_token().is_some(),
+                    prefers_inferred_suggestion(annotation.syntax()),
+                    &method.body().ok()?,
+                )
             }
             AnyFunctionLikeWithReturnType::JsMethodObjectMember(method) => {
                 if method.star_token().is_some() {
                     return None;
                 }
                 let annotation = method.return_type_annotation()?;
-                let name = method.name().ok()?.as_js_literal_member_name()?.name().ok()?;
-                let func_type = ctx.type_of_member(method.syntax(), name.text());
-                run_for_member(ctx, annotation.range(), &func_type, method.async_token().is_some(), &method.body().ok()?)
+                let name = method
+                    .name()
+                    .ok()?
+                    .as_js_literal_member_name()?
+                    .name()
+                    .ok()?;
+                let return_type =
+                    ctx.inferred_return_type_of_member(method.syntax(), name.text())?;
+                run_for_member(
+                    ctx,
+                    annotation.range(),
+                    return_type,
+                    method.async_token().is_some(),
+                    prefers_inferred_suggestion(annotation.syntax()),
+                    &method.body().ok()?,
+                )
             }
             AnyFunctionLikeWithReturnType::JsGetterClassMember(getter) => {
                 let annotation = getter.return_type()?;
@@ -360,8 +181,16 @@ impl Rule for NoMisleadingReturnType {
                 if any_getter.has_matching_setter(&name) {
                     return None;
                 }
-                let func_type = ctx.type_of_member(getter.syntax(), name.text());
-                run_for_member(ctx, annotation.range(), &func_type, false, &getter.body().ok()?)
+                let return_type =
+                    ctx.inferred_return_type_of_member(getter.syntax(), name.text())?;
+                run_for_member(
+                    ctx,
+                    annotation.range(),
+                    return_type,
+                    false,
+                    prefers_inferred_suggestion(annotation.syntax()),
+                    &getter.body().ok()?,
+                )
             }
             AnyFunctionLikeWithReturnType::JsGetterObjectMember(getter) => {
                 let annotation = getter.return_type()?;
@@ -370,8 +199,16 @@ impl Rule for NoMisleadingReturnType {
                 if any_getter.has_matching_setter(&name) {
                     return None;
                 }
-                let func_type = ctx.type_of_member(getter.syntax(), name.text());
-                run_for_member(ctx, annotation.range(), &func_type, false, &getter.body().ok()?)
+                let return_type =
+                    ctx.inferred_return_type_of_member(getter.syntax(), name.text())?;
+                run_for_member(
+                    ctx,
+                    annotation.range(),
+                    return_type,
+                    false,
+                    prefers_inferred_suggestion(annotation.syntax()),
+                    &getter.body().ok()?,
+                )
             }
         }
     }
@@ -388,7 +225,7 @@ impl Rule for NoMisleadingReturnType {
             "A wider return type hides the precise types that callers could rely on."
         });
 
-        let diag = if state.description_kind().is_some() {
+        let diag = if state.suggestion.is_some() {
             diag.note(markup! {
                 "Consider using "{state}" as the return type."
             })
@@ -400,7 +237,6 @@ impl Rule for NoMisleadingReturnType {
 
         Some(diag)
     }
-
 }
 
 /// Looks for sibling function declarations with the same name but no body,
@@ -422,9 +258,7 @@ fn is_overload_implementation(node: &AnyJsFunction) -> bool {
         if sibling == *node.syntax() {
             return false;
         }
-        if let Some(decl) =
-            TsDeclareFunctionDeclaration::cast(sibling.clone())
-        {
+        if let Some(decl) = TsDeclareFunctionDeclaration::cast(sibling.clone()) {
             return decl
                 .id()
                 .ok()
@@ -449,134 +283,92 @@ fn run_for_function(
 ) -> Option<RuleState> {
     let annotation = node.return_type_annotation()?;
     let annotation_range = annotation.range();
+    let prefer_inferred_suggestion = prefers_inferred_suggestion(annotation.syntax());
 
     if node.is_generator() || is_overload_implementation(node) {
         return None;
     }
 
-    let func_type = ctx.type_of_function(node);
+    let return_type = ctx.inferred_return_type_of_function(node)?;
     let is_async = node.async_token().is_some();
     let body = node.body().ok()?;
 
-    run_for_member_with_body(ctx, annotation_range, &func_type, is_async, &body)
+    run_for_member_with_body(
+        ctx,
+        annotation_range,
+        return_type,
+        is_async,
+        prefer_inferred_suggestion,
+        &body,
+    )
 }
 
-fn run_for_member(
-    ctx: &RuleContext<NoMisleadingReturnType>,
+fn run_for_member<'db>(
+    ctx: &'db RuleContext<NoMisleadingReturnType>,
     annotation_range: TextRange,
-    func_type: &Type,
+    return_type: InferredType<'db>,
     is_async: bool,
+    prefer_inferred_suggestion: bool,
     body: &JsFunctionBody,
 ) -> Option<RuleState> {
     run_for_member_with_body(
         ctx,
         annotation_range,
-        func_type,
+        return_type,
         is_async,
+        prefer_inferred_suggestion,
         &AnyJsFunctionBody::JsFunctionBody(body.clone()),
     )
 }
 
-fn run_for_member_with_body(
-    ctx: &RuleContext<NoMisleadingReturnType>,
+fn run_for_member_with_body<'db>(
+    ctx: &'db RuleContext<NoMisleadingReturnType>,
     annotation_range: TextRange,
-    func_type: &Type,
+    return_type: InferredType<'db>,
     is_async: bool,
+    prefer_inferred_suggestion: bool,
     body: &AnyJsFunctionBody,
 ) -> Option<RuleState> {
-    let return_ty = extract_return_type(func_type)?;
-
-    if is_escape_hatch(&return_ty) {
-        return None;
-    }
-
-    let effective_return_ty = if is_async {
-        unwrap_promise_inner(&return_ty)
-    } else {
-        return_ty.clone()
-    };
-
-    // Normalize `"a" | "b" | string` → `string` before widening checks.
-    let effective_return_ty =
-        collapse_union_absorbed_by_primitive(&effective_return_ty).unwrap_or(effective_return_ty);
-
-    let needs_object_bookkeeping = matches!(&*effective_return_ty, TypeData::ObjectKeyword);
-    let info = collect_return_info(ctx, body, needs_object_bookkeeping);
-
-    if info.types.is_empty() {
-        return None;
-    }
-
-    if info.is_single_primitive_literal() && !effective_return_ty.is_union() {
-        return None;
-    }
-
-    if info.all_opt_into_object() && matches!(&*effective_return_ty, TypeData::ObjectKeyword) {
-        return None;
-    }
-
-    if matches!(&*effective_return_ty, TypeData::Boolean)
-        && info.matches_boolean_value(true)
-        && info.matches_boolean_value(false)
-    {
-        return None;
-    }
-
-    if info.types.iter().any(is_any_contaminated) {
-        return None;
-    }
-
-    // tsc collapses any union containing `unknown` to `unknown`.
-    if matches!(&*effective_return_ty, TypeData::Union(_))
-        && effective_return_ty
-            .flattened_union_variants()
-            .any(|v| matches!(&*v, TypeData::UnknownKeyword | TypeData::Unknown))
-    {
-        return None;
-    }
-
-    if includes_undefined(&effective_return_ty)
-        && !info.types.iter().any(includes_undefined)
-    {
-        return None;
-    }
-
-    if info.types.iter().any(is_intersection_with_type_param) {
-        return None;
-    }
-
-    if !info.has_any_const
-        && is_only_property_literal_widening(&effective_return_ty, &info.types)
-    {
-        return None;
-    }
-
-    let is_misleading = if effective_return_ty.is_union() {
-        is_union_wider_than_returns(&effective_return_ty, &info.types)
-    } else if matches!(&*effective_return_ty, TypeData::ObjectKeyword) {
-        !info.types.iter().any(includes_object_keyword)
-            && info.object_wide_casts == 0
-            && (info.has_narrower_than_object
-                || info
-                    .types
-                    .iter()
-                    .any(|inferred| is_wider_than(&effective_return_ty, inferred)))
-    } else {
-        info.types
-            .iter()
-            .all(|inferred| is_wider_than(&effective_return_ty, inferred))
-    };
-
-    if !is_misleading {
-        return None;
-    }
-
+    let info = collect_return_info(ctx, body);
+    let analysis = return_type.check_misleading_return_type(
+        &info.types,
+        ReturnTypeEvidence {
+            has_any_const: info.has_any_const,
+            object_wide_casts: info.object_wide_casts,
+            has_narrower_than_object: info.has_narrower_than_object,
+            has_pinning_assertion: info.has_pinning_assertion,
+            prefer_inferred_suggestion,
+        },
+        is_async,
+    )?;
     Some(RuleState {
         annotation_range,
-        returns: info.types,
-        effective_return_ty,
-        has_any_const_return: info.has_any_const,
+        suggestion: analysis.suggestion,
     })
+}
+
+fn prefers_inferred_suggestion(annotation: &JsSyntaxNode) -> bool {
+    let mut primitives = [false; 4];
+    let mut literals = [false; 4];
+    for ty in annotation.descendants().filter_map(AnyTsType::cast) {
+        match ty {
+            AnyTsType::TsStringType(_) => primitives[0] = true,
+            AnyTsType::TsNumberType(_) => primitives[1] = true,
+            AnyTsType::TsBooleanType(_) => primitives[2] = true,
+            AnyTsType::TsBigintType(_) => primitives[3] = true,
+            AnyTsType::TsStringLiteralType(_) | AnyTsType::TsTemplateLiteralType(_) => {
+                literals[0] = true;
+            }
+            AnyTsType::TsNumberLiteralType(_) => literals[1] = true,
+            AnyTsType::TsBooleanLiteralType(_) => literals[2] = true,
+            AnyTsType::TsBigintLiteralType(_) => literals[3] = true,
+            _ => {}
+        }
+    }
+    primitives
+        .iter()
+        .zip(literals)
+        .any(|(primitive, literal)| *primitive && literal)
 }
 
 fn is_class_method_overload_implementation(method: &JsMethodClassMember) -> bool {
@@ -604,288 +396,10 @@ fn is_class_method_overload_implementation(method: &JsMethodClassMember) -> bool
         })
 }
 
-fn extract_return_type(func_type: &Type) -> Option<Type> {
-    match &**func_type {
-        TypeData::Function(function) => {
-            let ty_ref = function.return_type.as_type()?;
-            func_type.resolve(ty_ref)
-        }
-        _ => None,
-    }
-}
-
-fn is_escape_hatch(ty: &Type) -> bool {
-    matches!(
-        &**ty,
-        TypeData::AnyKeyword
-            | TypeData::VoidKeyword
-            | TypeData::UnknownKeyword
-            | TypeData::NeverKeyword
-            | TypeData::Unknown
-            | TypeData::ThisKeyword
-    )
-}
-
-/// Returns the primitive a union collapses to at the TS level, when exactly
-/// one variant is a primitive and every other variant is a literal of it.
-fn collapse_union_absorbed_by_primitive(ty: &Type) -> Option<Type> {
-    if !matches!(&**ty, TypeData::Union(_)) {
-        return None;
-    }
-    let variants: Vec<Type> = ty.flattened_union_variants().collect();
-    let mut primitive: Option<Type> = None;
-    for variant in &variants {
-        if matches!(
-            &**variant,
-            TypeData::String | TypeData::Number | TypeData::Boolean | TypeData::BigInt
-        ) {
-            if primitive.is_some() {
-                return None;
-            }
-            primitive = Some(variant.clone());
-        }
-    }
-    let primitive = primitive?;
-    let all_absorbed = variants.iter().all(|variant| {
-        types_match(variant, &primitive) || is_nonunion_wider(&primitive, variant)
-    });
-    all_absorbed.then_some(primitive)
-}
-
-/// Checks whether `object` appears directly or as a union variant.
-fn includes_object_keyword(ty: &Type) -> bool {
-    match &**ty {
-        TypeData::ObjectKeyword => true,
-        TypeData::Union(_) => ty
-            .flattened_union_variants()
-            .any(|variant| matches!(&*variant, TypeData::ObjectKeyword)),
-        _ => false,
-    }
-}
-
-/// For async functions the annotation is `Promise<T>`. We need `T` to compare
-/// against the return expressions, which are not wrapped in `Promise`.
-fn unwrap_promise_inner(return_ty: &Type) -> Type {
-    if let TypeData::InstanceOf(instance) = &**return_ty
-        && let Some(inner_ref) = instance.type_parameters.first()
-            && let Some(inner) = return_ty.resolve(inner_ref)
-                && !is_escape_hatch(&inner) {
-                    return inner;
-                }
-
-    return_ty.clone()
-}
-
-fn includes_undefined(ty: &Type) -> bool {
-    match &**ty {
-        TypeData::Undefined | TypeData::VoidKeyword => true,
-        TypeData::Union(_) => ty
-            .flattened_union_variants()
-            .any(|v| matches!(&*v, TypeData::Undefined | TypeData::VoidKeyword)),
-        _ => false,
-    }
-}
-
-fn is_any_contaminated(ty: &Type) -> bool {
-    match &**ty {
-        TypeData::AnyKeyword => true,
-        TypeData::Union(_) => ty
-            .flattened_union_variants()
-            .any(|v| matches!(&*v, TypeData::AnyKeyword)),
-        TypeData::Intersection(intersection) => intersection.types().iter().any(|member_ref| {
-            ty.resolve(member_ref)
-                .is_some_and(|resolved| matches!(&*resolved, TypeData::AnyKeyword))
-        }),
-        _ => false,
-    }
-}
-
-fn is_intersection_with_type_param(ty: &Type) -> bool {
-    match &**ty {
-        TypeData::Intersection(intersection) => intersection.types().iter().any(|member_ref| {
-            ty.resolve(member_ref)
-                .is_some_and(|resolved| matches!(&*resolved, TypeData::Generic(_)))
-        }),
-        _ => false,
-    }
-}
-
-fn is_literal_of_primitive(ty: &Type) -> bool {
-    match &**ty {
-        TypeData::Literal(lit) => lit.is_primitive(),
-        // The type resolver may wrap a single literal in a Union for mutable
-        // bindings.  Treat a one-element union of a primitive literal the same.
-        TypeData::Union(_) => {
-            let mut iter = ty.flattened_union_variants();
-            matches!(
-                (iter.next(), iter.next()),
-                (Some(v), None) if matches!(&*v, TypeData::Literal(lit) if lit.is_primitive())
-            )
-        }
-        _ => false,
-    }
-}
-
-fn is_single_literal_primitive_return(returns: &[Type]) -> bool {
-    returns.len() == 1 && is_literal_of_primitive(&returns[0])
-}
-
-/// Checks whether annotation differs from returns only by property-level
-/// literal widening that contextual typing would handle.
-fn is_only_property_literal_widening(annotation: &Type, returns: &[Type]) -> bool {
-    returns.iter().all(|inferred| {
-        let mut stack: Vec<(Type, Type)> = vec![(annotation.clone(), inferred.clone())];
-        let mut has_widening = false;
-        let mut iterations = 0usize;
-
-        while let Some((annotated, inferred)) = stack.pop() {
-            iterations += 1;
-            if iterations > MAX_TYPE_TRAVERSAL_ITERATIONS {
-                return false;
-            }
-
-            if let TypeData::Tuple(annotated_tuple) = &*annotated {
-                let TypeData::Tuple(inferred_tuple) = &*inferred else {
-                    return false;
-                };
-                let annotated_elements = annotated_tuple.elements();
-                let inferred_elements = inferred_tuple.elements();
-                if annotated_elements.len() != inferred_elements.len()
-                    || annotated_elements.is_empty()
-                {
-                    return false;
-                }
-                for (annotated_element, inferred_element) in
-                    annotated_elements.iter().zip(inferred_elements.iter())
-                {
-                    match (
-                        annotated.resolve(&annotated_element.ty),
-                        inferred.resolve(&inferred_element.ty),
-                    ) {
-                        (Some(annotated_type), Some(inferred_type)) => {
-                            if types_match(&annotated_type, &inferred_type) {
-                                continue;
-                            }
-                            if is_base_type_of_literal(&annotated_type, &inferred_type) {
-                                has_widening = true;
-                            } else {
-                                stack.push((annotated_type, inferred_type));
-                            }
-                        }
-                        _ => return false,
-                    }
-                }
-                continue;
-            }
-
-            let TypeData::Object(annotated_object) = &*annotated else {
-                return false;
-            };
-            if annotated_object.members.is_empty() {
-                return false;
-            }
-
-            let inferred_members = match &*inferred {
-                TypeData::Object(object) => &object.members,
-                TypeData::Literal(literal) => match literal.as_ref() {
-                    Literal::Object(object_literal) => object_literal.members(),
-                    _ => return false,
-                },
-                _ => return false,
-            };
-            if inferred_members.is_empty() {
-                return false;
-            }
-
-            let annotated_index_signature = annotated_object.members.iter().find(|member| {
-                matches!(
-                    member.kind,
-                    TypeMemberKind::IndexSignature(_)
-                )
-            });
-            if let Some(index_signature_member) = annotated_index_signature
-                && let Some(index_signature_value_type) =
-                    annotated.resolve(&index_signature_member.ty)
-            {
-                let mut index_signature_has_widening = false;
-                let all_inferred_covered = inferred_members.iter().all(|inferred_member| {
-                    if inferred_member.is_const_asserted() {
-                        return false;
-                    }
-                    if let Some(inferred_type) = inferred.resolve(&inferred_member.ty) {
-                        if types_match(&index_signature_value_type, &inferred_type) {
-                            return true;
-                        }
-                        if is_base_type_of_literal(&index_signature_value_type, &inferred_type) {
-                            index_signature_has_widening = true;
-                            return true;
-                        }
-                    }
-                    false
-                });
-                if !(all_inferred_covered && index_signature_has_widening) {
-                    return false;
-                }
-                has_widening = true;
-                continue;
-            }
-
-            for annotated_member in annotated_object.members.iter() {
-                let annotated_name = match &annotated_member.kind {
-                    TypeMemberKind::Named(name)
-                    | TypeMemberKind::NamedOptional(name) => name,
-                    _ => continue,
-                };
-                let Some(inferred_member) = inferred_members
-                    .iter()
-                    .find(|member| member.kind.has_name(annotated_name))
-                else {
-                    return false;
-                };
-                if inferred_member.is_const_asserted() {
-                    return false;
-                }
-                match (
-                    annotated.resolve(&annotated_member.ty),
-                    inferred.resolve(&inferred_member.ty),
-                ) {
-                    (Some(annotated_type), Some(inferred_type)) => {
-                        if types_match(&annotated_type, &inferred_type) {
-                            continue;
-                        }
-                        if is_base_type_of_literal(&annotated_type, &inferred_type) {
-                            has_widening = true;
-                        } else {
-                            stack.push((annotated_type, inferred_type));
-                        }
-                    }
-                    _ => return false,
-                }
-            }
-        }
-
-        has_widening
-    })
-}
-
-fn is_base_type_of_literal(base: &Type, literal: &Type) -> bool {
-    match (&**base, &**literal) {
-        (TypeData::String, TypeData::Literal(lit)) => {
-            matches!(lit.as_ref(), Literal::String(_) | Literal::Template(_))
-        }
-        (TypeData::Number, TypeData::Literal(lit)) => matches!(lit.as_ref(), Literal::Number(_)),
-        (TypeData::Boolean, TypeData::Literal(lit)) => {
-            matches!(lit.as_ref(), Literal::Boolean(_))
-        }
-        (TypeData::BigInt, TypeData::Literal(lit)) => matches!(lit.as_ref(), Literal::BigInt(_)),
-        _ => false,
-    }
-}
-
 /// Per-body accumulator for the misleading-return check.
 #[derive(Default)]
-struct ReturnInfo {
-    types: Vec<Type>,
+struct ReturnInfo<'db> {
+    types: Vec<InferredType<'db>>,
     has_any_const: bool,
     /// Count of return expressions with an assertion target treated as at least
     /// as wide as `object`.
@@ -899,63 +413,40 @@ struct ReturnInfo {
     has_pinning_assertion: bool,
 }
 
-impl ReturnInfo {
-    /// Single-return whose inferred type is a primitive literal and no `as const` or pinning assertion.
-    fn is_single_primitive_literal(&self) -> bool {
-        self.types.len() == 1
-            && !self.has_any_const
-            && !self.has_pinning_assertion
-            && is_literal_of_primitive(&self.types[0])
-    }
-
-    /// Every return carries an object-wide cast target (and no `as const`).
-    fn all_opt_into_object(&self) -> bool {
-        !self.has_any_const && self.object_wide_casts == self.types.len()
-    }
-
-    /// Whether any return type matches the boolean literal `value`.
-    fn matches_boolean_value(&self, value: bool) -> bool {
-        self.types.iter().any(|ty| ty.is_boolean_literal(value))
-    }
-}
-
 /// Walks the function body and populates a [`ReturnInfo`].
-/// Boolean return literals use the same canonical form as [`TypeData::union_of`].
-fn collect_return_info(
-    ctx: &RuleContext<NoMisleadingReturnType>,
+fn collect_return_info<'db>(
+    ctx: &'db RuleContext<NoMisleadingReturnType>,
     body: &AnyJsFunctionBody,
-    needs_object_bookkeeping: bool,
-) -> ReturnInfo {
+) -> ReturnInfo<'db> {
     let mut info = ReturnInfo::default();
 
     match body {
         AnyJsFunctionBody::JsFunctionBody(block) => {
-            collect_block_returns(ctx, block, &mut info, needs_object_bookkeeping);
+            collect_block_returns(ctx, block, &mut info);
         }
         AnyJsFunctionBody::AnyJsExpression(expr) => {
             if has_const_assertion(expr) {
                 info.has_any_const = true;
-            } else if needs_object_bookkeeping {
-                if has_object_wide_assertion(expr) {
+            } else {
+                if has_object_wide_assertion(ctx, expr) {
                     info.object_wide_casts += 1;
-                } else if has_narrow_cast(expr) || expression_reveals_narrow_object(expr) {
+                } else if has_narrow_cast(ctx, expr) || expression_reveals_narrow_object(expr) {
                     info.has_narrower_than_object = true;
                 }
             }
             info.has_pinning_assertion |= is_pinned_by_assertion(expr);
-            info.types.push(infer_expression_type(ctx, expr));
+            if let Some(ty) = infer_expression_type(ctx, expr) {
+                info.types.push(ty);
+            }
         }
     }
-
-    info.types = Type::normalized_boolean_union_variants(info.types);
     info
 }
 
-fn collect_block_returns(
-    ctx: &RuleContext<NoMisleadingReturnType>,
+fn collect_block_returns<'db>(
+    ctx: &'db RuleContext<NoMisleadingReturnType>,
     block: &JsFunctionBody,
-    info: &mut ReturnInfo,
-    needs_object_bookkeeping: bool,
+    info: &mut ReturnInfo<'db>,
 ) {
     for node in block
         .syntax()
@@ -969,15 +460,17 @@ fn collect_block_returns(
         {
             if has_const_assertion(&expr) {
                 info.has_any_const = true;
-            } else if needs_object_bookkeeping {
-                if has_object_wide_assertion(&expr) {
+            } else {
+                if has_object_wide_assertion(ctx, &expr) {
                     info.object_wide_casts += 1;
-                } else if has_narrow_cast(&expr) || expression_reveals_narrow_object(&expr) {
+                } else if has_narrow_cast(ctx, &expr) || expression_reveals_narrow_object(&expr) {
                     info.has_narrower_than_object = true;
                 }
             }
             info.has_pinning_assertion |= is_pinned_by_assertion(&expr);
-            info.types.push(infer_expression_type(ctx, &expr));
+            if let Some(ty) = infer_expression_type(ctx, &expr) {
+                info.types.push(ty);
+            }
         }
     }
 }
@@ -996,39 +489,50 @@ fn expression_reveals_narrow_object(expression: &AnyJsExpression) -> bool {
 
 /// Returns `true` when the expression contains a cast whose target is
 /// strictly narrower than the `object` keyword.
-fn has_narrow_cast(expression: &AnyJsExpression) -> bool {
+fn has_narrow_cast(
+    ctx: &RuleContext<NoMisleadingReturnType>,
+    expression: &AnyJsExpression,
+) -> bool {
     NonTransparentLeaves::new(expression, LogicalTraversal::All).any(|leaf| {
-        let cast: AnyTsCastExpression = match leaf {
-            AnyJsExpression::TsAsExpression(expression) => expression.into(),
-            AnyJsExpression::TsTypeAssertionExpression(expression) => expression.into(),
+        let cast = match &leaf {
+            AnyJsExpression::TsAsExpression(expression) => {
+                AnyTsCastExpression::from(expression.clone())
+            }
+            AnyJsExpression::TsTypeAssertionExpression(expression) => {
+                AnyTsCastExpression::from(expression.clone())
+            }
             _ => return false,
         };
-        let Some(cast_type) = cast.cast_type() else {
-            return false;
-        };
-        !cast_target_at_least_object_wide(&cast_type, &cast)
+        !cast_target_at_least_object_wide(ctx, &leaf, &cast)
     })
 }
 
 /// Whether some non-transparent leaf reached through the fallback walk has a
 /// type assertion that opts into `object` widening. `as const` is excluded
 /// because it narrows rather than widens.
-fn has_object_wide_assertion(expression: &AnyJsExpression) -> bool {
+fn has_object_wide_assertion(
+    ctx: &RuleContext<NoMisleadingReturnType>,
+    expression: &AnyJsExpression,
+) -> bool {
     let mut leaves = NonTransparentLeaves::new(expression, LogicalTraversal::FallbackOnly);
     let any_wide = leaves.by_ref().any(|leaf| {
-        let cast: AnyTsCastExpression = match leaf {
-            AnyJsExpression::TsAsExpression(expression) => expression.into(),
-            AnyJsExpression::TsTypeAssertionExpression(expression) => expression.into(),
+        let cast = match &leaf {
+            AnyJsExpression::TsAsExpression(expression) => {
+                AnyTsCastExpression::from(expression.clone())
+            }
+            AnyJsExpression::TsTypeAssertionExpression(expression) => {
+                AnyTsCastExpression::from(expression.clone())
+            }
             _ => return false,
         };
         let cast_type = cast.cast_type();
         if is_const_reference_type(&cast_type) {
             return false;
         }
-        let Some(cast_type) = cast_type else {
+        if cast_type.is_none() {
             return false;
-        };
-        cast_target_at_least_object_wide(&cast_type, &cast)
+        }
+        cast_target_at_least_object_wide(ctx, &leaf, &cast)
     });
     any_wide || leaves.cap_exceeded()
 }
@@ -1233,301 +737,42 @@ fn const_initializer_from_child(child: &JsSyntaxNode, name: &str) -> Option<AnyJ
 
 /// Returns `true` if the cast target is at least as wide as `object`;
 /// `false` if it is known to be strictly narrower.
-fn cast_target_at_least_object_wide(cast_target: &AnyTsType, anchor: &AnyTsCastExpression) -> bool {
-    match cast_target.clone().omit_parentheses() {
-        AnyTsType::TsNonPrimitiveType(_)
-        | AnyTsType::TsUnknownType(_)
-        | AnyTsType::TsAnyType(_)
-        | AnyTsType::TsTypeofType(_) => true,
-        AnyTsType::TsObjectType(object_type) => {
-            object_type.members().into_iter().next().is_none()
-        }
-        unwrapped @ (AnyTsType::TsReferenceType(_)
-        | AnyTsType::TsIntersectionType(_)
-        | AnyTsType::TsUnionType(_)) => {
-            compound_cast_target_at_least_object_wide(unwrapped, anchor)
-        }
-        AnyTsType::TsConditionalType(_) => true,
-        _ => false,
-    }
-}
-
-/// Returns `true` when a compound cast target is at least as wide as `object`.
-/// Intersections need every member object-wide (or one to be `any`); unions
-/// need one.
-fn compound_cast_target_at_least_object_wide(
-    root: AnyTsType,
-    anchor: &AnyTsCastExpression,
-) -> bool {
-    enum Task {
-        Visit(AnyTsType),
-        /// AND the top `N` results (intersection).
-        AllOf(usize),
-        /// OR the top `N` results (union).
-        AnyOf(usize),
-    }
-
-    let mut tasks: SmallVec<[Task; 4]> = smallvec![Task::Visit(root)];
-    let mut results: SmallVec<[bool; 4]> = SmallVec::new();
-    let mut iterations: usize = 0;
-
-    while let Some(task) = tasks.pop() {
-        iterations += 1;
-        if iterations > MAX_TYPE_TRAVERSAL_ITERATIONS {
-            return true;
-        }
-        match task {
-            Task::Visit(ty) => match ty.omit_parentheses() {
-                AnyTsType::TsNonPrimitiveType(_)
-                | AnyTsType::TsUnknownType(_)
-                | AnyTsType::TsAnyType(_) => results.push(true),
-                AnyTsType::TsObjectType(object_type) => {
-                    results.push(object_type.members().into_iter().next().is_none());
-                }
-                AnyTsType::TsReferenceType(reference_type) => {
-                    let Some(path) = reference_type_path(&reference_type) else {
-                        results.push(true);
-                        continue;
-                    };
-                    match find_named_type_declaration(&path, anchor.syntax()) {
-                        Some(FoundDeclaration::TypeAlias(body)) => {
-                            tasks.push(Task::Visit(body));
-                        }
-                        Some(FoundDeclaration::ObjectEquivalentNominal) => results.push(true),
-                        Some(FoundDeclaration::NarrowNominal) => results.push(false),
-                        None => results.push(true),
-                    }
-                }
-                AnyTsType::TsIntersectionType(intersection) => {
-                    let members: Vec<_> = intersection
-                        .types()
-                        .into_iter()
-                        .filter_map(|member_result| member_result.ok())
-                        .collect();
-                    if members.is_empty() {
-                        results.push(false);
-                    } else if members.iter().any(|member| {
-                        matches!(member.clone().omit_parentheses(), AnyTsType::TsAnyType(_))
-                    }) {
-                        results.push(true);
-                    } else {
-                        tasks.push(Task::AllOf(members.len()));
-                        for member in members {
-                            tasks.push(Task::Visit(member));
-                        }
-                    }
-                }
-                AnyTsType::TsUnionType(union_type) => {
-                    let members: Vec<_> = union_type
-                        .types()
-                        .into_iter()
-                        .filter_map(|member_result| member_result.ok())
-                        .collect();
-                    if members.is_empty() {
-                        results.push(false);
-                    } else {
-                        tasks.push(Task::AnyOf(members.len()));
-                        for member in members {
-                            tasks.push(Task::Visit(member));
-                        }
-                    }
-                }
-                AnyTsType::TsConditionalType(_) => results.push(true),
-                _ => results.push(false),
-            },
-            Task::AllOf(count) => {
-                let split = results.len().saturating_sub(count);
-                let all = results.drain(split..).all(|result| result);
-                results.push(all);
-            }
-            Task::AnyOf(count) => {
-                let split = results.len().saturating_sub(count);
-                let any = results.drain(split..).any(|result| result);
-                results.push(any);
-            }
-        }
-    }
-    results.pop().unwrap_or(true)
-}
-
-/// Shape of a named declaration.
-enum FoundDeclaration {
-    TypeAlias(AnyTsType),
-    /// Class or interface with no own instance shape; equivalent to `object`.
-    ObjectEquivalentNominal,
-    /// Class or interface with own members that narrow `object`.
-    NarrowNominal,
-}
-
-enum NamedTypeDecl {
-    TypeAlias(TsTypeAliasDeclaration),
-    Class(AnyJsClass),
-    Interface(TsInterfaceDeclaration),
-}
-
-impl NamedTypeDecl {
-    /// Whether this declaration's binding name matches `name`.
-    fn matches_name(&self, name: &str) -> bool {
-        let token = match self {
-            Self::TypeAlias(alias) => {
-                let Ok(binding) = alias.binding_identifier() else {
-                    return false;
-                };
-                let AnyTsIdentifierBinding::TsIdentifierBinding(binding) = binding else {
-                    return false;
-                };
-                binding.name_token().ok()
-            }
-            Self::Interface(interface) => {
-                let Ok(binding) = interface.id() else {
-                    return false;
-                };
-                let AnyTsIdentifierBinding::TsIdentifierBinding(binding) = binding else {
-                    return false;
-                };
-                binding.name_token().ok()
-            }
-            Self::Class(class) => {
-                let Some(binding) = class.id() else { return false };
-                let AnyJsBinding::JsIdentifierBinding(binding) = binding else {
-                    return false;
-                };
-                binding.name_token().ok()
-            }
-        };
-        token.is_some_and(|token| token.token_text_trimmed().text() == name)
-    }
-}
-
-/// Finds the matching type alias, class, or interface declaration reachable
-/// by walking `anchor`'s ancestors. Same-file only.
-fn find_named_type_declaration(
-    path: &[Text],
-    anchor: &JsSyntaxNode,
-) -> Option<FoundDeclaration> {
-    if path.is_empty() {
-        return None;
-    }
-    for ancestor in anchor.ancestors() {
-        if let Some(found) = find_named_type_declaration_in_children(&ancestor, path) {
-            return Some(found);
-        }
-    }
-    None
-}
-
-/// Finds a matching declaration among `parent`'s direct children.
-fn find_named_type_declaration_in_children(
-    parent: &JsSyntaxNode,
-    path: &[Text],
-) -> Option<FoundDeclaration> {
-    for child in parent.children() {
-        if let Some(found) = find_named_type_declaration_in_child(&child, path) {
-            return Some(found);
-        }
-    }
-    None
-}
-
-/// Finds a matching declaration represented by `child`.
-fn find_named_type_declaration_in_child(
-    child: &JsSyntaxNode,
-    path: &[Text],
-) -> Option<FoundDeclaration> {
-    if path.len() != 1 {
-        return None;
-    }
-    let clause = declaration_clause_from_child(child)?;
-    if let Some(declaration) = named_type_decl_from_clause(clause)
-        && declaration.matches_name(&path[0])
-    {
-        return declaration_shape(declaration);
-    }
-    None
-}
-
-/// Casts a syntax child to a declaration clause.
-fn declaration_clause_from_child(child: &JsSyntaxNode) -> Option<AnyJsDeclarationClause> {
-    AnyJsDeclarationClause::cast(child.clone())
-}
-
-/// Converts a declaration clause to the named type declarations this rule can inspect.
-fn named_type_decl_from_clause(clause: AnyJsDeclarationClause) -> Option<NamedTypeDecl> {
-    match clause {
-        AnyJsDeclarationClause::JsClassDeclaration(declaration) => {
-            Some(NamedTypeDecl::Class(declaration.into()))
-        }
-        AnyJsDeclarationClause::TsInterfaceDeclaration(declaration) => {
-            Some(NamedTypeDecl::Interface(declaration))
-        }
-        AnyJsDeclarationClause::TsTypeAliasDeclaration(declaration) => {
-            Some(NamedTypeDecl::TypeAlias(declaration))
-        }
-        _ => None,
-    }
-}
-
-/// Converts a named declaration to the shape information needed for `: object`.
-fn declaration_shape(declaration: NamedTypeDecl) -> Option<FoundDeclaration> {
-    match declaration {
-        NamedTypeDecl::TypeAlias(alias) => alias.ty().ok().map(FoundDeclaration::TypeAlias),
-        NamedTypeDecl::Class(class) => Some(if is_empty_class(&class) {
-            FoundDeclaration::ObjectEquivalentNominal
-        } else {
-            FoundDeclaration::NarrowNominal
-        }),
-        NamedTypeDecl::Interface(interface) => Some(if is_empty_interface(&interface) {
-            FoundDeclaration::ObjectEquivalentNominal
-        } else {
-            FoundDeclaration::NarrowNominal
-        }),
-    }
-}
-
-/// Whether the class has no own members.
-fn is_empty_class(class: &AnyJsClass) -> bool {
-    class.members().into_iter().next().is_none()
-}
-
-/// Whether the interface has no own members.
-fn is_empty_interface(interface: &TsInterfaceDeclaration) -> bool {
-    interface.members().into_iter().next().is_none()
-}
-
-/// Extracts the textual path of a reference type.
-fn reference_type_path(reference_type: &TsReferenceType) -> Option<Vec<Text>> {
-    let qualifier =
-        TypeReferenceQualifier::from_any_ts_name(ScopeId::GLOBAL, &reference_type.name().ok()?)?;
-    Some(qualifier.path.iter().cloned().collect())
-}
-
-/// Gets the type of a return expression. For identifiers bound to an
-/// `as const` initializer, walks the AST to find the original literal type
-/// since `type_of_expression` would return the widened type.
-fn infer_expression_type(
+fn cast_target_at_least_object_wide(
     ctx: &RuleContext<NoMisleadingReturnType>,
+    expression: &AnyJsExpression,
+    _cast: &AnyTsCastExpression,
+) -> bool {
+    ctx.inferred_type_of_expression(expression)
+        .is_none_or(InferredType::is_at_least_as_wide_as_object)
+}
+
+/// Gets the type of a return expression. For identifiers bound to an `as const`
+/// initializer, uses the initializer's literal type instead of the widened binding.
+fn infer_expression_type<'db>(
+    ctx: &'db RuleContext<NoMisleadingReturnType>,
     expr: &AnyJsExpression,
-) -> Type {
+) -> Option<InferredType<'db>> {
     let inner = unwrap_type_wrappers(expr);
 
     if let AnyJsExpression::JsIdentifierExpression(ref id_expr) = inner
-        && let Some(init_type) = resolve_identifier_initializer_type(ctx, id_expr) {
-            return init_type;
-        }
+        && let Some(init_type) = resolve_identifier_initializer_type(ctx, id_expr)
+    {
+        return Some(init_type);
+    }
 
-    ctx.type_of_expression(&inner)
+    ctx.inferred_type_of_expression(&inner)
 }
 
-fn resolve_identifier_initializer_type(
-    ctx: &RuleContext<NoMisleadingReturnType>,
+fn resolve_identifier_initializer_type<'db>(
+    ctx: &'db RuleContext<NoMisleadingReturnType>,
     id_expr: &JsIdentifierExpression,
-) -> Option<Type> {
+) -> Option<InferredType<'db>> {
     let init_expr = resolve_const_identifier_initializer_expression(id_expr)?;
     if !init_has_direct_const_assertion(&init_expr) {
         return None;
     }
     let unwrapped = unwrap_type_wrappers(&init_expr);
-    Some(ctx.type_of_expression(&unwrapped))
+    ctx.inferred_type_of_expression(&unwrapped)
 }
 
 fn unwrap_type_wrappers(expr: &AnyJsExpression) -> AnyJsExpression {
@@ -1571,7 +816,7 @@ fn has_const_assertion(expr: &AnyJsExpression) -> bool {
         match &current {
             AnyJsExpression::TsAsExpression(e) => return is_const_type_assertion(e),
             AnyJsExpression::TsTypeAssertionExpression(e) => {
-                return is_const_angle_bracket_assertion(e)
+                return is_const_angle_bracket_assertion(e);
             }
             AnyJsExpression::JsParenthesizedExpression(e) => match e.expression() {
                 Ok(inner) => current = inner,
@@ -1589,9 +834,7 @@ fn has_const_assertion(expr: &AnyJsExpression) -> bool {
     }
 }
 
-fn identifier_refers_to_const_assertion(
-    id_expr: &JsIdentifierExpression,
-) -> bool {
+fn identifier_refers_to_const_assertion(id_expr: &JsIdentifierExpression) -> bool {
     resolve_const_identifier_initializer_expression(id_expr)
         .is_some_and(|init_expr| init_has_direct_const_assertion(&init_expr))
 }
@@ -1603,7 +846,7 @@ fn init_has_direct_const_assertion(expr: &AnyJsExpression) -> bool {
         match &current {
             AnyJsExpression::TsAsExpression(e) => return is_const_type_assertion(e),
             AnyJsExpression::TsTypeAssertionExpression(e) => {
-                return is_const_angle_bracket_assertion(e)
+                return is_const_angle_bracket_assertion(e);
             }
             AnyJsExpression::JsParenthesizedExpression(e) => match e.expression() {
                 Ok(inner) => current = inner,
@@ -1653,407 +896,4 @@ declare_node_union! {
 
 fn is_nested_function_like(node: &JsSyntaxNode) -> bool {
     AnyNestedFunctionLike::can_cast(node.kind())
-}
-
-/// Follows generic constraints iteratively: `T extends U extends string` → `string`.
-fn resolve_generic_chain(ty: &Type) -> Type {
-    let mut current = ty.clone();
-    let mut steps = 0u8;
-    while let TypeData::Generic(generic) = &*current {
-        if steps > 5 || !generic.constraint.is_known() {
-            break;
-        }
-        match current.resolve(&generic.constraint) {
-            Some(resolved) => {
-                current = resolved;
-                steps += 1;
-            }
-            None => break,
-        }
-    }
-    current
-}
-
-/// Whether the inferred type reveals structure hidden by `: object`. Empty
-/// object shapes don't count because they're equivalent to `object`.
-fn is_strictly_narrower_than_object_keyword(inferred: &Type) -> bool {
-    match &**inferred {
-        TypeData::Object(obj) => !obj.members.is_empty(),
-        TypeData::InstanceOf(instance) => inferred
-            .resolve(&instance.ty)
-            .is_none_or(|resolved| match &*resolved {
-                TypeData::Class(class) => class_type_has_instance_shape(class),
-                _ => true,
-            }),
-        TypeData::Tuple(_) | TypeData::Function(_) => true,
-        TypeData::Literal(lit) => match lit.as_ref() {
-            Literal::RegExp(_) => true,
-            Literal::Object(obj) => !obj.members().is_empty(),
-            _ => false,
-        },
-        _ => false,
-    }
-}
-
-/// Whether the class type has own instance shape.
-fn class_type_has_instance_shape(class: &Class) -> bool {
-    class.members.iter().any(type_member_affects_instance_shape)
-}
-
-/// Whether a type-info member contributes instance shape.
-fn type_member_affects_instance_shape(member: &biome_js_type_info::TypeMember) -> bool {
-    !member.is_static()
-        && !member.is_getter()
-        && !member.is_index_signature_with_ty(|_| true)
-}
-
-/// Compares non-union type pairs using a work stack. Compound types
-/// (Instance params, Object properties) are decomposed into sub-pairs
-/// and pushed back onto the stack for further comparison.
-fn is_nonunion_wider(annotated: &Type, inferred: &Type) -> bool {
-    let mut stack: Vec<(Type, Type)> =
-        vec![(annotated.clone(), resolve_generic_chain(inferred))];
-    let mut found_wider = false;
-    let mut iterations = 0usize;
-
-    while let Some((ann, inf)) = stack.pop() {
-        iterations += 1;
-        if iterations > MAX_TYPE_TRAVERSAL_ITERATIONS {
-            return false;
-        }
-
-        if is_base_type_of_literal(&ann, &inf) {
-            found_wider = true;
-            continue;
-        }
-
-        if types_match(&ann, &inf) {
-            continue;
-        }
-
-        match (&*ann, &*inf) {
-            (TypeData::ObjectKeyword, TypeData::InstanceOf(_)) => {
-                found_wider = true;
-            }
-
-            (TypeData::InstanceOf(ann_inst), TypeData::InstanceOf(inf_inst)) => {
-                let same_base = match (ann.resolve(&ann_inst.ty), inf.resolve(&inf_inst.ty)) {
-                    (Some(a), Some(b)) => types_match(&a, &b),
-                    _ => false,
-                };
-                if !same_base {
-                    return false;
-                }
-                let ann_params = &ann_inst.type_parameters;
-                let inf_params = &inf_inst.type_parameters;
-                if ann_params.len() != inf_params.len() || ann_params.is_empty() {
-                    return false;
-                }
-                for (ann_p, inf_p) in ann_params.iter().zip(inf_params.iter()) {
-                    match (ann.resolve(ann_p), inf.resolve(inf_p)) {
-                        (Some(a), Some(b)) => stack.push((a, resolve_generic_chain(&b))),
-                        _ => return false,
-                    }
-                }
-            }
-
-            (TypeData::Object(ann_obj), TypeData::Object(inf_obj)) => {
-                if !push_object_pairs(&ann, ann_obj, &inf, inf_obj, &mut stack) {
-                    return false;
-                }
-            }
-
-            (TypeData::Object(ann_obj), TypeData::Literal(lit)) => match lit.as_ref() {
-                Literal::Object(inf_lit) => {
-                    if !push_object_literal_pairs(&ann, ann_obj, inf_lit, &mut stack) {
-                        return false;
-                    }
-                }
-                _ => return false,
-            },
-
-            (TypeData::ObjectKeyword, _) if is_strictly_narrower_than_object_keyword(&inf) =>
-            {
-                found_wider = true;
-            }
-
-            (TypeData::Tuple(ann_tuple), TypeData::Tuple(inf_tuple)) => {
-                let ann_elems = ann_tuple.elements();
-                let inf_elems = inf_tuple.elements();
-                if ann_elems.len() != inf_elems.len() || ann_elems.is_empty() {
-                    return false;
-                }
-                for (ann_e, inf_e) in ann_elems.iter().zip(inf_elems.iter()) {
-                    match (ann.resolve(&ann_e.ty), inf.resolve(&inf_e.ty)) {
-                        (Some(a), Some(b)) => stack.push((a, resolve_generic_chain(&b))),
-                        _ => return false,
-                    }
-                }
-            }
-
-            _ => return false,
-        }
-    }
-
-    found_wider
-}
-
-/// Pushes property type pairs onto the work stack for pairwise comparison.
-/// Also handles index signatures, which arise from `Record<K,V>` annotations.
-fn push_object_pairs(
-    annotated: &Type,
-    ann_obj: &biome_js_type_info::Object,
-    inferred: &Type,
-    inf_obj: &biome_js_type_info::Object,
-    stack: &mut Vec<(Type, Type)>,
-) -> bool {
-    if ann_obj.members.is_empty() || inf_obj.members.is_empty() {
-        return false;
-    }
-
-    let ann_index_sig = ann_obj.members.iter().find(|m| {
-        matches!(m.kind, TypeMemberKind::IndexSignature(_))
-    });
-    if let Some(sig_member) = ann_index_sig
-        && let Some(sig_value_ty) = annotated.resolve(&sig_member.ty)
-    {
-        for inf_m in inf_obj.members.iter() {
-            match inferred.resolve(&inf_m.ty) {
-                Some(inf_ty) => stack.push((sig_value_ty.clone(), resolve_generic_chain(&inf_ty))),
-                None => return false,
-            }
-        }
-        return true;
-    }
-
-    for ann_member in ann_obj.members.iter() {
-        let ann_name = match &ann_member.kind {
-            TypeMemberKind::Named(name)
-            | TypeMemberKind::NamedOptional(name) => name,
-            _ => continue,
-        };
-        let inf_member = inf_obj.members.iter().find(|m| m.kind.has_name(ann_name));
-        let Some(inf_member) = inf_member else {
-            return false;
-        };
-        match (annotated.resolve(&ann_member.ty), inferred.resolve(&inf_member.ty)) {
-            (Some(a), Some(b)) => stack.push((a, resolve_generic_chain(&b))),
-            _ => return false,
-        }
-    }
-
-    true
-}
-
-fn push_object_literal_pairs(
-    annotated: &Type,
-    ann_obj: &biome_js_type_info::Object,
-    inf_lit: &biome_js_type_info::ObjectLiteral,
-    stack: &mut Vec<(Type, Type)>,
-) -> bool {
-    if ann_obj.members.is_empty() || inf_lit.members().is_empty() {
-        return false;
-    }
-
-    for ann_member in ann_obj.members.iter() {
-        let ann_name = match &ann_member.kind {
-            TypeMemberKind::Named(name)
-            | TypeMemberKind::NamedOptional(name) => name,
-            _ => continue,
-        };
-        let inf_member = inf_lit.members().iter().find(|m| m.kind.has_name(ann_name));
-        let Some(inf_member) = inf_member else {
-            return false;
-        };
-        match (annotated.resolve(&ann_member.ty), annotated.resolve(&inf_member.ty)) {
-            (Some(a), Some(b)) => stack.push((a, resolve_generic_chain(&b))),
-            _ => return false,
-        }
-    }
-
-    true
-}
-
-/// Checks whether `annotated` is strictly wider than `inferred`.
-fn is_wider_than(annotated: &Type, inferred: &Type) -> bool {
-    let current = resolve_generic_chain(inferred);
-
-    match (&**annotated, &*current) {
-        (TypeData::String, TypeData::String)
-        | (TypeData::Number, TypeData::Number)
-        | (TypeData::Boolean, TypeData::Boolean)
-        | (TypeData::BigInt, TypeData::BigInt) => false,
-
-        (TypeData::Union(_), _) => is_union_wider(annotated, &current),
-        (_, TypeData::Union(_)) => {
-            // When the annotation's base type already appears as a variant in the
-            // inferred union, any literal subtypes are subsumed by it — the union
-            // collapses to the base type (e.g., 0 | number = number).  In that
-            // case the annotation is not wider than the inferred type.
-            let (has_base_variant, all_subsumed, all_covered, any_wider) = current
-                .flattened_union_variants()
-                .fold(
-                    (false, true, true, false),
-                    |(has_base_variant, all_subsumed, all_covered, any_wider), v| {
-                        let matches = types_match(annotated, &v);
-                        let wider = is_nonunion_wider(annotated, &v);
-                        (
-                            has_base_variant || matches,
-                            all_subsumed && (matches || is_base_type_of_literal(annotated, &v)),
-                            all_covered && (matches || wider),
-                            any_wider || wider,
-                        )
-                    },
-                );
-            if has_base_variant && all_subsumed {
-                return false;
-            }
-            all_covered && any_wider
-        }
-        _ => is_nonunion_wider(annotated, &current),
-    }
-}
-
-/// Flags when the annotation has an unreached variant or a variant strictly
-/// wider than a return that no other variant matches directly.
-fn is_union_wider_than_returns(annotated: &Type, returns: &[Type]) -> bool {
-    let all_covered = returns.iter().all(|ret| {
-        annotated
-            .flattened_union_variants()
-            .any(|ann_v| types_match(&ann_v, ret) || is_nonunion_wider(&ann_v, ret))
-    });
-
-    if !all_covered {
-        return false;
-    }
-
-    let variants: Vec<Type> = annotated.flattened_union_variants().collect();
-
-    let has_extra = variants.iter().any(|ann_v| {
-        !returns
-            .iter()
-            .any(|ret| types_match(ann_v, ret) || is_nonunion_wider(ann_v, ret))
-    });
-
-    // A return already matched directly by another variant is not treated as
-    // misleadingly widened.
-    let has_wider_variant = returns.iter().any(|ret| {
-        !variants.iter().any(|ann_v| types_match(ann_v, ret))
-            && variants.iter().any(|ann_v| is_nonunion_wider(ann_v, ret))
-    });
-
-    has_extra || has_wider_variant
-}
-
-/// Like `is_union_wider_than_returns` but for a single inferred type (used
-/// inside `is_wider_than`). Also filters out generic variants whose
-/// constraints are subsumed by other variants in the annotation union.
-fn is_union_wider(annotated: &Type, inferred: &Type) -> bool {
-    let all_inferred_covered = if let TypeData::Union(_) = &**inferred {
-        inferred.flattened_union_variants().all(|inf_v| {
-            annotated
-                .flattened_union_variants()
-                .any(|ann_v| types_match(&ann_v, &inf_v) || is_nonunion_wider(&ann_v, &inf_v))
-        })
-    } else {
-        annotated
-            .flattened_union_variants()
-            .any(|ann_v| types_match(&ann_v, inferred) || is_nonunion_wider(&ann_v, inferred))
-    };
-
-    if !all_inferred_covered {
-        return false;
-    }
-
-    let ann_variants: Vec<Type> = annotated.flattened_union_variants().collect();
-
-    let inf_variants: Vec<Type> = match &**inferred {
-        TypeData::Union(_) => inferred.flattened_union_variants().collect(),
-        _ => vec![inferred.clone()],
-    };
-
-    ann_variants
-        .iter()
-        .filter(|ann_v| {
-            if let TypeData::Generic(generic) = &***ann_v
-                && generic.constraint.is_known()
-                && let Some(constraint) = ann_v.resolve(&generic.constraint)
-            {
-                let subsumed = ann_variants.iter().any(|other| {
-                    !std::ptr::eq(*ann_v as *const Type, other as *const Type)
-                        && (types_match(other, &constraint)
-                            || is_nonunion_wider(other, &constraint))
-                });
-                return !subsumed;
-            }
-            true
-        })
-        .any(|ann_v| {
-            !inf_variants
-                .iter()
-                .any(|inf_v| types_match(ann_v, inf_v) || is_nonunion_wider(ann_v, inf_v))
-        })
-}
-
-/// Checks structural equality between two types.
-fn types_match(a: &Type, b: &Type) -> bool {
-    let mut a = a.clone();
-    let mut b = b.clone();
-    // Resolving `InstanceOf` bases loops forever on a circular alias (`type R = R`),
-    // so bound the walk like the rule's other type traversals.
-    for _ in 0..MAX_TYPE_TRAVERSAL_ITERATIONS {
-        match (&*a, &*b) {
-            (TypeData::String, TypeData::String)
-            | (TypeData::Number, TypeData::Number)
-            | (TypeData::Boolean, TypeData::Boolean)
-            | (TypeData::BigInt, TypeData::BigInt)
-            | (TypeData::Null, TypeData::Null)
-            | (TypeData::Undefined, TypeData::Undefined)
-            | (TypeData::VoidKeyword, TypeData::VoidKeyword)
-            | (TypeData::NeverKeyword, TypeData::NeverKeyword)
-            | (TypeData::ObjectKeyword, TypeData::ObjectKeyword) => return true,
-
-            (TypeData::Literal(a_lit), TypeData::Literal(b_lit)) => return a_lit == b_lit,
-
-            (TypeData::Generic(a_gen), TypeData::Generic(b_gen)) => {
-                return a_gen.name == b_gen.name
-            }
-
-            (TypeData::InstanceOf(a_inst), TypeData::InstanceOf(b_inst))
-                if a_inst.type_parameters.is_empty() && b_inst.type_parameters.is_empty() =>
-            {
-                match (a.resolve(&a_inst.ty), b.resolve(&b_inst.ty)) {
-                    (Some(a_base), Some(b_base)) => {
-                        a = a_base;
-                        b = b_base;
-                    }
-                    _ => return false,
-                }
-            }
-
-            (TypeData::Generic(a_gen), TypeData::InstanceOf(b_inst))
-                if b_inst.type_parameters.is_empty() =>
-            {
-                if let Some(base) = b.resolve(&b_inst.ty)
-                    && let TypeData::Generic(b_gen) = &*base
-                {
-                    return a_gen.name == b_gen.name;
-                }
-                return false;
-            }
-            (TypeData::InstanceOf(a_inst), TypeData::Generic(b_gen))
-                if a_inst.type_parameters.is_empty() =>
-            {
-                if let Some(base) = a.resolve(&a_inst.ty)
-                    && let TypeData::Generic(a_gen) = &*base
-                {
-                    return a_gen.name == b_gen.name;
-                }
-                return false;
-            }
-
-            _ => return false,
-        }
-    }
-    false
 }


### PR DESCRIPTION
## Summary

Ports `noMisleadingReturnType` from the legacy type APIs to the Salsa-backed inference APIs. Return-type comparison now delegates to `InferredType::check_misleading_return_type`, while the rule retains its syntax-level handling for return expressions and assertions. No behaviour change is intended.

## Test Plan

Green CI

## Docs

N/A

> This PR was created with AI assistance (OpenCode).