### PR TITLE
fix(css_formatter): format comments before !important

### DIFF
--- a/.changeset/fix-css-important-value-comment.md
+++ b/.changeset/fix-css-important-value-comment.md
@@ -1,0 +1,10 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed CSS formatting for comments between declaration values and `!important`.
+
+```diff
+-a { color: /* before */ /* after */ red !important; }
++a { color: /* before */ red /* after */ !important; }
+```

--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -5,13 +5,13 @@ use crate::utils::scss_include_comments::{
     place_separated_list_comment,
 };
 use biome_css_syntax::{
-    AnyCssDeclarationName, AnyCssMediaQuery, AnyCssRoot, CssComplexSelector,
-    CssDeclarationOrRuleBlock, CssFunction, CssGenericComponentValueList, CssGenericProperty,
-    CssIdentifier, CssLanguage, CssMediaQueryList, CssSyntaxKind, ScssAtRootAtRule,
-    ScssAtRootSelector, ScssEachHeader, ScssEachValueList, ScssExpression, ScssExpressionItemList,
-    ScssIfAtRule, ScssListExpression, ScssListExpressionElement, ScssMapExpression,
-    ScssMapExpressionPair, ScssVariableDeclaration, T, TextLen, TextSize,
-    is_in_scss_include_arguments,
+    AnyCssDeclarationName, AnyCssMediaQuery, AnyCssProperty, AnyCssRoot, CssComplexSelector,
+    CssDeclaration, CssDeclarationImportant, CssDeclarationOrRuleBlock, CssFunction,
+    CssGenericComponentValueList, CssGenericProperty, CssIdentifier, CssLanguage,
+    CssMediaQueryList, CssSyntaxKind, ScssAtRootAtRule, ScssAtRootSelector, ScssEachHeader,
+    ScssEachValueList, ScssExpression, ScssExpressionItemList, ScssIfAtRule, ScssListExpression,
+    ScssListExpressionElement, ScssMapExpression, ScssMapExpressionPair, ScssVariableDeclaration,
+    T, TextLen, TextSize, is_in_scss_include_arguments,
 };
 use biome_diagnostics::category;
 use biome_formatter::comments::{
@@ -121,6 +121,7 @@ impl CommentStyle for CssCommentStyle {
             .or_else(handle_media_separator_comment)
             // Handle SCSS variable name/colon comments before generic properties.
             .or_else(handle_scss_variable_declaration_comment)
+            .or_else(handle_declaration_important_comment)
             .or_else(handle_generic_property_comment)
             .or_else(handle_declaration_name_comment)
             .or_else(handle_complex_selector_comment)
@@ -459,6 +460,35 @@ fn is_between_variable_colon_and_value(
     };
 
     comment_start >= colon.text_trimmed_range().end() && comment_start < value_start
+}
+
+/// Attaches block comments between a property and `!important` to the declaration.
+///
+/// ```css
+/// a { color: red /* c */ !important; }
+/// ```
+fn handle_declaration_important_comment(
+    comment: DecoratedComment<CssLanguage>,
+) -> CommentPlacement<CssLanguage> {
+    if comment.kind().is_line() {
+        return CommentPlacement::Default(comment);
+    }
+
+    let Some(declaration) = CssDeclaration::cast_ref(comment.enclosing_node()) else {
+        return CommentPlacement::Default(comment);
+    };
+
+    if comment
+        .preceding_node()
+        .is_some_and(|node| AnyCssProperty::can_cast(node.kind()))
+        && comment
+            .following_node()
+            .is_some_and(|node| CssDeclarationImportant::can_cast(node.kind()))
+    {
+        CommentPlacement::dangling(declaration.into_syntax(), comment)
+    } else {
+        CommentPlacement::Default(comment)
+    }
 }
 
 fn handle_generic_property_comment(

--- a/crates/biome_css_formatter/src/css/auxiliary/declaration.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/declaration.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use biome_css_syntax::{CssDeclaration, CssDeclarationFields};
+use biome_formatter::trivia::format_dangling_comments;
 use biome_formatter::write;
 
 #[derive(Debug, Clone, Default)]
@@ -13,10 +14,33 @@ impl FormatNodeRule<CssDeclaration> for FormatCssDeclaration {
 
         write!(f, [property.format()])?;
 
-        if important.is_some() {
+        if let Some(important) = important {
+            if f.comments().has_dangling_comments(node.syntax()) {
+                write!(
+                    f,
+                    [
+                        space(),
+                        format_dangling_comments(node.syntax()).with_block_comments_on_line()
+                    ]
+                )?;
+            }
+
             write!(f, [space(), important.format()])?;
         }
 
         Ok(())
+    }
+
+    fn fmt_dangling_comments(
+        &self,
+        node: &CssDeclaration,
+        f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        if node.important().is_some() {
+            // `fmt_fields` prints value/important comments at their syntax boundary.
+            Ok(())
+        } else {
+            write!(f, [format_dangling_comments(node.syntax())])
+        }
     }
 }

--- a/crates/biome_css_formatter/tests/specs/css/comments/important-value-comments.css
+++ b/crates/biome_css_formatter/tests/specs/css/comments/important-value-comments.css
@@ -1,0 +1,5 @@
+a{color:/* before */red/* after */!important;}
+a{color:red/* first *//* second */!important;}
+a{color:red
+/* own */
+!important;}

--- a/crates/biome_css_formatter/tests/specs/css/comments/important-value-comments.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/comments/important-value-comments.css.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/comments/important-value-comments.css
+---
+
+# Input
+
+```css
+a{color:/* before */red/* after */!important;}
+a{color:red/* first *//* second */!important;}
+a{color:red
+/* own */
+!important;}
+
+```
+
+
+# Formatted
+
+```css
+a {
+	color:/* before */ red /* after */ !important;
+}
+a {
+	color: red /* first */ /* second */ !important;
+}
+a {
+	color: red /* own */ !important;
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
@@ -87,7 +87,7 @@ body
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,58 +1,57 @@
+@@ -1,8 +1,7 @@
  a {
    /* comment 1 */
 -  /* comment 2 */
@@ -97,11 +97,8 @@ body
 +    10px /* comment 6 */; /* comment 7 */
    /* comment 8 */
    transform: translate(/* comment 9 */ 10px /* comment 10 */);
--  color: /* comment 11 */ red /* comment 12 */ !important /* comment 13 */ ; /* comment 14 */
-+  color: /* comment 11 */ /* comment 12 */ red !important /* comment 13 */ ; /* comment 14 */
-   /* comment 15 */
- }
- 
+   color: /* comment 11 */ red /* comment 12 */ !important /* comment 13 */ ; /* comment 14 */
+@@ -12,47 +11,47 @@
  @font-face {
    font-family: "Prettier";
    src: /* comment 16 */
@@ -190,7 +187,7 @@ a {
     10px /* comment 6 */; /* comment 7 */
   /* comment 8 */
   transform: translate(/* comment 9 */ 10px /* comment 10 */);
-  color: /* comment 11 */ /* comment 12 */ red !important /* comment 13 */ ; /* comment 14 */
+  color: /* comment 11 */ red /* comment 12 */ !important /* comment 13 */ ; /* comment 14 */
   /* comment 15 */
 }
 
@@ -276,7 +273,7 @@ body {
 
 # Lines exceeding max width of 80 characters
 ```
-    7:   color: /* comment 11 */ /* comment 12 */ red !important /* comment 13 */ ; /* comment 14 */
+    7:   color: /* comment 11 */ red /* comment 12 */ !important /* comment 13 */ ; /* comment 14 */
    15:     /* comment 20 */ url("http://prettier.com/font.woff") /* comment 21 */; /* comment 22 */
    19:   /* comment 23 */ color/* comment 24 */:/* comment 25 */ blue /* comment 26 */; /* comment 27 */
    25:   /* comment 34 */ color/* comment 35 */ : /* comment 36 */ blue /* comment 37 */; /* comment 38 */

--- a/crates/biome_css_formatter/tests/specs/scss/comments/important-value-comments.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/comments/important-value-comments.scss
@@ -1,0 +1,5 @@
+a{color:/* before */red/* after */!important;}
+a{color:red/* first *//* second */!important;}
+a{color:red
+/* own */
+!important;}

--- a/crates/biome_css_formatter/tests/specs/scss/comments/important-value-comments.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/comments/important-value-comments.scss.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/comments/important-value-comments.scss
+---
+
+# Input
+
+```scss
+a{color:/* before */red/* after */!important;}
+a{color:red/* first *//* second */!important;}
+a{color:red
+/* own */
+!important;}
+
+```
+
+
+# Formatted
+
+```scss
+a {
+	color:/* before */ red /* after */ !important;
+}
+a {
+	color: red /* first */ /* second */ !important;
+}
+a {
+	color: red /* own */ !important;
+}
+
+```


### PR DESCRIPTION
> This PR was created with AI assistance.

## Summary

Fixes CSS/SCSS formatter comment placement between declaration values and `!important`, matching Prettier.

```diff
-a { color: /* before */ /* after */ red !important; }
+a { color: /* before */ red /* after */ !important; }
```

## Test Plan

- cargo test -p biome_css_formatter
