### PR TITLE
fix(module_graph): degrade invalid module-0 type references instead of panicking

### DIFF
--- a/.changeset/module-resolver-bounds-check.md
+++ b/.changeset/module-resolver-bounds-check.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Hardened the module resolver against the panic class behind [#10885](https://github.com/biomejs/biome/issues/10885): an out-of-bounds module-0 type reference now degrades to an unknown type (with a `debug_assert!` in debug builds) instead of killing the workspace worker with `index out of bounds`.

--- a/crates/biome_module_graph/src/js_module_info/module_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/module_resolver.rs
@@ -495,10 +495,16 @@ impl TypeResolver for ModuleResolver {
     /// be mapped to the resolver's own types instead.
     fn mapped_resolved_id(&self, resolved_id: ResolvedTypeId) -> ResolvedTypeId {
         if resolved_id.resolver_id() == MODULE_0_ID {
-            ResolvedTypeId::new(
-                TypeResolverLevel::Full,
-                self.type_id_map[resolved_id.id().index()],
-            )
+            match self.type_id_map.get(resolved_id.id().index()) {
+                Some(type_id) => ResolvedTypeId::new(TypeResolverLevel::Full, *type_id),
+                None => {
+                    // A module-local reference from another module leaked in
+                    // without its module ID applied. Degrade to unknown rather
+                    // than panicking on an out-of-bounds index.
+                    debug_assert!(false, "Invalid module 0 type reference: {resolved_id:?}");
+                    GLOBAL_UNKNOWN_ID
+                }
+            }
         } else {
             resolved_id
         }

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -567,6 +567,71 @@ fn test_export_default_imported_binding() {
 }
 
 #[test]
+fn test_overload_selection_does_not_leak_module_local_references() {
+    // Regression test for issue #10885 (fixed by #10891): overload selection
+    // compares a signature's parameter types against the argument types
+    // (`signature_accepts_arguments`). Resolving a parameter's function type
+    // used to clone the raw data from the imported module without applying
+    // its module ID, so the function's module-local return type reference was
+    // later looked up in module 0's `type_id_map`. When the imported module
+    // had more types than module 0, that lookup panicked with an index out of
+    // bounds; otherwise it silently resolved a wrong type.
+    let fs = MemoryFileSystem::default();
+
+    // The imported module needs more types than module 0 so a leaked
+    // reference lands out of bounds instead of resolving a wrong type.
+    let mut dep = String::new();
+    for i in 0..64 {
+        dep.push_str(&format!(
+            "export const pad{i} = {{ field{i}: {i}, other{i}: \"{i}\" }};\n"
+        ));
+    }
+    dep.push_str(
+        r#"
+        export function run(scope: () => Promise<void>): Promise<void>;
+        export function run(scope: () => void): void;
+        export function run(scope: () => Promise<void> | void): Promise<void> | void {
+            return scope();
+        }
+        "#,
+    );
+    fs.insert("/src/dep.ts".into(), dep);
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import { run } from "./dep.ts";
+
+            export default run(async () => {});
+        "#,
+    );
+
+    let added_paths = [
+        BiomePath::new("/src/dep.ts"),
+        BiomePath::new("/src/index.ts"),
+    ];
+    let added_paths = get_added_js_paths(&fs, &added_paths);
+
+    let db = build_js_db(&fs, &ProjectLayout::default(), &added_paths, true);
+
+    let index_module = db
+        .js_module_info_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    // Building the resolver runs inference, which flattens the call and
+    // selects the async overload. Before #10891, this panicked with
+    // "index out of bounds: the len is 6 but the index is 195" in
+    // `mapped_resolved_id`. A recurrence of the leak would trip the
+    // `debug_assert!` that replaced the hard index there.
+    let resolver = Arc::new(ModuleResolver::for_module(index_module, db.rc_module_db()));
+
+    // Liveness only: the default export must still be resolvable. The exact
+    // inferred type is not this test's concern.
+    resolver
+        .resolved_type_of_default_export()
+        .expect("default export must exist");
+}
+
+#[test]
 fn test_export_const_type_declaration_with_namespace() {
     let fs = MemoryFileSystem::default();
     fs.insert(


### PR DESCRIPTION
## Summary

Follow-up hardening for #10885 (fixed by #10891).

We hit the #10885 panic in production CI on 2.5.3/2.5.4 (`module_resolver.rs:500`, `index out of bounds: the len is 319 but the index is 446`, trigger: React 19's overloaded `startTransition` called with an async closure) and root-caused it independently before finding that #10891 had already landed the `resolve_function` fix on `main`. Two pieces from that investigation seemed worth contributing on top:

1. **`mapped_resolved_id` bounds-check** — the hard `type_id_map[index]` remains reachable by any future module-ID rebasing leak of the same class, and it kills the whole workspace worker when it fires. This PR switches it to `.get(...)`, degrading to `GLOBAL_UNKNOWN_ID` behind a `debug_assert!` — the same pattern `get_by_resolved_id`'s `Thin` branch already uses. Release builds degrade to an unknown type; debug/test builds still fail loudly, so leaks stay visible in CI.

2. **Regression spec test for the overload-selection path** — `test_overload_selection_does_not_leak_module_local_references` reproduces the #10891 leak directly through `signature_accepts_arguments`: a two-module fixture where the imported module's type table is larger than module 0's, so an un-rebased reference is out of bounds rather than silently resolving a wrong type. It panics on the pre-#10891 tree and passes on `main`; combined with (1), any regression trips the `debug_assert!`.

The silent-wrong-type variant (leaked index that happens to be *in* bounds) is the reason for the assert: overload selection would quietly compare against an unrelated type from the current module, which no snapshot obviously catches.

## Test Plan

- `cargo test -p biome_module_graph` — all green, including the new test.
- The new test, run against the tree at the `@biomejs/biome@2.5.4` tag (pre-#10891), reproduces the panic: `index out of bounds: the len is 6 but the index is 195` at `module_resolver.rs:500:33`.
- Real-world validation: a ~1,150-file monorepo where 15 files panicked under 2.5.4 (1 under 2.5.3) checks end-to-end with a debug build of this branch — zero panics, zero assert trips.

## AI assistance notice

This PR was written primarily by Claude Code (root-cause analysis, patch, and test), reviewed and driven by a human operator.