### PR TITLE
fix(plugins): include plugin path in read errors (salvage of #10850, credit @initiallyqq)

### DIFF
--- a/.changeset/fix-plugin-read-error-path.md
+++ b/.changeset/fix-plugin-read-error-path.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10846](https://github.com/biomejs/biome/issues/10846): Biome now includes the plugin file path when a `.grit` plugin file cannot be read.

--- a/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
@@ -38,7 +38,9 @@ impl AnalyzerGritPlugin {
         path: &Utf8Path,
         includes: Option<&[NormalizedGlob]>,
     ) -> Result<Self, PluginDiagnostic> {
-        let source = fs.read_file_from_path(path)?;
+        let source = fs
+            .read_file_from_path(path)
+            .map_err(|source| PluginDiagnostic::cant_read_file(path.to_path_buf(), source))?;
         let options = CompilePatternOptions::default()
             .with_extra_built_ins(vec![
                 BuiltInFunction::new(

--- a/crates/biome_plugin_loader/src/diagnostics.rs
+++ b/crates/biome_plugin_loader/src/diagnostics.rs
@@ -30,6 +30,9 @@ pub enum PluginDiagnostic {
     /// Error loading the plugin from the file system.
     FileSystem(FileSystemDiagnostic),
 
+    /// Error reading a plugin file from the file system.
+    CantReadFile(CantReadFile),
+
     /// When something is wrong with the manifest.
     InvalidManifest(InvalidManifest),
 
@@ -105,6 +108,14 @@ impl PluginDiagnostic {
     pub fn unsupported_rule_format(message: impl Display) -> Self {
         Self::UnsupportedRuleFormat(UnsupportedRuleFormat {
             message: MessageAndDescription::from(markup! {{message}}.to_owned()),
+        })
+    }
+
+    pub fn cant_read_file(path: Utf8PathBuf, source: FileSystemDiagnostic) -> Self {
+        Self::CantReadFile(CantReadFile {
+            message: MessageAndDescription::from(markup! {"Cannot read plugin file"}.to_owned()),
+            path: path.to_string(),
+            source: Some(Error::from(source)),
         })
     }
 
@@ -193,6 +204,24 @@ pub struct UnsupportedRuleFormat {
     #[message]
     #[description]
     pub message: MessageAndDescription,
+}
+
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+#[diagnostic(
+    category = "plugin",
+    severity = Error,
+)]
+pub struct CantReadFile {
+    #[message]
+    #[description]
+    message: MessageAndDescription,
+
+    #[location(resource)]
+    path: String,
+
+    #[serde(skip)]
+    #[source]
+    source: Option<Error>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]

--- a/crates/biome_plugin_loader/src/lib.rs
+++ b/crates/biome_plugin_loader/src/lib.rs
@@ -189,6 +189,31 @@ mod test {
     }
 
     #[test]
+    fn load_missing_single_rule_plugin() {
+        let fs = Arc::new(MemoryFileSystem::default()) as Arc<dyn FsWithResolverProxy>;
+        let error = BiomePlugin::load(fs, "./missing.grit", Utf8Path::new("/"), None)
+            .expect_err("Plugin loading should've failed");
+        snap_diagnostic("load_missing_single_rule_plugin", error.into());
+    }
+
+    #[test]
+    fn load_plugin_with_missing_rule_file() {
+        let fs = MemoryFileSystem::default();
+        fs.insert(
+            "/my-plugin/biome-manifest.jsonc".into(),
+            r#"{
+    "version": 1,
+    "rules": ["rules/missing.grit"]
+}"#,
+        );
+
+        let fs = Arc::new(fs) as Arc<dyn FsWithResolverProxy>;
+        let error = BiomePlugin::load(fs, "./my-plugin", Utf8Path::new("/"), None)
+            .expect_err("Plugin loading should've failed");
+        snap_diagnostic("load_plugin_with_missing_rule_file", error.into());
+    }
+
+    #[test]
     fn load_plugin_with_wrong_version() {
         let fs = MemoryFileSystem::default();
         fs.insert(

--- a/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_missing_single_rule_plugin.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_plugin_loader/src/lib.rs
+expression: content
+---
+/missing.grit plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Cannot read plugin file
+    
+    Caused by:
+      Cannot read file.
+    
+    Caused by:
+      path "/missing.grit" does not exists in memory filesystem

--- a/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
+++ b/crates/biome_plugin_loader/src/snapshots/load_plugin_with_missing_rule_file.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_plugin_loader/src/lib.rs
+expression: content
+---
+/my-plugin/rules/missing.grit plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Cannot read plugin file
+    
+    Caused by:
+      Cannot read file.
+    
+    Caused by:
+      path "/my-plugin/rules/missing.grit" does not exists in memory filesystem


### PR DESCRIPTION
## Summary

salvage: rebased and re-landed the useful fix from #10850 by @initiallyqq so missing `.grit` plugin reads report which plugin path failed (Fixes #10846).

Original PR was MERGEABLE but idle on main with incomplete CI engagement. This branch re-applies the same approach on current `main`:

- `PluginDiagnostic::CantReadFile` with path location
- map grit plugin file read failures through `cant_read_file`
- snapshot tests for missing single-rule plugin and missing manifest rule file
- patch changeset

Credit: @initiallyqq (#10850).

## Test Plan

```
cargo test -p biome_plugin_loader --lib
```

24/24 passed locally, including the two new snapshot tests.

## Docs

No website docs required; diagnostic improvement only.

## AI assistance disclosure

Original #10850 was prepared with Codex assistance by @initiallyqq. This salvage rebased/reapplied that work on current main with AI assistance (OpenClaw/Bartok); logic and tests remain the original approach.