### PR TITLE
fix(inference): improve imported and aliased types

### DIFF
--- a/.changeset/fuzzy-dodos-trade.md
+++ b/.changeset/fuzzy-dodos-trade.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved generic tuple inference for [`useIncludes`](https://biomejs.dev/linter/rules/use-includes/). The rule now recognizes specialised tuple element types returned through generic aliases.

--- a/crates/biome_js_analyze/tests/specs/nursery/useIncludes/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIncludes/invalid.ts
@@ -1,0 +1,4 @@
+type Factory<T> = () => [T];
+declare const makeStrings: Factory<string>;
+
+makeStrings().indexOf("value") !== -1;

--- a/crates/biome_js_analyze/tests/specs/nursery/useIncludes/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIncludes/invalid.ts.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```ts
+type Factory<T> = () => [T];
+declare const makeStrings: Factory<string>;
+
+makeStrings().indexOf("value") !== -1;
+
+```
+
+# Diagnostics
+```
+invalid.ts:4:1 lint/nursery/useIncludes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Checking the result of indexOf() against -1 to test for presence.
+  
+    2 │ declare const makeStrings: Factory<string>;
+    3 │ 
+  > 4 │ makeStrings().indexOf("value") !== -1;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 
+  
+  i indexOf() returns a numeric index, not a boolean. Comparing it against -1 is error-prone and harder to read.
+  
+  i Use includes() instead, which directly expresses the intent and returns a boolean.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Replace with .includes().
+  
+    2 2 │   declare const makeStrings: Factory<string>;
+    3 3 │   
+    4   │ - makeStrings().indexOf("value")·!==·-1;
+      4 │ + makeStrings().includes("value");
+    5 5 │   
+  
+
+```

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -57,107 +57,6 @@ pub struct TypeSubstitution<'db> {
     pub replacement: TypeData<'db>,
 }
 
