### PR TITLE
fix(html_analyze): noLabelWithoutControl interpolation

### DIFF
--- a/.changeset/cyan-bobcats-poke.md
+++ b/.changeset/cyan-bobcats-poke.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10930](https://github.com/biomejs/biome/issues/10930): [`noLabelWithoutControl`](https://biomejs.dev/linter/rules/no-label-without-control/) now correctly detects text interpolation in Astro, Svelte & Vue as valid accessible content.

--- a/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_label_without_control.rs
@@ -177,7 +177,10 @@ fn has_accessible_label(
     while let Some(event) = child_iter.next() {
         match event {
             WalkEvent::Enter(child) => match child.kind() {
-                HtmlSyntaxKind::HTML_TEXT_EXPRESSION | HtmlSyntaxKind::HTML_CONTENT => {
+                HtmlSyntaxKind::HTML_TEXT_EXPRESSION
+                | HtmlSyntaxKind::HTML_SINGLE_TEXT_EXPRESSION
+                | HtmlSyntaxKind::HTML_DOUBLE_TEXT_EXPRESSION
+                | HtmlSyntaxKind::HTML_CONTENT => {
                     return true;
                 }
                 HtmlSyntaxKind::HTML_ELEMENT

--- a/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/astro/valid.astro
@@ -1,6 +1,8 @@
 /* should not generate diagnostics */
 <a>documentation</a>
 
+<a>{stringVariable}</a>
+
 <a aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</a>
 
 <a><span aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/astro/valid.astro.snap
@@ -7,6 +7,8 @@ expression: valid.astro
 /* should not generate diagnostics */
 <a>documentation</a>
 
+<a>{stringVariable}</a>
+
 <a aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</a>
 
 <a><span aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/svelte/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/svelte/valid.svelte
@@ -1,6 +1,8 @@
 /* should not generate diagnostics */
 <a>documentation</a>
 
+<a>{stringVariable}</a>
+
 <a aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</a>
 
 <a><span aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/svelte/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/svelte/valid.svelte.snap
@@ -7,6 +7,8 @@ expression: valid.svelte
 /* should not generate diagnostics */
 <a>documentation</a>
 
+<a>{stringVariable}</a>
+
 <a aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</a>
 
 <a><span aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/vue/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/vue/valid.vue
@@ -1,6 +1,8 @@
 /* should not generate diagnostics */
 <a>documentation</a>
 
+<a>{{stringVariable}}</a>
+
 <a aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</a>
 
 <a><span aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/vue/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noAmbiguousAnchorText/vue/valid.vue.snap
@@ -7,6 +7,8 @@ expression: valid.vue
 /* should not generate diagnostics */
 <a>documentation</a>
 
+<a>{{stringVariable}}</a>
+
 <a aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</a>
 
 <a><span aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro
@@ -15,6 +15,7 @@
 <label><img alt="A label" /><input /></label>
 <label><img aria-label="A label" /><input /></label>
 <label><span>A label<input /></span></label>
+<label><span>{stringVariable}<input /></span></label>
 <label><span><span>A label<input /></span></span></label>
 <label><span><span><span>A label<input /></span></span></span></label>
 <label><span><span><span><span>A label</span><input /></span></span></span></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/astro/valid.astro.snap
@@ -21,6 +21,7 @@ expression: valid.astro
 <label><img alt="A label" /><input /></label>
 <label><img aria-label="A label" /><input /></label>
 <label><span>A label<input /></span></label>
+<label><span>{stringVariable}<input /></span></label>
 <label><span><span>A label<input /></span></span></label>
 <label><span><span><span>A label<input /></span></span></span></label>
 <label><span><span><span><span>A label</span><input /></span></span></span></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte
@@ -15,6 +15,7 @@
 <label><img alt="A label" /><input /></label>
 <label><img aria-label="A label" /><input /></label>
 <label><span>A label<input /></span></label>
+<label><span>{stringVariable}<input /></span></label>
 <label><span><span>A label<input /></span></span></label>
 <label><span><span><span>A label<input /></span></span></span></label>
 <label><span><span><span><span>A label</span><input /></span></span></span></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/svelte/valid.svelte.snap
@@ -21,6 +21,7 @@ expression: valid.svelte
 <label><img alt="A label" /><input /></label>
 <label><img aria-label="A label" /><input /></label>
 <label><span>A label<input /></span></label>
+<label><span>{stringVariable}<input /></span></label>
 <label><span><span>A label<input /></span></span></label>
 <label><span><span><span>A label<input /></span></span></span></label>
 <label><span><span><span><span>A label</span><input /></span></span></span></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue
@@ -15,6 +15,7 @@
 <label><img alt="A label" /><input /></label>
 <label><img aria-label="A label" /><input /></label>
 <label><span>A label<input /></span></label>
+<label><span>{{ stringVariable }}<input /></span></label>
 <label><span><span>A label<input /></span></span></label>
 <label><span><span><span>A label<input /></span></span></span></label>
 <label><span><span><span><span>A label</span><input /></span></span></span></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noLabelWithoutControl/vue/valid.vue.snap
@@ -21,6 +21,7 @@ expression: valid.vue
 <label><img alt="A label" /><input /></label>
 <label><img aria-label="A label" /><input /></label>
 <label><span>A label<input /></span></label>
+<label><span>{{ stringVariable }}<input /></span></label>
 <label><span><span>A label<input /></span></span></label>
 <label><span><span><span>A label<input /></span></span></span></label>
 <label><span><span><span><span>A label</span><input /></span></span></span></label>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAltText/vue/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAltText/vue/invalid.vue
@@ -1,0 +1,17 @@
+<!-- should generate diagnostics -->
+
+<!-- img without alt -->
+<img src="image.png" />
+<img src="image.png" class="photo" />
+
+<!-- area without alt -->
+<area href="foo" />
+<map name="map"><area shape="rect" coords="0,0,100,100" href="link" /></map>
+
+<!-- input type="image" without alt -->
+<input type="image" src="submit.png" />
+<input type="image" src="button.png" name="submit" />
+
+<!-- object without title -->
+<object data="movie.swf"></object>
+<object data="document.pdf" type="application/pdf"></object>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAltText/vue/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAltText/vue/invalid.vue.snap
@@ -1,0 +1,173 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+
+<!-- img without alt -->
+<img src="image.png" />
+<img src="image.png" class="photo" />
+
+<!-- area without alt -->
+<area href="foo" />
+<map name="map"><area shape="rect" coords="0,0,100,100" href="link" /></map>
+
+<!-- input type="image" without alt -->
+<input type="image" src="submit.png" />
+<input type="image" src="button.png" name="submit" />
+
+<!-- object without title -->
+<object data="movie.swf"></object>
+<object data="document.pdf" type="application/pdf"></object>
+
+```
+
+# Diagnostics
+```
+invalid.vue:4:1 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide a text alternative through the alt, aria-label, or aria-labelledby attribute.
+  
+    3 │ <!-- img without alt -->
+  > 4 │ <img src="image.png" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ <img src="image.png" class="photo" />
+    6 │ 
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+invalid.vue:5:1 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide a text alternative through the alt, aria-label, or aria-labelledby attribute.
+  
+    3 │ <!-- img without alt -->
+    4 │ <img src="image.png" />
+  > 5 │ <img src="image.png" class="photo" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ <!-- area without alt -->
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+invalid.vue:8:1 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide a text alternative through the alt, aria-label, or aria-labelledby attribute.
+  
+     7 │ <!-- area without alt -->
+   > 8 │ <area href="foo" />
+       │ ^^^^^^^^^^^^^^^^^^^
+     9 │ <map name="map"><area shape="rect" coords="0,0,100,100" href="link" /></map>
+    10 │ 
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+invalid.vue:9:17 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide a text alternative through the alt, aria-label, or aria-labelledby attribute.
+  
+     7 │ <!-- area without alt -->
+     8 │ <area href="foo" />
+   > 9 │ <map name="map"><area shape="rect" coords="0,0,100,100" href="link" /></map>
+       │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
+    11 │ <!-- input type="image" without alt -->
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+invalid.vue:12:1 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide a text alternative through the alt, aria-label, or aria-labelledby attribute.
+  
+    11 │ <!-- input type="image" without alt -->
+  > 12 │ <input type="image" src="submit.png" />
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ <input type="image" src="button.png" name="submit" />
+    14 │ 
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+invalid.vue:13:1 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide a text alternative through the alt, aria-label, or aria-labelledby attribute.
+  
+    11 │ <!-- input type="image" without alt -->
+    12 │ <input type="image" src="submit.png" />
+  > 13 │ <input type="image" src="button.png" name="submit" />
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+    15 │ <!-- object without title -->
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+invalid.vue:16:1 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide a text alternative through the title, aria-label, or aria-labelledby attribute.
+  
+    15 │ <!-- object without title -->
+  > 16 │ <object data="movie.swf"></object>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    17 │ <object data="document.pdf" type="application/pdf"></object>
+    18 │ 
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```
+
+```
+invalid.vue:17:1 lint/a11y/useAltText ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide a text alternative through the title, aria-label, or aria-labelledby attribute.
+  
+    15 │ <!-- object without title -->
+    16 │ <object data="movie.swf"></object>
+  > 17 │ <object data="document.pdf" type="application/pdf"></object>
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    18 │ 
+  
+  i Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.
+  
+  i If the content is decorative, redundant, or obscured, consider hiding it from assistive technologies with the aria-hidden attribute.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro
@@ -9,6 +9,7 @@
 
 <!-- Native anchors with accessible content -->
 <a>content</a>
+<a>{ stringVariable }</a>
 <a><span>content</span></a>
 <a><span aria-hidden="true"></span>content</a>
 <a><div aria-hidden="true"></div>content</a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/astro/valid.astro.snap
@@ -15,6 +15,7 @@ expression: valid.astro
 
 <!-- Native anchors with accessible content -->
 <a>content</a>
+<a>{ stringVariable }</a>
 <a><span>content</span></a>
 <a><span aria-hidden="true"></span>content</a>
 <a><div aria-hidden="true"></div>content</a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/svelte/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/svelte/valid.svelte
@@ -6,6 +6,7 @@
 
 <!-- Native anchors with accessible content -->
 <a>content</a>
+<a>{ stringVariable }</a>
 <a><span>content</span></a>
 <a><span aria-hidden="true"></span>content</a>
 <a><div aria-hidden="true"></div>content</a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/svelte/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/svelte/valid.svelte.snap
@@ -12,6 +12,7 @@ expression: valid.svelte
 
 <!-- Native anchors with accessible content -->
 <a>content</a>
+<a>{ stringVariable }</a>
 <a><span>content</span></a>
 <a><span aria-hidden="true"></span>content</a>
 <a><div aria-hidden="true"></div>content</a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/vue/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/vue/valid.vue
@@ -7,6 +7,7 @@
 
   <!-- Native anchors with accessible content -->
   <a>content</a>
+  <a>{{ stringVariable }}</a>
   <a><span>content</span></a>
   <a><span aria-hidden="true"></span>content</a>
   <a><div aria-hidden="true"></div>content</a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/vue/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAnchorContent/vue/valid.vue.snap
@@ -13,6 +13,7 @@ expression: valid.vue
 
   <!-- Native anchors with accessible content -->
   <a>content</a>
+  <a>{{ stringVariable }}</a>
   <a><span>content</span></a>
   <a><span aria-hidden="true"></span>content</a>
   <a><div aria-hidden="true"></div>content</a>


### PR DESCRIPTION
## Summary

Correctly detect noLabelWithoutControl text interpolation in Astro, Svelte & Vue.

Closes #10930

## Test Plan

Added unit tests (also for some text interpolation cases of other rules)

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
