### PR TITLE
docs(type-info): fix stale CONTRIBUTING links for TypeData and full inference

### DIFF
--- a/crates/biome_js_type_info/CONTRIBUTING.md
+++ b/crates/biome_js_type_info/CONTRIBUTING.md
@@ -57,7 +57,7 @@ own challenges.
 ## Type Data Structures
 
 In Biome, the most basic data structure for type information is a giant `enum`,
-called `TypeData`, defined in [`type_info.rs`](src/type_info.rs).
+called `TypeData`, defined in [`type_data.rs`](src/type_data.rs).
 
 This enum has many different variants in order to cover all the different kinds
 of types that TypeScript supports. But a few are specifically
@@ -216,7 +216,7 @@ we've seen before: Such a cache would get stale the moment a module is replaced,
 and we don't want to have complex cache invalidation schemes.
 
 Full inference is implemented in
-[`scoped_resolver.rs`](../biome_module_graph/src/js_module_info/scoped_resolver.rs).
+[`module_resolver.rs`](../biome_module_graph/src/js_module_info/module_resolver.rs).
 
 ## Type Resolvers
 


### PR DESCRIPTION
## Summary

Two relative links in `crates/biome_js_type_info/CONTRIBUTING.md` 404 on GitHub:

- `src/type_info.rs` → `src/type_data.rs` (`TypeData`)
- `../biome_module_graph/src/js_module_info/scoped_resolver.rs` → `module_resolver.rs` (full inference / `ModuleResolver`)

Docs-only against current `main`. Does not pre-empt the in-flight inference refactors (#10936 / #10937); only repairs links that are already broken today.

## Test Plan

Resolved each new relative path from `crates/biome_js_type_info/CONTRIBUTING.md` and confirmed the targets exist on `main`.

## Docs

This PR is the documentation fix.

## AI assistance disclosure

This PR was scoped and authored with AI assistance (OpenClaw/Bartok). The diff is a two-line path correction verified against the current tree.