-/// Item produced while rebuilding a type after generic substitution.
-///
-/// The iterator emits plain type values first, then a rebuild item once the
-/// values needed by that wrapper have already been emitted.
-#[derive(Clone, Copy, Debug)]
-enum TypeSubstitutionItem<'db> {
-    /// A type that can be pushed directly into the rebuilt result.
-    Type(TypeData<'db>),
-
-    /// Rebuilds an instance type.
-    ///
-    /// The result stack contains the instance target type followed by this many
-    /// type parameters.
-    RebuildInstance(usize),
-
-    /// Rebuilds a union type from this many already-emitted variants.
-    RebuildUnion(usize),
-
-    /// Rebuilds an intersection type from this many already-emitted variants.
-    RebuildIntersection(usize),
-}
-
-/// Iterates over a type without recursion and applies one generic substitution.
-///
-/// This yields enough information for the caller to rebuild the type: plain
-/// types are yielded as-is, and wrapper types yield a rebuild item after their
-/// children have been yielded.
-struct TypeSubstitutionIter<'db> {
-    db: &'db dyn TypeDb,
-    stack: Vec<TypeSubstitutionItem<'db>>,
-    substitution: TypeSubstitution<'db>,
-    remaining_steps: usize,
-    exceeded_step_limit: bool,
-}
-
-impl<'db> TypeSubstitutionIter<'db> {
-    fn new(db: &'db dyn TypeDb, ty: TypeData<'db>, substitution: TypeSubstitution<'db>) -> Self {
-        Self {
-            db,
-            stack: Vec::from([TypeSubstitutionItem::Type(ty)]),
-            substitution,
-            remaining_steps: MAX_TYPE_SUBSTITUTION_STEPS,
-            exceeded_step_limit: false,
-        }
-    }
-}
-
-impl<'db> Iterator for TypeSubstitutionIter<'db> {
-    type Item = TypeSubstitutionItem<'db>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        while let Some(item) = self.stack.pop() {
-            let TypeSubstitutionItem::Type(ty) = item else {
-                return Some(item);
-            };
-
-            if self.remaining_steps == 0 {
-                self.exceeded_step_limit = true;
-                return None;
-            }
-            self.remaining_steps -= 1;
-
-            if ty == self.substitution.generic {
-                return Some(TypeSubstitutionItem::Type(self.substitution.replacement));
-            }
-
-            match ty {
-                TypeData::InstanceOf(instance) => {
-                    self.stack.push(TypeSubstitutionItem::RebuildInstance(
-                        instance.type_parameters(self.db).len(),
-                    ));
-                    for parameter in instance.type_parameters(self.db).iter().rev() {
-                        self.stack.push(TypeSubstitutionItem::Type(*parameter));
-                    }
-                    self.stack
-                        .push(TypeSubstitutionItem::Type(instance.ty(self.db)));
-                }
-                TypeData::Union(union) => {
-                    self.stack.push(TypeSubstitutionItem::RebuildUnion(
-                        union.types(self.db).len(),
-                    ));
-                    for ty in union.types(self.db).iter().rev() {
-                        self.stack.push(TypeSubstitutionItem::Type(*ty));
-                    }
-                }
-                TypeData::Intersection(intersection) => {
-                    self.stack.push(TypeSubstitutionItem::RebuildIntersection(
-                        intersection.types(self.db).len(),
-                    ));
-                    for ty in intersection.types(self.db).iter().rev() {
-                        self.stack.push(TypeSubstitutionItem::Type(*ty));
-                    }
-                }
-                ty => return Some(TypeSubstitutionItem::Type(ty)),
-            }
-        }
-
-        None
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, salsa::Update)]
 pub struct ModuleKey {
     id: salsa::Id,
@@ -584,42 +483,18 @@ impl<'db> TypeData<'db> {
     }
 
     pub fn substitute_type(self, db: &'db dyn TypeDb, substitution: TypeSubstitution<'db>) -> Self {
-        let mut results = Vec::new();
-        let mut items = TypeSubstitutionIter::new(db, self, substitution);
+        let mut remaining_steps = MAX_TYPE_SUBSTITUTION_STEPS;
+        substitute_type(db, self, substitution, false, &mut remaining_steps).unwrap_or(self)
+    }
 
-        for item in items.by_ref() {
-            match item {
-                TypeSubstitutionItem::Type(ty) => results.push(ty),
-                TypeSubstitutionItem::RebuildInstance(type_parameter_count) => {
-                    let Some(start) = results.len().checked_sub(type_parameter_count + 1) else {
-                        return self;
-                    };
-                    let mut parts = results.split_off(start);
-                    let ty = parts.remove(0);
-                    results.push(Self::instance_of(db, ty, parts.into_boxed_slice()));
-                }
-                TypeSubstitutionItem::RebuildUnion(type_count) => {
-                    let Some(start) = results.len().checked_sub(type_count) else {
-                        return self;
-                    };
-                    let types = results.split_off(start);
-                    results.push(Self::union_from_types(db, types));
-                }
-                TypeSubstitutionItem::RebuildIntersection(type_count) => {
-                    let Some(start) = results.len().checked_sub(type_count) else {
-                        return self;
-                    };
-                    let types = results.split_off(start);
-                    results.push(Self::intersection_from_types(db, types));
-                }
-            }
-        }
-
-        if items.exceeded_step_limit {
-            return self;
-        }
-
-        results.pop().unwrap_or(self)
+    /// Substitutes inside the root generic declaration while preserving nested declarations.
+    pub fn substitute_type_in_root_body(
+        self,
+        db: &'db dyn TypeDb,
+        substitution: TypeSubstitution<'db>,
+    ) -> Self {
+        let mut remaining_steps = MAX_TYPE_SUBSTITUTION_STEPS;
+        substitute_type(db, self, substitution, true, &mut remaining_steps).unwrap_or(self)
     }
 
     /// Builds the smallest type that represents a list of union variants.
@@ -1102,6 +977,205 @@ impl<'db> TypeData<'db> {
     ) -> Option<raw::TypeReference> {
         ty.map(Self::to_raw_reference_lossy)
     }
+}
+
+fn substitute_type<'db>(
+    db: &'db dyn TypeDb,
+    ty: TypeData<'db>,
+    substitution: TypeSubstitution<'db>,
+    enter_root_binder: bool,
+    remaining_steps: &mut usize,
+) -> Option<TypeData<'db>> {
+    *remaining_steps = remaining_steps.checked_sub(1)?;
+    if ty == substitution.generic {
+        return Some(substitution.replacement);
+    }
+
+    let binder_generic = match substitution.generic {
+        TypeData::InstanceOf(instance)
+            if instance.type_parameters(db).is_empty()
+                && matches!(instance.ty(db), TypeData::Generic(_)) =>
+        {
+            instance.ty(db)
+        }
+        generic => generic,
+    };
+    let declares_generic = match ty {
+        TypeData::Class(class) => class.type_parameters(db).contains(&binder_generic),
+        TypeData::Constructor(constructor) => {
+            constructor.type_parameters(db).contains(&binder_generic)
+        }
+        TypeData::Function(function) => function.type_parameters(db).contains(&binder_generic),
+        TypeData::Interface(interface) => interface.type_parameters(db).contains(&binder_generic),
+        _ => false,
+    };
+    if declares_generic && !enter_root_binder {
+        return Some(ty);
+    }
+    let mut substitute = |child| substitute_type(db, child, substitution, false, remaining_steps);
+
+    Some(match ty {
+        TypeData::Function(function) => TypeData::Function(InternedFunction::new(
+            db,
+            function.type_parameters(db).to_vec().into_boxed_slice(),
+            function
+                .parameters(db)
+                .iter()
+                .map(|parameter| substitute_function_parameter(parameter, &mut substitute))
+                .collect::<Option<Box<[_]>>>()?,
+            substitute_return_type(function.return_type(db), &mut substitute)?,
+            function.is_async(db),
+            function.name(db).clone(),
+        )),
+        TypeData::Interface(interface) => TypeData::Interface(InternedInterface::new(
+            db,
+            interface.type_parameters(db).to_vec().into_boxed_slice(),
+            interface
+                .extends(db)
+                .iter()
+                .map(|ty| substitute(*ty))
+                .collect::<Option<Box<[_]>>>()?,
+            substitute_members(interface.members(db), &mut substitute)?,
+            interface.name(db).clone(),
+        )),
+        TypeData::Class(class) => TypeData::Class(InternedClass::new(
+            db,
+            class.type_parameters(db).to_vec().into_boxed_slice(),
+            match class.extends(db) {
+                Some(extends) => Some(substitute(extends)?),
+                None => None,
+            },
+            class
+                .implements(db)
+                .iter()
+                .map(|ty| substitute(*ty))
+                .collect::<Option<Box<[_]>>>()?,
+            substitute_members(class.members(db), &mut substitute)?,
+            class.name(db).clone(),
+            class.is_builtin(db),
+        )),
+        TypeData::Object(object) => TypeData::Object(InternedObject::new(
+            db,
+            match object.prototype(db) {
+                Some(prototype) => Some(substitute(prototype)?),
+                None => None,
+            },
+            substitute_members(object.members(db), &mut substitute)?,
+        )),
+        TypeData::Tuple(tuple) => TypeData::Tuple(InternedTuple::new(
+            db,
+            tuple
+                .elements(db)
+                .iter()
+                .map(|element| {
+                    Some(TupleElementType {
+                        ty: substitute(element.ty)?,
+                        name: element.name.clone(),
+                        is_optional: element.is_optional,
+                        is_rest: element.is_rest,
+                    })
+                })
+                .collect::<Option<Box<[_]>>>()?,
+        )),
+        TypeData::InstanceOf(instance) => TypeData::instance_of(
+            db,
+            substitute(instance.ty(db))?,
+            instance
+                .type_parameters(db)
+                .iter()
+                .map(|ty| substitute(*ty))
+                .collect::<Option<Box<[_]>>>()?,
+        ),
+        TypeData::Union(union) => TypeData::union_from_types(
+            db,
+            union
+                .types(db)
+                .iter()
+                .map(|ty| substitute(*ty))
+                .collect::<Option<Vec<_>>>()?,
+        ),
+        TypeData::Intersection(intersection) => TypeData::intersection_from_types(
+            db,
+            intersection
+                .types(db)
+                .iter()
+                .map(|ty| substitute(*ty))
+                .collect::<Option<Vec<_>>>()?,
+        ),
+        TypeData::TypeofType(typeof_type) => {
+            TypeData::TypeofType(InternedTypeofType::new(db, substitute(typeof_type.ty(db))?))
+        }
+        TypeData::TypeofValue(typeof_value) => TypeData::TypeofValue(InternedTypeofValue::new(
+            db,
+            substitute(typeof_value.ty(db))?,
+            typeof_value.identifier(db).clone(),
+            typeof_value.scope_id(db),
+        )),
+        ty => ty,
+    })
+}
+
+fn substitute_function_parameter<'db>(
+    parameter: &FunctionParameter<'db>,
+    substitute: &mut impl FnMut(TypeData<'db>) -> Option<TypeData<'db>>,
+) -> Option<FunctionParameter<'db>> {
+    Some(match parameter {
+        FunctionParameter::Named(parameter) => FunctionParameter::Named(NamedFunctionParameter {
+            name: parameter.name.clone(),
+            ty: substitute(parameter.ty)?,
+            is_optional: parameter.is_optional,
+            is_rest: parameter.is_rest,
+        }),
+        FunctionParameter::Pattern(parameter) => {
+            FunctionParameter::Pattern(PatternFunctionParameter {
+                bindings: parameter
+                    .bindings
+                    .iter()
+                    .map(|binding| {
+                        Some(FunctionParameterBinding {
+                            name: binding.name.clone(),
+                            ty: substitute(binding.ty)?,
+                        })
+                    })
+                    .collect::<Option<Box<[_]>>>()?,
+                ty: substitute(parameter.ty)?,
+                is_optional: parameter.is_optional,
+                is_rest: parameter.is_rest,
+            })
+        }
+    })
+}
+
+fn substitute_return_type<'db>(
+    return_type: &ReturnType<'db>,
+    substitute: &mut impl FnMut(TypeData<'db>) -> Option<TypeData<'db>>,
+) -> Option<ReturnType<'db>> {
+    Some(match return_type {
+        ReturnType::Type(ty) => ReturnType::Type(substitute(*ty)?),
+        ReturnType::Predicate(predicate) => ReturnType::Predicate(PredicateReturnType {
+            parameter_name: predicate.parameter_name.clone(),
+            ty: substitute(predicate.ty)?,
+        }),
+        ReturnType::Asserts(asserts) => ReturnType::Asserts(AssertsReturnType {
+            parameter_name: asserts.parameter_name.clone(),
+            ty: substitute(asserts.ty)?,
+        }),
+    })
+}
+
+fn substitute_members<'db>(
+    members: &[TypeMember<'db>],
+    substitute: &mut impl FnMut(TypeData<'db>) -> Option<TypeData<'db>>,
+) -> Option<Box<[TypeMember<'db>]>> {
+    members
+        .iter()
+        .map(|member| {
+            Some(TypeMember {
+                kind: member.kind.clone(),
+                ty: substitute(member.ty)?,
+            })
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update)]

--- a/crates/biome_module_graph/src/db/queries.rs
+++ b/crates/biome_module_graph/src/db/queries.rs
@@ -14,8 +14,8 @@
 
 use crate::css_module_info::traverse::{CssClassStep, ImportTreeTraversal};
 use crate::db::type_inference::{
-    collected_type_result, infer_module_types_cycle_result, normalize_type_cycle_result,
-    resolve_raw_types,
+    apply_substitutions_to_root_body, collected_type_result, infer_module_types_cycle_result,
+    normalize_type_cycle_result, resolve_raw_types, substitutions_for_instance,
 };
 use crate::module_for_key;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
@@ -183,7 +183,7 @@ pub fn infer_call_expression_type<'db>(
     input: CallExpressionTypeInput<'db>,
 ) -> InferredTypeData<'db> {
     let module = input.module(db);
-    let callee = input.callee(db);
+    let callee = normalize_type(db, NormalizeTypeInput::new(db, module, input.callee(db)));
     let args = input.args(db);
     let ty = infer_call_expression_return_type(db, callee, args);
 
@@ -273,54 +273,13 @@ fn infer_function_call_type<'db>(
 ) -> Option<InferredTypeData<'db>> {
     match callee {
         InferredTypeData::Function(function) => infer_function_return_type(db, function, args),
-        InferredTypeData::InstanceOf(instance) => match instance.ty(db) {
-            InferredTypeData::Function(function) => infer_function_return_type(db, function, args),
-            InferredTypeData::Interface(interface) => {
-                infer_call_signature_type(db, interface.members(db), args)
-            }
-            InferredTypeData::Object(object) => {
-                infer_call_signature_type(db, object.members(db), args)
-            }
-            InferredTypeData::Union(union) => {
-                infer_function_call_type(db, InferredTypeData::Union(union), args)
-            }
-            InferredTypeData::TypeofType(typeof_type) => {
-                infer_function_call_type(db, typeof_type.ty(db), args)
-            }
-            InferredTypeData::TypeofValue(typeof_value) => {
-                infer_function_call_type(db, typeof_value.ty(db), args)
-            }
-            InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
-            | InferredTypeData::Global
-            | InferredTypeData::BigInt
-            | InferredTypeData::Boolean
-            | InferredTypeData::Null
-            | InferredTypeData::Number
-            | InferredTypeData::String
-            | InferredTypeData::Symbol
-            | InferredTypeData::Undefined
-            | InferredTypeData::Conditional
-            | InferredTypeData::Class(_)
-            | InferredTypeData::Constructor(_)
-            | InferredTypeData::Module(_)
-            | InferredTypeData::Namespace(_)
-            | InferredTypeData::Tuple(_)
-            | InferredTypeData::Generic(_)
-            | InferredTypeData::Local(_)
-            | InferredTypeData::Intersection(_)
-            | InferredTypeData::TypeOperator(_)
-            | InferredTypeData::Literal(_)
-            | InferredTypeData::InstanceOf(_)
-            | InferredTypeData::MergedReference(_)
-            | InferredTypeData::TypeofExpression(_)
-            | InferredTypeData::AnyKeyword
-            | InferredTypeData::NeverKeyword
-            | InferredTypeData::ObjectKeyword
-            | InferredTypeData::ThisKeyword
-            | InferredTypeData::UnknownKeyword
-            | InferredTypeData::VoidKeyword => None,
-        },
+        InferredTypeData::InstanceOf(instance) => {
+            let target = instance.ty(db);
+            let substitutions =
+                substitutions_for_instance(db, target, instance.type_parameters(db), &[]);
+            let target = apply_substitutions_to_root_body(db, target, &substitutions);
+            infer_function_call_type(db, target, args)
+        }
         InferredTypeData::Interface(interface) => {
             infer_call_signature_type(db, interface.members(db), args)
         }

--- a/crates/biome_module_graph/src/db/type_inference/expressions.rs
+++ b/crates/biome_module_graph/src/db/type_inference/expressions.rs
@@ -32,6 +32,7 @@ const MAX_PROMISE_UNWRAP_STEPS: usize = 64;
 const MAX_REST_MEMBER_STEPS: usize = 1024;
 const MAX_STATIC_MEMBER_LOOKUP_STEPS: usize = 1024;
 const MAX_AWAIT_EXPRESSION_STEPS: usize = 1024;
+const MAX_CALL_CALLEE_STEPS: usize = 64;
 
 impl<'db> ResolutionCtx<'db, '_> {
     pub(in crate::db::type_inference) fn resolve_typeof_expression(
@@ -308,6 +309,7 @@ impl<'db> ResolutionCtx<'db, '_> {
         arguments: &[RawCallArgumentType],
     ) -> InferredTypeData<'db> {
         let args = self.resolve_call_arguments(arguments);
+        let callee = self.resolve_call_callee(callee);
         infer_call_expression_return_type_from_args(self.db, callee, &args)
     }
 
