### PR TITLE
refactor(inference): separate raw type collection

### DIFF
--- a/crates/biome_js_type_info/src/globals_ids.rs
+++ b/crates/biome_js_type_info/src/globals_ids.rs
@@ -25,6 +25,16 @@ impl GlobalTypeId {
         Self(id)
     }
 
+    /// Converts a type ID into a predefined global type ID when it indexes the
+    /// global manifest.
+    pub const fn try_from_type_id(id: TypeId) -> Option<Self> {
+        if id.index() < NUM_PREDEFINED_TYPES {
+            Some(Self(id))
+        } else {
+            None
+        }
+    }
+
     /// Test-only constructor for synthesizing `GlobalTypeId` values at
     /// arbitrary indices, including out-of-range indices used by negative-path
     /// tests.

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -32,7 +32,7 @@ mod type_traversal;
 pub use conditionals::*;
 pub use flattening::MAX_FLATTEN_DEPTH;
 pub use globals::{GLOBAL_RESOLVER, GlobalsResolver};
-pub use globals_ids::{GLOBAL_BOOLEAN_ID, GLOBAL_UNKNOWN_ID, NUM_PREDEFINED_TYPES};
+pub use globals_ids::{GLOBAL_BOOLEAN_ID, GLOBAL_UNKNOWN_ID, GlobalTypeId, NUM_PREDEFINED_TYPES};
 pub use inferred_type::{
     IgnoredPrimitiveTypes, InferredSwitchCase, InferredType, StringificationMode,
     StringificationUsefulness, TypeTraversalError,

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -29,17 +29,16 @@ use biome_rowan::{AstNode, SyntaxResult, Text, TextRange, TokenText};
 
 use crate::globals::{
     GLOBAL_GLOBAL_ID, GLOBAL_INSTANCEOF_PROMISE_ID, GLOBAL_NUMBER_ID, GLOBAL_STRING_ID,
-    GLOBAL_SYMBOL_ASYNC_DISPOSE_ID, GLOBAL_SYMBOL_DISPOSE_ID, GLOBAL_SYMBOL_ID,
-    GLOBAL_UNDEFINED_ID,
+    GLOBAL_SYMBOL_ASYNC_DISPOSE_ID, GLOBAL_SYMBOL_DISPOSE_ID, GLOBAL_UNDEFINED_ID,
 };
 use crate::literal::{BooleanLiteral, NumberLiteral, RegexpLiteral, StringLiteral};
 use crate::{
     AssertsReturnType, CallArgumentType, Class, Constructor, ConstructorParameter,
     DestructureField, Function, FunctionParameter, FunctionParameterBinding, GenericTypeParameter,
     Interface, Literal, Module, NamedFunctionParameter, Namespace, Object, Path,
-    PatternFunctionParameter, PredicateReturnType, ResolvedTypeId, ReturnType, ScopeId, Tuple,
+    PatternFunctionParameter, PredicateReturnType, RawTypeCollector, ReturnType, ScopeId, Tuple,
     TupleElementType, TypeData, TypeInstance, TypeMember, TypeMemberAccessibility, TypeMemberKind,
-    TypeOperator, TypeOperatorType, TypeReference, TypeReferenceQualifier, TypeResolver,
+    TypeOperator, TypeOperatorType, TypeReference, TypeReferenceQualifier,
     TypeofAdditionExpression, TypeofAwaitExpression, TypeofBitwiseNotExpression,
     TypeofCallExpression, TypeofConditionalExpression, TypeofDestructureExpression,
     TypeofExpression, TypeofIndexExpression, TypeofIterableValueOfExpression,
@@ -55,7 +54,7 @@ impl TypeData {
     /// associated types.
     pub fn apply_array_binding_pattern(
         &self,
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         pattern: &JsArrayBindingPattern,
     ) -> Box<[(Text, TypeReference)]> {
@@ -73,7 +72,7 @@ impl TypeData {
 
     fn apply_array_binding_pattern_element(
         &self,
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         i: usize,
         elem: AnyJsArrayBindingPatternElement,
@@ -136,7 +135,7 @@ impl TypeData {
     /// associated types.
     pub fn apply_object_binding_pattern(
         &self,
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         pattern: &JsObjectBindingPattern,
     ) -> Box<[(Text, TypeReference)]> {
@@ -190,7 +189,7 @@ impl TypeData {
 
     fn apply_object_binding_pattern_member(
         &self,
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         names: &[Text],
         member_name: Option<Text>,
@@ -261,7 +260,7 @@ impl TypeData {
     }
 
     pub fn from_any_js_declaration(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &AnyJsDeclaration,
     ) -> Self {
@@ -308,7 +307,7 @@ impl TypeData {
     }
 
     pub fn from_any_js_declaration_clause(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: AnyJsDeclarationClause,
     ) -> Self {
@@ -318,7 +317,7 @@ impl TypeData {
     }
 
     pub fn from_any_js_export_default_declaration(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &AnyJsExportDefaultDeclaration,
     ) -> Self {
@@ -427,7 +426,7 @@ impl TypeData {
     }
 
     pub fn from_any_js_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &AnyJsExpression,
     ) -> Self {
@@ -666,7 +665,7 @@ impl TypeData {
     }
 
     pub fn from_any_ts_type(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         ty: &AnyTsType,
     ) -> Self {
@@ -709,7 +708,7 @@ impl TypeData {
                         .unwrap_or_default(),
                 ]);
 
-                Self::union_of(resolver, types)
+                resolver.union_of(types)
             }
             AnyTsType::TsConstructorType(ty) => Self::Constructor(Box::new(Constructor {
                 type_parameters: generic_params_from_ts_type_params(
@@ -834,7 +833,7 @@ impl TypeData {
                     .map(|ty| TypeReference::from_any_ts_type(resolver, scope_id, &ty))
                     .collect();
 
-                Self::union_of(resolver, types)
+                resolver.union_of(types)
             }
             AnyTsType::TsUnknownType(_) => Self::UnknownKeyword,
             AnyTsType::TsVoidType(_) => Self::VoidKeyword,
@@ -842,7 +841,7 @@ impl TypeData {
     }
 
     pub fn from_any_ts_type_result(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         ty: SyntaxResult<AnyTsType>,
     ) -> Self {
@@ -851,7 +850,7 @@ impl TypeData {
     }
 
     pub fn from_js_arrow_function_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &JsArrowFunctionExpression,
     ) -> Self {
@@ -893,7 +892,7 @@ impl TypeData {
     }
 
     pub fn from_js_binary_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &JsBinaryExpression,
     ) -> Self {
@@ -956,7 +955,7 @@ impl TypeData {
     }
 
     pub fn from_js_class_declaration(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &JsClassDeclaration,
     ) -> Self {
@@ -987,7 +986,7 @@ impl TypeData {
     }
 
     pub fn from_js_class_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &JsClassExpression,
     ) -> Self {
@@ -1017,7 +1016,7 @@ impl TypeData {
     }
 
     pub fn from_js_function_declaration(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &JsFunctionDeclaration,
     ) -> Self {
@@ -1047,7 +1046,7 @@ impl TypeData {
     }
 
     pub fn from_js_function_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &JsFunctionExpression,
     ) -> Self {
@@ -1076,7 +1075,7 @@ impl TypeData {
     }
 
     pub fn from_js_logical_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &JsLogicalExpression,
     ) -> Option<Self> {
@@ -1105,7 +1104,7 @@ impl TypeData {
     }
 
     pub fn from_js_new_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &JsNewExpression,
     ) -> Option<Self> {
@@ -1120,7 +1119,7 @@ impl TypeData {
     }
 
     pub fn from_ts_instantiation_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &TsInstantiationExpression,
     ) -> Option<Self> {
@@ -1135,7 +1134,7 @@ impl TypeData {
     }
 
     pub fn from_js_object_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &JsObjectExpression,
     ) -> Self {
@@ -1158,7 +1157,7 @@ impl TypeData {
     }
 
     pub fn from_js_unary_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &JsUnaryExpression,
     ) -> Self {
@@ -1197,7 +1196,7 @@ impl TypeData {
     }
 
     pub fn from_js_variable_declarator<'a>(
-        resolver: &'a mut dyn TypeResolver,
+        resolver: &'a mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &JsVariableDeclarator,
     ) -> Option<Cow<'a, Self>> {
@@ -1220,7 +1219,7 @@ impl TypeData {
     }
 
     pub fn from_ts_declare_function_declaration(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &TsDeclareFunctionDeclaration,
     ) -> Self {
@@ -1262,7 +1261,7 @@ impl TypeData {
     }
 
     pub fn from_ts_interface_declaration(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &TsInterfaceDeclaration,
     ) -> Option<Self> {
@@ -1302,7 +1301,7 @@ impl TypeData {
     }
 
     pub fn from_ts_reference_type(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         ty: &TsReferenceType,
     ) -> Self {
@@ -1322,7 +1321,7 @@ impl TypeData {
     }
 
     pub fn from_ts_type_alias_declaration(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &TsTypeAliasDeclaration,
     ) -> Option<Self> {
@@ -1338,7 +1337,7 @@ impl TypeData {
     }
 
     pub fn from_ts_typeof_type(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         ty: &TsTypeofType,
     ) -> Self {
@@ -1378,7 +1377,7 @@ impl TypeData {
     }
 
     pub fn typed_bindings_from_js_binding_pattern(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         ty: Self,
         pattern: &AnyJsBindingPattern,
@@ -1411,7 +1410,7 @@ impl TypeData {
     }
 
     pub fn typed_bindings_from_js_for_statement(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &JsForVariableDeclaration,
     ) -> Option<Box<[(Text, TypeReference)]>> {
@@ -1439,7 +1438,7 @@ impl TypeData {
     }
 
     pub fn typed_bindings_from_js_variable_declaration(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &JsVariableDeclaration,
     ) -> Box<[(Text, TypeReference)]> {
@@ -1454,7 +1453,7 @@ impl TypeData {
     }
 
     pub fn typed_bindings_from_js_variable_declarator(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         decl: &JsVariableDeclarator,
     ) -> Option<Box<[(Text, TypeReference)]>> {
@@ -1466,7 +1465,7 @@ impl TypeData {
 
 impl CallArgumentType {
     pub fn types_from_js_call_arguments(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         arguments: Option<JsCallArguments>,
     ) -> Box<[Self]> {
@@ -1482,7 +1481,7 @@ impl CallArgumentType {
     }
 
     pub fn from_any_js_call_argument(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         arg: &AnyJsCallArgument,
     ) -> Self {
@@ -1502,7 +1501,7 @@ impl CallArgumentType {
 
 impl ConstructorParameter {
     pub fn from_any_js_constructor_parameter(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         param: &AnyJsConstructorParameter,
     ) -> Self {
@@ -1534,7 +1533,7 @@ impl ConstructorParameter {
     }
 
     pub fn params_from_js_constructor_parameters(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         params: &JsConstructorParameters,
     ) -> Box<[Self]> {
@@ -1550,7 +1549,7 @@ impl ConstructorParameter {
 
 impl FunctionParameter {
     pub fn from_any_js_formal_parameter(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         param: &AnyJsFormalParameter,
     ) -> Self {
@@ -1563,7 +1562,7 @@ impl FunctionParameter {
     }
 
     pub fn from_any_js_parameter(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         param: &AnyJsParameter,
     ) -> Self {
@@ -1588,7 +1587,7 @@ impl FunctionParameter {
     }
 
     pub fn from_js_formal_parameter(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         param: &JsFormalParameter,
     ) -> Self {
@@ -1603,7 +1602,7 @@ impl FunctionParameter {
     }
 
     pub fn from_js_rest_parameter(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         param: &JsRestParameter,
     ) -> Self {
@@ -1618,7 +1617,7 @@ impl FunctionParameter {
     }
 
     fn from_binding_with_annotation(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         binding: SyntaxResult<AnyJsBindingPattern>,
         annotation: Option<TsTypeAnnotation>,
@@ -1639,7 +1638,8 @@ impl FunctionParameter {
         // Optional parameters can be called without a value, so include `undefined` in the type
         let ty = if is_optional {
             let ty_ref = resolver.reference_to_owned_data(ty_data.clone());
-            ResolvedTypeId::new(resolver.level(), resolver.optional(ty_ref)).into()
+            let id = resolver.optional(ty_ref);
+            resolver.reference_to_id(id)
         } else {
             resolver.reference_to_owned_data(ty_data.clone())
         };
@@ -1669,7 +1669,7 @@ impl FunctionParameter {
     }
 
     pub fn params_from_js_parameters(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         params: &JsParameters,
     ) -> Box<[Self]> {
@@ -1691,7 +1691,7 @@ impl From<(Text, TypeReference)> for FunctionParameterBinding {
 
 impl FunctionParameterBinding {
     pub fn bindings_from_any_js_binding_pattern_of_type(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         pattern: &AnyJsBindingPattern,
         ty: &TypeData,
@@ -1723,7 +1723,7 @@ impl FunctionParameterBinding {
 
 impl GenericTypeParameter {
     pub fn from_ts_type_parameter(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         param: &TsTypeParameter,
     ) -> Option<Self> {
@@ -1751,7 +1751,7 @@ impl GenericTypeParameter {
     }
 
     pub fn params_from_ts_type_parameters(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         params: &TsTypeParameters,
     ) -> Box<[Self]> {
@@ -1766,7 +1766,7 @@ impl GenericTypeParameter {
 
 impl ReturnType {
     pub fn from_any_ts_return_type(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         ty: &AnyTsReturnType,
     ) -> Option<Self> {
@@ -1817,7 +1817,7 @@ impl ReturnType {
 
 impl TupleElementType {
     pub fn from_any_ts_tuple_type_element(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         el: &AnyTsTupleTypeElement,
     ) -> Self {
@@ -1864,7 +1864,7 @@ impl TupleElementType {
 
 impl TypeMember {
     pub fn from_any_js_class_member(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         member: &AnyJsClassMember,
     ) -> Option<Self> {
@@ -2043,7 +2043,7 @@ impl TypeMember {
     }
 
     pub fn from_any_js_object_member(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         member: &AnyJsObjectMember,
     ) -> Option<Self> {
@@ -2178,7 +2178,7 @@ impl TypeMember {
     }
 
     pub fn from_any_ts_type_member(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         member: &AnyTsTypeMember,
     ) -> Option<Self> {
@@ -2248,7 +2248,10 @@ impl TypeMember {
                 let ty = resolver.register_and_resolve(function.into()).into();
                 Some(Self {
                     kind: TypeMemberKind::Getter(name.into()),
-                    ty: ResolvedTypeId::new(resolver.level(), resolver.optional(ty)).into(),
+                    ty: {
+                        let id = resolver.optional(ty);
+                        resolver.reference_to_id(id)
+                    },
                 })
             }
             AnyTsTypeMember::TsIndexSignatureTypeMember(member) => {
@@ -2312,7 +2315,7 @@ impl TypeMember {
 
     #[inline]
     fn from_class_member_info(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         name: AnyJsClassMemberName,
         ty: TypeReference,
@@ -2349,7 +2352,7 @@ impl TypeMember {
 
     #[inline]
     fn from_name_and_optional_type(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         name: TokenText,
         ty: TypeReference,
         is_optional: bool,
@@ -2362,14 +2365,17 @@ impl TypeMember {
                 TypeMemberKind::Named(name)
             },
             ty: match is_optional {
-                true => ResolvedTypeId::new(resolver.level(), resolver.optional(ty)).into(),
+                true => {
+                    let id = resolver.optional(ty);
+                    resolver.reference_to_id(id)
+                }
                 false => ty,
             },
         }
     }
 
     fn members_from_class_member_list(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         member_list: JsClassMemberList,
     ) -> Box<[Self]> {
@@ -2383,8 +2389,8 @@ impl TypeMember {
         for i in 0..num_members {
             let member = &members[i];
             if member.is_constructor()
-                && let Some(member_ty) = resolver.resolve_and_get(&member.ty)
-                && let TypeData::Constructor(constructor) = member_ty.as_raw_data()
+                && let Some(member_ty) = resolver.get_by_reference(&member.ty)
+                && let TypeData::Constructor(constructor) = member_ty
             {
                 for param in &constructor.parameters {
                     if let Some(_accessibility) = param.accessibility
@@ -2409,7 +2415,7 @@ impl TypeMember {
 }
 
 fn computed_member_reference(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     expression: &AnyJsExpression,
 ) -> TypeReference {
@@ -2423,16 +2429,15 @@ fn computed_member_reference(
                 .and_then(|name| text_from_token(name.value_token())),
             member.member().ok().and_then(text_from_any_js_name),
         )
+        && object_name.text() == "Symbol"
+        && resolver.is_global_symbol(scope_id)
     {
-        let symbol_qualifier = TypeReferenceQualifier::from_path(scope_id, object_name.clone());
-        if resolver.resolve_qualifier(&symbol_qualifier) == Some(GLOBAL_SYMBOL_ID) {
-            match member_name.text() {
-                "dispose" => return TypeReference::Resolved(GLOBAL_SYMBOL_DISPOSE_ID),
-                "asyncDispose" => {
-                    return TypeReference::Resolved(GLOBAL_SYMBOL_ASYNC_DISPOSE_ID);
-                }
-                _ => {}
+        match member_name.text() {
+            "dispose" => return TypeReference::Resolved(GLOBAL_SYMBOL_DISPOSE_ID),
+            "asyncDispose" => {
+                return TypeReference::Resolved(GLOBAL_SYMBOL_ASYNC_DISPOSE_ID);
             }
+            _ => {}
         }
     }
 
@@ -2441,7 +2446,7 @@ fn computed_member_reference(
 
 impl TypeReference {
     pub fn from_any_js_expression(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         expr: &AnyJsExpression,
     ) -> Self {
@@ -2450,7 +2455,7 @@ impl TypeReference {
     }
 
     pub fn from_any_ts_type(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         ty: &AnyTsType,
     ) -> Self {
@@ -2466,7 +2471,7 @@ impl TypeReference {
     }
 
     pub fn from_ts_reference_type(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         ty: &TsReferenceType,
     ) -> Self {
@@ -2475,7 +2480,7 @@ impl TypeReference {
     }
 
     pub fn types_from_ts_type_arguments(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         arguments: Option<TsTypeArguments>,
     ) -> Box<[Self]> {
@@ -2491,7 +2496,7 @@ impl TypeReference {
     }
 
     pub fn types_from_ts_type_list(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         types: TsTypeList,
     ) -> Box<[Self]> {
@@ -2503,7 +2508,7 @@ impl TypeReference {
     }
 
     pub fn types_from_ts_type_parameters(
-        resolver: &mut dyn TypeResolver,
+        resolver: &mut dyn RawTypeCollector,
         scope_id: ScopeId,
         params: &TsTypeParameters,
     ) -> Box<[Self]> {
@@ -2696,7 +2701,7 @@ impl TypeofThisOrSuperExpression {
 }
 
 fn reference_to_extends_clause(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     extends: JsExtendsClause,
 ) -> Option<TypeReference> {
@@ -2735,7 +2740,7 @@ impl TypeMemberAccessibility {
 
 #[inline]
 fn constructor_params_from_js_constructor_params(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     params: SyntaxResult<JsConstructorParameters>,
 ) -> Box<[ConstructorParameter]> {
@@ -2748,7 +2753,7 @@ fn constructor_params_from_js_constructor_params(
 
 #[inline]
 fn constructor_params_from_js_params(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     params: SyntaxResult<JsParameters>,
 ) -> Box<[ConstructorParameter]> {
@@ -2770,7 +2775,7 @@ fn constructor_params_from_js_params(
 
 #[inline]
 fn function_params_from_js_params(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     params: SyntaxResult<JsParameters>,
 ) -> Box<[FunctionParameter]> {
@@ -2780,7 +2785,7 @@ fn function_params_from_js_params(
 }
 
 fn function_return_type(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     is_async: bool,
     annotation: Option<TsReturnTypeAnnotation>,
@@ -2817,7 +2822,7 @@ fn function_return_type(
 }
 
 fn getter_return_type(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     annotation: Option<TsTypeAnnotation>,
     body: Option<JsFunctionBody>,
@@ -2836,7 +2841,7 @@ fn getter_return_type(
 
 #[inline]
 fn generic_params_from_ts_type_params(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     params: Option<TsTypeParameters>,
 ) -> Box<[TypeReference]> {
@@ -2870,7 +2875,7 @@ fn path_from_any_ts_module_name(module_name: AnyTsModuleName) -> Option<Path> {
 
 #[inline]
 fn return_type_from_annotation(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     annotation: Option<TsReturnTypeAnnotation>,
 ) -> Option<ReturnType> {
@@ -2928,7 +2933,7 @@ fn text_from_token(token: SyntaxResult<JsSyntaxToken>) -> Option<Text> {
 
 #[inline]
 fn type_from_annotation(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     annotation: Option<TsTypeAnnotation>,
 ) -> Option<TypeReference> {
@@ -2938,7 +2943,7 @@ fn type_from_annotation(
 }
 
 fn type_from_function_body(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     body: JsFunctionBody,
 ) -> TypeData {
@@ -2967,7 +2972,7 @@ fn type_from_function_body(
                 .map(|ty| resolver.reference_to_owned_data(ty))
                 .collect();
 
-            TypeData::union_of(resolver, return_types)
+            resolver.union_of(return_types)
         }
     }
 }
@@ -3009,7 +3014,7 @@ fn expression_is_const_assertion(expression: &AnyJsExpression) -> bool {
 
 /// Builds the type produced by a const assertion expression.
 fn type_data_from_const_assertion_expression(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     scope_id: ScopeId,
     expression: &AnyJsExpression,
 ) -> TypeData {
@@ -3046,13 +3051,13 @@ fn type_data_from_const_assertion_expression(
 }
 
 /// Applies const assertion conversion to inferred tuple and object types.
-fn apply_deep_const(resolver: &mut dyn TypeResolver, inner_type: TypeData) -> TypeData {
+fn apply_deep_const(resolver: &mut dyn RawTypeCollector, inner_type: TypeData) -> TypeData {
     apply_deep_const_inner(resolver, inner_type, 0)
 }
 
 /// Recursively applies `as const` to tuple elements and object members.
 fn apply_deep_const_inner(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     inner_type: TypeData,
     depth: usize,
 ) -> TypeData {
@@ -3091,7 +3096,7 @@ fn apply_deep_const_inner(
 
 /// Resolves a type reference, applies const assertion conversion, and stores the result.
 fn apply_deep_const_reference(
-    resolver: &mut dyn TypeResolver,
+    resolver: &mut dyn RawTypeCollector,
     type_reference: &TypeReference,
     depth: usize,
 ) -> TypeReference {
@@ -3099,10 +3104,7 @@ fn apply_deep_const_reference(
         return type_reference.clone();
     }
 
-    let Some(inner_type) = resolver
-        .resolve_and_get(type_reference)
-        .map(|resolved| resolved.to_data())
-    else {
+    let Some(inner_type) = resolver.get_by_reference(type_reference).cloned() else {
         return type_reference.clone();
     };
 

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -2390,7 +2390,7 @@ impl TypeMember {
             let member = &members[i];
             if member.is_constructor()
                 && let Some(member_ty) = resolver.get_by_reference(&member.ty)
-                && let TypeData::Constructor(constructor) = member_ty
+                && let TypeData::Constructor(constructor) = member_ty.as_ref()
             {
                 for param in &constructor.parameters {
                     if let Some(_accessibility) = param.accessibility
@@ -3104,7 +3104,10 @@ fn apply_deep_const_reference(
         return type_reference.clone();
     }
 
-    let Some(inner_type) = resolver.get_by_reference(type_reference).cloned() else {
+    let Some(inner_type) = resolver
+        .get_by_reference(type_reference)
+        .map(Cow::into_owned)
+    else {
         return type_reference.clone();
     };
 

--- a/crates/biome_js_type_info/src/type_data.rs
+++ b/crates/biome_js_type_info/src/type_data.rs
@@ -20,7 +20,7 @@ use biome_resolver::ResolvedPath;
 use biome_rowan::Text;
 
 use crate::{
-    ModuleId, Resolvable, ResolvedTypeId, ResolverId, TypeResolver,
+    GlobalTypeId, ModuleId, Resolvable, ResolvedTypeId, ResolverId, TypeResolver,
     globals::{GLOBAL_NUMBER_ID, GLOBAL_STRING_ID, GLOBAL_UNKNOWN_ID},
     literal::RegexpLiteral,
     type_data::literal::{BooleanLiteral, NumberLiteral, StringLiteral},
@@ -35,6 +35,41 @@ pub(super) const UNKNOWN_DATA: TypeData = TypeData::Reference(UNKNOWN_REFERENCE)
 /// this, type IDs are only unique within a single module/resolver.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Resolvable)]
 pub struct TypeId(u32);
+
+/// Identity of a type in a collector's raw type table or the predefined global table.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RawTypeId {
+    Local(TypeId),
+    Global(GlobalTypeId),
+}
+
+impl RawTypeId {
+    pub const fn index(self) -> usize {
+        match self {
+            Self::Local(id) => id.index(),
+            Self::Global(id) => id.index(),
+        }
+    }
+
+    pub const fn is_unknown(self) -> bool {
+        matches!(self, Self::Global(id) if id.index() == 0)
+    }
+}
+
+impl From<RawTypeId> for ResolvedTypeId {
+    fn from(id: RawTypeId) -> Self {
+        match id {
+            RawTypeId::Local(id) => Self::new(crate::TypeResolverLevel::Thin, id),
+            RawTypeId::Global(id) => Self::new(crate::TypeResolverLevel::Global, id.as_type_id()),
+        }
+    }
+}
+
+impl From<RawTypeId> for TypeReference {
+    fn from(id: RawTypeId) -> Self {
+        Self::Resolved(id.into())
+    }
+}
 
 impl TypeId {
     pub const fn new(index: usize) -> Self {
@@ -1809,5 +1844,22 @@ impl Union {
 
     pub fn with_type(&self, ty: TypeReference) -> Self {
         Self(self.0.iter().cloned().chain(Some(ty)).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RawTypeId, TypeId};
+    use crate::{ResolvedTypeId, TypeResolverLevel, globals_ids::UNKNOWN_ID_GLOBAL_TYPE_ID};
+
+    #[test]
+    fn raw_type_ids_convert_to_legacy_resolver_levels() {
+        let local: ResolvedTypeId = RawTypeId::Local(TypeId::new(3)).into();
+        let global: ResolvedTypeId = RawTypeId::Global(UNKNOWN_ID_GLOBAL_TYPE_ID).into();
+
+        assert_eq!(local.level(), TypeResolverLevel::Thin);
+        assert_eq!(local.index(), 3);
+        assert_eq!(global.level(), TypeResolverLevel::Global);
+        assert!(global.is_unknown());
     }
 }

--- a/crates/biome_js_type_info/src/type_data.rs
+++ b/crates/biome_js_type_info/src/type_data.rs
@@ -52,7 +52,7 @@ impl RawTypeId {
     }
 
     pub const fn is_unknown(self) -> bool {
-        matches!(self, Self::Global(id) if id.index() == 0)
+        matches!(self, Self::Global(id) if id.index() == GLOBAL_UNKNOWN_ID.index())
     }
 }
 
@@ -1850,7 +1850,17 @@ impl Union {
 #[cfg(test)]
 mod tests {
     use super::{RawTypeId, TypeId};
-    use crate::{ResolvedTypeId, TypeResolverLevel, globals_ids::UNKNOWN_ID_GLOBAL_TYPE_ID};
+    use crate::{
+        ResolvedTypeId, TypeResolverLevel,
+        globals_ids::{STRING_ID_GLOBAL_TYPE_ID, UNKNOWN_ID_GLOBAL_TYPE_ID},
+    };
+
+    #[test]
+    fn raw_type_id_identifies_unknown() {
+        assert!(RawTypeId::Global(UNKNOWN_ID_GLOBAL_TYPE_ID).is_unknown());
+        assert!(!RawTypeId::Global(STRING_ID_GLOBAL_TYPE_ID).is_unknown());
+        assert!(!RawTypeId::Local(TypeId::new(0)).is_unknown());
+    }
 
     #[test]
     fn raw_type_ids_convert_to_legacy_resolver_levels() {

--- a/crates/biome_js_type_info/src/type_store.rs
+++ b/crates/biome_js_type_info/src/type_store.rs
@@ -8,7 +8,14 @@ use std::{
 use hashbrown::{HashTable, hash_table::Entry};
 use rustc_hash::FxHasher;
 
-use crate::{Resolvable, ResolvedTypeId, TypeData, TypeId, TypeReference, TypeResolverLevel};
+use biome_js_semantic::ScopeId;
+use biome_js_syntax::AnyJsExpression;
+use biome_rowan::Text;
+
+use crate::{
+    Resolvable, ResolvedTypeData, ResolvedTypeId, TypeData, TypeId, TypeReference,
+    TypeReferenceQualifier, TypeResolver, TypeResolverLevel, Union, globals::GLOBAL_UNDEFINED_ID,
+};
 
 /// Type store with efficient lookup mechanism.
 ///
@@ -265,6 +272,157 @@ fn hash_data(data: &TypeData) -> u64 {
     let mut hash = FxHasher::default();
     data.hash(&mut hash);
     hash.finish()
+}
+
+/// Minimal interface needed to collect syntax-local type data.
+pub trait RawTypeCollector {
+    fn find_type(&self, type_data: &TypeData) -> Option<TypeId>;
+    fn get_by_id(&self, id: TypeId) -> &TypeData;
+    fn register_type(&mut self, type_data: Cow<TypeData>) -> TypeId;
+    fn resolve_expression(
+        &mut self,
+        scope_id: ScopeId,
+        expression: &AnyJsExpression,
+    ) -> Cow<'_, TypeData>;
+
+    fn get_by_reference(&self, ty: &TypeReference) -> Option<&TypeData> {
+        let TypeReference::Resolved(id) = ty else {
+            return None;
+        };
+        (id.level() == TypeResolverLevel::Thin).then(|| self.get_by_id(id.id()))
+    }
+
+    fn reference_to_id(&self, id: TypeId) -> TypeReference {
+        TypeReference::Resolved(ResolvedTypeId::new(TypeResolverLevel::Thin, id))
+    }
+
+    fn reference_to_data(&self, type_data: &TypeData) -> Option<TypeReference> {
+        match type_data {
+            TypeData::Reference(reference) => Some(reference.clone()),
+            other => self.find_type(other).map(|id| self.reference_to_id(id)),
+        }
+    }
+
+    fn reference_to_registered_data(&mut self, type_data: &TypeData) -> TypeReference {
+        match type_data {
+            TypeData::Reference(reference) => reference.clone(),
+            _ => {
+                let id = self.register_type(Cow::Borrowed(type_data));
+                self.reference_to_id(id)
+            }
+        }
+    }
+
+    fn reference_to_owned_data(&mut self, type_data: TypeData) -> TypeReference {
+        match type_data {
+            TypeData::Reference(reference) => reference,
+            _ => {
+                let id = self.register_type(Cow::Owned(type_data));
+                self.reference_to_id(id)
+            }
+        }
+    }
+
+    fn reference_to_resolved_expression(
+        &mut self,
+        scope_id: ScopeId,
+        expression: &AnyJsExpression,
+    ) -> TypeReference {
+        let data = self.resolve_expression(scope_id, expression).into_owned();
+        self.reference_to_owned_data(data)
+    }
+
+    fn register_and_resolve(&mut self, type_data: TypeData) -> ResolvedTypeId {
+        match type_data {
+            TypeData::Reference(TypeReference::Resolved(id)) => id,
+            type_data => ResolvedTypeId::new(
+                TypeResolverLevel::Thin,
+                self.register_type(Cow::Owned(type_data)),
+            ),
+        }
+    }
+
+    fn optional(&mut self, ty: TypeReference) -> TypeId {
+        self.register_type(Cow::Owned(TypeData::Union(Box::new(Union(Box::new([
+            ty,
+            GLOBAL_UNDEFINED_ID.into(),
+        ]))))))
+    }
+
+    fn union_of(&mut self, types: Box<[TypeReference]>) -> TypeData {
+        TypeData::Union(Box::new(Union(types)))
+    }
+
+    fn is_global_symbol(&self, _scope_id: ScopeId) -> bool {
+        true
+    }
+}
+
+impl<T: TypeResolver> RawTypeCollector for T {
+    fn find_type(&self, type_data: &TypeData) -> Option<TypeId> {
+        TypeResolver::find_type(self, type_data)
+    }
+
+    fn get_by_id(&self, id: TypeId) -> &TypeData {
+        TypeResolver::get_by_id(self, id)
+    }
+
+    fn register_type(&mut self, type_data: Cow<TypeData>) -> TypeId {
+        TypeResolver::register_type(self, type_data)
+    }
+
+    fn resolve_expression(
+        &mut self,
+        scope_id: ScopeId,
+        expression: &AnyJsExpression,
+    ) -> Cow<'_, TypeData> {
+        TypeResolver::resolve_expression(self, scope_id, expression)
+    }
+
+    fn get_by_reference(&self, ty: &TypeReference) -> Option<&TypeData> {
+        TypeResolver::resolve_and_get(self, ty).map(ResolvedTypeData::as_raw_data)
+    }
+
+    fn reference_to_id(&self, id: TypeId) -> TypeReference {
+        TypeResolver::reference_to_id(self, id)
+    }
+
+    fn reference_to_data(&self, type_data: &TypeData) -> Option<TypeReference> {
+        TypeResolver::reference_to_data(self, type_data)
+    }
+
+    fn reference_to_registered_data(&mut self, type_data: &TypeData) -> TypeReference {
+        TypeResolver::reference_to_registered_data(self, type_data)
+    }
+
+    fn reference_to_owned_data(&mut self, type_data: TypeData) -> TypeReference {
+        TypeResolver::reference_to_owned_data(self, type_data)
+    }
+
+    fn reference_to_resolved_expression(
+        &mut self,
+        scope_id: ScopeId,
+        expression: &AnyJsExpression,
+    ) -> TypeReference {
+        TypeResolver::reference_to_resolved_expression(self, scope_id, expression)
+    }
+
+    fn register_and_resolve(&mut self, type_data: TypeData) -> ResolvedTypeId {
+        TypeResolver::register_and_resolve(self, type_data)
+    }
+
+    fn optional(&mut self, ty: TypeReference) -> TypeId {
+        TypeResolver::optional(self, ty)
+    }
+
+    fn union_of(&mut self, types: Box<[TypeReference]>) -> TypeData {
+        TypeData::union_of(self, types)
+    }
+
+    fn is_global_symbol(&self, scope_id: ScopeId) -> bool {
+        let qualifier = TypeReferenceQualifier::from_path(scope_id, Text::new_static("Symbol"));
+        TypeResolver::resolve_qualifier(self, &qualifier) == Some(crate::globals::GLOBAL_SYMBOL_ID)
+    }
 }
 
 #[cfg(test)]

--- a/crates/biome_js_type_info/src/type_store.rs
+++ b/crates/biome_js_type_info/src/type_store.rs
@@ -13,8 +13,8 @@ use biome_js_syntax::AnyJsExpression;
 use biome_rowan::Text;
 
 use crate::{
-    Resolvable, ResolvedTypeData, ResolvedTypeId, TypeData, TypeId, TypeReference,
-    TypeReferenceQualifier, TypeResolver, TypeResolverLevel, Union, globals::GLOBAL_UNDEFINED_ID,
+    Resolvable, ResolvedTypeId, TypeData, TypeId, TypeReference, TypeReferenceQualifier,
+    TypeResolver, TypeResolverLevel, Union, globals::GLOBAL_UNDEFINED_ID,
 };
 
 /// Type store with efficient lookup mechanism.
@@ -285,11 +285,11 @@ pub trait RawTypeCollector {
         expression: &AnyJsExpression,
     ) -> Cow<'_, TypeData>;
 
-    fn get_by_reference(&self, ty: &TypeReference) -> Option<&TypeData> {
+    fn get_by_reference(&self, ty: &TypeReference) -> Option<Cow<'_, TypeData>> {
         let TypeReference::Resolved(id) = ty else {
             return None;
         };
-        (id.level() == TypeResolverLevel::Thin).then(|| self.get_by_id(id.id()))
+        (id.level() == TypeResolverLevel::Thin).then(|| Cow::Borrowed(self.get_by_id(id.id())))
     }
 
     fn reference_to_id(&self, id: TypeId) -> TypeReference {
@@ -379,8 +379,8 @@ impl<T: TypeResolver> RawTypeCollector for T {
         TypeResolver::resolve_expression(self, scope_id, expression)
     }
 
-    fn get_by_reference(&self, ty: &TypeReference) -> Option<&TypeData> {
-        TypeResolver::resolve_and_get(self, ty).map(ResolvedTypeData::as_raw_data)
+    fn get_by_reference(&self, ty: &TypeReference) -> Option<Cow<'_, TypeData>> {
+        TypeResolver::resolve_and_get(self, ty).map(|data| Cow::Owned(data.to_data()))
     }
 
     fn reference_to_id(&self, id: TypeId) -> TypeReference {

--- a/crates/biome_js_type_info/tests/local_inference.rs
+++ b/crates/biome_js_type_info/tests/local_inference.rs
@@ -2,12 +2,14 @@ mod utils;
 
 use biome_js_semantic::ScopeId;
 use biome_js_type_info::{
-    GlobalsResolver, RawTypeCollector, TypeData, TypeReference, TypeResolver, TypeResolverLevel,
+    GLOBAL_BOOLEAN_ID, GlobalsResolver, ModuleId, RawTypeCollector, ResolvedTypeId, TypeData,
+    TypeId, TypeReference, TypeResolver, TypeResolverLevel,
 };
 
 use utils::{
-    TestTypeCollector, assert_type_data_snapshot, assert_typed_bindings_snapshot, get_expression,
-    get_function_declaration, get_variable_declaration, parse_ts,
+    HardcodedSymbolResolver, TestTypeCollector, assert_type_data_snapshot,
+    assert_typed_bindings_snapshot, get_expression, get_function_declaration,
+    get_variable_declaration, parse_ts,
 };
 
 #[test]
@@ -27,9 +29,36 @@ fn raw_collector_records_local_expression_references() {
 
     assert_eq!(id.level(), TypeResolverLevel::Thin);
     assert!(matches!(
-        collector.get_by_reference(&tuple.elements()[0].ty),
+        collector
+            .get_by_reference(&tuple.elements()[0].ty)
+            .as_deref(),
         Some(TypeData::Literal(_))
     ));
+}
+
+#[test]
+fn legacy_resolver_preserves_module_context_for_nested_references() {
+    let nested_id = ResolvedTypeId::new(TypeResolverLevel::Thin, TypeId::new(1));
+    let globals = GlobalsResolver::default();
+    let data = TypeData::union_of(
+        &globals,
+        Box::new([nested_id.into(), GLOBAL_BOOLEAN_ID.into()]),
+    );
+    let resolver = HardcodedSymbolResolver::new("value", data, globals);
+    let module_id = ModuleId::new(5);
+    let outer_id =
+        ResolvedTypeId::new(TypeResolverLevel::Thin, TypeId::new(0)).with_module_id(module_id);
+
+    let resolved =
+        RawTypeCollector::get_by_reference(&resolver, &outer_id.into()).expect("type must resolve");
+    let TypeData::Union(union) = resolved.as_ref() else {
+        panic!("expected union type");
+    };
+    let TypeReference::Resolved(nested_id) = &union.types()[0] else {
+        panic!("expected resolved nested type");
+    };
+
+    assert_eq!(nested_id.module_id(), module_id);
 }
 
 #[test]

--- a/crates/biome_js_type_info/tests/local_inference.rs
+++ b/crates/biome_js_type_info/tests/local_inference.rs
@@ -1,12 +1,36 @@
 mod utils;
 
 use biome_js_semantic::ScopeId;
-use biome_js_type_info::{GlobalsResolver, TypeData, TypeResolver};
+use biome_js_type_info::{
+    GlobalsResolver, RawTypeCollector, TypeData, TypeReference, TypeResolver, TypeResolverLevel,
+};
 
 use utils::{
-    assert_type_data_snapshot, assert_typed_bindings_snapshot, get_expression,
+    TestTypeCollector, assert_type_data_snapshot, assert_typed_bindings_snapshot, get_expression,
     get_function_declaration, get_variable_declaration, parse_ts,
 };
+
+#[test]
+fn raw_collector_records_local_expression_references() {
+    let root = parse_ts("[1]");
+    let expression = get_expression(&root);
+    let mut collector = TestTypeCollector::default();
+
+    let TypeData::Tuple(tuple) =
+        TypeData::from_any_js_expression(&mut collector, ScopeId::GLOBAL, &expression)
+    else {
+        panic!("expected tuple type");
+    };
+    let TypeReference::Resolved(id) = &tuple.elements()[0].ty else {
+        panic!("expected resolved element type");
+    };
+
+    assert_eq!(id.level(), TypeResolverLevel::Thin);
+    assert!(matches!(
+        collector.get_by_reference(&tuple.elements()[0].ty),
+        Some(TypeData::Literal(_))
+    ));
+}
 
 #[test]
 fn infer_type_of_identifier() {

--- a/crates/biome_js_type_info/tests/utils.rs
+++ b/crates/biome_js_type_info/tests/utils.rs
@@ -13,10 +13,38 @@ use biome_js_syntax::{AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsFunctionDecl
 use biome_js_type_info::{
     GlobalsResolver, NUM_PREDEFINED_TYPES, Resolvable, ResolvedTypeData, ResolvedTypeId, ScopeId,
     TypeData, TypeId, TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
+    TypeStore,
 };
 use biome_languages::JsFileSource;
 use biome_rowan::{AstNode, Text};
 use biome_test_utils::dump_registered_types;
+
+#[derive(Default)]
+pub struct TestTypeCollector {
+    pub types: TypeStore,
+}
+
+impl biome_js_type_info::RawTypeCollector for TestTypeCollector {
+    fn find_type(&self, type_data: &TypeData) -> Option<TypeId> {
+        self.types.find(type_data)
+    }
+
+    fn get_by_id(&self, id: TypeId) -> &TypeData {
+        self.types.get_by_id(id)
+    }
+
+    fn register_type(&mut self, type_data: Cow<TypeData>) -> TypeId {
+        self.types.insert_cow(type_data)
+    }
+
+    fn resolve_expression(
+        &mut self,
+        scope_id: ScopeId,
+        expression: &AnyJsExpression,
+    ) -> Cow<'_, TypeData> {
+        Cow::Owned(TypeData::from_any_js_expression(self, scope_id, expression))
+    }
+}
 
 pub fn assert_type_data_snapshot(
     source_code: &str,

--- a/crates/biome_module_graph/src/js_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/js_module_info/visitor.rs
@@ -8,7 +8,7 @@ use biome_js_syntax::{
     JsExportNamedFromClause, JsExportNamedSpecifierList, JsIdentifierBinding,
     JsVariableDeclaratorList, JsxAttribute, TsExportAssignmentClause, unescape_js_string,
 };
-use biome_js_type_info::{ImportSymbol, TypeData, TypeReference, TypeResolver};
+use biome_js_type_info::{ImportSymbol, RawTypeCollector, TypeData, TypeReference};
 use biome_resolver::{ResolveOptions, resolve};
 use biome_rowan::{AstNode, TokenText, WalkEvent};
 use camino::{Utf8Path, Utf8PathBuf};

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -76,15 +76,16 @@ use biome_js_syntax::{
     AnyJsExpression, AnyJsTemplateElement, JsCallArgumentList, JsCallArguments, JsCallExpression,
     JsTemplateExpression,
 };
+#[cfg(feature = "type_inference")]
+use biome_js_syntax::{
+    AnyJsExpression as TypeInfoExpression, JsClassDeclaration, JsClassExpression,
+    JsFunctionDeclaration, JsVariableDeclarator,
+};
 use biome_js_syntax::{
     AnyJsRoot, JsLanguage, JsSyntaxNode, JsTemplateChunkElement, TextRange, TextSize, TokenAtOffset,
 };
 #[cfg(feature = "type_inference")]
-use biome_js_syntax::{
-    JsClassDeclaration, JsClassExpression, JsFunctionDeclaration, JsVariableDeclarator,
-};
-#[cfg(feature = "type_inference")]
-use biome_js_type_info::{GlobalsResolver, ScopeId, TypeData, TypeResolver};
+use biome_js_type_info::{GlobalsResolver, RawTypeCollector, ScopeId, TypeData, TypeId, TypeStore};
 #[cfg(feature = "js_embeds")]
 use biome_languages::CssFileSource;
 #[cfg(all(feature = "js_embeds", feature = "lang_graphql"))]
@@ -941,7 +942,7 @@ fn debug_registered_types(
         let mut result = String::new();
         let preorder = tree.syntax().preorder();
 
-        let mut resolver = GlobalsResolver::default();
+        let mut resolver = DebugTypeCollector::default();
         let scope_id = ScopeId::GLOBAL;
 
         for event in preorder {
@@ -961,7 +962,7 @@ fn debug_registered_types(
             }
         }
 
-        for (i, ty) in resolver.registered_types().iter().enumerate() {
+        for (i, ty) in resolver.types.as_references().iter().enumerate() {
             result.push_str(&format!("\nTypeId({i}) => {ty}\n"));
         }
 
@@ -972,6 +973,35 @@ fn debug_registered_types(
     {
         let _ = (_path, parse, workspace_db);
         Err(WorkspaceError::feature_not_enabled())
+    }
+}
+
+#[cfg(feature = "type_inference")]
+#[derive(Default)]
+struct DebugTypeCollector {
+    types: TypeStore,
+}
+
+#[cfg(feature = "type_inference")]
+impl RawTypeCollector for DebugTypeCollector {
+    fn find_type(&self, type_data: &TypeData) -> Option<TypeId> {
+        self.types.find(type_data)
+    }
+
+    fn get_by_id(&self, id: TypeId) -> &TypeData {
+        self.types.get_by_id(id)
+    }
+
+    fn register_type(&mut self, type_data: Cow<TypeData>) -> TypeId {
+        self.types.insert_cow(type_data)
+    }
+
+    fn resolve_expression(
+        &mut self,
+        scope_id: ScopeId,
+        expression: &TypeInfoExpression,
+    ) -> Cow<'_, TypeData> {
+        Cow::Owned(TypeData::from_any_js_expression(self, scope_id, expression))
     }
 }
 


### PR DESCRIPTION
## Summary

Separates syntax-level type collection from type resolution by introducing raw type IDs and a raw collector. The legacy resolver remains available until the later consumer cutover.

## Test Plan

Added focused raw-collection tests and passed type-info, service, and module-graph checks.

## Docs

N/A

> This PR was created with AI assistance (OpenCode).