### PR TITLE
fix(useSortedAttributes): replace whole attribute list to avoid batch conflicts with nested JSX

### DIFF
--- a/.changeset/dark-pianos-eat.md
+++ b/.changeset/dark-pianos-eat.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10838](https://github.com/biomejs/biome/issues/10838): [`useSortedAttributes`](https://biomejs.dev/assist/actions/use-sorted-attributes/) no longer produces corrupted output when a JSX element nested inside an attribute value also has unsorted attributes.

--- a/crates/biome_cli/tests/cases/assist.rs
+++ b/crates/biome_cli/tests/cases/assist.rs
@@ -137,6 +137,62 @@ fn assist_emit_diagnostic_and_blocks_ci() {
     ));
 }
 
+/// Regression test for https://github.com/biomejs/biome/issues/10838
+///
+/// When the outer element and a JSX element nested inside one of its
+/// attribute values both need sorting, applying both fixes in the same
+/// `check --write` pass must not duplicate or drop attributes.
+#[test]
+fn assist_use_sorted_attributes_nested_jsx() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let config = Utf8Path::new("biome.json");
+    fs.insert(
+        config.into(),
+        r#"{
+            "assist": {
+                "enabled": true,
+                "actions": {
+                  "source": {
+                    "useSortedAttributes": "on"
+                  }
+                }
+            },
+            "formatter": { "enabled": false },
+            "linter": { "enabled": false }
+        }"#
+        .as_bytes(),
+    );
+    let file = Utf8Path::new("file.jsx");
+    fs.insert(
+        file.into(),
+        r#"export const A = <Outer z="x" a={<Inner z={1} a={2} />} />;"#.as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--write", file.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(
+        &fs,
+        file,
+        r#"export const A = <Outer a={<Inner a={2} z={1} />} z="x" />;"#,
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "assist_use_sorted_attributes_nested_jsx",
+        fs,
+        console,
+        result,
+    ));
+}
+
 #[test]
 fn assist_writes() {
     let fs = MemoryFileSystem::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_assist/assist_use_sorted_attributes_nested_jsx.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_assist/assist_use_sorted_attributes_nested_jsx.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "useSortedAttributes": "on"
+      }
+    }
+  },
+  "formatter": { "enabled": false },
+  "linter": { "enabled": false }
+}
+```
+
+## `file.jsx`
+
+```jsx
+export const A = <Outer a={<Inner a={2} z={1} />} z="x" />;
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_js_analyze/src/assist/source/use_sorted_attributes.rs
+++ b/crates/biome_js_analyze/src/assist/source/use_sorted_attributes.rs
@@ -12,7 +12,9 @@ use biome_js_syntax::{
     AnyJsxAttribute, JsLanguage, JsxAttribute, JsxAttributeList, JsxOpeningElement,
     JsxSelfClosingElement,
 };
-use biome_rowan::{AstNode, AstNodeExt, BatchMutationExt, SyntaxToken};
+use biome_rowan::{
+    AstNode, AstNodeExt, AstNodeList, AstNodeListExt, BatchMutationExt, SyntaxToken,
+};
 use biome_rule_options::use_sorted_attributes::{SortOrder, UseSortedAttributesOptions};
 
 use crate::JsRuleAction;