@@ -317,7 +319,29 @@ impl<'db> ResolutionCtx<'db, '_> {
         arguments: &[InferredCallArgumentType<'db>],
     ) -> InferredTypeData<'db> {
         let args = self.resolve_inferred_call_arguments(arguments);
+        let callee = self.resolve_call_callee(callee);
         infer_call_expression_return_type_from_args(self.db, callee, &args)
+    }
+
+    fn resolve_call_callee(&mut self, mut callee: InferredTypeData<'db>) -> InferredTypeData<'db> {
+        let mut instances = Vec::new();
+        for _ in 0..MAX_CALL_CALLEE_STEPS {
+            callee = self.resolve_inferred_type(callee);
+            let InferredTypeData::InstanceOf(instance) = callee else {
+                while let Some(type_parameters) = instances.pop() {
+                    callee = InferredTypeData::instance_of(self.db, callee, type_parameters);
+                }
+                return callee;
+            };
+            instances.push(
+                instance
+                    .type_parameters(self.db)
+                    .to_vec()
+                    .into_boxed_slice(),
+            );
+            callee = instance.ty(self.db);
+        }
+        InferredTypeData::Unknown
     }
 
     fn resolve_call_arguments(

--- a/crates/biome_module_graph/src/db/type_inference/imports.rs
+++ b/crates/biome_module_graph/src/db/type_inference/imports.rs
@@ -16,24 +16,47 @@ use salsa::plumbing::AsId;
 
 const MAX_EXPORT_RESOLUTION_STEPS: usize = 1024;
 
-struct NamespaceExportCollection<'db> {
-    members: Vec<InferredTypeMember<'db>>,
+struct NamespaceExportCollection {
+    names: Vec<Text>,
     seen_names: FxHashSet<String>,
     seen_modules: FxHashSet<ModuleKey>,
     stack: Vec<(ModuleInfo, bool)>,
     remaining_steps: usize,
 }
 
-impl NamespaceExportCollection<'_> {
+impl NamespaceExportCollection {
     fn new() -> Self {
         Self {
-            members: Vec::new(),
+            names: Vec::new(),
             seen_names: FxHashSet::default(),
             seen_modules: FxHashSet::default(),
             stack: Vec::new(),
             remaining_steps: MAX_EXPORT_RESOLUTION_STEPS,
         }
     }
+}
+
+#[derive(Clone, PartialEq)]
+struct ExportIdentity {
+    module: ModuleKey,
+    own_export: JsOwnExport,
+}
+
+struct ResolvedExport<'db> {
+    identity: ExportIdentity,
+    ty: InferredTypeData<'db>,
+}
+
+enum ExportResolution<'db> {
+    Missing,
+    Resolved(ResolvedExport<'db>),
+    Ambiguous,
+    Indeterminate,
+}
+
+enum ExportResolutionStep<'db> {
+    Continue,
+    Resolved(ResolvedExport<'db>),
 }
 
 impl<'db> ResolutionCtx<'db, '_> {
@@ -95,29 +118,48 @@ impl<'db> ResolutionCtx<'db, '_> {
     ) -> InferredTypeData<'db> {
         let mut collection = NamespaceExportCollection::new();
 
