### PR TITLE
fix(assist): preserve nested JSX attributes when sorting

### DIFF
--- a/.changeset/angry-moles-wash.md
+++ b/.changeset/angry-moles-wash.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10838](https://github.com/biomejs/biome/issues/10838): [`useSortedAttributes`](https://biomejs.dev/assist/actions/use-sorted-attributes/) no longer duplicates or drops attributes when sorting nested JSX.

--- a/crates/biome_cli/tests/cases/assist.rs
+++ b/crates/biome_cli/tests/cases/assist.rs
@@ -186,3 +186,71 @@ fn assist_writes() {
         result,
     ));
 }
+
+#[test]
+fn sorted_attributes_writes_nested_jsx_atomically() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file = Utf8Path::new("file.jsx");
+    fs.insert(
+        file.into(),
+        r#"<Outer z="x" a={<Inner z={1} a={2} />} />;
+<Outer
+	z="outer"
+	a={() => <Middle y={<Inner z={1} a={2} />} x="middle" />}
+/>;
+<Outer z={<Z b={2} a={1} />} a={<A d={4} c={3} />} />;
+<Outer z="x" a={<Inner z={1} a={2} />}>
+	child
+</Outer>;
+<Widget
+	// first group
+	z={<Inner z={1} a={2} />}
+	a="a"
+	{...props}
+	// second group
+	d="d"
+	c={<Inner y={1} x={2} />}
+/>;
+"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "check",
+                "--write",
+                "--only=assist/source/useSortedAttributes",
+                file.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(
+        &fs,
+        file,
+        r#"<Outer a={<Inner a={2} z={1} />} z="x" />;
+<Outer a={() => <Middle x="middle" y={<Inner a={2} z={1} />} />} z="outer" />;
+<Outer a={<A c={3} d={4} />} z={<Z a={1} b={2} />} />;
+<Outer a={<Inner a={2} z={1} />} z="x">
+	child
+</Outer>;
+<Widget
+	a="a"
+	// first group
+	z={<Inner a={2} z={1} />}
+	{...props}
+	c={<Inner x={2} y={1} />}
+	// second group
+	d="d"
+/>;
+"#,
+    );
+}

--- a/crates/biome_js_analyze/src/assist/source/use_sorted_attributes.rs
+++ b/crates/biome_js_analyze/src/assist/source/use_sorted_attributes.rs
@@ -12,7 +12,7 @@ use biome_js_syntax::{
     AnyJsxAttribute, JsLanguage, JsxAttribute, JsxAttributeList, JsxOpeningElement,
     JsxSelfClosingElement,
 };
-use biome_rowan::{AstNode, AstNodeExt, BatchMutationExt, SyntaxToken};
+use biome_rowan::{AstNode, AstNodeExt, AstNodeListExt, BatchMutationExt, SyntaxToken};
 use biome_rule_options::use_sorted_attributes::{SortOrder, UseSortedAttributesOptions};
 
 use crate::JsRuleAction;
