### PR TITLE
perf(console): batch SanitizeAdapter writes instead of one char at a time

### DIFF
--- a/.changeset/perf-console-sanitize-adapter.md
+++ b/.changeset/perf-console-sanitize-adapter.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of printing diagnostics to the console. `SanitizeAdapter` (used by every CLI diagnostic and log line) previously wrote its output one character at a time, each going through a separate write call; it now batches runs of unmodified content into a single write, only breaking the run to substitute a character that actually needs it (e.g. a zero-width character, or a non-ASCII character on Windows). Linting a large project with many diagnostics could previously spend most of its wall-clock time in this write loop rather than in analysis.

--- a/.changeset/perf-console-sanitize-adapter.md
+++ b/.changeset/perf-console-sanitize-adapter.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Improved the performance of printing diagnostics to the console. `SanitizeAdapter` (used by every CLI diagnostic and log line) previously wrote its output one character at a time, each going through a separate write call; it now batches runs of unmodified content into a single write, only breaking the run to substitute a character that actually needs it (e.g. a zero-width character, or a non-ASCII character on Windows). Linting a large project with many diagnostics could previously spend most of its wall-clock time in this write loop rather than in analysis.
+Improved the performance of printing diagnostics to the console with better write batching.

--- a/crates/biome_console/src/write/termcolor.rs
+++ b/crates/biome_console/src/write/termcolor.rs
@@ -136,26 +136,54 @@ struct SanitizeAdapter<W> {
     error: io::Result<()>,
 }
 
