### PR TITLE
fix(inference): suppress incomplete type results

### DIFF
--- a/.changeset/angry-jars-switch.md
+++ b/.changeset/angry-jars-switch.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [`useExhaustiveSwitchCases`](https://biomejs.dev/linter/rules/use-exhaustive-switch-cases/) for unions of bigint literals. The rule now reports missing bigint cases. For example, this switch now reports the missing `2n` case:
+
+```ts
+declare const value: 1n | 2n;
+switch (value) {
+	case 1n:
+		break;
+}
+```

--- a/.changeset/angry-jars-switch.md
+++ b/.changeset/angry-jars-switch.md
@@ -2,7 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [`useExhaustiveSwitchCases`](https://biomejs.dev/linter/rules/use-exhaustive-switch-cases/) for unions of bigint literals. The rule now reports missing bigint cases. For example, this switch now reports the missing `2n` case:
+Fixed [`useExhaustiveSwitchCases`](https://biomejs.dev/linter/rules/use-exhaustive-switch-cases/) for unions of bigint literals. The rule now reports missing bigint cases and compares bigint literals by value, including binary, octal, hexadecimal, and separator-containing spellings. For example, this switch now reports the missing `2n` case:
 
 ```ts
 declare const value: 1n | 2n;

--- a/.changeset/chubby-icons-brush.md
+++ b/.changeset/chubby-icons-brush.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed false positives in [`noBaseToString`](https://biomejs.dev/linter/rules/no-base-to-string/) and [`useNullishCoalescing`](https://biomejs.dev/linter/rules/use-nullish-coalescing/) when member, stringification, or nullish inference cannot complete. These rules now suppress diagnostics instead of reporting from partial type information. For example, neither expression is reported when a recursive type cannot be fully resolved:
+
+```ts
+type Recursive = Recursive;
+declare const value: Recursive;
+
+String(value);
+value || "fallback";
+```

--- a/.changeset/wild-beds-attack.md
+++ b/.changeset/wild-beds-attack.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed false positives in [`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/) and [`useAwaitThenable`](https://biomejs.dev/linter/rules/use-await-thenable/) when Promise or thenable inference cannot complete. These rules now suppress diagnostics instead of treating incomplete type information as a definite result. For example, `useAwaitThenable` no longer reports `await value` when the value's thenability is unknown:
+
+```ts
+declare const value: unknown;
+
+async function consume() {
+	await value;
+}
+```

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -231,8 +231,7 @@ fn find_misused_promise_expression(
 
     // Uncomment the following line for debugging convenience:
     //let printed = format!("type of {expression:?} = {ty:?}");
-    let should_signal = ty.is_promise_instance() || ty.has_promise_variant();
-    should_signal.then_some(state)
+    (ty.is_promise_instance() == Some(true)).then_some(state)
 }
 
 fn find_misused_promise_returning_callback(
@@ -240,7 +239,7 @@ fn find_misused_promise_returning_callback(
     expression: &AnyJsExpression,
     ty: InferredType,
 ) -> Option<NoMisusedPromisesState> {
-    if !ty.function_returns_promise() {
+    if ty.function_returns_promise() != Some(true) {
         return None;
     }
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_await_thenable.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_await_thenable.rs
@@ -11,12 +11,7 @@ use crate::services::typed::Typed;
 declare_lint_rule! {
     /// Enforce that `await` is _only_ used on `Promise` values.
     ///
-    /// :::caution
-    /// At the moment, this rule only checks for instances of the global
-    /// `Promise` class. This is a major shortcoming compared to the ESLint
-    /// rule if you are using custom `Promise`-like implementations such as
-    /// [Bluebird](http://bluebirdjs.com/) or in-house solutions.
-    /// :::
+    /// Values with a callable `then` member are treated as thenable.
     ///
     /// ## Examples
     ///
@@ -64,10 +59,12 @@ impl Rule for UseAwaitThenable {
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");
 
-        let is_maybe_promise = ty.is_promise_instance()
-            || ty.has_promise_variant()
-            || ctx.inferred_expression_has_callable_member(&expression, "then");
-        (ty.is_inferred() && !is_maybe_promise).then_some(())
+        match ty.is_promise_instance() {
+            Some(true) | None => return None,
+            Some(false) => {}
+        }
+
+        (!ctx.inferred_expression_has_callable_member(&expression, "then")?).then_some(())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
@@ -132,7 +132,7 @@ impl Rule for UseExhaustiveSwitchCases {
                 continue;
             };
             let ty = ctx.inferred_type_of_expression(&test)?;
-            let variants = ty.try_switch_case_variants()?;
+            let variants = ty.try_switch_case_variants().ok()?;
             if let [variant] = variants.as_slice()
                 && *variant != InferredSwitchCase::UnsupportedLiteral
             {
@@ -158,7 +158,8 @@ impl Rule for UseExhaustiveSwitchCases {
 
         let variants = ctx
             .inferred_type_of_expression(&discriminant)?
-            .try_switch_case_variants()?;
+            .try_switch_case_variants()
+            .ok()?;
 
         for variant in variants {
             if variant == InferredSwitchCase::Boolean {

--- a/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
@@ -123,22 +123,22 @@ impl Rule for UseExhaustiveSwitchCases {
             return None;
         }
 
-        let found_cases = cases
-            .iter()
-            .filter_map(|case| match case {
-                AnyJsSwitchClause::JsCaseClause(case) => {
-                    let test = case.test().ok()?;
-                    let variants = ctx
-                        .inferred_type_of_expression(&test)?
-                        .switch_case_variants();
-                    match variants.as_slice() {
-                        [variant] => Some(variant.clone()),
-                        _ => None,
-                    }
-                }
-                _ => None,
-            })
-            .collect::<Vec<_>>();
+        let mut found_cases = Vec::new();
+        for case in cases.iter() {
+            let AnyJsSwitchClause::JsCaseClause(case) = case else {
+                continue;
+            };
+            let Ok(test) = case.test() else {
+                continue;
+            };
+            let ty = ctx.inferred_type_of_expression(&test)?;
+            let variants = ty.try_switch_case_variants()?;
+            if let [variant] = variants.as_slice()
+                && *variant != InferredSwitchCase::UnsupportedLiteral
+            {
+                found_cases.push(variant.clone());
+            }
+        }
 
         let mut missing_cases = Vec::new();
 
@@ -158,7 +158,7 @@ impl Rule for UseExhaustiveSwitchCases {
 
         let variants = ctx
             .inferred_type_of_expression(&discriminant)?
-            .switch_case_variants();
+            .try_switch_case_variants()?;
 
         for variant in variants {
             if variant == InferredSwitchCase::Boolean {
@@ -297,6 +297,7 @@ impl Display for MissingCase {
             InferredSwitchCase::BooleanLiteral(value) => {
                 formatter.write_str(if *value { "true" } else { "false" })
             }
+            InferredSwitchCase::BigInt(bigint) => formatter.write_str(bigint.text()),
             InferredSwitchCase::Number(number) => formatter.write_str(number.text()),
             InferredSwitchCase::String(string) => {
                 formatter.write_fmt(format_args!("\"{}\"", string.text()))
@@ -326,6 +327,7 @@ fn missing_case_to_expression(case: &MissingCase) -> Option<AnyJsExpression> {
                 make::js_number_literal_expression(make::js_number_literal(number.text())).into(),
             ),
         ),
+        MissingCase(InferredSwitchCase::BigInt(_)) => None,
         MissingCase(InferredSwitchCase::String(string)) => Some(
             AnyJsExpression::AnyJsLiteralExpression(
                 make::js_string_literal_expression(make::js_string_literal(string.text())).into(),

--- a/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
@@ -474,16 +474,16 @@ fn run_logical_or(
     let left = logical.left().ok()?;
     let left_ty = ctx.inferred_type_of_expression(&left)?;
 
-    if !left_ty.has_nullish_variant() {
+    if !left_ty.has_nullish_variant()? {
         return None;
     }
 
-    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, left_ty) {
+    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, left_ty)? {
         return None;
     }
 
-    let can_fix =
-        left_ty.is_safe_for_nullish_coalescing() && is_safe_syntax_context_for_replacement(logical);
+    let can_fix = left_ty.is_safe_for_nullish_coalescing()?
+        && is_safe_syntax_context_for_replacement(logical);
 
     Some(UseNullishCoalescingState::LogicalOr {
         operator_range: logical.operator_token().ok()?.text_trimmed_range(),
@@ -524,15 +524,15 @@ fn run_logical_or_assignment(
         _ => return None,
     };
 
-    if !left_ty.has_nullish_variant() {
+    if !left_ty.has_nullish_variant()? {
         return None;
     }
 
-    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, left_ty) {
+    if options.has_any_ignore_primitives() && should_ignore_for_primitives(options, left_ty)? {
         return None;
     }
 
-    let can_fix = left_ty.is_safe_for_nullish_coalescing();
+    let can_fix = left_ty.is_safe_for_nullish_coalescing()?;
 
     Some(UseNullishCoalescingState::LogicalOrAssignment {
         operator_range: assignment.operator_token().ok()?.text_trimmed_range(),
@@ -547,7 +547,7 @@ fn run_logical_or_assignment(
 fn should_ignore_for_primitives(
     options: &UseNullishCoalescingOptions,
     ty: InferredType,
-) -> bool {
+) -> Option<bool> {
     ty.nullish_union_matches_ignored_primitives(IgnoredPrimitiveTypes {
         string: options.should_ignore_primitive_string(),
         number: options.should_ignore_primitive_number(),
@@ -756,11 +756,11 @@ fn run_ternary(
         check_ternary_nullish_pattern(&test, &consequent, &alternate)?;
 
     let options = ctx.options();
-    if options.has_any_ignore_primitives() {
-        let checked_ty = ctx.inferred_type_of_expression(&checked_expr)?;
-        if should_ignore_for_primitives(options, checked_ty) {
-            return None;
-        }
+    if options.has_any_ignore_primitives()
+        && let Some(ty) = ctx.inferred_type_of_expression(&checked_expr)
+        && should_ignore_for_primitives(options, ty)?
+    {
+        return None;
     }
 
     // The fix is unsafe when the checked expression contains calls or `new`, because
@@ -776,8 +776,8 @@ fn run_ternary(
             NullishCheckKind::StrictSingle(lit) => {
                 let ty = ctx.inferred_type_of_expression(&checked_expr)?;
                 match lit {
-                    NullishLiteral::Null => !ty.has_undefined_variant(),
-                    NullishLiteral::Undefined => !ty.has_null_variant(),
+                    NullishLiteral::Null => !ty.has_undefined_variant()?,
+                    NullishLiteral::Undefined => !ty.has_null_variant()?,
                 }
             }
         };

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -230,32 +230,32 @@ impl TypedService {
             .map(|data| data.ty)
     }
 
-    /// Returns whether an expression has a callable member with the given name.
+    /// Determines whether an expression has a callable member with the given name.
+    ///
+    /// Returns `None` when type inference is unavailable or the member's
+    /// callability cannot be determined conclusively.
     pub fn inferred_expression_has_callable_member(
         &self,
         expression: &AnyJsExpression,
         name: &str,
-    ) -> bool {
-        let Some(typed_module) = self.module.as_ref() else {
-            return false;
-        };
+    ) -> Option<bool> {
+        let typed_module = self.module.as_ref()?;
         let db = typed_module.db.as_ref();
-        let Some(inferred) = infer_module_types_bottom_up(db, typed_module.module) else {
-            return false;
-        };
-        let Some(ty) = inferred.expressions.get(&expression.range()).copied() else {
-            return false;
-        };
+        let inferred = infer_module_types_bottom_up(db, typed_module.module)?;
+        let ty = inferred.expressions.get(&expression.range()).copied()?;
         let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
-        let Some(member_ty) = inferred.find_member_type(db, ty, name) else {
-            return false;
+        if !InferredType::new(db, ty).is_inferred() {
+            return None;
+        }
+        let Some(member_ty) = inferred.find_value_member_type(db, ty, name) else {
+            return Some(false);
         };
         let member_ty = normalize_type(
             db,
             NormalizeTypeInput::new(db, typed_module.module, member_ty),
         );
 
-        is_callable_inferred_type(db, member_ty)
+        InferredType::new(db, member_ty).is_callable()
     }
 
     /// Returns the expected type for a call or constructor argument.
@@ -437,16 +437,6 @@ impl TypedService {
         self.model
             .as_ref()
             .is_some_and(|model| model.binding(reference).is_some())
-    }
-}
-
-fn is_callable_inferred_type(db: &dyn ModuleDb, ty: InferredTypeData) -> bool {
-    match ty {
-        InferredTypeData::Union(union) => union
-            .types(db)
-            .iter()
-            .any(|ty| is_callable_inferred_type(db, *ty)),
-        ty => ty.callable_function(db).is_some(),
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/indeterminateValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/indeterminateValid.ts
@@ -1,0 +1,5 @@
+// should not generate diagnostics
+type Recursive = Recursive;
+declare const value: Recursive;
+
+String(value);

--- a/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/indeterminateValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noBaseToString/indeterminateValid.ts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: indeterminateValid.ts
+---
+# Input
+```ts
+// should not generate diagnostics
+type Recursive = Recursive;
+declare const value: Recursive;
+
+String(value);
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/promiseIndeterminateValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/promiseIndeterminateValid.ts
@@ -1,0 +1,17 @@
+/* should not generate diagnostics */
+
+declare const unknownValue: unknown;
+declare const anyValue: any;
+declare const poisoned: boolean | unknown;
+
+interface Cycle extends Cycle {}
+declare const cycle: Cycle;
+
+if (unknownValue) {}
+if (anyValue) {}
+if (poisoned) {}
+if (cycle) {}
+
+declare function acceptsCallback(callback: () => void): void;
+declare const unknownCallback: () => unknown;
+acceptsCallback(unknownCallback);

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/promiseIndeterminateValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/promiseIndeterminateValid.ts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: promiseIndeterminateValid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+declare const unknownValue: unknown;
+declare const anyValue: any;
+declare const poisoned: boolean | unknown;
+
+interface Cycle extends Cycle {}
+declare const cycle: Cycle;
+
+if (unknownValue) {}
+if (anyValue) {}
+if (poisoned) {}
+if (cycle) {}
+
+declare function acceptsCallback(callback: () => void): void;
+declare const unknownCallback: () => unknown;
+acceptsCallback(unknownCallback);
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/promiseIndeterminateValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/promiseIndeterminateValid.ts
@@ -1,0 +1,19 @@
+/* should not generate diagnostics */
+
+declare const unknownValue: unknown;
+declare const anyValue: any;
+declare const poisoned: number | unknown;
+
+interface Cycle extends Cycle {}
+declare const cycle: Cycle;
+
+async function consume(): Promise<void> {
+	await unknownValue;
+	await anyValue;
+	await poisoned;
+	await cycle;
+}
+
+async function consumeGeneric<T>(value: T): Promise<void> {
+	await value;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/promiseIndeterminateValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/promiseIndeterminateValid.ts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: promiseIndeterminateValid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+declare const unknownValue: unknown;
+declare const anyValue: any;
+declare const poisoned: number | unknown;
+
+interface Cycle extends Cycle {}
+declare const cycle: Cycle;
+
+async function consume(): Promise<void> {
+	await unknownValue;
+	await anyValue;
+	await poisoned;
+	await cycle;
+}
+
+async function consumeGeneric<T>(value: T): Promise<void> {
+	await value;
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableInvalid.ts
@@ -2,7 +2,15 @@
 
 // A non-callable `then` member does not make a thenable, so `await` is still reported.
 interface NotThenable { then: number; }
+class PromiseLike<T> {}
+class InstanceThen { then() {} }
+class Other {}
 declare const value: unknown;
+declare const promiseLike: PromiseLike<void>;
+declare const constructors: typeof InstanceThen | typeof Other;
 async function awaitNonCallableThen(): Promise<void> {
     await (value as NotThenable);
+    await Promise;
+    await promiseLike;
+    await constructors;
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableInvalid.ts.snap
@@ -8,25 +8,96 @@ expression: thenableInvalid.ts
 
 // A non-callable `then` member does not make a thenable, so `await` is still reported.
 interface NotThenable { then: number; }
+class PromiseLike<T> {}
+class InstanceThen { then() {} }
+class Other {}
 declare const value: unknown;
+declare const promiseLike: PromiseLike<void>;
+declare const constructors: typeof InstanceThen | typeof Other;
 async function awaitNonCallableThen(): Promise<void> {
     await (value as NotThenable);
+    await Promise;
+    await promiseLike;
+    await constructors;
 }
 
 ```
 
 # Diagnostics
 ```
-thenableInvalid.ts:7:5 lint/nursery/useAwaitThenable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+thenableInvalid.ts:12:5 lint/nursery/useAwaitThenable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i `await` used on a non-Promise value.
   
-    5 │ declare const value: unknown;
-    6 │ async function awaitNonCallableThen(): Promise<void> {
-  > 7 │     await (value as NotThenable);
-      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    8 │ }
-    9 │ 
+    10 │ declare const constructors: typeof InstanceThen | typeof Other;
+    11 │ async function awaitNonCallableThen(): Promise<void> {
+  > 12 │     await (value as NotThenable);
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │     await Promise;
+    14 │     await promiseLike;
+  
+  i This may happen if you accidentally used `await` on a synchronous value.
+  
+  i Please ensure the value is not a custom "thenable" implementation before removing the `await`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+thenableInvalid.ts:13:5 lint/nursery/useAwaitThenable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i `await` used on a non-Promise value.
+  
+    11 │ async function awaitNonCallableThen(): Promise<void> {
+    12 │     await (value as NotThenable);
+  > 13 │     await Promise;
+       │     ^^^^^^^^^^^^^
+    14 │     await promiseLike;
+    15 │     await constructors;
+  
+  i This may happen if you accidentally used `await` on a synchronous value.
+  
+  i Please ensure the value is not a custom "thenable" implementation before removing the `await`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+thenableInvalid.ts:14:5 lint/nursery/useAwaitThenable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i `await` used on a non-Promise value.
+  
+    12 │     await (value as NotThenable);
+    13 │     await Promise;
+  > 14 │     await promiseLike;
+       │     ^^^^^^^^^^^^^^^^^
+    15 │     await constructors;
+    16 │ }
+  
+  i This may happen if you accidentally used `await` on a synchronous value.
+  
+  i Please ensure the value is not a custom "thenable" implementation before removing the `await`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+thenableInvalid.ts:15:5 lint/nursery/useAwaitThenable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i `await` used on a non-Promise value.
+  
+    13 │     await Promise;
+    14 │     await promiseLike;
+  > 15 │     await constructors;
+       │     ^^^^^^^^^^^^^^^^^^
+    16 │ }
+    17 │ 
   
   i This may happen if you accidentally used `await` on a synchronous value.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableValid.ts
@@ -1,15 +1,31 @@
 /* should not generate diagnostics */
 
 interface Thenable<T> { then(onfulfilled: (value: T) => void): void; }
+interface UnknownThen { then: unknown; }
+interface CallableThen { (value: number): void; }
+interface InterfaceThen { then: CallableThen; }
+type Recursive = Recursive;
+interface RecursiveThen { then: Recursive; }
 declare const thenable: Thenable<number>;
 declare const value: unknown;
+declare const unknownThen: UnknownThen;
+declare const interfaceThen: InterfaceThen;
+declare const recursiveThen: RecursiveThen;
 
 // Awaiting a value typed as a custom thenable (a callable `then`) is valid.
 async function awaitDeclaredThenable(): Promise<void> {
     await thenable;
+    await interfaceThen;
 }
 
 // Awaiting a value cast to a custom thenable is valid.
 async function awaitCastThenable(): Promise<void> {
     await (value as Thenable<number>);
+}
+
+// Unknown containers and explicitly unknown members are indeterminate.
+async function awaitUnknownValues(): Promise<void> {
+    await value;
+    await unknownThen;
+    await recursiveThen;
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useAwaitThenable/thenableValid.ts.snap
@@ -7,17 +7,33 @@ expression: thenableValid.ts
 /* should not generate diagnostics */
 
 interface Thenable<T> { then(onfulfilled: (value: T) => void): void; }
+interface UnknownThen { then: unknown; }
+interface CallableThen { (value: number): void; }
+interface InterfaceThen { then: CallableThen; }
+type Recursive = Recursive;
+interface RecursiveThen { then: Recursive; }
 declare const thenable: Thenable<number>;
 declare const value: unknown;
+declare const unknownThen: UnknownThen;
+declare const interfaceThen: InterfaceThen;
+declare const recursiveThen: RecursiveThen;
 
 // Awaiting a value typed as a custom thenable (a callable `then`) is valid.
 async function awaitDeclaredThenable(): Promise<void> {
     await thenable;
+    await interfaceThen;
 }
 
 // Awaiting a value cast to a custom thenable is valid.
 async function awaitCastThenable(): Promise<void> {
     await (value as Thenable<number>);
+}
+
+// Unknown containers and explicitly unknown members are indeterminate.
+async function awaitUnknownValues(): Promise<void> {
+    await value;
+    await unknownThen;
+    await recursiveThen;
 }
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalid.ts
@@ -120,3 +120,8 @@ function exhaustiveSwitchOnAsConstStringDiscriminant(): void {
 	switch (wrappedSwitch.kind) {
 	}
 }
+declare const bigintUnion: 1n | 2n;
+switch (bigintUnion) {
+	case 1n:
+		break;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalid.ts.snap
@@ -126,6 +126,11 @@ function exhaustiveSwitchOnAsConstStringDiscriminant(): void {
 	switch (wrappedSwitch.kind) {
 	}
 }
+declare const bigintUnion: 1n | 2n;
+switch (bigintUnion) {
+	case 1n:
+		break;
+}
 
 ```
 
@@ -709,7 +714,7 @@ invalid.ts:120:2 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━
   > 121 │ 	}
         │ 	^
     122 │ }
-    123 │ 
+    123 │ declare const bigintUnion: 1n | 2n;
   
   i Some variants of the union type are not handled here.
   
@@ -723,5 +728,31 @@ invalid.ts:120:2 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━
   
     120 │ → switch·(wrappedSwitch.kind)·{case·"wrapped":·throw·new·Error("TODO:·Not·implemented·yet");
         │                                +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+```
+
+```
+invalid.ts:124:1 lint/nursery/useExhaustiveSwitchCases ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The switch statement is not exhaustive.
+  
+    122 │ }
+    123 │ declare const bigintUnion: 1n | 2n;
+  > 124 │ switch (bigintUnion) {
+        │ ^^^^^^^^^^^^^^^^^^^^^^
+  > 125 │ 	case 1n:
+  > 126 │ 		break;
+  > 127 │ }
+        │ ^
+    128 │ 
+  
+  i Some variants of the union type are not handled here.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i These cases are missing:
+  
+  - 2n
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/valid.ts
@@ -174,3 +174,31 @@ switch (true) {
 	case x % 5 === 0:
 		break;
 }
+declare const exhaustiveBigintUnion: 1n | 2n;
+switch (exhaustiveBigintUnion) {
+	case 1n:
+		break;
+	case 2n:
+		break;
+}
+
+declare const alternateBigintSpelling: 1n;
+switch (alternateBigintSpelling) {
+	case 0x1n:
+		break;
+}
+
+switch (alternateBigintSpelling) {
+	case 0X1n:
+		break;
+}
+
+switch (alternateBigintSpelling) {
+	case 0O1n:
+		break;
+}
+
+switch (alternateBigintSpelling) {
+	case 0B1n:
+		break;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/valid.ts.snap
@@ -180,5 +180,33 @@ switch (true) {
 	case x % 5 === 0:
 		break;
 }
+declare const exhaustiveBigintUnion: 1n | 2n;
+switch (exhaustiveBigintUnion) {
+	case 1n:
+		break;
+	case 2n:
+		break;
+}
+
+declare const alternateBigintSpelling: 1n;
+switch (alternateBigintSpelling) {
+	case 0x1n:
+		break;
+}
+
+switch (alternateBigintSpelling) {
+	case 0X1n:
+		break;
+}
+
+switch (alternateBigintSpelling) {
+	case 0O1n:
+		break;
+}
+
+switch (alternateBigintSpelling) {
+	case 0B1n:
+		break;
+}
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/indeterminateValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/indeterminateValid.ts
@@ -1,0 +1,5 @@
+// should not generate diagnostics
+type Recursive = Recursive;
+declare const value: Recursive;
+
+value || "fallback";

--- a/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/indeterminateValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNullishCoalescing/indeterminateValid.ts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: indeterminateValid.ts
+---
+# Input
+```ts
+// should not generate diagnostics
+type Recursive = Recursive;
+declare const value: Recursive;
+
+value || "fallback";
+
+```

--- a/crates/biome_js_syntax/src/numbers.rs
+++ b/crates/biome_js_syntax/src/numbers.rs
@@ -47,14 +47,37 @@ pub fn parse_js_number(num: &str) -> Option<f64> {
     }
 }
 
+const BIGINT_LIMB_BASE: u64 = 1_000_000_000;
+
+fn bigint_digit_value(byte: u8) -> Option<u32> {
+    match byte {
+        b'0'..=b'9' => Some(u32::from(byte - b'0')),
+        b'a'..=b'f' => Some(u32::from(byte - b'a') + 10),
+        b'A'..=b'F' => Some(u32::from(byte - b'A') + 10),
+        _ => None,
+    }
+}
+
+fn multiply_add_bigint_chunk(limbs: &mut Vec<u32>, multiplier: u64, mut carry: u64) {
+    for limb in &mut *limbs {
+        let value = u64::from(*limb) * multiplier + carry;
+        *limb = (value % BIGINT_LIMB_BASE) as u32;
+        carry = value / BIGINT_LIMB_BASE;
+    }
+    while carry != 0 {
+        limbs.push((carry % BIGINT_LIMB_BASE) as u32);
+        carry /= BIGINT_LIMB_BASE;
+    }
+}
+
 /// Converts a possibly signed JavaScript bigint literal to decimal notation.
 ///
 /// The returned text has no separators or leading zeroes and uses a lowercase
-/// `n` suffix. Negative zero is represented as `0n`. Returns `None` if `input`
-/// is not a valid decimal, binary, octal, or hexadecimal bigint literal.
+/// `n` suffix. Negative zero is represented as `0n`. The input is returned
+/// borrowed when it is already canonical; transformed values are owned.
+/// Returns `None` if `input` is not a valid decimal, binary, octal, or
+/// hexadecimal bigint literal.
 pub fn canonicalize_js_bigint_literal(input: &str) -> Option<Cow<'_, str>> {
-    const LIMB_BASE: u64 = 1_000_000_000;
-
     let (is_negative, unsigned) = match input.strip_prefix('-') {
         Some(unsigned) => (true, unsigned),
         None => (false, input),
@@ -71,10 +94,11 @@ pub fn canonicalize_js_bigint_literal(input: &str) -> Option<Cow<'_, str>> {
             (10, body)
         };
 
-    let mut limbs = vec![0_u32];
     let mut digit_count = 0;
     let mut first_digit = None;
     let mut previous_was_separator = false;
+    let mut has_separator = false;
+    let mut is_zero = true;
 
     for byte in digits.bytes() {
         if byte == b'_' {
@@ -82,15 +106,11 @@ pub fn canonicalize_js_bigint_literal(input: &str) -> Option<Cow<'_, str>> {
                 return None;
             }
             previous_was_separator = true;
+            has_separator = true;
             continue;
         }
 
-        let digit = match byte {
-            b'0'..=b'9' => u32::from(byte - b'0'),
-            b'a'..=b'f' => u32::from(byte - b'a') + 10,
-            b'A'..=b'F' => u32::from(byte - b'A') + 10,
-            _ => return None,
-        };
+        let digit = bigint_digit_value(byte)?;
         if digit >= radix {
             return None;
         }
@@ -98,16 +118,7 @@ pub fn canonicalize_js_bigint_literal(input: &str) -> Option<Cow<'_, str>> {
         first_digit.get_or_insert(digit);
         digit_count += 1;
         previous_was_separator = false;
-
-        let mut carry = u64::from(digit);
-        for limb in &mut limbs {
-            let value = u64::from(*limb) * u64::from(radix) + carry;
-            *limb = (value % LIMB_BASE) as u32;
-            carry = value / LIMB_BASE;
-        }
-        if carry != 0 {
-            limbs.push(carry as u32);
-        }
+        is_zero &= digit == 0;
     }
 
     if digit_count == 0 || previous_was_separator {
@@ -116,14 +127,54 @@ pub fn canonicalize_js_bigint_literal(input: &str) -> Option<Cow<'_, str>> {
     if radix == 10 && digit_count > 1 && first_digit == Some(0) {
         return None;
     }
-
-    let is_zero = limbs.len() == 1 && limbs[0] == 0;
-    if radix == 10 && !digits.contains('_') && (!is_negative || !is_zero) {
-        return Some(Cow::Borrowed(input));
+    if radix == 10 {
+        if !has_separator && (!is_negative || !is_zero) {
+            return Some(Cow::Borrowed(input));
+        }
+        let canonical = if is_zero {
+            String::from("0n")
+        } else {
+            input.replace('_', "")
+        };
+        return Some(Cow::Owned(canonical));
+    }
+    if is_zero {
+        return Some(Cow::Owned(String::from("0n")));
     }
 
-    let mut canonical = String::new();
-    if is_negative && !is_zero {
+    let digits_per_chunk = match radix {
+        2 => 32,
+        8 => 10,
+        16 => 8,
+        _ => return None,
+    };
+    let radix = u64::from(radix);
+    let mut limbs = vec![0_u32];
+    let mut chunk_value = 0_u64;
+    let mut chunk_multiplier = 1_u64;
+    let mut chunk_digit_count = 0;
+
+    for byte in digits.bytes() {
+        if byte == b'_' {
+            continue;
+        }
+        chunk_value = chunk_value * radix + u64::from(bigint_digit_value(byte)?);
+        chunk_multiplier *= radix;
+        chunk_digit_count += 1;
+
+        if chunk_digit_count == digits_per_chunk {
+            multiply_add_bigint_chunk(&mut limbs, chunk_multiplier, chunk_value);
+            chunk_value = 0;
+            chunk_multiplier = 1;
+            chunk_digit_count = 0;
+        }
+    }
+    if chunk_digit_count != 0 {
+        multiply_add_bigint_chunk(&mut limbs, chunk_multiplier, chunk_value);
+    }
+
+    let mut canonical = String::with_capacity(limbs.len() * 9 + 2);
+    if is_negative {
         canonical.push('-');
     }
     let mut limbs = limbs.iter().rev();
@@ -139,6 +190,8 @@ pub fn canonicalize_js_bigint_literal(input: &str) -> Option<Cow<'_, str>> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::{canonicalize_js_bigint_literal, split_into_radix_and_number};
     use biome_js_factory::JsSyntaxTreeBuilder;
     use biome_js_factory::syntax::{JsNumberLiteralExpression, JsSyntaxKind::*};
@@ -164,10 +217,14 @@ mod tests {
             ("-123_456_789n", "-123456789n"),
             ("0b1010_0101n", "165n"),
             ("-0B1010n", "-10n"),
+            ("-0b0000n", "0n"),
+            ("0b100000000000000000000000000000000n", "4294967296n"),
             ("0o777_777n", "262143n"),
             ("-0O10n", "-8n"),
+            ("0o10000000000n", "1073741824n"),
             ("0xdead_beefn", "3735928559n"),
             ("-0XFFn", "-255n"),
+            ("0x100000000n", "4294967296n"),
             (
                 "0xffffffffffffffffffffffffffffffffn",
                 "340282366920938463463374607431768211455n",
@@ -183,10 +240,27 @@ mod tests {
     }
 
     #[test]
+    fn canonical_bigint_literal_ownership() {
+        let input = String::from("123456789n");
+        assert!(matches!(
+            canonicalize_js_bigint_literal(&input),
+            Some(Cow::Borrowed(canonical)) if std::ptr::eq(canonical, input.as_str())
+        ));
+        assert!(matches!(
+            canonicalize_js_bigint_literal("123_456_789n"),
+            Some(Cow::Owned(canonical)) if canonical == "123456789n"
+        ));
+        assert!(matches!(
+            canonicalize_js_bigint_literal("-0n"),
+            Some(Cow::Owned(canonical)) if canonical == "0n"
+        ));
+    }
+
+    #[test]
     fn rejects_invalid_bigint_literals() {
         let cases = [
-            "", "n", "-n", "+1n", "1", "1N", "01n", "0_0n", "_1n", "1_n", "1__0n", "0bn", "0b2n",
-            "0o8n", "0xgn", "--1n",
+            "", "n", "-n", "+1n", "1", "1N", "01n", "0_0n", "_1n", "1_n", "1__0n", "0bn", "0b_1n",
+            "0b1_n", "0b1__0n", "0b2n", "0o8n", "0xgn", "--1n",
         ];
 
         for input in cases {

--- a/crates/biome_js_syntax/src/numbers.rs
+++ b/crates/biome_js_syntax/src/numbers.rs
@@ -1,4 +1,4 @@
-//! JS Number parsing.
+//! JavaScript numeric literal parsing.
 
 use std::{borrow::Cow, str::FromStr};
 
@@ -47,9 +47,99 @@ pub fn parse_js_number(num: &str) -> Option<f64> {
     }
 }
 
+/// Converts a possibly signed JavaScript bigint literal to decimal notation.
+///
+/// The returned text has no separators or leading zeroes and uses a lowercase
+/// `n` suffix. Negative zero is represented as `0n`. Returns `None` if `input`
+/// is not a valid decimal, binary, octal, or hexadecimal bigint literal.
+pub fn canonicalize_js_bigint_literal(input: &str) -> Option<Cow<'_, str>> {
+    const LIMB_BASE: u64 = 1_000_000_000;
+
+    let (is_negative, unsigned) = match input.strip_prefix('-') {
+        Some(unsigned) => (true, unsigned),
+        None => (false, input),
+    };
+    let body = unsigned.strip_suffix('n')?;
+    let (radix, digits) =
+        if let Some(digits) = body.strip_prefix("0b").or_else(|| body.strip_prefix("0B")) {
+            (2_u32, digits)
+        } else if let Some(digits) = body.strip_prefix("0o").or_else(|| body.strip_prefix("0O")) {
+            (8, digits)
+        } else if let Some(digits) = body.strip_prefix("0x").or_else(|| body.strip_prefix("0X")) {
+            (16, digits)
+        } else {
+            (10, body)
+        };
+
+    let mut limbs = vec![0_u32];
+    let mut digit_count = 0;
+    let mut first_digit = None;
+    let mut previous_was_separator = false;
+
+    for byte in digits.bytes() {
+        if byte == b'_' {
+            if digit_count == 0 || previous_was_separator {
+                return None;
+            }
+            previous_was_separator = true;
+            continue;
+        }
+
+        let digit = match byte {
+            b'0'..=b'9' => u32::from(byte - b'0'),
+            b'a'..=b'f' => u32::from(byte - b'a') + 10,
+            b'A'..=b'F' => u32::from(byte - b'A') + 10,
+            _ => return None,
+        };
+        if digit >= radix {
+            return None;
+        }
+
+        first_digit.get_or_insert(digit);
+        digit_count += 1;
+        previous_was_separator = false;
+
+        let mut carry = u64::from(digit);
+        for limb in &mut limbs {
+            let value = u64::from(*limb) * u64::from(radix) + carry;
+            *limb = (value % LIMB_BASE) as u32;
+            carry = value / LIMB_BASE;
+        }
+        if carry != 0 {
+            limbs.push(carry as u32);
+        }
+    }
+
+    if digit_count == 0 || previous_was_separator {
+        return None;
+    }
+    if radix == 10 && digit_count > 1 && first_digit == Some(0) {
+        return None;
+    }
+
+    let is_zero = limbs.len() == 1 && limbs[0] == 0;
+    if radix == 10 && !digits.contains('_') && (!is_negative || !is_zero) {
+        return Some(Cow::Borrowed(input));
+    }
+
+    let mut canonical = String::new();
+    if is_negative && !is_zero {
+        canonical.push('-');
+    }
+    let mut limbs = limbs.iter().rev();
+    canonical.push_str(&limbs.next()?.to_string());
+    for limb in limbs {
+        let limb = limb.to_string();
+        canonical.extend(std::iter::repeat_n('0', 9 - limb.len()));
+        canonical.push_str(&limb);
+    }
+    canonical.push('n');
+    Some(Cow::Owned(canonical))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::split_into_radix_and_number;
+    use super::{canonicalize_js_bigint_literal, split_into_radix_and_number};
     use biome_js_factory::JsSyntaxTreeBuilder;
     use biome_js_factory::syntax::{JsNumberLiteralExpression, JsSyntaxKind::*};
     use biome_rowan::AstNode;
@@ -63,6 +153,45 @@ mod tests {
         let node = tree_builder.finish();
         let number_literal = JsNumberLiteralExpression::cast(node).unwrap();
         assert_eq!(number_literal.as_number(), Some(value))
+    }
+
+    #[test]
+    fn canonicalizes_bigint_literals() {
+        let cases = [
+            ("0n", "0n"),
+            ("-0n", "0n"),
+            ("123456789n", "123456789n"),
+            ("-123_456_789n", "-123456789n"),
+            ("0b1010_0101n", "165n"),
+            ("-0B1010n", "-10n"),
+            ("0o777_777n", "262143n"),
+            ("-0O10n", "-8n"),
+            ("0xdead_beefn", "3735928559n"),
+            ("-0XFFn", "-255n"),
+            (
+                "0xffffffffffffffffffffffffffffffffn",
+                "340282366920938463463374607431768211455n",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                canonicalize_js_bigint_literal(input).as_deref(),
+                Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_bigint_literals() {
+        let cases = [
+            "", "n", "-n", "+1n", "1", "1N", "01n", "0_0n", "_1n", "1_n", "1__0n", "0bn", "0b2n",
+            "0o8n", "0xgn", "--1n",
+        ];
+
+        for input in cases {
+            assert_eq!(canonicalize_js_bigint_literal(input), None, "{input}");
+        }
     }
 
     #[test]

--- a/crates/biome_js_syntax/src/static_value.rs
+++ b/crates/biome_js_syntax/src/static_value.rs
@@ -1,5 +1,6 @@
 use biome_rowan::TextRange;
 
+use crate::numbers::canonicalize_js_bigint_literal;
 use crate::{JsSyntaxKind, JsSyntaxToken};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -33,7 +34,8 @@ impl StaticValue {
             Self::Boolean(token) => token.text_trimmed() == "false",
             Self::Null(_) | Self::Undefined(_) | Self::EmptyString(_) => true,
             Self::Number(token) => token.text_trimmed() == "0",
-            Self::BigInt(token) => token.text_trimmed() == "0n",
+            Self::BigInt(token) => canonicalize_js_bigint_literal(token.text_trimmed())
+                .is_some_and(|text| text == "0n"),
             Self::String(_) => self.text().is_empty(),
         }
     }

--- a/crates/biome_js_type_info/src/conditionals.rs
+++ b/crates/biome_js_type_info/src/conditionals.rs
@@ -1,3 +1,4 @@
+use biome_js_syntax::numbers::canonicalize_js_bigint_literal;
 use biome_rowan::Text;
 
 use crate::{
@@ -167,9 +168,10 @@ impl ConditionalType {
                 None
             }
             TypeData::Literal(literal) => Some(match literal.as_ref() {
-                Literal::BigInt(text) => match text.text() {
-                    "0n" | "-0n" => Self::FalsyButNotNullish,
-                    _ => Self::Truthy,
+                Literal::BigInt(text) => match canonicalize_js_bigint_literal(text.text()) {
+                    Some(text) if text == "0n" => Self::FalsyButNotNullish,
+                    Some(_) => Self::Truthy,
+                    None => Self::Anything,
                 },
                 Literal::Boolean(boolean) => match boolean.as_bool() {
                     true => Self::Truthy,

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -2,9 +2,11 @@ use crate::TypeDb;
 use crate::interned_types::{
     ConditionalType, Literal, ReturnType, TypeData, TypeMember, TypeMemberKind,
 };
+use crate::type_traversal::{DepthFirstVisitor, TraversalOutcome, VisitContext};
+use biome_js_syntax::numbers::canonicalize_js_bigint_literal;
 use biome_rowan::Text;
 use rustc_hash::FxHashSet;
-use std::collections::VecDeque;
+use std::{borrow::Cow, collections::VecDeque, ops::ControlFlow};
 
 const MAX_TYPE_VARIANT_STEPS: usize = 1024;
 const MAX_PROMISE_TYPE_STEPS: usize = 64;
@@ -87,10 +89,11 @@ impl<'db> InferredType<'db> {
     }
 
     pub fn is_bigint_literal(self, value: i64) -> bool {
+        let expected = format!("{value}n");
         matches!(
             self.data,
             TypeData::Literal(literal)
-                if matches!(literal.literal(self.db), Literal::BigInt(number) if number.text().trim_end_matches('n').parse() == Ok(value))
+                if matches!(literal.literal(self.db), Literal::BigInt(number) if canonicalize_js_bigint_literal(number.text()).as_deref() == Some(expected.as_str()))
         )
     }
 
@@ -256,106 +259,19 @@ impl<'db> InferredType<'db> {
     /// Returns `None` when traversal encounters an unresolved or recursive type,
     /// or exceeds the type-variant traversal limit.
     pub fn is_callable(self) -> Option<bool> {
-        enum Visit<'db> {
-            Enter(TypeData<'db>),
-            Exit(TypeData<'db>),
+        let mut visitor = CallableVisitor {
+            db: self.db,
+            indeterminate: false,
+        };
+        match visitor.visit(self.data, MAX_TYPE_VARIANT_STEPS) {
+            TraversalOutcome::Break(is_callable) => Some(is_callable),
+            TraversalOutcome::Complete { encountered_cycle }
+                if !encountered_cycle && !visitor.indeterminate =>
+            {
+                Some(false)
+            }
+            TraversalOutcome::Complete { .. } | TraversalOutcome::LimitExceeded => None,
         }
-
-        let mut active = FxHashSet::default();
-        let mut completed = FxHashSet::default();
-        let mut pending = vec![Visit::Enter(self.data)];
-        let mut remaining_steps = MAX_TYPE_VARIANT_STEPS;
-        let mut indeterminate = false;
-
-        while let Some(visit) = pending.pop() {
-            let data = match visit {
-                Visit::Exit(data) => {
-                    active.remove(&data);
-                    completed.insert(data);
-                    continue;
-                }
-                Visit::Enter(data) => data,
-            };
-            if completed.contains(&data) {
-                continue;
-            }
-            if !active.insert(data) {
-                indeterminate = true;
-                continue;
-            }
-            if remaining_steps == 0 {
-                return None;
-            }
-            remaining_steps -= 1;
-            pending.push(Visit::Exit(data));
-
-            let has_call_signature = match data {
-                TypeData::Interface(interface) => interface
-                    .members(self.db)
-                    .iter()
-                    .any(|member| member.kind.is_call_signature()),
-                TypeData::Object(object) => object
-                    .members(self.db)
-                    .iter()
-                    .any(|member| member.kind.is_call_signature()),
-                _ => false,
-            };
-            if data.callable_function(self.db).is_some() || has_call_signature {
-                return Some(true);
-            }
-
-            match data {
-                TypeData::Unknown
-                | TypeData::Divergent(_)
-                | TypeData::Local(_)
-                | TypeData::TypeofExpression(_)
-                | TypeData::AnyKeyword
-                | TypeData::UnknownKeyword => indeterminate = true,
-                TypeData::Generic(generic) => {
-                    if let Some(constraint) = generic.constraint(self.db) {
-                        pending.push(Visit::Enter(constraint));
-                    } else {
-                        indeterminate = true;
-                    }
-                }
-                TypeData::InstanceOf(instance) => {
-                    pending.push(Visit::Enter(instance.ty(self.db)));
-                }
-                TypeData::Interface(interface) => {
-                    pending.extend(interface.extends(self.db).iter().copied().map(Visit::Enter));
-                }
-                TypeData::Intersection(intersection) => {
-                    pending.extend(
-                        intersection
-                            .types(self.db)
-                            .iter()
-                            .copied()
-                            .map(Visit::Enter),
-                    );
-                }
-                TypeData::MergedReference(reference) => {
-                    pending.extend(reference.targets(self.db).map(Visit::Enter));
-                }
-                TypeData::Object(object) => {
-                    pending.extend(object.prototype(self.db).map(Visit::Enter));
-                }
-                TypeData::TypeOperator(operator) => {
-                    pending.push(Visit::Enter(operator.ty(self.db)));
-                }
-                TypeData::TypeofType(typeof_type) => {
-                    pending.push(Visit::Enter(typeof_type.ty(self.db)));
-                }
-                TypeData::TypeofValue(typeof_value) => {
-                    pending.push(Visit::Enter(typeof_value.ty(self.db)));
-                }
-                TypeData::Union(union) => {
-                    pending.extend(union.types(self.db).iter().copied().map(Visit::Enter));
-                }
-                _ => {}
-            }
-        }
-
-        if indeterminate { None } else { Some(false) }
     }
 
     pub fn is_at_least_as_wide_as_object(self) -> bool {
@@ -694,7 +610,13 @@ impl<'db> InferredType<'db> {
                         InferredSwitchCase::String(Text::new_owned(string.as_str().into()))
                     }
                     Literal::BigInt(bigint) => {
-                        InferredSwitchCase::BigInt(canonical_bigint_text(bigint))
+                        match canonicalize_js_bigint_literal(bigint.text()) {
+                            Some(Cow::Borrowed(_)) => InferredSwitchCase::BigInt(bigint.clone()),
+                            Some(Cow::Owned(bigint)) => {
+                                InferredSwitchCase::BigInt(Text::new_owned(bigint.into()))
+                            }
+                            None => InferredSwitchCase::UnsupportedLiteral,
+                        }
                     }
                     Literal::Object(_) | Literal::RegExp(_) | Literal::Template(_) => {
                         InferredSwitchCase::UnsupportedLiteral
@@ -785,85 +707,21 @@ impl<'db> InferredType<'db> {
         matches!(self.data, TypeData::Undefined)
     }
 
-    fn try_all_variants_match(
-        self,
-        mut predicate: impl FnMut(TypeData<'db>) -> bool,
-    ) -> Option<bool> {
-        enum Visit<'db> {
-            Enter(TypeData<'db>),
-            Exit(TypeData<'db>),
-        }
-
-        let mut saw_variant = false;
-        let mut indeterminate = false;
-        let mut active = FxHashSet::default();
-        let mut completed = FxHashSet::default();
-        let mut pending = vec![Visit::Enter(self.data)];
-        let mut remaining_steps = MAX_TYPE_VARIANT_STEPS;
-
-        while let Some(visit) = pending.pop() {
-            let data = match visit {
-                Visit::Exit(data) => {
-                    active.remove(&data);
-                    completed.insert(data);
-                    continue;
-                }
-                Visit::Enter(data) => data,
-            };
-            if completed.contains(&data) {
-                continue;
+    fn try_all_variants_match(self, predicate: impl FnMut(TypeData<'db>) -> bool) -> Option<bool> {
+        let mut visitor = AllVariantsVisitor {
+            db: self.db,
+            predicate,
+            saw_variant: false,
+            indeterminate: false,
+        };
+        match visitor.visit(self.data, MAX_TYPE_VARIANT_STEPS) {
+            TraversalOutcome::Break(result) => Some(result),
+            TraversalOutcome::Complete { encountered_cycle }
+                if !encountered_cycle && !visitor.indeterminate =>
+            {
+                Some(visitor.saw_variant)
             }
-            if !active.insert(data) {
-                indeterminate = true;
-                continue;
-            }
-            if remaining_steps == 0 {
-                return None;
-            }
-            remaining_steps -= 1;
-            pending.push(Visit::Exit(data));
-
-            match data {
-                TypeData::Union(union) => {
-                    if union.types(self.db).is_empty() {
-                        return Some(false);
-                    }
-                    pending.extend(union.types(self.db).iter().copied().map(Visit::Enter));
-                }
-                TypeData::Intersection(intersection) => {
-                    let primitive_types = intersection
-                        .types(self.db)
-                        .iter()
-                        .copied()
-                        .filter(|ty| ty.is_primitive(self.db))
-                        .collect::<Vec<_>>();
-                    if primitive_types.is_empty() {
-                        if predicate(data) {
-                            saw_variant = true;
-                        } else {
-                            return Some(false);
-                        }
-                    } else {
-                        pending.extend(primitive_types.into_iter().map(Visit::Enter));
-                    }
-                }
-                TypeData::Generic(generic) => {
-                    let Some(constraint) = generic.constraint(self.db) else {
-                        indeterminate = true;
-                        continue;
-                    };
-                    pending.push(Visit::Enter(constraint));
-                }
-                data if is_indeterminate_type(data) => indeterminate = true,
-                _ if predicate(data) => saw_variant = true,
-                _ => return Some(false),
-            }
-        }
-
-        if indeterminate {
-            None
-        } else {
-            Some(saw_variant)
+            TraversalOutcome::Complete { .. } | TraversalOutcome::LimitExceeded => None,
         }
     }
 
@@ -966,83 +824,21 @@ impl<'db> InferredType<'db> {
         true
     }
 
-    fn try_any_variant_matches(
-        self,
-        mut predicate: impl FnMut(TypeData<'db>) -> bool,
-    ) -> Option<bool> {
-        enum Visit<'db> {
-            Enter(TypeData<'db>),
-            Exit(TypeData<'db>),
+    fn try_any_variant_matches(self, predicate: impl FnMut(TypeData<'db>) -> bool) -> Option<bool> {
+        let mut visitor = AnyVariantVisitor {
+            db: self.db,
+            predicate,
+            indeterminate: false,
+        };
+        match visitor.visit(self.data, MAX_TYPE_VARIANT_STEPS) {
+            TraversalOutcome::Break(result) => Some(result),
+            TraversalOutcome::Complete { encountered_cycle }
+                if !encountered_cycle && !visitor.indeterminate =>
+            {
+                Some(false)
+            }
+            TraversalOutcome::Complete { .. } | TraversalOutcome::LimitExceeded => None,
         }
-
-        let mut indeterminate = false;
-        let mut active = FxHashSet::default();
-        let mut completed = FxHashSet::default();
-        let mut pending = vec![Visit::Enter(self.data)];
-        let mut remaining_steps = MAX_TYPE_VARIANT_STEPS;
-
-        while let Some(visit) = pending.pop() {
-            let data = match visit {
-                Visit::Exit(data) => {
-                    active.remove(&data);
-                    completed.insert(data);
-                    continue;
-                }
-                Visit::Enter(data) => data,
-            };
-            if completed.contains(&data) {
-                continue;
-            }
-            if !active.insert(data) {
-                indeterminate = true;
-                continue;
-            }
-            if remaining_steps == 0 {
-                return None;
-            }
-            remaining_steps -= 1;
-            pending.push(Visit::Exit(data));
-
-            match data {
-                TypeData::Intersection(intersection) => {
-                    if predicate(data) {
-                        return Some(true);
-                    }
-                    pending.extend(
-                        intersection
-                            .types(self.db)
-                            .iter()
-                            .copied()
-                            .filter(|ty| ty.is_primitive(self.db))
-                            .map(Visit::Enter),
-                    );
-                }
-                TypeData::Generic(generic) => {
-                    if let Some(constraint) = generic.constraint(self.db) {
-                        pending.push(Visit::Enter(constraint));
-                    } else {
-                        indeterminate = true;
-                    }
-                }
-                TypeData::InstanceOf(instance) => {
-                    pending.push(Visit::Enter(instance.ty(self.db)));
-                }
-                TypeData::TypeofType(typeof_type) => {
-                    pending.push(Visit::Enter(typeof_type.ty(self.db)));
-                }
-                TypeData::TypeofValue(typeof_value) => {
-                    pending.push(Visit::Enter(typeof_value.ty(self.db)));
-                }
-                TypeData::Union(union) => {
-                    pending.extend(union.types(self.db).iter().copied().map(Visit::Enter));
-                }
-                data if is_indeterminate_type(data) => indeterminate = true,
-                data if predicate(data) => return Some(true),
-                _ => {}
-            }
-        }
-
-        if indeterminate { None } else { Some(false) }
     }
 
     fn function_return_matches(self, predicate: impl Fn(TypeData<'db>) -> bool) -> bool {
@@ -1122,6 +918,193 @@ impl<'db> InferredType<'db> {
         }
 
         false
+    }
+}
+
+/// Checks whether a type or any of its nested types is callable.
+///
+/// `indeterminate` records whether the visitor encountered a type it could not
+/// resolve. In that case, not finding a callable type cannot be reported as
+/// `false`. The visitor stops as soon as it finds a callable type.
+struct CallableVisitor<'db> {
+    db: &'db dyn TypeDb,
+    indeterminate: bool,
+}
+
+impl<'db> DepthFirstVisitor<TypeData<'db>> for CallableVisitor<'db> {
+    type Break = bool;
+
+    fn enter(
+        &mut self,
+        data: TypeData<'db>,
+        context: &mut VisitContext<'_, TypeData<'db>>,
+    ) -> ControlFlow<Self::Break> {
+        let has_call_signature = match data {
+            TypeData::Interface(interface) => interface
+                .members(self.db)
+                .iter()
+                .any(|member| member.kind.is_call_signature()),
+            TypeData::Object(object) => object
+                .members(self.db)
+                .iter()
+                .any(|member| member.kind.is_call_signature()),
+            _ => false,
+        };
+        if data.callable_function(self.db).is_some() || has_call_signature {
+            return ControlFlow::Break(true);
+        }
+
+        match data {
+            TypeData::Unknown
+            | TypeData::Divergent(_)
+            | TypeData::Local(_)
+            | TypeData::TypeofExpression(_)
+            | TypeData::AnyKeyword
+            | TypeData::UnknownKeyword => self.indeterminate = true,
+            TypeData::Generic(generic) => {
+                if let Some(constraint) = generic.constraint(self.db) {
+                    context.push(constraint);
+                } else {
+                    self.indeterminate = true;
+                }
+            }
+            TypeData::InstanceOf(instance) => context.push(instance.ty(self.db)),
+            TypeData::Interface(interface) => {
+                context.extend(interface.extends(self.db).iter().copied());
+            }
+            TypeData::Intersection(intersection) => {
+                context.extend(intersection.types(self.db).iter().copied());
+            }
+            TypeData::MergedReference(reference) => {
+                context.extend(reference.targets(self.db));
+            }
+            TypeData::Object(object) => context.extend(object.prototype(self.db)),
+            TypeData::TypeOperator(operator) => context.push(operator.ty(self.db)),
+            TypeData::TypeofType(typeof_type) => context.push(typeof_type.ty(self.db)),
+            TypeData::TypeofValue(typeof_value) => context.push(typeof_value.ty(self.db)),
+            TypeData::Union(union) => context.extend(union.types(self.db).iter().copied()),
+            _ => {}
+        }
+
+        ControlFlow::Continue(())
+    }
+}
+
+/// Checks whether every nested type satisfies a predicate.
+///
+/// `saw_variant` records whether the visitor found a type it could check.
+/// `indeterminate` records whether it encountered a type it could not resolve.
+/// The visitor stops as soon as a type does not satisfy the predicate.
+struct AllVariantsVisitor<'db, P> {
+    db: &'db dyn TypeDb,
+    predicate: P,
+    saw_variant: bool,
+    indeterminate: bool,
+}
+
+impl<'db, P> DepthFirstVisitor<TypeData<'db>> for AllVariantsVisitor<'db, P>
+where
+    P: FnMut(TypeData<'db>) -> bool,
+{
+    type Break = bool;
+
+    fn enter(
+        &mut self,
+        data: TypeData<'db>,
+        context: &mut VisitContext<'_, TypeData<'db>>,
+    ) -> ControlFlow<Self::Break> {
+        match data {
+            TypeData::Union(union) => {
+                if union.types(self.db).is_empty() {
+                    return ControlFlow::Break(false);
+                }
+                context.extend(union.types(self.db).iter().copied());
+            }
+            TypeData::Intersection(intersection) => {
+                let primitive_types = intersection
+                    .types(self.db)
+                    .iter()
+                    .copied()
+                    .filter(|ty| ty.is_primitive(self.db))
+                    .collect::<Vec<_>>();
+                if primitive_types.is_empty() {
+                    if (self.predicate)(data) {
+                        self.saw_variant = true;
+                    } else {
+                        return ControlFlow::Break(false);
+                    }
+                } else {
+                    context.extend(primitive_types);
+                }
+            }
+            TypeData::Generic(generic) => {
+                let Some(constraint) = generic.constraint(self.db) else {
+                    self.indeterminate = true;
+                    return ControlFlow::Continue(());
+                };
+                context.push(constraint);
+            }
+            data if is_indeterminate_type(data) => self.indeterminate = true,
+            _ if (self.predicate)(data) => self.saw_variant = true,
+            _ => return ControlFlow::Break(false),
+        }
+
+        ControlFlow::Continue(())
+    }
+}
+
+/// Checks whether any nested type satisfies a predicate.
+///
+/// `indeterminate` records whether the visitor encountered a type it could not
+/// resolve. In that case, not finding a match cannot be reported as `false`.
+/// The visitor stops as soon as a type satisfies the predicate.
+struct AnyVariantVisitor<'db, P> {
+    db: &'db dyn TypeDb,
+    predicate: P,
+    indeterminate: bool,
+}
+
+impl<'db, P> DepthFirstVisitor<TypeData<'db>> for AnyVariantVisitor<'db, P>
+where
+    P: FnMut(TypeData<'db>) -> bool,
+{
+    type Break = bool;
+
+    fn enter(
+        &mut self,
+        data: TypeData<'db>,
+        context: &mut VisitContext<'_, TypeData<'db>>,
+    ) -> ControlFlow<Self::Break> {
+        match data {
+            TypeData::Intersection(intersection) => {
+                if (self.predicate)(data) {
+                    return ControlFlow::Break(true);
+                }
+                context.extend(
+                    intersection
+                        .types(self.db)
+                        .iter()
+                        .copied()
+                        .filter(|ty| ty.is_primitive(self.db)),
+                );
+            }
+            TypeData::Generic(generic) => {
+                if let Some(constraint) = generic.constraint(self.db) {
+                    context.push(constraint);
+                } else {
+                    self.indeterminate = true;
+                }
+            }
+            TypeData::InstanceOf(instance) => context.push(instance.ty(self.db)),
+            TypeData::TypeofType(typeof_type) => context.push(typeof_type.ty(self.db)),
+            TypeData::TypeofValue(typeof_value) => context.push(typeof_value.ty(self.db)),
+            TypeData::Union(union) => context.extend(union.types(self.db).iter().copied()),
+            data if is_indeterminate_type(data) => self.indeterminate = true,
+            data if (self.predicate)(data) => return ControlFlow::Break(true),
+            _ => {}
+        }
+
+        ControlFlow::Continue(())
     }
 }
 
@@ -1710,66 +1693,6 @@ fn types_match<'db>(
         }
     }
     false
-}
-
-fn canonical_bigint_text(text: &Text) -> Text {
-    let raw = text.text().strip_suffix('n').unwrap_or(text.text());
-    let cleaned = raw.replace('_', "");
-    let (negative, unsigned) = cleaned
-        .strip_prefix('-')
-        .map_or((false, cleaned.as_str()), |value| (true, value));
-    let (radix, digits) = if let Some(value) = unsigned
-        .strip_prefix("0x")
-        .or_else(|| unsigned.strip_prefix("0X"))
-    {
-        (16, value)
-    } else if let Some(value) = unsigned
-        .strip_prefix("0o")
-        .or_else(|| unsigned.strip_prefix("0O"))
-    {
-        (8, value)
-    } else if let Some(value) = unsigned
-        .strip_prefix("0b")
-        .or_else(|| unsigned.strip_prefix("0B"))
-    {
-        (2, value)
-    } else {
-        (10, unsigned)
-    };
-
-    let mut decimal = vec![0_u8];
-    for digit in digits.chars() {
-        let Some(digit) = digit.to_digit(radix) else {
-            return text.clone();
-        };
-        let mut carry = digit;
-        for decimal_digit in &mut decimal {
-            let value = u32::from(*decimal_digit) * radix + carry;
-            *decimal_digit = (value % 10) as u8;
-            carry = value / 10;
-        }
-        while carry != 0 {
-            decimal.push((carry % 10) as u8);
-            carry /= 10;
-        }
-    }
-    while decimal.len() > 1 && decimal.last() == Some(&0) {
-        decimal.pop();
-    }
-
-    let is_zero = decimal == [0];
-    let mut result = String::with_capacity(decimal.len() + 2);
-    if negative && !is_zero {
-        result.push('-');
-    }
-    result.extend(
-        decimal
-            .into_iter()
-            .rev()
-            .map(|digit| char::from(b'0' + digit)),
-    );
-    result.push('n');
-    Text::new_owned(result.into())
 }
 
 fn is_at_least_as_wide_as_object<'db>(
@@ -2506,7 +2429,7 @@ fn type_description<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::interned_types::InternedUnion;
+    use crate::interned_types::{InternedLiteral, InternedUnion};
 
     #[salsa::db]
     #[derive(Default)]
@@ -2529,6 +2452,40 @@ mod tests {
 
     #[salsa::db]
     impl TypeDb for TestDb {}
+
+    fn bigint<'db>(db: &'db TestDb, text: &'static str) -> InferredType<'db> {
+        InferredType::new(
+            db,
+            TypeData::Literal(InternedLiteral::new(
+                db,
+                Literal::BigInt(Text::new_static(text)),
+            )),
+        )
+    }
+
+    #[test]
+    fn bigint_semantics_use_canonical_values() {
+        let db = TestDb::default();
+
+        for text in ["0n", "-0n", "0b0n", "0o0n", "0x0n"] {
+            let bigint = bigint(&db, text);
+            assert!(bigint.is_bigint_literal(0), "{text}");
+            assert!(bigint.is_always_falsy(), "{text}");
+            assert_eq!(
+                bigint.try_switch_case_variants(),
+                Some(vec![InferredSwitchCase::BigInt(Text::new_static("0n"))]),
+                "{text}"
+            );
+        }
+
+        let hexadecimal = bigint(&db, "0x10n");
+        assert!(hexadecimal.is_bigint_literal(16));
+        assert!(hexadecimal.is_always_truthy());
+        assert_eq!(
+            hexadecimal.try_switch_case_variants(),
+            Some(vec![InferredSwitchCase::BigInt(Text::new_static("16n"))])
+        );
+    }
 
     #[test]
     fn incomplete_predicates_are_indeterminate() {

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -4,13 +4,16 @@ use crate::interned_types::{
 };
 use biome_rowan::Text;
 use rustc_hash::FxHashSet;
+use std::collections::VecDeque;
 
 const MAX_TYPE_VARIANT_STEPS: usize = 1024;
+const MAX_PROMISE_TYPE_STEPS: usize = 64;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum InferredSwitchCase {
     Boolean,
     BooleanLiteral(bool),
+    BigInt(Text),
     Number(Text),
     String(Text),
     Null,
@@ -101,7 +104,7 @@ impl<'db> InferredType<'db> {
     }
 
     pub fn is_all_string_like(self) -> bool {
-        self.all_variants_match(|data| {
+        self.try_all_variants_match(|data| {
             matches!(data, TypeData::String)
                 || matches!(
                     data,
@@ -109,10 +112,11 @@ impl<'db> InferredType<'db> {
                         if matches!(literal.literal(self.db), Literal::String(_))
                 )
         })
+        .unwrap_or(false)
     }
 
     pub fn is_all_number_like(self) -> bool {
-        self.all_variants_match(|data| {
+        self.try_all_variants_match(|data| {
             matches!(data, TypeData::Number)
                 || matches!(
                     data,
@@ -120,10 +124,11 @@ impl<'db> InferredType<'db> {
                         if matches!(literal.literal(self.db), Literal::Number(_))
                 )
         })
+        .unwrap_or(false)
     }
 
     pub fn is_all_boolean_like(self) -> bool {
-        self.all_variants_match(|data| {
+        self.try_all_variants_match(|data| {
             matches!(data, TypeData::Boolean)
                 || matches!(
                     data,
@@ -131,10 +136,11 @@ impl<'db> InferredType<'db> {
                         if matches!(literal.literal(self.db), Literal::Boolean(_))
                 )
         })
+        .unwrap_or(false)
     }
 
     pub fn is_all_bigint_like(self) -> bool {
-        self.all_variants_match(|data| {
+        self.try_all_variants_match(|data| {
             matches!(data, TypeData::BigInt)
                 || matches!(
                     data,
@@ -142,10 +148,11 @@ impl<'db> InferredType<'db> {
                         if matches!(literal.literal(self.db), Literal::BigInt(_))
                 )
         })
+        .unwrap_or(false)
     }
 
     pub fn is_all_integer_like(self) -> bool {
-        self.all_variants_match(|data| match data {
+        self.try_all_variants_match(|data| match data {
             TypeData::BigInt => true,
             TypeData::Literal(literal) => match literal.literal(self.db) {
                 Literal::BigInt(_) => true,
@@ -156,10 +163,11 @@ impl<'db> InferredType<'db> {
             },
             _ => false,
         })
+        .unwrap_or(false)
     }
 
     pub fn is_all_string_array_or_tuple(self) -> bool {
-        self.all_variants_match(|data| {
+        self.try_all_variants_match(|data| {
             matches!(data, TypeData::String | TypeData::Tuple(_))
                 || matches!(
                     data,
@@ -172,6 +180,7 @@ impl<'db> InferredType<'db> {
                         if instance.ty(self.db).is_array_class(self.db)
                 )
         })
+        .unwrap_or(false)
     }
 
     pub fn is_regexp_literal_without_global_flag(self) -> bool {
@@ -196,16 +205,28 @@ impl<'db> InferredType<'db> {
         matches!(self.data, TypeData::InstanceOf(instance) if instance.ty(self.db).is_array_class(self.db))
     }
 
-    pub fn is_array_of_promise(self) -> bool {
+    /// Returns `Some(true)` for arrays whose element type resolves to a
+    /// `Promise` or `PromiseLike` instance, and `Some(false)` for conclusive
+    /// non-matches.
+    ///
+    /// Returns `None` when the element type is absent, unresolved, recursive,
+    /// or exceeds the promise traversal limit.
+    pub fn is_array_of_promise(self) -> Option<bool> {
         let TypeData::InstanceOf(instance) = self.data else {
-            return false;
+            return if is_indeterminate_type(self.data) {
+                None
+            } else {
+                Some(false)
+            };
         };
 
-        instance.ty(self.db).is_array_class(self.db)
-            && instance
-                .type_parameters(self.db)
-                .first()
-                .is_some_and(|ty| is_promise_instance(self.db, *ty))
+        if !instance.ty(self.db).is_array_class(self.db) {
+            return Some(false);
+        }
+        instance
+            .type_parameters(self.db)
+            .first()
+            .and_then(|ty| is_promise_instance(self.db, *ty))
     }
 
     pub fn is_disposable(self) -> bool {
@@ -216,12 +237,125 @@ impl<'db> InferredType<'db> {
         self.has_computed_member("Symbol.asyncDispose")
     }
 
-    pub fn is_promise_instance(self) -> bool {
+    /// Returns `Some(true)` when this type resolves through an instance to
+    /// `Promise` or `PromiseLike`, and `Some(false)` for conclusive non-matches.
+    ///
+    /// Returns `None` when traversal encounters an unresolved or recursive type,
+    /// or exceeds the promise traversal limit.
+    pub fn is_promise_instance(self) -> Option<bool> {
         is_promise_instance(self.db, self.data)
     }
 
     pub fn is_function(self) -> bool {
         self.data.callable_function(self.db).is_some()
+    }
+
+    /// Returns `Some(true)` when this type or any of its variants is callable,
+    /// and `Some(false)` for conclusive non-callable types.
+    ///
+    /// Returns `None` when traversal encounters an unresolved or recursive type,
+    /// or exceeds the type-variant traversal limit.
+    pub fn is_callable(self) -> Option<bool> {
+        enum Visit<'db> {
+            Enter(TypeData<'db>),
+            Exit(TypeData<'db>),
+        }
+
+        let mut active = FxHashSet::default();
+        let mut completed = FxHashSet::default();
+        let mut pending = vec![Visit::Enter(self.data)];
+        let mut remaining_steps = MAX_TYPE_VARIANT_STEPS;
+        let mut indeterminate = false;
+
+        while let Some(visit) = pending.pop() {
+            let data = match visit {
+                Visit::Exit(data) => {
+                    active.remove(&data);
+                    completed.insert(data);
+                    continue;
+                }
+                Visit::Enter(data) => data,
+            };
+            if completed.contains(&data) {
+                continue;
+            }
+            if !active.insert(data) {
+                indeterminate = true;
+                continue;
+            }
+            if remaining_steps == 0 {
+                return None;
+            }
+            remaining_steps -= 1;
+            pending.push(Visit::Exit(data));
+
+            let has_call_signature = match data {
+                TypeData::Interface(interface) => interface
+                    .members(self.db)
+                    .iter()
+                    .any(|member| member.kind.is_call_signature()),
+                TypeData::Object(object) => object
+                    .members(self.db)
+                    .iter()
+                    .any(|member| member.kind.is_call_signature()),
+                _ => false,
+            };
+            if data.callable_function(self.db).is_some() || has_call_signature {
+                return Some(true);
+            }
+
+            match data {
+                TypeData::Unknown
+                | TypeData::Divergent(_)
+                | TypeData::Local(_)
+                | TypeData::TypeofExpression(_)
+                | TypeData::AnyKeyword
+                | TypeData::UnknownKeyword => indeterminate = true,
+                TypeData::Generic(generic) => {
+                    if let Some(constraint) = generic.constraint(self.db) {
+                        pending.push(Visit::Enter(constraint));
+                    } else {
+                        indeterminate = true;
+                    }
+                }
+                TypeData::InstanceOf(instance) => {
+                    pending.push(Visit::Enter(instance.ty(self.db)));
+                }
+                TypeData::Interface(interface) => {
+                    pending.extend(interface.extends(self.db).iter().copied().map(Visit::Enter));
+                }
+                TypeData::Intersection(intersection) => {
+                    pending.extend(
+                        intersection
+                            .types(self.db)
+                            .iter()
+                            .copied()
+                            .map(Visit::Enter),
+                    );
+                }
+                TypeData::MergedReference(reference) => {
+                    pending.extend(reference.targets(self.db).map(Visit::Enter));
+                }
+                TypeData::Object(object) => {
+                    pending.extend(object.prototype(self.db).map(Visit::Enter));
+                }
+                TypeData::TypeOperator(operator) => {
+                    pending.push(Visit::Enter(operator.ty(self.db)));
+                }
+                TypeData::TypeofType(typeof_type) => {
+                    pending.push(Visit::Enter(typeof_type.ty(self.db)));
+                }
+                TypeData::TypeofValue(typeof_value) => {
+                    pending.push(Visit::Enter(typeof_value.ty(self.db)));
+                }
+                TypeData::Union(union) => {
+                    pending.extend(union.types(self.db).iter().copied().map(Visit::Enter));
+                }
+                _ => {}
+            }
+        }
+
+        if indeterminate { None } else { Some(false) }
     }
 
     pub fn is_at_least_as_wide_as_object(self) -> bool {
@@ -336,14 +470,23 @@ impl<'db> InferredType<'db> {
         Some(MisleadingReturnType { suggestion })
     }
 
-    pub fn function_returns_promise(self) -> bool {
+    /// Returns `Some(true)` when this callable returns a `Promise` or
+    /// `PromiseLike` instance, and `Some(false)` for conclusive non-matches.
+    ///
+    /// Returns `None` when the callable or its return type is unresolved,
+    /// recursive, or exceeds the promise traversal limit.
+    pub fn function_returns_promise(self) -> Option<bool> {
         let Some(function) = self.data.callable_function(self.db) else {
-            return false;
+            return if is_indeterminate_type(self.data) {
+                None
+            } else {
+                Some(false)
+            };
         };
         let ReturnType::Type(return_ty) = function.return_type(self.db) else {
-            return false;
+            return Some(false);
         };
-        contains_promise(self.db, *return_ty)
+        is_promise_instance(self.db, *return_ty)
     }
 
     pub fn function_returns_conditional(self) -> bool {
@@ -354,13 +497,15 @@ impl<'db> InferredType<'db> {
         self.function_return_matches(|ty| matches!(ty, TypeData::VoidKeyword))
     }
 
-    pub fn has_promise_variant(self) -> bool {
+    /// Returns `Some(true)` when a union contains a `Promise` or `PromiseLike`
+    /// instance, and `Some(false)` for non-unions or conclusive non-matches.
+    ///
+    /// Returns `None` when union traversal encounters an unresolved or recursive
+    /// type, or exceeds the promise traversal limit.
+    pub fn has_promise_variant(self) -> Option<bool> {
         match self.data {
-            TypeData::Union(union) => union
-                .types(self.db)
-                .iter()
-                .any(|ty| is_promise_instance(self.db, *ty)),
-            _ => false,
+            TypeData::Union(_) => is_promise_instance(self.db, self.data),
+            _ => Some(false),
         }
     }
 
@@ -394,8 +539,13 @@ impl<'db> InferredType<'db> {
         self.conditional_type().is_nullish()
     }
 
-    pub fn has_nullish_variant(self) -> bool {
-        self.any_variant_matches(|data| {
+    /// Returns `Some(true)` when any variant is `null`, `undefined`, or `void`,
+    /// and `Some(false)` when every variant is conclusively non-nullish.
+    ///
+    /// Returns `None` when no match is found and variant traversal encounters an
+    /// unresolved or recursive type, or exceeds the variant traversal limit.
+    pub fn has_nullish_variant(self) -> Option<bool> {
+        self.try_any_variant_matches(|data| {
             matches!(
                 data,
                 TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword
@@ -403,8 +553,13 @@ impl<'db> InferredType<'db> {
         })
     }
 
-    pub fn is_safe_for_nullish_coalescing(self) -> bool {
-        self.all_variants_match(|data| {
+    /// Returns whether every variant can be replaced safely in a nullish
+    /// coalescing expression.
+    ///
+    /// Returns `None` when variant traversal cannot establish a result because
+    /// it encounters an unresolved or recursive type, or exceeds its limit.
+    pub fn is_safe_for_nullish_coalescing(self) -> Option<bool> {
+        self.try_all_variants_match(|data| {
             if matches!(data, TypeData::InstanceOf(_)) {
                 return true;
             }
@@ -415,12 +570,20 @@ impl<'db> InferredType<'db> {
         })
     }
 
-    pub fn nullish_union_matches_ignored_primitives(self, ignored: IgnoredPrimitiveTypes) -> bool {
+    /// Returns whether every variant of a nullish union is nullish or an ignored
+    /// primitive. Non-union types return `Some(false)`.
+    ///
+    /// Returns `None` when variant traversal cannot establish a result because
+    /// it encounters an unresolved or recursive type, or exceeds its limit.
+    pub fn nullish_union_matches_ignored_primitives(
+        self,
+        ignored: IgnoredPrimitiveTypes,
+    ) -> Option<bool> {
         let TypeData::Union(_) = self.data else {
-            return false;
+            return Some(false);
         };
 
-        self.all_variants_match(|data| match data {
+        self.try_all_variants_match(|data| match data {
             TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword => true,
             TypeData::String => ignored.string,
             TypeData::Number => ignored.number,
@@ -437,16 +600,28 @@ impl<'db> InferredType<'db> {
         })
     }
 
-    pub fn has_null_variant(self) -> bool {
-        self.any_variant_matches(|data| matches!(data, TypeData::Null))
+    /// Returns `Some(true)` when any variant is `null`, and `Some(false)` when
+    /// every variant is conclusively non-null.
+    ///
+    /// Returns `None` when no match is found and variant traversal encounters an
+    /// unresolved or recursive type, or exceeds its limit.
+    pub fn has_null_variant(self) -> Option<bool> {
+        self.try_any_variant_matches(|data| matches!(data, TypeData::Null))
     }
 
-    pub fn has_undefined_variant(self) -> bool {
-        self.any_variant_matches(|data| matches!(data, TypeData::Undefined | TypeData::VoidKeyword))
+    /// Returns `Some(true)` when any variant is `undefined` or `void`, and
+    /// `Some(false)` when every variant conclusively excludes both.
+    ///
+    /// Returns `None` when no match is found and variant traversal encounters an
+    /// unresolved or recursive type, or exceeds its limit.
+    pub fn has_undefined_variant(self) -> Option<bool> {
+        self.try_any_variant_matches(|data| {
+            matches!(data, TypeData::Undefined | TypeData::VoidKeyword)
+        })
     }
 
     pub fn has_invalid_plus_operand_variant(self) -> bool {
-        self.any_variant_matches(|data| match data {
+        self.try_any_variant_matches(|data| match data {
             TypeData::NeverKeyword | TypeData::Symbol | TypeData::UnknownKeyword => true,
             TypeData::Literal(literal) => {
                 matches!(literal.literal(self.db), Literal::Object(_))
@@ -457,10 +632,11 @@ impl<'db> InferredType<'db> {
                 .all(|ty| is_object_like(self.db, *ty)),
             data => is_object_like(self.db, data),
         })
+        .unwrap_or(false)
     }
 
     pub fn has_number_like_variant(self) -> bool {
-        self.any_variant_matches(|data| {
+        self.try_any_variant_matches(|data| {
             matches!(data, TypeData::Number)
                 || matches!(
                     data,
@@ -468,10 +644,11 @@ impl<'db> InferredType<'db> {
                         if matches!(literal.literal(self.db), Literal::Number(_))
                 )
         })
+        .unwrap_or(false)
     }
 
     pub fn has_bigint_like_variant(self) -> bool {
-        self.any_variant_matches(|data| {
+        self.try_any_variant_matches(|data| {
             matches!(data, TypeData::BigInt)
                 || matches!(
                     data,
@@ -479,24 +656,32 @@ impl<'db> InferredType<'db> {
                         if matches!(literal.literal(self.db), Literal::BigInt(_))
                 )
         })
+        .unwrap_or(false)
     }
 
     pub fn plus_operand_description(self) -> String {
         type_description(self.db, self.data)
     }
 
-    pub fn switch_case_variants(self) -> Vec<InferredSwitchCase> {
+    /// Returns the deduplicated switch-case variants represented by this type.
+    ///
+    /// Returns `None` when traversal exceeds the type-variant limit. Literals
+    /// that cannot form supported cases are represented by
+    /// [`InferredSwitchCase::UnsupportedLiteral`].
+    pub fn try_switch_case_variants(self) -> Option<Vec<InferredSwitchCase>> {
         let mut cases = Vec::new();
         let mut seen = FxHashSet::default();
         let mut pending = vec![self.data];
+        let mut remaining_steps = MAX_TYPE_VARIANT_STEPS;
 
-        for _ in 0..MAX_TYPE_VARIANT_STEPS {
-            let Some(data) = pending.pop() else {
-                break;
-            };
+        while let Some(data) = pending.pop() {
             if !seen.insert(data) {
                 continue;
             }
+            if remaining_steps == 0 {
+                return None;
+            }
+            remaining_steps -= 1;
 
             match data {
                 TypeData::Boolean => cases.push(InferredSwitchCase::Boolean),
@@ -508,10 +693,12 @@ impl<'db> InferredType<'db> {
                     Literal::String(string) => {
                         InferredSwitchCase::String(Text::new_owned(string.as_str().into()))
                     }
-                    Literal::BigInt(_)
-                    | Literal::Object(_)
-                    | Literal::RegExp(_)
-                    | Literal::Template(_) => InferredSwitchCase::UnsupportedLiteral,
+                    Literal::BigInt(bigint) => {
+                        InferredSwitchCase::BigInt(canonical_bigint_text(bigint))
+                    }
+                    Literal::Object(_) | Literal::RegExp(_) | Literal::Template(_) => {
+                        InferredSwitchCase::UnsupportedLiteral
+                    }
                 }),
                 TypeData::Null => cases.push(InferredSwitchCase::Null),
                 TypeData::Undefined => cases.push(InferredSwitchCase::Undefined),
@@ -534,8 +721,9 @@ impl<'db> InferredType<'db> {
             }
         }
 
-        cases.dedup();
-        cases
+        let mut unique_cases = FxHashSet::default();
+        cases.retain(|case| unique_cases.insert(case.clone()));
+        Some(cases)
     }
 
     pub fn stringification_usefulness(
@@ -597,38 +785,86 @@ impl<'db> InferredType<'db> {
         matches!(self.data, TypeData::Undefined)
     }
 
-    fn all_variants_match(self, mut predicate: impl FnMut(TypeData<'db>) -> bool) -> bool {
-        let mut saw_variant = false;
-        let mut seen = FxHashSet::default();
-        let mut pending = vec![self.data];
+    fn try_all_variants_match(
+        self,
+        mut predicate: impl FnMut(TypeData<'db>) -> bool,
+    ) -> Option<bool> {
+        enum Visit<'db> {
+            Enter(TypeData<'db>),
+            Exit(TypeData<'db>),
+        }
 
-        for _ in 0..MAX_TYPE_VARIANT_STEPS {
-            let Some(data) = pending.pop() else {
-                return saw_variant;
+        let mut saw_variant = false;
+        let mut indeterminate = false;
+        let mut active = FxHashSet::default();
+        let mut completed = FxHashSet::default();
+        let mut pending = vec![Visit::Enter(self.data)];
+        let mut remaining_steps = MAX_TYPE_VARIANT_STEPS;
+
+        while let Some(visit) = pending.pop() {
+            let data = match visit {
+                Visit::Exit(data) => {
+                    active.remove(&data);
+                    completed.insert(data);
+                    continue;
+                }
+                Visit::Enter(data) => data,
             };
-            if !seen.insert(data) {
+            if completed.contains(&data) {
                 continue;
             }
+            if !active.insert(data) {
+                indeterminate = true;
+                continue;
+            }
+            if remaining_steps == 0 {
+                return None;
+            }
+            remaining_steps -= 1;
+            pending.push(Visit::Exit(data));
 
             match data {
                 TypeData::Union(union) => {
                     if union.types(self.db).is_empty() {
-                        return false;
+                        return Some(false);
                     }
-                    pending.extend(union.types(self.db).iter().copied());
+                    pending.extend(union.types(self.db).iter().copied().map(Visit::Enter));
+                }
+                TypeData::Intersection(intersection) => {
+                    let primitive_types = intersection
+                        .types(self.db)
+                        .iter()
+                        .copied()
+                        .filter(|ty| ty.is_primitive(self.db))
+                        .collect::<Vec<_>>();
+                    if primitive_types.is_empty() {
+                        if predicate(data) {
+                            saw_variant = true;
+                        } else {
+                            return Some(false);
+                        }
+                    } else {
+                        pending.extend(primitive_types.into_iter().map(Visit::Enter));
+                    }
                 }
                 TypeData::Generic(generic) => {
                     let Some(constraint) = generic.constraint(self.db) else {
-                        return false;
+                        indeterminate = true;
+                        continue;
                     };
-                    pending.push(constraint);
+                    pending.push(Visit::Enter(constraint));
                 }
+                data if is_indeterminate_type(data) => indeterminate = true,
                 _ if predicate(data) => saw_variant = true,
-                _ => return false,
+                _ => return Some(false),
             }
         }
 
-        false
+        if indeterminate {
+            None
+        } else {
+            Some(saw_variant)
+        }
     }
 
     fn conditional_type(self) -> ConditionalType {
@@ -730,36 +966,83 @@ impl<'db> InferredType<'db> {
         true
     }
 
-    fn any_variant_matches(self, mut predicate: impl FnMut(TypeData<'db>) -> bool) -> bool {
-        let mut seen = FxHashSet::default();
-        let mut pending = vec![self.data];
+    fn try_any_variant_matches(
+        self,
+        mut predicate: impl FnMut(TypeData<'db>) -> bool,
+    ) -> Option<bool> {
+        enum Visit<'db> {
+            Enter(TypeData<'db>),
+            Exit(TypeData<'db>),
+        }
 
-        for _ in 0..MAX_TYPE_VARIANT_STEPS {
-            let Some(data) = pending.pop() else {
-                return false;
+        let mut indeterminate = false;
+        let mut active = FxHashSet::default();
+        let mut completed = FxHashSet::default();
+        let mut pending = vec![Visit::Enter(self.data)];
+        let mut remaining_steps = MAX_TYPE_VARIANT_STEPS;
+
+        while let Some(visit) = pending.pop() {
+            let data = match visit {
+                Visit::Exit(data) => {
+                    active.remove(&data);
+                    completed.insert(data);
+                    continue;
+                }
+                Visit::Enter(data) => data,
             };
-            if !seen.insert(data) {
+            if completed.contains(&data) {
                 continue;
             }
+            if !active.insert(data) {
+                indeterminate = true;
+                continue;
+            }
+            if remaining_steps == 0 {
+                return None;
+            }
+            remaining_steps -= 1;
+            pending.push(Visit::Exit(data));
 
             match data {
+                TypeData::Intersection(intersection) => {
+                    if predicate(data) {
+                        return Some(true);
+                    }
+                    pending.extend(
+                        intersection
+                            .types(self.db)
+                            .iter()
+                            .copied()
+                            .filter(|ty| ty.is_primitive(self.db))
+                            .map(Visit::Enter),
+                    );
+                }
                 TypeData::Generic(generic) => {
                     if let Some(constraint) = generic.constraint(self.db) {
-                        pending.push(constraint);
+                        pending.push(Visit::Enter(constraint));
+                    } else {
+                        indeterminate = true;
                     }
                 }
-                TypeData::InstanceOf(instance) => pending.push(instance.ty(self.db)),
-                TypeData::TypeofType(typeof_type) => pending.push(typeof_type.ty(self.db)),
-                TypeData::TypeofValue(typeof_value) => pending.push(typeof_value.ty(self.db)),
-                TypeData::Union(union) => {
-                    pending.extend(union.types(self.db).iter().copied());
+                TypeData::InstanceOf(instance) => {
+                    pending.push(Visit::Enter(instance.ty(self.db)));
                 }
-                data if predicate(data) => return true,
+                TypeData::TypeofType(typeof_type) => {
+                    pending.push(Visit::Enter(typeof_type.ty(self.db)));
+                }
+                TypeData::TypeofValue(typeof_value) => {
+                    pending.push(Visit::Enter(typeof_value.ty(self.db)));
+                }
+                TypeData::Union(union) => {
+                    pending.extend(union.types(self.db).iter().copied().map(Visit::Enter));
+                }
+                data if is_indeterminate_type(data) => indeterminate = true,
+                data if predicate(data) => return Some(true),
                 _ => {}
             }
         }
 
-        false
+        if indeterminate { None } else { Some(false) }
     }
 
     fn function_return_matches(self, predicate: impl Fn(TypeData<'db>) -> bool) -> bool {
@@ -1429,6 +1712,66 @@ fn types_match<'db>(
     false
 }
 
+fn canonical_bigint_text(text: &Text) -> Text {
+    let raw = text.text().strip_suffix('n').unwrap_or(text.text());
+    let cleaned = raw.replace('_', "");
+    let (negative, unsigned) = cleaned
+        .strip_prefix('-')
+        .map_or((false, cleaned.as_str()), |value| (true, value));
+    let (radix, digits) = if let Some(value) = unsigned
+        .strip_prefix("0x")
+        .or_else(|| unsigned.strip_prefix("0X"))
+    {
+        (16, value)
+    } else if let Some(value) = unsigned
+        .strip_prefix("0o")
+        .or_else(|| unsigned.strip_prefix("0O"))
+    {
+        (8, value)
+    } else if let Some(value) = unsigned
+        .strip_prefix("0b")
+        .or_else(|| unsigned.strip_prefix("0B"))
+    {
+        (2, value)
+    } else {
+        (10, unsigned)
+    };
+
+    let mut decimal = vec![0_u8];
+    for digit in digits.chars() {
+        let Some(digit) = digit.to_digit(radix) else {
+            return text.clone();
+        };
+        let mut carry = digit;
+        for decimal_digit in &mut decimal {
+            let value = u32::from(*decimal_digit) * radix + carry;
+            *decimal_digit = (value % 10) as u8;
+            carry = value / 10;
+        }
+        while carry != 0 {
+            decimal.push((carry % 10) as u8);
+            carry /= 10;
+        }
+    }
+    while decimal.len() > 1 && decimal.last() == Some(&0) {
+        decimal.pop();
+    }
+
+    let is_zero = decimal == [0];
+    let mut result = String::with_capacity(decimal.len() + 2);
+    if negative && !is_zero {
+        result.push('-');
+    }
+    result.extend(
+        decimal
+            .into_iter()
+            .rev()
+            .map(|digit| char::from(b'0' + digit)),
+    );
+    result.push('n');
+    Text::new_owned(result.into())
+}
+
 fn is_at_least_as_wide_as_object<'db>(
     db: &'db dyn TypeDb,
     ty: TypeData<'db>,
@@ -1570,7 +1913,7 @@ fn stringification_usefulness<'db>(
     active: &mut FxHashSet<TypeData<'db>>,
     depth: usize,
 ) -> StringificationUsefulness {
-    use StringificationUsefulness::{Always, Never};
+    use StringificationUsefulness::Always;
 
     if depth >= MAX_TYPE_VARIANT_STEPS || !active.insert(data) {
         return Always;
@@ -1580,71 +1923,86 @@ fn stringification_usefulness<'db>(
         generic.constraint(db).map_or(Always, |constraint| {
             stringification_usefulness(db, constraint, mode, ignored_type_names, active, depth + 1)
         })
-    } else if matches!(mode, StringificationMode::ToString)
-        && (is_ignored_stringification_type(db, data, ignored_type_names)
-            || is_safe_stringification_type(db, data))
-    {
-        Always
-    } else {
-        match data {
-            TypeData::Union(union) => {
-                combine_stringification_union(union.types(db).iter().map(|ty| {
-                    stringification_usefulness(db, *ty, mode, ignored_type_names, active, depth + 1)
-                }))
-            }
-            TypeData::Intersection(intersection) => {
-                combine_stringification_intersection(intersection.types(db).iter().map(|ty| {
-                    stringification_usefulness(db, *ty, mode, ignored_type_names, active, depth + 1)
-                }))
-            }
-            TypeData::Tuple(tuple) => {
-                combine_stringification_tuple(tuple.elements(db).iter().map(|element| {
-                    stringification_usefulness(
-                        db,
-                        element.ty,
-                        StringificationMode::ToString,
-                        ignored_type_names,
-                        active,
-                        depth + 1,
-                    )
-                }))
-            }
-            TypeData::InstanceOf(instance) if instance.ty(db).is_array_class(db) => instance
-                .type_parameters(db)
-                .first()
-                .map_or(Always, |element| {
-                    stringification_usefulness(
-                        db,
-                        *element,
-                        StringificationMode::ToString,
-                        ignored_type_names,
-                        active,
-                        depth + 1,
-                    )
-                }),
-            TypeData::InstanceOf(instance) => stringification_usefulness(
+    } else if matches!(mode, StringificationMode::ToString) {
+        match is_ignored_stringification_type(db, data, ignored_type_names) {
+            None | Some(true) => Always,
+            Some(false) if is_safe_stringification_type(db, data) => Always,
+            Some(false) => stringification_usefulness_unignored(
                 db,
-                instance.ty(db),
+                data,
                 mode,
                 ignored_type_names,
                 active,
-                depth + 1,
+                depth,
             ),
-            _ if matches!(mode, StringificationMode::Join) => Always,
-            _ => match uses_base_object_stringification(
-                db,
-                data,
-                &mut FxHashSet::default(),
-                depth + 1,
-            ) {
-                Some(true) => Never,
-                Some(false) | None => Always,
-            },
         }
+    } else {
+        stringification_usefulness_unignored(db, data, mode, ignored_type_names, active, depth)
     };
 
     active.remove(&data);
     result
+}
+
+fn stringification_usefulness_unignored<'db>(
+    db: &'db dyn TypeDb,
+    data: TypeData<'db>,
+    mode: StringificationMode,
+    ignored_type_names: &[&str],
+    active: &mut FxHashSet<TypeData<'db>>,
+    depth: usize,
+) -> StringificationUsefulness {
+    use StringificationUsefulness::{Always, Never};
+
+    match data {
+        TypeData::Union(union) => combine_stringification_union(union.types(db).iter().map(|ty| {
+            stringification_usefulness(db, *ty, mode, ignored_type_names, active, depth + 1)
+        })),
+        TypeData::Intersection(intersection) => {
+            combine_stringification_intersection(intersection.types(db).iter().map(|ty| {
+                stringification_usefulness(db, *ty, mode, ignored_type_names, active, depth + 1)
+            }))
+        }
+        TypeData::Tuple(tuple) => {
+            combine_stringification_tuple(tuple.elements(db).iter().map(|element| {
+                stringification_usefulness(
+                    db,
+                    element.ty,
+                    StringificationMode::ToString,
+                    ignored_type_names,
+                    active,
+                    depth + 1,
+                )
+            }))
+        }
+        TypeData::InstanceOf(instance) if instance.ty(db).is_array_class(db) => instance
+            .type_parameters(db)
+            .first()
+            .map_or(Always, |element| {
+                stringification_usefulness(
+                    db,
+                    *element,
+                    StringificationMode::ToString,
+                    ignored_type_names,
+                    active,
+                    depth + 1,
+                )
+            }),
+        TypeData::InstanceOf(instance) => stringification_usefulness(
+            db,
+            instance.ty(db),
+            mode,
+            ignored_type_names,
+            active,
+            depth + 1,
+        ),
+        _ if matches!(mode, StringificationMode::Join) => Always,
+        _ => match uses_base_object_stringification(db, data, &mut FxHashSet::default(), depth + 1)
+        {
+            Some(true) => Never,
+            Some(false) | None => Always,
+        },
+    }
 }
 
 fn combine_stringification_union(
@@ -1723,17 +2081,19 @@ fn is_ignored_stringification_type<'db>(
     db: &'db dyn TypeDb,
     data: TypeData<'db>,
     ignored_type_names: &[&str],
-) -> bool {
+) -> Option<bool> {
     let mut seen = FxHashSet::default();
     let mut pending = vec![data];
+    let mut remaining_steps = MAX_TYPE_VARIANT_STEPS;
 
-    for _ in 0..MAX_TYPE_VARIANT_STEPS {
-        let Some(data) = pending.pop() else {
-            return false;
-        };
+    while let Some(data) = pending.pop() {
         if !seen.insert(data) {
             continue;
         }
+        if remaining_steps == 0 {
+            return None;
+        }
+        remaining_steps -= 1;
 
         let name = match data {
             TypeData::Class(class) => class.name(db).as_ref().map(Text::text),
@@ -1746,7 +2106,7 @@ fn is_ignored_stringification_type<'db>(
             _ => None,
         };
         if name.is_some_and(|name| ignored_type_names.contains(&name)) {
-            return true;
+            return Some(true);
         }
 
         match data {
@@ -1764,7 +2124,7 @@ fn is_ignored_stringification_type<'db>(
         }
     }
 
-    false
+    Some(false)
 }
 
 fn uses_base_object_stringification<'db>(
@@ -1846,22 +2206,232 @@ fn has_custom_stringification_member(members: &[crate::interned_types::TypeMembe
     })
 }
 
-fn is_promise_instance<'db>(db: &'db dyn TypeDb, mut data: TypeData<'db>) -> bool {
-    while let TypeData::InstanceOf(instance) = data {
-        data = instance.ty(db);
-        if data.is_promise_class(db) {
-            return true;
+fn is_promise_instance<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> Option<bool> {
+    let mut completed = FxHashSet::default();
+    let mut pending = VecDeque::from([(data, Vec::new(), false, false)]);
+    let mut processed = 0;
+    let mut indeterminate = false;
+
+    while let Some((data, path, is_instance_target, is_promise_like_target)) = pending.pop_front() {
+        if path.contains(&data) {
+            indeterminate = true;
+            continue;
+        }
+        if !completed.insert((data, is_instance_target, is_promise_like_target)) {
+            continue;
+        }
+        if processed == MAX_PROMISE_TYPE_STEPS {
+            indeterminate = true;
+            continue;
+        }
+        processed += 1;
+
+        if is_instance_target && data.is_promise_class(db) {
+            return Some(true);
+        }
+        let is_named_promise_like = is_instance_target
+            && match data {
+                TypeData::Class(class) => class
+                    .name(db)
+                    .as_ref()
+                    .is_some_and(|name| name.text() == "PromiseLike"),
+                TypeData::Interface(interface) => interface.name(db).text() == "PromiseLike",
+                _ => false,
+            };
+        let is_promise_like_target = is_promise_like_target || is_named_promise_like;
+        if is_promise_like_target {
+            let members = match data {
+                TypeData::Class(class) => Some(class.members(db)),
+                TypeData::Interface(interface) => Some(interface.members(db)),
+                TypeData::Object(object) => Some(object.members(db)),
+                _ => None,
+            };
+            if let Some(members) = members {
+                for member in members
+                    .iter()
+                    .filter(|member| !member.kind.is_static() && member.kind.has_name("then"))
+                {
+                    match InferredType::new(db, member.ty).is_callable() {
+                        Some(true) => return Some(true),
+                        Some(false) => {}
+                        None => indeterminate = true,
+                    }
+                }
+            }
+        }
+        if is_indeterminate_type(data) {
+            indeterminate = true;
+            continue;
+        }
+
+        let mut child_path = path;
+        child_path.push(data);
+        let remaining_steps = MAX_PROMISE_TYPE_STEPS - processed;
+        let available_frontier = remaining_steps.saturating_sub(pending.len());
+        match data {
+            TypeData::Class(class) => {
+                if let Some(base) = class.extends(db) {
+                    if available_frontier == 0 {
+                        return None;
+                    }
+                    pending.push_back((
+                        base,
+                        child_path,
+                        is_instance_target,
+                        is_promise_like_target,
+                    ));
+                }
+            }
+            TypeData::Generic(generic) => {
+                if let Some(constraint) = generic.constraint(db) {
+                    if available_frontier == 0 {
+                        return None;
+                    }
+                    pending.push_back((
+                        constraint,
+                        child_path,
+                        is_instance_target,
+                        is_promise_like_target,
+                    ));
+                } else {
+                    indeterminate = true;
+                }
+            }
+            TypeData::InstanceOf(instance) => {
+                if available_frontier == 0 {
+                    return None;
+                }
+                pending.push_back((instance.ty(db), child_path, true, is_promise_like_target));
+            }
+            TypeData::Interface(interface) => {
+                if interface.extends(db).len() > available_frontier {
+                    return None;
+                }
+                pending.extend(interface.extends(db).iter().copied().map(|child| {
+                    (
+                        child,
+                        child_path.clone(),
+                        is_instance_target,
+                        is_promise_like_target,
+                    )
+                }));
+            }
+            TypeData::Intersection(intersection) => {
+                if intersection.types(db).len() > available_frontier {
+                    return None;
+                }
+                pending.extend(intersection.types(db).iter().copied().map(|child| {
+                    (
+                        child,
+                        child_path.clone(),
+                        is_instance_target,
+                        is_promise_like_target,
+                    )
+                }));
+            }
+            TypeData::MergedReference(reference) => {
+                if reference.targets(db).count() > available_frontier {
+                    return None;
+                }
+                pending.extend(reference.targets(db).map(|child| {
+                    (
+                        child,
+                        child_path.clone(),
+                        is_instance_target,
+                        is_promise_like_target,
+                    )
+                }));
+            }
+            TypeData::TypeOperator(operator) => {
+                if available_frontier == 0 {
+                    return None;
+                }
+                pending.push_back((
+                    operator.ty(db),
+                    child_path,
+                    is_instance_target,
+                    is_promise_like_target,
+                ));
+            }
+            TypeData::TypeofType(typeof_type) => {
+                if available_frontier == 0 {
+                    return None;
+                }
+                pending.push_back((
+                    typeof_type.ty(db),
+                    child_path,
+                    is_instance_target,
+                    is_promise_like_target,
+                ));
+            }
+            TypeData::TypeofValue(typeof_value) => {
+                if available_frontier == 0 {
+                    return None;
+                }
+                pending.push_back((
+                    typeof_value.ty(db),
+                    child_path,
+                    is_instance_target,
+                    is_promise_like_target,
+                ));
+            }
+            TypeData::Union(union) => {
+                if union.types(db).len() > available_frontier {
+                    return None;
+                }
+                pending.extend(union.types(db).iter().copied().map(|child| {
+                    (
+                        child,
+                        child_path.clone(),
+                        is_instance_target,
+                        is_promise_like_target,
+                    )
+                }));
+            }
+            TypeData::Global
+            | TypeData::BigInt
+            | TypeData::Boolean
+            | TypeData::Null
+            | TypeData::Number
+            | TypeData::String
+            | TypeData::Symbol
+            | TypeData::Undefined
+            | TypeData::Conditional
+            | TypeData::Constructor(_)
+            | TypeData::Function(_)
+            | TypeData::Module(_)
+            | TypeData::Namespace(_)
+            | TypeData::Object(_)
+            | TypeData::Tuple(_)
+            | TypeData::Literal(_)
+            | TypeData::NeverKeyword
+            | TypeData::ObjectKeyword
+            | TypeData::ThisKeyword
+            | TypeData::VoidKeyword => {}
+            TypeData::Unknown
+            | TypeData::Divergent(_)
+            | TypeData::Local(_)
+            | TypeData::TypeofExpression(_)
+            | TypeData::AnyKeyword
+            | TypeData::UnknownKeyword => {
+                indeterminate = true;
+            }
         }
     }
 
-    false
+    if indeterminate { None } else { Some(false) }
 }
 
-fn contains_promise<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> bool {
-    match data {
-        TypeData::Union(union) => union.types(db).iter().any(|ty| contains_promise(db, *ty)),
-        data => is_promise_instance(db, data),
-    }
+const fn is_indeterminate_type(data: TypeData<'_>) -> bool {
+    matches!(
+        data,
+        TypeData::Unknown
+            | TypeData::Divergent(_)
+            | TypeData::Local(_)
+            | TypeData::TypeofExpression(_)
+            | TypeData::AnyKeyword
+            | TypeData::UnknownKeyword
+    )
 }
 
 fn is_object_like<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> bool {
@@ -1930,5 +2500,54 @@ fn type_description<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> String {
         | TypeData::Conditional
         | TypeData::Global
         | TypeData::ThisKeyword => format!("{data:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interned_types::InternedUnion;
+
+    #[salsa::db]
+    #[derive(Default)]
+    struct TestDb {
+        storage: salsa::Storage<Self>,
+    }
+
+    #[salsa::db]
+    impl salsa::Database for TestDb {}
+
+    #[salsa::db]
+    impl biome_db::Db for TestDb {
+        fn parsed_source_for_path(
+            &self,
+            _path: &camino::Utf8Path,
+        ) -> Option<biome_db::ParsedSource> {
+            None
+        }
+    }
+
+    #[salsa::db]
+    impl TypeDb for TestDb {}
+
+    #[test]
+    fn incomplete_predicates_are_indeterminate() {
+        let db = TestDb::default();
+        let unknown = InferredType::new(&db, TypeData::Unknown);
+
+        assert_eq!(unknown.is_promise_instance(), None);
+        assert_eq!(unknown.has_nullish_variant(), None);
+        assert_eq!(unknown.has_null_variant(), None);
+        assert_eq!(unknown.has_undefined_variant(), None);
+        assert_eq!(unknown.is_safe_for_nullish_coalescing(), None);
+
+        let null_or_unknown = TypeData::Union(InternedUnion::new(
+            &db,
+            Vec::from([TypeData::Null, TypeData::Unknown]).into_boxed_slice(),
+        ));
+        let union = InferredType::new(&db, null_or_unknown);
+        assert_eq!(union.has_nullish_variant(), Some(true));
+        assert_eq!(union.has_undefined_variant(), None);
+        assert_eq!(union.is_safe_for_nullish_coalescing(), None);
     }
 }

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -6,7 +6,7 @@ use crate::type_traversal::{DepthFirstVisitor, TraversalOutcome, VisitContext};
 use biome_js_syntax::numbers::canonicalize_js_bigint_literal;
 use biome_rowan::Text;
 use rustc_hash::FxHashSet;
-use std::{borrow::Cow, collections::VecDeque, ops::ControlFlow};
+use std::{borrow::Cow, collections::VecDeque, fmt, ops::ControlFlow};
 
 const MAX_TYPE_VARIANT_STEPS: usize = 1024;
 const MAX_PROMISE_TYPE_STEPS: usize = 64;
@@ -23,6 +23,29 @@ pub enum InferredSwitchCase {
     Symbol,
     UnsupportedLiteral,
 }
+
+/// Describes why traversing nested types could not produce a result.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TypeTraversalError {
+    /// A type required for the result could not be resolved.
+    UnresolvedType,
+    /// A nested type refers back to a type that is still being visited.
+    RecursiveType,
+    /// The traversal reached its maximum number of visited types.
+    LimitExceeded,
+}
+
+impl fmt::Display for TypeTraversalError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::UnresolvedType => "a type could not be resolved",
+            Self::RecursiveType => "a recursive type was encountered",
+            Self::LimitExceeded => "the type traversal limit was exceeded",
+        })
+    }
+}
+
+impl std::error::Error for TypeTraversalError {}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StringificationMode {
@@ -467,6 +490,7 @@ impl<'db> InferredType<'db> {
                 TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword
             )
         })
+        .ok()
     }
 
     /// Returns whether every variant can be replaced safely in a nullish
@@ -484,6 +508,7 @@ impl<'db> InferredType<'db> {
                 Some(ConditionalType::Truthy | ConditionalType::Nullish)
             )
         })
+        .ok()
     }
 
     /// Returns whether every variant of a nullish union is nullish or an ignored
@@ -514,6 +539,7 @@ impl<'db> InferredType<'db> {
             },
             _ => false,
         })
+        .ok()
     }
 
     /// Returns `Some(true)` when any variant is `null`, and `Some(false)` when
@@ -523,6 +549,7 @@ impl<'db> InferredType<'db> {
     /// unresolved or recursive type, or exceeds its limit.
     pub fn has_null_variant(self) -> Option<bool> {
         self.try_any_variant_matches(|data| matches!(data, TypeData::Null))
+            .ok()
     }
 
     /// Returns `Some(true)` when any variant is `undefined` or `void`, and
@@ -534,6 +561,7 @@ impl<'db> InferredType<'db> {
         self.try_any_variant_matches(|data| {
             matches!(data, TypeData::Undefined | TypeData::VoidKeyword)
         })
+        .ok()
     }
 
     pub fn has_invalid_plus_operand_variant(self) -> bool {
@@ -581,10 +609,10 @@ impl<'db> InferredType<'db> {
 
     /// Returns the deduplicated switch-case variants represented by this type.
     ///
-    /// Returns `None` when traversal exceeds the type-variant limit. Literals
-    /// that cannot form supported cases are represented by
+    /// Returns [`TypeTraversalError::LimitExceeded`] when traversal exceeds the
+    /// type-variant limit. Literals that cannot form supported cases are represented by
     /// [`InferredSwitchCase::UnsupportedLiteral`].
-    pub fn try_switch_case_variants(self) -> Option<Vec<InferredSwitchCase>> {
+    pub fn try_switch_case_variants(self) -> Result<Vec<InferredSwitchCase>, TypeTraversalError> {
         let mut cases = Vec::new();
         let mut seen = FxHashSet::default();
         let mut pending = vec![self.data];
@@ -595,7 +623,7 @@ impl<'db> InferredType<'db> {
                 continue;
             }
             if remaining_steps == 0 {
-                return None;
+                return Err(TypeTraversalError::LimitExceeded);
             }
             remaining_steps -= 1;
 
@@ -645,7 +673,7 @@ impl<'db> InferredType<'db> {
 
         let mut unique_cases = FxHashSet::default();
         cases.retain(|case| unique_cases.insert(case.clone()));
-        Some(cases)
+        Ok(cases)
     }
 
     pub fn stringification_usefulness(
@@ -707,7 +735,10 @@ impl<'db> InferredType<'db> {
         matches!(self.data, TypeData::Undefined)
     }
 
-    fn try_all_variants_match(self, predicate: impl FnMut(TypeData<'db>) -> bool) -> Option<bool> {
+    fn try_all_variants_match(
+        self,
+        predicate: impl FnMut(TypeData<'db>) -> bool,
+    ) -> Result<bool, TypeTraversalError> {
         let mut visitor = AllVariantsVisitor {
             db: self.db,
             predicate,
@@ -715,13 +746,17 @@ impl<'db> InferredType<'db> {
             indeterminate: false,
         };
         match visitor.visit(self.data, MAX_TYPE_VARIANT_STEPS) {
-            TraversalOutcome::Break(result) => Some(result),
+            TraversalOutcome::Break(result) => Ok(result),
             TraversalOutcome::Complete { encountered_cycle }
                 if !encountered_cycle && !visitor.indeterminate =>
             {
-                Some(visitor.saw_variant)
+                Ok(visitor.saw_variant)
             }
-            TraversalOutcome::Complete { .. } | TraversalOutcome::LimitExceeded => None,
+            TraversalOutcome::Complete {
+                encountered_cycle: true,
+            } => Err(TypeTraversalError::RecursiveType),
+            TraversalOutcome::Complete { .. } => Err(TypeTraversalError::UnresolvedType),
+            TraversalOutcome::LimitExceeded => Err(TypeTraversalError::LimitExceeded),
         }
     }
 
@@ -824,20 +859,27 @@ impl<'db> InferredType<'db> {
         true
     }
 
-    fn try_any_variant_matches(self, predicate: impl FnMut(TypeData<'db>) -> bool) -> Option<bool> {
+    fn try_any_variant_matches(
+        self,
+        predicate: impl FnMut(TypeData<'db>) -> bool,
+    ) -> Result<bool, TypeTraversalError> {
         let mut visitor = AnyVariantVisitor {
             db: self.db,
             predicate,
             indeterminate: false,
         };
         match visitor.visit(self.data, MAX_TYPE_VARIANT_STEPS) {
-            TraversalOutcome::Break(result) => Some(result),
+            TraversalOutcome::Break(result) => Ok(result),
             TraversalOutcome::Complete { encountered_cycle }
                 if !encountered_cycle && !visitor.indeterminate =>
             {
-                Some(false)
+                Ok(false)
             }
-            TraversalOutcome::Complete { .. } | TraversalOutcome::LimitExceeded => None,
+            TraversalOutcome::Complete {
+                encountered_cycle: true,
+            } => Err(TypeTraversalError::RecursiveType),
+            TraversalOutcome::Complete { .. } => Err(TypeTraversalError::UnresolvedType),
+            TraversalOutcome::LimitExceeded => Err(TypeTraversalError::LimitExceeded),
         }
     }
 
@@ -2473,7 +2515,7 @@ mod tests {
             assert!(bigint.is_always_falsy(), "{text}");
             assert_eq!(
                 bigint.try_switch_case_variants(),
-                Some(vec![InferredSwitchCase::BigInt(Text::new_static("0n"))]),
+                Ok(vec![InferredSwitchCase::BigInt(Text::new_static("0n"))]),
                 "{text}"
             );
         }
@@ -2483,7 +2525,7 @@ mod tests {
         assert!(hexadecimal.is_always_truthy());
         assert_eq!(
             hexadecimal.try_switch_case_variants(),
-            Some(vec![InferredSwitchCase::BigInt(Text::new_static("16n"))])
+            Ok(vec![InferredSwitchCase::BigInt(Text::new_static("16n"))])
         );
     }
 
@@ -2491,6 +2533,15 @@ mod tests {
     fn incomplete_predicates_are_indeterminate() {
         let db = TestDb::default();
         let unknown = InferredType::new(&db, TypeData::Unknown);
+
+        assert_eq!(
+            unknown.try_any_variant_matches(|_| false),
+            Err(TypeTraversalError::UnresolvedType)
+        );
+        assert_eq!(
+            unknown.try_all_variants_match(|_| true),
+            Err(TypeTraversalError::UnresolvedType)
+        );
 
         assert_eq!(unknown.is_promise_instance(), None);
         assert_eq!(unknown.has_nullish_variant(), None);

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -4,6 +4,7 @@
 //! for now. This module introduces the interned resolved representation that
 //! later phases will wire into module inference.
 
+use biome_js_syntax::numbers::canonicalize_js_bigint_literal;
 use biome_rowan::Text;
 use rustc_hash::FxHashSet;
 
@@ -299,9 +300,10 @@ impl<'db> TypeData<'db> {
             | Self::Symbol
             | Self::Tuple(_) => Some(ConditionalType::Truthy),
             Self::Literal(literal) => Some(match literal.literal(db) {
-                Literal::BigInt(text) => match text.text() {
-                    "0n" | "-0n" => ConditionalType::FalsyButNotNullish,
-                    _ => ConditionalType::Truthy,
+                Literal::BigInt(text) => match canonicalize_js_bigint_literal(text.text()) {
+                    Some(text) if text == "0n" => ConditionalType::FalsyButNotNullish,
+                    Some(_) => ConditionalType::Truthy,
+                    None => ConditionalType::Anything,
                 },
                 Literal::Boolean(boolean) => {
                     if boolean.as_bool() {

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -33,7 +33,7 @@ pub use globals::{GLOBAL_RESOLVER, GlobalsResolver};
 pub use globals_ids::{GLOBAL_BOOLEAN_ID, GLOBAL_UNKNOWN_ID, NUM_PREDEFINED_TYPES};
 pub use inferred_type::{
     IgnoredPrimitiveTypes, InferredSwitchCase, InferredType, MisleadingReturnType,
-    ReturnTypeEvidence, StringificationMode, StringificationUsefulness,
+    ReturnTypeEvidence, StringificationMode, StringificationUsefulness, TypeTraversalError,
 };
 pub use interned_types::TypeDb;
 pub use resolver::*;

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -25,6 +25,7 @@ mod resolver;
 mod r#type;
 mod type_data;
 mod type_store;
+mod type_traversal;
 
 pub use conditionals::*;
 pub use flattening::MAX_FLATTEN_DEPTH;

--- a/crates/biome_js_type_info/src/type.rs
+++ b/crates/biome_js_type_info/src/type.rs
@@ -12,6 +12,8 @@
 use std::fmt::Debug;
 use std::{ops::Deref, sync::Arc};
 
+use biome_js_syntax::numbers::canonicalize_js_bigint_literal;
+
 use crate::conditionals::ConditionalType;
 use crate::globals::GLOBAL_REGEXP_ID;
 use crate::{
@@ -263,13 +265,13 @@ impl Type {
 
     /// Returns whether this type is a bigint with the given `value`.
     pub fn is_bigint_literal(&self, value: i64) -> bool {
+        let expected = format!("{value}n");
         self.as_raw_data().is_some_and(|ty| match ty {
             TypeData::Literal(literal) => match literal.as_ref() {
-                Literal::BigInt(literal) => literal
-                    .trim_end_matches('n')
-                    .parse::<i64>()
-                    .ok()
-                    .is_some_and(|literal_value| literal_value == value),
+                Literal::BigInt(literal) => {
+                    canonicalize_js_bigint_literal(literal.text()).as_deref()
+                        == Some(expected.as_str())
+                }
                 _ => false,
             },
             _ => false,

--- a/crates/biome_js_type_info/src/type_traversal.rs
+++ b/crates/biome_js_type_info/src/type_traversal.rs
@@ -1,0 +1,178 @@
+use rustc_hash::FxHashSet;
+use std::{hash::Hash, ops::ControlFlow};
+
+enum TraversalEvent<N> {
+    Visit(N),
+    Finish(N),
+}
+
+/// Schedules children of the node currently passed to a [`DepthFirstVisitor`].
+///
+/// Children are visited in reverse scheduling order because traversal uses a
+/// stack. Scheduling `[first, second]` visits `second` before `first`.
+pub(crate) struct VisitContext<'a, N> {
+    pending: &'a mut Vec<TraversalEvent<N>>,
+}
+
+impl<N> VisitContext<'_, N> {
+    pub(crate) fn push(&mut self, child: N) {
+        self.pending.push(TraversalEvent::Visit(child));
+    }
+
+    pub(crate) fn extend(&mut self, children: impl IntoIterator<Item = N>) {
+        self.pending
+            .extend(children.into_iter().map(TraversalEvent::Visit));
+    }
+}
+
+/// Visits each distinct node in a depth-first traversal.
+///
+/// The traversal invokes `enter` only when a node is first entered. Nodes
+/// reached again after their visit finishes are skipped. Reaching a node that
+/// is still being visited is reported as a cycle in [`TraversalOutcome`].
+pub(crate) trait DepthFirstVisitor<N>
+where
+    N: Copy + Eq + Hash,
+{
+    type Break;
+
+    fn enter(&mut self, node: N, context: &mut VisitContext<'_, N>) -> ControlFlow<Self::Break>;
+
+    /// Visits the graph reachable from `root` without recursion.
+    ///
+    /// `max_visited` counts distinct node entries. Completed duplicates, cycle
+    /// edges, and internal finish events do not consume the limit.
+    fn visit(&mut self, root: N, max_visited: usize) -> TraversalOutcome<Self::Break> {
+        let mut active = FxHashSet::default();
+        let mut completed = FxHashSet::default();
+        let mut pending = vec![TraversalEvent::Visit(root)];
+        let mut remaining = max_visited;
+        let mut encountered_cycle = false;
+
+        while let Some(event) = pending.pop() {
+            let node = match event {
+                TraversalEvent::Finish(node) => {
+                    active.remove(&node);
+                    completed.insert(node);
+                    continue;
+                }
+                TraversalEvent::Visit(node) => node,
+            };
+            if completed.contains(&node) {
+                continue;
+            }
+            if !active.insert(node) {
+                encountered_cycle = true;
+                continue;
+            }
+            if remaining == 0 {
+                return TraversalOutcome::LimitExceeded;
+            }
+            remaining -= 1;
+            pending.push(TraversalEvent::Finish(node));
+
+            let mut context = VisitContext {
+                pending: &mut pending,
+            };
+            if let ControlFlow::Break(result) = self.enter(node, &mut context) {
+                return TraversalOutcome::Break(result);
+            }
+        }
+
+        TraversalOutcome::Complete { encountered_cycle }
+    }
+}
+
+/// Result of a bounded depth-first traversal.
+pub(crate) enum TraversalOutcome<B> {
+    /// The visitor stopped traversal with a conclusive result.
+    Break(B),
+    /// Every reachable node was processed.
+    Complete {
+        /// At least one edge reached a node on the active traversal path.
+        encountered_cycle: bool,
+    },
+    /// Processing another distinct node would exceed the traversal limit.
+    LimitExceeded,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestVisitor<'a> {
+        edges: &'a [(u8, &'a [u8])],
+        visited: Vec<u8>,
+        break_at: Option<u8>,
+    }
+
+    impl DepthFirstVisitor<u8> for TestVisitor<'_> {
+        type Break = u8;
+
+        fn enter(
+            &mut self,
+            node: u8,
+            context: &mut VisitContext<'_, u8>,
+        ) -> ControlFlow<Self::Break> {
+            self.visited.push(node);
+            if self.break_at == Some(node) {
+                return ControlFlow::Break(node);
+            }
+            if let Some((_, children)) = self.edges.iter().find(|(parent, _)| *parent == node) {
+                context.extend(children.iter().copied());
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    #[test]
+    fn distinguishes_cycles_from_completed_duplicates() {
+        let mut cycle = TestVisitor {
+            edges: &[(0, &[1]), (1, &[0])],
+            visited: Vec::new(),
+            break_at: None,
+        };
+        assert!(matches!(
+            cycle.visit(0, 3),
+            TraversalOutcome::Complete {
+                encountered_cycle: true
+            }
+        ));
+        assert_eq!(cycle.visited, [0, 1]);
+
+        let mut diamond = TestVisitor {
+            edges: &[(0, &[1, 2]), (1, &[3]), (2, &[3])],
+            visited: Vec::new(),
+            break_at: None,
+        };
+        assert!(matches!(
+            diamond.visit(0, 4),
+            TraversalOutcome::Complete {
+                encountered_cycle: false
+            }
+        ));
+        assert_eq!(diamond.visited, [0, 2, 3, 1]);
+    }
+
+    #[test]
+    fn reports_limits_and_breaks() {
+        let mut limited = TestVisitor {
+            edges: &[(0, &[1]), (1, &[2])],
+            visited: Vec::new(),
+            break_at: None,
+        };
+        assert!(matches!(
+            limited.visit(0, 2),
+            TraversalOutcome::LimitExceeded
+        ));
+        assert_eq!(limited.visited, [0, 1]);
+
+        let mut breaking = TestVisitor {
+            edges: &[(0, &[1, 2])],
+            visited: Vec::new(),
+            break_at: Some(2),
+        };
+        assert!(matches!(breaking.visit(0, 3), TraversalOutcome::Break(2)));
+        assert_eq!(breaking.visited, [0, 2]);
+    }
+}

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -64,6 +64,16 @@ impl<'db> InferredModuleTypes<'db> {
         let mut resolver = self;
         find_member_type_with_resolver(db, &mut resolver, ty, name, MemberLookupMode::Any)
     }
+
+    pub(in crate::db::type_inference) fn find_value_member_type_iterative(
+        &self,
+        db: &'db dyn ModuleDb,
+        ty: InferredTypeData<'db>,
+        name: &str,
+    ) -> Option<InferredTypeData<'db>> {
+        let mut resolver = self;
+        find_member_type_with_resolver(db, &mut resolver, ty, name, MemberLookupMode::Value)
+    }
 }
 
 /// Selects which side of a type participates in member lookup.
@@ -75,6 +85,8 @@ pub(in crate::db::type_inference) enum MemberLookupMode {
     Class,
     /// Accepts non-static members and index signatures.
     Instance,
+    /// Selects class-side or instance-side members from the traversed value type.
+    Value,
 }
 
 impl MemberLookupMode {
@@ -83,11 +95,12 @@ impl MemberLookupMode {
             Self::Any => true,
             Self::Class => kind.is_static() && !kind.is_constructor(),
             Self::Instance => !kind.is_static(),
+            Self::Value => false,
         }
     }
 
     fn allows_index_signature(self) -> bool {
-        !matches!(self, Self::Class)
+        !matches!(self, Self::Class | Self::Value)
     }
 }
 
@@ -248,7 +261,10 @@ pub(in crate::db::type_inference) fn find_member_type_with_resolver<'db>(
         match ty {
             InferredTypeData::Class(class) => {
                 if let Some(mut extends) = class.extends(db) {
-                    if matches!(state.mode, MemberLookupMode::Any | MemberLookupMode::Class) {
+                    if matches!(
+                        state.mode,
+                        MemberLookupMode::Any | MemberLookupMode::Class | MemberLookupMode::Value
+                    ) {
                         extends = class_side_type(db, extends);
                     }
                     pending.push(state.child(db, extends, state.collect_result));
@@ -504,16 +520,35 @@ fn find_own_member_type<'db>(
     };
 
     match ty {
-        InferredTypeData::Class(class) => find(
-            class.members(db),
-            mode,
-            matches!(mode, MemberLookupMode::Instance),
-        ),
+        InferredTypeData::Class(class) => {
+            let mode = if matches!(mode, MemberLookupMode::Value) {
+                MemberLookupMode::Class
+            } else {
+                mode
+            };
+            find(
+                class.members(db),
+                mode,
+                matches!(mode, MemberLookupMode::Instance),
+            )
+        }
         InferredTypeData::Interface(interface) => {
+            let mode = if matches!(mode, MemberLookupMode::Value) {
+                MemberLookupMode::Instance
+            } else {
+                mode
+            };
             find(interface.members(db), mode, mode.allows_index_signature())
         }
         InferredTypeData::Literal(literal) => match literal.literal(db) {
-            InferredLiteral::Object(members) => find(members, mode, mode.allows_index_signature()),
+            InferredLiteral::Object(members) => {
+                let mode = if matches!(mode, MemberLookupMode::Value) {
+                    MemberLookupMode::Instance
+                } else {
+                    mode
+                };
+                find(members, mode, mode.allows_index_signature())
+            }
             InferredLiteral::BigInt(_)
             | InferredLiteral::Boolean(_)
             | InferredLiteral::Number(_)
@@ -526,6 +561,11 @@ fn find_own_member_type<'db>(
             find(namespace.members(db), MemberLookupMode::Any, true)
         }
         InferredTypeData::Object(object) => {
+            let mode = if matches!(mode, MemberLookupMode::Value) {
+                MemberLookupMode::Instance
+            } else {
+                mode
+            };
             find(object.members(db), mode, mode.allows_index_signature())
         }
         InferredTypeData::Unknown

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -78,6 +78,20 @@ impl<'db> InferredModuleTypes<'db> {
     ) -> Option<InferredTypeData<'db>> {
         self.find_member_type_iterative(db, ty, name)
     }
+
+    /// Finds a named member available on a value of `ty`.
+    ///
+    /// Class values expose static members, while instances expose non-static
+    /// members. Type arguments from instances are substituted into the member
+    /// type. Returns `None` when no reachable supported type defines `name`.
+    pub fn find_value_member_type(
+        &self,
+        db: &'db dyn ModuleDb,
+        ty: InferredTypeData<'db>,
+        name: &str,
+    ) -> Option<InferredTypeData<'db>> {
+        self.find_value_member_type_iterative(db, ty, name)
+    }
 }
 
 pub(super) fn collected_type_result<'db>(


### PR DESCRIPTION
## Summary

Makes type-aware rules conservative when inference reaches recursion or traversal limits. `noMisusedPromises`, `useAwaitThenable`, `noBaseToString`, and `useNullishCoalescing` now suppress diagnostics derived from incomplete type information; bigint switch variants are also preserved.

The PR now implements a conservative approach when a type can't be inferred. Some methods are now called with `try_*` and if they can't infer a type - e.g. a deep-nested loop - they return a specific signal. This is more or less like what TypeScript does in cases where there are complex, deeply nested types. At the moment, our rules don't use this signal, and they just return `None` if a type can't be inferred.

We could plan to fire a proper error in these cases. 


The PR also adds a visitor-like utility, used in different instances, in case there are specific logics where we need to visit the nested types. 

## Test Plan

Extended unit tests and analyzer specs for incomplete inference, recursive types, Promise checks, and bigint switch cases.

## Docs

N/A

> This PR was created with AI assistance (OpenCode).