@@ -83,8 +83,8 @@ declare_source_rule! {
 
 impl Rule for UseSortedAttributes {
     type Query = Ast<JsxAttributeList>;
-    type State = AttributeGroup<SortableJsxAttribute>;
-    type Signals = Box<[Self::State]>;
+    type State = Box<[AttributeGroup<SortableJsxAttribute>]>;
+    type Signals = Option<Self::State>;
     type Options = UseSortedAttributesOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -104,10 +104,12 @@ impl Rule for UseSortedAttributes {
             comparator(a, b) != Ordering::Greater
         };
 
-        for prop in props {
+        for (index, prop) in props.into_iter().enumerate() {
             match prop {
                 AnyJsxAttribute::JsxAttribute(attr) => {
-                    current_prop_group.attrs.push(SortableJsxAttribute(attr));
+                    current_prop_group
+                        .attrs
+                        .push(SortableJsxAttribute { attr, index });
                 }
                 // spread or shorthand attribute resets sort order: it carries
                 // an opaque expression that may have side effects on the
@@ -131,7 +133,7 @@ impl Rule for UseSortedAttributes {
         if !current_prop_group.is_empty() && !current_prop_group.is_sorted(boolean_comparator) {
             prop_groups.push(current_prop_group);
         }
-        prop_groups.into_boxed_slice()
+        (!prop_groups.is_empty()).then(|| prop_groups.into_boxed_slice())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
@@ -153,7 +155,8 @@ impl Rule for UseSortedAttributes {
     }
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
-        let mut mutation = ctx.root().begin();
+        let list = ctx.query();
+        let mut attrs: Vec<_> = list.into_iter().collect();
         let options = ctx.options();
         let sort_by = options.sort_order.unwrap_or_default();
 
@@ -162,11 +165,22 @@ impl Rule for UseSortedAttributes {
             SortOrder::Lexicographic => SortableJsxAttribute::lexicographic_cmp,
         };
 
-        for (SortableJsxAttribute(attr), SortableJsxAttribute(sorted_attr)) in
-            zip(state.attrs.iter(), state.get_sorted_attributes(comparator)?)
-        {
-            mutation.replace_node_discard_trivia(attr.clone(), sorted_attr);
+        for group in state {
+            for (current_attr, sorted_attr) in zip(
+                group.attrs.iter(),
+                group.get_sorted_attributes(comparator)?,
+            ) {
+                *attrs.get_mut(current_attr.index)? =
+                    AnyJsxAttribute::JsxAttribute(sorted_attr.attr);
+            }
         }
+
+        // Replace the complete list as a single mutation. Attribute values can
+        // contain JSX with their own list mutations, so replacing individual
+        // attributes would make the parent and nested mutations overlap.
+        let new_list = list.clone().splice(0..attrs.len(), attrs);
+        let mut mutation = ctx.root().begin();
+        mutation.replace_node_discard_trivia(list.clone(), new_list);
 
         Some(RuleAction::new(
             rule_action_category!(),
@@ -178,17 +192,20 @@ impl Rule for UseSortedAttributes {
 }
 
 #[derive(PartialEq, Eq, Clone)]
-pub struct SortableJsxAttribute(JsxAttribute);
+pub struct SortableJsxAttribute {
+    attr: JsxAttribute,
+    index: usize,
+}
 
 impl SortableAttribute for SortableJsxAttribute {
     type Language = JsLanguage;
 
     fn name(&self) -> Option<SyntaxToken<Self::Language>> {
-        self.0.name().ok()?.name_token().ok()
+        self.attr.name().ok()?.name_token().ok()
     }
 
     fn node(&self) -> &impl AstNode<Language = Self::Language> {
-        &self.0
+        &self.attr
     }
 
     fn replace_token(
@@ -199,9 +216,11 @@ impl SortableAttribute for SortableJsxAttribute {
     where
         Self: Sized,
     {
-        Some(Self(
-            self.0
+        Some(Self {
+            attr: self
+                .attr
                 .replace_token_discard_trivia(prev_token, next_token)?,
-        ))
+            index: self.index,
+        })
     }
 }

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/unsorted.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/unsorted.jsx.snap
@@ -69,31 +69,7 @@ unsorted.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━�
      3  3 │   	firstName="John"
      4  4 │   />;
      5    │ - <Hello·tel={5555555}·address="NY"·{...this.props}·lastName="Smith"·firstName="John"·/>;
-        5 │ + <Hello·tel={5555555}·address="NY"·{...this.props}·firstName="John"·lastName="Smith"·/>;
-     6  6 │   <Hello a10="" a9="" A="" />;
-     7  7 │   
-  
-
-```
-
-```
-unsorted.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i The attributes are not sorted. 
-  
-    3 │ 	firstName="John"
-    4 │ />;
-  > 5 │ <Hello tel={5555555} address="NY" {...this.props} lastName="Smith" firstName="John" />;
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    6 │ <Hello a10="" a9="" A="" />;
-    7 │ 
-  
-  i Safe fix: Sort the JSX props.
-  
-     3  3 │   	firstName="John"
-     4  4 │   />;
-     5    │ - <Hello·tel={5555555}·address="NY"·{...this.props}·lastName="Smith"·firstName="John"·/>;
-        5 │ + <Hello·address="NY"·tel={5555555}·{...this.props}·lastName="Smith"·firstName="John"·/>;
+        5 │ + <Hello·address="NY"·tel={5555555}·{...this.props}·firstName="John"·lastName="Smith"·/>;
      6  6 │   <Hello a10="" a9="" A="" />;
      7  7 │   
   

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/with-comments.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/with-comments.jsx.snap
@@ -39,45 +39,17 @@ with-comments.jsx:1:1 assist/source/useSortedAttributes  FIXABLE  ━━━━�
   
      1  1 │   <Hello
      2    │ - → //·Simple·comment
-     3    │ - → tel={5555555}
-     4    │ - → address="NY"
         2 │ + → address="NY"
         3 │ + → //·Simple·comment
-        4 │ + → tel={5555555}
-     5  5 │     {...this.props}
-     6  6 │     // Another simple comment
-  
-
-```
-
-```
-with-comments.jsx:1:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i The attributes are not sorted. 
-  
-   > 1 │ <Hello
-       │ ^^^^^^
-   > 2 │ 	// Simple comment
-   > 3 │ 	tel={5555555}
-   > 4 │ 	address="NY"
-   > 5 │ 	{...this.props}
-   > 6 │ 	// Another simple comment
-   > 7 │ 	lastName="Smith"
-   > 8 │ 	firstName="John" // Inline comment
-   > 9 │ />
-       │ ^^
-    10 │ 
-  
-  i Safe fix: Sort the JSX props.
-  
-     4  4 │     address="NY"
-     5  5 │     {...this.props}
+     3  4 │     tel={5555555}
+     4    │ - → address="NY"
+     5    │ - → {...this.props}
      6    │ - → //·Another·simple·comment
-     7    │ - → lastName="Smith"
-     8    │ - → firstName="John"·//·Inline·comment
+        5 │ + → {...this.props}
         6 │ + → firstName="John"·//·Inline·comment
         7 │ + → //·Another·simple·comment
-        8 │ + → lastName="Smith"
+     7  8 │     lastName="Smith"
+     8    │ - → firstName="John"·//·Inline·comment
      9  9 │   />
     10 10 │   
   


### PR DESCRIPTION
## Summary

Fixes #10838.

[`useSortedAttributes`](https://biomejs.dev/assist/actions/use-sorted-attributes/) no longer duplicates or drops attributes when sorting nested JSX.

## Test Plan

- `cargo test -p biome_cli --test main cases::assist`: 5 passed.
- Analyzer `use_sorted_attributes` specs: 8 passed.
- `cargo fmt --all -- --check`
- `git diff --check`

## Docs

Not applicable.