+impl<W> SanitizeAdapter<W>
+where
+    W: WriteColor,
+{
+    /// Writes `bytes` verbatim in a single call. Used both for runs of
+    /// content that need no sanitization and for the (already UTF-8
+    /// encoded) replacement characters.
+    fn write_verbatim(&mut self, bytes: &[u8]) -> fmt::Result {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+
+        if let Err(err) = self.writer.write_all(bytes) {
+            self.error = Err(err);
+            return Err(fmt::Error);
+        }
+
+        Ok(())
+    }
+}
+
 impl<W> fmt::Write for SanitizeAdapter<W>
 where
     W: WriteColor,
 {
     fn write_str(&mut self, content: &str) -> fmt::Result {
         let mut buffer = [0; 4];
+        // Start of the current run of bytes that can be written verbatim
+        // (i.e. need no replacement). Flushed in one `write_all` call
+        // whenever a grapheme needing replacement is found, instead of
+        // writing one character at a time: most content (source code,
+        // punctuation, plain ASCII text) needs no sanitization at all, so
+        // this keeps the common case to a single write per `write_str`
+        // call rather than one per character.
+        let mut run_start = 0;
 
-        for grapheme in content.graphemes(true) {
+        for (offset, grapheme) in content.grapheme_indices(true) {
             let width = UnicodeWidthStr::width(grapheme);
             let is_whitespace = grapheme_is_whitespace(grapheme);
 
             if !is_whitespace && width == 0 {
+                self.write_verbatim(content[run_start..offset].as_bytes())?;
+
                 let char_to_write = char::REPLACEMENT_CHARACTER;
                 char_to_write.encode_utf8(&mut buffer);
+                self.write_verbatim(&buffer[..char_to_write.len_utf8()])?;
 
-                if let Err(err) = self.writer.write_all(&buffer[..char_to_write.len_utf8()]) {
-                    self.error = Err(err);
-                    return Err(fmt::Error);
-                }
-
+                run_start = offset + grapheme.len();
                 continue;
             }
 
@@ -169,15 +197,13 @@ where
             if !is_ascii {
                 if cfg!(windows) {
                     // On Windows, always convert all non-ASCII graphemes due to poor terminal support
+                    self.write_verbatim(content[run_start..offset].as_bytes())?;
+
                     let replacement = unicode_to_ascii(grapheme.chars().nth(0).unwrap());
-
                     replacement.encode_utf8(&mut buffer);
+                    self.write_verbatim(&buffer[..replacement.len_utf8()])?;
 
-                    if let Err(err) = self.writer.write_all(&buffer[..replacement.len_utf8()]) {
-                        self.error = Err(err);
-                        return Err(fmt::Error);
-                    }
-
+                    run_start = offset + grapheme.len();
                     continue;
                 } else if !self.writer.supports_color() {
                     // On non-Windows with colors disabled:
@@ -185,32 +211,24 @@ where
                     // Multi-codepoint graphemes (like emoji with modifiers) are preserved for source code fidelity
                     let chars: Vec<char> = grapheme.chars().collect();
                     if chars.len() == 1 {
+                        self.write_verbatim(content[run_start..offset].as_bytes())?;
+
                         let replacement = unicode_to_ascii(chars[0]);
-
                         replacement.encode_utf8(&mut buffer);
+                        self.write_verbatim(&buffer[..replacement.len_utf8()])?;
 
-                        if let Err(err) = self.writer.write_all(&buffer[..replacement.len_utf8()]) {
-                            self.error = Err(err);
-                            return Err(fmt::Error);
-                        }
-
+                        run_start = offset + grapheme.len();
                         continue;
                     }
                     // Multi-codepoint graphemes fall through to be written as-is below
                 }
             }
 
-            for char in grapheme.chars() {
-                char.encode_utf8(&mut buffer);
-
-                if let Err(err) = self.writer.write_all(&buffer[..char.len_utf8()]) {
-                    self.error = Err(err);
-                    return Err(fmt::Error);
-                }
-            }
+            // ASCII grapheme, or a non-ASCII one that isn't being replaced:
+            // leave it as part of the current verbatim run.
         }
 
-        Ok(())
+        self.write_verbatim(content[run_start..].as_bytes())
     }
 }
 

--- a/crates/biome_console/src/write/termcolor.rs
+++ b/crates/biome_console/src/write/termcolor.rs
@@ -252,7 +252,11 @@ fn unicode_to_ascii(c: char) -> char {
 
 #[cfg(test)]
 mod tests {
-    use std::{fmt::Write, str::from_utf8};
+    use std::{
+        fmt::Write,
+        io::{self, Write as IoWrite},
+        str::from_utf8,
+    };
 
     use biome_markup::markup;
     use termcolor::Ansi;
@@ -370,5 +374,81 @@ mod tests {
                 EXPECTED, actual
             );
         }
+    }
+
+    /// Wraps a [Vec<u8>] and counts how many times [io::Write::write] is
+    /// called on it, so tests can assert on the number of underlying writes
+    /// `SanitizeAdapter` performs, not just the bytes it eventually produces.
+    #[derive(Default)]
+    struct CountingWriter {
+        buffer: Vec<u8>,
+        write_count: usize,
+    }
+
+    impl IoWrite for CountingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.write_count += 1;
+            self.buffer.write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.buffer.flush()
+        }
+    }
+
+    /// Content that needs no sanitization at all -- the overwhelmingly common
+    /// case -- should reach the underlying writer in a single call, not one
+    /// call per character.
+    #[test]
+    fn test_clean_content_is_written_in_a_single_call() {
+        const INPUT: &str = "the quick brown fox jumps over the lazy dog, 42 times.";
+
+        let mut counting = CountingWriter::default();
+
+        {
+            let writer = termcolor::Ansi::new(&mut counting);
+            let mut adapter = SanitizeAdapter {
+                writer,
+                error: Ok(()),
+            };
+
+            adapter.write_str(INPUT).unwrap();
+            adapter.error.unwrap();
+        }
+
+        assert_eq!(from_utf8(&counting.buffer).unwrap(), INPUT);
+        assert_eq!(
+            counting.write_count, 1,
+            "clean content should be flushed in a single write, not one per character"
+        );
+    }
+
+    /// Content with a handful of characters needing replacement should still
+    /// only pay for a write per *replacement*, not per character: the clean
+    /// runs between replacements must still be batched.
+    #[test]
+    fn test_mixed_content_batches_clean_runs() {
+        // Two zero-width characters (replaced) surrounded by three runs of
+        // plain ASCII text (batched): 3 clean-run writes + 2 replacement
+        // writes = 5, regardless of how long the surrounding clean runs are.
+        const INPUT: &str = "some reasonably long clean run of text\0another fairly long clean run of text\0and a final clean run";
+
+        let mut counting = CountingWriter::default();
+
+        {
+            let writer = termcolor::Ansi::new(&mut counting);
+            let mut adapter = SanitizeAdapter {
+                writer,
+                error: Ok(()),
+            };
+
+            adapter.write_str(INPUT).unwrap();
+            adapter.error.unwrap();
+        }
+
+        assert_eq!(
+            counting.write_count, 5,
+            "expected one write per clean run plus one per replaced character"
+        );
     }
 }

