### PR TITLE
refactor(inference): add structural type mapping

### DIFF
--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -8,7 +8,6 @@ use biome_js_syntax::numbers::canonicalize_js_bigint_literal;
 use biome_rowan::Text;
 use rustc_hash::FxHashSet;
 use std::iter::FusedIterator;
-use std::ops::ControlFlow;
 
 use crate::{
     ScopeId,
@@ -24,11 +23,12 @@ use crate::{
     type_data as raw,
 };
 
+pub use crate::type_transform::{TypeSubstitution, TypeTransformError, TypeTransformResult};
+
 pub type RawTypeData = raw::TypeData;
 pub type ReferenceResolver<'db, 'resolver> =
     dyn FnMut(&raw::TypeReference) -> TypeData<'db> + 'resolver;
 const MAX_GENERIC_REPLACEMENT_STEPS: usize = 64;
-const MAX_TYPE_SUBSTITUTION_STEPS: usize = 1024;
 const MAX_OBJECT_RELATION_DEPTH: usize = 50;
 
 pub fn well_known_symbol_name(reference: &raw::TypeReference) -> Option<Text> {
@@ -54,38 +54,6 @@ pub fn well_known_symbol_name(reference: &raw::TypeReference) -> Option<Text> {
         _ => None,
     }
 }
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update)]
-pub struct TypeSubstitution<'db> {
-    pub generic: TypeData<'db>,
-    pub replacement: TypeData<'db>,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum StructuralTypeMapItem<'db> {
-    Enter(TypeData<'db>),
-    Rebuild(TypeData<'db>, usize),
-    Exit(TypeData<'db>),
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum StructuralMapError {
-    /// The caller must degrade the incomplete result to `Unknown`.
-    StepLimitExceeded,
-    /// A child sequence could not rebuild the original structural shape.
-    InvalidRebuild,
-}
-
-impl std::fmt::Display for StructuralMapError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            Self::StepLimitExceeded => "structural type traversal exceeded its step limit",
-            Self::InvalidRebuild => "structural type children could not rebuild their parent",
-        })
-    }
-}
-
-impl std::error::Error for StructuralMapError {}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, salsa::Update)]
 pub struct ModuleKey {
@@ -641,8 +609,8 @@ impl<'db> TypeData<'db> {
     /// `replacement` is `string`.
     ///
     /// The walk is iterative and returns `None` if it cannot finish within a
-    /// fixed number of steps. Already-seen edges can still complete after the
-    /// budget is consumed, so cyclic shapes terminate without false exhaustion.
+    /// fixed number of steps. Types already being visited do not consume another
+    /// step.
     pub fn collect_generic_replacements(
         self,
         db: &'db dyn TypeDb,
@@ -688,194 +656,19 @@ impl<'db> TypeData<'db> {
         Some(replacements)
     }
 
-    /// Substitutes a generic throughout a type, stopping below nested binders.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`StructuralMapError::StepLimitExceeded`] if traversal exhausts
-    /// its budget, or [`StructuralMapError::InvalidRebuild`] if transformed
-    /// children cannot reconstruct their parent type.
-    pub fn substitute_type(
-        self,
-        db: &'db dyn TypeDb,
-        substitution: TypeSubstitution<'db>,
-    ) -> Result<Self, StructuralMapError> {
-        let mut remaining_steps = MAX_TYPE_SUBSTITUTION_STEPS;
-        self.substitute_type_with_budget(db, substitution, &mut remaining_steps)
+    // #endregion
+
+    // #region Structural mapping
+
+    /// Extracts this type's immediate `TypeData` fields in reconstruction order.
+    /// Nested slots are not included.
+    pub(crate) fn type_slots(self, db: &'db dyn TypeDb) -> TypeDataSlots<'db> {
+        TypeDataSlots::collect(db, self)
     }
 
-    fn substitute_type_with_budget(
-        self,
-        db: &'db dyn TypeDb,
-        substitution: TypeSubstitution<'db>,
-        remaining_steps: &mut usize,
-    ) -> Result<Self, StructuralMapError> {
-        let binder_generic = substitution.binder_generic(db);
-        self.try_map_structural_with_budget(
-            db,
-            remaining_steps,
-            |ty| {
-                if ty.declares_generic(db, binder_generic) {
-                    ControlFlow::Break(ty)
-                } else if ty == substitution.generic {
-                    ControlFlow::Break(substitution.replacement)
-                } else {
-                    ControlFlow::Continue(ty)
-                }
-            },
-            |ty| ty,
-        )
-    }
+    // #endregion
 
-    /// Substitutes inside the root binder while respecting nested binders.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`StructuralMapError::StepLimitExceeded`] if traversal exhausts
-    /// its budget, or [`StructuralMapError::InvalidRebuild`] if transformed
-    /// children cannot reconstruct their parent type.
-    pub fn substitute_type_in_root_body(
-        self,
-        db: &'db dyn TypeDb,
-        substitution: TypeSubstitution<'db>,
-    ) -> Result<Self, StructuralMapError> {
-        if !self.declares_generic(db, substitution.binder_generic(db)) {
-            return self.substitute_type(db, substitution);
-        }
-
-        let mut remaining_steps = MAX_TYPE_SUBSTITUTION_STEPS;
-        if structural_type_child_count(db, self) > remaining_steps {
-            return Err(StructuralMapError::StepLimitExceeded);
-        }
-        let root_type_parameter_count = declared_type_parameters(db, self).map_or(0, <[_]>::len);
-        let children = structural_type_children(db, self)
-            .into_iter()
-            .enumerate()
-            .map(|(index, child)| {
-                if index < root_type_parameter_count {
-                    Ok(child)
-                } else {
-                    child.substitute_type_with_budget(db, substitution, &mut remaining_steps)
-                }
-            })
-            .collect::<Result<_, _>>()?;
-        rebuild_structural_type(db, self, children).ok_or(StructuralMapError::InvalidRebuild)
-    }
-
-    fn declares_generic(self, db: &'db dyn TypeDb, generic: Self) -> bool {
-        declared_type_parameters(db, self).is_some_and(|parameters| parameters.contains(&generic))
-    }
-
-    /// Iteratively maps this type and all structurally nested types.
-    ///
-    /// `map` runs before children are visited. Returning `Break` replaces a
-    /// complete subtree, while `Continue` descends into the returned type.
-    /// `finish` runs after a descended type has been rebuilt.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`StructuralMapError::StepLimitExceeded`] when `max_steps` is
-    /// exhausted, or [`StructuralMapError::InvalidRebuild`] when mapped children
-    /// cannot reconstruct their parent type.
-    pub fn try_map_structural(
-        self,
-        db: &'db dyn TypeDb,
-        max_steps: usize,
-        map: impl FnMut(Self) -> ControlFlow<Self, Self>,
-        finish: impl FnMut(Self) -> Self,
-    ) -> Result<Self, StructuralMapError> {
-        let mut remaining_steps = max_steps;
-        self.try_map_structural_with_budget(db, &mut remaining_steps, map, finish)
-    }
-
-    fn try_map_structural_with_budget(
-        self,
-        db: &'db dyn TypeDb,
-        remaining_steps: &mut usize,
-        mut map: impl FnMut(Self) -> ControlFlow<Self, Self>,
-        mut finish: impl FnMut(Self) -> Self,
-    ) -> Result<Self, StructuralMapError> {
-        // Count every child before adding it to the stack. This prevents the
-        // walk from starting a group of children that it cannot finish with
-        // the steps that remain. A child that points to an active parent reuses
-        // that parent, so following that link does not use another step.
-        let mut stack = Vec::from([StructuralTypeMapItem::Enter(self)]);
-        let mut results = Vec::new();
-        let mut active = FxHashSet::default();
-
-        while let Some(item) = stack.pop() {
-            match item {
-                StructuralTypeMapItem::Enter(ty) => {
-                    if active.contains(&ty) {
-                        results.push(ty);
-                        continue;
-                    }
-
-                    if *remaining_steps == 0 {
-                        return Err(StructuralMapError::StepLimitExceeded);
-                    }
-                    *remaining_steps -= 1;
-
-                    let source = ty;
-                    let ty = match map(ty) {
-                        ControlFlow::Break(ty) => {
-                            results.push(ty);
-                            continue;
-                        }
-                        ControlFlow::Continue(ty) => ty,
-                    };
-                    let child_count = structural_type_child_count(db, ty);
-                    if child_count == 0 {
-                        results.push(finish(ty));
-                        continue;
-                    }
-                    let queued_entries = stack
-                        .iter()
-                        .filter(|item| matches!(item, StructuralTypeMapItem::Enter(_)))
-                        .count();
-                    let available_steps = remaining_steps.saturating_sub(queued_entries);
-                    if child_count
-                        > available_steps
-                            .saturating_add(active.len())
-                            .saturating_add(1)
-                    {
-                        return Err(StructuralMapError::StepLimitExceeded);
-                    }
-                    let children = structural_type_children(db, ty);
-                    let new_children = children
-                        .iter()
-                        .filter(|child| **child != source && !active.contains(*child))
-                        .count();
-                    if new_children > available_steps {
-                        return Err(StructuralMapError::StepLimitExceeded);
-                    }
-
-                    active.insert(source);
-                    stack.push(StructuralTypeMapItem::Exit(source));
-                    stack.push(StructuralTypeMapItem::Rebuild(ty, child_count));
-                    stack.extend(children.into_iter().rev().map(StructuralTypeMapItem::Enter));
-                }
-                StructuralTypeMapItem::Rebuild(ty, child_count) => {
-                    let start = results
-                        .len()
-                        .checked_sub(child_count)
-                        .ok_or(StructuralMapError::InvalidRebuild)?;
-                    let children = results.split_off(start);
-                    let rebuilt = rebuild_structural_type(db, ty, children)
-                        .ok_or(StructuralMapError::InvalidRebuild)?;
-                    results.push(finish(rebuilt));
-                }
-                StructuralTypeMapItem::Exit(ty) => {
-                    active.remove(&ty);
-                }
-            }
-        }
-
-        match results.as_slice() {
-            [result] => Ok(*result),
-            _ => Err(StructuralMapError::InvalidRebuild),
-        }
-    }
+    // #region Structural construction
 
     // #endregion
 
@@ -1373,297 +1166,158 @@ impl<'db> TypeData<'db> {
     // #endregion
 }
 
-impl<'db> TypeSubstitution<'db> {
-    fn binder_generic(self, db: &'db dyn TypeDb) -> TypeData<'db> {
-        if let TypeData::InstanceOf(instance) = self.generic
-            && instance.type_parameters(db).is_empty()
-            && matches!(instance.ty(db), TypeData::Generic(_))
-        {
-            instance.ty(db)
-        } else {
-            self.generic
+/// Immediate type slots and the parent needed to rebuild them.
+#[derive(Debug)]
+pub(crate) struct TypeDataSlots<'db> {
+    parent: TypeData<'db>,
+    slots: Vec<TypeData<'db>>,
+}
+
+/// Retains the parent and slot count produced by one slot extraction.
+pub(crate) struct TypeDataSlotRebuilder<'db> {
+    parent: TypeData<'db>,
+    slot_count: usize,
+}
+
+impl<'db> TypeDataSlots<'db> {
+    fn new(parent: TypeData<'db>) -> Self {
+        Self {
+            parent,
+            slots: Vec::new(),
         }
     }
-}
 
-fn declared_type_parameters<'db>(
-    db: &'db dyn TypeDb,
-    ty: TypeData<'db>,
-) -> Option<&'db [TypeData<'db>]> {
-    if let TypeData::Class(class) = ty {
-        Some(class.type_parameters(db))
-    } else if let TypeData::Constructor(constructor) = ty {
-        Some(constructor.type_parameters(db))
-    } else if let TypeData::Function(function) = ty {
-        Some(function.type_parameters(db))
-    } else if let TypeData::Interface(interface) = ty {
-        Some(interface.type_parameters(db))
-    } else {
-        None
-    }
-}
-
-fn function_parameter_child_count(parameter: &FunctionParameter<'_>) -> usize {
-    match parameter {
-        FunctionParameter::Named(_) => 1,
-        FunctionParameter::Pattern(parameter) => parameter.bindings.len().saturating_add(1),
-    }
-}
-
-fn type_member_child_count(member: &TypeMember<'_>) -> usize {
-    let key_count = usize::from(matches!(
-        &member.kind,
-        TypeMemberKind::ComputedValue(_)
-            | TypeMemberKind::ComputedValueNamed(_, _)
-            | TypeMemberKind::ConstAssertedComputedValue(_)
-            | TypeMemberKind::ConstAssertedComputedValueNamed(_, _)
-            | TypeMemberKind::ConstAssertedIndexSignature(_)
-            | TypeMemberKind::IndexSignature(_)
-    ));
-    key_count + 1
-}
-
-fn typeof_expression_child_count(expression: &TypeofExpression<'_>) -> usize {
-    match expression {
-        TypeofExpression::Addition(_)
-        | TypeofExpression::LogicalAnd(_)
-        | TypeofExpression::LogicalOr(_)
-        | TypeofExpression::NullishCoalescing(_) => 2,
-        TypeofExpression::Conditional(_) => 3,
-        TypeofExpression::Call(expression) => expression.arguments.len().saturating_add(1),
-        TypeofExpression::New(expression) => expression.arguments.len().saturating_add(1),
-        TypeofExpression::Await(_)
-        | TypeofExpression::BitwiseNot(_)
-        | TypeofExpression::Destructure(_)
-        | TypeofExpression::Index(_)
-        | TypeofExpression::IterableValueOf(_)
-        | TypeofExpression::StaticMember(_)
-        | TypeofExpression::Super(_)
-        | TypeofExpression::This(_)
-        | TypeofExpression::Typeof(_)
-        | TypeofExpression::UnaryMinus(_) => 1,
-    }
-}
-
-#[deny(clippy::wildcard_enum_match_arm)]
-fn structural_type_child_count<'db>(db: &'db dyn TypeDb, ty: TypeData<'db>) -> usize {
-    match ty {
-        TypeData::Class(class) => class
-            .type_parameters(db)
-            .len()
-            .saturating_add(usize::from(class.extends(db).is_some()))
-            .saturating_add(class.implements(db).len())
-            .saturating_add(class.members(db).iter().map(type_member_child_count).sum()),
-        TypeData::Constructor(constructor) => constructor
-            .type_parameters(db)
-            .len()
-            .saturating_add(
-                constructor
-                    .parameters(db)
-                    .iter()
-                    .map(|parameter| function_parameter_child_count(&parameter.parameter))
-                    .sum(),
-            )
-            .saturating_add(usize::from(constructor.return_type(db).is_some())),
-        TypeData::Function(function) => function
-            .type_parameters(db)
-            .len()
-            .saturating_add(
-                function
-                    .parameters(db)
-                    .iter()
-                    .map(function_parameter_child_count)
-                    .sum(),
-            )
-            .saturating_add(1),
-        TypeData::Interface(interface) => interface
-            .type_parameters(db)
-            .len()
-            .saturating_add(interface.extends(db).len())
-            .saturating_add(
-                interface
-                    .members(db)
-                    .iter()
-                    .map(type_member_child_count)
-                    .sum(),
-            ),
-        TypeData::Module(module) => module.members(db).iter().map(type_member_child_count).sum(),
-        TypeData::Namespace(namespace) => namespace
-            .members(db)
-            .iter()
-            .map(type_member_child_count)
-            .sum(),
-        TypeData::Object(object) => usize::from(object.prototype(db).is_some())
-            .saturating_add(object.members(db).iter().map(type_member_child_count).sum()),
-        TypeData::Tuple(tuple) => tuple.elements(db).len(),
-        TypeData::Generic(generic) => {
-            usize::from(generic.constraint(db).is_some())
-                + usize::from(generic.default(db).is_some())
-        }
-        TypeData::Intersection(intersection) => intersection.types(db).len(),
-        TypeData::Union(union) => union.types(db).len(),
-        TypeData::TypeOperator(_) => 1,
-        TypeData::Literal(literal) => match literal.literal(db) {
-            Literal::Object(members) => members.iter().map(type_member_child_count).sum(),
-            Literal::BigInt(_)
-            | Literal::Boolean(_)
-            | Literal::Number(_)
-            | Literal::RegExp(_)
-            | Literal::String(_)
-            | Literal::Template(_) => 0,
-        },
-        TypeData::InstanceOf(instance) => instance.type_parameters(db).len().saturating_add(1),
-        TypeData::MergedReference(reference) => {
-            usize::from(reference.ty(db).is_some())
-                + usize::from(reference.value_ty(db).is_some())
-                + usize::from(reference.namespace_ty(db).is_some())
-        }
-        TypeData::TypeofExpression(expression) => {
-            typeof_expression_child_count(expression.expression(db))
-        }
-        TypeData::TypeofType(_) | TypeData::TypeofValue(_) => 1,
-        TypeData::Unknown
-        | TypeData::Divergent(_)
-        | TypeData::Global
-        | TypeData::BigInt
-        | TypeData::Boolean
-        | TypeData::Null
-        | TypeData::Number
-        | TypeData::String
-        | TypeData::Symbol
-        | TypeData::Undefined
-        | TypeData::Conditional
-        | TypeData::Local(_)
-        | TypeData::AnyKeyword
-        | TypeData::NeverKeyword
-        | TypeData::ObjectKeyword
-        | TypeData::ThisKeyword
-        | TypeData::UnknownKeyword
-        | TypeData::VoidKeyword => 0,
-    }
-}
-
-#[deny(clippy::wildcard_enum_match_arm)]
-fn structural_type_children<'db>(db: &'db dyn TypeDb, ty: TypeData<'db>) -> Vec<TypeData<'db>> {
-    let mut children = Vec::new();
-    match ty {
-        TypeData::Class(class) => {
-            children.extend_from_slice(class.type_parameters(db));
-            children.extend(class.extends(db));
-            children.extend_from_slice(class.implements(db));
-            push_type_member_children(class.members(db), &mut children);
-        }
-        TypeData::Constructor(constructor) => {
-            children.extend_from_slice(constructor.type_parameters(db));
-            for parameter in constructor.parameters(db) {
-                push_function_parameter_children(&parameter.parameter, &mut children);
+    fn collect(db: &'db dyn TypeDb, parent: TypeData<'db>) -> Self {
+        let mut result = Self::new(parent);
+        match parent {
+            TypeData::Class(class) => {
+                result.slots.extend_from_slice(class.type_parameters(db));
+                result.slots.extend(class.extends(db));
+                result.slots.extend_from_slice(class.implements(db));
+                result.push_type_members_slots(class.members(db));
             }
-            children.extend(constructor.return_type(db));
-        }
-        TypeData::Function(function) => {
-            children.extend_from_slice(function.type_parameters(db));
-            for parameter in function.parameters(db) {
-                push_function_parameter_children(parameter, &mut children);
+            TypeData::Constructor(constructor) => {
+                result
+                    .slots
+                    .extend_from_slice(constructor.type_parameters(db));
+                for parameter in constructor.parameters(db) {
+                    result.push_function_parameter_slots(&parameter.parameter);
+                }
+                result.slots.extend(constructor.return_type(db));
             }
-            push_return_type_children(function.return_type(db), &mut children);
+            TypeData::Function(function) => {
+                result.slots.extend_from_slice(function.type_parameters(db));
+                for parameter in function.parameters(db) {
+                    result.push_function_parameter_slots(parameter);
+                }
+                result.push_return_type_slot(function.return_type(db));
+            }
+            TypeData::Interface(interface) => {
+                result
+                    .slots
+                    .extend_from_slice(interface.type_parameters(db));
+                result.slots.extend_from_slice(interface.extends(db));
+                result.push_type_members_slots(interface.members(db));
+            }
+            TypeData::Module(module) => result.push_type_members_slots(module.members(db)),
+            TypeData::Namespace(namespace) => {
+                result.push_type_members_slots(namespace.members(db));
+            }
+            TypeData::Object(object) => {
+                result.slots.extend(object.prototype(db));
+                result.push_type_members_slots(object.members(db));
+            }
+            TypeData::Tuple(tuple) => {
+                result
+                    .slots
+                    .extend(tuple.elements(db).iter().map(|element| element.ty));
+            }
+            TypeData::Generic(generic) => {
+                result.slots.extend(generic.constraint(db));
+                result.slots.extend(generic.default(db));
+            }
+            TypeData::Intersection(intersection) => {
+                result.slots.extend_from_slice(intersection.types(db));
+            }
+            TypeData::Union(union) => result.slots.extend_from_slice(union.types(db)),
+            TypeData::TypeOperator(operator) => result.slots.push(operator.ty(db)),
+            TypeData::Literal(literal) => {
+                if let Literal::Object(members) = literal.literal(db) {
+                    result.push_type_members_slots(members);
+                }
+            }
+            TypeData::InstanceOf(instance) => {
+                result.slots.push(instance.ty(db));
+                result.slots.extend_from_slice(instance.type_parameters(db));
+            }
+            TypeData::MergedReference(reference) => {
+                result.slots.extend(reference.ty(db));
+                result.slots.extend(reference.value_ty(db));
+                result.slots.extend(reference.namespace_ty(db));
+            }
+            TypeData::TypeofExpression(expression) => {
+                result.push_typeof_expression_slots(expression.expression(db));
+            }
+            TypeData::TypeofType(ty) => result.slots.push(ty.ty(db)),
+            TypeData::TypeofValue(value) => result.slots.push(value.ty(db)),
+            _ => {}
         }
-        TypeData::Interface(interface) => {
-            children.extend_from_slice(interface.type_parameters(db));
-            children.extend_from_slice(interface.extends(db));
-            push_type_member_children(interface.members(db), &mut children);
-        }
-        TypeData::Module(module) => push_type_member_children(module.members(db), &mut children),
-        TypeData::Namespace(namespace) => {
-            push_type_member_children(namespace.members(db), &mut children);
-        }
-        TypeData::Object(object) => {
-            children.extend(object.prototype(db));
-            push_type_member_children(object.members(db), &mut children);
-        }
-        TypeData::Tuple(tuple) => {
-            children.extend(tuple.elements(db).iter().map(|element| element.ty));
-        }
-        TypeData::Generic(generic) => {
-            children.extend(generic.constraint(db));
-            children.extend(generic.default(db));
-        }
-        TypeData::Intersection(intersection) => children.extend_from_slice(intersection.types(db)),
-        TypeData::Union(union) => children.extend_from_slice(union.types(db)),
-        TypeData::TypeOperator(operator) => children.push(operator.ty(db)),
-        TypeData::Literal(literal) => {
-            if let Literal::Object(members) = literal.literal(db) {
-                push_type_member_children(members, &mut children);
+        result
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    pub(crate) fn iter(
+        &self,
+    ) -> impl ExactSizeIterator<Item = TypeData<'db>> + DoubleEndedIterator + '_ {
+        self.slots.iter().copied()
+    }
+
+    pub(crate) fn into_parts(self) -> (TypeDataSlotRebuilder<'db>, Vec<TypeData<'db>>) {
+        let rebuilder = TypeDataSlotRebuilder {
+            parent: self.parent,
+            slot_count: self.slots.len(),
+        };
+        (rebuilder, self.slots)
+    }
+
+    /// Pattern bindings precede the parameter type during reconstruction.
+    fn push_function_parameter_slots(&mut self, parameter: &FunctionParameter<'db>) {
+        match parameter {
+            FunctionParameter::Named(parameter) => self.slots.push(parameter.ty),
+            FunctionParameter::Pattern(parameter) => {
+                self.slots
+                    .extend(parameter.bindings.iter().map(|binding| binding.ty));
+                self.slots.push(parameter.ty);
             }
         }
-        TypeData::InstanceOf(instance) => {
-            children.push(instance.ty(db));
-            children.extend_from_slice(instance.type_parameters(db));
-        }
-        TypeData::MergedReference(reference) => {
-            children.extend(reference.ty(db));
-            children.extend(reference.value_ty(db));
-            children.extend(reference.namespace_ty(db));
-        }
-        TypeData::TypeofExpression(expression) => {
-            push_typeof_expression_children(expression.expression(db), &mut children);
-        }
-        TypeData::TypeofType(ty) => children.push(ty.ty(db)),
-        TypeData::TypeofValue(value) => children.push(value.ty(db)),
-        TypeData::Unknown
-        | TypeData::Divergent(_)
-        | TypeData::Global
-        | TypeData::BigInt
-        | TypeData::Boolean
-        | TypeData::Null
-        | TypeData::Number
-        | TypeData::String
-        | TypeData::Symbol
-        | TypeData::Undefined
-        | TypeData::Conditional
-        | TypeData::Local(_)
-        | TypeData::AnyKeyword
-        | TypeData::NeverKeyword
-        | TypeData::ObjectKeyword
-        | TypeData::ThisKeyword
-        | TypeData::UnknownKeyword
-        | TypeData::VoidKeyword => {}
     }
-    children
-}
 
-fn push_function_parameter_children<'db>(
-    parameter: &FunctionParameter<'db>,
-    children: &mut Vec<TypeData<'db>>,
-) {
-    match parameter {
-        FunctionParameter::Named(parameter) => children.push(parameter.ty),
-        FunctionParameter::Pattern(parameter) => {
-            children.extend(parameter.bindings.iter().map(|binding| binding.ty));
-            children.push(parameter.ty);
+    fn push_return_type_slot(&mut self, return_type: &ReturnType<'db>) {
+        self.slots.push(match return_type {
+            ReturnType::Type(ty) => *ty,
+            ReturnType::Predicate(predicate) => predicate.ty,
+            ReturnType::Asserts(asserts) => asserts.ty,
+        });
+    }
+
+    fn push_type_members_slots(&mut self, members: &[TypeMember<'db>]) {
+        for member in members {
+            self.push_type_member_slots(member);
         }
     }
-}
 
-fn push_return_type_children<'db>(
-    return_type: &ReturnType<'db>,
-    children: &mut Vec<TypeData<'db>>,
-) {
-    children.push(match return_type {
-        ReturnType::Type(ty) => *ty,
-        ReturnType::Predicate(predicate) => predicate.ty,
-        ReturnType::Asserts(asserts) => asserts.ty,
-    });
-}
-
-fn push_type_member_children<'db>(members: &[TypeMember<'db>], children: &mut Vec<TypeData<'db>>) {
-    for member in members {
+    /// Computed and index keys precede the member type during reconstruction.
+    fn push_type_member_slots(&mut self, member: &TypeMember<'db>) {
         match &member.kind {
             TypeMemberKind::ComputedValue(ty)
             | TypeMemberKind::ComputedValueNamed(_, ty)
             | TypeMemberKind::ConstAssertedComputedValue(ty)
             | TypeMemberKind::ConstAssertedComputedValueNamed(_, ty)
             | TypeMemberKind::ConstAssertedIndexSignature(ty)
-            | TypeMemberKind::IndexSignature(ty) => children.push(*ty),
+            | TypeMemberKind::IndexSignature(ty) => self.slots.push(*ty),
             TypeMemberKind::CallSignature
             | TypeMemberKind::ConstAssertedCallSignature
             | TypeMemberKind::ConstAssertedConstructor
@@ -1677,446 +1331,481 @@ fn push_type_member_children<'db>(members: &[TypeMember<'db>], children: &mut Ve
             | TypeMemberKind::NamedOptional(_)
             | TypeMemberKind::NamedStatic(_) => {}
         }
-        children.push(member.ty);
+        self.slots.push(member.ty);
+    }
+
+    /// Expression slots follow source evaluation order.
+    fn push_typeof_expression_slots(&mut self, expression: &TypeofExpression<'db>) {
+        match expression {
+            TypeofExpression::Addition(expression) => {
+                self.slots.extend([expression.left, expression.right]);
+            }
+            TypeofExpression::Await(expression) => self.slots.push(expression.argument),
+            TypeofExpression::BitwiseNot(expression) => self.slots.push(expression.argument),
+            TypeofExpression::Call(expression) => {
+                self.slots.push(expression.callee);
+                self.push_call_argument_slots(&expression.arguments);
+            }
+            TypeofExpression::Conditional(expression) => {
+                self.slots
+                    .extend([expression.test, expression.consequent, expression.alternate]);
+            }
+            TypeofExpression::Destructure(expression) => self.slots.push(expression.ty),
+            TypeofExpression::Index(expression) => self.slots.push(expression.object),
+            TypeofExpression::IterableValueOf(expression) => self.slots.push(expression.ty),
+            TypeofExpression::LogicalAnd(expression) => {
+                self.slots.extend([expression.left, expression.right]);
+            }
+            TypeofExpression::LogicalOr(expression) => {
+                self.slots.extend([expression.left, expression.right]);
+            }
+            TypeofExpression::New(expression) => {
+                self.slots.push(expression.callee);
+                self.push_call_argument_slots(&expression.arguments);
+            }
+            TypeofExpression::NullishCoalescing(expression) => {
+                self.slots.extend([expression.left, expression.right]);
+            }
+            TypeofExpression::StaticMember(expression) => {
+                self.slots.push(expression.object);
+            }
+            TypeofExpression::Super(expression) | TypeofExpression::This(expression) => {
+                self.slots.push(expression.parent);
+            }
+            TypeofExpression::Typeof(expression) => self.slots.push(expression.argument),
+            TypeofExpression::UnaryMinus(expression) => self.slots.push(expression.argument),
+        }
+    }
+
+    fn push_call_argument_slots(&mut self, arguments: &[CallArgumentType<'db>]) {
+        self.slots
+            .extend(arguments.iter().map(|argument| match argument {
+                CallArgumentType::Argument(ty) | CallArgumentType::Spread(ty) => *ty,
+            }));
+    }
+
+    /// Rebuilds the parent with replacements in slot order.
+    ///
+    /// Returns [`TypeTransformResult::InvalidRebuild`] if the replacement count
+    /// does not match the slot count.
+    pub(crate) fn rebuild(
+        self,
+        db: &'db dyn TypeDb,
+        replacements: Vec<TypeData<'db>>,
+    ) -> TypeTransformResult<TypeData<'db>> {
+        let (rebuilder, _) = self.into_parts();
+        rebuilder.rebuild(db, replacements)
     }
 }
 
-#[deny(clippy::wildcard_enum_match_arm)]
-fn push_typeof_expression_children<'db>(
-    expression: &TypeofExpression<'db>,
-    children: &mut Vec<TypeData<'db>>,
-) {
-    match expression {
-        TypeofExpression::Addition(expression) => {
-            children.extend([expression.left, expression.right]);
-        }
-        TypeofExpression::Await(expression) => children.push(expression.argument),
-        TypeofExpression::BitwiseNot(expression) => children.push(expression.argument),
-        TypeofExpression::Call(expression) => {
-            children.push(expression.callee);
-            push_call_argument_children(&expression.arguments, children);
-        }
-        TypeofExpression::Conditional(expression) => {
-            children.extend([expression.test, expression.consequent, expression.alternate]);
-        }
-        TypeofExpression::Destructure(expression) => children.push(expression.ty),
-        TypeofExpression::Index(expression) => children.push(expression.object),
-        TypeofExpression::IterableValueOf(expression) => children.push(expression.ty),
-        TypeofExpression::LogicalAnd(expression) => {
-            children.extend([expression.left, expression.right]);
-        }
-        TypeofExpression::LogicalOr(expression) => {
-            children.extend([expression.left, expression.right]);
-        }
-        TypeofExpression::New(expression) => {
-            children.push(expression.callee);
-            push_call_argument_children(&expression.arguments, children);
-        }
-        TypeofExpression::NullishCoalescing(expression) => {
-            children.extend([expression.left, expression.right]);
-        }
-        TypeofExpression::StaticMember(expression) => children.push(expression.object),
-        TypeofExpression::Super(expression) | TypeofExpression::This(expression) => {
-            children.push(expression.parent);
-        }
-        TypeofExpression::Typeof(expression) => children.push(expression.argument),
-        TypeofExpression::UnaryMinus(expression) => children.push(expression.argument),
+impl<'db> IntoIterator for TypeDataSlots<'db> {
+    type Item = TypeData<'db>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.slots.into_iter()
     }
 }
 
-fn push_call_argument_children<'db>(
-    arguments: &[CallArgumentType<'db>],
-    children: &mut Vec<TypeData<'db>>,
-) {
-    children.extend(arguments.iter().map(|argument| match argument {
-        CallArgumentType::Argument(ty) | CallArgumentType::Spread(ty) => *ty,
-    }));
+impl<'db> TypeDataSlotRebuilder<'db> {
+    pub(crate) fn len(&self) -> usize {
+        self.slot_count
+    }
+
+    pub(crate) fn rebuild(
+        self,
+        db: &'db dyn TypeDb,
+        replacements: Vec<TypeData<'db>>,
+    ) -> TypeTransformResult<TypeData<'db>> {
+        TypeDataSlotReplacements::new(replacements, self.slot_count)
+            .and_then(|replacements| replacements.rebuild(db, self.parent))
+            .map_or(
+                TypeTransformResult::InvalidRebuild,
+                TypeTransformResult::Transformed,
+            )
+    }
 }
 
-#[deny(clippy::wildcard_enum_match_arm)]
-fn rebuild_structural_type<'db>(
-    db: &'db dyn TypeDb,
-    ty: TypeData<'db>,
-    children: Vec<TypeData<'db>>,
-) -> Option<TypeData<'db>> {
-    let mut children = children.into_iter();
-    let rebuilt = match ty {
-        TypeData::Class(class) => TypeData::Class(InternedClass::new(
-            db,
-            take_types(&mut children, class.type_parameters(db).len())?,
-            take_optional_type(&mut children, class.extends(db))?,
-            take_types(&mut children, class.implements(db).len())?,
-            rebuild_type_members(class.members(db), &mut children)?,
-            class.name(db).clone(),
-            class.is_builtin(db),
-        )),
-        TypeData::Constructor(constructor) => TypeData::Constructor(InternedConstructor::new(
-            db,
-            take_types(&mut children, constructor.type_parameters(db).len())?,
-            constructor
-                .parameters(db)
-                .iter()
-                .map(|parameter| {
-                    Some(ConstructorParameter {
-                        parameter: rebuild_function_parameter(&parameter.parameter, &mut children)?,
-                        accessibility: parameter.accessibility,
-                    })
-                })
-                .collect::<Option<Box<[_]>>>()?,
-            take_optional_type(&mut children, constructor.return_type(db))?,
-        )),
-        TypeData::Function(function) => TypeData::Function(InternedFunction::new(
-            db,
-            take_types(&mut children, function.type_parameters(db).len())?,
-            function
-                .parameters(db)
-                .iter()
-                .map(|parameter| rebuild_function_parameter(parameter, &mut children))
-                .collect::<Option<Box<[_]>>>()?,
-            rebuild_return_type(function.return_type(db), &mut children)?,
-            function.is_async(db),
-            function.name(db).clone(),
-        )),
-        TypeData::Interface(interface) => TypeData::Interface(InternedInterface::new(
-            db,
-            take_types(&mut children, interface.type_parameters(db).len())?,
-            take_types(&mut children, interface.extends(db).len())?,
-            rebuild_type_members(interface.members(db), &mut children)?,
-            interface.name(db).clone(),
-        )),
-        TypeData::Module(module) => TypeData::Module(InternedModule::new(
-            db,
-            rebuild_type_members(module.members(db), &mut children)?,
-            module.name(db).clone(),
-        )),
-        TypeData::Namespace(namespace) => TypeData::Namespace(InternedNamespace::new(
-            db,
-            rebuild_type_members(namespace.members(db), &mut children)?,
-            namespace.path(db).clone(),
-        )),
-        TypeData::Object(object) => TypeData::Object(InternedObject::new(
-            db,
-            take_optional_type(&mut children, object.prototype(db))?,
-            rebuild_type_members(object.members(db), &mut children)?,
-        )),
-        TypeData::Tuple(tuple) => TypeData::Tuple(InternedTuple::new(
-            db,
-            tuple
-                .elements(db)
-                .iter()
-                .map(|element| {
-                    let mut element = element.clone();
-                    element.ty = children.next()?;
-                    Some(element)
-                })
-                .collect::<Option<Box<[_]>>>()?,
-        )),
-        TypeData::Generic(generic) => TypeData::Generic(InternedGenericTypeParameter::new(
-            db,
-            take_optional_type(&mut children, generic.constraint(db))?,
-            take_optional_type(&mut children, generic.default(db))?,
-            generic.name(db).clone(),
-        )),
-        TypeData::Intersection(intersection) => TypeData::intersection_from_types(
-            db,
-            take_types(&mut children, intersection.types(db).len())?.into_vec(),
-        ),
-        TypeData::Union(union) => TypeData::union_from_types(
-            db,
-            take_types(&mut children, union.types(db).len())?.into_vec(),
-        ),
-        TypeData::TypeOperator(operator) => TypeData::TypeOperator(InternedTypeOperatorType::new(
-            db,
-            children.next()?,
-            operator.operator(db),
-        )),
-        TypeData::Literal(literal) => TypeData::Literal(InternedLiteral::new(
-            db,
-            match literal.literal(db) {
-                Literal::Object(members) => {
-                    Literal::Object(rebuild_type_members(members, &mut children)?)
-                }
-                literal @ (Literal::BigInt(_)
-                | Literal::Boolean(_)
-                | Literal::Number(_)
-                | Literal::RegExp(_)
-                | Literal::String(_)
-                | Literal::Template(_)) => literal.clone(),
-            },
-        )),
-        TypeData::InstanceOf(instance) => TypeData::instance_of(
-            db,
-            children.next()?,
-            take_types(&mut children, instance.type_parameters(db).len())?,
-        ),
-        TypeData::MergedReference(reference) => {
-            TypeData::MergedReference(InternedMergedReference::new(
+/// Replacement types consumed while rebuilding a parent from its slots.
+struct TypeDataSlotReplacements<'db> {
+    replacements: std::vec::IntoIter<TypeData<'db>>,
+}
+
+impl<'db> TypeDataSlotReplacements<'db> {
+    /// Returns `None` unless there is one replacement for every extracted slot.
+    fn new(replacements: Vec<TypeData<'db>>, slot_count: usize) -> Option<Self> {
+        (replacements.len() == slot_count).then(|| Self {
+            replacements: replacements.into_iter(),
+        })
+    }
+
+    fn rebuild(mut self, db: &'db dyn TypeDb, parent: TypeData<'db>) -> Option<TypeData<'db>> {
+        let rebuilt = match parent {
+            TypeData::Class(class) => TypeData::Class(InternedClass::new(
                 db,
-                take_optional_type(&mut children, reference.ty(db))?,
-                take_optional_type(&mut children, reference.value_ty(db))?,
-                take_optional_type(&mut children, reference.namespace_ty(db))?,
-            ))
-        }
-        TypeData::TypeofExpression(expression) => {
-            TypeData::TypeofExpression(InternedTypeofExpression::new(
+                self.take_types(class.type_parameters(db).len())?,
+                self.take_optional_type(class.extends(db))?,
+                self.take_types(class.implements(db).len())?,
+                self.rebuild_type_members(class.members(db))?,
+                class.name(db).clone(),
+                class.is_builtin(db),
+            )),
+            TypeData::Constructor(constructor) => TypeData::Constructor(InternedConstructor::new(
                 db,
-                rebuild_typeof_expression(expression.expression(db), &mut children)?,
-            ))
-        }
-        TypeData::TypeofType(_) => {
-            TypeData::TypeofType(InternedTypeofType::new(db, children.next()?))
-        }
-        TypeData::TypeofValue(value) => TypeData::TypeofValue(InternedTypeofValue::new(
-            db,
-            children.next()?,
-            value.identifier(db).clone(),
-            value.scope_id(db),
-        )),
-        TypeData::Unknown
-        | TypeData::Divergent(_)
-        | TypeData::Global
-        | TypeData::BigInt
-        | TypeData::Boolean
-        | TypeData::Null
-        | TypeData::Number
-        | TypeData::String
-        | TypeData::Symbol
-        | TypeData::Undefined
-        | TypeData::Conditional
-        | TypeData::Local(_)
-        | TypeData::AnyKeyword
-        | TypeData::NeverKeyword
-        | TypeData::ObjectKeyword
-        | TypeData::ThisKeyword
-        | TypeData::UnknownKeyword
-        | TypeData::VoidKeyword => ty,
-    };
-    children.next().is_none().then_some(rebuilt)
-}
-
-fn take_types<'db>(
-    children: &mut impl Iterator<Item = TypeData<'db>>,
-    count: usize,
-) -> Option<Box<[TypeData<'db>]>> {
-    (0..count).map(|_| children.next()).collect()
-}
-
-fn take_optional_type<'db>(
-    children: &mut impl Iterator<Item = TypeData<'db>>,
-    original: Option<TypeData<'db>>,
-) -> Option<Option<TypeData<'db>>> {
-    if original.is_some() {
-        Some(Some(children.next()?))
-    } else {
-        Some(None)
-    }
-}
-
-fn rebuild_function_parameter<'db>(
-    parameter: &FunctionParameter<'db>,
-    children: &mut impl Iterator<Item = TypeData<'db>>,
-) -> Option<FunctionParameter<'db>> {
-    Some(match parameter {
-        FunctionParameter::Named(parameter) => FunctionParameter::Named(NamedFunctionParameter {
-            name: parameter.name.clone(),
-            ty: children.next()?,
-            is_optional: parameter.is_optional,
-            is_rest: parameter.is_rest,
-        }),
-        FunctionParameter::Pattern(parameter) => {
-            FunctionParameter::Pattern(PatternFunctionParameter {
-                bindings: parameter
-                    .bindings
+                self.take_types(constructor.type_parameters(db).len())?,
+                constructor
+                    .parameters(db)
                     .iter()
-                    .map(|binding| {
-                        Some(FunctionParameterBinding {
-                            name: binding.name.clone(),
-                            ty: children.next()?,
+                    .map(|parameter| {
+                        Some(ConstructorParameter {
+                            parameter: self.rebuild_function_parameter(&parameter.parameter)?,
+                            accessibility: parameter.accessibility,
                         })
                     })
                     .collect::<Option<Box<[_]>>>()?,
-                ty: children.next()?,
-                is_optional: parameter.is_optional,
-                is_rest: parameter.is_rest,
-            })
+                self.take_optional_type(constructor.return_type(db))?,
+            )),
+            TypeData::Function(function) => TypeData::Function(InternedFunction::new(
+                db,
+                self.take_types(function.type_parameters(db).len())?,
+                function
+                    .parameters(db)
+                    .iter()
+                    .map(|parameter| self.rebuild_function_parameter(parameter))
+                    .collect::<Option<Box<[_]>>>()?,
+                self.rebuild_return_type(function.return_type(db))?,
+                function.is_async(db),
+                function.name(db).clone(),
+            )),
+            TypeData::Interface(interface) => TypeData::Interface(InternedInterface::new(
+                db,
+                self.take_types(interface.type_parameters(db).len())?,
+                self.take_types(interface.extends(db).len())?,
+                self.rebuild_type_members(interface.members(db))?,
+                interface.name(db).clone(),
+            )),
+            TypeData::Module(module) => TypeData::Module(InternedModule::new(
+                db,
+                self.rebuild_type_members(module.members(db))?,
+                module.name(db).clone(),
+            )),
+            TypeData::Namespace(namespace) => TypeData::Namespace(InternedNamespace::new(
+                db,
+                self.rebuild_type_members(namespace.members(db))?,
+                namespace.path(db).clone(),
+            )),
+            TypeData::Object(object) => TypeData::Object(InternedObject::new(
+                db,
+                self.take_optional_type(object.prototype(db))?,
+                self.rebuild_type_members(object.members(db))?,
+            )),
+            TypeData::Tuple(tuple) => TypeData::Tuple(InternedTuple::new(
+                db,
+                tuple
+                    .elements(db)
+                    .iter()
+                    .map(|element| {
+                        let mut element = element.clone();
+                        element.ty = self.take_type()?;
+                        Some(element)
+                    })
+                    .collect::<Option<Box<[_]>>>()?,
+            )),
+            TypeData::Generic(generic) => TypeData::Generic(InternedGenericTypeParameter::new(
+                db,
+                self.take_optional_type(generic.constraint(db))?,
+                self.take_optional_type(generic.default(db))?,
+                generic.name(db).clone(),
+            )),
+            TypeData::Intersection(intersection) => TypeData::intersection_from_types(
+                db,
+                self.take_types(intersection.types(db).len())?.into_vec(),
+            ),
+            TypeData::Union(union) => {
+                TypeData::union_from_types(db, self.take_types(union.types(db).len())?.into_vec())
+            }
+            TypeData::TypeOperator(operator) => TypeData::TypeOperator(
+                InternedTypeOperatorType::new(db, self.take_type()?, operator.operator(db)),
+            ),
+            TypeData::Literal(literal) => TypeData::Literal(InternedLiteral::new(
+                db,
+                match literal.literal(db) {
+                    Literal::Object(members) => {
+                        Literal::Object(self.rebuild_type_members(members)?)
+                    }
+                    literal @ (Literal::BigInt(_)
+                    | Literal::Boolean(_)
+                    | Literal::Number(_)
+                    | Literal::RegExp(_)
+                    | Literal::String(_)
+                    | Literal::Template(_)) => literal.clone(),
+                },
+            )),
+            TypeData::InstanceOf(instance) => TypeData::instance_of(
+                db,
+                self.take_type()?,
+                self.take_types(instance.type_parameters(db).len())?,
+            ),
+            TypeData::MergedReference(reference) => {
+                TypeData::MergedReference(InternedMergedReference::new(
+                    db,
+                    self.take_optional_type(reference.ty(db))?,
+                    self.take_optional_type(reference.value_ty(db))?,
+                    self.take_optional_type(reference.namespace_ty(db))?,
+                ))
+            }
+            TypeData::TypeofExpression(expression) => {
+                TypeData::TypeofExpression(InternedTypeofExpression::new(
+                    db,
+                    self.rebuild_typeof_expression(expression.expression(db))?,
+                ))
+            }
+            TypeData::TypeofType(_) => {
+                TypeData::TypeofType(InternedTypeofType::new(db, self.take_type()?))
+            }
+            TypeData::TypeofValue(value) => TypeData::TypeofValue(InternedTypeofValue::new(
+                db,
+                self.take_type()?,
+                value.identifier(db).clone(),
+                value.scope_id(db),
+            )),
+            _ => parent,
+        };
+        self.finish(rebuilt)
+    }
+
+    fn take_type(&mut self) -> Option<TypeData<'db>> {
+        self.replacements.next()
+    }
+
+    fn take_types(&mut self, count: usize) -> Option<Box<[TypeData<'db>]>> {
+        (0..count).map(|_| self.take_type()).collect()
+    }
+
+    fn take_optional_type(
+        &mut self,
+        original: Option<TypeData<'db>>,
+    ) -> Option<Option<TypeData<'db>>> {
+        if original.is_some() {
+            Some(Some(self.take_type()?))
+        } else {
+            Some(None)
         }
-    })
-}
+    }
 
-fn rebuild_return_type<'db>(
-    return_type: &ReturnType<'db>,
-    children: &mut impl Iterator<Item = TypeData<'db>>,
-) -> Option<ReturnType<'db>> {
-    Some(match return_type {
-        ReturnType::Type(_) => ReturnType::Type(children.next()?),
-        ReturnType::Predicate(predicate) => ReturnType::Predicate(PredicateReturnType {
-            parameter_name: predicate.parameter_name.clone(),
-            ty: children.next()?,
-        }),
-        ReturnType::Asserts(asserts) => ReturnType::Asserts(AssertsReturnType {
-            parameter_name: asserts.parameter_name.clone(),
-            ty: children.next()?,
-        }),
-    })
-}
-
-fn rebuild_type_members<'db>(
-    members: &[TypeMember<'db>],
-    children: &mut impl Iterator<Item = TypeData<'db>>,
-) -> Option<Box<[TypeMember<'db>]>> {
-    members
-        .iter()
-        .map(|member| {
-            Some(TypeMember {
-                kind: rebuild_type_member_kind(&member.kind, children)?,
-                ty: children.next()?,
-            })
+    fn rebuild_function_parameter(
+        &mut self,
+        parameter: &FunctionParameter<'db>,
+    ) -> Option<FunctionParameter<'db>> {
+        Some(match parameter {
+            FunctionParameter::Named(parameter) => {
+                FunctionParameter::Named(NamedFunctionParameter {
+                    name: parameter.name.clone(),
+                    ty: self.take_type()?,
+                    is_optional: parameter.is_optional,
+                    is_rest: parameter.is_rest,
+                })
+            }
+            FunctionParameter::Pattern(parameter) => {
+                FunctionParameter::Pattern(PatternFunctionParameter {
+                    bindings: parameter
+                        .bindings
+                        .iter()
+                        .map(|binding| {
+                            Some(FunctionParameterBinding {
+                                name: binding.name.clone(),
+                                ty: self.take_type()?,
+                            })
+                        })
+                        .collect::<Option<Box<[_]>>>()?,
+                    ty: self.take_type()?,
+                    is_optional: parameter.is_optional,
+                    is_rest: parameter.is_rest,
+                })
+            }
         })
-        .collect()
-}
+    }
 
-fn rebuild_type_member_kind<'db>(
-    kind: &TypeMemberKind<'db>,
-    children: &mut impl Iterator<Item = TypeData<'db>>,
-) -> Option<TypeMemberKind<'db>> {
-    Some(match kind {
-        TypeMemberKind::CallSignature => TypeMemberKind::CallSignature,
-        TypeMemberKind::ComputedValue(_) => TypeMemberKind::ComputedValue(children.next()?),
-        TypeMemberKind::ComputedValueNamed(name, _) => {
-            TypeMemberKind::ComputedValueNamed(name.clone(), children.next()?)
-        }
-        TypeMemberKind::ConstAssertedCallSignature => TypeMemberKind::ConstAssertedCallSignature,
-        TypeMemberKind::ConstAssertedComputedValue(_) => {
-            TypeMemberKind::ConstAssertedComputedValue(children.next()?)
-        }
-        TypeMemberKind::ConstAssertedComputedValueNamed(name, _) => {
-            TypeMemberKind::ConstAssertedComputedValueNamed(name.clone(), children.next()?)
-        }
-        TypeMemberKind::ConstAssertedConstructor => TypeMemberKind::ConstAssertedConstructor,
-        TypeMemberKind::ConstAssertedGetter(name) => {
-            TypeMemberKind::ConstAssertedGetter(name.clone())
-        }
-        TypeMemberKind::ConstAssertedIndexSignature(_) => {
-            TypeMemberKind::ConstAssertedIndexSignature(children.next()?)
-        }
-        TypeMemberKind::ConstAssertedNamed(name) => {
-            TypeMemberKind::ConstAssertedNamed(name.clone())
-        }
-        TypeMemberKind::ConstAssertedNamedOptional(name) => {
-            TypeMemberKind::ConstAssertedNamedOptional(name.clone())
-        }
-        TypeMemberKind::ConstAssertedNamedStatic(name) => {
-            TypeMemberKind::ConstAssertedNamedStatic(name.clone())
-        }
-        TypeMemberKind::Constructor => TypeMemberKind::Constructor,
-        TypeMemberKind::Getter(name) => TypeMemberKind::Getter(name.clone()),
-        TypeMemberKind::IndexSignature(_) => TypeMemberKind::IndexSignature(children.next()?),
-        TypeMemberKind::Named(name) => TypeMemberKind::Named(name.clone()),
-        TypeMemberKind::NamedOptional(name) => TypeMemberKind::NamedOptional(name.clone()),
-        TypeMemberKind::NamedStatic(name) => TypeMemberKind::NamedStatic(name.clone()),
-    })
-}
-
-#[deny(clippy::wildcard_enum_match_arm)]
-fn rebuild_typeof_expression<'db>(
-    expression: &TypeofExpression<'db>,
-    children: &mut impl Iterator<Item = TypeData<'db>>,
-) -> Option<TypeofExpression<'db>> {
-    Some(match expression {
-        TypeofExpression::Addition(_) => TypeofExpression::Addition(TypeofAdditionExpression {
-            left: children.next()?,
-            right: children.next()?,
-        }),
-        TypeofExpression::Await(_) => TypeofExpression::Await(TypeofAwaitExpression {
-            argument: children.next()?,
-        }),
-        TypeofExpression::BitwiseNot(_) => {
-            TypeofExpression::BitwiseNot(TypeofBitwiseNotExpression {
-                argument: children.next()?,
-            })
-        }
-        TypeofExpression::Call(expression) => TypeofExpression::Call(TypeofCallExpression {
-            callee: children.next()?,
-            arguments: rebuild_call_arguments(&expression.arguments, children)?,
-        }),
-        TypeofExpression::Conditional(_) => {
-            TypeofExpression::Conditional(TypeofConditionalExpression {
-                test: children.next()?,
-                consequent: children.next()?,
-                alternate: children.next()?,
-            })
-        }
-        TypeofExpression::Destructure(expression) => {
-            TypeofExpression::Destructure(TypeofDestructureExpression {
-                ty: children.next()?,
-                destructure_field: expression.destructure_field.clone(),
-            })
-        }
-        TypeofExpression::Index(expression) => TypeofExpression::Index(TypeofIndexExpression {
-            object: children.next()?,
-            index: expression.index,
-        }),
-        TypeofExpression::IterableValueOf(_) => {
-            TypeofExpression::IterableValueOf(TypeofIterableValueOfExpression {
-                ty: children.next()?,
-            })
-        }
-        TypeofExpression::LogicalAnd(_) => {
-            TypeofExpression::LogicalAnd(TypeofLogicalAndExpression {
-                left: children.next()?,
-                right: children.next()?,
-            })
-        }
-        TypeofExpression::LogicalOr(_) => TypeofExpression::LogicalOr(TypeofLogicalOrExpression {
-            left: children.next()?,
-            right: children.next()?,
-        }),
-        TypeofExpression::New(expression) => TypeofExpression::New(TypeofNewExpression {
-            callee: children.next()?,
-            arguments: rebuild_call_arguments(&expression.arguments, children)?,
-        }),
-        TypeofExpression::NullishCoalescing(_) => {
-            TypeofExpression::NullishCoalescing(TypeofNullishCoalescingExpression {
-                left: children.next()?,
-                right: children.next()?,
-            })
-        }
-        TypeofExpression::StaticMember(expression) => {
-            TypeofExpression::StaticMember(TypeofStaticMemberExpression {
-                object: children.next()?,
-                member: expression.member.clone(),
-            })
-        }
-        TypeofExpression::Super(_) => TypeofExpression::Super(TypeofThisOrSuperExpression {
-            parent: children.next()?,
-        }),
-        TypeofExpression::This(_) => TypeofExpression::This(TypeofThisOrSuperExpression {
-            parent: children.next()?,
-        }),
-        TypeofExpression::Typeof(_) => TypeofExpression::Typeof(TypeofTypeofExpression {
-            argument: children.next()?,
-        }),
-        TypeofExpression::UnaryMinus(_) => {
-            TypeofExpression::UnaryMinus(TypeofUnaryMinusExpression {
-                argument: children.next()?,
-            })
-        }
-    })
-}
-
-fn rebuild_call_arguments<'db>(
-    arguments: &[CallArgumentType<'db>],
-    children: &mut impl Iterator<Item = TypeData<'db>>,
-) -> Option<Box<[CallArgumentType<'db>]>> {
-    arguments
-        .iter()
-        .map(|argument| {
-            Some(match argument {
-                CallArgumentType::Argument(_) => CallArgumentType::Argument(children.next()?),
-                CallArgumentType::Spread(_) => CallArgumentType::Spread(children.next()?),
-            })
+    fn rebuild_return_type(&mut self, return_type: &ReturnType<'db>) -> Option<ReturnType<'db>> {
+        Some(match return_type {
+            ReturnType::Type(_) => ReturnType::Type(self.take_type()?),
+            ReturnType::Predicate(predicate) => ReturnType::Predicate(PredicateReturnType {
+                parameter_name: predicate.parameter_name.clone(),
+                ty: self.take_type()?,
+            }),
+            ReturnType::Asserts(asserts) => ReturnType::Asserts(AssertsReturnType {
+                parameter_name: asserts.parameter_name.clone(),
+                ty: self.take_type()?,
+            }),
         })
-        .collect()
+    }
+
+    fn rebuild_type_members(
+        &mut self,
+        members: &[TypeMember<'db>],
+    ) -> Option<Box<[TypeMember<'db>]>> {
+        members
+            .iter()
+            .map(|member| {
+                Some(TypeMember {
+                    kind: self.rebuild_type_member_kind(&member.kind)?,
+                    ty: self.take_type()?,
+                })
+            })
+            .collect()
+    }
+
+    fn rebuild_type_member_kind(
+        &mut self,
+        kind: &TypeMemberKind<'db>,
+    ) -> Option<TypeMemberKind<'db>> {
+        Some(match kind {
+            TypeMemberKind::CallSignature => TypeMemberKind::CallSignature,
+            TypeMemberKind::ComputedValue(_) => TypeMemberKind::ComputedValue(self.take_type()?),
+            TypeMemberKind::ComputedValueNamed(name, _) => {
+                TypeMemberKind::ComputedValueNamed(name.clone(), self.take_type()?)
+            }
+            TypeMemberKind::ConstAssertedCallSignature => {
+                TypeMemberKind::ConstAssertedCallSignature
+            }
+            TypeMemberKind::ConstAssertedComputedValue(_) => {
+                TypeMemberKind::ConstAssertedComputedValue(self.take_type()?)
+            }
+            TypeMemberKind::ConstAssertedComputedValueNamed(name, _) => {
+                TypeMemberKind::ConstAssertedComputedValueNamed(name.clone(), self.take_type()?)
+            }
+            TypeMemberKind::ConstAssertedConstructor => TypeMemberKind::ConstAssertedConstructor,
+            TypeMemberKind::ConstAssertedGetter(name) => {
+                TypeMemberKind::ConstAssertedGetter(name.clone())
+            }
+            TypeMemberKind::ConstAssertedIndexSignature(_) => {
+                TypeMemberKind::ConstAssertedIndexSignature(self.take_type()?)
+            }
+            TypeMemberKind::ConstAssertedNamed(name) => {
+                TypeMemberKind::ConstAssertedNamed(name.clone())
+            }
+            TypeMemberKind::ConstAssertedNamedOptional(name) => {
+                TypeMemberKind::ConstAssertedNamedOptional(name.clone())
+            }
+            TypeMemberKind::ConstAssertedNamedStatic(name) => {
+                TypeMemberKind::ConstAssertedNamedStatic(name.clone())
+            }
+            TypeMemberKind::Constructor => TypeMemberKind::Constructor,
+            TypeMemberKind::Getter(name) => TypeMemberKind::Getter(name.clone()),
+            TypeMemberKind::IndexSignature(_) => TypeMemberKind::IndexSignature(self.take_type()?),
+            TypeMemberKind::Named(name) => TypeMemberKind::Named(name.clone()),
+            TypeMemberKind::NamedOptional(name) => TypeMemberKind::NamedOptional(name.clone()),
+            TypeMemberKind::NamedStatic(name) => TypeMemberKind::NamedStatic(name.clone()),
+        })
+    }
+
+    fn rebuild_typeof_expression(
+        &mut self,
+        expression: &TypeofExpression<'db>,
+    ) -> Option<TypeofExpression<'db>> {
+        Some(match expression {
+            TypeofExpression::Addition(_) => TypeofExpression::Addition(TypeofAdditionExpression {
+                left: self.take_type()?,
+                right: self.take_type()?,
+            }),
+            TypeofExpression::Await(_) => TypeofExpression::Await(TypeofAwaitExpression {
+                argument: self.take_type()?,
+            }),
+            TypeofExpression::BitwiseNot(_) => {
+                TypeofExpression::BitwiseNot(TypeofBitwiseNotExpression {
+                    argument: self.take_type()?,
+                })
+            }
+            TypeofExpression::Call(expression) => TypeofExpression::Call(TypeofCallExpression {
+                callee: self.take_type()?,
+                arguments: self.rebuild_call_arguments(&expression.arguments)?,
+            }),
+            TypeofExpression::Conditional(_) => {
+                TypeofExpression::Conditional(TypeofConditionalExpression {
+                    test: self.take_type()?,
+                    consequent: self.take_type()?,
+                    alternate: self.take_type()?,
+                })
+            }
+            TypeofExpression::Destructure(expression) => {
+                TypeofExpression::Destructure(TypeofDestructureExpression {
+                    ty: self.take_type()?,
+                    destructure_field: expression.destructure_field.clone(),
+                })
+            }
+            TypeofExpression::Index(expression) => TypeofExpression::Index(TypeofIndexExpression {
+                object: self.take_type()?,
+                index: expression.index,
+            }),
+            TypeofExpression::IterableValueOf(_) => {
+                TypeofExpression::IterableValueOf(TypeofIterableValueOfExpression {
+                    ty: self.take_type()?,
+                })
+            }
+            TypeofExpression::LogicalAnd(_) => {
+                TypeofExpression::LogicalAnd(TypeofLogicalAndExpression {
+                    left: self.take_type()?,
+                    right: self.take_type()?,
+                })
+            }
+            TypeofExpression::LogicalOr(_) => {
+                TypeofExpression::LogicalOr(TypeofLogicalOrExpression {
+                    left: self.take_type()?,
+                    right: self.take_type()?,
+                })
+            }
+            TypeofExpression::New(expression) => TypeofExpression::New(TypeofNewExpression {
+                callee: self.take_type()?,
+                arguments: self.rebuild_call_arguments(&expression.arguments)?,
+            }),
+            TypeofExpression::NullishCoalescing(_) => {
+                TypeofExpression::NullishCoalescing(TypeofNullishCoalescingExpression {
+                    left: self.take_type()?,
+                    right: self.take_type()?,
+                })
+            }
+            TypeofExpression::StaticMember(expression) => {
+                TypeofExpression::StaticMember(TypeofStaticMemberExpression {
+                    object: self.take_type()?,
+                    member: expression.member.clone(),
+                })
+            }
+            TypeofExpression::Super(_) => TypeofExpression::Super(TypeofThisOrSuperExpression {
+                parent: self.take_type()?,
+            }),
+            TypeofExpression::This(_) => TypeofExpression::This(TypeofThisOrSuperExpression {
+                parent: self.take_type()?,
+            }),
+            TypeofExpression::Typeof(_) => TypeofExpression::Typeof(TypeofTypeofExpression {
+                argument: self.take_type()?,
+            }),
+            TypeofExpression::UnaryMinus(_) => {
+                TypeofExpression::UnaryMinus(TypeofUnaryMinusExpression {
+                    argument: self.take_type()?,
+                })
+            }
+        })
+    }
+
+    fn rebuild_call_arguments(
+        &mut self,
+        arguments: &[CallArgumentType<'db>],
+    ) -> Option<Box<[CallArgumentType<'db>]>> {
+        arguments
+            .iter()
+            .map(|argument| {
+                Some(match argument {
+                    CallArgumentType::Argument(_) => CallArgumentType::Argument(self.take_type()?),
+                    CallArgumentType::Spread(_) => CallArgumentType::Spread(self.take_type()?),
+                })
+            })
+            .collect()
+    }
+
+    /// Returns `rebuilt` only if reconstruction consumed every replacement.
+    fn finish(self, rebuilt: TypeData<'db>) -> Option<TypeData<'db>> {
+        self.replacements.as_slice().is_empty().then_some(rebuilt)
+    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update)]
@@ -3280,6 +2969,9 @@ fn raw_call_arguments_from_types<'db>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::type_transform::{
+        MAX_TYPE_SUBSTITUTION_STEPS, TypeDataTransformer, TypeSubstituter,
+    };
     use salsa::plumbing::FromId;
 
     #[salsa::db]
@@ -3303,6 +2995,21 @@ mod tests {
 
     #[salsa::db]
     impl TypeDb for TestDb {}
+
+    #[test]
+    fn slot_replacements_require_exact_and_complete_consumption() {
+        assert!(TypeDataSlotReplacements::new(Vec::new(), 1).is_none());
+
+        let replacements = TypeDataSlotReplacements::new(vec![TypeData::String], 1).unwrap();
+        assert_eq!(replacements.finish(TypeData::Number), None);
+
+        let mut replacements = TypeDataSlotReplacements::new(vec![TypeData::String], 1).unwrap();
+        assert_eq!(replacements.take_type(), Some(TypeData::String));
+        assert_eq!(
+            replacements.finish(TypeData::Number),
+            Some(TypeData::Number)
+        );
+    }
 
     #[derive(Default)]
     struct Sentinels(usize);
@@ -3395,42 +3102,53 @@ mod tests {
 
     fn assert_identity<'db>(db: &'db TestDb, build: impl FnOnce(&mut Sentinels) -> TypeData<'db>) {
         let ty = build(&mut Sentinels::default());
-        let children = structural_type_children(db, ty);
-        assert!(!children.is_empty());
+        let slots = ty.type_slots(db);
+        let slot_types: Vec<_> = slots.iter().collect();
+        assert!(!slot_types.is_empty());
+        assert_eq!(slots.len(), slots.iter().len());
         assert_eq!(
-            children.iter().copied().collect::<FxHashSet<_>>().len(),
-            children.len(),
-            "test shape must use distinct children"
+            slot_types.iter().copied().collect::<FxHashSet<_>>().len(),
+            slot_types.len(),
+            "test shape must use distinct type slots"
         );
 
         assert_eq!(
-            ty.try_map_structural(
-                db,
-                usize::MAX,
-                ControlFlow::Continue,
-                std::convert::identity,
-            ),
-            Ok(ty)
+            slots.rebuild(db, slot_types.clone()),
+            TypeTransformResult::Transformed(ty)
         );
-        assert_eq!(rebuild_structural_type(db, ty, children.clone()), Some(ty));
-        assert!(rebuild_structural_type(db, ty, children[..children.len() - 1].to_vec()).is_none());
-        let mut extra_children = children;
-        extra_children.push(TypeData::Unknown);
-        assert!(rebuild_structural_type(db, ty, extra_children).is_none());
+        assert_eq!(
+            ty.type_slots(db)
+                .rebuild(db, slot_types[..slot_types.len() - 1].to_vec()),
+            TypeTransformResult::InvalidRebuild
+        );
+        let mut extra_slots = slot_types;
+        extra_slots.push(TypeData::Unknown);
+        assert_eq!(
+            ty.type_slots(db).rebuild(db, extra_slots),
+            TypeTransformResult::InvalidRebuild
+        );
     }
 
     #[test]
-    fn structural_map_reports_step_limit_exceeded() {
+    fn type_substituter_reports_step_limit_exceeded() {
         let db = TestDb::default();
         let ty = TypeData::TypeOperator(InternedTypeOperatorType::new(
             &db,
             TypeData::String,
             raw::TypeOperator::Keyof,
         ));
+        let mut transformer = TypeDataTransformer::new(1);
+        let mut substituter = TypeSubstituter::new(
+            &db,
+            TypeSubstitution {
+                generic: TypeData::Number,
+                replacement: TypeData::Boolean,
+            },
+        );
 
         assert_eq!(
-            ty.try_map_structural(&db, 1, ControlFlow::Continue, std::convert::identity,),
-            Err(StructuralMapError::StepLimitExceeded)
+            substituter.substitute(&mut transformer, &db, ty),
+            TypeTransformResult::LimitExceeded
         );
     }
 
@@ -3462,11 +3180,11 @@ mod tests {
             let result =
                 typeof_chain(&db, distinct_types, generic).substitute_type(&db, substitution);
             if distinct_types <= MAX_TYPE_SUBSTITUTION_STEPS {
-                assert!(result.is_ok(), "distinct types {distinct_types}");
+                assert!(result.is_transformed(), "distinct types {distinct_types}");
             } else {
                 assert_eq!(
                     result,
-                    Err(StructuralMapError::StepLimitExceeded),
+                    TypeTransformResult::LimitExceeded,
                     "distinct types {distinct_types}"
                 );
             }
@@ -3493,11 +3211,11 @@ mod tests {
             ));
             let result = function.substitute_type_in_root_body(&db, substitution);
             if distinct_types <= MAX_TYPE_SUBSTITUTION_STEPS {
-                assert!(result.is_ok(), "distinct types {distinct_types}");
+                assert!(result.is_transformed(), "distinct types {distinct_types}");
             } else {
                 assert_eq!(
                     result,
-                    Err(StructuralMapError::StepLimitExceeded),
+                    TypeTransformResult::LimitExceeded,
                     "distinct types {distinct_types}"
                 );
             }
@@ -3535,7 +3253,7 @@ mod tests {
 
         assert_eq!(
             function.substitute_type_in_root_body(&db, substitution),
-            Err(StructuralMapError::StepLimitExceeded)
+            TypeTransformResult::LimitExceeded
         );
     }
 
@@ -3556,15 +3274,15 @@ mod tests {
             false,
             None,
         ));
-        let substituted = function
-            .substitute_type_in_root_body(
-                &db,
-                TypeSubstitution {
-                    generic,
-                    replacement: TypeData::String,
-                },
-            )
-            .expect("root body substitution must complete");
+        let TypeTransformResult::Transformed(substituted) = function.substitute_type_in_root_body(
+            &db,
+            TypeSubstitution {
+                generic,
+                replacement: TypeData::String,
+            },
+        ) else {
+            panic!("root body substitution must complete");
+        };
         let TypeData::Function(substituted) = substituted else {
             panic!("expected a function");
         };
@@ -3578,7 +3296,7 @@ mod tests {
     }
 
     #[test]
-    fn substitution_completes_back_edge_after_budget_is_consumed() {
+    fn substitution_reuses_an_active_type_after_budget_is_consumed() {
         let db = TestDb::default();
         // IDs 0..1022 build the path. The next interned value receives ID 1023,
         // which closes the final child back to the root.
@@ -3597,12 +3315,12 @@ mod tests {
                     replacement: TypeData::String,
                 }
             ),
-            Ok(root)
+            TypeTransformResult::Transformed(root)
         );
     }
 
     #[test]
-    fn generic_replacement_collection_completes_seen_back_edges_at_the_limit() {
+    fn generic_replacement_collection_reuses_active_types_at_the_limit() {
         let db = TestDb::default();
         let generic = TypeData::Generic(InternedGenericTypeParameter::new(
             &db,
@@ -3622,14 +3340,14 @@ mod tests {
 
         let replacements = pattern
             .collect_generic_replacements(&db, actual)
-            .expect("an already-seen back edge must complete after the budget is consumed");
+            .expect("an active type must be reused after the budget is consumed");
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].replacement, TypeData::String);
     }
 
     #[test]
-    fn structural_map_identity_round_trips_all_child_bearing_shapes() {
+    fn type_slots_round_trip_all_types_with_slots() {
         let db = TestDb::default();
 
         assert_identity(&db, |s| {

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -661,14 +661,19 @@ impl<'db> TypeData<'db> {
     // #region Structural mapping
 
     /// Extracts this type's immediate `TypeData` fields in reconstruction order.
-    /// Nested slots are not included.
+    ///
+    /// Extraction is not recursive. Given this declaration:
+    ///
+    /// ```ts
+    /// declare function transform<T>(value: T): Promise<T>;
+    /// ```
+    ///
+    /// the immediate slots are the declaration of `T`, the parameter type `T`,
+    /// and the return type `Promise<T>`. The nested `T` inside `Promise<T>` is a
+    /// slot of the `Promise<T>` value and is visited when that value is processed.
     pub(crate) fn type_slots(self, db: &'db dyn TypeDb) -> TypeDataSlots<'db> {
         TypeDataSlots::collect(db, self)
     }
-
-    // #endregion
-
-    // #region Structural construction
 
     // #endregion
 
@@ -1166,14 +1171,22 @@ impl<'db> TypeData<'db> {
     // #endregion
 }
 
-/// Immediate type slots and the parent needed to rebuild them.
+/// Immediate type slots paired with the parent that produced them.
+///
+/// Slot order is the contract between extraction and reconstruction. Replacing
+/// every slot and calling [`Self::rebuild`] writes the replacements into the
+/// same type-valued fields while preserving names, modifiers, and other
+/// non-type data from the parent.
 #[derive(Debug)]
 pub(crate) struct TypeDataSlots<'db> {
     parent: TypeData<'db>,
     slots: Vec<TypeData<'db>>,
 }
 
-/// Retains the parent and slot count produced by one slot extraction.
+/// Rebuilds the parent retained by one [`TypeDataSlots`] extraction.
+///
+/// The parent and slot count cannot be supplied independently, preventing
+/// replacements extracted from one parent from being validated against another.
 pub(crate) struct TypeDataSlotRebuilder<'db> {
     parent: TypeData<'db>,
     slot_count: usize,

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -8,6 +8,7 @@ use biome_js_syntax::numbers::canonicalize_js_bigint_literal;
 use biome_rowan::Text;
 use rustc_hash::FxHashSet;
 use std::iter::FusedIterator;
+use std::ops::ControlFlow;
 
 use crate::{
     ScopeId,
@@ -59,6 +60,32 @@ pub struct TypeSubstitution<'db> {
     pub generic: TypeData<'db>,
     pub replacement: TypeData<'db>,
 }
+
+#[derive(Clone, Copy, Debug)]
+enum StructuralTypeMapItem<'db> {
+    Enter(TypeData<'db>),
+    Rebuild(TypeData<'db>, usize),
+    Exit(TypeData<'db>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StructuralMapError {
+    /// The caller must degrade the incomplete result to `Unknown`.
+    StepLimitExceeded,
+    /// A child sequence could not rebuild the original structural shape.
+    InvalidRebuild,
+}
+
+impl std::fmt::Display for StructuralMapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::StepLimitExceeded => "structural type traversal exceeded its step limit",
+            Self::InvalidRebuild => "structural type children could not rebuild their parent",
+        })
+    }
+}
+
+impl std::error::Error for StructuralMapError {}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, salsa::Update)]
 pub struct ModuleKey {
@@ -613,13 +640,14 @@ impl<'db> TypeData<'db> {
     /// `Promise<string>` returns a replacement where `generic` is `T` and
     /// `replacement` is `string`.
     ///
-    /// The walk is iterative and stops after a fixed number of steps so a bad
-    /// or cyclic type shape cannot loop forever.
+    /// The walk is iterative and returns `None` if it cannot finish within a
+    /// fixed number of steps. Already-seen edges can still complete after the
+    /// budget is consumed, so cyclic shapes terminate without false exhaustion.
     pub fn collect_generic_replacements(
         self,
         db: &'db dyn TypeDb,
         actual: Self,
-    ) -> Vec<TypeSubstitution<'db>> {
+    ) -> Option<Vec<TypeSubstitution<'db>>> {
         let mut replacements = Vec::new();
         let mut stack = Vec::from([(self, actual)]);
         let mut seen = FxHashSet::default();
@@ -630,7 +658,7 @@ impl<'db> TypeData<'db> {
                 continue;
             }
             if remaining_steps == 0 {
-                break;
+                return None;
             }
             remaining_steps -= 1;
 
@@ -657,22 +685,196 @@ impl<'db> TypeData<'db> {
             stack.push((pattern.ty(db), actual.ty(db)));
         }
 
-        replacements
+        Some(replacements)
     }
 
-    pub fn substitute_type(self, db: &'db dyn TypeDb, substitution: TypeSubstitution<'db>) -> Self {
+    /// Substitutes a generic throughout a type, stopping below nested binders.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StructuralMapError::StepLimitExceeded`] if traversal exhausts
+    /// its budget, or [`StructuralMapError::InvalidRebuild`] if transformed
+    /// children cannot reconstruct their parent type.
+    pub fn substitute_type(
+        self,
+        db: &'db dyn TypeDb,
+        substitution: TypeSubstitution<'db>,
+    ) -> Result<Self, StructuralMapError> {
         let mut remaining_steps = MAX_TYPE_SUBSTITUTION_STEPS;
-        substitute_type(db, self, substitution, false, &mut remaining_steps).unwrap_or(self)
+        self.substitute_type_with_budget(db, substitution, &mut remaining_steps)
     }
 
-    /// Substitutes inside the root generic declaration while preserving nested declarations.
+    fn substitute_type_with_budget(
+        self,
+        db: &'db dyn TypeDb,
+        substitution: TypeSubstitution<'db>,
+        remaining_steps: &mut usize,
+    ) -> Result<Self, StructuralMapError> {
+        let binder_generic = substitution.binder_generic(db);
+        self.try_map_structural_with_budget(
+            db,
+            remaining_steps,
+            |ty| {
+                if ty.declares_generic(db, binder_generic) {
+                    ControlFlow::Break(ty)
+                } else if ty == substitution.generic {
+                    ControlFlow::Break(substitution.replacement)
+                } else {
+                    ControlFlow::Continue(ty)
+                }
+            },
+            |ty| ty,
+        )
+    }
+
+    /// Substitutes inside the root binder while respecting nested binders.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StructuralMapError::StepLimitExceeded`] if traversal exhausts
+    /// its budget, or [`StructuralMapError::InvalidRebuild`] if transformed
+    /// children cannot reconstruct their parent type.
     pub fn substitute_type_in_root_body(
         self,
         db: &'db dyn TypeDb,
         substitution: TypeSubstitution<'db>,
-    ) -> Self {
+    ) -> Result<Self, StructuralMapError> {
+        if !self.declares_generic(db, substitution.binder_generic(db)) {
+            return self.substitute_type(db, substitution);
+        }
+
         let mut remaining_steps = MAX_TYPE_SUBSTITUTION_STEPS;
-        substitute_type(db, self, substitution, true, &mut remaining_steps).unwrap_or(self)
+        if structural_type_child_count(db, self) > remaining_steps {
+            return Err(StructuralMapError::StepLimitExceeded);
+        }
+        let root_type_parameter_count = declared_type_parameters(db, self).map_or(0, <[_]>::len);
+        let children = structural_type_children(db, self)
+            .into_iter()
+            .enumerate()
+            .map(|(index, child)| {
+                if index < root_type_parameter_count {
+                    Ok(child)
+                } else {
+                    child.substitute_type_with_budget(db, substitution, &mut remaining_steps)
+                }
+            })
+            .collect::<Result<_, _>>()?;
+        rebuild_structural_type(db, self, children).ok_or(StructuralMapError::InvalidRebuild)
+    }
+
+    fn declares_generic(self, db: &'db dyn TypeDb, generic: Self) -> bool {
+        declared_type_parameters(db, self).is_some_and(|parameters| parameters.contains(&generic))
+    }
+
+    /// Iteratively maps this type and all structurally nested types.
+    ///
+    /// `map` runs before children are visited. Returning `Break` replaces a
+    /// complete subtree, while `Continue` descends into the returned type.
+    /// `finish` runs after a descended type has been rebuilt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StructuralMapError::StepLimitExceeded`] when `max_steps` is
+    /// exhausted, or [`StructuralMapError::InvalidRebuild`] when mapped children
+    /// cannot reconstruct their parent type.
+    pub fn try_map_structural(
+        self,
+        db: &'db dyn TypeDb,
+        max_steps: usize,
+        map: impl FnMut(Self) -> ControlFlow<Self, Self>,
+        finish: impl FnMut(Self) -> Self,
+    ) -> Result<Self, StructuralMapError> {
+        let mut remaining_steps = max_steps;
+        self.try_map_structural_with_budget(db, &mut remaining_steps, map, finish)
+    }
+
+    fn try_map_structural_with_budget(
+        self,
+        db: &'db dyn TypeDb,
+        remaining_steps: &mut usize,
+        mut map: impl FnMut(Self) -> ControlFlow<Self, Self>,
+        mut finish: impl FnMut(Self) -> Self,
+    ) -> Result<Self, StructuralMapError> {
+        // Count every child before adding it to the stack. This prevents the
+        // walk from starting a group of children that it cannot finish with
+        // the steps that remain. A child that points to an active parent reuses
+        // that parent, so following that link does not use another step.
+        let mut stack = Vec::from([StructuralTypeMapItem::Enter(self)]);
+        let mut results = Vec::new();
+        let mut active = FxHashSet::default();
+
+        while let Some(item) = stack.pop() {
+            match item {
+                StructuralTypeMapItem::Enter(ty) => {
+                    if active.contains(&ty) {
+                        results.push(ty);
+                        continue;
+                    }
+
+                    if *remaining_steps == 0 {
+                        return Err(StructuralMapError::StepLimitExceeded);
+                    }
+                    *remaining_steps -= 1;
+
+                    let source = ty;
+                    let ty = match map(ty) {
+                        ControlFlow::Break(ty) => {
+                            results.push(ty);
+                            continue;
+                        }
+                        ControlFlow::Continue(ty) => ty,
+                    };
+                    let child_count = structural_type_child_count(db, ty);
+                    if child_count == 0 {
+                        results.push(finish(ty));
+                        continue;
+                    }
+                    let queued_entries = stack
+                        .iter()
+                        .filter(|item| matches!(item, StructuralTypeMapItem::Enter(_)))
+                        .count();
+                    let available_steps = remaining_steps.saturating_sub(queued_entries);
+                    if child_count
+                        > available_steps
+                            .saturating_add(active.len())
+                            .saturating_add(1)
+                    {
+                        return Err(StructuralMapError::StepLimitExceeded);
+                    }
+                    let children = structural_type_children(db, ty);
+                    let new_children = children
+                        .iter()
+                        .filter(|child| **child != source && !active.contains(*child))
+                        .count();
+                    if new_children > available_steps {
+                        return Err(StructuralMapError::StepLimitExceeded);
+                    }
+
+                    active.insert(source);
+                    stack.push(StructuralTypeMapItem::Exit(source));
+                    stack.push(StructuralTypeMapItem::Rebuild(ty, child_count));
+                    stack.extend(children.into_iter().rev().map(StructuralTypeMapItem::Enter));
+                }
+                StructuralTypeMapItem::Rebuild(ty, child_count) => {
+                    let start = results
+                        .len()
+                        .checked_sub(child_count)
+                        .ok_or(StructuralMapError::InvalidRebuild)?;
+                    let children = results.split_off(start);
+                    let rebuilt = rebuild_structural_type(db, ty, children)
+                        .ok_or(StructuralMapError::InvalidRebuild)?;
+                    results.push(finish(rebuilt));
+                }
+                StructuralTypeMapItem::Exit(ty) => {
+                    active.remove(&ty);
+                }
+            }
+        }
+
+        match results.as_slice() {
+            [result] => Ok(*result),
+            _ => Err(StructuralMapError::InvalidRebuild),
+        }
     }
 
     // #endregion
@@ -1171,88 +1373,431 @@ impl<'db> TypeData<'db> {
     // #endregion
 }
 
-fn substitute_type<'db>(
-    db: &'db dyn TypeDb,
-    ty: TypeData<'db>,
-    substitution: TypeSubstitution<'db>,
-    enter_root_binder: bool,
-    remaining_steps: &mut usize,
-) -> Option<TypeData<'db>> {
-    *remaining_steps = remaining_steps.checked_sub(1)?;
-    if ty == substitution.generic {
-        return Some(substitution.replacement);
-    }
-
-    let binder_generic = match substitution.generic {
-        TypeData::InstanceOf(instance)
-            if instance.type_parameters(db).is_empty()
-                && matches!(instance.ty(db), TypeData::Generic(_)) =>
+impl<'db> TypeSubstitution<'db> {
+    fn binder_generic(self, db: &'db dyn TypeDb) -> TypeData<'db> {
+        if let TypeData::InstanceOf(instance) = self.generic
+            && instance.type_parameters(db).is_empty()
+            && matches!(instance.ty(db), TypeData::Generic(_))
         {
             instance.ty(db)
+        } else {
+            self.generic
         }
-        generic => generic,
-    };
-    let declares_generic = match ty {
-        TypeData::Class(class) => class.type_parameters(db).contains(&binder_generic),
-        TypeData::Constructor(constructor) => {
-            constructor.type_parameters(db).contains(&binder_generic)
-        }
-        TypeData::Function(function) => function.type_parameters(db).contains(&binder_generic),
-        TypeData::Interface(interface) => interface.type_parameters(db).contains(&binder_generic),
-        _ => false,
-    };
-    if declares_generic && !enter_root_binder {
-        return Some(ty);
     }
-    let mut substitute = |child| substitute_type(db, child, substitution, false, remaining_steps);
+}
 
-    Some(match ty {
+fn declared_type_parameters<'db>(
+    db: &'db dyn TypeDb,
+    ty: TypeData<'db>,
+) -> Option<&'db [TypeData<'db>]> {
+    if let TypeData::Class(class) = ty {
+        Some(class.type_parameters(db))
+    } else if let TypeData::Constructor(constructor) = ty {
+        Some(constructor.type_parameters(db))
+    } else if let TypeData::Function(function) = ty {
+        Some(function.type_parameters(db))
+    } else if let TypeData::Interface(interface) = ty {
+        Some(interface.type_parameters(db))
+    } else {
+        None
+    }
+}
+
+fn function_parameter_child_count(parameter: &FunctionParameter<'_>) -> usize {
+    match parameter {
+        FunctionParameter::Named(_) => 1,
+        FunctionParameter::Pattern(parameter) => parameter.bindings.len().saturating_add(1),
+    }
+}
+
+fn type_member_child_count(member: &TypeMember<'_>) -> usize {
+    let key_count = usize::from(matches!(
+        &member.kind,
+        TypeMemberKind::ComputedValue(_)
+            | TypeMemberKind::ComputedValueNamed(_, _)
+            | TypeMemberKind::ConstAssertedComputedValue(_)
+            | TypeMemberKind::ConstAssertedComputedValueNamed(_, _)
+            | TypeMemberKind::ConstAssertedIndexSignature(_)
+            | TypeMemberKind::IndexSignature(_)
+    ));
+    key_count + 1
+}
+
+fn typeof_expression_child_count(expression: &TypeofExpression<'_>) -> usize {
+    match expression {
+        TypeofExpression::Addition(_)
+        | TypeofExpression::LogicalAnd(_)
+        | TypeofExpression::LogicalOr(_)
+        | TypeofExpression::NullishCoalescing(_) => 2,
+        TypeofExpression::Conditional(_) => 3,
+        TypeofExpression::Call(expression) => expression.arguments.len().saturating_add(1),
+        TypeofExpression::New(expression) => expression.arguments.len().saturating_add(1),
+        TypeofExpression::Await(_)
+        | TypeofExpression::BitwiseNot(_)
+        | TypeofExpression::Destructure(_)
+        | TypeofExpression::Index(_)
+        | TypeofExpression::IterableValueOf(_)
+        | TypeofExpression::StaticMember(_)
+        | TypeofExpression::Super(_)
+        | TypeofExpression::This(_)
+        | TypeofExpression::Typeof(_)
+        | TypeofExpression::UnaryMinus(_) => 1,
+    }
+}
+
+#[deny(clippy::wildcard_enum_match_arm)]
+fn structural_type_child_count<'db>(db: &'db dyn TypeDb, ty: TypeData<'db>) -> usize {
+    match ty {
+        TypeData::Class(class) => class
+            .type_parameters(db)
+            .len()
+            .saturating_add(usize::from(class.extends(db).is_some()))
+            .saturating_add(class.implements(db).len())
+            .saturating_add(class.members(db).iter().map(type_member_child_count).sum()),
+        TypeData::Constructor(constructor) => constructor
+            .type_parameters(db)
+            .len()
+            .saturating_add(
+                constructor
+                    .parameters(db)
+                    .iter()
+                    .map(|parameter| function_parameter_child_count(&parameter.parameter))
+                    .sum(),
+            )
+            .saturating_add(usize::from(constructor.return_type(db).is_some())),
+        TypeData::Function(function) => function
+            .type_parameters(db)
+            .len()
+            .saturating_add(
+                function
+                    .parameters(db)
+                    .iter()
+                    .map(function_parameter_child_count)
+                    .sum(),
+            )
+            .saturating_add(1),
+        TypeData::Interface(interface) => interface
+            .type_parameters(db)
+            .len()
+            .saturating_add(interface.extends(db).len())
+            .saturating_add(
+                interface
+                    .members(db)
+                    .iter()
+                    .map(type_member_child_count)
+                    .sum(),
+            ),
+        TypeData::Module(module) => module.members(db).iter().map(type_member_child_count).sum(),
+        TypeData::Namespace(namespace) => namespace
+            .members(db)
+            .iter()
+            .map(type_member_child_count)
+            .sum(),
+        TypeData::Object(object) => usize::from(object.prototype(db).is_some())
+            .saturating_add(object.members(db).iter().map(type_member_child_count).sum()),
+        TypeData::Tuple(tuple) => tuple.elements(db).len(),
+        TypeData::Generic(generic) => {
+            usize::from(generic.constraint(db).is_some())
+                + usize::from(generic.default(db).is_some())
+        }
+        TypeData::Intersection(intersection) => intersection.types(db).len(),
+        TypeData::Union(union) => union.types(db).len(),
+        TypeData::TypeOperator(_) => 1,
+        TypeData::Literal(literal) => match literal.literal(db) {
+            Literal::Object(members) => members.iter().map(type_member_child_count).sum(),
+            Literal::BigInt(_)
+            | Literal::Boolean(_)
+            | Literal::Number(_)
+            | Literal::RegExp(_)
+            | Literal::String(_)
+            | Literal::Template(_) => 0,
+        },
+        TypeData::InstanceOf(instance) => instance.type_parameters(db).len().saturating_add(1),
+        TypeData::MergedReference(reference) => {
+            usize::from(reference.ty(db).is_some())
+                + usize::from(reference.value_ty(db).is_some())
+                + usize::from(reference.namespace_ty(db).is_some())
+        }
+        TypeData::TypeofExpression(expression) => {
+            typeof_expression_child_count(expression.expression(db))
+        }
+        TypeData::TypeofType(_) | TypeData::TypeofValue(_) => 1,
+        TypeData::Unknown
+        | TypeData::Divergent(_)
+        | TypeData::Global
+        | TypeData::BigInt
+        | TypeData::Boolean
+        | TypeData::Null
+        | TypeData::Number
+        | TypeData::String
+        | TypeData::Symbol
+        | TypeData::Undefined
+        | TypeData::Conditional
+        | TypeData::Local(_)
+        | TypeData::AnyKeyword
+        | TypeData::NeverKeyword
+        | TypeData::ObjectKeyword
+        | TypeData::ThisKeyword
+        | TypeData::UnknownKeyword
+        | TypeData::VoidKeyword => 0,
+    }
+}
+
+#[deny(clippy::wildcard_enum_match_arm)]
+fn structural_type_children<'db>(db: &'db dyn TypeDb, ty: TypeData<'db>) -> Vec<TypeData<'db>> {
+    let mut children = Vec::new();
+    match ty {
+        TypeData::Class(class) => {
+            children.extend_from_slice(class.type_parameters(db));
+            children.extend(class.extends(db));
+            children.extend_from_slice(class.implements(db));
+            push_type_member_children(class.members(db), &mut children);
+        }
+        TypeData::Constructor(constructor) => {
+            children.extend_from_slice(constructor.type_parameters(db));
+            for parameter in constructor.parameters(db) {
+                push_function_parameter_children(&parameter.parameter, &mut children);
+            }
+            children.extend(constructor.return_type(db));
+        }
+        TypeData::Function(function) => {
+            children.extend_from_slice(function.type_parameters(db));
+            for parameter in function.parameters(db) {
+                push_function_parameter_children(parameter, &mut children);
+            }
+            push_return_type_children(function.return_type(db), &mut children);
+        }
+        TypeData::Interface(interface) => {
+            children.extend_from_slice(interface.type_parameters(db));
+            children.extend_from_slice(interface.extends(db));
+            push_type_member_children(interface.members(db), &mut children);
+        }
+        TypeData::Module(module) => push_type_member_children(module.members(db), &mut children),
+        TypeData::Namespace(namespace) => {
+            push_type_member_children(namespace.members(db), &mut children);
+        }
+        TypeData::Object(object) => {
+            children.extend(object.prototype(db));
+            push_type_member_children(object.members(db), &mut children);
+        }
+        TypeData::Tuple(tuple) => {
+            children.extend(tuple.elements(db).iter().map(|element| element.ty));
+        }
+        TypeData::Generic(generic) => {
+            children.extend(generic.constraint(db));
+            children.extend(generic.default(db));
+        }
+        TypeData::Intersection(intersection) => children.extend_from_slice(intersection.types(db)),
+        TypeData::Union(union) => children.extend_from_slice(union.types(db)),
+        TypeData::TypeOperator(operator) => children.push(operator.ty(db)),
+        TypeData::Literal(literal) => {
+            if let Literal::Object(members) = literal.literal(db) {
+                push_type_member_children(members, &mut children);
+            }
+        }
+        TypeData::InstanceOf(instance) => {
+            children.push(instance.ty(db));
+            children.extend_from_slice(instance.type_parameters(db));
+        }
+        TypeData::MergedReference(reference) => {
+            children.extend(reference.ty(db));
+            children.extend(reference.value_ty(db));
+            children.extend(reference.namespace_ty(db));
+        }
+        TypeData::TypeofExpression(expression) => {
+            push_typeof_expression_children(expression.expression(db), &mut children);
+        }
+        TypeData::TypeofType(ty) => children.push(ty.ty(db)),
+        TypeData::TypeofValue(value) => children.push(value.ty(db)),
+        TypeData::Unknown
+        | TypeData::Divergent(_)
+        | TypeData::Global
+        | TypeData::BigInt
+        | TypeData::Boolean
+        | TypeData::Null
+        | TypeData::Number
+        | TypeData::String
+        | TypeData::Symbol
+        | TypeData::Undefined
+        | TypeData::Conditional
+        | TypeData::Local(_)
+        | TypeData::AnyKeyword
+        | TypeData::NeverKeyword
+        | TypeData::ObjectKeyword
+        | TypeData::ThisKeyword
+        | TypeData::UnknownKeyword
+        | TypeData::VoidKeyword => {}
+    }
+    children
+}
+
+fn push_function_parameter_children<'db>(
+    parameter: &FunctionParameter<'db>,
+    children: &mut Vec<TypeData<'db>>,
+) {
+    match parameter {
+        FunctionParameter::Named(parameter) => children.push(parameter.ty),
+        FunctionParameter::Pattern(parameter) => {
+            children.extend(parameter.bindings.iter().map(|binding| binding.ty));
+            children.push(parameter.ty);
+        }
+    }
+}
+
+fn push_return_type_children<'db>(
+    return_type: &ReturnType<'db>,
+    children: &mut Vec<TypeData<'db>>,
+) {
+    children.push(match return_type {
+        ReturnType::Type(ty) => *ty,
+        ReturnType::Predicate(predicate) => predicate.ty,
+        ReturnType::Asserts(asserts) => asserts.ty,
+    });
+}
+
+fn push_type_member_children<'db>(members: &[TypeMember<'db>], children: &mut Vec<TypeData<'db>>) {
+    for member in members {
+        match &member.kind {
+            TypeMemberKind::ComputedValue(ty)
+            | TypeMemberKind::ComputedValueNamed(_, ty)
+            | TypeMemberKind::ConstAssertedComputedValue(ty)
+            | TypeMemberKind::ConstAssertedComputedValueNamed(_, ty)
+            | TypeMemberKind::ConstAssertedIndexSignature(ty)
+            | TypeMemberKind::IndexSignature(ty) => children.push(*ty),
+            TypeMemberKind::CallSignature
+            | TypeMemberKind::ConstAssertedCallSignature
+            | TypeMemberKind::ConstAssertedConstructor
+            | TypeMemberKind::ConstAssertedGetter(_)
+            | TypeMemberKind::ConstAssertedNamed(_)
+            | TypeMemberKind::ConstAssertedNamedOptional(_)
+            | TypeMemberKind::ConstAssertedNamedStatic(_)
+            | TypeMemberKind::Constructor
+            | TypeMemberKind::Getter(_)
+            | TypeMemberKind::Named(_)
+            | TypeMemberKind::NamedOptional(_)
+            | TypeMemberKind::NamedStatic(_) => {}
+        }
+        children.push(member.ty);
+    }
+}
+
+#[deny(clippy::wildcard_enum_match_arm)]
+fn push_typeof_expression_children<'db>(
+    expression: &TypeofExpression<'db>,
+    children: &mut Vec<TypeData<'db>>,
+) {
+    match expression {
+        TypeofExpression::Addition(expression) => {
+            children.extend([expression.left, expression.right]);
+        }
+        TypeofExpression::Await(expression) => children.push(expression.argument),
+        TypeofExpression::BitwiseNot(expression) => children.push(expression.argument),
+        TypeofExpression::Call(expression) => {
+            children.push(expression.callee);
+            push_call_argument_children(&expression.arguments, children);
+        }
+        TypeofExpression::Conditional(expression) => {
+            children.extend([expression.test, expression.consequent, expression.alternate]);
+        }
+        TypeofExpression::Destructure(expression) => children.push(expression.ty),
+        TypeofExpression::Index(expression) => children.push(expression.object),
+        TypeofExpression::IterableValueOf(expression) => children.push(expression.ty),
+        TypeofExpression::LogicalAnd(expression) => {
+            children.extend([expression.left, expression.right]);
+        }
+        TypeofExpression::LogicalOr(expression) => {
+            children.extend([expression.left, expression.right]);
+        }
+        TypeofExpression::New(expression) => {
+            children.push(expression.callee);
+            push_call_argument_children(&expression.arguments, children);
+        }
+        TypeofExpression::NullishCoalescing(expression) => {
+            children.extend([expression.left, expression.right]);
+        }
+        TypeofExpression::StaticMember(expression) => children.push(expression.object),
+        TypeofExpression::Super(expression) | TypeofExpression::This(expression) => {
+            children.push(expression.parent);
+        }
+        TypeofExpression::Typeof(expression) => children.push(expression.argument),
+        TypeofExpression::UnaryMinus(expression) => children.push(expression.argument),
+    }
+}
+
+fn push_call_argument_children<'db>(
+    arguments: &[CallArgumentType<'db>],
+    children: &mut Vec<TypeData<'db>>,
+) {
+    children.extend(arguments.iter().map(|argument| match argument {
+        CallArgumentType::Argument(ty) | CallArgumentType::Spread(ty) => *ty,
+    }));
+}
+
+#[deny(clippy::wildcard_enum_match_arm)]
+fn rebuild_structural_type<'db>(
+    db: &'db dyn TypeDb,
+    ty: TypeData<'db>,
+    children: Vec<TypeData<'db>>,
+) -> Option<TypeData<'db>> {
+    let mut children = children.into_iter();
+    let rebuilt = match ty {
+        TypeData::Class(class) => TypeData::Class(InternedClass::new(
+            db,
+            take_types(&mut children, class.type_parameters(db).len())?,
+            take_optional_type(&mut children, class.extends(db))?,
+            take_types(&mut children, class.implements(db).len())?,
+            rebuild_type_members(class.members(db), &mut children)?,
+            class.name(db).clone(),
+            class.is_builtin(db),
+        )),
+        TypeData::Constructor(constructor) => TypeData::Constructor(InternedConstructor::new(
+            db,
+            take_types(&mut children, constructor.type_parameters(db).len())?,
+            constructor
+                .parameters(db)
+                .iter()
+                .map(|parameter| {
+                    Some(ConstructorParameter {
+                        parameter: rebuild_function_parameter(&parameter.parameter, &mut children)?,
+                        accessibility: parameter.accessibility,
+                    })
+                })
+                .collect::<Option<Box<[_]>>>()?,
+            take_optional_type(&mut children, constructor.return_type(db))?,
+        )),
         TypeData::Function(function) => TypeData::Function(InternedFunction::new(
             db,
-            function.type_parameters(db).to_vec().into_boxed_slice(),
+            take_types(&mut children, function.type_parameters(db).len())?,
             function
                 .parameters(db)
                 .iter()
-                .map(|parameter| substitute_function_parameter(parameter, &mut substitute))
+                .map(|parameter| rebuild_function_parameter(parameter, &mut children))
                 .collect::<Option<Box<[_]>>>()?,
-            substitute_return_type(function.return_type(db), &mut substitute)?,
+            rebuild_return_type(function.return_type(db), &mut children)?,
             function.is_async(db),
             function.name(db).clone(),
         )),
         TypeData::Interface(interface) => TypeData::Interface(InternedInterface::new(
             db,
-            interface.type_parameters(db).to_vec().into_boxed_slice(),
-            interface
-                .extends(db)
-                .iter()
-                .map(|ty| substitute(*ty))
-                .collect::<Option<Box<[_]>>>()?,
-            substitute_members(interface.members(db), &mut substitute)?,
+            take_types(&mut children, interface.type_parameters(db).len())?,
+            take_types(&mut children, interface.extends(db).len())?,
+            rebuild_type_members(interface.members(db), &mut children)?,
             interface.name(db).clone(),
         )),
-        TypeData::Class(class) => TypeData::Class(InternedClass::new(
+        TypeData::Module(module) => TypeData::Module(InternedModule::new(
             db,
-            class.type_parameters(db).to_vec().into_boxed_slice(),
-            match class.extends(db) {
-                Some(extends) => Some(substitute(extends)?),
-                None => None,
-            },
-            class
-                .implements(db)
-                .iter()
-                .map(|ty| substitute(*ty))
-                .collect::<Option<Box<[_]>>>()?,
-            substitute_members(class.members(db), &mut substitute)?,
-            class.name(db).clone(),
-            class.is_builtin(db),
+            rebuild_type_members(module.members(db), &mut children)?,
+            module.name(db).clone(),
+        )),
+        TypeData::Namespace(namespace) => TypeData::Namespace(InternedNamespace::new(
+            db,
+            rebuild_type_members(namespace.members(db), &mut children)?,
+            namespace.path(db).clone(),
         )),
         TypeData::Object(object) => TypeData::Object(InternedObject::new(
             db,
-            match object.prototype(db) {
-                Some(prototype) => Some(substitute(prototype)?),
-                None => None,
-            },
-            substitute_members(object.members(db), &mut substitute)?,
+            take_optional_type(&mut children, object.prototype(db))?,
+            rebuild_type_members(object.members(db), &mut children)?,
         )),
         TypeData::Tuple(tuple) => TypeData::Tuple(InternedTuple::new(
             db,
@@ -1260,61 +1805,121 @@ fn substitute_type<'db>(
                 .elements(db)
                 .iter()
                 .map(|element| {
-                    Some(TupleElementType {
-                        ty: substitute(element.ty)?,
-                        name: element.name.clone(),
-                        is_optional: element.is_optional,
-                        is_rest: element.is_rest,
-                    })
+                    let mut element = element.clone();
+                    element.ty = children.next()?;
+                    Some(element)
                 })
                 .collect::<Option<Box<[_]>>>()?,
         )),
-        TypeData::InstanceOf(instance) => TypeData::instance_of(
+        TypeData::Generic(generic) => TypeData::Generic(InternedGenericTypeParameter::new(
             db,
-            substitute(instance.ty(db))?,
-            instance
-                .type_parameters(db)
-                .iter()
-                .map(|ty| substitute(*ty))
-                .collect::<Option<Box<[_]>>>()?,
+            take_optional_type(&mut children, generic.constraint(db))?,
+            take_optional_type(&mut children, generic.default(db))?,
+            generic.name(db).clone(),
+        )),
+        TypeData::Intersection(intersection) => TypeData::intersection_from_types(
+            db,
+            take_types(&mut children, intersection.types(db).len())?.into_vec(),
         ),
         TypeData::Union(union) => TypeData::union_from_types(
             db,
-            union
-                .types(db)
-                .iter()
-                .map(|ty| substitute(*ty))
-                .collect::<Option<Vec<_>>>()?,
+            take_types(&mut children, union.types(db).len())?.into_vec(),
         ),
-        TypeData::Intersection(intersection) => TypeData::intersection_from_types(
+        TypeData::TypeOperator(operator) => TypeData::TypeOperator(InternedTypeOperatorType::new(
             db,
-            intersection
-                .types(db)
-                .iter()
-                .map(|ty| substitute(*ty))
-                .collect::<Option<Vec<_>>>()?,
-        ),
-        TypeData::TypeofType(typeof_type) => {
-            TypeData::TypeofType(InternedTypeofType::new(db, substitute(typeof_type.ty(db))?))
-        }
-        TypeData::TypeofValue(typeof_value) => TypeData::TypeofValue(InternedTypeofValue::new(
-            db,
-            substitute(typeof_value.ty(db))?,
-            typeof_value.identifier(db).clone(),
-            typeof_value.scope_id(db),
+            children.next()?,
+            operator.operator(db),
         )),
-        ty => ty,
-    })
+        TypeData::Literal(literal) => TypeData::Literal(InternedLiteral::new(
+            db,
+            match literal.literal(db) {
+                Literal::Object(members) => {
+                    Literal::Object(rebuild_type_members(members, &mut children)?)
+                }
+                literal @ (Literal::BigInt(_)
+                | Literal::Boolean(_)
+                | Literal::Number(_)
+                | Literal::RegExp(_)
+                | Literal::String(_)
+                | Literal::Template(_)) => literal.clone(),
+            },
+        )),
+        TypeData::InstanceOf(instance) => TypeData::instance_of(
+            db,
+            children.next()?,
+            take_types(&mut children, instance.type_parameters(db).len())?,
+        ),
+        TypeData::MergedReference(reference) => {
+            TypeData::MergedReference(InternedMergedReference::new(
+                db,
+                take_optional_type(&mut children, reference.ty(db))?,
+                take_optional_type(&mut children, reference.value_ty(db))?,
+                take_optional_type(&mut children, reference.namespace_ty(db))?,
+            ))
+        }
+        TypeData::TypeofExpression(expression) => {
+            TypeData::TypeofExpression(InternedTypeofExpression::new(
+                db,
+                rebuild_typeof_expression(expression.expression(db), &mut children)?,
+            ))
+        }
+        TypeData::TypeofType(_) => {
+            TypeData::TypeofType(InternedTypeofType::new(db, children.next()?))
+        }
+        TypeData::TypeofValue(value) => TypeData::TypeofValue(InternedTypeofValue::new(
+            db,
+            children.next()?,
+            value.identifier(db).clone(),
+            value.scope_id(db),
+        )),
+        TypeData::Unknown
+        | TypeData::Divergent(_)
+        | TypeData::Global
+        | TypeData::BigInt
+        | TypeData::Boolean
+        | TypeData::Null
+        | TypeData::Number
+        | TypeData::String
+        | TypeData::Symbol
+        | TypeData::Undefined
+        | TypeData::Conditional
+        | TypeData::Local(_)
+        | TypeData::AnyKeyword
+        | TypeData::NeverKeyword
+        | TypeData::ObjectKeyword
+        | TypeData::ThisKeyword
+        | TypeData::UnknownKeyword
+        | TypeData::VoidKeyword => ty,
+    };
+    children.next().is_none().then_some(rebuilt)
 }
 
-fn substitute_function_parameter<'db>(
+fn take_types<'db>(
+    children: &mut impl Iterator<Item = TypeData<'db>>,
+    count: usize,
+) -> Option<Box<[TypeData<'db>]>> {
+    (0..count).map(|_| children.next()).collect()
+}
+
+fn take_optional_type<'db>(
+    children: &mut impl Iterator<Item = TypeData<'db>>,
+    original: Option<TypeData<'db>>,
+) -> Option<Option<TypeData<'db>>> {
+    if original.is_some() {
+        Some(Some(children.next()?))
+    } else {
+        Some(None)
+    }
+}
+
+fn rebuild_function_parameter<'db>(
     parameter: &FunctionParameter<'db>,
