### PR TITLE
fix: preview ci

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+ignore = [
+	# `quick-xml` is pulled in by `self_update` and `quick-junit`; no released compatible upgrade avoids the advisory yet.
+	"RUSTSEC-2026-0194",
+	# `quick-xml` is pulled in by `self_update` and `quick-junit`; no released compatible upgrade avoids the advisory yet.
+	"RUSTSEC-2026-0195",
+]


### PR DESCRIPTION
## Summary

Fix preview CI, which currently fails on quick-xml from self_update and junit. We do already exclude this in the [deny.toml](https://github.com/biomejs/biome/blob/main/deny.toml#L17-L18) for `cargo deny`, but in some CI we use `cargo audit` instead

https://github.com/biomejs/biome/actions/runs/29622691645/job/88020767297

Should we even use 2 different tools, with each their own config? (`cargo deny` has the same capabilities as `cargo audit`)

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
