### PR TITLE
perf(services/typed): cache ModuleResolver per file, drop module from normalize_type's cache key

### DIFF
--- a/.changeset/perf-typed-service-resolver-cache.md
+++ b/.changeset/perf-typed-service-resolver-cache.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of type-aware lint rules by no longer re-resolving a file's module types for every single expression checked.

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -22,6 +22,7 @@ use biome_module_graph::{
     infer_module_types_bottom_up, normalize_type,
 };
 use biome_rowan::{AstNode, AstSeparatedList, TextRange};
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -29,11 +30,22 @@ use std::sync::Arc;
 pub(crate) struct TypedModule {
     db: Rc<dyn ModuleDb>,
     module: ModuleInfo,
+    // `TypedModule` is registered once per file in the `ServiceBag`, but
+    // `FromServices::from_services` clones it out fresh for every rule
+    // invocation on every matched node. The `Rc` ensures all of those clones
+    // still share one cache cell, so `ModuleResolver::for_module` -- which
+    // re-resolves the module's entire import graph -- runs at most once per
+    // file instead of once per `type_of_*` call.
+    resolver: Rc<RefCell<Option<Arc<ModuleResolver>>>>,
 }
 
 impl TypedModule {
     pub(crate) fn new(db: Rc<dyn ModuleDb>, module: ModuleInfo) -> Self {
-        Self { db, module }
+        Self {
+            db,
+            module,
+            resolver: Rc::new(RefCell::new(None)),
+        }
     }
 }
 
@@ -54,7 +66,7 @@ impl TypedService {
     ) -> Option<InferredType<'db>> {
         let typed_module = self.module.as_ref()?;
         let db = typed_module.db.as_ref();
-        let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
+        let ty = normalize_type(db, NormalizeTypeInput::new(db, ty));
         Some(InferredType::new(db, ty))
     }
 
@@ -67,7 +79,7 @@ impl TypedService {
         let db = typed_module.db.as_ref();
         let inferred = infer_module_types_bottom_up(db, typed_module.module)?;
         let ty = inferred.expressions.get(&expression.range()).copied()?;
-        let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
+        let ty = normalize_type(db, NormalizeTypeInput::new(db, ty));
 
         Some(InferredType::new(db, ty))
     }
@@ -94,7 +106,7 @@ impl TypedService {
             .binding_type_data
             .get(&binding.tree().syntax().text_trimmed_range())?
             .ty;
-        let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
+        let ty = normalize_type(db, NormalizeTypeInput::new(db, ty));
 
         Some(InferredType::new(db, ty))
     }