-    substitute: &mut impl FnMut(TypeData<'db>) -> Option<TypeData<'db>>,
+    children: &mut impl Iterator<Item = TypeData<'db>>,
 ) -> Option<FunctionParameter<'db>> {
     Some(match parameter {
         FunctionParameter::Named(parameter) => FunctionParameter::Named(NamedFunctionParameter {
             name: parameter.name.clone(),
-            ty: substitute(parameter.ty)?,
+            ty: children.next()?,
             is_optional: parameter.is_optional,
             is_rest: parameter.is_rest,
         }),
@@ -1326,11 +1931,11 @@ fn substitute_function_parameter<'db>(
                     .map(|binding| {
                         Some(FunctionParameterBinding {
                             name: binding.name.clone(),
-                            ty: substitute(binding.ty)?,
+                            ty: children.next()?,
                         })
                     })
                     .collect::<Option<Box<[_]>>>()?,
-                ty: substitute(parameter.ty)?,
+                ty: children.next()?,
                 is_optional: parameter.is_optional,
                 is_rest: parameter.is_rest,
             })
@@ -1338,33 +1943,177 @@ fn substitute_function_parameter<'db>(
     })
 }
 
-fn substitute_return_type<'db>(
+fn rebuild_return_type<'db>(
     return_type: &ReturnType<'db>,