-        self.collect_namespace_members(module, inferred_types, true, &mut collection);
+        collection
+            .seen_modules
+            .insert(ModuleKey::new(module.as_id()));
+        if !self.collect_namespace_members(module, true, &mut collection) {
+            return InferredTypeData::Unknown;
+        }
 
         while let Some((module, include_default)) = collection.stack.pop() {
+            let module_key = ModuleKey::new(module.as_id());
+            if collection.seen_modules.contains(&module_key) {
+                continue;
+            }
             if collection.remaining_steps == 0 {
-                break;
+                return InferredTypeData::Unknown;
             }
             collection.remaining_steps -= 1;
+            collection.seen_modules.insert(module_key);
 
-            let Some(inferred_types) = infer_module_types(self.db, module) else {
-                continue;
+            if infer_module_types(self.db, module).is_none() {
+                return InferredTypeData::Unknown;
+            }
+
+            if !self.collect_namespace_members(module, include_default, &mut collection) {
+                return InferredTypeData::Unknown;
+            }
+        }
+
+        let mut members = Vec::with_capacity(collection.names.len());
+        for name in collection.names {
+            match self.resolve_export_name_result(module, inferred_types, name.text()) {
+                ExportResolution::Resolved(resolved) => members.push(InferredTypeMember {
+                    kind: InferredTypeMemberKind::Named(name),
+                    ty: resolved.ty,
+                }),
+                ExportResolution::Missing | ExportResolution::Ambiguous => {}
+                ExportResolution::Indeterminate => return InferredTypeData::Unknown,
             };
-
-            self.collect_namespace_members(
-                module,
-                &inferred_types,
-                include_default,
-                &mut collection,
-            );
         }
 
         InferredTypeData::Namespace(InferredNamespace::new(
             self.db,
-            collection.members.into_boxed_slice(),
+            members.into_boxed_slice(),
             Path::from(Text::from(module.path(self.db).to_string())),
         ))
     }