@@ -175,7 +187,7 @@ impl TypedService {
         })?;
         let parent_ty = normalize_type(
             db,
-            NormalizeTypeInput::new(db, typed_module.module, parent_ty),
+            NormalizeTypeInput::new(db, parent_ty),
         );
         let member_ty = inferred.find_member_type(db, parent_ty, member_name)?;
         let return_ty = member_ty.callable_function(db).and_then(|function| {
@@ -246,13 +258,13 @@ impl TypedService {
         let Some(ty) = inferred.expressions.get(&expression.range()).copied() else {
             return false;
         };
-        let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
+        let ty = normalize_type(db, NormalizeTypeInput::new(db, ty));
         let Some(member_ty) = inferred.find_member_type(db, ty, name) else {
             return false;
         };
         let member_ty = normalize_type(
             db,
-            NormalizeTypeInput::new(db, typed_module.module, member_ty),
+            NormalizeTypeInput::new(db, member_ty),
         );
 
         is_callable_inferred_type(db, member_ty)
@@ -271,7 +283,7 @@ impl TypedService {
         let callee_ty = inferred.expressions.get(&callee.range()).copied()?;
         let callee_ty = normalize_type(
             db,
-            NormalizeTypeInput::new(db, typed_module.module, callee_ty),
+            NormalizeTypeInput::new(db, callee_ty),
         );
         let argument_ty = if is_constructor {
             constructor_argument_type(db, callee_ty, argument_index)?
@@ -280,7 +292,7 @@ impl TypedService {
         };
         let argument_ty = normalize_type(
             db,
-            NormalizeTypeInput::new(db, typed_module.module, argument_ty),
+            NormalizeTypeInput::new(db, argument_ty),
         );
 
         Some(InferredType::new(db, argument_ty))
@@ -301,7 +313,7 @@ impl TypedService {
         let callee_ty = inferred.expressions.get(&callee.range()).copied()?;
         let callee_ty = normalize_type(
             db,
-            NormalizeTypeInput::new(db, typed_module.module, callee_ty),
+            NormalizeTypeInput::new(db, callee_ty),
         );
         let arguments = arguments
             .iter()
@@ -312,7 +324,7 @@ impl TypedService {
                     AnyJsCallArgument::JsSpread(spread) => (spread.argument().ok()?, true),
                 };
                 let ty = inferred.expressions.get(&expression.range()).copied()?;
-                let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
+                let ty = normalize_type(db, NormalizeTypeInput::new(db, ty));
                 Some(if is_spread {
                     InferredCallArgumentType::Spread(ty)
                 } else {
@@ -329,7 +341,7 @@ impl TypedService {
         };
         let argument_ty = normalize_type(
             db,
-            NormalizeTypeInput::new(db, typed_module.module, argument_ty),
+            NormalizeTypeInput::new(db, argument_ty),
         );
 
         Some(InferredType::new(db, argument_ty))
@@ -341,6 +353,11 @@ impl TypedService {
     )]
     fn resolver(&self) -> Option<Arc<ModuleResolver>> {
         let typed_module = self.module.as_ref()?;
+
+        if let Some(resolver) = typed_module.resolver.borrow().as_ref() {
+            return Some(resolver.clone());
+        }
+
         // NOTE: commented, no need to do useless computation. Comment this out once we're ready to migrate to the new engine.
         // let _ = infer_module_types_bottom_up(typed_module.db.as_ref(), typed_module.module);
         let ModuleInfoKind::Js(module_info) = typed_module.module.kind(typed_module.db.as_ref())
@@ -348,10 +365,12 @@ impl TypedService {
             return None;
         };
 
-        Some(Arc::new(ModuleResolver::for_module(
+        let resolver = Arc::new(ModuleResolver::for_module(
             module_info.clone(),
             typed_module.db.clone(),
-        )))
+        ));
+        *typed_module.resolver.borrow_mut() = Some(resolver.clone());
+        Some(resolver)
     }
 
     /// Returns the [`Type`] for the given `expression`.
@@ -561,5 +580,52 @@ where
 
     fn unwrap_match(_: &ServiceBag, node: &Self::Input) -> Self::Output {
         N::unwrap_cast(node.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use biome_project_layout::ProjectLayout;
+    use biome_test_utils::module_graph_for_test_file;
+    use camino::Utf8PathBuf;
+
+    /// `TypedModule` is registered once per file, but `FromServices` clones it
+    /// out of the `ServiceBag` fresh for every rule invocation on every
+    /// matched node -- so `resolver()` must return the *same* `ModuleResolver`
+    /// on repeated calls rather than rebuilding it (which re-resolves the
+    /// module's entire import graph) every time.
+    #[test]
+    fn resolver_is_cached_across_repeated_calls() {
+        let dir = std::env::temp_dir().join("biome_typed_service_resolver_cache_test");
+        std::fs::create_dir_all(&dir).expect("must create temp dir");
+        let file_path = dir.join("fixture.ts");
+        std::fs::write(
+            &file_path,
+            "export async function returnsPromise(): Promise<string> { return 'value'; }\n",
+        )
+        .expect("must write fixture file");
+
+        let input_file =
+            Utf8PathBuf::from_path_buf(file_path).expect("temp path must be valid UTF-8");
+        let project_layout = ProjectLayout::default();
+        let db = module_graph_for_test_file(&input_file, &project_layout);
+        let module = db
+            .module_for_path(&input_file)
+            .expect("module must be registered");
+
+        let service = TypedService {
+            module: Some(TypedModule::new(db.rc_module_db(), module)),
+            model: None,
+        };
+
+        let first = service.resolver().expect("resolver must be constructed");
+        let second = service.resolver().expect("resolver must be constructed");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "resolver() must reuse the cached ModuleResolver instead of reconstructing it"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -162,12 +162,11 @@ pub fn infer_call_expression_type<'db>(
     db: &'db dyn ModuleDb,
     input: CallExpressionTypeInput<'db>,
 ) -> InferredTypeData<'db> {
-    let module = input.module(db);
-    let callee = normalize_type(db, NormalizeTypeInput::new(db, module, input.callee(db)));
+    let callee = normalize_type(db, NormalizeTypeInput::new(db, input.callee(db)));
     let args = input.args(db);
     let ty = infer_call_expression_return_type(db, callee, args);
 
-    normalize_type(db, NormalizeTypeInput::new(db, module, ty))
+    normalize_type(db, NormalizeTypeInput::new(db, ty))
 }
 
 // #endregion
@@ -1562,11 +1561,7 @@ pub fn normalize_type<'db>(
     db: &'db dyn ModuleDb,
     input: NormalizeTypeInput<'db>,
 ) -> InferredTypeData<'db> {
-    let module = input.module(db);
     let ty = input.ty(db);
-    let Some(inferred) = infer_module_types(db, module) else {
-        return ty;
-    };
 
     let original = ty;
     let mut stack = Vec::from([TypeNormalizationItem::Type(ty)]);
@@ -1592,8 +1587,11 @@ pub fn normalize_type<'db>(
                             continue;
                         }
                         exit_local = Some((module, type_id));
-                        inferred.resolve_type(db, ty)
+                        resolve_local_type(db, ty)
                     }
+                    // Every other variant is returned unchanged below regardless
+                    // of module context (see the second match on `ty`), so there
+                    // is nothing to resolve here.
                     ty @ (InferredTypeData::Unknown
                     | InferredTypeData::Divergent(_)
                     | InferredTypeData::Global
@@ -1628,7 +1626,7 @@ pub fn normalize_type<'db>(
                     | InferredTypeData::ObjectKeyword
                     | InferredTypeData::ThisKeyword
                     | InferredTypeData::UnknownKeyword
-                    | InferredTypeData::VoidKeyword) => inferred.resolve_type(db, ty),
+                    | InferredTypeData::VoidKeyword) => ty,
                 };
 
                 if let Some((module, type_id)) = exit_local {
@@ -1901,7 +1899,6 @@ enum TypeNormalizationItem<'db> {
 #[salsa::interned]
 #[derive(Debug)]
 pub struct CallExpressionTypeInput<'db> {
-    pub module: ModuleInfo,
     pub callee: InferredTypeData<'db>,
     #[returns(ref)]
     pub args: Box<[InferredTypeData<'db>]>,
@@ -1920,7 +1917,6 @@ pub struct CallArgumentTypeInput<'db> {
 #[salsa::interned]
 #[derive(Debug)]
 pub struct NormalizeTypeInput<'db> {
-    pub module: ModuleInfo,
     pub ty: InferredTypeData<'db>,
 }
 

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -552,22 +552,22 @@ fn local_type_id_of_instance<'db>(
 
 fn infer_call_expression_type<'db>(
     db: &'db dyn ModuleDb,
-    module: ModuleInfo,
+    _module: ModuleInfo,
     callee: InferredTypeData<'db>,
     args: Vec<InferredTypeData<'db>>,
 ) -> InferredTypeData<'db> {
     infer_call_expression_type_query(
         db,
-        CallExpressionTypeInput::new(db, module, callee, args.into_boxed_slice()),
+        CallExpressionTypeInput::new(db, callee, args.into_boxed_slice()),
     )
 }
 
 fn normalize_type<'db>(
     db: &'db dyn ModuleDb,
-    module: ModuleInfo,
+    _module: ModuleInfo,
     ty: InferredTypeData<'db>,
 ) -> InferredTypeData<'db> {
-    normalize_type_query(db, NormalizeTypeInput::new(db, module, ty))
+    normalize_type_query(db, NormalizeTypeInput::new(db, ty))
 }
 
 fn interface_member_ty<'db>(
