### PR TITLE
fix(html): preserve XML declaration attributes

### DIFF
--- a/.changeset/fuzzy-pans-appear.md
+++ b/.changeset/fuzzy-pans-appear.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10922](https://github.com/biomejs/biome/issues/10922): [`useSortedAttributes`](https://biomejs.dev/assist/actions/use-sorted-attributes/) no longer reorders attributes in processing instructions such as XML declarations.

--- a/crates/biome_cli/tests/cases/html.rs
+++ b/crates/biome_cli/tests/cases/html.rs
@@ -1,5 +1,5 @@
 use crate::run_cli;
-use crate::snap_test::{SnapshotPayload, assert_cli_snapshot};
+use crate::snap_test::{SnapshotPayload, assert_cli_snapshot, assert_file_contents};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
 use bpaf::Args;
@@ -562,6 +562,71 @@ fn should_lint_a_html_file() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "should_lint_a_html_file",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn use_sorted_attributes_preserves_xml_declaration() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let svg_file = Utf8Path::new("image.svg");
+    let svg_source = r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"></svg>
+"#;
+    fs.insert(svg_file.into(), svg_source.as_bytes());
+
+    let html_file = Utf8Path::new("file.html");
+    fs.insert(
+        html_file.into(),
+        r#"<input type="text" id="name" name="name" />
+"#
+        .as_bytes(),
+    );
+
+    fs.insert(
+        Utf8Path::new("biome.json").into(),
+        r#"{
+    "formatter": {
+        "enabled": false
+    },
+    "assist": {
+        "enabled": true
+    }
+}"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "check",
+                "--write",
+                "--only=assist/source/useSortedAttributes",
+                svg_file.as_str(),
+                html_file.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+    assert_file_contents(&fs, svg_file, svg_source);
+    assert_file_contents(
+        &fs,
+        html_file,
+        r#"<input id="name" name="name" type="text" />
+"#,
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "use_sorted_attributes_preserves_xml_declaration",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_html/use_sorted_attributes_preserves_xml_declaration.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_html/use_sorted_attributes_preserves_xml_declaration.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": true
+  }
+}
+```
+
+## `file.html`
+
+```html
+<input id="name" name="name" type="text" />
+
+```
+
+## `image.svg`
+
+```svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"></svg>
+
+```
+
+# Emitted Messages
+
+```block
+Checked 2 files in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_html_analyze/src/assist/source/use_sorted_attributes.rs
+++ b/crates/biome_html_analyze/src/assist/source/use_sorted_attributes.rs
@@ -10,7 +10,7 @@ use biome_diagnostics::Applicability;
 use biome_html_syntax::{
     AnyAstroDirective, AnyHtmlAttribute, AnySvelteBindingProperty, AnySvelteDirective,
     AnyVueDirective, AnyVueDirectiveArgument, AstroDirectiveValue, HtmlAttributeList, HtmlLanguage,
-    HtmlOpeningElement, HtmlSelfClosingElement, SvelteDirectiveValue,
+    HtmlOpeningElement, HtmlProcessingInstruction, HtmlSelfClosingElement, SvelteDirectiveValue,
 };
 use biome_rowan::{AstNode, AstNodeExt, BatchMutationExt, SyntaxToken};
 use biome_rule_options::use_sorted_attributes::{SortOrder, UseSortedAttributesOptions};
@@ -135,6 +135,14 @@ impl Rule for UseSortedAttributes {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let attrs = ctx.query();
+        if attrs
+            .syntax()
+            .parent()
+            .is_some_and(|parent| HtmlProcessingInstruction::can_cast(parent.kind()))
+        {
+            return Box::default();
+        }
+
         let options = ctx.options();
 
         let mut current_attr_group = AttributeGroup::default();

--- a/crates/biome_html_analyze/tests/specs/source/useSortedAttributes/html/processing-instruction.html
+++ b/crates/biome_html_analyze/tests/specs/source/useSortedAttributes/html/processing-instruction.html
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<input type="text" id="name" name="name" />

--- a/crates/biome_html_analyze/tests/specs/source/useSortedAttributes/html/processing-instruction.html.snap
+++ b/crates/biome_html_analyze/tests/specs/source/useSortedAttributes/html/processing-instruction.html.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: processing-instruction.html
+---
+# Input
+```html
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<input type="text" id="name" name="name" />
+
+```
+
+# Diagnostics
+```
+processing-instruction.html:2:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The attributes are not sorted.
+  
+    1 │ <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+  > 2 │ <input type="text" id="name" name="name" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Safe fix: Sort the HTML attributes.
+  
+    1 1 │   <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+    2   │ - <input·type="text"·id="name"·name="name"·/>
+      2 │ + <input·id="name"·name="name"·type="text"·/>
+    3 3 │   
+  
+
+```


### PR DESCRIPTION
## Summary

Fixes #10922.

[`useSortedAttributes`](https://biomejs.dev/assist/actions/use-sorted-attributes/) no longer reorders attributes in processing instructions such as XML declarations.

## Test Plan

- Analyzer `use_sorted_attributes` suite: 13 passed.
- CLI HTML cases: 14 passed.
- `cargo fmt --all -- --check`
- `cargo clippy -p biome_html_analyze -p biome_cli --all-features --all-targets -- --deny warnings`

## Docs

Not applicable.