@@ -125,17 +167,11 @@ impl<'db> ResolutionCtx<'db, '_> {
     fn collect_namespace_members(
         &self,
         module: ModuleInfo,
-        inferred_types: &InferredModuleTypes<'db>,
         include_default: bool,
-        collection: &mut NamespaceExportCollection<'db>,
-    ) {
-        let module_key = ModuleKey::new(module.as_id());
-        if !collection.seen_modules.insert(module_key) {
-            return;
-        }
-
+        collection: &mut NamespaceExportCollection,
+    ) -> bool {
         let ModuleInfoKind::Js(js_info) = module.kind(self.db) else {
-            return;
+            return false;
         };
 
         for (name, _) in js_info.exports.iter() {
@@ -147,17 +183,17 @@ impl<'db> ResolutionCtx<'db, '_> {
                 continue;
             }
 
-            collection.members.push(InferredTypeMember {
-                kind: InferredTypeMemberKind::Named(name.clone()),
-                ty: self.resolve_export_name(module, inferred_types, name.text()),
-            });
+            collection.names.push(name.clone());
         }
 
         for reexport in js_info.blanket_reexports.iter().rev() {
-            if let Some(module) = self.module_for_resolved_path(&reexport.import.resolved_path) {
-                collection.stack.push((module, false));
-            }
+            let Some(module) = self.module_for_resolved_path(&reexport.import.resolved_path) else {
+                return false;
+            };
+            collection.stack.push((module, false));
         }