-    substitute: &mut impl FnMut(TypeData<'db>) -> Option<TypeData<'db>>,
+    children: &mut impl Iterator<Item = TypeData<'db>>,
 ) -> Option<ReturnType<'db>> {
     Some(match return_type {
-        ReturnType::Type(ty) => ReturnType::Type(substitute(*ty)?),
+        ReturnType::Type(_) => ReturnType::Type(children.next()?),
         ReturnType::Predicate(predicate) => ReturnType::Predicate(PredicateReturnType {
             parameter_name: predicate.parameter_name.clone(),
-            ty: substitute(predicate.ty)?,
+            ty: children.next()?,
         }),
         ReturnType::Asserts(asserts) => ReturnType::Asserts(AssertsReturnType {
             parameter_name: asserts.parameter_name.clone(),
-            ty: substitute(asserts.ty)?,
+            ty: children.next()?,
         }),
     })
 }
 
-fn substitute_members<'db>(
+fn rebuild_type_members<'db>(
     members: &[TypeMember<'db>],
-    substitute: &mut impl FnMut(TypeData<'db>) -> Option<TypeData<'db>>,
+    children: &mut impl Iterator<Item = TypeData<'db>>,
 ) -> Option<Box<[TypeMember<'db>]>> {
     members
         .iter()
         .map(|member| {
             Some(TypeMember {
-                kind: member.kind.clone(),
-                ty: substitute(member.ty)?,
+                kind: rebuild_type_member_kind(&member.kind, children)?,
+                ty: children.next()?,
+            })
+        })
+        .collect()
+}
+
+fn rebuild_type_member_kind<'db>(
+    kind: &TypeMemberKind<'db>,
+    children: &mut impl Iterator<Item = TypeData<'db>>,
+) -> Option<TypeMemberKind<'db>> {
+    Some(match kind {
+        TypeMemberKind::CallSignature => TypeMemberKind::CallSignature,
+        TypeMemberKind::ComputedValue(_) => TypeMemberKind::ComputedValue(children.next()?),
+        TypeMemberKind::ComputedValueNamed(name, _) => {
+            TypeMemberKind::ComputedValueNamed(name.clone(), children.next()?)
+        }
+        TypeMemberKind::ConstAssertedCallSignature => TypeMemberKind::ConstAssertedCallSignature,
+        TypeMemberKind::ConstAssertedComputedValue(_) => {
+            TypeMemberKind::ConstAssertedComputedValue(children.next()?)
+        }
+        TypeMemberKind::ConstAssertedComputedValueNamed(name, _) => {
+            TypeMemberKind::ConstAssertedComputedValueNamed(name.clone(), children.next()?)
+        }
+        TypeMemberKind::ConstAssertedConstructor => TypeMemberKind::ConstAssertedConstructor,
+        TypeMemberKind::ConstAssertedGetter(name) => {
+            TypeMemberKind::ConstAssertedGetter(name.clone())
+        }
+        TypeMemberKind::ConstAssertedIndexSignature(_) => {
+            TypeMemberKind::ConstAssertedIndexSignature(children.next()?)
+        }
+        TypeMemberKind::ConstAssertedNamed(name) => {
+            TypeMemberKind::ConstAssertedNamed(name.clone())
+        }
+        TypeMemberKind::ConstAssertedNamedOptional(name) => {
+            TypeMemberKind::ConstAssertedNamedOptional(name.clone())
+        }
+        TypeMemberKind::ConstAssertedNamedStatic(name) => {
+            TypeMemberKind::ConstAssertedNamedStatic(name.clone())
+        }
+        TypeMemberKind::Constructor => TypeMemberKind::Constructor,
+        TypeMemberKind::Getter(name) => TypeMemberKind::Getter(name.clone()),
+        TypeMemberKind::IndexSignature(_) => TypeMemberKind::IndexSignature(children.next()?),
+        TypeMemberKind::Named(name) => TypeMemberKind::Named(name.clone()),
+        TypeMemberKind::NamedOptional(name) => TypeMemberKind::NamedOptional(name.clone()),
+        TypeMemberKind::NamedStatic(name) => TypeMemberKind::NamedStatic(name.clone()),
+    })
+}
+
+#[deny(clippy::wildcard_enum_match_arm)]
+fn rebuild_typeof_expression<'db>(
+    expression: &TypeofExpression<'db>,
+    children: &mut impl Iterator<Item = TypeData<'db>>,
+) -> Option<TypeofExpression<'db>> {
+    Some(match expression {
+        TypeofExpression::Addition(_) => TypeofExpression::Addition(TypeofAdditionExpression {
+            left: children.next()?,
+            right: children.next()?,
+        }),
+        TypeofExpression::Await(_) => TypeofExpression::Await(TypeofAwaitExpression {
+            argument: children.next()?,
+        }),
+        TypeofExpression::BitwiseNot(_) => {
+            TypeofExpression::BitwiseNot(TypeofBitwiseNotExpression {
+                argument: children.next()?,
+            })
+        }
+        TypeofExpression::Call(expression) => TypeofExpression::Call(TypeofCallExpression {
+            callee: children.next()?,
+            arguments: rebuild_call_arguments(&expression.arguments, children)?,
+        }),
+        TypeofExpression::Conditional(_) => {
+            TypeofExpression::Conditional(TypeofConditionalExpression {
+                test: children.next()?,
+                consequent: children.next()?,
+                alternate: children.next()?,
+            })
+        }
+        TypeofExpression::Destructure(expression) => {
+            TypeofExpression::Destructure(TypeofDestructureExpression {
+                ty: children.next()?,
+                destructure_field: expression.destructure_field.clone(),
+            })
+        }
+        TypeofExpression::Index(expression) => TypeofExpression::Index(TypeofIndexExpression {
+            object: children.next()?,
+            index: expression.index,
+        }),
+        TypeofExpression::IterableValueOf(_) => {
+            TypeofExpression::IterableValueOf(TypeofIterableValueOfExpression {
+                ty: children.next()?,
+            })
+        }
+        TypeofExpression::LogicalAnd(_) => {
+            TypeofExpression::LogicalAnd(TypeofLogicalAndExpression {
+                left: children.next()?,
+                right: children.next()?,
+            })
+        }
+        TypeofExpression::LogicalOr(_) => TypeofExpression::LogicalOr(TypeofLogicalOrExpression {
+            left: children.next()?,
+            right: children.next()?,
+        }),
+        TypeofExpression::New(expression) => TypeofExpression::New(TypeofNewExpression {
+            callee: children.next()?,
+            arguments: rebuild_call_arguments(&expression.arguments, children)?,
+        }),
+        TypeofExpression::NullishCoalescing(_) => {
+            TypeofExpression::NullishCoalescing(TypeofNullishCoalescingExpression {
+                left: children.next()?,
+                right: children.next()?,
+            })
+        }
+        TypeofExpression::StaticMember(expression) => {
+            TypeofExpression::StaticMember(TypeofStaticMemberExpression {
+                object: children.next()?,
+                member: expression.member.clone(),
+            })
+        }
+        TypeofExpression::Super(_) => TypeofExpression::Super(TypeofThisOrSuperExpression {
+            parent: children.next()?,
+        }),
+        TypeofExpression::This(_) => TypeofExpression::This(TypeofThisOrSuperExpression {
+            parent: children.next()?,
+        }),
+        TypeofExpression::Typeof(_) => TypeofExpression::Typeof(TypeofTypeofExpression {
+            argument: children.next()?,
+        }),
+        TypeofExpression::UnaryMinus(_) => {
+            TypeofExpression::UnaryMinus(TypeofUnaryMinusExpression {
+                argument: children.next()?,
+            })
+        }
+    })
+}
+
+fn rebuild_call_arguments<'db>(
+    arguments: &[CallArgumentType<'db>],
+    children: &mut impl Iterator<Item = TypeData<'db>>,
+) -> Option<Box<[CallArgumentType<'db>]>> {
+    arguments
+        .iter()
+        .map(|argument| {
+            Some(match argument {
+                CallArgumentType::Argument(_) => CallArgumentType::Argument(children.next()?),
+                CallArgumentType::Spread(_) => CallArgumentType::Spread(children.next()?),
             })
         })
         .collect()
@@ -2526,4 +3275,660 @@ fn raw_call_arguments_from_types<'db>(
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use salsa::plumbing::FromId;
+
+    #[salsa::db]
+    #[derive(Default)]
+    struct TestDb {
+        storage: salsa::Storage<Self>,
+    }
+
+    #[salsa::db]
+    impl salsa::Database for TestDb {}
+
+    #[salsa::db]
+    impl biome_db::Db for TestDb {
+        fn parsed_source_for_path(
+            &self,
+            _path: &camino::Utf8Path,
+        ) -> Option<biome_db::ParsedSource> {
+            None
+        }
+    }
+
+    #[salsa::db]
+    impl TypeDb for TestDb {}
+
+    #[derive(Default)]
+    struct Sentinels(usize);
+
+    impl Sentinels {
+        fn next<'db>(&mut self) -> TypeData<'db> {
+            let ty = [
+                TypeData::Global,
+                TypeData::BigInt,
+                TypeData::Boolean,
+                TypeData::Null,
+                TypeData::Number,
+                TypeData::String,
+                TypeData::Symbol,
+                TypeData::Undefined,
+                TypeData::Conditional,
+                TypeData::AnyKeyword,
+                TypeData::NeverKeyword,
+                TypeData::ObjectKeyword,
+                TypeData::ThisKeyword,
+                TypeData::UnknownKeyword,
+                TypeData::VoidKeyword,
+                TypeData::Unknown,
+            ][self.0];
+            self.0 += 1;
+            ty
+        }
+    }
+
+    fn text(value: &'static str) -> Text {
+        Text::new_static(value)
+    }
+
+    fn boxed<T, const N: usize>(values: [T; N]) -> Box<[T]> {
+        Box::new(values)
+    }
+
+    fn named_parameter<'db>(sentinels: &mut Sentinels) -> FunctionParameter<'db> {
+        FunctionParameter::Named(NamedFunctionParameter {
+            name: text("named"),
+            ty: sentinels.next(),
+            is_optional: false,
+            is_rest: false,
+        })
+    }
+
+    fn pattern_parameter<'db>(sentinels: &mut Sentinels) -> FunctionParameter<'db> {
+        FunctionParameter::Pattern(PatternFunctionParameter {
+            bindings: [FunctionParameterBinding {
+                name: text("binding"),
+                ty: sentinels.next(),
+            }]
+            .into(),
+            ty: sentinels.next(),
+            is_optional: true,
+            is_rest: true,
+        })
+    }
+
+    fn named_member<'db>(sentinels: &mut Sentinels) -> TypeMember<'db> {
+        TypeMember {
+            kind: TypeMemberKind::Named(text("member")),
+            ty: sentinels.next(),
+        }
+    }
+
+    fn child_bearing_members<'db>(sentinels: &mut Sentinels) -> Box<[TypeMember<'db>]> {
+        [
+            TypeMemberKind::ComputedValue(sentinels.next()),
+            TypeMemberKind::ComputedValueNamed(text("computed"), sentinels.next()),
+            TypeMemberKind::ConstAssertedComputedValue(sentinels.next()),
+            TypeMemberKind::ConstAssertedComputedValueNamed(
+                text("constComputed"),
+                sentinels.next(),
+            ),
+            TypeMemberKind::ConstAssertedIndexSignature(sentinels.next()),
+            TypeMemberKind::IndexSignature(sentinels.next()),
+        ]
+        .into_iter()
+        .map(|kind| TypeMember {
+            kind,
+            ty: sentinels.next(),
+        })
+        .collect()
+    }
+
+    fn typeof_type<'db>(db: &'db TestDb, expression: TypeofExpression<'db>) -> TypeData<'db> {
+        TypeData::TypeofExpression(InternedTypeofExpression::new(db, expression))
+    }
+
+    fn assert_identity<'db>(db: &'db TestDb, build: impl FnOnce(&mut Sentinels) -> TypeData<'db>) {
+        let ty = build(&mut Sentinels::default());
+        let children = structural_type_children(db, ty);
+        assert!(!children.is_empty());
+        assert_eq!(
+            children.iter().copied().collect::<FxHashSet<_>>().len(),
+            children.len(),
+            "test shape must use distinct children"
+        );
+
+        assert_eq!(
+            ty.try_map_structural(
+                db,
+                usize::MAX,
+                ControlFlow::Continue,
+                std::convert::identity,
+            ),
+            Ok(ty)
+        );
+        assert_eq!(rebuild_structural_type(db, ty, children.clone()), Some(ty));
+        assert!(rebuild_structural_type(db, ty, children[..children.len() - 1].to_vec()).is_none());
+        let mut extra_children = children;
+        extra_children.push(TypeData::Unknown);
+        assert!(rebuild_structural_type(db, ty, extra_children).is_none());
+    }
+
+    #[test]
+    fn structural_map_reports_step_limit_exceeded() {
+        let db = TestDb::default();
+        let ty = TypeData::TypeOperator(InternedTypeOperatorType::new(
+            &db,
+            TypeData::String,
+            raw::TypeOperator::Keyof,
+        ));
+
+        assert_eq!(
+            ty.try_map_structural(&db, 1, ControlFlow::Continue, std::convert::identity,),
+            Err(StructuralMapError::StepLimitExceeded)
+        );
+    }
+
+    fn typeof_chain<'db>(
+        db: &'db TestDb,
+        distinct_types: usize,
+        leaf: TypeData<'db>,
+    ) -> TypeData<'db> {
+        assert!(distinct_types > 0);
+        (1..distinct_types).fold(leaf, |ty, _| {
+            TypeData::TypeofType(InternedTypeofType::new(db, ty))
+        })
+    }
+
+    fn generic<'db>(db: &'db TestDb) -> TypeData<'db> {
+        TypeData::Generic(InternedGenericTypeParameter::new(db, None, None, text("T")))
+    }
+
+    #[test]
+    fn substitution_reports_direct_step_boundaries() {
+        let db = TestDb::default();
+        let generic = generic(&db);
+        let substitution = TypeSubstitution {
+            generic,
+            replacement: TypeData::String,
+        };
+
+        for distinct_types in [1023, 1024, 1025] {
+            let result =
+                typeof_chain(&db, distinct_types, generic).substitute_type(&db, substitution);
+            if distinct_types <= MAX_TYPE_SUBSTITUTION_STEPS {
+                assert!(result.is_ok(), "distinct types {distinct_types}");
+            } else {
+                assert_eq!(
+                    result,
+                    Err(StructuralMapError::StepLimitExceeded),
+                    "distinct types {distinct_types}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn root_body_substitution_reports_direct_step_boundaries() {
+        let db = TestDb::default();
+        let generic = generic(&db);
+        let substitution = TypeSubstitution {
+            generic,
+            replacement: TypeData::String,
+        };
+
+        for distinct_types in [1023, 1024, 1025] {
+            let function = TypeData::Function(InternedFunction::new(
+                &db,
+                boxed([generic]),
+                Box::default(),
+                ReturnType::Type(typeof_chain(&db, distinct_types, generic)),
+                false,
+                None,
+            ));
+            let result = function.substitute_type_in_root_body(&db, substitution);
+            if distinct_types <= MAX_TYPE_SUBSTITUTION_STEPS {
+                assert!(result.is_ok(), "distinct types {distinct_types}");
+            } else {
+                assert_eq!(
+                    result,
+                    Err(StructuralMapError::StepLimitExceeded),
+                    "distinct types {distinct_types}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn root_body_substitution_shares_one_budget_across_children() {
+        let db = TestDb::default();
+        let generic = generic(&db);
+        let substitution = TypeSubstitution {
+            generic,
+            replacement: TypeData::String,
+        };
+        let parameter = |name, ty| {
+            FunctionParameter::Named(NamedFunctionParameter {
+                name: text(name),
+                ty,
+                is_optional: false,
+                is_rest: false,
+            })
+        };
+        let function = TypeData::Function(InternedFunction::new(
+            &db,
+            boxed([generic]),
+            Vec::from([
+                parameter("first", typeof_chain(&db, 600, generic)),
+                parameter("second", typeof_chain(&db, 600, generic)),
+            ])
+            .into_boxed_slice(),
+            ReturnType::Type(generic),
+            false,
+            None,
+        ));
+
+        assert_eq!(
+            function.substitute_type_in_root_body(&db, substitution),
+            Err(StructuralMapError::StepLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn root_body_substitution_preserves_the_root_binder() {
+        let db = TestDb::default();
+        let generic = generic(&db);
+        let function = TypeData::Function(InternedFunction::new(
+            &db,
+            boxed([generic]),
+            boxed([FunctionParameter::Named(NamedFunctionParameter {
+                name: text("value"),
+                ty: generic,
+                is_optional: false,
+                is_rest: false,
+            })]),
+            ReturnType::Type(generic),
+            false,
+            None,
+        ));
+        let substituted = function
+            .substitute_type_in_root_body(
+                &db,
+                TypeSubstitution {
+                    generic,
+                    replacement: TypeData::String,
+                },
+            )
+            .expect("root body substitution must complete");
+        let TypeData::Function(substituted) = substituted else {
+            panic!("expected a function");
+        };
+
+        assert_eq!(substituted.type_parameters(&db).as_ref(), &[generic]);
+        assert_eq!(substituted.parameters(&db)[0].ty(), TypeData::String);
+        assert_eq!(
+            substituted.return_type(&db),
+            &ReturnType::Type(TypeData::String)
+        );
+    }
+
+    #[test]
+    fn substitution_completes_back_edge_after_budget_is_consumed() {
+        let db = TestDb::default();
+        // IDs 0..1022 build the path. The next interned value receives ID 1023,
+        // which closes the final child back to the root.
+        let root_reference = InternedTypeofType::from_id(unsafe { salsa::Id::from_index(1023) });
+        let child = (0..MAX_TYPE_SUBSTITUTION_STEPS - 1)
+            .fold(TypeData::TypeofType(root_reference), |ty, _| {
+                TypeData::TypeofType(InternedTypeofType::new(&db, ty))
+            });
+        let root = TypeData::TypeofType(InternedTypeofType::new(&db, child));
+
+        assert_eq!(
+            root.substitute_type(
+                &db,
+                TypeSubstitution {
+                    generic: TypeData::Number,
+                    replacement: TypeData::String,
+                }
+            ),
+            Ok(root)
+        );
+    }
+
+    #[test]
+    fn generic_replacement_collection_completes_seen_back_edges_at_the_limit() {
+        let db = TestDb::default();
+        let generic = TypeData::Generic(InternedGenericTypeParameter::new(
+            &db,
+            None,
+            None,
+            text("T"),
+        ));
+        let pattern = (0..MAX_GENERIC_REPLACEMENT_STEPS - 3).fold(generic, |ty, _| {
+            TypeData::instance_of(&db, TypeData::ObjectKeyword, boxed([ty]))
+        });
+        let actual = (0..MAX_GENERIC_REPLACEMENT_STEPS - 3).fold(TypeData::String, |ty, _| {
+            TypeData::instance_of(&db, TypeData::ObjectKeyword, boxed([ty]))
+        });
+        let pattern =
+            TypeData::instance_of(&db, TypeData::ObjectKeyword, boxed([pattern, pattern]));
+        let actual = TypeData::instance_of(&db, TypeData::ObjectKeyword, boxed([actual, actual]));
+
+        let replacements = pattern
+            .collect_generic_replacements(&db, actual)
+            .expect("an already-seen back edge must complete after the budget is consumed");
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].replacement, TypeData::String);
+    }
+
+    #[test]
+    fn structural_map_identity_round_trips_all_child_bearing_shapes() {
+        let db = TestDb::default();
+
+        assert_identity(&db, |s| {
+            TypeData::Class(InternedClass::new(
+                &db,
+                boxed([s.next()]),
+                Some(s.next()),
+                boxed([s.next()]),
+                boxed([named_member(s)]),
+                Some(text("Class")),
+                false,
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Constructor(InternedConstructor::new(
+                &db,
+                boxed([s.next()]),
+                boxed([ConstructorParameter {
+                    parameter: named_parameter(s),
+                    accessibility: None,
+                }]),
+                Some(s.next()),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Function(InternedFunction::new(
+                &db,
+                boxed([s.next()]),
+                boxed([named_parameter(s), pattern_parameter(s)]),
+                ReturnType::Type(s.next()),
+                false,
+                Some(text("function")),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Function(InternedFunction::new(
+                &db,
+                Box::default(),
+                Box::default(),
+                ReturnType::Predicate(PredicateReturnType {
+                    parameter_name: text("value"),
+                    ty: s.next(),
+                }),
+                false,
+                None,
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Function(InternedFunction::new(
+                &db,
+                Box::default(),
+                Box::default(),
+                ReturnType::Asserts(AssertsReturnType {
+                    parameter_name: text("value"),
+                    ty: s.next(),
+                }),
+                false,
+                None,
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Interface(InternedInterface::new(
+                &db,
+                boxed([s.next()]),
+                boxed([s.next()]),
+                boxed([named_member(s)]),
+                text("Interface"),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Module(InternedModule::new(
+                &db,
+                child_bearing_members(s),
+                text("module"),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Namespace(InternedNamespace::new(
+                &db,
+                boxed([named_member(s)]),
+                raw::Path::from(text("namespace")),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Object(InternedObject::new(
+                &db,
+                Some(s.next()),
+                boxed([named_member(s)]),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Tuple(InternedTuple::new(
+                &db,
+                boxed([
+                    TupleElementType {
+                        ty: s.next(),
+                        name: Some(text("first")),
+                        is_optional: false,
+                        is_rest: false,
+                    },
+                    TupleElementType {
+                        ty: s.next(),
+                        name: None,
+                        is_optional: true,
+                        is_rest: true,
+                    },
+                ]),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Generic(InternedGenericTypeParameter::new(
+                &db,
+                Some(s.next()),
+                Some(s.next()),
+                text("T"),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Intersection(InternedIntersection::new(&db, boxed([s.next(), s.next()])))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Union(InternedUnion::new(&db, boxed([s.next(), s.next()])))
+        });
+        assert_identity(&db, |s| {
+            TypeData::TypeOperator(InternedTypeOperatorType::new(
+                &db,
+                s.next(),
+                raw::TypeOperator::Readonly,
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::Literal(InternedLiteral::new(
+                &db,
+                Literal::Object([named_member(s)].into()),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::InstanceOf(InternedTypeInstance::new(
+                &db,
+                s.next(),
+                boxed([s.next(), s.next()]),
+            ))
+        });
+        assert_identity(&db, |s| {
+            TypeData::MergedReference(InternedMergedReference::new(
+                &db,
+                Some(s.next()),
+                Some(s.next()),
+                Some(s.next()),
+            ))
+        });
+
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::Addition(TypeofAdditionExpression {
+                    left: s.next(),
+                    right: s.next(),
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::Await(TypeofAwaitExpression { argument: s.next() }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::BitwiseNot(TypeofBitwiseNotExpression { argument: s.next() }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::Call(TypeofCallExpression {
+                    callee: s.next(),
+                    arguments: [
+                        CallArgumentType::Argument(s.next()),
+                        CallArgumentType::Spread(s.next()),
+                    ]
+                    .into(),
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::Conditional(TypeofConditionalExpression {
+                    test: s.next(),
+                    consequent: s.next(),
+                    alternate: s.next(),
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::Destructure(TypeofDestructureExpression {
+                    ty: s.next(),
+                    destructure_field: raw::DestructureField::Index(0),
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::Index(TypeofIndexExpression {
+                    object: s.next(),
+                    index: 1,
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::IterableValueOf(TypeofIterableValueOfExpression { ty: s.next() }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::LogicalAnd(TypeofLogicalAndExpression {
+                    left: s.next(),
+                    right: s.next(),
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::LogicalOr(TypeofLogicalOrExpression {
+                    left: s.next(),
+                    right: s.next(),
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::New(TypeofNewExpression {
+                    callee: s.next(),
+                    arguments: [
+                        CallArgumentType::Argument(s.next()),
+                        CallArgumentType::Spread(s.next()),
+                    ]
+                    .into(),
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::NullishCoalescing(TypeofNullishCoalescingExpression {
+                    left: s.next(),
+                    right: s.next(),
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::StaticMember(TypeofStaticMemberExpression {
+                    object: s.next(),
+                    member: text("member"),
+                }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::Super(TypeofThisOrSuperExpression { parent: s.next() }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::This(TypeofThisOrSuperExpression { parent: s.next() }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::Typeof(TypeofTypeofExpression { argument: s.next() }),
+            )
+        });
+        assert_identity(&db, |s| {
+            typeof_type(
+                &db,
+                TypeofExpression::UnaryMinus(TypeofUnaryMinusExpression { argument: s.next() }),
+            )
+        });
+
+        assert_identity(&db, |s| {
+            TypeData::TypeofType(InternedTypeofType::new(&db, s.next()))
+        });
+        assert_identity(&db, |s| {
+            TypeData::TypeofValue(InternedTypeofValue::new(&db, s.next(), text("value"), None))
+        });
+    }
 }

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -3168,6 +3168,67 @@ mod tests {
     }
 
     #[test]
+    fn substitution_descends_into_empty_generic_instance() {
+        let db = TestDb::default();
+        let generic = generic(&db);
+        let reference = TypeData::instance_of(&db, generic, Box::default());
+
+        assert_eq!(
+            reference.substitute_type(
+                &db,
+                TypeSubstitution {
+                    generic,
+                    replacement: TypeData::String,
+                },
+            ),
+            TypeTransformResult::Transformed(TypeData::instance_of(
+                &db,
+                TypeData::String,
+                Box::default(),
+            ))
+        );
+    }
+
+    #[test]
+    fn substitution_preserves_unmatched_generic_declaration_identity() {
+        let db = TestDb::default();
+        let generic_t = generic(&db);
+        let reference_t = TypeData::instance_of(&db, generic_t, Box::default());
+        let generic_u = TypeData::Generic(InternedGenericTypeParameter::new(
+            &db,
+            None,
+            Some(reference_t),
+            text("U"),
+        ));
+        let reference_u = TypeData::instance_of(&db, generic_u, Box::default());
+
+        assert_eq!(
+            reference_u.substitute_type(
+                &db,
+                TypeSubstitution {
+                    generic: generic_t,
+                    replacement: TypeData::String,
+                },
+            ),
+            TypeTransformResult::Transformed(reference_u)
+        );
+        assert_eq!(
+            reference_u.substitute_type(
+                &db,
+                TypeSubstitution {
+                    generic: generic_u,
+                    replacement: TypeData::Number,
+                },
+            ),
+            TypeTransformResult::Transformed(TypeData::instance_of(
+                &db,
+                TypeData::Number,
+                Box::default(),
+            ))
+        );
+    }
+
+    #[test]
     fn substitution_reports_direct_step_boundaries() {
         let db = TestDb::default();
         let generic = generic(&db);

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -27,6 +27,7 @@ mod return_type_relation;
 mod r#type;
 mod type_data;
 mod type_store;
+mod type_transform;
 mod type_traversal;
 
 pub use conditionals::*;

--- a/crates/biome_js_type_info/src/resolved.rs
+++ b/crates/biome_js_type_info/src/resolved.rs
@@ -25,7 +25,7 @@ pub use crate::interned_types::{
     NamedFunctionParameter as InferredNamedFunctionParameter,
     PatternFunctionParameter as InferredPatternFunctionParameter,
     PredicateReturnType as InferredPredicateReturnType, ReturnType as InferredReturnType,
-    TupleElementType as InferredTupleElementType, TypeData as InferredTypeData,
+    StructuralMapError, TupleElementType as InferredTupleElementType, TypeData as InferredTypeData,
     TypeMember as InferredTypeMember, TypeMemberKind as InferredTypeMemberKind,
     TypeSubstitution as InferredTypeSubstitution, TypeofExpression as InferredTypeofExpression,
     well_known_symbol_name,

--- a/crates/biome_js_type_info/src/resolved.rs
+++ b/crates/biome_js_type_info/src/resolved.rs
@@ -25,8 +25,8 @@ pub use crate::interned_types::{
     NamedFunctionParameter as InferredNamedFunctionParameter,
     PatternFunctionParameter as InferredPatternFunctionParameter,
     PredicateReturnType as InferredPredicateReturnType, ReturnType as InferredReturnType,
-    StructuralMapError, TupleElementType as InferredTupleElementType, TypeData as InferredTypeData,
+    TupleElementType as InferredTupleElementType, TypeData as InferredTypeData,
     TypeMember as InferredTypeMember, TypeMemberKind as InferredTypeMemberKind,
-    TypeSubstitution as InferredTypeSubstitution, TypeofExpression as InferredTypeofExpression,
-    well_known_symbol_name,
+    TypeSubstitution as InferredTypeSubstitution, TypeTransformError, TypeTransformResult,
+    TypeofExpression as InferredTypeofExpression, well_known_symbol_name,
 };

--- a/crates/biome_js_type_info/src/type_transform.rs
+++ b/crates/biome_js_type_info/src/type_transform.rs
@@ -1,0 +1,400 @@
+//! Bounded transformations of nested types.
+//!
+//! A transformation visits each type and its slots. The traversal is private;
+//! callers use operations such as generic substitution.
+
+use crate::interned_types::{TypeData, TypeDataSlotRebuilder, TypeDb};
+use rustc_hash::FxHashSet;
+
+pub(crate) const MAX_TYPE_SUBSTITUTION_STEPS: usize = 1024;
+
+/// Replaces `generic` with `replacement` outside nested declarations of the
+/// same generic parameter.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update)]
+pub struct TypeSubstitution<'db> {
+    /// Type to replace.
+    pub generic: TypeData<'db>,
+    /// Replacement type.
+    pub replacement: TypeData<'db>,
+}
+
+impl<'db> TypeSubstitution<'db> {
+    /// Removes an empty generic instantiation used as a substitution pattern.
+    fn binder_generic(self, db: &'db dyn TypeDb) -> TypeData<'db> {
+        if let TypeData::InstanceOf(instance) = self.generic
+            && instance.type_parameters(db).is_empty()
+            && matches!(instance.ty(db), TypeData::Generic(_))
+        {
+            instance.ty(db)
+        } else {
+            self.generic
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TypeTransformError {
+    /// The transformation exceeded its step limit.
+    StepLimitExceeded,
+    /// The replacements did not match the extracted slots.
+    InvalidRebuild,
+}
+
+impl std::fmt::Display for TypeTransformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::StepLimitExceeded => "type transformation exceeded its step limit",
+            Self::InvalidRebuild => "replacement types could not rebuild their parent",
+        })
+    }
+}
+
+impl std::error::Error for TypeTransformError {}
+
+/// Result of transforming a type and its nested slots.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[must_use = "a type transformation failure must be handled"]
+pub enum TypeTransformResult<T> {
+    /// Every required type was transformed.
+    Transformed(T),
+    /// The transformation exceeded its step limit.
+    LimitExceeded,
+    /// The replacements did not match the extracted slots.
+    InvalidRebuild,
+}
+
+impl<T> TypeTransformResult<T> {
+    /// Applies `map` to a transformed value while preserving failures.
+    pub fn map<U>(self, map: impl FnOnce(T) -> U) -> TypeTransformResult<U> {
+        match self {
+            Self::Transformed(value) => TypeTransformResult::Transformed(map(value)),
+            Self::LimitExceeded => TypeTransformResult::LimitExceeded,
+            Self::InvalidRebuild => TypeTransformResult::InvalidRebuild,
+        }
+    }
+
+    /// Applies `map` to the transformed value, or returns `default` on failure.
+    pub fn map_or<U>(self, default: U, map: impl FnOnce(T) -> U) -> U {
+        match self {
+            Self::Transformed(value) => map(value),
+            Self::LimitExceeded | Self::InvalidRebuild => default,
+        }
+    }
+
+    /// Applies `map` to the transformed value, or computes a fallback on failure.
+    pub fn map_or_else<U>(self, default: impl FnOnce() -> U, map: impl FnOnce(T) -> U) -> U {
+        match self {
+            Self::Transformed(value) => map(value),
+            Self::LimitExceeded | Self::InvalidRebuild => default(),
+        }
+    }
+
+    /// Returns the transformed value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the transformation failed.
+    pub fn unwrap(self) -> T {
+        self.expect("type transformation failed")
+    }
+
+    /// Returns the transformed value using `message` if the transformation failed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the transformation failed.
+    pub fn expect(self, message: &str) -> T {
+        match self {
+            Self::Transformed(value) => value,
+            Self::LimitExceeded => panic!("{message}: step limit exceeded"),
+            Self::InvalidRebuild => panic!("{message}: invalid slot reconstruction"),
+        }
+    }
+
+    /// Returns whether every required type was transformed.
+    pub const fn is_transformed(&self) -> bool {
+        matches!(self, Self::Transformed(_))
+    }
+
+    /// Converts this domain-specific result into a standard [`Result`].
+    pub fn into_result(self) -> Result<T, TypeTransformError> {
+        match self {
+            Self::Transformed(value) => Ok(value),
+            Self::LimitExceeded => Err(TypeTransformError::StepLimitExceeded),
+            Self::InvalidRebuild => Err(TypeTransformError::InvalidRebuild),
+        }
+    }
+}
+
+impl<T> From<Result<T, TypeTransformError>> for TypeTransformResult<T> {
+    fn from(result: Result<T, TypeTransformError>) -> Self {
+        match result {
+            Ok(value) => Self::Transformed(value),
+            Err(TypeTransformError::StepLimitExceeded) => Self::LimitExceeded,
+            Err(TypeTransformError::InvalidRebuild) => Self::InvalidRebuild,
+        }
+    }
+}
+
+enum TypeTransformEvent<'db> {
+    Enter(TypeData<'db>),
+    Rebuild {
+        rebuilder: TypeDataSlotRebuilder<'db>,
+    },
+    Exit {
+        source: TypeData<'db>,
+        transformed: TypeData<'db>,
+    },
+}
+
+pub(crate) enum TypeTransformAction<'db> {
+    Descend(TypeData<'db>),
+    Replace(TypeData<'db>),
+}
+
+pub(crate) trait TypeTransform<'db> {
+    /// Chooses whether to visit a type's slots or replace the type directly.
+    fn enter(&mut self, db: &'db dyn TypeDb, ty: TypeData<'db>) -> TypeTransformAction<'db>;
+
+    /// Transforms a type after its slots have been transformed.
+    fn leave(&mut self, db: &'db dyn TypeDb, ty: TypeData<'db>) -> TypeData<'db>;
+}
+
+pub(crate) struct TypeDataTransformer {
+    remaining_steps: usize,
+}
+
+impl TypeDataTransformer {
+    pub(crate) fn new(max_steps: usize) -> Self {
+        Self {
+            remaining_steps: max_steps,
+        }
+    }
+
+    /// Transforms `root` and its nested slots.
+    ///
+    /// Each visited type consumes one step. Reusing this transformer shares the
+    /// remaining steps across roots. A type already being transformed is reused
+    /// without consuming another step.
+    ///
+    /// Slot extraction and reconstruction must agree on slot count and order.
+    pub(crate) fn transform<'db>(
+        &mut self,
+        root: TypeData<'db>,
+        db: &'db dyn TypeDb,
+        operation: &mut impl TypeTransform<'db>,
+    ) -> TypeTransformResult<TypeData<'db>> {
+        let mut stack = Vec::from([TypeTransformEvent::Enter(root)]);
+        let mut results = Vec::new();
+        let mut active = FxHashSet::default();
+
+        while let Some(event) = stack.pop() {
+            match event {
+                TypeTransformEvent::Enter(source) => {
+                    if active.contains(&source) {
+                        results.push(source);
+                        continue;
+                    }
+                    if self.remaining_steps == 0 {
+                        return TypeTransformResult::LimitExceeded;
+                    }
+                    self.remaining_steps -= 1;
+
+                    let transformed = match operation.enter(db, source) {
+                        TypeTransformAction::Replace(transformed) => {
+                            results.push(transformed);
+                            continue;
+                        }
+                        TypeTransformAction::Descend(transformed) => transformed,
+                    };
+                    let slots = transformed.type_slots(db);
+                    let slot_count = slots.len();
+                    if slot_count == 0 {
+                        results.push(operation.leave(db, transformed));
+                        continue;
+                    }
+
+                    active.insert(source);
+                    active.insert(transformed);
+                    let queued_entries = stack
+                        .iter()
+                        .filter(|event| matches!(event, TypeTransformEvent::Enter(_)))
+                        .count();
+                    let available_steps = self.remaining_steps.saturating_sub(queued_entries);
+                    let new_types = slots.iter().filter(|ty| !active.contains(ty)).count();
+                    if new_types > available_steps {
+                        return TypeTransformResult::LimitExceeded;
+                    }
+
+                    let (rebuilder, pending_types) = slots.into_parts();
+                    stack.push(TypeTransformEvent::Exit {
+                        source,
+                        transformed,
+                    });
+                    stack.push(TypeTransformEvent::Rebuild { rebuilder });
+                    stack.extend(
+                        pending_types
+                            .into_iter()
+                            .rev()
+                            .map(TypeTransformEvent::Enter),
+                    );
+                }
+                TypeTransformEvent::Rebuild { rebuilder } => {
+                    let slot_count = rebuilder.len();
+                    let Some(start) = results.len().checked_sub(slot_count) else {
+                        return TypeTransformResult::InvalidRebuild;
+                    };
+                    let replacements = results.split_off(start);
+                    match rebuilder.rebuild(db, replacements) {
+                        TypeTransformResult::Transformed(rebuilt) => {
+                            results.push(operation.leave(db, rebuilt));
+                        }
+                        TypeTransformResult::LimitExceeded => {
+                            return TypeTransformResult::LimitExceeded;
+                        }
+                        TypeTransformResult::InvalidRebuild => {
+                            return TypeTransformResult::InvalidRebuild;
+                        }
+                    }
+                }
+                TypeTransformEvent::Exit {
+                    source,
+                    transformed,
+                } => {
+                    active.remove(&source);
+                    active.remove(&transformed);
+                }
+            }
+        }
+
+        match results.as_slice() {
+            [result] => TypeTransformResult::Transformed(*result),
+            _ => TypeTransformResult::InvalidRebuild,
+        }
+    }
+}
+
+pub(crate) struct TypeSubstituter<'db> {
+    substitution: TypeSubstitution<'db>,
+    binder_generic: TypeData<'db>,
+}
+
+impl<'db> TypeSubstituter<'db> {
+    pub(crate) fn new(db: &'db dyn TypeDb, substitution: TypeSubstitution<'db>) -> Self {
+        Self {
+            substitution,
+            binder_generic: substitution.binder_generic(db),
+        }
+    }
+
+    pub(crate) fn substitute(
+        &mut self,
+        transformer: &mut TypeDataTransformer,
+        db: &'db dyn TypeDb,
+        ty: TypeData<'db>,
+    ) -> TypeTransformResult<TypeData<'db>> {
+        transformer.transform(ty, db, self)
+    }
+}
+
+impl<'db> TypeTransform<'db> for TypeSubstituter<'db> {
+    fn enter(&mut self, db: &'db dyn TypeDb, ty: TypeData<'db>) -> TypeTransformAction<'db> {
+        if ty.declares_generic(db, self.binder_generic) {
+            TypeTransformAction::Replace(ty)
+        } else if ty == self.substitution.generic {
+            TypeTransformAction::Replace(self.substitution.replacement)
+        } else {
+            TypeTransformAction::Descend(ty)
+        }
+    }
+
+    fn leave(&mut self, _db: &'db dyn TypeDb, ty: TypeData<'db>) -> TypeData<'db> {
+        ty
+    }
+}
+
+impl<'db> TypeData<'db> {
+    /// Substitutes a generic throughout this type, excluding nested types that
+    /// declare the same generic parameter.
+    pub fn substitute_type(
+        self,
+        db: &'db dyn TypeDb,
+        substitution: TypeSubstitution<'db>,
+    ) -> TypeTransformResult<Self> {
+        let mut transformer = TypeDataTransformer::new(MAX_TYPE_SUBSTITUTION_STEPS);
+        TypeSubstituter::new(db, substitution).substitute(&mut transformer, db, self)
+    }
+
+    /// Substitutes inside the body of this type while preserving generic
+    /// parameters declared by the root and by nested binders.
+    pub fn substitute_type_in_root_body(
+        self,
+        db: &'db dyn TypeDb,
+        substitution: TypeSubstitution<'db>,
+    ) -> TypeTransformResult<Self> {
+        if !self.declares_generic(db, substitution.binder_generic(db)) {
+            return self.substitute_type(db, substitution);
+        }
+
+        let root_type_parameter_count = self.declared_type_parameters(db).map_or(0, <[_]>::len);
+        let slots = self.type_slots(db);
+        let mut replacements = Vec::with_capacity(slots.len());
+        let mut transformer = TypeDataTransformer::new(MAX_TYPE_SUBSTITUTION_STEPS);
+        let mut substituter = TypeSubstituter::new(db, substitution);
+        for (index, ty) in slots.iter().enumerate() {
+            if index < root_type_parameter_count {
+                replacements.push(ty);
+            } else {
+                match substituter.substitute(&mut transformer, db, ty) {
+                    TypeTransformResult::Transformed(ty) => replacements.push(ty),
+                    TypeTransformResult::LimitExceeded => {
+                        return TypeTransformResult::LimitExceeded;
+                    }
+                    TypeTransformResult::InvalidRebuild => {
+                        return TypeTransformResult::InvalidRebuild;
+                    }
+                }
+            }
+        }
+        slots.rebuild(db, replacements)
+    }
+
+    /// Returns the generic parameters declared directly by this type.
+    ///
+    /// Classes, constructors, functions, and interfaces are generic binders.
+    /// `Some(&[])` identifies one of those binders without parameters, while
+    /// `None` identifies a type that cannot declare generic parameters.
+    fn declared_type_parameters(self, db: &'db dyn TypeDb) -> Option<&'db [Self]> {
+        match self {
+            Self::Class(class) => Some(class.type_parameters(db)),
+            Self::Constructor(constructor) => Some(constructor.type_parameters(db)),
+            Self::Function(function) => Some(function.type_parameters(db)),
+            Self::Interface(interface) => Some(interface.type_parameters(db)),
+            _ => None,
+        }
+    }
+
+    fn declares_generic(self, db: &'db dyn TypeDb, generic: Self) -> bool {
+        self.declared_type_parameters(db)
+            .is_some_and(|parameters| parameters.contains(&generic))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TypeTransformResult;
+
+    #[test]
+    #[should_panic(expected = "type transformation failed: step limit exceeded")]
+    fn unwrap_panics_on_limit_exceeded() {
+        let result: TypeTransformResult<()> = TypeTransformResult::LimitExceeded;
+        result.unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "substitution failed: invalid slot reconstruction")]
+    fn expect_panics_on_invalid_rebuild() {
+        let result: TypeTransformResult<()> = TypeTransformResult::InvalidRebuild;
+        result.expect("substitution failed");
+    }
+}

--- a/crates/biome_js_type_info/src/type_transform.rs
+++ b/crates/biome_js_type_info/src/type_transform.rs
@@ -301,8 +301,7 @@ impl<'db> TypeTransform<'db> for TypeSubstituter<'db> {
     fn enter(&mut self, db: &'db dyn TypeDb, ty: TypeData<'db>) -> TypeTransformAction<'db> {
         if ty == self.substitution.generic {
             TypeTransformAction::Replace(self.substitution.replacement)
-        } else if matches!(ty, TypeData::Generic(_))
-            || ty.declares_generic(db, self.binder_generic)
+        } else if matches!(ty, TypeData::Generic(_)) || ty.declares_generic(db, self.binder_generic)
         {
             TypeTransformAction::Replace(ty)
         } else {

--- a/crates/biome_js_type_info/src/type_transform.rs
+++ b/crates/biome_js_type_info/src/type_transform.rs
@@ -1,15 +1,32 @@
-//! Bounded transformations of nested types.
+//! Bounded transformations of interned types.
 //!
-//! A transformation visits each type and its slots. The traversal is private;
-//! callers use operations such as generic substitution.
+//! Each [`TypeData`] value exposes its immediate type-valued fields as slots.
+//! Transformations visit those slots iteratively and rebuild their parent after
+//! the nested types have been transformed. The traversal remains private;
+//! callers use semantic operations such as generic substitution.
 
 use crate::interned_types::{TypeData, TypeDataSlotRebuilder, TypeDb};
 use rustc_hash::FxHashSet;
 
 pub(crate) const MAX_TYPE_SUBSTITUTION_STEPS: usize = 1024;
 
-/// Replaces `generic` with `replacement` outside nested declarations of the
-/// same generic parameter.
+/// A generic type and the type that replaces its references.
+///
+/// Substitution does not cross a declaration that shadows the same generic.
+/// For example, substituting the outer `T` with `string` changes `value`, but
+/// preserves the `T` declared by `map`:
+///
+/// ```ts
+/// type Container<T> = {
+///     value: T;
+///     map: <T>(value: T) => T;
+/// };
+///
+/// type Substituted = {
+///     value: string;
+///     map: <T>(value: T) => T;
+/// };
+/// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update)]
 pub struct TypeSubstitution<'db> {
     /// Type to replace.
@@ -32,6 +49,10 @@ impl<'db> TypeSubstitution<'db> {
     }
 }
 
+/// Failure produced by a bounded type transformation.
+///
+/// [`TypeTransformResult`] retains these cases as variants for direct matching;
+/// [`TypeTransformResult::into_result`] converts them to this error type.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TypeTransformError {
     /// The transformation exceeded its step limit.
@@ -52,6 +73,10 @@ impl std::fmt::Display for TypeTransformError {
 impl std::error::Error for TypeTransformError {}
 
 /// Result of transforming a type and its nested slots.
+///
+/// A transformed value is returned only after every visited parent has been
+/// rebuilt. The failure variants distinguish an exhausted traversal budget
+/// from disagreement between slot extraction and reconstruction.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[must_use = "a type transformation failure must be handled"]
 pub enum TypeTransformResult<T> {
@@ -315,8 +340,11 @@ impl<'db> TypeTransform<'db> for TypeSubstituter<'db> {
 }
 
 impl<'db> TypeData<'db> {
-    /// Substitutes a generic throughout this type, excluding nested types that
-    /// declare the same generic parameter.
+    /// Replaces references to a generic throughout this type.
+    ///
+    /// Nested declarations of the same generic remain unchanged. Unmatched
+    /// generic declarations are also preserved as interned identities rather
+    /// than rebuilt from their constraints or defaults.
     pub fn substitute_type(
         self,
         db: &'db dyn TypeDb,
@@ -326,8 +354,21 @@ impl<'db> TypeData<'db> {
         TypeSubstituter::new(db, substitution).substitute(&mut transformer, db, self)
     }
 
-    /// Substitutes inside the body of this type while preserving generic
-    /// parameters declared by the root and by nested binders.
+    /// Replaces references inside a root generic declaration without replacing
+    /// the root's declared type parameters.
+    ///
+    /// This is used after inference binds a root generic. For example, binding
+    /// `T` to `string` preserves the declaration of `T`, while replacing its
+    /// parameter and return-type references:
+    ///
+    /// ```ts
+    /// declare function identity<T>(value: T): T;
+    ///
+    /// // Internal representation after root-body substitution of T with string:
+    /// declare function identity<T>(value: string): string;
+    /// ```
+    ///
+    /// Nested declarations that shadow `T` remain unchanged.
     pub fn substitute_type_in_root_body(
         self,
         db: &'db dyn TypeDb,

--- a/crates/biome_js_type_info/src/type_transform.rs
+++ b/crates/biome_js_type_info/src/type_transform.rs
@@ -299,10 +299,12 @@ impl<'db> TypeSubstituter<'db> {
 
 impl<'db> TypeTransform<'db> for TypeSubstituter<'db> {
     fn enter(&mut self, db: &'db dyn TypeDb, ty: TypeData<'db>) -> TypeTransformAction<'db> {
-        if ty.declares_generic(db, self.binder_generic) {
-            TypeTransformAction::Replace(ty)
-        } else if ty == self.substitution.generic {
+        if ty == self.substitution.generic {
             TypeTransformAction::Replace(self.substitution.replacement)
+        } else if matches!(ty, TypeData::Generic(_))
+            || ty.declares_generic(db, self.binder_generic)
+        {
+            TypeTransformAction::Replace(ty)
         } else {
             TypeTransformAction::Descend(ty)
         }

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -1824,7 +1824,10 @@ fn infer_generic_return_type<'db>(
                 generic: parameter_ty,
                 replacement: arg,
             };
-            return_ty = return_ty.substitute_type(db, substitution);
+            let Ok(substituted) = return_ty.substitute_type(db, substitution) else {
+                return InferredTypeData::Unknown;
+            };
+            return_ty = substituted;
             substitutions.push(substitution);
             continue;
         }
@@ -1842,10 +1845,16 @@ fn infer_generic_return_type<'db>(
             continue;
         };
 
-        for substitution in
+        let Some(callback_substitutions) =
             collect_callback_return_replacements(db, *parameter_return_ty, *argument_return_ty)
-        {
-            return_ty = return_ty.substitute_type(db, substitution);
+        else {
+            return InferredTypeData::Unknown;
+        };
+        for substitution in callback_substitutions {
+            let Ok(substituted) = return_ty.substitute_type(db, substitution) else {
+                return InferredTypeData::Unknown;
+            };
+            return_ty = substituted;
             substitutions.push(substitution);
         }
     }
@@ -1854,14 +1863,19 @@ fn infer_generic_return_type<'db>(
         if let InferredTypeData::Generic(generic) = type_parameter
             && let Some(default) = generic.default(db)
         {
-            let replacement = substitutions.iter().fold(default, |ty, substitution| {
-                ty.substitute_type(db, *substitution)
-            });
+            let Some(replacement) = substitutions.iter().try_fold(default, |ty, substitution| {
+                ty.substitute_type(db, *substitution).ok()
+            }) else {
+                return InferredTypeData::Unknown;
+            };
             let substitution = InferredTypeSubstitution {
                 generic: *type_parameter,
                 replacement,
             };
-            return_ty = return_ty.substitute_type(db, substitution);
+            let Ok(substituted) = return_ty.substitute_type(db, substitution) else {
+                return InferredTypeData::Unknown;
+            };
+            return_ty = substituted;
             substitutions.push(substitution);
         }
     }
@@ -1882,7 +1896,7 @@ fn collect_callback_return_replacements<'db>(
     db: &'db dyn ModuleDb,
     parameter_return_ty: InferredTypeData<'db>,
     argument_return_ty: InferredTypeData<'db>,
-) -> Vec<InferredTypeSubstitution<'db>> {
+) -> Option<Vec<InferredTypeSubstitution<'db>>> {
     if let InferredTypeData::Union(union) = parameter_return_ty {
         if let InferredTypeData::InstanceOf(argument) = argument_return_ty {
             for parameter in union.types(db) {
@@ -1894,9 +1908,9 @@ fn collect_callback_return_replacements<'db>(
                         && argument.ty(db).is_promise_class(db)
                 {
                     let replacements =
-                        parameter.collect_generic_replacements(db, argument_return_ty);
+                        parameter.collect_generic_replacements(db, argument_return_ty)?;
                     if !replacements.is_empty() {
-                        return replacements;
+                        return Some(replacements);
                     }
                 }
             }
@@ -1915,10 +1929,10 @@ fn collect_callback_return_replacements<'db>(
                 )
             })
         {
-            return Vec::from([InferredTypeSubstitution {
+            return Some(Vec::from([InferredTypeSubstitution {
                 generic: *generic,
                 replacement: argument_return_ty,
-            }]);
+            }]));
         }
     }
 

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -32,6 +32,7 @@ use biome_js_type_info::{
         LocalTypeId as InferredLocalTypeId, ModuleKey as InferredModuleKey, ReturnType,
         TupleElementType as InferredTupleElementType, TypeData as InferredTypeData,
         TypeMember as InferredTypeMember, TypeSubstitution as InferredTypeSubstitution,
+        TypeTransformResult,
     },
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1824,7 +1825,9 @@ fn infer_generic_return_type<'db>(
                 generic: parameter_ty,
                 replacement: arg,
             };
-            let Ok(substituted) = return_ty.substitute_type(db, substitution) else {
+            let TypeTransformResult::Transformed(substituted) =
+                return_ty.substitute_type(db, substitution)
+            else {
                 return InferredTypeData::Unknown;
             };
             return_ty = substituted;
@@ -1851,7 +1854,9 @@ fn infer_generic_return_type<'db>(
             return InferredTypeData::Unknown;
         };
         for substitution in callback_substitutions {
-            let Ok(substituted) = return_ty.substitute_type(db, substitution) else {
+            let TypeTransformResult::Transformed(substituted) =
+                return_ty.substitute_type(db, substitution)
+            else {
                 return InferredTypeData::Unknown;
             };
             return_ty = substituted;
@@ -1864,7 +1869,7 @@ fn infer_generic_return_type<'db>(
             && let Some(default) = generic.default(db)
         {
             let Some(replacement) = substitutions.iter().try_fold(default, |ty, substitution| {
-                ty.substitute_type(db, *substitution).ok()
+                ty.substitute_type(db, *substitution).map_or(None, Some)
             }) else {
                 return InferredTypeData::Unknown;
             };
@@ -1872,7 +1877,9 @@ fn infer_generic_return_type<'db>(
                 generic: *type_parameter,
                 replacement,
             };
-            let Ok(substituted) = return_ty.substitute_type(db, substitution) else {
+            let TypeTransformResult::Transformed(substituted) =
+                return_ty.substitute_type(db, substitution)
+            else {
                 return InferredTypeData::Unknown;
             };
             return_ty = substituted;

--- a/crates/biome_module_graph/src/db/type_inference/expressions.rs
+++ b/crates/biome_module_graph/src/db/type_inference/expressions.rs
@@ -716,7 +716,9 @@ impl<'db> ResolutionCtx<'db, '_> {
             explicit_type_parameters
         } else if constructed_ty == class_ty {
             constructor
-                .map(|constructor| self.infer_constructor_type_parameters(class, constructor, args))
+                .and_then(|constructor| {
+                    self.infer_constructor_type_parameters(class, constructor, args)
+                })
                 .unwrap_or_default()
         } else {
             Box::default()
@@ -734,16 +736,17 @@ impl<'db> ResolutionCtx<'db, '_> {
         class: InferredClass<'db>,
         constructor: InferredConstructor<'db>,
         args: &[InferredTypeData<'db>],
-    ) -> Box<[InferredTypeData<'db>]> {
+    ) -> Option<Box<[InferredTypeData<'db>]>> {
         let declared_parameters = class.type_parameters(self.db);
         if declared_parameters.is_empty() {
-            return Box::default();
+            return Some(Box::default());
         }
 
         let mut inferred_parameters = declared_parameters.to_vec();
         for (parameter, arg) in constructor.parameters(self.db).iter().zip(args) {
             let parameter_ty = parameter.parameter.ty();
-            for substitution in parameter_ty.collect_generic_replacements(self.db, *arg) {
+            let substitutions = parameter_ty.collect_generic_replacements(self.db, *arg)?;
+            for substitution in substitutions {
                 for (index, declared_parameter) in declared_parameters.iter().enumerate() {
                     if substitution.generic == *declared_parameter
                         || substitution.generic
@@ -775,9 +778,9 @@ impl<'db> ResolutionCtx<'db, '_> {
                 continue;
             };
 
-            for substitution in
-                parameter_return_ty.collect_generic_replacements(self.db, *argument_return_ty)
-            {
+            let substitutions =
+                parameter_return_ty.collect_generic_replacements(self.db, *argument_return_ty)?;
+            for substitution in substitutions {
                 for (index, declared_parameter) in declared_parameters.iter().enumerate() {
                     if substitution.generic == *declared_parameter
                         || substitution.generic
@@ -793,7 +796,7 @@ impl<'db> ResolutionCtx<'db, '_> {
             }
         }
 
-        inferred_parameters.into_boxed_slice()
+        Some(inferred_parameters.into_boxed_slice())
     }
 
     fn resolve_await_expression(

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -431,7 +431,10 @@ pub(in crate::db::type_inference) fn apply_substitutions<'db>(
     substitutions: &[InferredTypeSubstitution<'db>],
 ) -> InferredTypeData<'db> {
     for substitution in substitutions {
-        ty = ty.substitute_type(db, *substitution);
+        let Ok(substituted) = ty.substitute_type(db, *substitution) else {
+            return InferredTypeData::Unknown;
+        };
+        ty = substituted;
     }
     ty
 }
@@ -442,7 +445,10 @@ pub(in crate::db) fn apply_substitutions_to_root_body<'db>(
     substitutions: &[InferredTypeSubstitution<'db>],
 ) -> InferredTypeData<'db> {
     for substitution in substitutions {
-        ty = ty.substitute_type_in_root_body(db, *substitution);
+        let Ok(substituted) = ty.substitute_type_in_root_body(db, *substitution) else {
+            return InferredTypeData::Unknown;
+        };
+        ty = substituted;
     }
     ty
 }

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -6,6 +6,7 @@ use biome_js_type_info::interned_types::{
     Literal as InferredLiteral, LocalTypeHandle, ModuleKey, ReturnType as InferredReturnType,
     TypeData as InferredTypeData, TypeMember as InferredTypeMember,
     TypeMemberKind as InferredTypeMemberKind, TypeSubstitution as InferredTypeSubstitution,
+    TypeTransformResult,
 };
 use rustc_hash::FxHashSet;
 use salsa::plumbing::{AsId, FromId};
@@ -431,7 +432,8 @@ pub(in crate::db::type_inference) fn apply_substitutions<'db>(
     substitutions: &[InferredTypeSubstitution<'db>],
 ) -> InferredTypeData<'db> {
     for substitution in substitutions {
-        let Ok(substituted) = ty.substitute_type(db, *substitution) else {
+        let TypeTransformResult::Transformed(substituted) = ty.substitute_type(db, *substitution)
+        else {
             return InferredTypeData::Unknown;
         };
         ty = substituted;
@@ -445,7 +447,9 @@ pub(in crate::db) fn apply_substitutions_to_root_body<'db>(
     substitutions: &[InferredTypeSubstitution<'db>],
 ) -> InferredTypeData<'db> {
     for substitution in substitutions {
-        let Ok(substituted) = ty.substitute_type_in_root_body(db, *substitution) else {
+        let TypeTransformResult::Transformed(substituted) =
+            ty.substitute_type_in_root_body(db, *substitution)
+        else {
             return InferredTypeData::Unknown;
         };
         ty = substituted;


### PR DESCRIPTION
## Summary

This PR adds some plumbing to substitute generics inside a graph of types. Generics are called "slots".

There's also some plumbing for:
- transformation
- substitutions

Both work using a DFS iterator.


The new implementation:

- Extracts immediate type slots with `TypeDataSlots` and rebuilds their original parent through `TypeDataSlotRebuilder`.
- Uses `TypeDataSlotReplacements` to validate replacement counts and ensure every replacement is consumed.
- Adds an iterative `TypeDataTransformer` with a shared step limit and protection against recursive types.
- Adds `TypeSubstitution`, `TypeTransformResult`, and `TypeTransformError`.
- Exposes semantic substitution through `TypeData::substitute_type` and `TypeData::substitute_type_in_root_body`.
- Preserves generic binder boundaries and generic declaration identity during substitution.
- Updates inference consumers to handle incomplete transformations conservatively.

The generic transformation machinery remains private; callers use the semantic substitution APIs.

## Test Plan

Added structural mapping unit tests and passed type-info tests and all-target clippy.

## Docs

N/A

> This PR was created with AI assistance (OpenCode).