### PR TITLE
fix(inference): handle import cycles

### DIFF
--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -15,9 +15,9 @@
 //! shapes produce `Unknown` or `None` instead of a TypeScript diagnostic.
 
 use crate::db::type_inference::{
-    apply_substitutions_to_root_body, collected_type_result, infer_module_types_cycle_result,
-    normalize_structural_type, normalize_type_cycle_result, resolve_raw_types,
-    substitutions_for_instance,
+    ImportResolution, apply_substitutions_to_root_body, collected_type_result,
+    infer_module_types_cycle_result, normalize_structural_type, normalize_type_cycle_result,
+    resolve_raw_types, substitutions_for_instance,
 };
 use crate::module_for_key;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
@@ -77,7 +77,12 @@ pub fn infer_module_types<'db>(
         }
     }
 
-    Some(resolve_raw_types(db, module, &js_info))
+    Some(resolve_raw_types(
+        db,
+        module,
+        &js_info,
+        ImportResolution::Full,
+    ))
 }
 
 // NOTE: this is the only exception to the rule, it's a public query and not tracked. Keep it here.

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -1,11 +1,12 @@
 #![deny(clippy::wildcard_enum_match_arm)]
 
-use crate::ModuleDb;
+use crate::module_graph::{ModuleInfo, ModuleInfoKind};
+use crate::{JsExport, JsOwnExport, ModuleDb, ResolvedPath};
 use biome_css_syntax::TextRange;
 use biome_js_type_info::interned_types::{
     LocalTypeId, ModuleKey, TypeData as InferredTypeData, TypeTransformError,
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 mod expressions;
 mod globals;
@@ -15,7 +16,7 @@ mod qualifiers;
 mod resolver;
 
 pub(in crate::db) use lookup::{apply_substitutions_to_root_body, substitutions_for_instance};
-pub(in crate::db) use resolver::resolve_raw_types;
+pub(in crate::db) use resolver::{ImportResolution, resolve_raw_types};
 
 /// Type information attached to one binding declaration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, salsa::Update)]
@@ -155,11 +156,117 @@ pub(in crate::db) fn normalize_structural_type<'db>(
 }
 
 pub(super) fn infer_module_types_cycle_result<'db>(
-    _db: &'db dyn ModuleDb,
+    db: &'db dyn ModuleDb,
     _id: salsa::Id,
-    _module: crate::module_graph::ModuleInfo,
+    module: ModuleInfo,
 ) -> Option<InferredModuleTypes<'db>> {
-    None
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    if !js_info.infer_types {
+        return None;
+    }
+
+    let blocked = inference_scc(db, module);
+    Some(resolve_raw_types(
+        db,
+        module,
+        &js_info,
+        ImportResolution::CycleFallback(&blocked),
+    ))
+}
+
+fn inference_scc(db: &dyn ModuleDb, root: ModuleInfo) -> FxHashSet<ModuleInfo> {
+    const MAX_DEPENDENCY_STEPS: usize = 1024;
+
+    // Salsa invokes this from the cycle fallback. The first pass records every
+    // dependency reachable from the root and builds reverse edges; the second
+    // walks predecessors back to the root, retaining only its strongly
+    // connected component for CycleFallback import suppression.
+    let mut reachable = FxHashSet::default();
+    let mut reverse = FxHashMap::<ModuleInfo, Vec<ModuleInfo>>::default();
+    let mut pending = vec![root];
+    let mut remaining_dependency_steps = MAX_DEPENDENCY_STEPS;
+    reachable.insert(root);
+
+    while let Some(source) = pending.pop() {
+        db.unwind_if_revision_cancelled();
+        for target in inferable_dependencies(db, source) {
+            reverse.entry(target).or_default().push(source);
+            if reachable.insert(target) {
+                if remaining_dependency_steps == 0 {
+                    // The search cannot determine the exact cycle within its
+                    // step limit. Block every dependency found so far to avoid
+                    // starting another long inference chain from the fallback.
+                    return reachable;
+                }
+                remaining_dependency_steps -= 1;
+                pending.push(target);
+            }
+        }
+    }
+
+    let mut scc = FxHashSet::default();
+    let mut pending = vec![root];
+    let mut remaining_dependency_steps = MAX_DEPENDENCY_STEPS;
+    scc.insert(root);
+    while let Some(target) = pending.pop() {
+        db.unwind_if_revision_cancelled();
+        if let Some(predecessors) = reverse.get(&target) {
+            for predecessor in predecessors {
+                if scc.insert(*predecessor) {
+                    if remaining_dependency_steps == 0 {
+                        return scc;
+                    }
+                    remaining_dependency_steps -= 1;
+                    pending.push(*predecessor);
+                }
+            }
+        }
+    }
+    scc
+}
+
+fn inferable_dependencies(db: &dyn ModuleDb, module: ModuleInfo) -> Vec<ModuleInfo> {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return Vec::new();
+    };
+    if !js_info.infer_types {
+        return Vec::new();
+    }
+
+    let mut dependencies = Vec::new();
+    let mut push = |resolved_path: &ResolvedPath| {
+        let Some(path) = resolved_path.as_path() else {
+            return;
+        };
+        let Some(target) = db.module_for_path(path) else {
+            return;
+        };
+        if matches!(target.kind(db), ModuleInfoKind::Js(info) if info.infer_types) {
+            dependencies.push(target);
+        }
+    };
+
+    for import in js_info.static_import_paths.values() {
+        push(&import.resolved_path);
+    }
+    for reexport in &js_info.blanket_reexports {
+        push(&reexport.import.resolved_path);
+    }
+    for export in js_info.exports.values() {
+        match export {
+            JsExport::Reexport(reexport) | JsExport::ReexportType(reexport) => {
+                push(&reexport.import.resolved_path);
+            }
+            JsExport::Own(JsOwnExport::Namespace(reexport))
+            | JsExport::OwnType(JsOwnExport::Namespace(reexport)) => {
+                push(&reexport.import.resolved_path);
+            }
+            JsExport::Own(_) | JsExport::OwnType(_) => {}
+        }
+    }
+    dependencies
 }
 
 pub(super) fn normalize_type_cycle_result<'db>(

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::wildcard_enum_match_arm)]
 
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
-use crate::{JsExport, JsOwnExport, ModuleDb, ResolvedPath};
+use crate::{JsExport, JsModuleInfo, JsOwnExport, ModuleDb};
 use biome_css_syntax::TextRange;
 use biome_js_type_info::interned_types::{
     LocalTypeId, ModuleKey, TypeData as InferredTypeData, TypeTransformError,
@@ -167,7 +167,7 @@ pub(super) fn infer_module_types_cycle_result<'db>(
         return None;
     }
 