+
+        true
     }
 
     fn resolve_export_name(
@@ -166,25 +202,37 @@ impl<'db> ResolutionCtx<'db, '_> {
         inferred_types: &InferredModuleTypes<'db>,
         name: &str,
     ) -> InferredTypeData<'db> {
+        match self.resolve_export_name_result(module, inferred_types, name) {
+            ExportResolution::Resolved(resolved) => resolved.ty,
+            ExportResolution::Missing
+            | ExportResolution::Ambiguous
+            | ExportResolution::Indeterminate => InferredTypeData::Unknown,
+        }
+    }
+
+    fn resolve_export_name_result(
+        &self,
+        module: ModuleInfo,
+        inferred_types: &InferredModuleTypes<'db>,
+        name: &str,
+    ) -> ExportResolution<'db> {
         let mut stack = Vec::new();
         let mut seen = FxHashSet::default();
-        // Shared across direct stack pops and blanket reexport scans.
+        let mut resolved: Option<ResolvedExport<'db>> = None;
         let mut remaining_steps = MAX_EXPORT_RESOLUTION_STEPS;
 
-        if let Some(ty) = self.resolve_export_name_in_module(
-            module,
-            inferred_types,
-            name,
-            &mut stack,
-            &mut seen,
-            &mut remaining_steps,
-        ) {
-            return ty;
+        seen.insert((ModuleKey::new(module.as_id()), name.to_string()));
+        match self.resolve_export_name_in_module(module, inferred_types, name, &mut stack) {
+            ExportResolutionStep::Continue => {}
+            ExportResolutionStep::Resolved(candidate) => resolved = Some(candidate),
         }
 
         while let Some((module, name)) = stack.pop() {
+            if !seen.insert((ModuleKey::new(module.as_id()), name.clone())) {
+                continue;
+            }
             if remaining_steps == 0 {
-                return InferredTypeData::Unknown;
+                return ExportResolution::Indeterminate;
             }
             remaining_steps -= 1;
 
@@ -192,19 +240,21 @@ impl<'db> ResolutionCtx<'db, '_> {
                 continue;
             };
 
-            if let Some(ty) = self.resolve_export_name_in_module(
-                module,
-                &inferred_types,
-                &name,
-                &mut stack,
-                &mut seen,
-                &mut remaining_steps,
-            ) {
-                return ty;
+            match self.resolve_export_name_in_module(module, &inferred_types, &name, &mut stack) {
+                ExportResolutionStep::Continue => {}
+                ExportResolutionStep::Resolved(candidate) => {
+                    if let Some(previous) = &resolved {
+                        if previous.identity != candidate.identity {
+                            return ExportResolution::Ambiguous;
+                        }
+                    } else {
+                        resolved = Some(candidate);
+                    }
+                }
             }
         }
 
-        InferredTypeData::Unknown
+        resolved.map_or(ExportResolution::Missing, ExportResolution::Resolved)
     }
 
     fn resolve_export_name_in_module(
@@ -213,39 +263,35 @@ impl<'db> ResolutionCtx<'db, '_> {
         inferred_types: &InferredModuleTypes<'db>,
         name: &str,
         stack: &mut Vec<(ModuleInfo, String)>,
-        seen: &mut FxHashSet<(ModuleKey, String)>,
-        remaining_steps: &mut usize,
-    ) -> Option<InferredTypeData<'db>> {
+    ) -> ExportResolutionStep<'db> {
         let module_key = ModuleKey::new(module.as_id());
