### PR TITLE
refactor(inference): port Salsa module inference

### DIFF
--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -1690,7 +1690,7 @@ fn infer_generic_return_type<'db>(
         let Some(type_parameter) = substitutions
             .iter()
             .try_fold(*type_parameter, |ty, substitution| {
-                ty.substitute_type(db, *substitution).ok()
+                ty.substitute_type(db, *substitution).map_or(None, Some)
             })
         else {
             return InferredTypeData::Unknown;
@@ -1734,7 +1734,9 @@ fn infer_generic_return_type<'db>(
                     generic: alternate,
                     replacement,
                 };
-                let Ok(substituted) = return_ty.substitute_type(db, substitution) else {
+                let TypeTransformResult::Transformed(substituted) =
+                    return_ty.substitute_type(db, substitution)
+                else {
                     return InferredTypeData::Unknown;
                 };
                 return_ty = substituted;

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -36,7 +36,7 @@ use biome_js_type_info::{
         TypeTransformResult,
     },
 };
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 /// Inferred type tables for one JavaScript or TypeScript module.
 pub use crate::db::type_inference::InferredModuleTypes;
@@ -69,17 +69,15 @@ pub fn infer_module_types<'db>(
         return None;
     }
 
-    let mut import_types = FxHashMap::default();
     for import_path in js_info.static_import_paths.values() {
         if let Some(path) = import_path.as_path()
             && let Some(target) = db.module_for_path(path)
-            && let Some(target_types) = infer_module_types(db, target)
         {
-            import_types.insert(import_path.resolved_path.clone(), target_types);
+            let _ = infer_module_types(db, target);
         }
     }
 
-    Some(resolve_raw_types(db, module, &js_info, &import_types))
+    Some(resolve_raw_types(db, module, &js_info))
 }
 
 // NOTE: this is the only exception to the rule, it's a public query and not tracked. Keep it here.
@@ -1689,16 +1687,37 @@ fn infer_generic_return_type<'db>(
     }
 
     for type_parameter in function.type_parameters(db) {
-        if let InferredTypeData::Generic(generic) = type_parameter
-            && let Some(default) = generic.default(db)
-        {
+        let Some(type_parameter) = substitutions
+            .iter()
+            .try_fold(*type_parameter, |ty, substitution| {
+                ty.substitute_type(db, *substitution).ok()
+            })
+        else {
+            return InferredTypeData::Unknown;
+        };
+        let (generic, alternate) = match type_parameter {
+            InferredTypeData::Generic(generic) => (
+                Some(generic),
+                Some(InferredTypeData::instance_of(
+                    db,
+                    type_parameter,
+                    Box::default(),
+                )),
+            ),
+            InferredTypeData::InstanceOf(instance) => match instance.ty(db) {
+                ty @ InferredTypeData::Generic(generic) => (Some(generic), Some(ty)),
+                _ => (None, None),
+            },
+            _ => (None, None),
+        };
+        if let Some(default) = generic.and_then(|generic| generic.default(db)) {
             let Some(replacement) = substitutions.iter().try_fold(default, |ty, substitution| {
                 ty.substitute_type(db, *substitution).map_or(None, Some)
             }) else {
                 return InferredTypeData::Unknown;
             };
             let substitution = InferredTypeSubstitution {
-                generic: *type_parameter,
+                generic: type_parameter,
                 replacement,
             };
             let TypeTransformResult::Transformed(substituted) =
@@ -1708,6 +1727,19 @@ fn infer_generic_return_type<'db>(
             };
             return_ty = substituted;
             substitutions.push(substitution);
+            if let Some(alternate) = alternate
+                && alternate != type_parameter
+            {
+                let substitution = InferredTypeSubstitution {
+                    generic: alternate,
+                    replacement,
+                };
+                let Ok(substituted) = return_ty.substitute_type(db, substitution) else {
+                    return InferredTypeData::Unknown;
+                };
+                return_ty = substituted;
+                substitutions.push(substitution);
+            }
         }
     }
 

--- a/crates/biome_module_graph/src/db/type_inference/imports.rs
+++ b/crates/biome_module_graph/src/db/type_inference/imports.rs
@@ -1,5 +1,4 @@
 use super::{InferredModuleTypes, globals::global_type, resolver::ResolutionCtx};
-use crate::db::queries::infer_module_types;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
 use crate::{JsExport, JsImport, JsOwnExport, ModuleDb, ResolvedPath};
 use biome_js_type_info::{
@@ -64,22 +63,14 @@ impl<'db> ResolutionCtx<'db, '_> {
         &mut self,
         qualifier: &TypeImportQualifier,
     ) -> InferredTypeData<'db> {
