### PR TITLE
perf(nursery/noMisusedPromises): skip type inference for irrelevant expressions

### DIFF
--- a/.changeset/perf-no-misused-promises.md
+++ b/.changeset/perf-no-misused-promises.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Improved the performance of [`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/). The rule queries every expression in a file, then ran full type inference on each one before checking whether it was even in a syntactic position the rule cares about (a conditional/loop test, a spread element, or a call/new argument). That cheap, purely syntactic check now runs first, skipping type inference entirely for expressions that cannot match regardless of their type. On a large real-world project, this rule alone accounted for the majority of total lint time; with this change its own cost dropped roughly 4-5x, with no change in reported diagnostics.
+Improved the performance of [`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/) by skipping type inference for expressions that can't trigger the rule.

--- a/.changeset/perf-no-misused-promises.md
+++ b/.changeset/perf-no-misused-promises.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of [`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/). The rule queries every expression in a file, then ran full type inference on each one before checking whether it was even in a syntactic position the rule cares about (a conditional/loop test, a spread element, or a call/new argument). That cheap, purely syntactic check now runs first, skipping type inference entirely for expressions that cannot match regardless of their type. On a large real-world project, this rule alone accounted for the majority of total lint time; with this change its own cost dropped roughly 4-5x, with no change in reported diagnostics.

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -108,6 +108,20 @@ impl Rule for NoMisusedPromises {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let expression = ctx.query();
+
+        // Both branches below only ever produce a signal when `expression`
+        // sits in one of a handful of specific syntactic positions (a
+        // conditional/loop test, a spread element, or a call/new argument)
+        // -- see `is_relevant_position`, which mirrors their syntactic
+        // preconditions exactly. Checking that first avoids running type
+        // inference -- comparatively expensive, and previously run
+        // unconditionally for every expression in the file -- on the vast
+        // majority of a typical file's expressions, which cannot match
+        // regardless of their type.
+        if !is_relevant_position(expression) {
+            return None;
+        }
+
         let ty = ctx.inferred_type_of_expression(expression)?;
         if ty.is_function() {
             find_misused_promise_returning_callback(ctx, expression, ty)
@@ -208,6 +222,66 @@ impl Rule for NoMisusedPromises {
             mutation,
         ))
     }
+}
+
+/// Cheap syntactic pre-check for [NoMisusedPromises]: only expressions in
+/// one of these positions can possibly trigger the rule, regardless of
+/// their inferred type. Mirrors the parent-kind match in
+/// `find_misused_promise_expression` (for the conditional/spread case) and
+/// the full argument/call-or-new-expression chain checked by
+/// `find_misused_promise_returning_callback` (for the callback-argument
+/// case) -- *not* just its first `AnyJsCallArgument::cast` step, which by
+/// itself matches almost any nested expression (`AnyJsCallArgument` is just
+/// `{AnyJsExpression | JsSpread}`) and so barely narrows anything down on
+/// its own, especially in JSX-heavy code where most expressions sit inside
+/// some call somewhere.
+fn is_relevant_position(expression: &AnyJsExpression) -> bool {
+    if let Some(parent) = expression.syntax().parent() {
+        let is_conditional_test = || {
+            JsConditionalExpression::cast(parent.clone()).is_some_and(|conditional| {
+                conditional.test().is_ok_and(|test| test == *expression)
+            })
+        };
+        match parent.kind() {
+            JsSyntaxKind::JS_CONDITIONAL_EXPRESSION if is_conditional_test() => return true,
+            JsSyntaxKind::JS_DO_WHILE_STATEMENT
+            | JsSyntaxKind::JS_IF_STATEMENT
+            | JsSyntaxKind::JS_SPREAD
+            | JsSyntaxKind::JS_WHILE_STATEMENT => return true,
+            _ => {}
+        }
+    }
+
+    is_relevant_argument_position(expression)
+}
+
+/// Purely syntactic precondition for
+/// `find_misused_promise_returning_callback`: `expression` must be a direct
+/// call/new argument, whose argument list is itself owned by a call or new
+/// expression. None of this requires type information.
+fn is_relevant_argument_position(expression: &AnyJsExpression) -> bool {
+    let Some(argument) = expression
+        .syntax()
+        .ancestors()
+        .find_map(AnyJsCallArgument::cast)
+    else {
+        return false;
+    };
+    let Some(argument_list) = argument.parent::<JsCallArgumentList>() else {
+        return false;
+    };
+    argument_list
+        .syntax()
+        .ancestors()
+        .skip(1)
+        .find_map(JsCallExpression::cast)
+        .is_some()
+        || argument_list
+            .syntax()
+            .ancestors()
+            .skip(1)
+            .find_map(JsNewExpression::cast)
+            .is_some()
 }
 
 fn find_misused_promise_expression(

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -108,20 +108,6 @@ impl Rule for NoMisusedPromises {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let expression = ctx.query();
-
-        // Both branches below only ever produce a signal when `expression`
-        // sits in one of a handful of specific syntactic positions (a
-        // conditional/loop test, a spread element, or a call/new argument)
-        // -- see `is_relevant_position`, which mirrors their syntactic
-        // preconditions exactly. Checking that first avoids running type
-        // inference -- comparatively expensive, and previously run
-        // unconditionally for every expression in the file -- on the vast
-        // majority of a typical file's expressions, which cannot match
-        // regardless of their type.
-        if !is_relevant_position(expression) {
-            return None;
-        }
-
         let ty = ctx.inferred_type_of_expression(expression)?;
         if ty.is_function() {
             find_misused_promise_returning_callback(ctx, expression, ty)
@@ -222,66 +208,6 @@ impl Rule for NoMisusedPromises {
             mutation,
         ))
     }
-}
-
-/// Cheap syntactic pre-check for [NoMisusedPromises]: only expressions in
-/// one of these positions can possibly trigger the rule, regardless of
-/// their inferred type. Mirrors the parent-kind match in
-/// `find_misused_promise_expression` (for the conditional/spread case) and
-/// the full argument/call-or-new-expression chain checked by
-/// `find_misused_promise_returning_callback` (for the callback-argument
-/// case) -- *not* just its first `AnyJsCallArgument::cast` step, which by
-/// itself matches almost any nested expression (`AnyJsCallArgument` is just
-/// `{AnyJsExpression | JsSpread}`) and so barely narrows anything down on
-/// its own, especially in JSX-heavy code where most expressions sit inside
-/// some call somewhere.
-fn is_relevant_position(expression: &AnyJsExpression) -> bool {
-    if let Some(parent) = expression.syntax().parent() {
-        let is_conditional_test = || {
-            JsConditionalExpression::cast(parent.clone()).is_some_and(|conditional| {
-                conditional.test().is_ok_and(|test| test == *expression)
-            })
-        };
-        match parent.kind() {
-            JsSyntaxKind::JS_CONDITIONAL_EXPRESSION if is_conditional_test() => return true,
-            JsSyntaxKind::JS_DO_WHILE_STATEMENT
-            | JsSyntaxKind::JS_IF_STATEMENT
-            | JsSyntaxKind::JS_SPREAD
-            | JsSyntaxKind::JS_WHILE_STATEMENT => return true,
-            _ => {}
-        }
-    }
-
-    is_relevant_argument_position(expression)
-}
-
-/// Purely syntactic precondition for
-/// `find_misused_promise_returning_callback`: `expression` must be a direct
-/// call/new argument, whose argument list is itself owned by a call or new
-/// expression. None of this requires type information.
-fn is_relevant_argument_position(expression: &AnyJsExpression) -> bool {
-    let Some(argument) = expression
-        .syntax()
-        .ancestors()
-        .find_map(AnyJsCallArgument::cast)
-    else {
-        return false;
-    };
-    let Some(argument_list) = argument.parent::<JsCallArgumentList>() else {
-        return false;
-    };
-    argument_list
-        .syntax()
-        .ancestors()
-        .skip(1)
-        .find_map(JsCallExpression::cast)
-        .is_some()
-        || argument_list
-            .syntax()
-            .ancestors()
-            .skip(1)
-            .find_map(JsNewExpression::cast)
-            .is_some()
 }
 
 fn find_misused_promise_expression(


### PR DESCRIPTION
## Summary

`NoMisusedPromises`'s `Query` is `Typed<AnyJsExpression>`, so `run()` is invoked for every expression in a file. It previously called `ctx.inferred_type_of_expression()` - full type inference - on each one *before* checking whether the expression was even in one of the few syntactic positions the rule can fire on: a conditional/loop test, a spread element, or a call/new argument. That check is cheap and purely syntactic (no type information needed); running it first lets the rule skip inference entirely for expressions that cannot match regardless of their type.

The first version of this fix used only the initial `.ancestors().find_map(AnyJsCallArgument::cast)` step as the "is this a call argument" pre-check, mirroring what `find_misused_promise_returning_callback` does before it needs a type. That turned out to filter almost nothing: `AnyJsCallArgument` is just `{ AnyJsExpression | JsSpread }`, so the cast succeeds for nearly any nested expression, not just ones that are actually a direct call/new argument. The version in this PR replicates the *full* precondition instead - the found argument's parent must be a `JsCallArgumentList`, itself owned by an actual call or new expression - which is what makes the pre-check effective.

## Measurement

On a large real-world TypeScript/React project (~3300 files), profiled with `--profile-rules`:

| | cumulative rule time | invocations | avg |
|---|---|---|---|
| before | ~521s | 638,434 | 817µs |
| after | ~111s | 638,434 | 174µs |

Diagnostics reported are byte-identical before/after (same file, same count, same rule breakdown) - this is a pure performance change, no behavior change.

This rule alone accounted for the large majority of total lint time on that project before this fix.

## Testing

- All 18 existing `noMisusedPromises` spec tests pass unchanged.
- All 478 tests in the `nursery` rule group pass unchanged (checked for collateral effects, since the pre-check reuses syntax matching also used elsewhere in the file).

## A couple of notes for maintainers

Sorry for the volume of PRs from this account recently (#10946, #10988, this one) - realize that's a lot to review at once, and appreciate the time either way.

Also: we're continuing to profile biome against the same real-world project, and current data points at `normalize_type`/the underlying Salsa-based type-inference caching in `biome_module_graph` as the next thing worth understanding - shared by every type-aware rule, not specific to this one. Flagging now in case it's already known/being worked on, or in case there's context that would help before we go digging further into that layer.

## Disclosure

Found and fixed with Claude's (Anthropic) assistance while profiling biome's rule execution against a large real-world project - reviewed and verified locally (unit tests, byte-identical diagnostic diff, release build) before submitting.