### PR TITLE
docs(useIterableCallbackReturn): fix list bullet for the from method

### DIFF
--- a/crates/biome_js_analyze/src/lint/suspicious/use_iterable_callback_return.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_iterable_callback_return.rs
@@ -43,7 +43,7 @@ declare_lint_rule! {
     /// - `some`
     /// - `sort`
     /// - `toSorted`
-    /// — `from` (when called on `Array`)
+    /// - `from` (when called on `Array`)
     ///
     /// A return value is disallowed in the method `forEach`.
     ///


### PR DESCRIPTION
In the `useIterableCallbackReturn` rule docs, the `from` entry in the "methods that require a return" list uses an em-dash instead of a hyphen, so it does not render as part of the list on the docs site. Changed it to a hyphen to match the other entries.