-        self.resolve_import_qualifier(qualifier)
-    }
-
-    fn resolve_import_qualifier(&self, qualifier: &TypeImportQualifier) -> InferredTypeData<'db> {
         let Some(module) = self.module_for_resolved_path(&qualifier.resolved_path) else {
             return InferredTypeData::Unknown;
         };
 
-        let Some(imported_types) = self.import_types.get(&qualifier.resolved_path) else {
-            return infer_module_types(self.db, module)
-                .map_or(InferredTypeData::Unknown, |types| {
-                    self.resolve_import_symbol(module, types, &qualifier.symbol)
-                });
-        };
-
-        self.resolve_import_symbol(module, imported_types, &qualifier.symbol)
+        self.infer_imported_module(module)
+            .map_or(InferredTypeData::Unknown, |types| {
+                self.resolve_import_symbol(module, types, &qualifier.symbol)
+            })
     }
 
     fn module_for_resolved_path(&self, resolved_path: &ResolvedPath) -> Option<ModuleInfo> {
@@ -105,7 +96,7 @@ impl<'db> ResolutionCtx<'db, '_> {
     fn resolve_js_import(&self, import: &JsImport) -> InferredTypeData<'db> {
         self.module_for_resolved_path(&import.resolved_path)
             .and_then(|module| {
-                infer_module_types(self.db, module)
+                self.infer_imported_module(module)
                     .map(|types| self.resolve_import_symbol(module, types, &import.symbol))
             })
             .unwrap_or(InferredTypeData::Unknown)
@@ -136,7 +127,7 @@ impl<'db> ResolutionCtx<'db, '_> {
             collection.remaining_steps -= 1;
             collection.seen_modules.insert(module_key);
 
-            if infer_module_types(self.db, module).is_none() {
+            if self.infer_imported_module(module).is_none() {
                 return InferredTypeData::Unknown;
             }
 
@@ -174,7 +165,7 @@ impl<'db> ResolutionCtx<'db, '_> {
             return false;
         };
 
-        for (name, _) in js_info.exports.iter() {
+        for (name, _) in js_info.raw_exports.iter() {
             if !include_default && name.text() == "default" {
                 continue;
             }
@@ -236,7 +227,7 @@ impl<'db> ResolutionCtx<'db, '_> {
             }
             remaining_steps -= 1;
 
-            let Some(inferred_types) = infer_module_types(self.db, module) else {
+            let Some(inferred_types) = self.infer_imported_module(module) else {
                 continue;
             };
 
@@ -269,7 +260,7 @@ impl<'db> ResolutionCtx<'db, '_> {
             return ExportResolutionStep::Continue;
         };
 
-        match js_info.exports.get(name) {
+        match js_info.raw_exports.get(name) {
             Some(JsExport::Own(own_export) | JsExport::OwnType(own_export)) => {
                 ExportResolutionStep::Resolved(ResolvedExport {
                     identity: ExportIdentity {

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -39,20 +39,52 @@ pub struct InferredModuleTypes<'db> {
     pub binding_type_data: FxHashMap<TextRange, BindingTypeData<'db>>,
 }
 
-// SAFETY: This struct does not borrow from the database. It owns the ranges, and
-// the types are small handles created by Salsa. Comparing the old maps with the
-// new maps is safe; if they differ, replacing the old maps exposes the same data
-// as updating each entry one by one.
+// SAFETY: This aggregate owns its containers and contains only Salsa handles.
+// Updating every field delegates cross-revision transitions to each field's
+// `Update` implementation.
 unsafe impl salsa::Update for InferredModuleTypes<'_> {
     unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
-        let old_value = unsafe { &mut *old_pointer };
-        if *old_value == new_value {
-            false
-        } else {
-            *old_value = new_value;
-            true
-        }
+        let Self {
+            module_key,
+            named_type_ids,
+            types,
+            expressions,
+            binding_type_data,
+        } = new_value;
+        let mut changed = false;
+        changed |=
+            unsafe { salsa::Update::maybe_update(&raw mut (*old_pointer).module_key, module_key) };
+        changed |= unsafe {
+            salsa::Update::maybe_update(&raw mut (*old_pointer).named_type_ids, named_type_ids)
+        };
+        changed |= unsafe { salsa::Update::maybe_update(&raw mut (*old_pointer).types, types) };
+        changed |=
+            unsafe { maybe_update_range_map(&raw mut (*old_pointer).expressions, expressions) };
+        changed |= unsafe {
+            maybe_update_range_map(&raw mut (*old_pointer).binding_type_data, binding_type_data)
+        };
+        changed
     }
+}
+
+unsafe fn maybe_update_range_map<V: salsa::Update>(
+    old_pointer: *mut FxHashMap<TextRange, V>,
+    new_map: FxHashMap<TextRange, V>,
+) -> bool {
+    let old_map = unsafe { &mut *old_pointer };
+    if old_map.len() != new_map.len() || old_map.keys().any(|key| !new_map.contains_key(key)) {
+        *old_map = new_map;
+        return true;
+    }
+
+    let mut changed = false;
+    for (key, new_value) in new_map {
+        let old_value = old_map
+            .get_mut(&key)
+            .expect("range keys were checked above");
+        changed |= unsafe { V::maybe_update(old_value, new_value) };
+    }
+    changed
 }
 
 impl<'db> InferredModuleTypes<'db> {

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -39,9 +39,12 @@ pub struct InferredModuleTypes<'db> {
     pub binding_type_data: FxHashMap<TextRange, BindingTypeData<'db>>,
 }
 
-// SAFETY: This aggregate owns its containers and contains only Salsa handles.
-// Updating every field delegates cross-revision transitions to each field's
-// `Update` implementation.
+// SAFETY: None of the fields contains a Rust reference tied to `'db`.
+// `InferredTypeData<'db>` uses the lifetime only to brand Salsa handles, whose
+// `Update` implementations support comparison across revisions; all containers
+// and map keys are owned. Each field is updated exactly once through its own
+// `Update` implementation, and `maybe_update_range_map` either replaces an
+// owned map or delegates updates to the values under an unchanged set of keys.
 unsafe impl salsa::Update for InferredModuleTypes<'_> {
     unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
         let Self {

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -120,6 +120,11 @@ fn is_named_type_declaration(declaration_kind: JsDeclarationKind) -> bool {
 }
 
 impl<'db> ResolutionCtx<'db, '_> {
+    /// Infers `module` as a dependency of the module currently being resolved.
+    ///
+    /// The tracked query records the imported result as a dependency of the
+    /// current inference. Returns `None` for unsupported modules, disabled type
+    /// inference, or an import cycle.
     pub(in crate::db::type_inference) fn infer_imported_module(
         &self,
         module: ModuleInfo,
@@ -197,6 +202,36 @@ impl<'db> ResolutionCtx<'db, '_> {
         ty
     }
 
+    /// Rebuilds a raw module or namespace type with the bindings declared
+    /// directly in its semantic scope.
+    ///
+    /// `fallback` is the ordinary inferred conversion of the raw type at
+    /// `type_id`. It retains that inferred representation when the type is not
+    /// a module or namespace, or when the declaration's semantic scope cannot
+    /// be identified. When the scope is available, this function replaces that
+    /// conversion with a module or namespace whose static members correspond
+    /// to the bindings declared directly in the scope.
+    ///
+    /// For example:
+    ///
+    /// ```ts
+    /// namespace Outer {
+    ///     export namespace Inner {
+    ///         export interface Value {
+    ///             field: string;
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// declare const value: Outer.Inner.Value;
+    /// ```
+    ///
+    /// Resolving the raw type for `Outer` uses its binding scope to attach
+    /// `Inner` as a static member. Resolving `Inner` repeats the process and
+    /// attaches `Value`. Member lookup can then consume one segment at a time:
+    /// `Outer` to `Inner`, then `Inner` to `Value`. If either declaration scope
+    /// cannot be found, its existing `fallback` conversion is preserved instead
+    /// of replacing it with a partially reconstructed namespace.
     fn with_namespace_members(
         &mut self,
         type_id: TypeId,

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -7,9 +7,7 @@ use biome_js_type_info::{
     GlobalTypeId, RawTypeData, ResolvedTypeId, ScopeId, TypeId, TypeReference,
     TypeReferenceQualifier, TypeResolverLevel,
     interned_types::{
-        InternedModule as InferredModule, InternedNamespace as InferredNamespace,
         InternedTypeofValue, LocalTypeHandle, LocalTypeId, ModuleKey, TypeData as InferredTypeData,
-        TypeMember as InferredTypeMember, TypeMemberKind as InferredTypeMemberKind,
     },
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -195,118 +193,10 @@ impl<'db> ResolutionCtx<'db, '_> {
             .raw_types
             .get(type_id.index())
             .map_or(InferredTypeData::Unknown, |raw| self.resolve_raw_type(raw));
-        let ty = self.with_namespace_members(type_id, ty);
 
         self.in_progress.remove(&type_id);
         self.resolved.insert(type_id, ty);
         ty
-    }
-
-    /// Rebuilds a raw module or namespace type with the bindings declared
-    /// directly in its semantic scope.
-    ///
-    /// `fallback` is the ordinary inferred conversion of the raw type at
-    /// `type_id`. It retains that inferred representation when the type is not
-    /// a module or namespace, or when the declaration's semantic scope cannot
-    /// be identified. When the scope is available, this function replaces that
-    /// conversion with a module or namespace whose static members correspond
-    /// to the bindings declared directly in the scope.
-    ///
-    /// For example:
-    ///
-    /// ```ts
-    /// namespace Outer {
-    ///     export namespace Inner {
-    ///         export interface Value {
-    ///             field: string;
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// declare const value: Outer.Inner.Value;
-    /// ```
-    ///
-    /// Resolving the raw type for `Outer` uses its binding scope to attach
-    /// `Inner` as a static member. Resolving `Inner` repeats the process and
-    /// attaches `Value`. Member lookup can then consume one segment at a time:
-    /// `Outer` to `Inner`, then `Inner` to `Value`. If either declaration scope
-    /// cannot be found, its existing `fallback` conversion is preserved instead
-    /// of replacing it with a partially reconstructed namespace.
-    fn with_namespace_members(
-        &mut self,
-        type_id: TypeId,
-        fallback: InferredTypeData<'db>,
-    ) -> InferredTypeData<'db> {
-        enum NamespaceMetadata {
-            Module(biome_rowan::Text),
-            Namespace(biome_js_type_info::Path),
-        }
-
-        let metadata = match self.js_info.raw_types.get(type_id.index()) {
-            Some(RawTypeData::Module(module)) => NamespaceMetadata::Module(module.name.clone()),
-            Some(RawTypeData::Namespace(namespace)) => {
-                NamespaceMetadata::Namespace(namespace.path.clone())
-            }
-            _ => return fallback,
-        };
-        let scope_id = self
-            .js_info
-            .semantic_model
-            .all_bindings()
-            .find_map(|binding| {
-                let reference = self
-                    .js_info
-                    .raw_binding_types
-                    .get(&binding.syntax().text_trimmed_range())?;
-                matches!(
-                    reference,
-                    TypeReference::Resolved(id)
-                        if id.level() == TypeResolverLevel::Thin && id.id() == type_id
-                )
-                .then(|| binding.scope().id())
-            });
-        let Some(scope_id) = scope_id else {
-            return fallback;
-        };
-
-        let members = self
-            .js_info
-            .semantic_model
-            .all_bindings()
-            .filter(|binding| {
-                binding
-                    .scope()
-                    .parent()
-                    .is_some_and(|parent| parent.id() == scope_id)
-            })
-            .filter_map(|binding| {
-                let name = binding
-                    .tree()
-                    .name_token()
-                    .ok()?
-                    .token_text_trimmed()
-                    .into();
-                let reference = self
-                    .js_info
-                    .raw_binding_types
-                    .get(&binding.syntax().text_trimmed_range())?
-                    .clone();
-                Some((name, reference))
-            })
-            .map(|(name, reference)| InferredTypeMember {
-                kind: InferredTypeMemberKind::NamedStatic(name),
-                ty: self.resolve(&reference),
-            })
-            .collect::<Box<[_]>>();
-
-        match metadata {
-            NamespaceMetadata::Module(name) => {
-                InferredTypeData::Module(InferredModule::new(self.db, members, name))
-            }
-            NamespaceMetadata::Namespace(path) => {
-                InferredTypeData::Namespace(InferredNamespace::new(self.db, members, path))
-            }
-        }
     }
 
     fn resolve_raw_type(&mut self, raw: &RawTypeData) -> InferredTypeData<'db> {

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -1,13 +1,15 @@
 use super::{BindingTypeData, InferredModuleTypes, globals::global_type, lookup::module_for_key};
 use crate::db::queries::infer_module_types;
 use crate::module_graph::ModuleInfo;
-use crate::{JsModuleInfo, ModuleDb, ResolvedPath};
+use crate::{JsModuleInfo, ModuleDb};
 use biome_js_semantic::JsDeclarationKind;
 use biome_js_type_info::{
     GlobalTypeId, RawTypeData, ResolvedTypeId, ScopeId, TypeId, TypeReference,
     TypeReferenceQualifier, TypeResolverLevel,
     interned_types::{
+        InternedModule as InferredModule, InternedNamespace as InferredNamespace,
         InternedTypeofValue, LocalTypeHandle, LocalTypeId, ModuleKey, TypeData as InferredTypeData,
+        TypeMember as InferredTypeMember, TypeMemberKind as InferredTypeMemberKind,
     },
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -26,8 +28,6 @@ pub(in crate::db::type_inference) struct ResolutionCtx<'db, 'a> {
     pub(in crate::db::type_inference) db: &'db dyn ModuleDb,
     pub(in crate::db::type_inference) module_key: ModuleKey,
     pub(in crate::db::type_inference) js_info: &'a JsModuleInfo,
-    pub(in crate::db::type_inference) import_types:
-        &'a FxHashMap<ResolvedPath, &'db InferredModuleTypes<'db>>,
     pub(in crate::db::type_inference) named_type_ids: FxHashSet<TypeId>,
     pub(in crate::db::type_inference) resolved: FxHashMap<TypeId, InferredTypeData<'db>>,
     pub(in crate::db::type_inference) in_progress: FxHashSet<TypeId>,
@@ -38,7 +38,6 @@ pub(in crate::db) fn resolve_raw_types<'db>(
     db: &'db dyn ModuleDb,
     module: ModuleInfo,
     js_info: &JsModuleInfo,
-    import_types: &FxHashMap<ResolvedPath, &'db InferredModuleTypes<'db>>,
 ) -> InferredModuleTypes<'db> {
     let module_key = ModuleKey::new(module.as_id());
     let named_type_ids = named_type_ids(js_info);
@@ -46,7 +45,6 @@ pub(in crate::db) fn resolve_raw_types<'db>(
         db,
         module_key,
         js_info,
-        import_types,
         named_type_ids,
         resolved: FxHashMap::default(),
         in_progress: FxHashSet::default(),
@@ -122,6 +120,13 @@ fn is_named_type_declaration(declaration_kind: JsDeclarationKind) -> bool {
 }
 
 impl<'db> ResolutionCtx<'db, '_> {
+    pub(in crate::db::type_inference) fn infer_imported_module(
+        &self,
+        module: ModuleInfo,
+    ) -> Option<&'db InferredModuleTypes<'db>> {
+        infer_module_types(self.db, module)
+    }
+
     pub(in crate::db::type_inference) fn resolve(
         &mut self,
         reference: &TypeReference,
@@ -185,10 +190,88 @@ impl<'db> ResolutionCtx<'db, '_> {
             .raw_types
             .get(type_id.index())
             .map_or(InferredTypeData::Unknown, |raw| self.resolve_raw_type(raw));
+        let ty = self.with_namespace_members(type_id, ty);
 
         self.in_progress.remove(&type_id);
         self.resolved.insert(type_id, ty);
         ty
+    }
+
+    fn with_namespace_members(
+        &mut self,
+        type_id: TypeId,
+        fallback: InferredTypeData<'db>,
+    ) -> InferredTypeData<'db> {
+        enum NamespaceMetadata {
+            Module(biome_rowan::Text),
+            Namespace(biome_js_type_info::Path),
+        }
+
+        let metadata = match self.js_info.raw_types.get(type_id.index()) {
+            Some(RawTypeData::Module(module)) => NamespaceMetadata::Module(module.name.clone()),
+            Some(RawTypeData::Namespace(namespace)) => {
+                NamespaceMetadata::Namespace(namespace.path.clone())
+            }
+            _ => return fallback,
+        };
+        let scope_id = self
+            .js_info
+            .semantic_model
+            .all_bindings()
+            .find_map(|binding| {
+                let reference = self
+                    .js_info
+                    .raw_binding_types
+                    .get(&binding.syntax().text_trimmed_range())?;
+                matches!(
+                    reference,
+                    TypeReference::Resolved(id)
+                        if id.level() == TypeResolverLevel::Thin && id.id() == type_id
+                )
+                .then(|| binding.scope().id())
+            });
+        let Some(scope_id) = scope_id else {
+            return fallback;
+        };
+
+        let members = self
+            .js_info
+            .semantic_model
+            .all_bindings()
+            .filter(|binding| {
+                binding
+                    .scope()
+                    .parent()
+                    .is_some_and(|parent| parent.id() == scope_id)
+            })
+            .filter_map(|binding| {
+                let name = binding
+                    .tree()
+                    .name_token()
+                    .ok()?
+                    .token_text_trimmed()
+                    .into();
+                let reference = self
+                    .js_info
+                    .raw_binding_types
+                    .get(&binding.syntax().text_trimmed_range())?
+                    .clone();
+                Some((name, reference))
+            })
+            .map(|(name, reference)| InferredTypeMember {
+                kind: InferredTypeMemberKind::NamedStatic(name),
+                ty: self.resolve(&reference),
+            })
+            .collect::<Box<[_]>>();
+
+        match metadata {
+            NamespaceMetadata::Module(name) => {
+                InferredTypeData::Module(InferredModule::new(self.db, members, name))
+            }
+            NamespaceMetadata::Namespace(path) => {
+                InferredTypeData::Namespace(InferredNamespace::new(self.db, members, path))
+            }
+        }
     }
 
     fn resolve_raw_type(&mut self, raw: &RawTypeData) -> InferredTypeData<'db> {
@@ -316,7 +399,7 @@ impl<'db> ResolutionCtx<'db, '_> {
                 self.resolve_raw_type_id(TypeId::new(local_type_id.index()))
             } else {
                 module_for_key(self.db, module_key)
-                    .and_then(|module| infer_module_types(self.db, module))
+                    .and_then(|module| self.infer_imported_module(module))
                     .and_then(|types| types.types.get(local_type_id.index()).copied())
                     .unwrap_or(InferredTypeData::Unknown)
             };

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -247,6 +247,9 @@ pub struct JsModuleInfoInner {
     /// [Self::forwarding_exports] instead.
     pub exports: Exports,
 
+    /// Exports whose type IDs index [`Self::raw_types`].
+    pub(crate) raw_exports: Exports,
+
     /// Re-exports that apply to all symbols from another module, without
     /// assigning a name to them.
     pub blanket_reexports: Vec<JsReexport>,

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -386,7 +386,7 @@ impl JsModuleInfoCollector {
 
         self.populate_namespace_and_module_members();
 
-        self.register_export_types();
+        let raw_exports = self.collect_exports_from(self.exports.clone(), true);
 
         let raw_types = self.raw_types();
         let raw_expressions = self.raw_expressions();
@@ -407,6 +407,7 @@ impl JsModuleInfoCollector {
 
         FinalisedModuleTypes {
             exports,
+            raw_exports,
             binding_type_data,
             raw_types,
             raw_expressions,
@@ -820,18 +821,10 @@ impl JsModuleInfoCollector {
         }
     }
 
-    fn register_export_types(&mut self) {
-        let _ = self.collect_exports_from(self.exports.clone());
-    }
-
-    fn collect_exports(&mut self) -> IndexMap<Text, JsExport> {
-        let exports = std::mem::take(&mut self.exports);
-        self.collect_exports_from(exports)
-    }
-
     fn collect_exports_from(
         &mut self,
         exports: Vec<JsCollectedExport>,
+        raw: bool,
     ) -> IndexMap<Text, JsExport> {
         let mut finalised_exports = IndexMap::new();
 
@@ -852,51 +845,74 @@ impl JsModuleInfoCollector {
                     }
                 }
                 JsCollectedExport::ExportDefault { ty } => {
-                    let resolved = self.resolve_reference(&ty).unwrap_or(GLOBAL_UNKNOWN_ID);
+                    let resolved = if raw {
+                        self.raw_resolved_id(&ty)
+                    } else {
+                        self.resolve_reference(&ty).unwrap_or(GLOBAL_UNKNOWN_ID)
+                    };
 
                     let export = JsExport::Own(JsOwnExport::Type(resolved));
                     finalised_exports.insert(Text::new_static("default"), export);
                 }
                 JsCollectedExport::ExportDefaultAssignment { ty } => {
-                    let resolved = self.resolve_reference(&ty).unwrap_or(GLOBAL_UNKNOWN_ID);
+                    let resolved = if raw {
+                        self.raw_resolved_id(&ty)
+                    } else {
+                        self.resolve_reference(&ty).unwrap_or(GLOBAL_UNKNOWN_ID)
+                    };
                     let mut found_members = false;
 
-                    if let Some(data) = self.get_by_resolved_id(resolved) {
-                        for member in data.as_raw_data().own_members() {
-                            let Some(name) = member.name() else {
-                                continue;
-                            };
-
-                            // DANGER: Normally, when resolving a type reference
-                            //         retrieved through `as_raw_data()`, we
-                            //         should call
-                            //         `apply_module_id_to_reference()` on the
-                            //         reference first. But because we know we
-                            //         are resolving inside the collector,
-                            //         before any module IDs _could_ be applied,
-                            //         we can omit this here.
-                            if let Some(resolved_member) = self.resolve_reference(&member.ty) {
-                                let export = JsExport::Own(JsOwnExport::Type(resolved_member));
-                                finalised_exports.insert(name, export);
-                                found_members = true;
+                    if raw {
+                        if let Some(data) = self.raw_type_by_resolved_id(resolved) {
+                            for member in data.own_members() {
+                                let Some(name) = member.name() else {
+                                    continue;
+                                };
+                                if let TypeReference::Resolved(resolved_member) = member.ty {
+                                    let export = JsExport::Own(JsOwnExport::Type(resolved_member));
+                                    finalised_exports.insert(name, export);
+                                    found_members = true;
+                                }
                             }
                         }
-                    }
 
-                    // If the resolved type has no members (e.g., the
-                    // reference is still an unresolved qualifier), fall back
-                    // to the scope tree to collect namespace bindings directly.
-                    if !found_members
-                        && let Some(data) = self.get_by_resolved_id(resolved)
-                        && let TypeData::Reference(TypeReference::Qualifier(qualifier)) =
-                            data.as_raw_data()
-                        && let Some(first_part) = qualifier.path.iter().next()
-                    {
-                        self.collect_namespace_exports_for_binding(
-                            first_part,
-                            qualifier.scope_id,
-                            &mut finalised_exports,
-                        );
+                        if !found_members
+                            && let Some(data) = self.raw_type_by_resolved_id(resolved)
+                            && let TypeData::Reference(TypeReference::Qualifier(qualifier)) = data
+                            && let Some(first_part) = qualifier.path.iter().next()
+                        {
+                            self.collect_namespace_exports_for_binding(
+                                first_part,
+                                qualifier.scope_id,
+                                &mut finalised_exports,
+                            );
+                        }
+                    } else {
+                        if let Some(data) = self.get_by_resolved_id(resolved) {
+                            for member in data.as_raw_data().own_members() {
+                                let Some(name) = member.name() else {
+                                    continue;
+                                };
+                                if let Some(resolved_member) = self.resolve_reference(&member.ty) {
+                                    let export = JsExport::Own(JsOwnExport::Type(resolved_member));
+                                    finalised_exports.insert(name, export);
+                                    found_members = true;
+                                }
+                            }
+                        }
+
+                        if !found_members
+                            && let Some(data) = self.get_by_resolved_id(resolved)
+                            && let TypeData::Reference(TypeReference::Qualifier(qualifier)) =
+                                data.as_raw_data()
+                            && let Some(first_part) = qualifier.path.iter().next()
+                        {
+                            self.collect_namespace_exports_for_binding(
+                                first_part,
+                                qualifier.scope_id,
+                                &mut finalised_exports,
+                            );
+                        }
                     }
 
                     let export = JsExport::Own(JsOwnExport::Type(resolved));
@@ -923,6 +939,25 @@ impl JsModuleInfoCollector {
         }
 
         finalised_exports
+    }
+
+    fn collect_exports(&mut self) -> IndexMap<Text, JsExport> {
+        let exports = std::mem::take(&mut self.exports);
+        self.collect_exports_from(exports, false)
+    }
+
+    fn raw_resolved_id(&mut self, ty: &TypeReference) -> ResolvedTypeId {
+        match ty {
+            TypeReference::Resolved(id) => *id,
+            _ => ResolvedTypeId::new(
+                TypeResolverLevel::Thin,
+                self.register_type(Cow::Owned(TypeData::reference(ty.clone()))),
+            ),
+        }
+    }
+
+    fn raw_type_by_resolved_id(&self, id: ResolvedTypeId) -> Option<&TypeData> {
+        (id.level() == TypeResolverLevel::Thin).then(|| self.types.get_by_id(id.id()))
     }
 
     fn get_export_for_local_name(&mut self, local_name: TokenText) -> Option<JsOwnExport> {
@@ -1166,6 +1201,7 @@ impl JsModuleInfo {
             static_import_paths: collector.static_import_paths,
             dynamic_import_paths: collector.dynamic_import_paths,
             exports: Exports(finalised.exports),
+            raw_exports: Exports(finalised.raw_exports),
             blanket_reexports: collector.blanket_reexports,
             semantic_model,
             binding_type_data: finalised.binding_type_data,
@@ -1183,6 +1219,7 @@ impl JsModuleInfo {
 
 struct FinalisedModuleTypes {
     exports: IndexMap<Text, JsExport>,
+    raw_exports: IndexMap<Text, JsExport>,
     binding_type_data: FxHashMap<TextRange, BindingTypeData>,
     raw_types: Vec<RawTypeData>,
     raw_expressions: FxHashMap<TextRange, TypeReference>,

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -42,6 +42,8 @@ use salsa::plumbing::{AsId, FromId};
 mod expected_argument_inference;
 #[path = "spec_tests_v2/globals.test.rs"]
 mod globals;
+#[path = "spec_tests_v2/imports.test.rs"]
+mod imports;
 #[path = "spec_tests_v2/intersections.test.rs"]
 mod intersections;
 #[path = "spec_tests_v2/normalization.test.rs"]
@@ -4832,59 +4834,6 @@ fn test_infer_module_types_backdates_equal_output() {
 
     assert_function_query_was_run(&db, infer_module_types, index_module, &events);
     assert_function_query_was_not_run(&db, inferred_expression_count, index_module, &events);
-}
-
-#[test]
-fn test_infer_module_types_documents_react_export_equals_gap() {
-    let fs = MemoryFileSystem::default();
-    fs.insert(
-        "/node_modules/@types/react/index.d.ts".into(),
-        include_bytes!("../../biome_resolver/tests/fixtures/resolver_cases_5/node_modules/@types/react/index.d.ts")
-    );
-    fs.insert(
-        "/src/index.ts".into(),
-        r#"import { useCallback } from "react";
-
-        const fn = useCallback(async () => {});
-        const promise = fn();
-        "#,
-    );
-
-    let project_layout = ProjectLayout::default();
-    project_layout.insert_node_manifest(
-        "/".into(),
-        PackageJson::new("frontend")
-            .with_version("0.0.0")
-            .with_dependencies(Dependencies(Box::new([("react".into(), "19.0.0".into())]))),
-    );
-
-    let tsconfig_json = parse_json(r#"{}"#, JsonParserOptions::default());
-    project_layout
-        .insert_serialized_tsconfig("/".into(), &tsconfig_json.syntax().as_send().unwrap());
-
-    let db = build_js_test_module_db_with_layout(
-        &fs,
-        &project_layout,
-        &["/node_modules/@types/react/index.d.ts", "/src/index.ts"],
-        true,
-    );
-    let index_module = db
-        .module_for_path(Utf8Path::new("/src/index.ts"))
-        .expect("module must exist");
-    let inferred = infer_module_types_bottom_up(&db, index_module).expect("types must be inferred");
-
-    // React types are exposed through `export = React`, which the new engine
-    // does not resolve yet. Once it does, these assertions must be upgraded to
-    // expect a callable `useCallback` and a `Promise` instance for `promise`.
-    let use_callback_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "useCallback")
-        .expect("useCallback binding type must be inferred");
-    let use_callback_ty = inferred.resolve_type(&db, use_callback_ty);
-    assert!(use_callback_ty.callable_function(&db).is_none());
-
-    let promise_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "promise")
-        .expect("promise binding type must be inferred");
-    let promise_ty = inferred.resolve_type(&db, promise_ty);
-    assert!(!promise_ty.is_promise_instance(&db));
 }
 
 #[test]

--- a/crates/biome_module_graph/tests/spec_tests_v2/imports.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/imports.test.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+#[test]
+fn test_infer_module_types_resolves_react_export_equals_namespace() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/node_modules/@types/react/index.d.ts".into(),
+        include_bytes!("../../../biome_resolver/tests/fixtures/resolver_cases_5/node_modules/@types/react/index.d.ts")
+    );
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"import { useCallback } from "react";
+
+        const fn = useCallback(async () => {});
+        const promise = fn();
+        "#,
+    );
+
+    let project_layout = ProjectLayout::default();
+    project_layout.insert_node_manifest(
+        "/".into(),
+        PackageJson::new("frontend")
+            .with_version("0.0.0")
+            .with_dependencies(Dependencies(Box::new([("react".into(), "19.0.0".into())]))),
+    );
+
+    let tsconfig_json = parse_json(r#"{}"#, JsonParserOptions::default());
+    project_layout
+        .insert_serialized_tsconfig("/".into(), &tsconfig_json.syntax().as_send().unwrap());
+
+    let db = build_js_test_module_db_with_layout(
+        &fs,
+        &project_layout,
+        &["/node_modules/@types/react/index.d.ts", "/src/index.ts"],
+        true,
+    );
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, index_module).expect("types must be inferred");
+    let use_callback_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "useCallback")
+        .expect("useCallback binding type must be inferred");
+    let use_callback_ty = inferred.resolve_type(&db, use_callback_ty);
+    assert!(use_callback_ty.callable_function(&db).is_some());
+
+    let promise_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "promise")
+        .expect("promise binding type must be inferred");
+    let promise_ty = inferred.resolve_type(&db, promise_ty);
+    assert!(promise_ty.is_promise_instance(&db));
+}


### PR DESCRIPTION
## Summary

This PR moves the module-inference engine from legacy to a new salsa-backed infrastructure. Up until now, types resolved from imported modules were using legacy, which was incorrect.

The new representation is backed by `InferredModuleTypes`, where we manually implement the `salsa::Update` trait. With this, we're now able to solve cycle imports during inference

```
at.s -> imports -> b.ts -> imports -> a.ts
```

## Test Plan

Added new tests to cover the resolution of the new raw exports. 

## Docs

N/A

> This PR was created with AI assistance (OpenCode).