-        if !seen.insert((module_key, name.to_string())) {
-            return None;
-        }
-
         let ModuleInfoKind::Js(js_info) = module.kind(self.db) else {
-            return None;
+            return ExportResolutionStep::Continue;
         };
 
         match js_info.exports.get(name) {
             Some(JsExport::Own(own_export) | JsExport::OwnType(own_export)) => {
-                Some(self.resolve_own_export(inferred_types, own_export))
+                ExportResolutionStep::Resolved(ResolvedExport {
+                    identity: ExportIdentity {
+                        module: module_key,
+                        own_export: own_export.clone(),
+                    },
+                    ty: self.resolve_own_export(inferred_types, own_export),
+                })
             }
             Some(JsExport::Reexport(reexport) | JsExport::ReexportType(reexport)) => {
                 self.push_reexport_target(reexport.import.clone(), name, stack);
-                None
+                ExportResolutionStep::Continue
             }
             None => {
                 for reexport in js_info.blanket_reexports.iter().rev() {
-                    if *remaining_steps == 0 {
-                        return Some(InferredTypeData::Unknown);
-                    }
-                    *remaining_steps -= 1;
                     if let Some(module) =
                         self.module_for_resolved_path(&reexport.import.resolved_path)
                     {
                         stack.push((module, name.to_string()));
                     }
                 }
-                None
+                ExportResolutionStep::Continue
             }
         }
     }

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -361,7 +361,7 @@ impl<'db> MemberLookupState<'db> {
     }
 }
 
-pub(in crate::db::type_inference) fn substitutions_for_instance<'db>(
+pub(in crate::db) fn substitutions_for_instance<'db>(
     db: &'db dyn ModuleDb,
     target: InferredTypeData<'db>,
     type_parameters: &[InferredTypeData<'db>],
@@ -445,6 +445,17 @@ pub(in crate::db::type_inference) fn apply_substitutions<'db>(
 ) -> InferredTypeData<'db> {
     for substitution in substitutions {
         ty = ty.substitute_type(db, *substitution);
+    }
+    ty
+}
+
+pub(in crate::db) fn apply_substitutions_to_root_body<'db>(
+    db: &'db dyn ModuleDb,
+    mut ty: InferredTypeData<'db>,
+    substitutions: &[InferredTypeSubstitution<'db>],
+) -> InferredTypeData<'db> {
+    for substitution in substitutions {
+        ty = ty.substitute_type_in_root_body(db, *substitution);
     }
     ty
 }

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -12,6 +12,7 @@ mod lookup;
 mod qualifiers;
 mod resolver;
 
+pub(in crate::db) use lookup::{apply_substitutions_to_root_body, substitutions_for_instance};
 pub(in crate::db) use resolver::resolve_raw_types;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, salsa::Update)]

--- a/crates/biome_module_graph/tests/snapshots/test_infer_module_types_calls_imported_generic_function_type_aliases.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_infer_module_types_calls_imported_generic_function_type_aliases.snap
@@ -1,0 +1,50 @@
+---
+source: crates/biome_module_graph/tests/spec_tests_v2.rs
+expression: content
+---
+
+# `/src/factory.ts`
+
+## Source
+
+```ts
+type Factory<T> = () => Promise<T>;
+export declare const makeString: Factory<string>;
+```
+
+## Inferred types
+
+```
+Binding Factory "Factory" => instanceof sync Function {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise<instanceof T>
+}<T>
+
+Binding T "T" => T
+
+Binding makeString "makeString" => instanceof Factory<string>
+```
+
+# `/src/index.ts`
+
+## Source
+
+```ts
+import { makeString } from "./factory";
+export const result = makeString();
+```
+
+## Inferred types
+
+```
+Binding makeString "makeString" => instanceof Factory<string>
+
+Binding result "result" => instanceof Promise<string>
+
+Expression "makeString" => instanceof Factory<string>
+
+Expression "makeString()" => instanceof Promise<string>
+```

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -4644,6 +4644,203 @@ fn test_infer_call_expression_type_substitutes_nested_generic_return_type() {
 }
 
 #[test]
