### PR TITLE
fix(useConsistentObjectDefinitions): don't shorthand named function expressions

### DIFF
--- a/.changeset/fix-consistent-object-definitions-named-fn.md
+++ b/.changeset/fix-consistent-object-definitions-named-fn.md
@@ -1,0 +1,15 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10212](https://github.com/biomejs/biome/issues/10212): [`useConsistentObjectDefinitions`](https://biomejs.dev/linter/rules/use-consistent-object-definitions/) no longer converts named function expressions to shorthand methods.
+
+Shorthanding a named function expression renames it after the property key, which changes the function's `name`:
+
+```js
+const obj = {
+  b: function c() {}, // obj.b.name === "c", but a shorthand `b() {}` would make it "b"
+};
+```
+
+Anonymous function expressions are still converted, since they already take their name from the property key.

--- a/crates/biome_js_analyze/src/lint/style/use_consistent_object_definitions.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_object_definitions.rs
@@ -148,8 +148,16 @@ impl Rule for UseConsistentObjectDefinitions {
                         let variable_token = identifier_token.name().ok()?.value_token().ok()?;
                         inner_string_text(&variable_token)
                     }
-                    AnyJsExpression::JsFunctionExpression(_function_token) => {
-                        // Functions are always shorthandable
+                    AnyJsExpression::JsFunctionExpression(function) => {
+                        // A named function expression keeps its own name, so for
+                        // `a: function b() {}` the value of `obj.a.name` is `"b"`. Converting it
+                        // to a shorthand method renames it after the property key, changing
+                        // `obj.a.name` to `"a"`, so it isn't safe to shorthand. Anonymous function
+                        // expressions already take their name from the property key and stay
+                        // shorthandable.
+                        if function.id().is_some() {
+                            return None;
+                        }
                         match syntax {
                             ObjectPropertySyntax::Shorthand => return Some(()),
                             ObjectPropertySyntax::Explicit => return None,

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentObjectDefinitions/validShorthand.js
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentObjectDefinitions/validShorthand.js
@@ -47,5 +47,12 @@ const validShorthand = {
     get getter() { return "getter"; },
     set setter(value) { this._setter = value; },
 
+    // Named function expressions: shorthanding would rename the function after the property
+    // key, changing `named.name` from "actualName" to "named", so they can't be shorthanded
+    named: function actualName() {},
+    namedGenerator: function* actualGenerator() {},
+    // ...also with a computed key
+    ["computedName"]: function computedNamed() {},
+
     ...spread,
 };


### PR DESCRIPTION
Fixes #10212