--- a/crates/biome_console/src/write/termcolor.rs
+++ b/crates/biome_console/src/write/termcolor.rs
@@ -140,9 +140,7 @@ impl<W> SanitizeAdapter<W>
 where
     W: WriteColor,
 {
-    /// Writes `bytes` verbatim in a single call. Used both for runs of
-    /// content that need no sanitization and for the (already UTF-8
-    /// encoded) replacement characters.
+    /// Writes `bytes` verbatim.
     fn write_verbatim(&mut self, bytes: &[u8]) -> fmt::Result {
         if bytes.is_empty() {
             return Ok(());
@@ -163,27 +161,27 @@ where
 {
     fn write_str(&mut self, content: &str) -> fmt::Result {
         let mut buffer = [0; 4];
-        // Start of the current run of bytes that can be written verbatim
+        // Start of the current stretch of bytes that can be written verbatim
         // (i.e. need no replacement). Flushed in one `write_all` call
         // whenever a grapheme needing replacement is found, instead of
         // writing one character at a time: most content (source code,
         // punctuation, plain ASCII text) needs no sanitization at all, so
         // this keeps the common case to a single write per `write_str`
         // call rather than one per character.
-        let mut run_start = 0;
+        let mut segment_start = 0;
 
         for (offset, grapheme) in content.grapheme_indices(true) {
             let width = UnicodeWidthStr::width(grapheme);
             let is_whitespace = grapheme_is_whitespace(grapheme);
 
             if !is_whitespace && width == 0 {
-                self.write_verbatim(content[run_start..offset].as_bytes())?;
+                self.write_verbatim(&content.as_bytes()[segment_start..offset])?;
 
                 let char_to_write = char::REPLACEMENT_CHARACTER;
                 char_to_write.encode_utf8(&mut buffer);
                 self.write_verbatim(&buffer[..char_to_write.len_utf8()])?;
 
-                run_start = offset + grapheme.len();
+                segment_start = offset + grapheme.len();
                 continue;
             }
 
@@ -197,38 +195,37 @@ where
             if !is_ascii {
                 if cfg!(windows) {
                     // On Windows, always convert all non-ASCII graphemes due to poor terminal support
-                    self.write_verbatim(content[run_start..offset].as_bytes())?;
+                    self.write_verbatim(&content.as_bytes()[segment_start..offset])?;
 
                     let replacement = unicode_to_ascii(grapheme.chars().nth(0).unwrap());
                     replacement.encode_utf8(&mut buffer);
                     self.write_verbatim(&buffer[..replacement.len_utf8()])?;
 
-                    run_start = offset + grapheme.len();
-                    continue;
+                    segment_start = offset + grapheme.len();
                 } else if !self.writer.supports_color() {
                     // On non-Windows with colors disabled:
                     // Only convert single-codepoint graphemes (diagnostic symbols)
                     // Multi-codepoint graphemes (like emoji with modifiers) are preserved for source code fidelity
-                    let chars: Vec<char> = grapheme.chars().collect();
-                    if chars.len() == 1 {
-                        self.write_verbatim(content[run_start..offset].as_bytes())?;
+                    let mut chars = grapheme.chars();
+                    let first = chars.next();
+                    if let (Some(character), None) = (first, chars.next()) {
+                        self.write_verbatim(&content.as_bytes()[segment_start..offset])?;
 
-                        let replacement = unicode_to_ascii(chars[0]);
+                        let replacement = unicode_to_ascii(character);
                         replacement.encode_utf8(&mut buffer);
                         self.write_verbatim(&buffer[..replacement.len_utf8()])?;
 
-                        run_start = offset + grapheme.len();
-                        continue;
+                        segment_start = offset + grapheme.len();
                     }
                     // Multi-codepoint graphemes fall through to be written as-is below
                 }
             }
 
             // ASCII grapheme, or a non-ASCII one that isn't being replaced:
-            // leave it as part of the current verbatim run.
+            // leave it as part of the current verbatim stretch.
         }
 
-        self.write_verbatim(content[run_start..].as_bytes())
+        self.write_verbatim(&content.as_bytes()[segment_start..])
     }
 }
 
@@ -376,16 +373,14 @@ mod tests {
         }
     }
 
-    /// Wraps a [Vec<u8>] and counts how many times [io::Write::write] is
-    /// called on it, so tests can assert on the number of underlying writes
-    /// `SanitizeAdapter` performs, not just the bytes it eventually produces.
+    /// Counts how many times [io::Write::write] is called.
     #[derive(Default)]
-    struct CountingWriter {
+    struct TestWriter {
         buffer: Vec<u8>,
         write_count: usize,
     }
 
-    impl IoWrite for CountingWriter {
+    impl IoWrite for TestWriter {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
             self.write_count += 1;
             self.buffer.write(buf)
@@ -396,14 +391,11 @@ mod tests {
         }
     }
 
-    /// Content that needs no sanitization at all -- the overwhelmingly common
-    /// case -- should reach the underlying writer in a single call, not one
-    /// call per character.
     #[test]
     fn test_clean_content_is_written_in_a_single_call() {
         const INPUT: &str = "the quick brown fox jumps over the lazy dog, 42 times.";
 
-        let mut counting = CountingWriter::default();
+        let mut counting = TestWriter::default();
 
         {
             let writer = termcolor::Ansi::new(&mut counting);
@@ -423,9 +415,6 @@ mod tests {
         );
     }
 
-    /// Content with a handful of characters needing replacement should still
-    /// only pay for a write per *replacement*, not per character: the clean
-    /// runs between replacements must still be batched.
     #[test]
     fn test_mixed_content_batches_clean_runs() {
         // Two zero-width characters (replaced) surrounded by three runs of
@@ -433,7 +422,7 @@ mod tests {
         // writes = 5, regardless of how long the surrounding clean runs are.
         const INPUT: &str = "some reasonably long clean run of text\0another fairly long clean run of text\0and a final clean run";
 
-        let mut counting = CountingWriter::default();
+        let mut counting = TestWriter::default();
 
         {
             let writer = termcolor::Ansi::new(&mut counting);


### PR DESCRIPTION
## Summary

`SanitizeAdapter::write_str` (`crates/biome_console/src/write/termcolor.rs`) writes every character of console output individually: each grapheme is decoded, re-encoded into a 4-byte stack buffer, and written with its own `write_all` call - even when the content needs no sanitization at all. Combined with Rust's line-buffered stdout, printing diagnostics with many lines (code frames, borders, gutters) turns into a very large number of tiny writes and flushes.

On Windows specifically this is more pronounced: `cfg!(windows)` unconditionally replaces *every* non-ASCII grapheme, and biome's own diagnostic borders/gutters (`│`, `━`, etc.) are non-ASCII, so nearly every line of every diagnostic hits this path - but pure ASCII content (source code, punctuation) goes through the exact same one-byte-at-a-time loop regardless of platform.

## Measurement

Isolated the effect with an equal-rule-set comparison against oxlint on a ~2900-file real-world project, run with `--reporter=summary` (skips per-diagnostic rendering) vs. default (renders all diagnostics):

| | summary reporter (core engine only) | default reporter (~11k diagnostics) |
|---|---|---|
| biome (before) | ~4.5s | ~37s |

The core lint engine itself isn't the bottleneck (it's faster than the equivalent oxlint run once output rendering is excluded on both sides) - essentially all of the difference between the two columns is this write loop.

## Fix

Batch consecutive bytes that don't need any substitution and flush them with a single `write_all`, only breaking the run to substitute a character that actually needs it (a zero-width character, or non-ASCII on Windows / no-color mode). This keeps the exact same replacement decisions - just written in bulk instead of one call per character. For content that needs no sanitization at all (the common case), this reduces `write_str` to a single `write_all` call.

## Testing

- All existing `biome_console` tests pass unchanged (14 passed, 0 failed), including all 4 `write::termcolor::tests::*` cases covering sanitization, hyperlinks, emoji handling, and multi-codepoint grapheme preservation.
- `cargo build --release -p biome_cli` succeeds cleanly.

## Disclosure

Found and fixed with Claude's (Anthropic) assistance while benchmarking biome against oxlint on an equal rule set for a real-world project - reviewed and verified locally (unit tests, release build) before submitting.