-    let blocked = inference_scc(db, module);
+    let blocked = inference_scc(db, module, &js_info);
     Some(resolve_raw_types(
         db,
         module,
@@ -176,22 +176,71 @@ pub(super) fn infer_module_types_cycle_result<'db>(
     ))
 }
 
-fn inference_scc(db: &dyn ModuleDb, root: ModuleInfo) -> FxHashSet<ModuleInfo> {
+/// Returns the inferable modules in the strongly connected component containing
+/// `root`.
+///
+/// The cycle fallback blocks imports within this set to stop recursive Salsa
+/// queries while continuing to infer dependencies outside the cycle. A module
+/// belongs to the set when it is reachable from `root` and can also reach
+/// `root`.
+fn inference_scc(
+    db: &dyn ModuleDb,
+    root: ModuleInfo,
+    root_info: &JsModuleInfo,
+) -> FxHashSet<ModuleInfo> {
     const MAX_DEPENDENCY_STEPS: usize = 1024;
 
-    // Salsa invokes this from the cycle fallback. The first pass records every
-    // dependency reachable from the root and builds reverse edges; the second
-    // walks predecessors back to the root, retaining only its strongly
-    // connected component for CycleFallback import suppression.
+    // Record every dependency reachable from the root while building the
+    // reverse graph needed to determine which modules can reach it again.
     let mut reachable = FxHashSet::default();
     let mut reverse = FxHashMap::<ModuleInfo, Vec<ModuleInfo>>::default();
-    let mut pending = vec![root];
+    let mut pending = vec![(root, root_info.clone())];
     let mut remaining_dependency_steps = MAX_DEPENDENCY_STEPS;
     reachable.insert(root);
 
-    while let Some(source) = pending.pop() {
+    while let Some((source, source_info)) = pending.pop() {
         db.unwind_if_revision_cancelled();
-        for target in inferable_dependencies(db, source) {
+
+        let dependency_paths = source_info
+            .static_import_paths
+            .values()
+            .map(|import| &import.resolved_path)
+            .chain(
+                source_info
+                    .blanket_reexports
+                    .iter()
+                    .map(|reexport| &reexport.import.resolved_path),
+            )
+            .chain(
+                source_info
+                    .exports
+                    .values()
+                    .filter_map(|export| match export {
+                        JsExport::Reexport(reexport) | JsExport::ReexportType(reexport) => {
+                            Some(&reexport.import.resolved_path)
+                        }
+                        JsExport::Own(JsOwnExport::Namespace(reexport))
+                        | JsExport::OwnType(JsOwnExport::Namespace(reexport)) => {
+                            Some(&reexport.import.resolved_path)
+                        }
+                        JsExport::Own(_) | JsExport::OwnType(_) => None,
+                    }),
+            );
+
+        for resolved_path in dependency_paths {
+            let Some(path) = resolved_path.as_path() else {
+                continue;
+            };
+            let Some(target) = db.module_for_path(path) else {
+                continue;
+            };
+            let ModuleInfoKind::Js(target_info) = target.kind(db) else {
+                continue;
+            };
+            if !target_info.infer_types {
+                continue;
+            }
+
             reverse.entry(target).or_default().push(source);
             if reachable.insert(target) {
                 if remaining_dependency_steps == 0 {
@@ -201,11 +250,14 @@ fn inference_scc(db: &dyn ModuleDb, root: ModuleInfo) -> FxHashSet<ModuleInfo> {
                     return reachable;
                 }
                 remaining_dependency_steps -= 1;
-                pending.push(target);
+                pending.push((target, target_info));
             }
         }
     }
 
+    // Walking predecessors from the root intersects the reachable set with
+    // modules that can reach the root, yielding its strongly connected
+    // component. Acyclic dependencies have no reverse path and remain usable.
     let mut scc = FxHashSet::default();
     let mut pending = vec![root];
     let mut remaining_dependency_steps = MAX_DEPENDENCY_STEPS;
@@ -225,48 +277,6 @@ fn inference_scc(db: &dyn ModuleDb, root: ModuleInfo) -> FxHashSet<ModuleInfo> {
         }
     }
     scc
-}
-
-fn inferable_dependencies(db: &dyn ModuleDb, module: ModuleInfo) -> Vec<ModuleInfo> {
-    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
-        return Vec::new();
-    };
-    if !js_info.infer_types {
-        return Vec::new();
-    }
-
-    let mut dependencies = Vec::new();
-    let mut push = |resolved_path: &ResolvedPath| {
-        let Some(path) = resolved_path.as_path() else {
-            return;
-        };
-        let Some(target) = db.module_for_path(path) else {
-            return;
-        };
-        if matches!(target.kind(db), ModuleInfoKind::Js(info) if info.infer_types) {
-            dependencies.push(target);
-        }
-    };
-
-    for import in js_info.static_import_paths.values() {
-        push(&import.resolved_path);
-    }
-    for reexport in &js_info.blanket_reexports {
-        push(&reexport.import.resolved_path);
-    }
-    for export in js_info.exports.values() {
-        match export {
-            JsExport::Reexport(reexport) | JsExport::ReexportType(reexport) => {
-                push(&reexport.import.resolved_path);
-            }
-            JsExport::Own(JsOwnExport::Namespace(reexport))
-            | JsExport::OwnType(JsOwnExport::Namespace(reexport)) => {
-                push(&reexport.import.resolved_path);
-            }
-            JsExport::Own(_) | JsExport::OwnType(_) => {}
-        }
-    }
-    dependencies
 }
 
 pub(super) fn normalize_type_cycle_result<'db>(

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -22,10 +22,17 @@ const MAX_RAW_TYPE_RESOLUTION_DEPTH: usize = 64;
 const MAX_INFERRED_EXPRESSION_WRAPPER_STEPS: usize = 64;
 const MAX_LOCAL_TYPE_RESOLUTION_STEPS: usize = 1024;
 
+#[derive(Clone, Copy)]
+pub(in crate::db) enum ImportResolution<'a> {
+    Full,
+    CycleFallback(&'a FxHashSet<ModuleInfo>),
+}
+
 pub(in crate::db::type_inference) struct ResolutionCtx<'db, 'a> {
     pub(in crate::db::type_inference) db: &'db dyn ModuleDb,
     pub(in crate::db::type_inference) module_key: ModuleKey,
     pub(in crate::db::type_inference) js_info: &'a JsModuleInfo,
+    pub(in crate::db::type_inference) import_resolution: ImportResolution<'a>,
     pub(in crate::db::type_inference) named_type_ids: FxHashSet<TypeId>,
     pub(in crate::db::type_inference) resolved: FxHashMap<TypeId, InferredTypeData<'db>>,
     pub(in crate::db::type_inference) in_progress: FxHashSet<TypeId>,
@@ -36,6 +43,7 @@ pub(in crate::db) fn resolve_raw_types<'db>(
     db: &'db dyn ModuleDb,
     module: ModuleInfo,
     js_info: &JsModuleInfo,
+    import_resolution: ImportResolution<'_>,
 ) -> InferredModuleTypes<'db> {
     let module_key = ModuleKey::new(module.as_id());
     let named_type_ids = named_type_ids(js_info);
@@ -43,6 +51,7 @@ pub(in crate::db) fn resolve_raw_types<'db>(
         db,
         module_key,
         js_info,
+        import_resolution,
         named_type_ids,
         resolved: FxHashMap::default(),
         in_progress: FxHashSet::default(),
@@ -127,7 +136,16 @@ impl<'db> ResolutionCtx<'db, '_> {
         &self,
         module: ModuleInfo,
     ) -> Option<&'db InferredModuleTypes<'db>> {
-        infer_module_types(self.db, module)
+        match self.import_resolution {
+            ImportResolution::Full => infer_module_types(self.db, module),
+            ImportResolution::CycleFallback(blocked) => {
+                if blocked.contains(&module) {
+                    None
+                } else {
+                    infer_module_types(self.db, module)
+                }
+            }
+        }
     }
 
     pub(in crate::db::type_inference) fn resolve(

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -38,6 +38,8 @@ use camino::{Utf8Path, Utf8PathBuf};
 use salsa::Storage;
 use salsa::plumbing::{AsId, FromId};
 
+#[path = "spec_tests_v2/cycles.test.rs"]
+mod cycles;
 #[path = "spec_tests_v2/expected_argument_inference.test.rs"]
 mod expected_argument_inference;
 #[path = "spec_tests_v2/globals.test.rs"]
@@ -1250,42 +1252,6 @@ fn test_infer_module_types_bottom_up_warms_blanket_reexports() {
     assert!(
         leaf_position < mid_position && mid_position < index_position,
         "bottom-up inference must warm blanket re-export dependencies before their importers"
-    );
-}
-
-#[test]
-fn test_infer_module_types_bottom_up_returns_none_for_import_cycles() {
-    let fs = MemoryFileSystem::default();
-    fs.insert(
-        "/src/a.ts".into(),
-        r#"
-            import { b } from "./b.ts";
-            export const a = b;
-        "#,
-    );
-    fs.insert(
-        "/src/b.ts".into(),
-        r#"
-            import { a } from "./a.ts";
-            export const b = a;
-        "#,
-    );
-
-    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
-    let a_module = db
-        .module_for_path(Utf8Path::new("/src/a.ts"))
-        .expect("a module must exist");
-    let b_module = db
-        .module_for_path(Utf8Path::new("/src/b.ts"))
-        .expect("b module must exist");
-
-    assert!(
-        infer_module_types_bottom_up(&db, a_module).is_none(),
-        "the import cycle must use the documented no-result fallback"
-    );
-    assert!(
-        infer_module_types_bottom_up(&db, b_module).is_none(),
-        "cycle recovery must remain stable from either entry module"
     );
 }
 

--- a/crates/biome_module_graph/tests/spec_tests_v2/cycles.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/cycles.test.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+#[test]
+fn test_infer_module_types_bottom_up_handles_import_cycles() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            import { b } from "./b.ts";
+            import { value } from "./value.ts";
+            export const a = b;
+            export const acyclic = value;
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { a } from "./a.ts";
+            export const b = a;
+        "#,
+    );
+    fs.insert("/src/value.ts".into(), "export const value = 1;");
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts", "/src/value.ts"], true);
+    let a_module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("a module must exist");
+    let b_module = db
+        .module_for_path(Utf8Path::new("/src/b.ts"))
+        .expect("b module must exist");
+
+    let a_types = infer_module_types_bottom_up(&db, a_module).expect("types must be inferred");
+    let a_ty = inferred_binding_ty_by_name(&db, a_module, a_types, "a")
+        .expect("a binding type must be inferred");
+    assert_eq!(a_ty, InferredTypeData::Unknown);
+    let acyclic_ty = inferred_binding_ty_by_name(&db, a_module, a_types, "acyclic")
+        .expect("acyclic binding type must be inferred");
+    assert!(is_inferred_number(&db, acyclic_ty));
+
+    let b_types = infer_module_types_bottom_up(&db, b_module).expect("types must be inferred");
+    let b_ty = inferred_binding_ty_by_name(&db, b_module, b_types, "b")
+        .expect("b binding type must be inferred");
+    assert_eq!(b_ty, InferredTypeData::Unknown);
+}


### PR DESCRIPTION
## Summary

Adds cycle-safe Salsa inference for imported modules. Imports inside the active strongly connected component resolve conservatively while dependencies outside the cycle remain inferred.

## Test Plan

Moved cycle coverage to a focused test file and passed all module-graph tests and all-target clippy.

## Docs

N/A

> This PR was created with AI assistance (OpenCode).