### PR TITLE
fix(html_analyze): account for shorthand attributes when computing implicit ARIA roles

### DIFF
--- a/.changeset/fix-aria-role-shorthand-attributes.md
+++ b/.changeset/fix-aria-role-shorthand-attributes.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10980](https://github.com/biomejs/biome/issues/10980): [`useAriaPropsSupportedByRole`](https://biomejs.dev/linter/rules/use-aria-props-supported-by-role/) no longer reports false positives when the attribute that determines an element's implicit ARIA role is written as a shorthand attribute, such as `<a {href} aria-label="...">` in Astro and Svelte files.
+
+Shorthand attributes are now taken into account when computing the implicit role, so the anchor above correctly resolves to the `link` role instead of `generic`.

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/astro/valid.astro
@@ -1,4 +1,6 @@
 <!-- should not generate diagnostics -->
+<span role={roleValue}></span>
+<span {role}></span>
 <span role="checkbox" aria-checked="true"></span>
 <span role="combobox" aria-controls="true" aria-expanded="true"></span>
 <span role="heading" aria-level="1"></span>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/astro/valid.astro.snap
@@ -5,6 +5,8 @@ expression: valid.astro
 # Input
 ```astro
 <!-- should not generate diagnostics -->
+<span role={roleValue}></span>
+<span {role}></span>
 <span role="checkbox" aria-checked="true"></span>
 <span role="combobox" aria-controls="true" aria-expanded="true"></span>
 <span role="heading" aria-level="1"></span>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/svelte/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/svelte/valid.svelte
@@ -1,4 +1,6 @@
 <!-- should not generate diagnostics -->
+<span role={roleValue}></span>
+<span {role}></span>
 <span role="checkbox" aria-checked="true"></span>
 <span role="combobox" aria-controls="true" aria-expanded="true"></span>
 <span role="heading" aria-level="1"></span>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/svelte/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/svelte/valid.svelte.snap
@@ -5,6 +5,8 @@ expression: valid.svelte
 # Input
 ```svelte
 <!-- should not generate diagnostics -->
+<span role={roleValue}></span>
+<span {role}></span>
 <span role="checkbox" aria-checked="true"></span>
 <span role="combobox" aria-controls="true" aria-expanded="true"></span>
 <span role="heading" aria-level="1"></span>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/vue/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/vue/valid.vue
@@ -1,5 +1,6 @@
 <!-- should not generate diagnostics: Vue v-bind shorthand (:aria-*) bindings satisfy required aria props -->
 <template>
+	<span :role="roleValue"></span>
 	<span role="checkbox" :aria-checked="isChecked"></span>
 	<span role="radio" :aria-checked="true"></span>
 	<span role="switch" :aria-checked="dynamicValue"></span>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/vue/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsForRole/vue/valid.vue.snap
@@ -6,6 +6,7 @@ expression: valid.vue
 ```vue
 <!-- should not generate diagnostics: Vue v-bind shorthand (:aria-*) bindings satisfy required aria props -->
 <template>
+	<span :role="roleValue"></span>
 	<span role="checkbox" :aria-checked="isChecked"></span>
 	<span role="radio" :aria-checked="true"></span>
 	<span role="switch" :aria-checked="dynamicValue"></span>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsSupportedByRole/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsSupportedByRole/astro/valid.astro
@@ -94,3 +94,4 @@
 <select aria-expanded="true"></select>
 <div role="heading" aria-level></div>
 <div role="heading" aria-level="1"></div>
+<a {href} aria-label="label"></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsSupportedByRole/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsSupportedByRole/astro/valid.astro.snap
@@ -100,5 +100,6 @@ expression: valid.astro
 <select aria-expanded="true"></select>
 <div role="heading" aria-level></div>
 <div role="heading" aria-level="1"></div>
+<a {href} aria-label="label"></a>
 
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsSupportedByRole/svelte/valid.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsSupportedByRole/svelte/valid.svelte
@@ -94,3 +94,4 @@
 <select aria-expanded="true" />
 <div role="heading" aria-level />
 <div role="heading" aria-level="1" />
+<a {href} aria-label="label"></a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsSupportedByRole/svelte/valid.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useAriaPropsSupportedByRole/svelte/valid.svelte.snap
@@ -100,5 +100,6 @@ expression: valid.svelte
 <select aria-expanded="true" />
 <div role="heading" aria-level />
 <div role="heading" aria-level="1" />
+<a {href} aria-label="label"></a>
 
 ```

--- a/crates/biome_html_syntax/src/attribute_ext.rs
+++ b/crates/biome_html_syntax/src/attribute_ext.rs
@@ -100,7 +100,16 @@ impl HtmlAttributeName {
 
 impl Attribute for AnyHtmlAttribute {
     fn name(&self) -> Option<impl AsRef<str>> {
-        self.name()
+        match self {
+            // Shorthand attributes like `{href}` use the expression text as the attribute name.
+            Self::HtmlAttributeSingleTextExpression(expr) => expr
+                .expression()
+                .ok()?
+                .html_literal_token()
+                .ok()
+                .map(|token| token.token_text_trimmed()),
+            _ => self.name(),
+        }
     }
 
     fn value(&self) -> Option<impl AsRef<str>> {

--- a/crates/biome_html_syntax/src/attribute_ext.rs
+++ b/crates/biome_html_syntax/src/attribute_ext.rs
@@ -100,16 +100,7 @@ impl HtmlAttributeName {
 
 impl Attribute for AnyHtmlAttribute {
     fn name(&self) -> Option<impl AsRef<str>> {
-        match self {
-            // Shorthand attributes like `{href}` use the expression text as the attribute name.
-            Self::HtmlAttributeSingleTextExpression(expr) => expr
-                .expression()
-                .ok()?
-                .html_literal_token()
-                .ok()
-                .map(|token| token.token_text_trimmed()),
-            _ => self.name(),
-        }
+        self.name()
     }
 
     fn value(&self) -> Option<impl AsRef<str>> {
@@ -121,6 +112,11 @@ impl AnyHtmlAttribute {
     pub fn name(&self) -> Option<TokenText> {
         match self {
             Self::HtmlAttribute(attr) => attr.name().ok()?.token_text_trimmed(),
+            Self::HtmlAttributeSingleTextExpression(attr) => attr
+                .expression()
+                .ok()
+                .and_then(|expr| expr.html_literal_token().ok())
+                .map(|html_literal| html_literal.token_text_trimmed()),
             Self::AnyVueDirective(vue) => match vue {
                 // :attr="..." — shorthand Vue binding
                 AnyVueDirective::VueVBindShorthandDirective(d) => d

--- a/crates/biome_html_syntax/src/element_ext.rs
+++ b/crates/biome_html_syntax/src/element_ext.rs
@@ -630,7 +630,9 @@ impl biome_aria::Element for AnyHtmlTagElement {
         Self::attributes(self).into_iter().filter(|attr| {
             matches!(
                 attr,
-                AnyHtmlAttribute::HtmlAttribute(_) | AnyHtmlAttribute::AnyVueDirective(_)
+                AnyHtmlAttribute::HtmlAttribute(_)
+                    | AnyHtmlAttribute::AnyVueDirective(_)
+                    | AnyHtmlAttribute::HtmlAttributeSingleTextExpression(_)
             )
         })
     }


### PR DESCRIPTION
## Summary

Fixes #10980. `useAriaPropsSupportedByRole` flagged `aria-label` on `<a {href} ...>` in Astro files, and the same thing happens in Svelte. The ARIA helpers never saw shorthand attributes: the `biome_aria::Element` impl for `AnyHtmlTagElement` filters the attribute list down to plain attributes and Vue bindings, so `get_implicit_role` thought the anchor had no `href`, resolved it to `generic`, and `generic` prohibits `aria-label`.

Shorthand attributes now pass through that filter and expose their expression text as the attribute name (with no static value, since the value is dynamic at runtime), so `<a {href}>` correctly resolves to the `link` role.

## Test Plan

Added `<a {href} aria-label="label"></a>` to the astro and svelte valid fixtures for the rule. Both produced the false positive before the change and are clean after. Full `cargo test --workspace --features=js_plugin` and `cargo lint` pass locally, and no other snapshots changed, so the wider ARIA consumers (implicit roles are also used by `noRedundantRoles`, interactivity checks, etc.) keep their current behavior except now seeing shorthand attributes as present.

## Docs

N/A

---

Honesty note: I used Claude Code to help trace where the attribute filtering happens and to double check the blast radius of the change. The final diff is small but I read through `element_ext.rs` and the aria trait impls myself to make sure I actually understood it. I'm a college freshman still getting comfortable with Rust, so if widening that filter has side effects I missed, I'd genuinely love to learn about them :)