@@ -83,8 +85,8 @@ declare_source_rule! {
 
 impl Rule for UseSortedAttributes {
     type Query = Ast<JsxAttributeList>;
-    type State = AttributeGroup<SortableJsxAttribute>;
-    type Signals = Box<[Self::State]>;
+    type State = UnsortedAttributeGroups;
+    type Signals = Option<Self::State>;
     type Options = UseSortedAttributesOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -131,7 +133,11 @@ impl Rule for UseSortedAttributes {
         if !current_prop_group.is_empty() && !current_prop_group.is_sorted(boolean_comparator) {
             prop_groups.push(current_prop_group);
         }
-        prop_groups.into_boxed_slice()
+        if !prop_groups.is_empty() {
+            Some(UnsortedAttributeGroups(prop_groups))
+        } else {
+            None
+        }
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
@@ -153,7 +159,7 @@ impl Rule for UseSortedAttributes {
     }
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
-        let mut mutation = ctx.root().begin();
+        let list = ctx.query();
         let options = ctx.options();
         let sort_by = options.sort_order.unwrap_or_default();
 
@@ -162,11 +168,26 @@ impl Rule for UseSortedAttributes {
             SortOrder::Lexicographic => SortableJsxAttribute::lexicographic_cmp,
         };
 
-        for (SortableJsxAttribute(attr), SortableJsxAttribute(sorted_attr)) in
-            zip(state.attrs.iter(), state.get_sorted_attributes(comparator)?)
-        {
-            mutation.replace_node_discard_trivia(attr.clone(), sorted_attr);
+        // Build the sorted attribute list once and register a single
+        // list-level replacement. Replacing attributes slot by slot conflicts
+        // during batch commit with mutations propagated up from nested JSX
+        // elements whose own attributes are sorted in the same fix pass,
+        // duplicating one attribute and dropping another (issues #9884 and
+        // #10838).
+        let mut new_attrs: Vec<AnyJsxAttribute> = list.iter().collect();
+        for group in &state.0 {
+            for (SortableJsxAttribute(attr), SortableJsxAttribute(sorted_attr)) in
+                zip(group.attrs.iter(), group.get_sorted_attributes(comparator)?)
+            {
+                new_attrs[attr.syntax().index()] = sorted_attr.into();
+            }
         }
+
+        let range = 0..new_attrs.len();
+        let new_list = list.clone().splice(range, new_attrs);
+
+        let mut mutation = ctx.root().begin();
+        mutation.replace_node_discard_trivia(list.clone(), new_list);
 
         Some(RuleAction::new(
             rule_action_category!(),
@@ -176,6 +197,11 @@ impl Rule for UseSortedAttributes {
         ))
     }
 }
+
+/// All the unsorted attribute groups of a single [JsxAttributeList], so that
+/// the whole list can be sorted with a single action.
+#[derive(Clone)]
+pub struct UnsortedAttributeGroups(Vec<AttributeGroup<SortableJsxAttribute>>);
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct SortableJsxAttribute(JsxAttribute);

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/unsorted.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/unsorted.jsx.snap
@@ -69,31 +69,7 @@ unsorted.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━�
      3  3 │   	firstName="John"
      4  4 │   />;
      5    │ - <Hello·tel={5555555}·address="NY"·{...this.props}·lastName="Smith"·firstName="John"·/>;
-        5 │ + <Hello·tel={5555555}·address="NY"·{...this.props}·firstName="John"·lastName="Smith"·/>;
-     6  6 │   <Hello a10="" a9="" A="" />;
-     7  7 │   
-  
-
-```
-
-```
-unsorted.jsx:5:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i The attributes are not sorted. 
-  
-    3 │ 	firstName="John"
-    4 │ />;
-  > 5 │ <Hello tel={5555555} address="NY" {...this.props} lastName="Smith" firstName="John" />;
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    6 │ <Hello a10="" a9="" A="" />;
-    7 │ 
-  
-  i Safe fix: Sort the JSX props.
-  
-     3  3 │   	firstName="John"
-     4  4 │   />;
-     5    │ - <Hello·tel={5555555}·address="NY"·{...this.props}·lastName="Smith"·firstName="John"·/>;
-        5 │ + <Hello·address="NY"·tel={5555555}·{...this.props}·lastName="Smith"·firstName="John"·/>;
+        5 │ + <Hello·address="NY"·tel={5555555}·{...this.props}·firstName="John"·lastName="Smith"·/>;
      6  6 │   <Hello a10="" a9="" A="" />;
      7  7 │   
   

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/with-comments.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/with-comments.jsx.snap
@@ -39,45 +39,17 @@ with-comments.jsx:1:1 assist/source/useSortedAttributes  FIXABLE  ━━━━�
   
      1  1 │   <Hello
      2    │ - → //·Simple·comment
-     3    │ - → tel={5555555}
-     4    │ - → address="NY"
         2 │ + → address="NY"
         3 │ + → //·Simple·comment
-        4 │ + → tel={5555555}
-     5  5 │     {...this.props}
-     6  6 │     // Another simple comment
-  
-
-```
-
-```
-with-comments.jsx:1:1 assist/source/useSortedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i The attributes are not sorted. 
-  
-   > 1 │ <Hello
-       │ ^^^^^^
-   > 2 │ 	// Simple comment
-   > 3 │ 	tel={5555555}
-   > 4 │ 	address="NY"
-   > 5 │ 	{...this.props}
-   > 6 │ 	// Another simple comment
-   > 7 │ 	lastName="Smith"
-   > 8 │ 	firstName="John" // Inline comment
-   > 9 │ />
-       │ ^^
-    10 │ 
-  
-  i Safe fix: Sort the JSX props.
-  
-     4  4 │     address="NY"
-     5  5 │     {...this.props}
+     3  4 │     tel={5555555}
+     4    │ - → address="NY"
+     5    │ - → {...this.props}
      6    │ - → //·Another·simple·comment
-     7    │ - → lastName="Smith"
-     8    │ - → firstName="John"·//·Inline·comment
+        5 │ + → {...this.props}
         6 │ + → firstName="John"·//·Inline·comment
         7 │ + → //·Another·simple·comment
-        8 │ + → lastName="Smith"
+     7  8 │     lastName="Smith"
+     8    │ - → firstName="John"·//·Inline·comment
      9  9 │   />
     10 10 │   
   


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

the clanker described the regression as this:

> Root cause of the regression: the merge of main into next (commit 963a0c5487, shipped in 2.5.0) resolved `use_sorted_attributes.rs` in favor of next's rewrite on the shared `sort_attributes` infrastructure — silently dropping the #10163 fix. The rewrite went back to replacing attributes slot-by-slot with `replace_node_discard_trivia`. Since `ProcessFixAll::process_batch_actions` merges all mutations from the same rule into one BatchMutation, the outer element's slot-level swaps collide at commit time with the nested element's mutations propagating up through the same subtree — exactly the #9884 mechanism. The spec snapshots never caught it because they render each action's diff in isolation.

generated with fable 5

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #10838

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added a regression test

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