@@ -4348,6 +4348,78 @@ fn test_infer_call_expression_type_selects_callable_object_overload_by_arity() {
         &db,
         &fs,
     );
+}
+
+#[test]
+fn test_normalize_type_and_call_expression_type_are_shared_across_modules() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/shared.ts".into(),
+        r#"
+            export function wrap(): string {
+                return "value";
+            }
+        "#,
+    );
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            import { wrap } from "./shared.ts";
+            export const a = wrap();
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { wrap } from "./shared.ts";
+            export const b = wrap();
+        "#,
+    );
+
+    let mut db =
+        build_js_test_module_db(&fs, &["/src/shared.ts", "/src/a.ts", "/src/b.ts"], true);
+    let a_module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("module a must exist");
+    let b_module = db
+        .module_for_path(Utf8Path::new("/src/b.ts"))
+        .expect("module b must exist");
+
+    let a_inferred = infer_module_types(&db, a_module).expect("a types must be inferred");
+    let wrap_ty_a = inferred_binding_ty_by_name(&db, a_module, &a_inferred, "wrap")
+        .expect("wrap binding must be inferred in a.ts");
+    let resolved_a = a_inferred.resolve_type(&db, wrap_ty_a);
+    let call_ty_a = infer_call_expression_type(&db, a_module, resolved_a, Vec::new());
+    assert!(is_inferred_string(&db, call_ty_a));
+
+    db.clear_salsa_events();
+
+    let b_inferred = infer_module_types(&db, b_module).expect("b types must be inferred");
+    let wrap_ty_b = inferred_binding_ty_by_name(&db, b_module, &b_inferred, "wrap")
+        .expect("wrap binding must be inferred in b.ts");
+    let resolved_b = b_inferred.resolve_type(&db, wrap_ty_b);
+    let call_ty_b = infer_call_expression_type(&db, b_module, resolved_b, Vec::new());
+    assert!(is_inferred_string(&db, call_ty_b));
+
+    // `wrap`'s resolved type and the (empty) argument list are identical from
+    // both modules' perspective, so resolving the call from module B must hit
+    // Salsa's cache rather than recomputing -- these queries no longer key on
+    // the calling module (see NormalizeTypeInput / CallExpressionTypeInput).
+    let events = db.take_salsa_events();
+    for event in &events {
+        if let salsa::EventKind::WillExecute { database_key } = event.kind {
+            let name =
+                salsa::Database::ingredient_debug_name(&db, database_key.ingredient_index());
+            assert_ne!(
+                name, "normalize_type",
+                "normalize_type must be shared across modules for an identical `ty`, not recomputed"
+            );
+            assert_ne!(
+                name, "infer_call_expression_type",
+                "infer_call_expression_type must be shared across modules for an identical (callee, args) pair, not recomputed"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two related fixes to type-aware rule performance, found while profiling a large real-world TypeScript/React monorepo:

**1. `TypedService::resolver()` rebuilt the entire module resolver on every call.**

`type_of_expression()`, `type_of_named_value()`, and `type_of_function()` (the legacy, non-Salsa `ModuleResolver` API) all go through `TypedService::resolver()`, which called `ModuleResolver::for_module(...)` -- re-resolving the file's *entire* import graph -- with no caching at all, not even within a single file. `TypedModule` is registered once per file in the `ServiceBag`, but `FromServices::from_services` clones it out fresh for every rule invocation on every matched node, so this ran once per expression checked rather than once per file.

Measured directly: linting one real 1440-line file with `noFloatingPromises` produced **125 separate `ModuleResolver` reconstructions for 154 rule invocations**.

Fix: cache the constructed `Arc<ModuleResolver>` in `TypedModule` behind `Rc<RefCell<...>>`, so every clone pulled from the `ServiceBag` shares one cache cell and the resolver is built at most once per file.

**2. `normalize_type` / `infer_call_expression_type` keyed their Salsa cache on the calling module unnecessarily.**

`NormalizeTypeInput` and `CallExpressionTypeInput` both carried a `module: ModuleInfo` field. Tracing through `normalize_type`'s body: that field is only ever used to resolve `InferredTypeData::Local` references, and `type_for_local_handle` *already* falls back correctly (via `module_for_key` + a fresh `infer_module_types` call) whenever the local's own module doesn't match the "current" one. That fallback path is exactly what `resolve_local_type` (an existing free function used elsewhere in this file) does directly, with no "current module" argument at all -- so the field wasn't needed for correctness, only as a minor same-module fast-path hint.

The cost: two calls with an identical, already-fully-resolved `ty`/`callee`+`args` from *different* files were treated as different Salsa cache entries purely because of this field, so cross-file sharing never happened for either query.

Fix: dropped `module` from both interned structs; `normalize_type` now resolves `Local` values via `resolve_local_type` (deriving the needed module directly from the `Local`'s own embedded module reference) instead of a caller-supplied one.

## Testing

- Added `resolver_is_cached_across_repeated_calls` (`biome_js_analyze`), asserting `Arc::ptr_eq` across two `resolver()` calls. Verified it actually catches the bug: temporarily disabled the cache check and confirmed the test fails, then re-enabled it.
- Added `test_normalize_type_and_call_expression_type_are_shared_across_modules` (`biome_module_graph`), using the existing Salsa event-log test harness (`biome_db::testing`) to assert `normalize_type` and `infer_call_expression_type` do *not* re-execute for an identical value requested from a second module.
- Full existing suites pass unchanged: `biome_js_analyze` (2713 spec tests + 267 lib tests), `biome_module_graph` (111 `spec_tests_v2` tests). The only failures in a full `cargo test` run are two pre-existing, Windows-symlink-specific failures in `biome_module_graph`'s `spec_tests.rs`, present before this change and unrelated to it.
- Diffed full JSON diagnostic output before/after across a real ~3300-file monorepo (all configured lint rules): **0 diagnostic differences** out of 11,331 errors.
- Profiled the same monorepo: `noFloatingPromises` on the single worst-case file dropped from **2.564s to 22ms** cumulative rule time (~116x) -- effectively all of it was redundant `ModuleResolver` reconstruction, confirmed by removing the cache and watching the cost reappear.

## Note on fix #2's real-world impact

Fix #2 is real and verified at the mechanism level (the added test fails without it), but its measured wall-clock effect on `noMisusedPromises` specifically turned out smaller than expected (~4% on an isolated cross-file repro) -- most of that rule's cost comes from work done inside `infer_module_types`'s own per-file expression walk, which doesn't yet route through the separately-cacheable `normalize_type`/`infer_call_expression_type` queries this PR fixes. That's a deeper, separate change (or this same fix applied in another spot); happy to keep digging with maintainer input on the best target.

## Disclosure

Found and fixed with Claude's (Anthropic) assistance while continuing to profile the same real-world project as earlier PRs -- reviewed and verified locally (unit tests, full-suite pass, byte-identical diagnostic diff across the whole monorepo) before submitting. Apologies again for the growing PR count from this investigation -- happy to consolidate or slow down if that's preferred.