+fn test_infer_module_types_calls_generic_function_type_aliases() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            type Factory<T> = () => Promise<T>;
+            declare const makeString: Factory<string>;
+            export const result = makeString();
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+    let result_ty = inferred_binding_ty_by_name(&db, module, &inferred, "result")
+        .expect("result type must be inferred");
+
+    let result_ty = inferred.resolve_type(&db, result_ty);
+    assert!(
+        is_inferred_promise_with_type_parameter(&db, result_ty, |ty| is_inferred_string(&db, ty)),
+        "generic alias must return Promise<string>, got {}",
+        format_inferred_type(&db, result_ty)
+    );
+}
+
+#[test]
+fn test_infer_module_types_calls_imported_generic_function_type_aliases() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/factory.ts".into(),
+        r#"
+            type Factory<T> = () => Promise<T>;
+            export declare const makeString: Factory<string>;
+        "#,
+    );
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import { makeString } from "./factory";
+            export const result = makeString();
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/factory.ts", "/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+    let result_ty = inferred_binding_ty_by_name(&db, module, &inferred, "result")
+        .expect("result type must be inferred");
+    let result_ty = inferred.resolve_type(&db, result_ty);
+
+    assert!(is_inferred_promise_with_type_parameter(
+        &db,
+        result_ty,
+        |ty| is_inferred_string(&db, ty)
+    ));
+    assert_inferred_type_snapshot(
+        "test_infer_module_types_calls_imported_generic_function_type_aliases",
+        &db,
+        &fs,
+    );
+}
+
+#[test]
+fn test_infer_module_types_calls_nested_generic_callable_aliases() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            interface Callable<T> {
+                (value: T): T;
+            }
+
+            type First<T> = Callable<T>;
+            type Second<T> = First<T>;
+            declare const call: Second<string>;
+            export const result = call("value");
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+    let result_ty = inferred_binding_ty_by_name(&db, module, &inferred, "result")
+        .expect("result type must be inferred");
+
+    let result_ty = inferred.resolve_type(&db, result_ty);
+    assert!(
+        is_inferred_string(&db, result_ty),
+        "nested generic alias must return string, got {}",
+        format_inferred_type(&db, result_ty)
+    );
+}
+
+#[test]
+fn test_infer_call_expression_type_substitutes_generic_in_function_return_type() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            export function wrap<T>(value: T): () => T {
+                return () => value;
+            }
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+    let wrap_ty = inferred_binding_ty_by_name(&db, module, &inferred, "wrap")
+        .expect("wrap binding type must be inferred");
+    let call_ty = infer_call_expression_type(
+        &db,
+        module,
+        inferred.resolve_type(&db, wrap_ty),
+        Vec::from([InferredTypeData::Number]),
+    );
+    let InferredTypeData::Function(function) = call_ty else {
+        panic!("wrap must return a function, got {call_ty:?}");
+    };
+    let InferredReturnType::Type(return_ty) = function.return_type(&db) else {
+        panic!("nested function return type must be inferred");
+    };
+
+    assert!(is_inferred_number(&db, *return_ty));
+}
+
+#[test]
+fn test_infer_call_expression_type_preserves_shadowed_nested_function_generic() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            export function makeIdentity<T>(value: T): <T>(value: T) => T {
+                return value => value;
+            }
+
+            const identity = makeIdentity(1);
+            export const result = identity("value");
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+    let result_ty = inferred_binding_ty_by_name(&db, module, &inferred, "result")
+        .expect("result type must be inferred");
+
+    assert!(is_inferred_string_literal(
+        &db,
+        inferred.resolve_type(&db, result_ty),
+        "value"
+    ));
+}
+
+#[test]
+fn test_infer_module_types_preserves_shadowed_class_method_generic() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            class Box<T> {
+                map<T>(value: T): T {
+                    return value;
+                }
+            }
+
+            declare const box: Box<number>;
+            export const result = box.map("value");
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+    let result_ty = inferred_binding_ty_by_name(&db, module, &inferred, "result")
+        .expect("result type must be inferred");
+
+    assert!(is_inferred_string_literal(
+        &db,
+        inferred.resolve_type(&db, result_ty),
+        "value"
+    ));
+}
+
+#[test]
 fn test_infer_call_expression_type_substitutes_generic_inside_promise_union_return_type() {
     let fs = MemoryFileSystem::default();
     fs.insert(


### PR DESCRIPTION
## Summary

Improves the Salsa-backed inference engine for namespace imports, namespace re-exports, aliased generic callables, shadowed generic parameters, and specialised tuple elements. `useIncludes` can now recognize string tuples returned through generic aliases.

## Test Plan

Extended module graph tests for namespace and callable-alias inference. Added a `useIncludes` regression test for a generic factory returning `[T]`.

## Docs

N/A

> This PR was created with AI assistance (OpenCode).