### PR TITLE
fix(daemon): avoid disconnection from clients

### DIFF
--- a/.changeset/plenty-queens-buy.md
+++ b/.changeset/plenty-queens-buy.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where closing one editor stopped a shared Biome daemon used by other editors. LSP proxy processes now exit when either the editor or daemon disconnects.

--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -127,56 +127,52 @@ pub(crate) fn lsp_proxy(
     log_options: LogOptions,
 ) -> Result<(), CliDiagnostic> {
     let rt = Runtime::new()?;
-    rt.block_on(start_lsp_proxy(&rt, watcher_options, log_options))?;
+    rt.block_on(start_lsp_proxy(watcher_options, log_options))?;
 
     Ok(())
+}
+
+async fn forward_lsp<I, O, R, W>(
+    mut input: I,
+    mut output: O,
+    mut socket_read: R,
+    mut socket_write: W,
+) where
+    I: io::AsyncRead + Unpin,
+    O: io::AsyncWrite + Unpin,
+    R: io::AsyncRead + Unpin,
+    W: io::AsyncWrite + Unpin,
+{
+    tokio::select! {
+        result = io::copy(&mut input, &mut socket_write) => {
+            if result.is_ok() {
+                let _ = io::AsyncWriteExt::flush(&mut socket_write).await;
+            }
+        }
+        result = io::copy(&mut socket_read, &mut output) => {
+            if result.is_ok() {
+                let _ = io::AsyncWriteExt::flush(&mut output).await;
+            }
+        }
+    }
 }
 
 /// Start a proxy process.
 /// Receives a process via `stdin` and then copy the content to the LSP socket.
 /// Copy to the process on `stdout` when the LSP responds to a message
 async fn start_lsp_proxy(
-    rt: &Runtime,
     watcher_options: WatcherOptions,
     log_options: LogOptions,
 ) -> Result<(), CliDiagnostic> {
     ensure_daemon(true, watcher_options, log_options).await?;
 
     match open_socket().await? {
-        Some((mut owned_read_half, mut owned_write_half)) => {
-            // forward stdin to socket
-            let mut stdin = io::stdin();
-            let input_handle = rt.spawn(async move {
-                loop {
-                    match io::copy(&mut stdin, &mut owned_write_half).await {
-                        Ok(b) => {
-                            if b == 0 {
-                                return Ok(());
-                            }
-                        }
-                        Err(err) => return Err(err),
-                    };
-                }
-            });
+        Some((owned_read_half, owned_write_half)) => {
+            forward_lsp(io::stdin(), io::stdout(), owned_read_half, owned_write_half).await;
 
-            // receive socket response to stdout
-            let mut stdout = io::stdout();
-            let out_put_handle = rt.spawn(async move {
-                loop {
-                    match io::copy(&mut owned_read_half, &mut stdout).await {
-                        Ok(b) => {
-                            if b == 0 {
-                                return Ok(());
-                            }
-                        }
-                        Err(err) => return Err(err),
-                    };
-                }
-            });
-
-            let _ = input_handle.await;
-            let _ = out_put_handle.await;
-            Ok(())
+            // Tokio standard I/O uses blocking reads that cannot be cancelled.
+            // Exit so a pending read cannot keep a disconnected proxy alive.
+            process::exit(0);
         }
         None => Ok(()),
     }
@@ -284,5 +280,41 @@ impl<S> Filter<S> for LoggingFilter {
 
     fn max_level_hint(&self) -> Option<LevelFilter> {
         Some(SELF_FILTER)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::forward_lsp;
+    use std::time::Duration;
+    use tokio::io::{duplex, empty, sink, split};
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn forwarding_stops_when_the_daemon_disconnects() {
+        let (input, _input_writer) = duplex(64);
+        let (socket, remote) = duplex(64);
+        let (socket_read, socket_write) = split(socket);
+        drop(remote);
+
+        timeout(
+            Duration::from_secs(1),
+            forward_lsp(input, sink(), socket_read, socket_write),
+        )
+        .await
+        .expect("forwarding should stop after the daemon disconnects");
+    }
+
+    #[tokio::test]
+    async fn forwarding_stops_when_the_editor_disconnects() {
+        let (socket, _remote) = duplex(64);
+        let (socket_read, socket_write) = split(socket);
+
+        timeout(
+            Duration::from_secs(1),
+            forward_lsp(empty(), sink(), socket_read, socket_write),
+        )
+        .await
+        .expect("forwarding should stop after the editor disconnects");
     }
 }

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -39,13 +39,14 @@ salsa                = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }
 tokio                = { workspace = true, features = ["io-std", "rt", "time"] }
+tower                = { workspace = true }
 tower-lsp-server     = { workspace = true }
 tracing              = { workspace = true, features = ["attributes"] }
 url                  = { workspace = true }
 uuid                 = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-util", "macros", "rt", "rt-multi-thread"] }
 tower = { workspace = true, features = ["timeout"] }
 
 [lints]

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -21,12 +21,15 @@ use futures::future::ready;
 use rustc_hash::FxHashMap;
 use serde_json::json;
 use std::panic::{AssertUnwindSafe, RefUnwindSafe};
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use tokio::io::{AsyncRead, AsyncWrite};
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::{Notify, watch};
 use tokio::task::spawn_blocking;
-use tower_lsp_server::jsonrpc::Result as LspResult;
+use tower::Service;
+use tower_lsp_server::jsonrpc::{Request as JsonRpcRequest, Result as LspResult};
 use tower_lsp_server::{ClientSocket, ls_types::*};
 use tower_lsp_server::{LanguageServer, LspService, Server};
 use tracing::{debug, error, info, instrument, warn};
@@ -35,12 +38,7 @@ pub struct LSPServer {
     pub(crate) session: SessionHandle,
     /// Map of all sessions connected to the same [ServerFactory] as this [LSPServer].
     sessions: Sessions,
-    /// If this is true the server will broadcast a shutdown signal once the
-    /// last client disconnected
-    stop_on_disconnect: bool,
-    /// This shared flag is set to true once at least one session has been
-    /// initialized on this server instance
-    is_initialized: Arc<AtomicBool>,
+    lifecycle: Arc<SessionLifecycle>,
 }
 
 impl RefUnwindSafe for LSPServer {}
@@ -55,17 +53,11 @@ where
 }
 
 impl LSPServer {
-    fn new(
-        session: SessionHandle,
-        sessions: Sessions,
-        stop_on_disconnect: bool,
-        is_initialized: Arc<AtomicBool>,
-    ) -> Self {
+    fn new(session: SessionHandle, sessions: Sessions, lifecycle: Arc<SessionLifecycle>) -> Self {
         Self {
             session,
             sessions,
-            stop_on_disconnect,
-            is_initialized,
+            lifecycle,
         }
     }
 
@@ -354,7 +346,7 @@ impl LanguageServer for LSPServer {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn initialize(&self, params: InitializeParams) -> LspResult<InitializeResult> {
         info!("Starting Biome Language Server...");
-        self.is_initialized.store(true, Ordering::Relaxed);
+        self.lifecycle.mark_initialized();
 
         let server_capabilities = server_capabilities(&params.capabilities);
         if params.root_path.is_some() {
@@ -404,9 +396,6 @@ impl LanguageServer for LSPServer {
     }
 
     async fn shutdown(&self) -> LspResult<()> {
-        if self.stop_on_disconnect {
-            self.session.broadcast_shutdown();
-        }
         Ok(())
     }
 
@@ -605,22 +594,125 @@ impl LanguageServer for LSPServer {
 
 impl Drop for LSPServer {
     fn drop(&mut self) {
-        if let Ok(mut sessions) = self.sessions.lock() {
-            let _removed = sessions.remove(&self.session.key);
-            debug_assert!(_removed.is_some(), "Session did not exist.");
-
-            if self.stop_on_disconnect
-                && sessions.is_empty()
-                && self.is_initialized.load(Ordering::Relaxed)
-            {
-                self.session.cancellation.notify_one();
-            }
-        }
+        self.lifecycle.disconnect();
     }
 }
 
 /// Map of active sessions connected to a [ServerFactory].
 type Sessions = Arc<Mutex<FxHashMap<SessionKey, SessionHandle>>>;
+
+struct SessionLifecycle {
+    session_key: SessionKey,
+    sessions: Sessions,
+    cancellation: Arc<Notify>,
+    stop_on_disconnect: bool,
+    is_initialized: Arc<AtomicBool>,
+    is_disconnected: AtomicBool,
+}
+
+impl SessionLifecycle {
+    fn mark_initialized(&self) {
+        self.is_initialized.store(true, Ordering::Release);
+    }
+
+    fn disconnect(&self) {
+        if self.is_disconnected.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let Ok(mut sessions) = self.sessions.lock() else {
+            return;
+        };
+        let removed = sessions.remove(&self.session_key);
+        debug_assert!(removed.is_some(), "Session did not exist.");
+
+        if removed.is_some()
+            && self.stop_on_disconnect
+            && sessions.is_empty()
+            && self.is_initialized.load(Ordering::Acquire)
+        {
+            self.cancellation.notify_one();
+        }
+    }
+}
+
+struct DisconnectOnExit<S> {
+    inner: S,
+    lifecycle: Arc<SessionLifecycle>,
+}
+
+impl<S> DisconnectOnExit<S> {
+    fn new(inner: S, lifecycle: Arc<SessionLifecycle>) -> Self {
+        Self { inner, lifecycle }
+    }
+}
+
+impl<S> Service<JsonRpcRequest> for DisconnectOnExit<S>
+where
+    S: Service<JsonRpcRequest>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: JsonRpcRequest) -> Self::Future {
+        let should_disconnect = request.method() == "exit";
+        let response = self.inner.call(request);
+
+        if should_disconnect {
+            self.lifecycle.disconnect();
+        }
+
+        response
+    }
+}
+
+struct DisconnectOnEof<R> {
+    inner: R,
+    lifecycle: Arc<SessionLifecycle>,
+}
+
+impl<R> DisconnectOnEof<R> {
+    fn new(inner: R, lifecycle: Arc<SessionLifecycle>) -> Self {
+        Self { inner, lifecycle }
+    }
+}
+
+impl<R> AsyncRead for DisconnectOnEof<R>
+where
+    R: AsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        let remaining = buffer.remaining();
+        let filled = buffer.filled().len();
+        let result = Pin::new(&mut this.inner).poll_read(cx, buffer);
+
+        match &result {
+            Poll::Ready(Ok(())) if remaining > 0 && buffer.filled().len() == filled => {
+                this.lifecycle.disconnect();
+            }
+            Poll::Ready(Err(_)) => this.lifecycle.disconnect(),
+            Poll::Pending | Poll::Ready(Ok(())) => {}
+        }
+
+        result
+    }
+}
+
+impl<R> Drop for DisconnectOnEof<R> {
+    fn drop(&mut self) {
+        self.lifecycle.disconnect();
+    }
+}
 
 /// Helper method for wrapping a [Workspace] method in a `custom_method` for
 /// the [LSPServer]
@@ -758,6 +850,15 @@ impl ServerFactory {
         let db_state = self.db_state.clone();
 
         let session_key = SessionKey(self.next_session_key.fetch_add(1, Ordering::Relaxed));
+        let lifecycle = Arc::new(SessionLifecycle {
+            session_key,
+            sessions: self.sessions.clone(),
+            cancellation: self.cancellation.clone(),
+            stop_on_disconnect: self.stop_on_disconnect,
+            is_initialized: self.is_initialized.clone(),
+            is_disconnected: AtomicBool::new(false),
+        });
+        let server_lifecycle = lifecycle.clone();
 
         let mut builder = LspService::build(move |client| {
             let session = Session::new(
@@ -773,12 +874,7 @@ impl ServerFactory {
             let mut sessions = self.sessions.lock().unwrap();
             sessions.insert(session_key, handle.clone());
 
-            LSPServer::new(
-                handle,
-                self.sessions.clone(),
-                self.stop_on_disconnect,
-                self.is_initialized.clone(),
-            )
+            LSPServer::new(handle, self.sessions.clone(), server_lifecycle)
         });
 
         builder = builder.custom_method(SYNTAX_TREE_REQUEST, LSPServer::syntax_tree_request);
@@ -823,7 +919,11 @@ impl ServerFactory {
         workspace_method!(builder, drop_pattern);
 
         let (service, socket) = builder.finish();
-        ServerConnection { socket, service }
+        ServerConnection {
+            socket,
+            service,
+            lifecycle,
+        }
     }
 
     /// Return a handle to the cancellation token for this server process
@@ -845,6 +945,7 @@ impl ServerFactory {
 pub struct ServerConnection {
     socket: ClientSocket,
     service: LspService<LSPServer>,
+    lifecycle: Arc<SessionLifecycle>,
 }
 
 impl ServerConnection {
@@ -860,11 +961,15 @@ impl ServerConnection {
         I: AsyncRead + Unpin,
         O: AsyncWrite,
     {
-        Server::new(stdin, stdout, self.socket)
-            .serve(self.service)
-            .await;
+        let stdin = DisconnectOnEof::new(stdin, self.lifecycle.clone());
+        let service = DisconnectOnExit::new(self.service, self.lifecycle);
+        Server::new(stdin, stdout, self.socket).serve(service).await;
     }
 }
+
+#[cfg(test)]
+#[path = "server_lifecycle.tests.rs"]
+mod server_lifecycle;
 
 #[cfg(test)]
 #[path = "server.tests.rs"]

--- a/crates/biome_lsp/src/server_lifecycle.tests.rs
+++ b/crates/biome_lsp/src/server_lifecycle.tests.rs
@@ -1,0 +1,98 @@
+use super::*;
+use crate::server_test_utils::Server as TestServer;
+use anyhow::Result;
+use futures::FutureExt;
+use std::convert::Infallible;
+use std::future::{Pending, pending};
+use std::task::{Context, Poll};
+use tokio::io::AsyncReadExt;
+use tower::Service;
+use tower_lsp_server::jsonrpc::Request;
+
+struct PendingService;
+
+impl Service<Request> for PendingService {
+    type Response = ();
+    type Error = Infallible;
+    type Future = Pending<std::result::Result<(), Infallible>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Infallible>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _request: Request) -> Self::Future {
+        pending()
+    }
+}
+
+#[tokio::test]
+async fn shutdown_does_not_cancel_other_sessions() -> Result<()> {
+    let factory = ServerFactory::default();
+    let cancellation = factory.cancellation();
+
+    let (first_service, _first_client) = factory.create().into_inner();
+    let (second_service, _second_client) = factory.create().into_inner();
+    let mut first = TestServer::new(first_service);
+    let mut second = TestServer::new(second_service);
+
+    first.initialize().await?;
+    second.initialize().await?;
+
+    let result = first.request::<_, ()>("shutdown", "shutdown", ()).await?;
+    assert_eq!(result, Some(()));
+    assert!(cancellation.notified().now_or_never().is_none());
+
+    Ok(())
+}
+
+#[test]
+fn exit_disconnects_before_the_service_future_completes() {
+    let factory = ServerFactory::default();
+    let cancellation = factory.cancellation();
+    let first = factory.create();
+    let second = factory.create();
+
+    first.lifecycle.mark_initialized();
+
+    let mut first_service = DisconnectOnExit::new(PendingService, first.lifecycle.clone());
+    let mut second_service = DisconnectOnExit::new(PendingService, second.lifecycle.clone());
+
+    let _first_response = first_service.call(Request::build("exit").finish());
+    assert_eq!(factory.sessions.lock().unwrap().len(), 1);
+    assert!(cancellation.notified().now_or_never().is_none());
+
+    let _second_response = second_service.call(Request::build("exit").finish());
+    assert!(factory.sessions.lock().unwrap().is_empty());
+    assert!(cancellation.notified().now_or_never().is_some());
+}
+
+#[tokio::test]
+async fn eof_disconnects_the_session() {
+    let factory = ServerFactory::default();
+    let cancellation = factory.cancellation();
+    let connection = factory.create();
+
+    connection.lifecycle.mark_initialized();
+
+    let mut input = DisconnectOnEof::new(tokio::io::empty(), connection.lifecycle.clone());
+    let mut buffer = [0; 1];
+    assert_eq!(input.read(&mut buffer).await.unwrap(), 0);
+    assert!(factory.sessions.lock().unwrap().is_empty());
+    assert!(cancellation.notified().now_or_never().is_some());
+}
+
+#[test]
+fn disconnect_does_not_stop_a_persistent_daemon() {
+    let factory = ServerFactory {
+        stop_on_disconnect: false,
+        ..ServerFactory::default()
+    };
+    let cancellation = factory.cancellation();
+    let connection = factory.create();
+
+    connection.lifecycle.mark_initialized();
+    connection.lifecycle.disconnect();
+
+    assert!(factory.sessions.lock().unwrap().is_empty());
+    assert!(cancellation.notified().now_or_never().is_none());
+}


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes a bug where, when multiple clients are connected to a daemon and one client disconnects, it can shut down the daemon, leaving the LSP-proxy of the other client pending.

This PR introduces a specialised `SessionLifecycle` type to handle this situation. The disconnection operation no longer happens inside `Drop` as before.

The code is created via coding agents and reviewed multiple times from different instances, and it seems to hold. I admit that I don't understand some parts of it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new unit tests, and manually tested using VSCode and Zed at the same time. The bug is gone.

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
