### PR TITLE
fix(grit): use byte offsets for WASM snippets

### DIFF
--- a/.changeset/twenty-mugs-boil.md
+++ b/.changeset/twenty-mugs-boil.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10242](https://github.com/biomejs/biome/issues/10242): GritQL patterns with multiple metavariables now match snippets correctly in WASM.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ef8ee0b4eedc5a877a8a768fecfabbe4c8b9791e17763225139a858dabd8e7"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,6 +1982,7 @@ dependencies = [
  "biome_console",
  "biome_diagnostics",
  "biome_fs",
+ "biome_grit_patterns",
  "biome_js_factory",
  "biome_js_formatter",
  "biome_languages",
@@ -1985,6 +1997,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -4182,6 +4195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4317,6 +4336,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4437,6 +4466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4493,9 +4523,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -6670,6 +6700,45 @@ checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
 
 [[package]]
 name = "wasm-encoder"

--- a/crates/biome_grit_patterns/src/grit_css_parser.rs
+++ b/crates/biome_grit_patterns/src/grit_css_parser.rs
@@ -62,12 +62,6 @@ impl Parser for GritCssParser {
     ) -> SnippetTree<GritTargetTree> {
         let context = format!("{prefix}{source}{postfix}");
 
-        let len = if cfg!(target_arch = "wasm32") {
-            |src: &str| src.chars().count() as u32
-        } else {
-            |src: &str| src.len() as u32
-        };
-
         let parse_result = parse_css(
             &context,
             CssFileSource::css(),
@@ -79,8 +73,8 @@ impl Parser for GritCssParser {
             source: source.to_owned(),
             prefix,
             postfix,
-            snippet_start: (len(prefix) + len(source) - len(source.trim_start())),
-            snippet_end: (len(prefix) + len(source.trim_end())),
+            snippet_start: (prefix.len() + source.len() - source.trim_start().len()) as u32,
+            snippet_end: (prefix.len() + source.trim_end().len()) as u32,
         }
     }
 }

--- a/crates/biome_grit_patterns/src/grit_js_parser.rs
+++ b/crates/biome_grit_patterns/src/grit_js_parser.rs
@@ -70,12 +70,6 @@ impl Parser for GritJsParser {
     ) -> SnippetTree<GritTargetTree> {
         let context = format!("{prefix}{source}{postfix}");
 
-        let len = if cfg!(target_arch = "wasm32") {
-            |src: &str| src.chars().count() as u32
-        } else {
-            |src: &str| src.len() as u32
-        };
-
         let parse_result = parse(
             &context,
             JsFileSource::tsx(),
@@ -87,8 +81,8 @@ impl Parser for GritJsParser {
             source: source.to_owned(),
             prefix,
             postfix,
-            snippet_start: (len(prefix) + len(source) - len(source.trim_start())),
-            snippet_end: (len(prefix) + len(source.trim_end())),
+            snippet_start: (prefix.len() + source.len() - source.trim_start().len()) as u32,
+            snippet_end: (prefix.len() + source.trim_end().len()) as u32,
         }
     }
 }

--- a/crates/biome_grit_patterns/src/grit_json_parser.rs
+++ b/crates/biome_grit_patterns/src/grit_json_parser.rs
@@ -57,12 +57,6 @@ impl Parser for GritJsonParser {
     ) -> SnippetTree<GritTargetTree> {
         let context = format!("{prefix}{source}{postfix}");
 
-        let len = if cfg!(target_arch = "wasm32") {
-            |src: &str| src.chars().count() as u32
-        } else {
-            |src: &str| src.len() as u32
-        };
-
         let parse_result = parse_json(&context, JsonParserOptions::default().allow_metavariables());
 
         SnippetTree {
@@ -70,8 +64,8 @@ impl Parser for GritJsonParser {
             source: source.to_owned(),
             prefix,
             postfix,
-            snippet_start: (len(prefix) + len(source) - len(source.trim_start())),
-            snippet_end: (len(prefix) + len(source.trim_end())),
+            snippet_start: (prefix.len() + source.len() - source.trim_start().len()) as u32,
+            snippet_end: (prefix.len() + source.trim_end().len()) as u32,
         }
     }
 }

--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -35,6 +35,10 @@ serde-wasm-bindgen       = "0.6.5"
 # IMPORTANT: if you update this package, you must update justfile and workflows so we install the same CLI version
 wasm-bindgen             = { version = "=0.2.117", features = ["serde-serialize"] }
 
+[dev-dependencies]
+biome_grit_patterns = { workspace = true }
+wasm-bindgen-test   = "0.3.67"
+
 [build-dependencies]
 biome_js_factory   = { workspace = true }
 biome_js_formatter = { workspace = true }

--- a/crates/biome_wasm/tests/grit.rs
+++ b/crates/biome_wasm/tests/grit.rs
@@ -1,0 +1,19 @@
+#![cfg(target_arch = "wasm32")]
+
+use biome_grit_patterns::testing::{compile_js_query, make_js_file};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[wasm_bindgen_test]
+fn empty_call_with_multiple_metavariables() {
+    let query = compile_js_query(
+        r#"`expect($arg).$method()` where {
+            $arg <: 1,
+            $method <: `toBeTruthy`,
+        }"#,
+    );
+    let result = query
+        .execute(make_js_file("expect(1).toBeTruthy()"))
+        .expect("could not execute query");
+
+    assert_eq!(result.effects.len(), 1);
+}


### PR DESCRIPTION
## Summary

Fixes #10242.

Biome syntax ranges use UTF-8 byte offsets on every target, but the Grit snippet parsers used character counts on WASM. Replacing multiple metavariables with the non-ASCII `µ` prefix therefore shifted the snippet boundary and prevented the empty call expression from matching.

This change uses byte lengths consistently for JavaScript, CSS, and JSON snippets, and adds a WASM regression test for the reported query.

This pull request was implemented and validated with OpenAI Codex assistance.

## Test Plan

- `cargo +stable-x86_64-pc-windows-gnu test -p biome_grit_patterns`
- `cargo +stable-x86_64-pc-windows-gnu test -p biome_wasm --target wasm32-unknown-unknown --test grit empty_call_with_multiple_metavariables -- --exact`
- `just f`

## Docs

Not applicable; this restores the documented GritQL matching behavior.
