### PR TITLE
refactor(analyzer): cut over inferred type consumers

### DIFF
--- a/.changeset/light-carrots-throw.md
+++ b/.changeset/light-carrots-throw.md
@@ -2,4 +2,14 @@
 "@biomejs/biome": patch
 ---
 
-Improved type-aware lint rules to detect floating Promises returned through aliased callbacks and async array mapping.
+Improved the accuracy of type-aware lint rules by resolving more inferred types. For example, [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-floating-promises/) now detects floating Promises returned by aliased callbacks and arrays of Promises created by async mapping callbacks.
+
+The following statements are now reported:
+
+```ts
+type AsyncCallback = () => Promise<void>;
+declare const callback: AsyncCallback;
+callback();
+
+[1, 2, 3].map(async value => value);
+```

--- a/.changeset/light-carrots-throw.md
+++ b/.changeset/light-carrots-throw.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved type-aware lint rules to detect floating Promises returned through aliased callbacks and async array mapping.

--- a/.changeset/rotten-bars-shout.md
+++ b/.changeset/rotten-bars-shout.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a performance regression in type-aware JavaScript lint rules by inferring only requested types and memoizing export resolution.

--- a/crates/biome_js_analyze/src/lint/complexity/use_array_find.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_array_find.rs
@@ -46,7 +46,7 @@ declare_lint_rule! {
 }
 
 fn is_first_position(ctx: &RuleContext<UseArrayFind>, express: &AnyJsExpression) -> bool {
-    ctx.inferred_type_of_expression(express)
+    ctx.type_of_expression(express)
         .is_some_and(|ty| ty.is_number_literal(0.) || ty.is_bigint_literal(0))
 }
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_base_to_string.rs
@@ -214,14 +214,14 @@ fn run_binary_expression(
     let right = node.right().ok()?;
 
     if ctx
-        .inferred_type_of_expression(&left)
+        .type_of_expression(&left)
         .is_some_and(InferredType::is_all_string_like)
     {
         return check_expression(ctx, &right, DiagnosticKind::BaseToString);
     }
 
     if ctx
-        .inferred_type_of_expression(&right)
+        .type_of_expression(&right)
         .is_some_and(InferredType::is_all_string_like)
     {
         return check_expression(ctx, &left, DiagnosticKind::BaseToString);
@@ -294,7 +294,7 @@ fn type_of_assignment<'a>(
         match current {
             AnyJsAssignment::JsIdentifierAssignment(identifier) => {
                 let name = identifier.name_token().ok()?;
-                return ctx.inferred_type_of_named_value(
+                return ctx.type_of_named_value(
                     name.text_trimmed_range(),
                     name.text_trimmed(),
                 );
@@ -330,7 +330,7 @@ fn check_expression(
         return None;
     }
 
-    let ty = ctx.inferred_type_of_expression(expression)?;
+    let ty = ctx.type_of_expression(expression)?;
     let ignored_type_names = ctx
         .options()
         .ignored_type_names

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -176,17 +176,15 @@ impl Rule for NoFloatingPromises {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let expression = node.expression().ok()?;
-        let ty = ctx.type_of_expression(&expression);
+        let ty = ctx.type_of_expression(&expression)?;
 
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");
-        if ty.is_array_of(|ty| ty.is_promise_instance()) {
+        if ty.is_array_of_promise() == Some(true) {
             return Some(NoFloatingPromisesState::ArrayOfPromises);
         }
 
-        let is_maybe_promise =
-            ty.is_promise_instance() || ty.has_variant(|ty| ty.is_promise_instance());
-        if !is_maybe_promise {
+        if ty.is_promise_instance() != Some(true) {
             return None;
         }
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -176,16 +176,27 @@ impl Rule for NoFloatingPromises {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let expression = node.expression().ok()?;
-        let ty = ctx.type_of_expression(&expression)?;
 
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");
-        if ty.is_array_of_promise() == Some(true) {
+        let is_array_of_promises = ctx.expression_is_array_of_promises(&expression);
+        if is_array_of_promises == Some(true) {
             return Some(NoFloatingPromisesState::ArrayOfPromises);
         }
 
-        if ty.is_promise_instance() != Some(true) {
-            return None;
+        let is_promise = ctx.expression_is_promise(&expression);
+        if is_promise != Some(true) {
+            if is_array_of_promises == Some(false) && is_promise == Some(false) {
+                return None;
+            }
+
+            let ty = ctx.type_of_expression(&expression)?;
+            if ty.is_array_of_promise() == Some(true) {
+                return Some(NoFloatingPromisesState::ArrayOfPromises);
+            }
+            if ty.is_promise_instance() != Some(true) {
+                return None;
+            }
         }
 
         if is_handled_promise(expression).unwrap_or_default() {

--- a/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type/analysis.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misleading_return_type/analysis.rs
@@ -49,7 +49,7 @@ pub(super) fn run(ctx: &RuleContext<NoMisleadingReturnType>) -> Option<RuleState
                 .as_js_literal_member_name()?
                 .name()
                 .ok()?;
-            let return_type = ctx.inferred_return_type_of_member(method.syntax(), name.text())?;
+            let return_type = ctx.return_type_of_member(method.syntax(), name.text())?;
             run_for_member(
                 ctx,
                 annotation.range(),
@@ -70,7 +70,7 @@ pub(super) fn run(ctx: &RuleContext<NoMisleadingReturnType>) -> Option<RuleState
                 .as_js_literal_member_name()?
                 .name()
                 .ok()?;
-            let return_type = ctx.inferred_return_type_of_member(method.syntax(), name.text())?;
+            let return_type = ctx.return_type_of_member(method.syntax(), name.text())?;
             run_for_member(
                 ctx,
                 annotation.range(),
@@ -87,7 +87,7 @@ pub(super) fn run(ctx: &RuleContext<NoMisleadingReturnType>) -> Option<RuleState
             if any_getter.has_matching_setter(&name) {
                 return None;
             }
-            let return_type = ctx.inferred_return_type_of_member(getter.syntax(), name.text())?;
+            let return_type = ctx.return_type_of_member(getter.syntax(), name.text())?;
             run_for_member(
                 ctx,
                 annotation.range(),
@@ -104,7 +104,7 @@ pub(super) fn run(ctx: &RuleContext<NoMisleadingReturnType>) -> Option<RuleState
             if any_getter.has_matching_setter(&name) {
                 return None;
             }
-            let return_type = ctx.inferred_return_type_of_member(getter.syntax(), name.text())?;
+            let return_type = ctx.return_type_of_member(getter.syntax(), name.text())?;
             run_for_member(
                 ctx,
                 annotation.range(),
@@ -167,7 +167,7 @@ fn run_for_function(
         return None;
     }
 
-    let return_type = ctx.inferred_return_type_of_function(node)?;
+    let return_type = ctx.return_type_of_function(node)?;
     let is_async = node.async_token().is_some();
     let body = node.body().ok()?;
 
@@ -770,7 +770,7 @@ fn cast_target_at_least_object_wide(
     expression: &AnyJsExpression,
     _cast: &AnyTsCastExpression,
 ) -> bool {
-    ctx.inferred_type_of_expression(expression)
+    ctx.type_of_expression(expression)
         .is_none_or(InferredType::is_at_least_as_wide_as_object)
 }
 
@@ -788,7 +788,7 @@ fn infer_expression_type<'db>(
         return Some(init_type);
     }
 
-    ctx.inferred_type_of_expression(&inner)
+    ctx.type_of_expression(&inner)
 }
 
 /// Returns the initializer's literal type when the identifier resolves to a
@@ -802,7 +802,7 @@ fn resolve_identifier_initializer_type<'db>(
         return None;
     }
     let unwrapped = unwrap_type_wrappers(&init_expr);
-    ctx.inferred_type_of_expression(&unwrapped)
+    ctx.type_of_expression(&unwrapped)
 }
 
 /// Removes parentheses and type wrappers that preserve literal inference.

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -109,7 +109,7 @@ impl Rule for NoMisusedPromises {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let expression = ctx.query();
         if let Some(state) = misused_promise_expression_state(expression) {
-            let ty = ctx.inferred_type_of_expression(expression)?;
+            let ty = ctx.type_of_expression(expression)?;
             return (ty.is_promise_instance() == Some(true)).then_some(state);
         }
         if expression.as_any_js_literal_expression().is_some()
@@ -121,7 +121,7 @@ impl Rule for NoMisusedPromises {
             return None;
         }
 
-        let ty = ctx.inferred_type_of_expression(expression)?;
+        let ty = ctx.type_of_expression(expression)?;
         if !ty.is_function() {
             return None;
         }
@@ -267,7 +267,7 @@ fn find_misused_promise_returning_callback(
         .skip(1)
         .find_map(JsCallExpression::cast)
     {
-        ctx.inferred_expected_argument_type_for_arguments(
+        ctx.expected_argument_type(
             &call_expression.callee().ok()?,
             &argument_list,
             argument_index,
@@ -279,7 +279,7 @@ fn find_misused_promise_returning_callback(
         .skip(1)
         .find_map(JsNewExpression::cast)
     {
-        ctx.inferred_expected_argument_type_for_arguments(
+        ctx.expected_argument_type(
             &new_expression.callee().ok()?,
             &argument_list,
             argument_index,

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -7,7 +7,6 @@ use biome_js_syntax::{
     AnyJsCallArgument, AnyJsExpression, JsCallArgumentList, JsCallExpression,
     JsConditionalExpression, JsNewExpression, JsSyntaxKind,
 };
-use biome_js_type_info::InferredType;
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TriviaPieceKind};
 use biome_rule_options::no_misused_promises::NoMisusedPromisesOptions;
 
@@ -109,8 +108,7 @@ impl Rule for NoMisusedPromises {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let expression = ctx.query();
         if let Some(state) = misused_promise_expression_state(expression) {
-            let ty = ctx.type_of_expression(expression)?;
-            return (ty.is_promise_instance() == Some(true)).then_some(state);
+            return (ctx.expression_is_promise(expression) == Some(true)).then_some(state);
         }
         if expression.as_any_js_literal_expression().is_some()
             || !expression
@@ -121,11 +119,10 @@ impl Rule for NoMisusedPromises {
             return None;
         }
 
-        let ty = ctx.type_of_expression(expression)?;
-        if !ty.is_function() {
+        if ctx.expression_function_returns_promise(expression) != Some(true) {
             return None;
         }
-        find_misused_promise_returning_callback(ctx, expression, ty)
+        find_misused_promise_returning_callback(ctx, expression)
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
@@ -246,12 +243,7 @@ fn misused_promise_expression_state(
 fn find_misused_promise_returning_callback(
     ctx: &RuleContext<NoMisusedPromises>,
     expression: &AnyJsExpression,
-    ty: InferredType,
 ) -> Option<NoMisusedPromisesState> {
-    if ty.function_returns_promise() != Some(true) {
-        return None;
-    }
-
     let argument = expression
         .syntax()
         .ancestors()

--- a/crates/biome_js_analyze/src/lint/nursery/no_unsafe_plus_operands.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unsafe_plus_operands.rs
@@ -177,7 +177,7 @@ fn run_assignment(
     let right = assignment.right().ok()?;
     let left_ty = type_of_assignment_target(ctx, assignment, &left)?;
 
-    let right_ty = ctx.inferred_type_of_expression(&right)?;
+    let right_ty = ctx.type_of_expression(&right)?;
 
     let left = OperandInfo {
         range: left.range(),
@@ -213,7 +213,7 @@ fn type_of_assignment<'a>(
     match target {
         AnyJsAssignment::JsIdentifierAssignment(identifier) => {
             let name = identifier.name_token().ok()?;
-            ctx.inferred_type_of_named_value(assignment.range(), name.text_trimmed())
+            ctx.type_of_named_value(assignment.range(), name.text_trimmed())
         }
         AnyJsAssignment::JsParenthesizedAssignment(parenthesized) => {
             type_of_assignment(ctx, assignment, &parenthesized.assignment().ok()?)
@@ -302,7 +302,7 @@ fn analyze_expression(
 
     let operand = OperandInfo {
         range: expression.range(),
-        ty: ctx.inferred_type_of_expression(&expression)?,
+        ty: ctx.type_of_expression(&expression)?,
     };
 
     if operand.ty.has_invalid_plus_operand_variant() {
@@ -378,7 +378,7 @@ fn type_for_range_in_expression<'a>(
     let expression = expression.omit_parentheses();
 
     if expression.range() == range {
-        return ctx.inferred_type_of_expression(&expression);
+        return ctx.type_of_expression(&expression);
     }
 
     if let AnyJsExpression::JsBinaryExpression(binary) = &expression
@@ -404,7 +404,7 @@ fn type_for_range_in_assignment<'a>(
     }
 
     if right.range() == range {
-        return ctx.inferred_type_of_expression(&right);
+        return ctx.type_of_expression(&right);
     }
 
     None

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_type_conversion.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_type_conversion.rs
@@ -242,7 +242,7 @@ fn run_builtin_call(
 
     let first_argument = arguments.first()?.ok()?;
     let argument = first_argument.as_any_js_expression()?;
-    let ty = ctx.inferred_type_of_expression(argument)?;
+    let ty = ctx.type_of_expression(argument)?;
 
     matches_primitive_type(ty, primitive).then_some(RuleState {
         kind: ConversionKind::BuiltinCall,
@@ -281,7 +281,7 @@ fn run_to_string_call(
     }
 
     let object = member_expression.object().ok()?;
-    let ty = ctx.inferred_type_of_expression(&object)?;
+    let ty = ctx.type_of_expression(&object)?;
 
     matches_primitive_type(ty, PrimitiveKind::String).then_some(RuleState {
         kind: ConversionKind::ToString,
@@ -325,7 +325,7 @@ fn run_binary_expression(
         return None;
     };
 
-    let ty = ctx.inferred_type_of_expression(&expression)?;
+    let ty = ctx.type_of_expression(&expression)?;
     matches_primitive_type(ty, PrimitiveKind::String).then_some(RuleState {
         kind: ConversionKind::StringConcatenation,
         primitive: PrimitiveKind::String,
@@ -366,7 +366,7 @@ fn run_assignment_expression(
             // `type_of_expression()` works on expressions, but the left-hand side
             // of `+=` is an assignment target. Resolve the named value instead so
             // we can ask for the variable's current type.
-            ctx.inferred_type_of_named_value(node.range(), name.text_trimmed())?
+            ctx.type_of_named_value(node.range(), name.text_trimmed())?
         }
         _ => return None,
     };
@@ -405,7 +405,7 @@ fn run_unary_expression(
 
     match node.operator().ok()? {
         JsUnaryOperator::Plus => {
-            let ty = ctx.inferred_type_of_expression(&argument)?;
+            let ty = ctx.type_of_expression(&argument)?;
             matches_primitive_type(ty, PrimitiveKind::Number).then_some(RuleState {
                 kind: ConversionKind::UnaryPlus,
                 primitive: PrimitiveKind::Number,
@@ -419,7 +419,7 @@ fn run_unary_expression(
             }
 
             let nested_argument = nested.argument().ok()?;
-            let ty = ctx.inferred_type_of_expression(&nested_argument)?;
+            let ty = ctx.type_of_expression(&nested_argument)?;
             matches_primitive_type(ty, PrimitiveKind::Boolean).then_some(RuleState {
                 kind: ConversionKind::DoubleNegation,
                 primitive: PrimitiveKind::Boolean,
@@ -433,7 +433,7 @@ fn run_unary_expression(
             }
 
             let nested_argument = nested.argument().ok()?;
-            let ty = ctx.inferred_type_of_expression(&nested_argument)?;
+            let ty = ctx.type_of_expression(&nested_argument)?;
             let primitive = if matches_primitive_type(ty, PrimitiveKind::BigInt) {
                 PrimitiveKind::BigInt
             } else if ty.is_all_integer_like() {

--- a/crates/biome_js_analyze/src/lint/nursery/use_await_thenable.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_await_thenable.rs
@@ -54,7 +54,7 @@ impl Rule for UseAwaitThenable {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let expression = node.argument().ok()?;
-        let ty = ctx.inferred_type_of_expression(&expression)?;
+        let ty = ctx.type_of_expression(&expression)?;
 
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");
@@ -64,7 +64,7 @@ impl Rule for UseAwaitThenable {
             Some(false) => {}
         }
 
-        (!ctx.inferred_expression_has_callable_member(&expression, "then")?).then_some(())
+        (!ctx.expression_has_callable_member(&expression, "then")?).then_some(())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/nursery/use_disposables.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_disposables.rs
@@ -86,7 +86,7 @@ impl Rule for UseDisposables {
         let decl = ctx.query();
         let initializer = decl.initializer()?;
         let expression = initializer.expression().ok()?;
-        let ty = ctx.inferred_type_of_expression(&expression)?;
+        let ty = ctx.type_of_expression(&expression)?;
         // Lookup the parent declaration which possibly has `await` and/or `using` tokens.
         let parent = decl
             .parent::<JsVariableDeclaratorList>()?

--- a/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
@@ -131,7 +131,7 @@ impl Rule for UseExhaustiveSwitchCases {
             let Ok(test) = case.test() else {
                 continue;
             };
-            let ty = ctx.inferred_type_of_expression(&test)?;
+            let ty = ctx.type_of_expression(&test)?;
             let variants = ty.try_switch_case_variants().ok()?;
             if let [variant] = variants.as_slice()
                 && *variant != InferredSwitchCase::UnsupportedLiteral
@@ -157,7 +157,7 @@ impl Rule for UseExhaustiveSwitchCases {
         };
 
         let variants = ctx
-            .inferred_type_of_expression(&discriminant)?
+            .type_of_expression(&discriminant)?
             .try_switch_case_variants()
             .ok()?;
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_includes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_includes.rs
@@ -325,6 +325,6 @@ fn ensure_known_includes_type(ctx: &RuleContext<UseIncludes>, call: &JsCallExpre
         return false;
     };
 
-    ctx.inferred_type_of_expression(&object)
+    ctx.type_of_expression(&object)
         .is_some_and(|ty| ty.is_all_string_array_or_tuple())
 }

--- a/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_nullish_coalescing.rs
@@ -472,7 +472,7 @@ fn run_logical_or(
     }
 
     let left = logical.left().ok()?;
-    let left_ty = ctx.inferred_type_of_expression(&left)?;
+    let left_ty = ctx.type_of_expression(&left)?;
 
     if !left_ty.has_nullish_variant()? {
         return None;
@@ -519,7 +519,7 @@ fn run_logical_or_assignment(
         AnyJsAssignmentPattern::AnyJsAssignment(assign) => {
             let id = assign.as_js_identifier_assignment()?;
             let name = id.name_token().ok()?;
-            ctx.inferred_type_of_named_value(assignment.range(), name.text_trimmed())?
+            ctx.type_of_named_value(assignment.range(), name.text_trimmed())?
         }
         _ => return None,
     };
@@ -757,7 +757,7 @@ fn run_ternary(
 
     let options = ctx.options();
     if options.has_any_ignore_primitives()
-        && let Some(ty) = ctx.inferred_type_of_expression(&checked_expr)
+        && let Some(ty) = ctx.type_of_expression(&checked_expr)
         && should_ignore_for_primitives(options, ty)?
     {
         return None;
@@ -774,7 +774,7 @@ fn run_ternary(
             // A single strict check only covers one nullish variant. The fix to `??`
             // is safe only if the type cannot be the opposite variant.
             NullishCheckKind::StrictSingle(lit) => {
-                let ty = ctx.inferred_type_of_expression(&checked_expr)?;
+                let ty = ctx.type_of_expression(&checked_expr)?;
                 match lit {
                     NullishLiteral::Null => !ty.has_undefined_variant()?,
                     NullishLiteral::Undefined => !ty.has_null_variant()?,

--- a/crates/biome_js_analyze/src/lint/nursery/use_regexp_exec.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_regexp_exec.rs
@@ -53,7 +53,7 @@ impl Rule for UseRegexpExec {
 
         let call_object = callee.object().ok()?;
         if !ctx
-            .inferred_type_of_expression(&call_object)
+            .type_of_expression(&call_object)
             .is_some_and(|ty| ty.is_string_or_string_literal())
         {
             return None;
@@ -76,7 +76,7 @@ impl Rule for UseRegexpExec {
         let express = first_arg.as_any_js_expression()?;
 
         if ctx
-            .inferred_type_of_expression(express)
+            .type_of_expression(express)
             .is_some_and(|ty| ty.is_regexp_literal_without_global_flag())
         {
             return Some(());

--- a/crates/biome_js_analyze/src/lint/nursery/use_string_starts_ends_with.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_string_starts_ends_with.rs
@@ -777,7 +777,7 @@ fn ensure_known_string_type(
     ctx: &RuleContext<UseStringStartsEndsWith>,
     expression: &AnyJsExpression,
 ) -> bool {
-    ctx.inferred_type_of_expression(expression)
+    ctx.type_of_expression(expression)
         .is_some_and(|ty| ty.is_all_string_like())
 }
 
@@ -785,7 +785,7 @@ fn is_zero_number_expression(
     ctx: &RuleContext<UseStringStartsEndsWith>,
     expression: &AnyJsExpression,
 ) -> bool {
-    ctx.inferred_type_of_expression(expression)
+    ctx.type_of_expression(expression)
         .is_some_and(|ty| ty.is_number_literal(0.0))
 }
 
@@ -937,7 +937,7 @@ fn build_method_call_with_regex_literal(
     method: PreferredMethod,
     negated: bool,
 ) -> Option<AnyJsExpression> {
-    let (pattern, flags) = ctx.inferred_type_of_expression(regex)?.regexp_literal()?;
+    let (pattern, flags) = ctx.type_of_expression(regex)?.regexp_literal()?;
 
     if !flags.text().is_empty() {
         return None;
@@ -1034,7 +1034,7 @@ fn matches_length_expression(
     if let Some(expected_len) = compared_string_utf16_len(value) {
         // Literal strings are the easy case: the target length is known up front.
         return ctx
-            .inferred_type_of_expression(expression)
+            .type_of_expression(expression)
             .is_some_and(|ty| ty.is_number_literal(expected_len as f64));
     }
 
@@ -1193,7 +1193,7 @@ fn extract_plain_anchored_regex(
     expression: &AnyJsExpression,
 ) -> Option<PreferredMethod> {
     let (pattern, flags) = ctx
-        .inferred_type_of_expression(expression)?
+        .type_of_expression(expression)?
         .regexp_literal()?;
 
     if !flags.text().is_empty() {

--- a/crates/biome_js_analyze/src/lint/style/use_consistent_enum_value_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_enum_value_type.rs
@@ -100,7 +100,7 @@ impl Rule for UseConsistentEnumValueType {
                 continue;
             };
 
-            let expr_type = ctx.inferred_type_of_expression(&expr);
+            let expr_type = ctx.type_of_expression(&expr);
 
             if expr_type.is_some_and(|ty| ty.is_string_or_string_literal()) {
                 if let Some(enum_type) = enum_type.clone() {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unnecessary_conditions.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unnecessary_conditions.rs
@@ -457,7 +457,7 @@ fn check_condition_necessity(
                 return Some(IssueKind::AlwaysFalsyCondition(expr.range()));
             }
 
-            let ty = ctx.inferred_type_of_expression(expr)?;
+            let ty = ctx.type_of_expression(expr)?;
             if ty.is_always_truthy() {
                 return Some(IssueKind::AlwaysTruthyCondition(expr.range()));
             } else if ty.is_always_falsy() {
@@ -491,7 +491,7 @@ fn check_condition_necessity(
                 return None;
             }
 
-            let ty = ctx.inferred_type_of_expression(expr)?;
+            let ty = ctx.type_of_expression(expr)?;
             if ty.is_always_truthy() {
                 return Some(IssueKind::AlwaysTruthyCondition(expr.range()));
             } else if ty.is_always_falsy() {
@@ -545,7 +545,7 @@ fn check_nullish_necessity(
     }
 
     // Type-aware path: report when the left-hand side is statically non-nullish.
-    let ty = ctx.inferred_type_of_expression(expr)?;
+    let ty = ctx.type_of_expression(expr)?;
     if ty.is_non_nullish() {
         return Some(IssueKind::UnnecessaryCoalescing(
             expr.range(),
@@ -579,7 +579,7 @@ fn check_optional_chain_necessity(
     }
 
     // Type-aware path: report when the object is statically non-nullish.
-    let ty = ctx.inferred_type_of_expression(expr)?;
+    let ty = ctx.type_of_expression(expr)?;
     if ty.is_non_nullish() {
         return Some(IssueKind::UnnecessaryOptionalChain(
             expr.range(),
@@ -738,7 +738,7 @@ fn check_comparison_necessity(
         _ => return None,
     };
 
-    let ty = ctx.inferred_type_of_expression(typed_side)?;
+    let ty = ctx.type_of_expression(typed_side)?;
 
     // Is the non-null side known to be non-nullish? Then the comparison is unnecessary
     // for any equality operator: `x === null`, `x !== undefined`, `x == null` are
@@ -829,7 +829,7 @@ fn check_case_clause_reachability(
         .find_map(JsSwitchStatement::cast)?;
     let discriminant = switch_stmt.discriminant().ok()?;
 
-    let discriminant_ty = ctx.inferred_type_of_expression(&discriminant)?;
+    let discriminant_ty = ctx.type_of_expression(&discriminant)?;
     if type_could_equal_literal(discriminant_ty, &case_literal) {
         None
     } else {

--- a/crates/biome_js_analyze/src/lint/suspicious/use_array_sort_compare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_array_sort_compare.rs
@@ -63,7 +63,7 @@ impl Rule for UseArraySortCompare {
 
         let call_object = callee.object().ok()?;
         if !ctx
-            .inferred_type_of_expression(&call_object)
+            .type_of_expression(&call_object)
             .is_some_and(|ty| ty.is_array())
         {
             return None;
@@ -85,7 +85,7 @@ impl Rule for UseArraySortCompare {
         let binding = arguments.first()?.ok()?;
         let first_arg = binding.as_any_js_expression()?;
         if ctx
-            .inferred_type_of_expression(first_arg)
+            .type_of_expression(first_arg)
             .is_some_and(|ty| ty.is_undefined() || ty.is_null())
         {
             return Some(());

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -9,27 +9,24 @@ use biome_js_syntax::{
     JsSyntaxNode,
 };
 use biome_js_type_info::{
-    InferredType, Type, TypeResolverLevel,
+    InferredType, TypeResolverLevel,
     interned_types::{
-        CallArgumentType as InferredCallArgumentType,
-        FunctionParameter as InferredFunctionParameter, LocalTypeHandle, LocalTypeId,
+        CallArgumentType as InferredCallArgumentType, LocalTypeHandle, LocalTypeId,
         ReturnType as InferredReturnType, TypeData as InferredTypeData,
     },
 };
 use biome_module_graph::{
     CallArgumentTypeInput, InferredModuleTypes, JsOwnExport, ModuleDb, ModuleInfo, ModuleInfoKind,
-    ModuleResolver, NormalizeTypeInput, infer_call_argument_type, infer_constructor_argument_type,
+    NormalizeTypeInput, infer_call_argument_type, infer_constructor_argument_type,
     infer_module_types, infer_module_types_bottom_up, normalize_type,
 };
 use biome_rowan::{AstNode, AstSeparatedList, TextRange};
 use std::cell::OnceCell;
 use std::rc::Rc;
-use std::sync::Arc;
 
 #[derive(Default)]
 struct TypedModuleState {
     inference_available: OnceCell<bool>,
-    legacy_resolver: OnceCell<Option<Arc<ModuleResolver>>>,
 }
 
 #[derive(Clone)]
@@ -60,31 +57,12 @@ impl TypedModule {
         let _ = self.state.inference_available.set(inferred.is_some());
         inferred
     }
-
-    #[expect(
-        clippy::arc_with_non_send_sync,
-        reason = "The legacy ModuleResolver and Type APIs require Arc while this migration keeps them in place."
-    )]
-    fn legacy_resolver(&self) -> Option<Arc<ModuleResolver>> {
-        self.state
-            .legacy_resolver
-            .get_or_init(|| {
-                let ModuleInfoKind::Js(module_info) = self.module.kind(self.db.as_ref()) else {
-                    return None;
-                };
-                Some(Arc::new(ModuleResolver::for_module(
-                    module_info,
-                    self.db.clone(),
-                )))
-            })
-            .clone()
-    }
 }
 
 /// Service for use with type inference rules.
 ///
-/// This service is used for retrieving [`Type`] instances for arbitrary
-/// expressions or function definitions from the module graph.
+/// This service retrieves inferred types for arbitrary expressions or function
+/// definitions from the module graph.
 #[derive(Clone)]
 pub struct TypedService {
     module: Option<TypedModule>,
@@ -103,7 +81,7 @@ impl TypedService {
     }
 
     /// Returns the Salsa-inferred type for an expression.
-    pub fn inferred_type_of_expression<'db>(
+    pub fn type_of_expression<'db>(
         &'db self,
         expression: &AnyJsExpression,
     ) -> Option<InferredType<'db>> {
@@ -117,7 +95,7 @@ impl TypedService {
     }
 
     /// Returns the Salsa-inferred type for a named value visible at `range`.
-    pub fn inferred_type_of_named_value<'db>(
+    pub fn type_of_named_value<'db>(
         &'db self,
         range: TextRange,
         name: &str,
@@ -144,7 +122,7 @@ impl TypedService {
     }
 
     /// Returns the normalized Salsa-inferred return type for a function.
-    pub fn inferred_return_type_of_function<'db>(
+    pub fn return_type_of_function<'db>(
         &'db self,
         function: &AnyJsFunction,
     ) -> Option<InferredType<'db>> {
@@ -187,7 +165,7 @@ impl TypedService {
     }
 
     /// Returns the normalized Salsa-inferred return type for a class or object member.
-    pub fn inferred_return_type_of_member<'db>(
+    pub fn return_type_of_member<'db>(
         &'db self,
         member_syntax: &JsSyntaxNode,
         member_name: &str,
@@ -279,7 +257,7 @@ impl TypedService {
     ///
     /// Returns `None` when type inference is unavailable or the member's
     /// callability cannot be determined conclusively.
-    pub fn inferred_expression_has_callable_member(
+    pub fn expression_has_callable_member(
         &self,
         expression: &AnyJsExpression,
         name: &str,
@@ -303,37 +281,9 @@ impl TypedService {
         InferredType::new(db, member_ty).is_callable()
     }
 
-    /// Returns the expected type for a call or constructor argument.
-    pub fn inferred_expected_argument_type<'db>(
-        &'db self,
-        callee: &AnyJsExpression,
-        argument_index: usize,
-        is_constructor: bool,
-    ) -> Option<InferredType<'db>> {
-        let typed_module = self.module.as_ref()?;
-        let db = typed_module.db.as_ref();
-        let inferred = typed_module.inferred_types()?;
-        let callee_ty = inferred.expressions.get(&callee.range()).copied()?;
-        let callee_ty = normalize_type(
-            db,
-            NormalizeTypeInput::new(db, typed_module.module, callee_ty),
-        );
-        let argument_ty = if is_constructor {
-            constructor_argument_type(db, callee_ty, argument_index)?
-        } else {
-            call_argument_type(db, callee_ty, argument_index)?
-        };
-        let argument_ty = normalize_type(
-            db,
-            NormalizeTypeInput::new(db, typed_module.module, argument_ty),
-        );
-
-        Some(InferredType::new(db, argument_ty))
-    }
-
     /// Returns the expected type for a call or constructor argument, selecting
     /// overloads using the other arguments in the same argument list.
-    pub fn inferred_expected_argument_type_for_arguments<'db>(
+    pub fn expected_argument_type<'db>(
         &'db self,
         callee: &AnyJsExpression,
         arguments: &JsCallArgumentList,
@@ -380,140 +330,11 @@ impl TypedService {
         Some(InferredType::new(db, argument_ty))
     }
 
-    fn resolver(&self) -> Option<Arc<ModuleResolver>> {
-        self.module.as_ref()?.legacy_resolver()
-    }
-
-    /// Returns the [`Type`] for the given `expression`.
-    pub fn type_of_expression(&self, expression: &AnyJsExpression) -> Type {
-        self.resolver()
-            .map(|resolver| resolver.resolved_type_of_expression(expression))
-            .unwrap_or_default()
-    }
-
-    /// Returns the [`Type`] of the value with the given `name`, as defined
-    /// in the scope that contains `range`.
-    pub fn type_of_named_value(&self, range: TextRange, name: &str) -> Type {
-        self.resolver()
-            .map(|resolver| resolver.resolved_type_of_named_value(range, name))
-            .unwrap_or_default()
-    }
-
-    /// Returns the [`Type`] for the given `function`.
-    pub fn type_of_function(&self, function: &AnyJsFunction) -> Type {
-        match function {
-            AnyJsFunction::JsArrowFunctionExpression(expr) => {
-                self.type_of_expression(&AnyJsExpression::JsArrowFunctionExpression(expr.clone()))
-            }
-            AnyJsFunction::JsFunctionDeclaration(decl) => decl
-                .id()
-                .ok()
-                .as_ref()
-                .and_then(AnyJsBinding::as_js_identifier_binding)
-                .and_then(|identifier| identifier.name_token().ok())
-                .and_then(|name| {
-                    self.resolver().map(|resolver| {
-                        resolver.resolved_type_of_named_value(function.range(), name.text())
-                    })
-                })
-                .unwrap_or_default(),
-            AnyJsFunction::JsFunctionExportDefaultDeclaration(_decl) => self
-                .resolver()
-                .and_then(|resolver| resolver.resolved_type_of_default_export())
-                .unwrap_or_default(),
-            AnyJsFunction::JsFunctionExpression(expr) => {
-                self.type_of_expression(&AnyJsExpression::JsFunctionExpression(expr.clone()))
-            }
-        }
-    }
-
-    /// Returns the [`Type`] for a class/object member by navigating to the
-    /// parent and looking up the member by name.
-    pub fn type_of_member(&self, member_syntax: &JsSyntaxNode, member_name: &str) -> Type {
-        let parent_type = member_syntax
-            .ancestors()
-            .find_map(|ancestor| {
-                if let Some(class) = JsClassDeclaration::cast(ancestor.clone()) {
-                    return class
-                        .id()
-                        .ok()
-                        .and_then(|id| id.as_js_identifier_binding().cloned())
-                        .and_then(|id| id.name_token().ok())
-                        .map(|name| {
-                            let trimmed = name.token_text_trimmed();
-                            self.type_of_named_value(name.text_trimmed_range(), trimmed.text())
-                        });
-                }
-                if let Some(class_expr) = JsClassExpression::cast(ancestor.clone()) {
-                    return Some(
-                        self.type_of_expression(&AnyJsExpression::JsClassExpression(class_expr)),
-                    );
-                }
-                if let Some(obj_expr) = JsObjectExpression::cast(ancestor.clone()) {
-                    return Some(
-                        self.type_of_expression(&AnyJsExpression::JsObjectExpression(obj_expr)),
-                    );
-                }
-                None
-            })
-            .unwrap_or_default();
-
-        parent_type
-            .find_member_type(member_name)
-            .unwrap_or_default()
-    }
-
     pub fn has_binding(&self, reference: &JsReferenceIdentifier) -> bool {
         self.model
             .as_ref()
             .is_some_and(|model| model.binding(reference).is_some())
     }
-}
-
-fn call_argument_type<'db>(
-    db: &'db dyn ModuleDb,
-    ty: InferredTypeData<'db>,
-    argument_index: usize,
-) -> Option<InferredTypeData<'db>> {
-    let function = ty.callable_function(db)?;
-    function_parameter_type(function.parameters(db), argument_index)
-}
-
-fn constructor_argument_type<'db>(
-    db: &'db dyn ModuleDb,
-    ty: InferredTypeData<'db>,
-    argument_index: usize,
-) -> Option<InferredTypeData<'db>> {
-    let ty = match ty {
-        InferredTypeData::InstanceOf(instance) => instance.ty(db),
-        ty => ty,
-    };
-    let InferredTypeData::Class(class) = ty else {
-        return None;
-    };
-
-    class.members(db).iter().find_map(|member| {
-        if !member.kind.is_constructor() {
-            return None;
-        }
-        match member.ty {
-            InferredTypeData::Constructor(constructor) => constructor
-                .parameters(db)
-                .get(argument_index)
-                .map(|parameter| parameter.parameter.ty()),
-            ty => call_argument_type(db, ty, argument_index),
-        }
-    })
-}
-
-fn function_parameter_type<'db>(
-    parameters: &[InferredFunctionParameter<'db>],
-    argument_index: usize,
-) -> Option<InferredTypeData<'db>> {
-    parameters
-        .get(argument_index)
-        .or_else(|| parameters.last().filter(|parameter| parameter.is_rest()))
-        .map(InferredFunctionParameter::ty)
 }
 
 impl FromServices for TypedService {

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -19,7 +19,9 @@ use biome_module_graph::{
     BindingTypeInput, CallArgumentTypeInput, ExpressionTypeInput, ModuleDb, ModuleInfo,
     NormalizeTypeInput, SymbolFromModuleInfo, find_member_type, find_value_member_type,
     infer_binding_type, infer_call_argument_type, infer_constructor_argument_type,
-    infer_export_type, infer_expression_type, normalize_type,
+    infer_export_type, infer_expression_function_returns_promise,
+    infer_expression_is_array_of_promises, infer_expression_is_promise, infer_expression_type,
+    normalize_type,
 };
 use biome_rowan::{AstNode, AstSeparatedList, TextRange};
 use std::rc::Rc;
@@ -86,6 +88,41 @@ impl TypedService {
         let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
 
         Some(InferredType::new(db, ty))
+    }
+
+    /// Returns whether an expression is a Promise without resolving unrelated members.
+    pub fn expression_is_promise(&self, expression: &AnyJsExpression) -> Option<bool> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        infer_expression_is_promise(
+            db,
+            ExpressionTypeInput::new(db, typed_module.module, expression.range()),
+        )
+    }
+
+    /// Returns whether an expression is an array of Promises without
+    /// normalizing unrelated nested types.
+    pub fn expression_is_array_of_promises(&self, expression: &AnyJsExpression) -> Option<bool> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        infer_expression_is_array_of_promises(
+            db,
+            ExpressionTypeInput::new(db, typed_module.module, expression.range()),
+        )
+    }
+
+    /// Returns whether an expression is callable and returns a Promise without
+    /// normalizing callable parameters or unrelated nested types.
+    pub fn expression_function_returns_promise(
+        &self,
+        expression: &AnyJsExpression,
+    ) -> Option<bool> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        infer_expression_function_returns_promise(
+            db,
+            ExpressionTypeInput::new(db, typed_module.module, expression.range()),
+        )
     }
 
     /// Returns the Salsa-inferred type for a named value visible at `range`.
@@ -256,10 +293,6 @@ impl TypedService {
         let typed_module = self.module.as_ref()?;
         let db = typed_module.db.as_ref();
         let callee_ty = self.inferred_expression_data(callee.range())?;
-        let callee_ty = normalize_type(
-            db,
-            NormalizeTypeInput::new(db, typed_module.module, callee_ty),
-        );
         let arguments = arguments
             .iter()
             .map(|argument| {
@@ -269,7 +302,6 @@ impl TypedService {
                     AnyJsCallArgument::JsSpread(spread) => (spread.argument().ok()?, true),
                 };
                 let ty = self.inferred_expression_data(expression.range())?;
-                let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
                 Some(if is_spread {
                     InferredCallArgumentType::Spread(ty)
                 } else {
@@ -284,10 +316,6 @@ impl TypedService {
         } else {
             infer_call_argument_type(db, input)?
         };
-        let argument_ty = normalize_type(
-            db,
-            NormalizeTypeInput::new(db, typed_module.module, argument_ty),
-        );
 
         Some(InferredType::new(db, argument_ty))
     }

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -21,7 +21,7 @@ use biome_module_graph::{
     infer_binding_type, infer_call_argument_type, infer_constructor_argument_type,
     infer_export_type, infer_expression_function_returns_promise,
     infer_expression_is_array_of_promises, infer_expression_is_promise, infer_expression_type,
-    normalize_type,
+    normalize_type, resolve_callable_type,
 };
 use biome_rowan::{AstNode, AstSeparatedList, TextRange};
 use std::rc::Rc;
@@ -316,6 +316,7 @@ impl TypedService {
         } else {
             infer_call_argument_type(db, input)?
         };
+        let argument_ty = resolve_callable_type(db, argument_ty)?;
 
         Some(InferredType::new(db, argument_ty))
     }

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -9,53 +9,30 @@ use biome_js_syntax::{
     JsSyntaxNode,
 };
 use biome_js_type_info::{
-    InferredType, TypeResolverLevel,
+    InferredType,
     interned_types::{
-        CallArgumentType as InferredCallArgumentType, LocalTypeHandle, LocalTypeId,
-        ReturnType as InferredReturnType, TypeData as InferredTypeData,
+        CallArgumentType as InferredCallArgumentType, ReturnType as InferredReturnType,
+        TypeData as InferredTypeData,
     },
 };
 use biome_module_graph::{
-    CallArgumentTypeInput, InferredModuleTypes, JsOwnExport, ModuleDb, ModuleInfo, ModuleInfoKind,
-    NormalizeTypeInput, infer_call_argument_type, infer_constructor_argument_type,
-    infer_module_types, infer_module_types_bottom_up, normalize_type,
+    BindingTypeInput, CallArgumentTypeInput, ExpressionTypeInput, ModuleDb, ModuleInfo,
+    NormalizeTypeInput, SymbolFromModuleInfo, find_member_type, find_value_member_type,
+    infer_binding_type, infer_call_argument_type, infer_constructor_argument_type,
+    infer_export_type, infer_expression_type, normalize_type,
 };
 use biome_rowan::{AstNode, AstSeparatedList, TextRange};
-use std::cell::OnceCell;
 use std::rc::Rc;
-
-#[derive(Default)]
-struct TypedModuleState {
-    inference_available: OnceCell<bool>,
-}
 
 #[derive(Clone)]
 pub(crate) struct TypedModule {
     db: Rc<dyn ModuleDb>,
     module: ModuleInfo,
-    state: Rc<TypedModuleState>,
 }
 
 impl TypedModule {
     pub(crate) fn new(db: Rc<dyn ModuleDb>, module: ModuleInfo) -> Self {
-        Self {
-            db,
-            module,
-            state: Rc::new(TypedModuleState::default()),
-        }
-    }
-
-    fn inferred_types<'db>(&'db self) -> Option<&'db InferredModuleTypes<'db>> {
-        let db = self.db.as_ref();
-        if let Some(is_available) = self.state.inference_available.get() {
-            return is_available
-                .then(|| infer_module_types(db, self.module))
-                .flatten();
-        }
-
-        let inferred = infer_module_types_bottom_up(db, self.module);
-        let _ = self.state.inference_available.set(inferred.is_some());
-        inferred
+        Self { db, module }
     }
 }
 
@@ -70,6 +47,24 @@ pub struct TypedService {
 }
 
 impl TypedService {
+    fn inferred_expression_data<'db>(
+        &'db self,
+        expression: TextRange,
+    ) -> Option<InferredTypeData<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        infer_expression_type(
+            db,
+            ExpressionTypeInput::new(db, typed_module.module, expression),
+        )
+    }
+
+    fn inferred_binding_data<'db>(&'db self, range: TextRange) -> Option<InferredTypeData<'db>> {
+        let typed_module = self.module.as_ref()?;
+        let db = typed_module.db.as_ref();
+        infer_binding_type(db, BindingTypeInput::new(db, typed_module.module, range))
+    }
+
     fn normalized_inferred_type<'db>(
         &'db self,
         ty: InferredTypeData<'db>,
@@ -87,8 +82,7 @@ impl TypedService {
     ) -> Option<InferredType<'db>> {
         let typed_module = self.module.as_ref()?;
         let db = typed_module.db.as_ref();
-        let inferred = typed_module.inferred_types()?;
-        let ty = inferred.expressions.get(&expression.range()).copied()?;
+        let ty = self.inferred_expression_data(expression.range())?;
         let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
 
         Some(InferredType::new(db, ty))
@@ -111,11 +105,7 @@ impl TypedService {
         };
 
         let db = typed_module.db.as_ref();
-        let inferred = typed_module.inferred_types()?;
-        let ty = inferred
-            .binding_type_data
-            .get(&binding.tree().syntax().text_trimmed_range())?
-            .ty;
+        let ty = self.inferred_binding_data(binding.tree().syntax().text_trimmed_range())?;
         let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
 
         Some(InferredType::new(db, ty))
@@ -128,10 +118,9 @@ impl TypedService {
     ) -> Option<InferredType<'db>> {
         let typed_module = self.module.as_ref()?;
         let db = typed_module.db.as_ref();
-        let inferred = typed_module.inferred_types()?;
         let function_ty = match function {
             AnyJsFunction::JsArrowFunctionExpression(expression) => {
-                inferred.expressions.get(&expression.range()).copied()
+                self.inferred_expression_data(expression.range())
             }
             AnyJsFunction::JsFunctionDeclaration(declaration) => declaration
                 .id()
@@ -154,7 +143,7 @@ impl TypedService {
                 }
             }
             AnyJsFunction::JsFunctionExpression(expression) => {
-                inferred.expressions.get(&expression.range()).copied()
+                self.inferred_expression_data(expression.range())
             }
         }?;
         let function = function_ty.callable_function(db)?;
@@ -172,7 +161,6 @@ impl TypedService {
     ) -> Option<InferredType<'db>> {
         let typed_module = self.module.as_ref()?;
         let db = typed_module.db.as_ref();
-        let inferred = typed_module.inferred_types()?;
         let parent_ty = member_syntax.ancestors().find_map(|ancestor| {
             if let Some(class) = JsClassDeclaration::cast(ancestor.clone()) {
                 let binding_range = class
@@ -182,16 +170,13 @@ impl TypedService {
                     .name_token()
                     .ok()?
                     .text_trimmed_range();
-                return inferred
-                    .binding_type_data
-                    .get(&binding_range)
-                    .map(|data| data.ty);
+                return self.inferred_binding_data(binding_range);
             }
             if let Some(class) = JsClassExpression::cast(ancestor.clone()) {
-                return inferred.expressions.get(&class.range()).copied();
+                return self.inferred_expression_data(class.range());
             }
             if let Some(object) = JsObjectExpression::cast(ancestor) {
-                return inferred.expressions.get(&object.range()).copied();
+                return self.inferred_expression_data(object.range());
             }
             None
         })?;
@@ -199,7 +184,7 @@ impl TypedService {
             db,
             NormalizeTypeInput::new(db, typed_module.module, parent_ty),
         );
-        let member_ty = inferred.find_member_type(db, parent_ty, member_name)?;
+        let member_ty = find_member_type(db, parent_ty, member_name)?;
         let return_ty = member_ty.callable_function(db).and_then(|function| {
             let InferredReturnType::Type(return_ty) = function.return_type(db) else {
                 return None;
@@ -212,24 +197,8 @@ impl TypedService {
     fn inferred_default_export_data<'db>(&'db self) -> Option<InferredTypeData<'db>> {
         let typed_module = self.module.as_ref()?;
         let db = typed_module.db.as_ref();
-        let inferred = typed_module.inferred_types()?;
-        let ModuleInfoKind::Js(js_info) = typed_module.module.kind(db) else {
-            return None;
-        };
-        let own_export = js_info.exports.get("default")?.as_own_export()?;
-        let ty = match own_export {
-            JsOwnExport::Binding(range) => inferred.binding_type_data.get(range)?.ty,
-            JsOwnExport::Type(resolved) if resolved.level() == TypeResolverLevel::Thin => {
-                let type_id = LocalTypeId::new(resolved.index());
-                if inferred.named_type_ids.contains(&type_id) {
-                    InferredTypeData::Local(LocalTypeHandle::new(db, inferred.module_key, type_id))
-                } else {
-                    *inferred.types.get(resolved.index())?
-                }
-            }
-            JsOwnExport::Type(_) | JsOwnExport::Namespace(_) => return None,
-        };
-        Some(ty)
+        let symbol = SymbolFromModuleInfo::new(db, "default", typed_module.module);
+        infer_export_type(db, symbol)
     }
 
     fn inferred_named_value_data<'db>(
@@ -237,7 +206,6 @@ impl TypedService {
         range: TextRange,
         name: &str,
     ) -> Option<InferredTypeData<'db>> {
-        let typed_module = self.module.as_ref()?;
         let model = self.model.as_ref()?;
         let mut scope = model.scope_for_range(range);
         let binding = loop {
@@ -246,11 +214,7 @@ impl TypedService {
             }
             scope = scope.parent()?;
         };
-        typed_module
-            .inferred_types()?
-            .binding_type_data
-            .get(&binding.tree().syntax().text_trimmed_range())
-            .map(|data| data.ty)
+        self.inferred_binding_data(binding.tree().syntax().text_trimmed_range())
     }
 
     /// Determines whether an expression has a callable member with the given name.
@@ -264,13 +228,12 @@ impl TypedService {
     ) -> Option<bool> {
         let typed_module = self.module.as_ref()?;
         let db = typed_module.db.as_ref();
-        let inferred = typed_module.inferred_types()?;
-        let ty = inferred.expressions.get(&expression.range()).copied()?;
+        let ty = self.inferred_expression_data(expression.range())?;
         let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
         if !InferredType::new(db, ty).is_inferred() {
             return None;
         }
-        let Some(member_ty) = inferred.find_value_member_type(db, ty, name) else {
+        let Some(member_ty) = find_value_member_type(db, ty, name) else {
             return Some(false);
         };
         let member_ty = normalize_type(
@@ -292,8 +255,7 @@ impl TypedService {
     ) -> Option<InferredType<'db>> {
         let typed_module = self.module.as_ref()?;
         let db = typed_module.db.as_ref();
-        let inferred = typed_module.inferred_types()?;
-        let callee_ty = inferred.expressions.get(&callee.range()).copied()?;
+        let callee_ty = self.inferred_expression_data(callee.range())?;
         let callee_ty = normalize_type(
             db,
             NormalizeTypeInput::new(db, typed_module.module, callee_ty),
@@ -306,7 +268,7 @@ impl TypedService {
                     AnyJsCallArgument::AnyJsExpression(expression) => (expression, false),
                     AnyJsCallArgument::JsSpread(spread) => (spread.argument().ok()?, true),
                 };
-                let ty = inferred.expressions.get(&expression.range()).copied()?;
+                let ty = self.inferred_expression_data(expression.range())?;
                 let ty = normalize_type(db, NormalizeTypeInput::new(db, typed_module.module, ty));
                 Some(if is_spread {
                     InferredCallArgumentType::Spread(ty)

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesInvalid.ts
@@ -1,0 +1,13 @@
+// should generate diagnostics
+async function asyncValues(): Promise<Array<Promise<void>>> {
+	return [];
+}
+function syncValues(): Promise<Array<Promise<void>>> {
+	return Promise.resolve([]);
+}
+declare const directValues: Promise<Array<Promise<void>>>;
+
+await asyncValues();
+await syncValues();
+await directValues;
+await await asyncValues();

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesInvalid.ts.snap
@@ -1,0 +1,96 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: awaitedArrayOfPromisesInvalid.ts
+---
+# Input
+```ts
+// should generate diagnostics
+async function asyncValues(): Promise<Array<Promise<void>>> {
+	return [];
+}
+function syncValues(): Promise<Array<Promise<void>>> {
+	return Promise.resolve([]);
+}
+declare const directValues: Promise<Array<Promise<void>>>;
+
+await asyncValues();
+await syncValues();
+await directValues;
+await await asyncValues();
+
+```
+
+# Diagnostics
+```
+awaitedArrayOfPromisesInvalid.ts:10:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+     8 │ declare const directValues: Promise<Array<Promise<void>>>;
+     9 │ 
+  > 10 │ await asyncValues();
+       │ ^^^^^^^^^^^^^^^^^^^^
+    11 │ await syncValues();
+    12 │ await directValues;
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+awaitedArrayOfPromisesInvalid.ts:11:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    10 │ await asyncValues();
+  > 11 │ await syncValues();
+       │ ^^^^^^^^^^^^^^^^^^^
+    12 │ await directValues;
+    13 │ await await asyncValues();
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+awaitedArrayOfPromisesInvalid.ts:12:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    10 │ await asyncValues();
+    11 │ await syncValues();
+  > 12 │ await directValues;
+       │ ^^^^^^^^^^^^^^^^^^^
+    13 │ await await asyncValues();
+    14 │ 
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+awaitedArrayOfPromisesInvalid.ts:13:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    11 │ await syncValues();
+    12 │ await directValues;
+  > 13 │ await await asyncValues();
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesValid.ts
@@ -1,0 +1,4 @@
+// should not generate diagnostics
+declare const uncertain: unknown;
+
+await uncertain;

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesValid.ts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: awaitedArrayOfPromisesValid.ts
+---
+# Input
+```ts
+// should not generate diagnostics
+declare const uncertain: unknown;
+
+await uncertain;
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -365,3 +365,10 @@ getReqP().p;
 
 declare function getReadonlyP(): Readonly<{p: Promise<void>}>;
 getReadonlyP().p;
+
+type AsyncCallback<T> = () => Promise<T>;
+declare const aliasedCallback: AsyncCallback<void>;
+aliasedCallback();
+
+declare const explicitArray: Array<number>;
+explicitArray.map(async value => value);

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -372,6 +372,13 @@ getReqP().p;
 declare function getReadonlyP(): Readonly<{p: Promise<void>}>;
 getReadonlyP().p;
 
+type AsyncCallback<T> = () => Promise<T>;
+declare const aliasedCallback: AsyncCallback<void>;
+aliasedCallback();
+
+declare const explicitArray: Array<number>;
+explicitArray.map(async value => value);
+
 ```
 
 # Diagnostics
@@ -1905,8 +1912,45 @@ invalid.ts:367:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
   > 367 │ getReadonlyP().p;
         │ ^^^^^^^^^^^^^^^^^
     368 │ 
+    369 │ type AsyncCallback<T> = () => Promise<T>;
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:371:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    369 │ type AsyncCallback<T> = () => Promise<T>;
+    370 │ declare const aliasedCallback: AsyncCallback<void>;
+  > 371 │ aliasedCallback();
+        │ ^^^^^^^^^^^^^^^^^^
+    372 │ 
+    373 │ declare const explicitArray: Array<number>;
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.ts:374:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    373 │ declare const explicitArray: Array<number>;
+  > 374 │ explicitArray.map(async value => value);
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    375 │ 
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/promiseStaticMethodsInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/promiseStaticMethodsInvalid.ts
@@ -1,0 +1,7 @@
+// should generate diagnostics
+const promises = [Promise.resolve(1), Promise.resolve(2)];
+
+Promise.allSettled(promises);
+Promise.any(promises);
+Promise.race(promises);
+Promise.try(() => 1);

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/promiseStaticMethodsInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/promiseStaticMethodsInvalid.ts.snap
@@ -1,0 +1,90 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: promiseStaticMethodsInvalid.ts
+---
+# Input
+```ts
+// should generate diagnostics
+const promises = [Promise.resolve(1), Promise.resolve(2)];
+
+Promise.allSettled(promises);
+Promise.any(promises);
+Promise.race(promises);
+Promise.try(() => 1);
+
+```
+
+# Diagnostics
+```
+promiseStaticMethodsInvalid.ts:4:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    2 │ const promises = [Promise.resolve(1), Promise.resolve(2)];
+    3 │ 
+  > 4 │ Promise.allSettled(promises);
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ Promise.any(promises);
+    6 │ Promise.race(promises);
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+promiseStaticMethodsInvalid.ts:5:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    4 │ Promise.allSettled(promises);
+  > 5 │ Promise.any(promises);
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    6 │ Promise.race(promises);
+    7 │ Promise.try(() => 1);
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+promiseStaticMethodsInvalid.ts:6:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    4 │ Promise.allSettled(promises);
+    5 │ Promise.any(promises);
+  > 6 │ Promise.race(promises);
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ Promise.try(() => 1);
+    8 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+promiseStaticMethodsInvalid.ts:7:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    5 │ Promise.any(promises);
+    6 │ Promise.race(promises);
+  > 7 │ Promise.try(() => 1);
+      │ ^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesInvalid.ts
@@ -1,0 +1,22 @@
+// should generate diagnostics
+interface Handler {
+	(): void;
+}
+
+interface AsyncHandler {
+	(): Promise<void>;
+}
+
+interface HandlerDerived extends Handler {}
+interface AsyncHandlerDerived extends AsyncHandler {}
+
+declare function consumeHandler(callback: Handler): void;
+declare function consumeInline(callback: () => void): void;
+declare function consumeInherited(callback: HandlerDerived): void;
+declare const asyncHandler: AsyncHandler;
+declare const inheritedAsyncHandler: AsyncHandlerDerived;
+
+consumeHandler(async () => {});
+consumeInline(asyncHandler);
+consumeHandler(asyncHandler);
+consumeInherited(inheritedAsyncHandler);

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesInvalid.ts
@@ -10,13 +10,19 @@ interface AsyncHandler {
 interface HandlerDerived extends Handler {}
 interface AsyncHandlerDerived extends AsyncHandler {}
 
+type AsyncObject = {
+	(): Promise<void>;
+};
+
 declare function consumeHandler(callback: Handler): void;
 declare function consumeInline(callback: () => void): void;
 declare function consumeInherited(callback: HandlerDerived): void;
 declare const asyncHandler: AsyncHandler;
 declare const inheritedAsyncHandler: AsyncHandlerDerived;
+declare const asyncObject: AsyncObject;
 
 consumeHandler(async () => {});
 consumeInline(asyncHandler);
 consumeHandler(asyncHandler);
 consumeInherited(inheritedAsyncHandler);
+consumeInline(asyncObject);

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesInvalid.ts.snap
@@ -16,31 +16,37 @@ interface AsyncHandler {
 interface HandlerDerived extends Handler {}
 interface AsyncHandlerDerived extends AsyncHandler {}
 
+type AsyncObject = {
+	(): Promise<void>;
+};
+
 declare function consumeHandler(callback: Handler): void;
 declare function consumeInline(callback: () => void): void;
 declare function consumeInherited(callback: HandlerDerived): void;
 declare const asyncHandler: AsyncHandler;
 declare const inheritedAsyncHandler: AsyncHandlerDerived;
+declare const asyncObject: AsyncObject;
 
 consumeHandler(async () => {});
 consumeInline(asyncHandler);
 consumeHandler(asyncHandler);
 consumeInherited(inheritedAsyncHandler);
+consumeInline(asyncObject);
 
 ```
 
 # Diagnostics
 ```
-callableInterfacesInvalid.ts:19:16 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+callableInterfacesInvalid.ts:24:16 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i This function returns a Promise, but no return value was expected.
   
-    17 │ declare const inheritedAsyncHandler: AsyncHandlerDerived;
-    18 │ 
-  > 19 │ consumeHandler(async () => {});
+    22 │ declare const asyncObject: AsyncObject;
+    23 │ 
+  > 24 │ consumeHandler(async () => {});
        │                ^^^^^^^^^^^^^^
-    20 │ consumeInline(asyncHandler);
-    21 │ consumeHandler(asyncHandler);
+    25 │ consumeInline(asyncHandler);
+    26 │ consumeHandler(asyncHandler);
   
   i This may not have the desired result if you expect the Promise to be `await`-ed.
   
@@ -50,15 +56,15 @@ callableInterfacesInvalid.ts:19:16 lint/nursery/noMisusedPromises ━━━━�
 ```
 
 ```
-callableInterfacesInvalid.ts:20:15 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+callableInterfacesInvalid.ts:25:15 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i This function returns a Promise, but no return value was expected.
   
-    19 │ consumeHandler(async () => {});
-  > 20 │ consumeInline(asyncHandler);
+    24 │ consumeHandler(async () => {});
+  > 25 │ consumeInline(asyncHandler);
        │               ^^^^^^^^^^^^
-    21 │ consumeHandler(asyncHandler);
-    22 │ consumeInherited(inheritedAsyncHandler);
+    26 │ consumeHandler(asyncHandler);
+    27 │ consumeInherited(inheritedAsyncHandler);
   
   i This may not have the desired result if you expect the Promise to be `await`-ed.
   
@@ -68,16 +74,16 @@ callableInterfacesInvalid.ts:20:15 lint/nursery/noMisusedPromises ━━━━�
 ```
 
 ```
-callableInterfacesInvalid.ts:21:16 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+callableInterfacesInvalid.ts:26:16 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i This function returns a Promise, but no return value was expected.
   
-    19 │ consumeHandler(async () => {});
-    20 │ consumeInline(asyncHandler);
-  > 21 │ consumeHandler(asyncHandler);
+    24 │ consumeHandler(async () => {});
+    25 │ consumeInline(asyncHandler);
+  > 26 │ consumeHandler(asyncHandler);
        │                ^^^^^^^^^^^^
-    22 │ consumeInherited(inheritedAsyncHandler);
-    23 │ 
+    27 │ consumeInherited(inheritedAsyncHandler);
+    28 │ consumeInline(asyncObject);
   
   i This may not have the desired result if you expect the Promise to be `await`-ed.
   
@@ -87,15 +93,34 @@ callableInterfacesInvalid.ts:21:16 lint/nursery/noMisusedPromises ━━━━�
 ```
 
 ```
-callableInterfacesInvalid.ts:22:18 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+callableInterfacesInvalid.ts:27:18 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i This function returns a Promise, but no return value was expected.
   
-    20 │ consumeInline(asyncHandler);
-    21 │ consumeHandler(asyncHandler);
-  > 22 │ consumeInherited(inheritedAsyncHandler);
+    25 │ consumeInline(asyncHandler);
+    26 │ consumeHandler(asyncHandler);
+  > 27 │ consumeInherited(inheritedAsyncHandler);
        │                  ^^^^^^^^^^^^^^^^^^^^^
-    23 │ 
+    28 │ consumeInline(asyncObject);
+    29 │ 
+  
+  i This may not have the desired result if you expect the Promise to be `await`-ed.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+callableInterfacesInvalid.ts:28:15 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This function returns a Promise, but no return value was expected.
+  
+    26 │ consumeHandler(asyncHandler);
+    27 │ consumeInherited(inheritedAsyncHandler);
+  > 28 │ consumeInline(asyncObject);
+       │               ^^^^^^^^^^^
+    29 │ 
   
   i This may not have the desired result if you expect the Promise to be `await`-ed.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesInvalid.ts.snap
@@ -1,0 +1,105 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: callableInterfacesInvalid.ts
+---
+# Input
+```ts
+// should generate diagnostics
+interface Handler {
+	(): void;
+}
+
+interface AsyncHandler {
+	(): Promise<void>;
+}
+
+interface HandlerDerived extends Handler {}
+interface AsyncHandlerDerived extends AsyncHandler {}
+
+declare function consumeHandler(callback: Handler): void;
+declare function consumeInline(callback: () => void): void;
+declare function consumeInherited(callback: HandlerDerived): void;
+declare const asyncHandler: AsyncHandler;
+declare const inheritedAsyncHandler: AsyncHandlerDerived;
+
+consumeHandler(async () => {});
+consumeInline(asyncHandler);
+consumeHandler(asyncHandler);
+consumeInherited(inheritedAsyncHandler);
+
+```
+
+# Diagnostics
+```
+callableInterfacesInvalid.ts:19:16 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This function returns a Promise, but no return value was expected.
+  
+    17 │ declare const inheritedAsyncHandler: AsyncHandlerDerived;
+    18 │ 
+  > 19 │ consumeHandler(async () => {});
+       │                ^^^^^^^^^^^^^^
+    20 │ consumeInline(asyncHandler);
+    21 │ consumeHandler(asyncHandler);
+  
+  i This may not have the desired result if you expect the Promise to be `await`-ed.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+callableInterfacesInvalid.ts:20:15 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This function returns a Promise, but no return value was expected.
+  
+    19 │ consumeHandler(async () => {});
+  > 20 │ consumeInline(asyncHandler);
+       │               ^^^^^^^^^^^^
+    21 │ consumeHandler(asyncHandler);
+    22 │ consumeInherited(inheritedAsyncHandler);
+  
+  i This may not have the desired result if you expect the Promise to be `await`-ed.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+callableInterfacesInvalid.ts:21:16 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This function returns a Promise, but no return value was expected.
+  
+    19 │ consumeHandler(async () => {});
+    20 │ consumeInline(asyncHandler);
+  > 21 │ consumeHandler(asyncHandler);
+       │                ^^^^^^^^^^^^
+    22 │ consumeInherited(inheritedAsyncHandler);
+    23 │ 
+  
+  i This may not have the desired result if you expect the Promise to be `await`-ed.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+callableInterfacesInvalid.ts:22:18 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This function returns a Promise, but no return value was expected.
+  
+    20 │ consumeInline(asyncHandler);
+    21 │ consumeHandler(asyncHandler);
+  > 22 │ consumeInherited(inheritedAsyncHandler);
+       │                  ^^^^^^^^^^^^^^^^^^^^^
+    23 │ 
+  
+  i This may not have the desired result if you expect the Promise to be `await`-ed.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesValid.ts
@@ -25,10 +25,22 @@ interface OverloadedExpected {
 interface CyclicA extends CyclicB {}
 interface CyclicB extends CyclicA {}
 
+type OverloadedObject = {
+	(): Promise<void>;
+	(value: string): Promise<void>;
+};
+
+type MixedObject = {
+	(): void;
+	(value: string): Promise<void>;
+};
+
 declare const overloadedActual: OverloadedActual;
 declare const mixedActual: MixedActual;
 declare const maybeAsync: Handler | AsyncHandler;
 declare const cyclicActual: CyclicA;
+declare const overloadedObject: OverloadedObject;
+declare const mixedObject: MixedObject;
 declare function consumeVoid(callback: () => void): void;
 declare function consumeOverloaded(callback: OverloadedExpected): void;
 declare function consumeUnion(callback: Handler | AsyncHandler): void;
@@ -37,5 +49,7 @@ consumeVoid(overloadedActual);
 consumeVoid(mixedActual);
 consumeVoid(maybeAsync);
 consumeVoid(cyclicActual);
+consumeVoid(overloadedObject);
+consumeVoid(mixedObject);
 consumeOverloaded(async () => {});
 consumeUnion(async () => {});

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesValid.ts
@@ -1,0 +1,41 @@
+// should not generate diagnostics
+interface Handler {
+	(): void;
+}
+
+interface AsyncHandler {
+	(): Promise<void>;
+}
+
+interface OverloadedActual {
+	(): Promise<void>;
+	(value: string): Promise<void>;
+}
+
+interface MixedActual {
+	(): void;
+	(value: string): Promise<void>;
+}
+
+interface OverloadedExpected {
+	(): void;
+	(value: string): Promise<void>;
+}
+
+interface CyclicA extends CyclicB {}
+interface CyclicB extends CyclicA {}
+
+declare const overloadedActual: OverloadedActual;
+declare const mixedActual: MixedActual;
+declare const maybeAsync: Handler | AsyncHandler;
+declare const cyclicActual: CyclicA;
+declare function consumeVoid(callback: () => void): void;
+declare function consumeOverloaded(callback: OverloadedExpected): void;
+declare function consumeUnion(callback: Handler | AsyncHandler): void;
+
+consumeVoid(overloadedActual);
+consumeVoid(mixedActual);
+consumeVoid(maybeAsync);
+consumeVoid(cyclicActual);
+consumeOverloaded(async () => {});
+consumeUnion(async () => {});

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesValid.ts.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: callableInterfacesValid.ts
+---
+# Input
+```ts
+// should not generate diagnostics
+interface Handler {
+	(): void;
+}
+
+interface AsyncHandler {
+	(): Promise<void>;
+}
+
+interface OverloadedActual {
+	(): Promise<void>;
+	(value: string): Promise<void>;
+}
+
+interface MixedActual {
+	(): void;
+	(value: string): Promise<void>;
+}
+
+interface OverloadedExpected {
+	(): void;
+	(value: string): Promise<void>;
+}
+
+interface CyclicA extends CyclicB {}
+interface CyclicB extends CyclicA {}
+
+declare const overloadedActual: OverloadedActual;
+declare const mixedActual: MixedActual;
+declare const maybeAsync: Handler | AsyncHandler;
+declare const cyclicActual: CyclicA;
+declare function consumeVoid(callback: () => void): void;
+declare function consumeOverloaded(callback: OverloadedExpected): void;
+declare function consumeUnion(callback: Handler | AsyncHandler): void;
+
+consumeVoid(overloadedActual);
+consumeVoid(mixedActual);
+consumeVoid(maybeAsync);
+consumeVoid(cyclicActual);
+consumeOverloaded(async () => {});
+consumeUnion(async () => {});
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/callableInterfacesValid.ts.snap
@@ -31,10 +31,22 @@ interface OverloadedExpected {
 interface CyclicA extends CyclicB {}
 interface CyclicB extends CyclicA {}
 
+type OverloadedObject = {
+	(): Promise<void>;
+	(value: string): Promise<void>;
+};
+
+type MixedObject = {
+	(): void;
+	(value: string): Promise<void>;
+};
+
 declare const overloadedActual: OverloadedActual;
 declare const mixedActual: MixedActual;
 declare const maybeAsync: Handler | AsyncHandler;
 declare const cyclicActual: CyclicA;
+declare const overloadedObject: OverloadedObject;
+declare const mixedObject: MixedObject;
 declare function consumeVoid(callback: () => void): void;
 declare function consumeOverloaded(callback: OverloadedExpected): void;
 declare function consumeUnion(callback: Handler | AsyncHandler): void;
@@ -43,6 +55,8 @@ consumeVoid(overloadedActual);
 consumeVoid(mixedActual);
 consumeVoid(maybeAsync);
 consumeVoid(cyclicActual);
+consumeVoid(overloadedObject);
+consumeVoid(mixedObject);
 consumeOverloaded(async () => {});
 consumeUnion(async () => {});
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/promiseStaticMethodsInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/promiseStaticMethodsInvalid.ts
@@ -1,0 +1,7 @@
+// should generate diagnostics
+const promises = [Promise.resolve(1), Promise.resolve(2)];
+
+if (Promise.allSettled(promises)) {}
+if (Promise.any(promises)) {}
+if (Promise.race(promises)) {}
+if (Promise.try(() => 1)) {}

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/promiseStaticMethodsInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/promiseStaticMethodsInvalid.ts.snap
@@ -1,0 +1,98 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: promiseStaticMethodsInvalid.ts
+---
+# Input
+```ts
+// should generate diagnostics
+const promises = [Promise.resolve(1), Promise.resolve(2)];
+
+if (Promise.allSettled(promises)) {}
+if (Promise.any(promises)) {}
+if (Promise.race(promises)) {}
+if (Promise.try(() => 1)) {}
+
+```
+
+# Diagnostics
+```
+promiseStaticMethodsInvalid.ts:4:5 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a conditional was expected.
+  
+    2 │ const promises = [Promise.resolve(1), Promise.resolve(2)];
+    3 │ 
+  > 4 │ if (Promise.allSettled(promises)) {}
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ if (Promise.any(promises)) {}
+    6 │ if (Promise.race(promises)) {}
+  
+  i A Promise is always truthy, so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+promiseStaticMethodsInvalid.ts:5:5 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a conditional was expected.
+  
+    4 │ if (Promise.allSettled(promises)) {}
+  > 5 │ if (Promise.any(promises)) {}
+      │     ^^^^^^^^^^^^^^^^^^^^^
+    6 │ if (Promise.race(promises)) {}
+    7 │ if (Promise.try(() => 1)) {}
+  
+  i A Promise is always truthy, so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+promiseStaticMethodsInvalid.ts:6:5 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a conditional was expected.
+  
+    4 │ if (Promise.allSettled(promises)) {}
+    5 │ if (Promise.any(promises)) {}
+  > 6 │ if (Promise.race(promises)) {}
+      │     ^^^^^^^^^^^^^^^^^^^^^^
+    7 │ if (Promise.try(() => 1)) {}
+    8 │ 
+  
+  i A Promise is always truthy, so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+promiseStaticMethodsInvalid.ts:7:5 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where a conditional was expected.
+  
+    5 │ if (Promise.any(promises)) {}
+    6 │ if (Promise.race(promises)) {}
+  > 7 │ if (Promise.try(() => 1)) {}
+      │     ^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i A Promise is always truthy, so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise instead.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_type_info/src/format_inferred_type_info.rs
+++ b/crates/biome_js_type_info/src/format_inferred_type_info.rs
@@ -73,7 +73,6 @@ impl<'db> Format<FormatInferredTypeContext<'db>> for TypeData<'db> {
         let db = f.context().db();
         match *self {
             Self::Unknown => write!(f, [token("unknown")]),
-            Self::Divergent(_) => write!(f, [token("divergent")]),
             Self::Global => write!(f, [token("globalThis")]),
             Self::BigInt => write!(f, [token("BigInt")]),
             Self::Boolean => write!(f, [token("boolean")]),

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -1,4 +1,5 @@
 use crate::TypeDb;
+use crate::global_types;
 use crate::interned_types::{ConditionalType, Literal, ReturnType, TypeData};
 use crate::return_type_relation::{
     ReturnTypeRelation, compare_declared_return_type_owned,
@@ -330,7 +331,12 @@ impl<'db> InferredType<'db> {
     }
 
     pub fn function_returns_void(self) -> bool {
-        self.function_return_matches(|ty| matches!(ty, TypeData::VoidKeyword))
+        self.function_return_matches(|ty| match ty {
+            TypeData::GlobalType(id) => {
+                matches!(global_types(self.db).get(id), TypeData::VoidKeyword)
+            }
+            ty => matches!(ty, TypeData::VoidKeyword),
+        })
     }
 
     /// Returns `Some(true)` when a union contains a `Promise` or `PromiseLike`
@@ -685,7 +691,18 @@ impl<'db> InferredType<'db> {
                         pending.push(constraint);
                     }
                     TypeData::GlobalType(id) => pending.push(crate::global_types(self.db).get(id)),
-                    TypeData::InstanceOf(instance) => pending.push(instance.ty(self.db)),
+                    TypeData::InstanceOf(instance) => {
+                        let target = instance.ty(self.db);
+                        if target.is_array_class(self.db) {
+                            conditional = if conditional == ConditionalType::Unknown {
+                                ConditionalType::Truthy
+                            } else {
+                                conditional.merged_with(ConditionalType::Truthy)
+                            };
+                        } else {
+                            pending.push(target);
+                        }
+                    }
                     TypeData::Intersection(intersection) => {
                         pending.extend(intersection.types(self.db).iter().copied());
                     }

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -5,6 +5,9 @@ use crate::return_type_relation::{
     ReturnTypeRelation, compare_declared_return_type_owned,
     is_escape_hatch as relation_is_escape_hatch, promise_inner as relation_promise_inner,
 };
+use crate::stringification::{
+    StringificationAnalyzer, StringificationMode, StringificationUsefulness,
+};
 use crate::type_traversal::{DepthFirstVisitor, TraversalOutcome, VisitContext};
 use biome_js_syntax::numbers::canonicalize_js_bigint_literal;
 use biome_rowan::Text;
@@ -50,19 +53,6 @@ impl fmt::Display for TypeTraversalError {
 }
 
 impl std::error::Error for TypeTraversalError {}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum StringificationMode {
-    Join,
-    ToString,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum StringificationUsefulness {
-    Always,
-    Sometimes,
-    Never,
-}
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct IgnoredPrimitiveTypes {
@@ -229,7 +219,7 @@ impl<'db> InferredType<'db> {
     /// or exceeds the promise traversal limit.
     pub fn is_array_of_promise(self) -> Option<bool> {
         let TypeData::InstanceOf(instance) = self.data else {
-            return if is_indeterminate_type(self.data) {
+            return if self.data.is_indeterminate() {
                 None
             } else {
                 Some(false)
@@ -242,7 +232,7 @@ impl<'db> InferredType<'db> {
         instance
             .type_parameters(self.db)
             .first()
-            .and_then(|ty| is_promise_instance(self.db, *ty))
+            .and_then(|ty| InferredType::new(self.db, *ty).is_promise_instance())
     }
 
     /// Returns whether this type is an array of Promises while resolving only
@@ -266,7 +256,8 @@ impl<'db> InferredType<'db> {
                         return Some(false);
                     }
                     let element = instance.type_parameters(self.db).first()?;
-                    return is_promise_instance_with(self.db, *element, &mut resolve);
+                    return InferredType::new(self.db, *element)
+                        .is_promise_instance_with(&mut resolve);
                 }
                 TypeData::MergedReference(reference) => {
                     let mut targets = reference.targets(self.db);
@@ -308,16 +299,251 @@ impl<'db> InferredType<'db> {
     /// Returns `None` when traversal encounters an unresolved or recursive type,
     /// or exceeds the promise traversal limit.
     pub fn is_promise_instance(self) -> Option<bool> {
-        is_promise_instance(self.db, self.data)
+        self.is_promise_instance_with(|data| data)
     }
 
-    /// Returns whether this type is a Promise while resolving types only as
-    /// they are reached by the Promise traversal.
+    /// Returns whether this type resolves through an instance to `Promise` or
+    /// `PromiseLike`, resolving each type only when traversal reaches it.
+    ///
+    /// `resolve` receives every type before it is inspected. `Some(true)` means
+    /// at least one traversed branch is Promise-like. `Some(false)` means every
+    /// branch was conclusively rejected. `None` means an unresolved type,
+    /// recursive path, callable ambiguity, or traversal limit prevented a
+    /// conclusive negative result.
+    ///
+    /// Traversal follows class and interface bases, generic constraints,
+    /// instances, unions, intersections, merged references, type operators,
+    /// and `typeof` wrappers. It does not resolve unrelated members or generic
+    /// arguments.
     pub fn is_promise_instance_with(
         self,
         mut resolve: impl FnMut(TypeData<'db>) -> TypeData<'db>,
     ) -> Option<bool> {
-        is_promise_instance_with(self.db, self.data, &mut resolve)
+        let mut completed = FxHashSet::default();
+        let mut pending = VecDeque::from([(self.data, Vec::new(), false, false)]);
+        let mut processed = 0;
+        let mut indeterminate = false;
+
+        while let Some((data, path, is_instance_target, is_promise_like_target)) =
+            pending.pop_front()
+        {
+            let data = resolve(data);
+            if path.contains(&data) {
+                indeterminate = true;
+                continue;
+            }
+            if !completed.insert((data, is_instance_target, is_promise_like_target)) {
+                continue;
+            }
+            if processed == MAX_PROMISE_TYPE_STEPS {
+                indeterminate = true;
+                continue;
+            }
+            processed += 1;
+
+            if is_instance_target && data.is_promise_class(self.db) {
+                return Some(true);
+            }
+            let is_named_promise_like = is_instance_target
+                && match data {
+                    TypeData::Class(class) => class
+                        .name(self.db)
+                        .as_ref()
+                        .is_some_and(|name| name.text() == "PromiseLike"),
+                    TypeData::Interface(interface) => {
+                        interface.name(self.db).text() == "PromiseLike"
+                    }
+                    _ => false,
+                };
+            let is_promise_like_target = is_promise_like_target || is_named_promise_like;
+            if is_promise_like_target {
+                let members = match data {
+                    TypeData::Class(class) => Some(class.members(self.db)),
+                    TypeData::Interface(interface) => Some(interface.members(self.db)),
+                    TypeData::Object(object) => Some(object.members(self.db)),
+                    _ => None,
+                };
+                if let Some(members) = members {
+                    for member in members
+                        .iter()
+                        .filter(|member| !member.kind.is_static() && member.kind.has_name("then"))
+                    {
+                        let member_ty = resolve(member.ty);
+                        match InferredType::new(self.db, member_ty).is_callable() {
+                            Some(true) => return Some(true),
+                            Some(false) => {}
+                            None => indeterminate = true,
+                        }
+                    }
+                }
+            }
+            if data.is_indeterminate() {
+                indeterminate = true;
+                continue;
+            }
+
+            let mut child_path = path;
+            child_path.push(data);
+            let remaining_steps = MAX_PROMISE_TYPE_STEPS - processed;
+            let available_frontier = remaining_steps.saturating_sub(pending.len());
+            match data {
+                TypeData::Class(class) => {
+                    if let Some(base) = class.extends(self.db) {
+                        if available_frontier == 0 {
+                            return None;
+                        }
+                        pending.push_back((
+                            base,
+                            child_path,
+                            is_instance_target,
+                            is_promise_like_target,
+                        ));
+                    }
+                }
+                TypeData::Generic(generic) => {
+                    if let Some(constraint) = generic.constraint(self.db) {
+                        if available_frontier == 0 {
+                            return None;
+                        }
+                        pending.push_back((
+                            constraint,
+                            child_path,
+                            is_instance_target,
+                            is_promise_like_target,
+                        ));
+                    } else {
+                        indeterminate = true;
+                    }
+                }
+                TypeData::InstanceOf(instance) => {
+                    if available_frontier == 0 {
+                        return None;
+                    }
+                    pending.push_back((
+                        instance.ty(self.db),
+                        child_path,
+                        true,
+                        is_promise_like_target,
+                    ));
+                }
+                TypeData::Interface(interface) => {
+                    if interface.extends(self.db).len() > available_frontier {
+                        return None;
+                    }
+                    pending.extend(interface.extends(self.db).iter().copied().map(|child| {
+                        (
+                            child,
+                            child_path.clone(),
+                            is_instance_target,
+                            is_promise_like_target,
+                        )
+                    }));
+                }
+                TypeData::Intersection(intersection) => {
+                    if intersection.types(self.db).len() > available_frontier {
+                        return None;
+                    }
+                    pending.extend(intersection.types(self.db).iter().copied().map(|child| {
+                        (
+                            child,
+                            child_path.clone(),
+                            is_instance_target,
+                            is_promise_like_target,
+                        )
+                    }));
+                }
+                TypeData::MergedReference(reference) => {
+                    if reference.targets(self.db).count() > available_frontier {
+                        return None;
+                    }
+                    pending.extend(reference.targets(self.db).map(|child| {
+                        (
+                            child,
+                            child_path.clone(),
+                            is_instance_target,
+                            is_promise_like_target,
+                        )
+                    }));
+                }
+                TypeData::TypeOperator(operator) => {
+                    if available_frontier == 0 {
+                        return None;
+                    }
+                    pending.push_back((
+                        operator.ty(self.db),
+                        child_path,
+                        is_instance_target,
+                        is_promise_like_target,
+                    ));
+                }
+                TypeData::TypeofType(typeof_type) => {
+                    if available_frontier == 0 {
+                        return None;
+                    }
+                    pending.push_back((
+                        typeof_type.ty(self.db),
+                        child_path,
+                        is_instance_target,
+                        is_promise_like_target,
+                    ));
+                }
+                TypeData::TypeofValue(typeof_value) => {
+                    if available_frontier == 0 {
+                        return None;
+                    }
+                    pending.push_back((
+                        typeof_value.ty(self.db),
+                        child_path,
+                        is_instance_target,
+                        is_promise_like_target,
+                    ));
+                }
+                TypeData::Union(union) => {
+                    if union.types(self.db).len() > available_frontier {
+                        return None;
+                    }
+                    pending.extend(union.types(self.db).iter().copied().map(|child| {
+                        (
+                            child,
+                            child_path.clone(),
+                            is_instance_target,
+                            is_promise_like_target,
+                        )
+                    }));
+                }
+                TypeData::Global
+                | TypeData::GlobalType(_)
+                | TypeData::BigInt
+                | TypeData::Boolean
+                | TypeData::Null
+                | TypeData::Number
+                | TypeData::String
+                | TypeData::Symbol
+                | TypeData::Undefined
+                | TypeData::Conditional
+                | TypeData::Constructor(_)
+                | TypeData::Function(_)
+                | TypeData::Module(_)
+                | TypeData::Namespace(_)
+                | TypeData::Object(_)
+                | TypeData::Tuple(_)
+                | TypeData::Literal(_)
+                | TypeData::NeverKeyword
+                | TypeData::ObjectKeyword
+                | TypeData::ThisKeyword
+                | TypeData::VoidKeyword => {}
+                TypeData::Unknown
+                | TypeData::Divergent(_)
+                | TypeData::Local(_)
+                | TypeData::TypeofExpression(_)
+                | TypeData::AnyKeyword
+                | TypeData::UnknownKeyword => {
+                    indeterminate = true;
+                }
+            }
+        }
+
+        if indeterminate { None } else { Some(false) }
     }
 
     pub fn is_function(self) -> bool {
@@ -346,7 +572,140 @@ impl<'db> InferredType<'db> {
     }
 
     pub fn is_at_least_as_wide_as_object(self) -> bool {
-        is_at_least_as_wide_as_object(self.db, self.data, &mut FxHashSet::default(), 0)
+        enum Combination {
+            Single,
+            All,
+            Any,
+        }
+
+        enum Frame<'db> {
+            Enter {
+                data: TypeData<'db>,
+                depth: usize,
+            },
+            Combine {
+                data: TypeData<'db>,
+                combination: Combination,
+                child_count: usize,
+            },
+        }
+
+        let mut active = FxHashSet::default();
+        let mut frames = vec![Frame::Enter {
+            data: self.data,
+            depth: 0,
+        }];
+        let mut results = Vec::new();
+
+        while let Some(frame) = frames.pop() {
+            match frame {
+                Frame::Enter { data, depth } => {
+                    if depth >= MAX_TYPE_RELATION_DEPTH || !active.insert(data) {
+                        results.push(true);
+                        continue;
+                    }
+
+                    let children = match data {
+                        TypeData::AnyKeyword
+                        | TypeData::Unknown
+                        | TypeData::UnknownKeyword
+                        | TypeData::ObjectKeyword
+                        | TypeData::Conditional
+                        | TypeData::TypeofExpression(_)
+                        | TypeData::TypeofType(_)
+                        | TypeData::TypeofValue(_) => None,
+                        TypeData::Object(object) => {
+                            active.remove(&data);
+                            results.push(object.members(self.db).is_empty());
+                            continue;
+                        }
+                        TypeData::Interface(interface) => {
+                            active.remove(&data);
+                            results.push(interface.members(self.db).is_empty());
+                            continue;
+                        }
+                        TypeData::Class(class) => {
+                            active.remove(&data);
+                            results.push(
+                                class
+                                    .members(self.db)
+                                    .iter()
+                                    .all(|member| member.kind.is_static()),
+                            );
+                            continue;
+                        }
+                        TypeData::Generic(generic) => {
+                            let Some(constraint) = generic.constraint(self.db) else {
+                                active.remove(&data);
+                                results.push(true);
+                                continue;
+                            };
+                            Some((Combination::Single, vec![constraint]))
+                        }
+                        TypeData::InstanceOf(instance) => {
+                            Some((Combination::Single, vec![instance.ty(self.db)]))
+                        }
+                        TypeData::Intersection(intersection) => {
+                            if intersection
+                                .types(self.db)
+                                .iter()
+                                .any(|ty| matches!(ty, TypeData::AnyKeyword))
+                            {
+                                active.remove(&data);
+                                results.push(true);
+                                continue;
+                            }
+                            Some((Combination::All, intersection.types(self.db).to_vec()))
+                        }
+                        TypeData::Union(union) => {
+                            Some((Combination::Any, union.types(self.db).to_vec()))
+                        }
+                        TypeData::MergedReference(reference) => {
+                            Some((Combination::Any, reference.targets(self.db).collect()))
+                        }
+                        _ => {
+                            active.remove(&data);
+                            results.push(false);
+                            continue;
+                        }
+                    };
+
+                    let Some((combination, children)) = children else {
+                        active.remove(&data);
+                        results.push(true);
+                        continue;
+                    };
+                    frames.push(Frame::Combine {
+                        data,
+                        combination,
+                        child_count: children.len(),
+                    });
+                    frames.extend(children.into_iter().rev().map(|data| Frame::Enter {
+                        data,
+                        depth: depth + 1,
+                    }));
+                }
+                Frame::Combine {
+                    data,
+                    combination,
+                    child_count,
+                } => {
+                    let first_child = results.len() - child_count;
+                    let result = match combination {
+                        Combination::Single => {
+                            results[first_child..].first().copied().unwrap_or(true)
+                        }
+                        Combination::All => results[first_child..].iter().all(|result| *result),
+                        Combination::Any => results[first_child..].iter().any(|result| *result),
+                    };
+                    results.truncate(first_child);
+                    results.push(result);
+                    active.remove(&data);
+                }
+            }
+        }
+
+        results.pop().unwrap_or(true)
     }
 
     pub fn promise_inner_type(self) -> Option<Self> {
@@ -372,7 +731,7 @@ impl<'db> InferredType<'db> {
     /// recursive, or exceeds the promise traversal limit.
     pub fn function_returns_promise(self) -> Option<bool> {
         let Some(function) = self.data.callable_function(self.db) else {
-            return if is_indeterminate_type(self.data) {
+            return if self.data.is_indeterminate() {
                 None
             } else {
                 Some(false)
@@ -381,7 +740,7 @@ impl<'db> InferredType<'db> {
         let ReturnType::Type(return_ty) = function.return_type(self.db) else {
             return Some(false);
         };
-        is_promise_instance(self.db, *return_ty)
+        InferredType::new(self.db, *return_ty).is_promise_instance()
     }
 
     /// Returns whether this callable returns a Promise while resolving only
@@ -407,7 +766,8 @@ impl<'db> InferredType<'db> {
                 let ReturnType::Type(return_ty) = function.return_type(self.db) else {
                     continue;
                 };
-                match is_promise_instance_with(self.db, *return_ty, &mut resolve) {
+                match InferredType::new(self.db, *return_ty).is_promise_instance_with(&mut resolve)
+                {
                     Some(true) => return Some(true),
                     Some(false) => continue,
                     None => {
@@ -465,7 +825,7 @@ impl<'db> InferredType<'db> {
     /// type, or exceeds the promise traversal limit.
     pub fn has_promise_variant(self) -> Option<bool> {
         match self.data {
-            TypeData::Union(_) => is_promise_instance(self.db, self.data),
+            TypeData::Union(_) => self.is_promise_instance(),
             _ => Some(false),
         }
     }
@@ -595,8 +955,8 @@ impl<'db> InferredType<'db> {
             TypeData::Intersection(intersection) => intersection
                 .types(self.db)
                 .iter()
-                .all(|ty| is_object_like(self.db, *ty)),
-            data => is_object_like(self.db, data),
+                .all(|ty| ty.is_object_like(self.db)),
+            data => data.is_object_like(self.db),
         })
         .unwrap_or(false)
     }
@@ -625,8 +985,8 @@ impl<'db> InferredType<'db> {
         .unwrap_or(false)
     }
 
-    pub fn plus_operand_description(self) -> String {
-        type_description(self.db, self.data)
+    pub fn plus_operand_description(self) -> &'static str {
+        self.data.type_description(self.db)
     }
 
     /// Returns the deduplicated switch-case variants represented by this type.
@@ -703,8 +1063,7 @@ impl<'db> InferredType<'db> {
         mode: StringificationMode,
         ignored_type_names: &[&str],
     ) -> StringificationUsefulness {
-        let mut active = FxHashSet::default();
-        stringification_usefulness(self.db, self.data, mode, ignored_type_names, &mut active, 0)
+        StringificationAnalyzer::new(self.db, ignored_type_names).analyze(self.data, mode)
     }
 
     pub fn could_equal_string_literal(self, value: &str) -> bool {
@@ -1121,7 +1480,7 @@ where
                 };
                 context.push(constraint);
             }
-            data if is_indeterminate_type(data) => self.indeterminate = true,
+            data if data.is_indeterminate() => self.indeterminate = true,
             _ if (self.predicate)(data) => self.saw_variant = true,
             _ => return ControlFlow::Break(false),
         }
@@ -1176,7 +1535,7 @@ where
             TypeData::TypeofType(typeof_type) => context.push(typeof_type.ty(self.db)),
             TypeData::TypeofValue(typeof_value) => context.push(typeof_value.ty(self.db)),
             TypeData::Union(union) => context.extend(union.types(self.db).iter().copied()),
-            data if is_indeterminate_type(data) => self.indeterminate = true,
+            data if data.is_indeterminate() => self.indeterminate = true,
             data if (self.predicate)(data) => return ControlFlow::Break(true),
             _ => {}
         }
@@ -1185,673 +1544,13 @@ where
     }
 }
 
-fn is_at_least_as_wide_as_object<'db>(
-    db: &'db dyn TypeDb,
-    ty: TypeData<'db>,
-    seen: &mut FxHashSet<TypeData<'db>>,
-    depth: usize,
-) -> bool {
-    if depth >= MAX_TYPE_RELATION_DEPTH || !seen.insert(ty) {
-        return true;
-    }
-    let result = match ty {
-        TypeData::AnyKeyword
-        | TypeData::Unknown
-        | TypeData::UnknownKeyword
-        | TypeData::ObjectKeyword
-        | TypeData::Conditional
-        | TypeData::TypeofExpression(_)
-        | TypeData::TypeofType(_)
-        | TypeData::TypeofValue(_) => true,
-        TypeData::Object(object) => object.members(db).is_empty(),
-        TypeData::Interface(interface) => interface.members(db).is_empty(),
-        TypeData::Class(class) => class
-            .members(db)
-            .iter()
-            .all(|member| member.kind.is_static()),
-        TypeData::Generic(generic) => generic
-            .constraint(db)
-            .is_none_or(|ty| is_at_least_as_wide_as_object(db, ty, seen, depth + 1)),
-        TypeData::InstanceOf(instance) => {
-            is_at_least_as_wide_as_object(db, instance.ty(db), seen, depth + 1)
-        }
-        TypeData::Intersection(intersection) => {
-            intersection
-                .types(db)
-                .iter()
-                .any(|ty| matches!(ty, TypeData::AnyKeyword))
-                || intersection
-                    .types(db)
-                    .iter()
-                    .all(|ty| is_at_least_as_wide_as_object(db, *ty, seen, depth + 1))
-        }
-        TypeData::Union(union) => union
-            .types(db)
-            .iter()
-            .any(|ty| is_at_least_as_wide_as_object(db, *ty, seen, depth + 1)),
-        TypeData::MergedReference(reference) => reference
-            .targets(db)
-            .any(|ty| is_at_least_as_wide_as_object(db, ty, seen, depth + 1)),
-        _ => false,
-    };
-    seen.remove(&ty);
-    result
-}
-
-fn stringification_usefulness<'db>(
-    db: &'db dyn TypeDb,
-    data: TypeData<'db>,
-    mode: StringificationMode,
-    ignored_type_names: &[&str],
-    active: &mut FxHashSet<TypeData<'db>>,
-    depth: usize,
-) -> StringificationUsefulness {
-    use StringificationUsefulness::Always;
-
-    if depth >= MAX_TYPE_VARIANT_STEPS || !active.insert(data) {
-        return Always;
-    }
-
-    let result = if let TypeData::Generic(generic) = data {
-        generic.constraint(db).map_or(Always, |constraint| {
-            stringification_usefulness(db, constraint, mode, ignored_type_names, active, depth + 1)
-        })
-    } else if matches!(mode, StringificationMode::ToString) {
-        match is_ignored_stringification_type(db, data, ignored_type_names) {
-            None | Some(true) => Always,
-            Some(false) if is_safe_stringification_type(db, data) => Always,
-            Some(false) => stringification_usefulness_unignored(
-                db,
-                data,
-                mode,
-                ignored_type_names,
-                active,
-                depth,
-            ),
-        }
-    } else {
-        stringification_usefulness_unignored(db, data, mode, ignored_type_names, active, depth)
-    };
-
-    active.remove(&data);
-    result
-}
-
-fn stringification_usefulness_unignored<'db>(
-    db: &'db dyn TypeDb,
-    data: TypeData<'db>,
-    mode: StringificationMode,
-    ignored_type_names: &[&str],
-    active: &mut FxHashSet<TypeData<'db>>,
-    depth: usize,
-) -> StringificationUsefulness {
-    use StringificationUsefulness::{Always, Never};
-
-    match data {
-        TypeData::Union(union) => combine_stringification_union(union.types(db).iter().map(|ty| {
-            stringification_usefulness(db, *ty, mode, ignored_type_names, active, depth + 1)
-        })),
-        TypeData::Intersection(intersection) => {
-            combine_stringification_intersection(intersection.types(db).iter().map(|ty| {
-                stringification_usefulness(db, *ty, mode, ignored_type_names, active, depth + 1)
-            }))
-        }
-        TypeData::Tuple(tuple) => {
-            combine_stringification_tuple(tuple.elements(db).iter().map(|element| {
-                stringification_usefulness(
-                    db,
-                    element.ty,
-                    StringificationMode::ToString,
-                    ignored_type_names,
-                    active,
-                    depth + 1,
-                )
-            }))
-        }
-        TypeData::InstanceOf(instance) if instance.ty(db).is_array_class(db) => instance
-            .type_parameters(db)
-            .first()
-            .map_or(Always, |element| {
-                stringification_usefulness(
-                    db,
-                    *element,
-                    StringificationMode::ToString,
-                    ignored_type_names,
-                    active,
-                    depth + 1,
-                )
-            }),
-        TypeData::InstanceOf(instance) => stringification_usefulness(
-            db,
-            instance.ty(db),
-            mode,
-            ignored_type_names,
-            active,
-            depth + 1,
-        ),
-        _ if matches!(mode, StringificationMode::Join) => Always,
-        _ => match uses_base_object_stringification(db, data, &mut FxHashSet::default(), depth + 1)
-        {
-            Some(true) => Never,
-            Some(false) | None => Always,
-        },
-    }
-}
-
-fn combine_stringification_union(
-    usefulness: impl Iterator<Item = StringificationUsefulness>,
-) -> StringificationUsefulness {
-    let mut combined = None;
-    for usefulness in usefulness {
-        match combined {
-            None => combined = Some(usefulness),
-            Some(existing) if existing == usefulness => {}
-            Some(_) => return StringificationUsefulness::Sometimes,
-        }
-    }
-    combined.unwrap_or(StringificationUsefulness::Always)
-}
-
-fn combine_stringification_intersection(
-    usefulness: impl Iterator<Item = StringificationUsefulness>,
-) -> StringificationUsefulness {
-    if usefulness
-        .into_iter()
-        .any(|usefulness| usefulness == StringificationUsefulness::Always)
-    {
-        StringificationUsefulness::Always
-    } else {
-        StringificationUsefulness::Never
-    }
-}
-
-fn combine_stringification_tuple(
-    usefulness: impl Iterator<Item = StringificationUsefulness>,
-) -> StringificationUsefulness {
-    let mut saw_sometimes = false;
-    for usefulness in usefulness {
-        match usefulness {
-            StringificationUsefulness::Always => {}
-            StringificationUsefulness::Sometimes => saw_sometimes = true,
-            StringificationUsefulness::Never => return StringificationUsefulness::Never,
-        }
-    }
-    if saw_sometimes {
-        StringificationUsefulness::Sometimes
-    } else {
-        StringificationUsefulness::Always
-    }
-}
-
-fn is_safe_stringification_type<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> bool {
-    match data {
-        TypeData::AnyKeyword
-        | TypeData::BigInt
-        | TypeData::Boolean
-        | TypeData::Function(_)
-        | TypeData::Null
-        | TypeData::Number
-        | TypeData::String
-        | TypeData::Symbol
-        | TypeData::Undefined
-        | TypeData::Unknown
-        | TypeData::UnknownKeyword
-        | TypeData::NeverKeyword
-        | TypeData::VoidKeyword => true,
-        TypeData::Literal(literal) => matches!(
-            literal.literal(db),
-            Literal::BigInt(_)
-                | Literal::Boolean(_)
-                | Literal::Number(_)
-                | Literal::String(_)
-                | Literal::Template(_)
-        ),
-        _ => false,
-    }
-}
-
-fn is_ignored_stringification_type<'db>(
-    db: &'db dyn TypeDb,
-    data: TypeData<'db>,
-    ignored_type_names: &[&str],
-) -> Option<bool> {
-    let mut seen = FxHashSet::default();
-    let mut pending = vec![data];
-    let mut remaining_steps = MAX_TYPE_VARIANT_STEPS;
-
-    while let Some(data) = pending.pop() {
-        if !seen.insert(data) {
-            continue;
-        }
-        if remaining_steps == 0 {
-            return None;
-        }
-        remaining_steps -= 1;
-
-        let name = match data {
-            TypeData::Class(class) => class.name(db).as_ref().map(Text::text),
-            TypeData::Generic(generic) => Some(generic.name(db).text()),
-            TypeData::Interface(interface) => Some(interface.name(db).text()),
-            TypeData::Literal(literal) if matches!(literal.literal(db), Literal::RegExp(_)) => {
-                Some("RegExp")
-            }
-            TypeData::TypeofValue(value) => Some(value.identifier(db).text()),
-            _ => None,
-        };
-        if name.is_some_and(|name| ignored_type_names.contains(&name)) {
-            return Some(true);
-        }
-
-        match data {
-            TypeData::Class(class) => pending.extend(class.extends(db)),
-            TypeData::Generic(generic) => pending.extend(generic.constraint(db)),
-            TypeData::InstanceOf(instance) => pending.push(instance.ty(db)),
-            TypeData::Interface(interface) => {
-                pending.extend(interface.extends(db).iter().copied());
-            }
-            TypeData::MergedReference(reference) => pending.extend(reference.targets(db)),
-            TypeData::TypeOperator(operator) => pending.push(operator.ty(db)),
-            TypeData::TypeofType(typeof_type) => pending.push(typeof_type.ty(db)),
-            TypeData::TypeofValue(typeof_value) => pending.push(typeof_value.ty(db)),
-            _ => {}
-        }
-    }
-
-    Some(false)
-}
-
-fn uses_base_object_stringification<'db>(
-    db: &'db dyn TypeDb,
-    data: TypeData<'db>,
-    active: &mut FxHashSet<TypeData<'db>>,
-    depth: usize,
-) -> Option<bool> {
-    if depth >= MAX_TYPE_VARIANT_STEPS || !active.insert(data) {
-        return Some(false);
-    }
-
-    let result = match data {
-        TypeData::Class(class) => {
-            if has_custom_stringification_member(class.members(db)) {
-                Some(false)
-            } else if let Some(base) = class.extends(db) {
-                uses_base_object_stringification(db, base, active, depth + 1)
-            } else {
-                Some(true)
-            }
-        }
-        TypeData::InstanceOf(instance) => {
-            uses_base_object_stringification(db, instance.ty(db), active, depth + 1)
-        }
-        TypeData::Interface(interface) => {
-            if has_custom_stringification_member(interface.members(db)) {
-                Some(false)
-            } else if interface.extends(db).is_empty() {
-                Some(true)
-            } else {
-                combine_base_stringification(
-                    interface
-                        .extends(db)
-                        .iter()
-                        .map(|base| uses_base_object_stringification(db, *base, active, depth + 1)),
-                )
-            }
-        }
-        TypeData::Literal(literal) => match literal.literal(db) {
-            Literal::Object(members) => Some(!has_custom_stringification_member(members)),
-            Literal::RegExp(_) => Some(true),
-            _ => Some(false),
-        },
-        TypeData::MergedReference(reference) => combine_base_stringification(
-            reference
-                .targets(db)
-                .map(|target| uses_base_object_stringification(db, target, active, depth + 1)),
-        ),
-        TypeData::Object(object) => Some(!has_custom_stringification_member(object.members(db))),
-        TypeData::ObjectKeyword => Some(true),
-        TypeData::TypeofValue(value) => {
-            uses_base_object_stringification(db, value.ty(db), active, depth + 1)
-        }
-        _ => None,
-    };
-
-    active.remove(&data);
-    result
-}
-
-fn combine_base_stringification(results: impl Iterator<Item = Option<bool>>) -> Option<bool> {
-    let mut saw_true = false;
-    for result in results {
-        match result {
-            Some(false) => return Some(false),
-            Some(true) => saw_true = true,
-            None => {}
-        }
-    }
-    saw_true.then_some(true)
-}
-
-fn has_custom_stringification_member(members: &[crate::interned_types::TypeMember<'_>]) -> bool {
-    members.iter().any(|member| {
-        ["toLocaleString", "toString", "valueOf"]
-            .iter()
-            .any(|name| member.kind.has_name(name))
-    })
-}
-
-fn is_promise_instance<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> Option<bool> {
-    is_promise_instance_with(db, data, &mut |data| data)
-}
-
-fn is_promise_instance_with<'db>(
-    db: &'db dyn TypeDb,
-    data: TypeData<'db>,
-    resolve: &mut impl FnMut(TypeData<'db>) -> TypeData<'db>,
-) -> Option<bool> {
-    let mut completed = FxHashSet::default();
-    let mut pending = VecDeque::from([(data, Vec::new(), false, false)]);
-    let mut processed = 0;
-    let mut indeterminate = false;
-
-    while let Some((data, path, is_instance_target, is_promise_like_target)) = pending.pop_front() {
-        let data = resolve(data);
-        if path.contains(&data) {
-            indeterminate = true;
-            continue;
-        }
-        if !completed.insert((data, is_instance_target, is_promise_like_target)) {
-            continue;
-        }
-        if processed == MAX_PROMISE_TYPE_STEPS {
-            indeterminate = true;
-            continue;
-        }
-        processed += 1;
-
-        if is_instance_target && data.is_promise_class(db) {
-            return Some(true);
-        }
-        let is_named_promise_like = is_instance_target
-            && match data {
-                TypeData::Class(class) => class
-                    .name(db)
-                    .as_ref()
-                    .is_some_and(|name| name.text() == "PromiseLike"),
-                TypeData::Interface(interface) => interface.name(db).text() == "PromiseLike",
-                _ => false,
-            };
-        let is_promise_like_target = is_promise_like_target || is_named_promise_like;
-        if is_promise_like_target {
-            let members = match data {
-                TypeData::Class(class) => Some(class.members(db)),
-                TypeData::Interface(interface) => Some(interface.members(db)),
-                TypeData::Object(object) => Some(object.members(db)),
-                _ => None,
-            };
-            if let Some(members) = members {
-                for member in members
-                    .iter()
-                    .filter(|member| !member.kind.is_static() && member.kind.has_name("then"))
-                {
-                    let member_ty = resolve(member.ty);
-                    match InferredType::new(db, member_ty).is_callable() {
-                        Some(true) => return Some(true),
-                        Some(false) => {}
-                        None => indeterminate = true,
-                    }
-                }
-            }
-        }
-        if is_indeterminate_type(data) {
-            indeterminate = true;
-            continue;
-        }
-
-        let mut child_path = path;
-        child_path.push(data);
-        let remaining_steps = MAX_PROMISE_TYPE_STEPS - processed;
-        let available_frontier = remaining_steps.saturating_sub(pending.len());
-        match data {
-            TypeData::Class(class) => {
-                if let Some(base) = class.extends(db) {
-                    if available_frontier == 0 {
-                        return None;
-                    }
-                    pending.push_back((
-                        base,
-                        child_path,
-                        is_instance_target,
-                        is_promise_like_target,
-                    ));
-                }
-            }
-            TypeData::Generic(generic) => {
-                if let Some(constraint) = generic.constraint(db) {
-                    if available_frontier == 0 {
-                        return None;
-                    }
-                    pending.push_back((
-                        constraint,
-                        child_path,
-                        is_instance_target,
-                        is_promise_like_target,
-                    ));
-                } else {
-                    indeterminate = true;
-                }
-            }
-            TypeData::InstanceOf(instance) => {
-                if available_frontier == 0 {
-                    return None;
-                }
-                pending.push_back((instance.ty(db), child_path, true, is_promise_like_target));
-            }
-            TypeData::Interface(interface) => {
-                if interface.extends(db).len() > available_frontier {
-                    return None;
-                }
-                pending.extend(interface.extends(db).iter().copied().map(|child| {
-                    (
-                        child,
-                        child_path.clone(),
-                        is_instance_target,
-                        is_promise_like_target,
-                    )
-                }));
-            }
-            TypeData::Intersection(intersection) => {
-                if intersection.types(db).len() > available_frontier {
-                    return None;
-                }
-                pending.extend(intersection.types(db).iter().copied().map(|child| {
-                    (
-                        child,
-                        child_path.clone(),
-                        is_instance_target,
-                        is_promise_like_target,
-                    )
-                }));
-            }
-            TypeData::MergedReference(reference) => {
-                if reference.targets(db).count() > available_frontier {
-                    return None;
-                }
-                pending.extend(reference.targets(db).map(|child| {
-                    (
-                        child,
-                        child_path.clone(),
-                        is_instance_target,
-                        is_promise_like_target,
-                    )
-                }));
-            }
-            TypeData::TypeOperator(operator) => {
-                if available_frontier == 0 {
-                    return None;
-                }
-                pending.push_back((
-                    operator.ty(db),
-                    child_path,
-                    is_instance_target,
-                    is_promise_like_target,
-                ));
-            }
-            TypeData::TypeofType(typeof_type) => {
-                if available_frontier == 0 {
-                    return None;
-                }
-                pending.push_back((
-                    typeof_type.ty(db),
-                    child_path,
-                    is_instance_target,
-                    is_promise_like_target,
-                ));
-            }
-            TypeData::TypeofValue(typeof_value) => {
-                if available_frontier == 0 {
-                    return None;
-                }
-                pending.push_back((
-                    typeof_value.ty(db),
-                    child_path,
-                    is_instance_target,
-                    is_promise_like_target,
-                ));
-            }
-            TypeData::Union(union) => {
-                if union.types(db).len() > available_frontier {
-                    return None;
-                }
-                pending.extend(union.types(db).iter().copied().map(|child| {
-                    (
-                        child,
-                        child_path.clone(),
-                        is_instance_target,
-                        is_promise_like_target,
-                    )
-                }));
-            }
-            TypeData::Global
-            | TypeData::GlobalType(_)
-            | TypeData::BigInt
-            | TypeData::Boolean
-            | TypeData::Null
-            | TypeData::Number
-            | TypeData::String
-            | TypeData::Symbol
-            | TypeData::Undefined
-            | TypeData::Conditional
-            | TypeData::Constructor(_)
-            | TypeData::Function(_)
-            | TypeData::Module(_)
-            | TypeData::Namespace(_)
-            | TypeData::Object(_)
-            | TypeData::Tuple(_)
-            | TypeData::Literal(_)
-            | TypeData::NeverKeyword
-            | TypeData::ObjectKeyword
-            | TypeData::ThisKeyword
-            | TypeData::VoidKeyword => {}
-            TypeData::Unknown
-            | TypeData::Divergent(_)
-            | TypeData::Local(_)
-            | TypeData::TypeofExpression(_)
-            | TypeData::AnyKeyword
-            | TypeData::UnknownKeyword => {
-                indeterminate = true;
-            }
-        }
-    }
-
-    if indeterminate { None } else { Some(false) }
-}
-
-const fn is_indeterminate_type(data: TypeData<'_>) -> bool {
-    matches!(
-        data,
-        TypeData::Unknown
-            | TypeData::Divergent(_)
-            | TypeData::Local(_)
-            | TypeData::TypeofExpression(_)
-            | TypeData::AnyKeyword
-            | TypeData::UnknownKeyword
-    )
-}
-
-fn is_object_like<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> bool {
-    match data {
-        TypeData::Class(_)
-        | TypeData::Constructor(_)
-        | TypeData::Function(_)
-        | TypeData::Interface(_)
-        | TypeData::Module(_)
-        | TypeData::Namespace(_)
-        | TypeData::Object(_)
-        | TypeData::ObjectKeyword
-        | TypeData::Tuple(_) => true,
-        TypeData::InstanceOf(instance) => is_object_like(db, instance.ty(db)),
-        _ => false,
-    }
-}
-
-fn type_description<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> String {
-    match data {
-        TypeData::Unknown | TypeData::UnknownKeyword | TypeData::Divergent(_) => "unknown".into(),
-        TypeData::AnyKeyword => "any".into(),
-        TypeData::NeverKeyword => "never".into(),
-        TypeData::Null => "null".into(),
-        TypeData::Undefined | TypeData::VoidKeyword => "undefined".into(),
-        TypeData::Boolean => "boolean".into(),
-        TypeData::Number => "number".into(),
-        TypeData::String => "string".into(),
-        TypeData::BigInt => "bigint".into(),
-        TypeData::Symbol => "symbol".into(),
-        TypeData::ObjectKeyword | TypeData::Object(_) => "object".into(),
-        TypeData::Interface(_) => "interface".into(),
-        TypeData::Class(_) => "class".into(),
-        TypeData::Function(_) => "function".into(),
-        TypeData::Tuple(_) => "tuple".into(),
-        TypeData::Module(_) | TypeData::Namespace(_) => "namespace".into(),
-        TypeData::Constructor(_) => "constructor".into(),
-        TypeData::InstanceOf(instance) => type_description(db, instance.ty(db)),
-        TypeData::Intersection(intersection) => intersection
-            .types(db)
-            .iter()
-            .map(|ty| type_description(db, *ty))
-            .collect::<Vec<_>>()
-            .join(" & "),
-        TypeData::Union(union) => union
-            .types(db)
-            .iter()
-            .map(|ty| type_description(db, *ty))
-            .collect::<Vec<_>>()
-            .join(" | "),
-        TypeData::Literal(literal) => match literal.literal(db) {
-            Literal::BigInt(_) => "bigint".into(),
-            Literal::Boolean(_) => "boolean".into(),
-            Literal::Number(_) => "number".into(),
-            Literal::String(_) | Literal::Template(_) => "string".into(),
-            Literal::Object(_) => "object".into(),
-            Literal::RegExp(_) => "RegExp".into(),
-        },
-        TypeData::Generic(_)
-        | TypeData::Local(_)
-        | TypeData::MergedReference(_)
-        | TypeData::TypeOperator(_)
-        | TypeData::TypeofExpression(_)
-        | TypeData::TypeofType(_)
-        | TypeData::TypeofValue(_)
-        | TypeData::Conditional
-        | TypeData::Global
-        | TypeData::GlobalType(_)
-        | TypeData::ThisKeyword => format!("{data:?}"),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::interned_types::{InternedLiteral, InternedUnion};
+    use crate::interned_types::{
+        InternedIntersection, InternedLiteral, InternedObject, InternedUnion, TypeMember,
+        TypeMemberKind,
+    };
 
     #[salsa::db]
     #[derive(Default)]
@@ -1949,5 +1648,93 @@ mod tests {
         assert_eq!(union.has_nullish_variant(), Some(true));
         assert_eq!(union.has_undefined_variant(), None);
         assert_eq!(union.is_safe_for_nullish_coalescing(), None);
+    }
+
+    #[test]
+    fn type_data_inspection_uses_static_categories() {
+        let db = TestDb::default();
+        let union = TypeData::Union(InternedUnion::new(
+            &db,
+            Vec::from([TypeData::String, TypeData::Number]).into_boxed_slice(),
+        ));
+
+        assert!(TypeData::Unknown.is_indeterminate());
+        assert!(TypeData::AnyKeyword.is_indeterminate());
+        assert!(!TypeData::ObjectKeyword.is_indeterminate());
+        assert!(TypeData::ObjectKeyword.is_object_like(&db));
+        assert!(!TypeData::String.is_object_like(&db));
+        assert_eq!(TypeData::String.type_description(&db), "string");
+        assert_eq!(union.type_description(&db), "union");
+    }
+
+    #[test]
+    fn custom_stringification_members_are_name_based() {
+        let custom = TypeMember {
+            kind: TypeMemberKind::Named(Text::new_static("toString")),
+            ty: TypeData::String,
+        };
+        let regular = TypeMember {
+            kind: TypeMemberKind::Named(Text::new_static("serialize")),
+            ty: TypeData::String,
+        };
+
+        assert!(custom.is_custom_stringification_member());
+        assert!(!regular.is_custom_stringification_member());
+    }
+
+    #[test]
+    fn stringification_combines_compound_types_iteratively() {
+        let db = TestDb::default();
+        let object = TypeData::Object(InternedObject::new(&db, None, Box::default()));
+        let custom_object = TypeData::Object(InternedObject::new(
+            &db,
+            None,
+            Vec::from([TypeMember {
+                kind: TypeMemberKind::Named(Text::new_static("toString")),
+                ty: TypeData::String,
+            }])
+            .into_boxed_slice(),
+        ));
+        let union = TypeData::Union(InternedUnion::new(
+            &db,
+            Vec::from([TypeData::String, object]).into_boxed_slice(),
+        ));
+
+        assert_eq!(
+            InferredType::new(&db, object)
+                .stringification_usefulness(StringificationMode::ToString, &[]),
+            StringificationUsefulness::Never
+        );
+        assert_eq!(
+            InferredType::new(&db, custom_object)
+                .stringification_usefulness(StringificationMode::ToString, &[]),
+            StringificationUsefulness::Always
+        );
+        assert_eq!(
+            InferredType::new(&db, union)
+                .stringification_usefulness(StringificationMode::ToString, &[]),
+            StringificationUsefulness::Sometimes
+        );
+    }
+
+    #[test]
+    fn object_width_combines_compound_types_iteratively() {
+        let db = TestDb::default();
+        let union = TypeData::Union(InternedUnion::new(
+            &db,
+            Vec::from([TypeData::Number, TypeData::ObjectKeyword]).into_boxed_slice(),
+        ));
+        let narrow_intersection = TypeData::Intersection(InternedIntersection::new(
+            &db,
+            Vec::from([TypeData::ObjectKeyword, TypeData::Number]).into_boxed_slice(),
+        ));
+        let any_intersection = TypeData::Intersection(InternedIntersection::new(
+            &db,
+            Vec::from([TypeData::AnyKeyword, TypeData::Number]).into_boxed_slice(),
+        ));
+
+        assert!(InferredType::new(&db, union).is_at_least_as_wide_as_object());
+        assert!(!InferredType::new(&db, narrow_intersection).is_at_least_as_wide_as_object());
+        assert!(InferredType::new(&db, any_intersection).is_at_least_as_wide_as_object());
     }
 }

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -245,6 +245,55 @@ impl<'db> InferredType<'db> {
             .and_then(|ty| is_promise_instance(self.db, *ty))
     }
 
+    /// Returns whether this type is an array of Promises while resolving only
+    /// its outer wrappers and element type.
+    pub fn is_array_of_promise_with(
+        self,
+        mut resolve: impl FnMut(TypeData<'db>) -> TypeData<'db>,
+    ) -> Option<bool> {
+        let mut data = self.data;
+        let mut seen = FxHashSet::default();
+
+        for _ in 0..MAX_PROMISE_TYPE_STEPS {
+            data = resolve(data).expand_structural_global(self.db);
+            if !seen.insert(data) {
+                return None;
+            }
+
+            data = match data {
+                TypeData::InstanceOf(instance) => {
+                    if !instance.ty(self.db).is_array_class(self.db) {
+                        return Some(false);
+                    }
+                    let element = instance.type_parameters(self.db).first()?;
+                    return is_promise_instance_with(self.db, *element, &mut resolve);
+                }
+                TypeData::MergedReference(reference) => {
+                    let mut targets = reference.targets(self.db);
+                    let Some(first) = targets.next() else {
+                        return Some(false);
+                    };
+                    if targets.all(|target| target == first) {
+                        first
+                    } else {
+                        return Some(false);
+                    }
+                }
+                TypeData::TypeofType(typeof_type) => typeof_type.ty(self.db),
+                TypeData::TypeofValue(typeof_value) => typeof_value.ty(self.db),
+                TypeData::Unknown
+                | TypeData::Divergent(_)
+                | TypeData::Local(_)
+                | TypeData::TypeofExpression(_)
+                | TypeData::AnyKeyword
+                | TypeData::UnknownKeyword => return None,
+                _ => return Some(false),
+            };
+        }
+
+        None
+    }
+
     pub fn is_disposable(self) -> bool {
         self.has_computed_member("Symbol.dispose")
     }
@@ -260,6 +309,15 @@ impl<'db> InferredType<'db> {
     /// or exceeds the promise traversal limit.
     pub fn is_promise_instance(self) -> Option<bool> {
         is_promise_instance(self.db, self.data)
+    }
+
+    /// Returns whether this type is a Promise while resolving types only as
+    /// they are reached by the Promise traversal.
+    pub fn is_promise_instance_with(
+        self,
+        mut resolve: impl FnMut(TypeData<'db>) -> TypeData<'db>,
+    ) -> Option<bool> {
+        is_promise_instance_with(self.db, self.data, &mut resolve)
     }
 
     pub fn is_function(self) -> bool {
@@ -324,6 +382,67 @@ impl<'db> InferredType<'db> {
             return Some(false);
         };
         is_promise_instance(self.db, *return_ty)
+    }
+
+    /// Returns whether this callable returns a Promise while resolving only
+    /// its outer callable wrappers and return type.
+    pub fn function_returns_promise_with(
+        self,
+        mut resolve: impl FnMut(TypeData<'db>) -> TypeData<'db>,
+    ) -> Option<bool> {
+        let mut pending = VecDeque::from([self.data]);
+        let mut seen = FxHashSet::default();
+        let mut indeterminate = false;
+
+        for _ in 0..MAX_PROMISE_TYPE_STEPS {
+            let Some(data) = pending.pop_front() else {
+                return if indeterminate { None } else { Some(false) };
+            };
+            let data = resolve(data).expand_structural_global(self.db);
+            if !seen.insert(data) {
+                indeterminate = true;
+                continue;
+            }
+            if let Some(function) = data.callable_function(self.db) {
+                let ReturnType::Type(return_ty) = function.return_type(self.db) else {
+                    continue;
+                };
+                match is_promise_instance_with(self.db, *return_ty, &mut resolve) {
+                    Some(true) => return Some(true),
+                    Some(false) => continue,
+                    None => {
+                        indeterminate = true;
+                        continue;
+                    }
+                }
+            }
+
+            match data {
+                TypeData::InstanceOf(instance) => pending.push_back(instance.ty(self.db)),
+                TypeData::MergedReference(reference) => {
+                    pending.extend(reference.targets(self.db));
+                }
+                TypeData::TypeofType(typeof_type) => pending.push_back(typeof_type.ty(self.db)),
+                TypeData::TypeofValue(typeof_value) => pending.push_back(typeof_value.ty(self.db)),
+                TypeData::Union(union) => {
+                    if union.types(self.db).len() > MAX_PROMISE_TYPE_STEPS - seen.len() {
+                        return None;
+                    }
+                    pending.extend(union.types(self.db).iter().copied());
+                }
+                TypeData::Unknown
+                | TypeData::Divergent(_)
+                | TypeData::Local(_)
+                | TypeData::TypeofExpression(_)
+                | TypeData::AnyKeyword
+                | TypeData::UnknownKeyword => {
+                    indeterminate = true;
+                }
+                _ => {}
+            }
+        }
+
+        None
     }
 
     pub fn function_returns_conditional(self) -> bool {
@@ -1421,12 +1540,21 @@ fn has_custom_stringification_member(members: &[crate::interned_types::TypeMembe
 }
 
 fn is_promise_instance<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> Option<bool> {
+    is_promise_instance_with(db, data, &mut |data| data)
+}
+
+fn is_promise_instance_with<'db>(
+    db: &'db dyn TypeDb,
+    data: TypeData<'db>,
+    resolve: &mut impl FnMut(TypeData<'db>) -> TypeData<'db>,
+) -> Option<bool> {
     let mut completed = FxHashSet::default();
     let mut pending = VecDeque::from([(data, Vec::new(), false, false)]);
     let mut processed = 0;
     let mut indeterminate = false;
 
     while let Some((data, path, is_instance_target, is_promise_like_target)) = pending.pop_front() {
+        let data = resolve(data);
         if path.contains(&data) {
             indeterminate = true;
             continue;
@@ -1465,7 +1593,8 @@ fn is_promise_instance<'db>(db: &'db dyn TypeDb, data: TypeData<'db>) -> Option<
                     .iter()
                     .filter(|member| !member.kind.is_static() && member.kind.has_name("then"))
                 {
-                    match InferredType::new(db, member.ty).is_callable() {
+                    let member_ty = resolve(member.ty);
+                    match InferredType::new(db, member_ty).is_callable() {
                         Some(true) => return Some(true),
                         Some(false) => {}
                         None => indeterminate = true,

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -16,6 +16,7 @@ use std::{borrow::Cow, collections::VecDeque, fmt, ops::ControlFlow};
 
 const MAX_TYPE_VARIANT_STEPS: usize = 1024;
 const MAX_TYPE_RELATION_DEPTH: usize = 50;
+const MAX_CALLABLE_TYPE_STEPS: usize = 64;
 const MAX_PROMISE_TYPE_STEPS: usize = 64;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -273,7 +274,6 @@ impl<'db> InferredType<'db> {
                 TypeData::TypeofType(typeof_type) => typeof_type.ty(self.db),
                 TypeData::TypeofValue(typeof_value) => typeof_value.ty(self.db),
                 TypeData::Unknown
-                | TypeData::Divergent(_)
                 | TypeData::Local(_)
                 | TypeData::TypeofExpression(_)
                 | TypeData::AnyKeyword
@@ -533,7 +533,6 @@ impl<'db> InferredType<'db> {
                 | TypeData::ThisKeyword
                 | TypeData::VoidKeyword => {}
                 TypeData::Unknown
-                | TypeData::Divergent(_)
                 | TypeData::Local(_)
                 | TypeData::TypeofExpression(_)
                 | TypeData::AnyKeyword
@@ -791,7 +790,6 @@ impl<'db> InferredType<'db> {
                     pending.extend(union.types(self.db).iter().copied());
                 }
                 TypeData::Unknown
-                | TypeData::Divergent(_)
                 | TypeData::Local(_)
                 | TypeData::TypeofExpression(_)
                 | TypeData::AnyKeyword
@@ -800,6 +798,80 @@ impl<'db> InferredType<'db> {
                 }
                 _ => {}
             }
+        }
+
+        None
+    }
+
+    /// Resolves the outer wrappers of a callable without traversing its
+    /// parameters or unrelated members.
+    ///
+    /// Interfaces and objects must expose exactly one call signature. An
+    /// interface without an own call signature may extend exactly one type.
+    pub fn callable_type_with(
+        self,
+        mut resolve: impl FnMut(TypeData<'db>) -> TypeData<'db>,
+    ) -> Option<TypeData<'db>> {
+        let mut data = self.data;
+        let mut seen = FxHashSet::default();
+
+        for _ in 0..MAX_CALLABLE_TYPE_STEPS {
+            data = resolve(data).expand_structural_global(self.db);
+            if !seen.insert(data) {
+                return None;
+            }
+            if data.callable_function(self.db).is_some() {
+                return Some(data);
+            }
+
+            data = match data {
+                TypeData::InstanceOf(instance) => instance.ty(self.db),
+                TypeData::Interface(interface) => {
+                    let mut signatures = interface
+                        .members(self.db)
+                        .iter()
+                        .filter(|member| member.kind.is_call_signature());
+                    if let Some(signature) = signatures.next() {
+                        if signatures.next().is_some() {
+                            return None;
+                        }
+                        signature.ty
+                    } else {
+                        let extends = interface.extends(self.db);
+                        let [extends] = extends.as_ref() else {
+                            return None;
+                        };
+                        *extends
+                    }
+                }
+                TypeData::Literal(literal) => {
+                    let Literal::Object(members) = literal.literal(self.db) else {
+                        return None;
+                    };
+                    let mut signatures = members
+                        .iter()
+                        .filter(|member| member.kind.is_call_signature());
+                    let signature = signatures.next()?;
+                    if signatures.next().is_some() {
+                        return None;
+                    }
+                    signature.ty
+                }
+                TypeData::Object(object) => {
+                    let mut signatures = object
+                        .members(self.db)
+                        .iter()
+                        .filter(|member| member.kind.is_call_signature());
+                    let signature = signatures.next()?;
+                    if signatures.next().is_some() {
+                        return None;
+                    }
+                    signature.ty
+                }
+                TypeData::TypeofType(typeof_type) => typeof_type.ty(self.db),
+                TypeData::TypeofValue(typeof_value) => typeof_value.ty(self.db),
+                _ => return None,
+            };
         }
 
         None
@@ -837,10 +909,7 @@ impl<'db> InferredType<'db> {
     pub const fn is_inferred(self) -> bool {
         !matches!(
             self.data,
-            TypeData::Unknown
-                | TypeData::Divergent(_)
-                | TypeData::Local(_)
-                | TypeData::TypeofExpression(_)
+            TypeData::Unknown | TypeData::Local(_) | TypeData::TypeofExpression(_)
         )
     }
 
@@ -1224,7 +1293,6 @@ impl<'db> InferredType<'db> {
 
             match data {
                 TypeData::Unknown
-                | TypeData::Divergent(_)
                 | TypeData::AnyKeyword
                 | TypeData::UnknownKeyword
                 | TypeData::Local(_)
@@ -1392,7 +1460,6 @@ impl<'db> DepthFirstVisitor<TypeData<'db>> for CallableVisitor<'db> {
 
         match data {
             TypeData::Unknown
-            | TypeData::Divergent(_)
             | TypeData::Local(_)
             | TypeData::TypeofExpression(_)
             | TypeData::AnyKeyword

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -99,16 +99,10 @@ pub trait TypeDb: biome_db::Db {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update)]
-pub struct DivergentType {
-    pub id: salsa::Id,
-}
-
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, salsa::Update)]
 pub enum TypeData<'db> {
     #[default]
     Unknown,
-    Divergent(DivergentType),
     Global,
     BigInt,
     Boolean,
@@ -252,17 +246,12 @@ pub enum ConditionalSubset {
 impl<'db> TypeData<'db> {
     // #region Type inspection
 
-    pub fn divergent(id: salsa::Id) -> Self {
-        Self::Divergent(DivergentType { id })
-    }
-
     /// Returns whether this type prevents a consumer from reaching a
     /// conclusive negative result without further resolution.
     pub const fn is_indeterminate(self) -> bool {
         matches!(
             self,
             Self::Unknown
-                | Self::Divergent(_)
                 | Self::Local(_)
                 | Self::TypeofExpression(_)
                 | Self::AnyKeyword
@@ -307,7 +296,7 @@ impl<'db> TypeData<'db> {
                 return "object";
             }
             return match self {
-                Self::Unknown | Self::UnknownKeyword | Self::Divergent(_) => "unknown",
+                Self::Unknown | Self::UnknownKeyword => "unknown",
                 Self::AnyKeyword => "any",
                 Self::NeverKeyword => "never",
                 Self::Null => "null",
@@ -596,8 +585,7 @@ impl<'db> TypeData<'db> {
                 Literal::Template(_) => ConditionalType::Anything,
             }),
             Self::Null | Self::Undefined | Self::VoidKeyword => Some(ConditionalType::Nullish),
-            Self::Divergent(_)
-            | Self::Generic(_)
+            Self::Generic(_)
             | Self::GlobalType(_)
             | Self::Local(_)
             | Self::TypeOperator(_)
@@ -641,7 +629,6 @@ impl<'db> TypeData<'db> {
             | Self::Tuple(_)
             | Self::Union(_) => type_parameters.is_empty(),
             Self::Class(_)
-            | Self::Divergent(_)
             | Self::Generic(_)
             | Self::GlobalType(_)
             | Self::Local(_)
@@ -886,7 +873,6 @@ impl<'db> TypeData<'db> {
             | Self::Namespace(_)
             | Self::Object(_) => self,
             expanded @ (Self::Unknown
-            | Self::Divergent(_)
             | Self::Global
             | Self::GlobalType(_)
             | Self::BigInt
@@ -1193,7 +1179,7 @@ impl<'db> TypeData<'db> {
 
     pub fn to_raw_lossy(self, db: &'db dyn TypeDb) -> RawTypeData {
         match self {
-            Self::Unknown | Self::Divergent(_) => raw::TypeData::Unknown,
+            Self::Unknown => raw::TypeData::Unknown,
             Self::GlobalType(id) => raw::TypeData::Reference(raw::RawTypeId::Global(id).into()),
             Self::Global => raw::TypeData::Global,
             Self::BigInt => raw::TypeData::BigInt,
@@ -1318,7 +1304,7 @@ impl<'db> TypeData<'db> {
 
     pub fn to_raw_reference_lossy(self) -> raw::TypeReference {
         match self {
-            Self::Unknown | Self::Divergent(_) => raw::TypeReference::Resolved(GLOBAL_UNKNOWN_ID),
+            Self::Unknown => raw::TypeReference::Resolved(GLOBAL_UNKNOWN_ID),
             Self::GlobalType(id) => raw::RawTypeId::Global(id).into(),
             Self::Global => raw::TypeReference::Resolved(GLOBAL_GLOBAL_ID),
             Self::Boolean => raw::TypeReference::Resolved(GLOBAL_BOOLEAN_ID),

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -256,6 +256,100 @@ impl<'db> TypeData<'db> {
         Self::Divergent(DivergentType { id })
     }
 
+    /// Returns whether this type prevents a consumer from reaching a
+    /// conclusive negative result without further resolution.
+    pub const fn is_indeterminate(self) -> bool {
+        matches!(
+            self,
+            Self::Unknown
+                | Self::Divergent(_)
+                | Self::Local(_)
+                | Self::TypeofExpression(_)
+                | Self::AnyKeyword
+                | Self::UnknownKeyword
+        )
+    }
+
+    /// Returns whether this type represents an object-like value.
+    ///
+    /// Instance targets are followed iteratively. A recursive instance chain is
+    /// considered object-like.
+    pub fn is_object_like(mut self, db: &'db dyn TypeDb) -> bool {
+        let mut seen = FxHashSet::default();
+        loop {
+            if !seen.insert(self) {
+                return true;
+            }
+            match self {
+                Self::Class(_)
+                | Self::Constructor(_)
+                | Self::Function(_)
+                | Self::Interface(_)
+                | Self::Module(_)
+                | Self::Namespace(_)
+                | Self::Object(_)
+                | Self::ObjectKeyword
+                | Self::Tuple(_) => return true,
+                Self::InstanceOf(instance) => self = instance.ty(db),
+                _ => return false,
+            }
+        }
+    }
+
+    /// Returns a stable category name suitable for diagnostics.
+    ///
+    /// Instance targets are followed iteratively. Compound types use their
+    /// category name instead of constructing a description from their members.
+    pub fn type_description(mut self, db: &'db dyn TypeDb) -> &'static str {
+        let mut seen = FxHashSet::default();
+        loop {
+            if !seen.insert(self) {
+                return "object";
+            }
+            return match self {
+                Self::Unknown | Self::UnknownKeyword | Self::Divergent(_) => "unknown",
+                Self::AnyKeyword => "any",
+                Self::NeverKeyword => "never",
+                Self::Null => "null",
+                Self::Undefined | Self::VoidKeyword => "undefined",
+                Self::Boolean => "boolean",
+                Self::Number => "number",
+                Self::String => "string",
+                Self::BigInt => "bigint",
+                Self::Symbol => "symbol",
+                Self::ObjectKeyword | Self::Object(_) => "object",
+                Self::Interface(_) => "interface",
+                Self::Class(_) => "class",
+                Self::Function(_) => "function",
+                Self::Tuple(_) => "tuple",
+                Self::Module(_) | Self::Namespace(_) => "namespace",
+                Self::Constructor(_) => "constructor",
+                Self::InstanceOf(instance) => {
+                    self = instance.ty(db);
+                    continue;
+                }
+                Self::Intersection(_) => "intersection",
+                Self::Union(_) => "union",
+                Self::Literal(literal) => match literal.literal(db) {
+                    Literal::BigInt(_) => "bigint",
+                    Literal::Boolean(_) => "boolean",
+                    Literal::Number(_) => "number",
+                    Literal::String(_) | Literal::Template(_) => "string",
+                    Literal::Object(_) => "object",
+                    Literal::RegExp(_) => "RegExp",
+                },
+                Self::Generic(_) => "generic",
+                Self::Local(_) => "unresolved",
+                Self::MergedReference(_) => "merged type",
+                Self::TypeOperator(_) => "type operator",
+                Self::TypeofExpression(_) | Self::TypeofType(_) | Self::TypeofValue(_) => "typeof",
+                Self::Conditional => "conditional",
+                Self::Global | Self::GlobalType(_) => "global",
+                Self::ThisKeyword => "this",
+            };
+        }
+    }
+
     pub fn is_string_key_type(self, db: &'db dyn TypeDb) -> bool {
         match self {
             Self::String => true,
@@ -2000,9 +2094,22 @@ pub struct TypeMember<'db> {
     pub ty: TypeData<'db>,
 }
 
+const CUSTOM_STRINGIFICATION_MEMBER_NAMES: [&str; 3] = ["toLocaleString", "toString", "valueOf"];
+
 impl TypeMember<'_> {
     pub(crate) fn name(&self) -> Option<Text> {
         self.kind.name()
+    }
+
+    /// Returns whether this member declares one of JavaScript's object
+    /// conversion hooks.
+    ///
+    /// Classification is name-based. It does not resolve the member type or
+    /// require the member to be callable.
+    pub(crate) fn is_custom_stringification_member(&self) -> bool {
+        CUSTOM_STRINGIFICATION_MEMBER_NAMES
+            .iter()
+            .any(|name| self.kind.has_name(name))
     }
 }
 

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -24,6 +24,7 @@ mod local_inference;
 pub mod resolved;
 mod resolver;
 mod return_type_relation;
+mod stringification;
 mod r#type;
 mod type_data;
 mod type_store;
@@ -38,14 +39,14 @@ pub use globals::{
 };
 pub use globals_ids::{GLOBAL_BOOLEAN_ID, GLOBAL_UNKNOWN_ID, GlobalTypeId, NUM_PREDEFINED_TYPES};
 pub use inferred_type::{
-    IgnoredPrimitiveTypes, InferredSwitchCase, InferredType, StringificationMode,
-    StringificationUsefulness, TypeTraversalError,
+    IgnoredPrimitiveTypes, InferredSwitchCase, InferredType, TypeTraversalError,
 };
 pub use interned_types::TypeDb;
 pub use resolver::*;
 pub use return_type_relation::{
     NarrowedTypeCandidates, ReturnTypeRelation, ReturnTypeVerdict, compare_declared_return_type,
 };
+pub use stringification::{StringificationMode, StringificationUsefulness};
 pub use r#type::Type;
 pub use type_data::TypeData as RawTypeData;
 pub use type_data::*;

--- a/crates/biome_js_type_info/src/stringification.rs
+++ b/crates/biome_js_type_info/src/stringification.rs
@@ -1,0 +1,495 @@
+//! Classification of values converted to strings by JavaScript operations.
+//!
+//! String conversion depends on the operation, compound-type composition,
+//! configured ignored names, and whether an object inherits the default object
+//! conversion hooks. [`StringificationAnalyzer`] owns those rules and evaluates
+//! nested types iteratively so recursive types cannot consume the Rust stack.
+
+use crate::{
+    TypeDb,
+    interned_types::{Literal, TypeData, TypeMember},
+};
+use rustc_hash::FxHashSet;
+
+const MAX_STRINGIFICATION_DEPTH: usize = 1024;
+
+/// JavaScript operation that triggers string conversion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StringificationMode {
+    /// An array or tuple is converted by `Array.prototype.join`.
+    Join,
+    /// Ordinary conversion through object conversion hooks and primitives.
+    ToString,
+}
+
+/// Whether string conversion produces a useful representation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StringificationUsefulness {
+    /// No possible type is known to require the base object representation.
+    Always,
+    /// Some possible types use the base object representation.
+    Sometimes,
+    /// Every possible type uses the base object representation.
+    Never,
+}
+
+pub(crate) struct StringificationAnalyzer<'db, 'names> {
+    db: &'db dyn TypeDb,
+    ignored_type_names: &'names [&'names str],
+}
+
+impl<'db, 'names> StringificationAnalyzer<'db, 'names> {
+    pub(crate) fn new(db: &'db dyn TypeDb, ignored_type_names: &'names [&'names str]) -> Self {
+        Self {
+            db,
+            ignored_type_names,
+        }
+    }
+
+    pub(crate) fn analyze(
+        &self,
+        root: TypeData<'db>,
+        mode: StringificationMode,
+    ) -> StringificationUsefulness {
+        let mut active = FxHashSet::default();
+        let mut frames = vec![StringificationFrame::Enter {
+            data: root,
+            mode,
+            depth: 0,
+        }];
+        let mut results = Vec::new();
+
+        while let Some(frame) = frames.pop() {
+            match frame {
+                StringificationFrame::Enter { data, mode, depth } => {
+                    if depth >= MAX_STRINGIFICATION_DEPTH || !active.insert(data) {
+                        results.push(StringificationUsefulness::Always);
+                        continue;
+                    }
+
+                    let step = if let TypeData::Generic(generic) = data {
+                        generic.constraint(self.db).map_or(
+                            StringificationStep::Complete(StringificationUsefulness::Always),
+                            |constraint| StringificationStep::Children {
+                                combination: StringificationCombination::Single,
+                                children: vec![(constraint, mode)],
+                            },
+                        )
+                    } else if matches!(mode, StringificationMode::ToString) {
+                        match self.is_ignored_type(data) {
+                            None | Some(true) => {
+                                StringificationStep::Complete(StringificationUsefulness::Always)
+                            }
+                            Some(false) if self.is_safe_type(data) => {
+                                StringificationStep::Complete(StringificationUsefulness::Always)
+                            }
+                            Some(false) => self.unignored_step(data, mode, depth),
+                        }
+                    } else {
+                        self.unignored_step(data, mode, depth)
+                    };
+
+                    match step {
+                        StringificationStep::Complete(result) => {
+                            active.remove(&data);
+                            results.push(result);
+                        }
+                        StringificationStep::Children {
+                            combination,
+                            children,
+                        } => {
+                            frames.push(StringificationFrame::Combine {
+                                data,
+                                combination,
+                                child_count: children.len(),
+                            });
+                            frames.extend(children.into_iter().rev().map(|(data, mode)| {
+                                StringificationFrame::Enter {
+                                    data,
+                                    mode,
+                                    depth: depth + 1,
+                                }
+                            }));
+                        }
+                    }
+                }
+                StringificationFrame::Combine {
+                    data,
+                    combination,
+                    child_count,
+                } => {
+                    let first_child = results.len() - child_count;
+                    let result = combination.combine(&results[first_child..]);
+                    results.truncate(first_child);
+                    results.push(result);
+                    active.remove(&data);
+                }
+            }
+        }
+
+        results.pop().unwrap_or(StringificationUsefulness::Always)
+    }
+
+    fn unignored_step(
+        &self,
+        data: TypeData<'db>,
+        mode: StringificationMode,
+        depth: usize,
+    ) -> StringificationStep<'db> {
+        match data {
+            TypeData::Union(union) => StringificationStep::Children {
+                combination: StringificationCombination::Union,
+                children: union
+                    .types(self.db)
+                    .iter()
+                    .copied()
+                    .map(|ty| (ty, mode))
+                    .collect(),
+            },
+            TypeData::Intersection(intersection) => StringificationStep::Children {
+                combination: StringificationCombination::Intersection,
+                children: intersection
+                    .types(self.db)
+                    .iter()
+                    .copied()
+                    .map(|ty| (ty, mode))
+                    .collect(),
+            },
+            TypeData::Tuple(tuple) => StringificationStep::Children {
+                combination: StringificationCombination::Tuple,
+                children: tuple
+                    .elements(self.db)
+                    .iter()
+                    .map(|element| (element.ty, StringificationMode::ToString))
+                    .collect(),
+            },
+            TypeData::InstanceOf(instance) if instance.ty(self.db).is_array_class(self.db) => {
+                instance.type_parameters(self.db).first().map_or(
+                    StringificationStep::Complete(StringificationUsefulness::Always),
+                    |element| StringificationStep::Children {
+                        combination: StringificationCombination::Single,
+                        children: vec![(*element, StringificationMode::ToString)],
+                    },
+                )
+            }
+            TypeData::InstanceOf(instance) => StringificationStep::Children {
+                combination: StringificationCombination::Single,
+                children: vec![(instance.ty(self.db), mode)],
+            },
+            _ if matches!(mode, StringificationMode::Join) => {
+                StringificationStep::Complete(StringificationUsefulness::Always)
+            }
+            _ => StringificationStep::Complete(
+                self.base_stringification(data, depth + 1).into_usefulness(),
+            ),
+        }
+    }
+
+    fn is_safe_type(&self, data: TypeData<'db>) -> bool {
+        match data {
+            TypeData::AnyKeyword
+            | TypeData::BigInt
+            | TypeData::Boolean
+            | TypeData::Function(_)
+            | TypeData::Null
+            | TypeData::Number
+            | TypeData::String
+            | TypeData::Symbol
+            | TypeData::Undefined
+            | TypeData::Unknown
+            | TypeData::UnknownKeyword
+            | TypeData::NeverKeyword
+            | TypeData::VoidKeyword => true,
+            TypeData::Literal(literal) => matches!(
+                literal.literal(self.db),
+                Literal::BigInt(_)
+                    | Literal::Boolean(_)
+                    | Literal::Number(_)
+                    | Literal::String(_)
+                    | Literal::Template(_)
+            ),
+            _ => false,
+        }
+    }
+
+    fn is_ignored_type(&self, root: TypeData<'db>) -> Option<bool> {
+        let mut seen = FxHashSet::default();
+        let mut pending = vec![root];
+        let mut remaining_steps = MAX_STRINGIFICATION_DEPTH;
+
+        while let Some(data) = pending.pop() {
+            if !seen.insert(data) {
+                continue;
+            }
+            if remaining_steps == 0 {
+                return None;
+            }
+            remaining_steps -= 1;
+
+            let name = match data {
+                TypeData::Class(class) => class.name(self.db).as_ref().map(|name| name.text()),
+                TypeData::Generic(generic) => Some(generic.name(self.db).text()),
+                TypeData::Interface(interface) => Some(interface.name(self.db).text()),
+                TypeData::Literal(literal)
+                    if matches!(literal.literal(self.db), Literal::RegExp(_)) =>
+                {
+                    Some("RegExp")
+                }
+                TypeData::TypeofValue(value) => Some(value.identifier(self.db).text()),
+                _ => None,
+            };
+            if name.is_some_and(|name| self.ignored_type_names.contains(&name)) {
+                return Some(true);
+            }
+
+            match data {
+                TypeData::Class(class) => pending.extend(class.extends(self.db)),
+                TypeData::Generic(generic) => pending.extend(generic.constraint(self.db)),
+                TypeData::InstanceOf(instance) => pending.push(instance.ty(self.db)),
+                TypeData::Interface(interface) => {
+                    pending.extend(interface.extends(self.db).iter().copied());
+                }
+                TypeData::MergedReference(reference) => {
+                    pending.extend(reference.targets(self.db));
+                }
+                TypeData::TypeOperator(operator) => pending.push(operator.ty(self.db)),
+                TypeData::TypeofType(typeof_type) => pending.push(typeof_type.ty(self.db)),
+                TypeData::TypeofValue(typeof_value) => pending.push(typeof_value.ty(self.db)),
+                _ => {}
+            }
+        }
+
+        Some(false)
+    }
+
+    fn base_stringification(&self, root: TypeData<'db>, root_depth: usize) -> BaseStringification {
+        let mut active = FxHashSet::default();
+        let mut frames = vec![BaseStringificationFrame::Enter {
+            data: root,
+            depth: root_depth,
+        }];
+        let mut results = Vec::new();
+
+        while let Some(frame) = frames.pop() {
+            match frame {
+                BaseStringificationFrame::Enter { data, depth } => {
+                    if depth >= MAX_STRINGIFICATION_DEPTH || !active.insert(data) {
+                        results.push(BaseStringification::Suppress);
+                        continue;
+                    }
+
+                    let step = match data {
+                        TypeData::Class(class) => {
+                            if class
+                                .members(self.db)
+                                .iter()
+                                .any(TypeMember::is_custom_stringification_member)
+                            {
+                                BaseStringificationStep::Complete(BaseStringification::Suppress)
+                            } else if let Some(base) = class.extends(self.db) {
+                                BaseStringificationStep::Children(vec![base])
+                            } else {
+                                BaseStringificationStep::Complete(BaseStringification::Report)
+                            }
+                        }
+                        TypeData::InstanceOf(instance) => {
+                            BaseStringificationStep::Children(vec![instance.ty(self.db)])
+                        }
+                        TypeData::Interface(interface) => {
+                            if interface
+                                .members(self.db)
+                                .iter()
+                                .any(TypeMember::is_custom_stringification_member)
+                            {
+                                BaseStringificationStep::Complete(BaseStringification::Suppress)
+                            } else if interface.extends(self.db).is_empty() {
+                                BaseStringificationStep::Complete(BaseStringification::Report)
+                            } else {
+                                BaseStringificationStep::Children(
+                                    interface.extends(self.db).to_vec(),
+                                )
+                            }
+                        }
+                        TypeData::Literal(literal) => match literal.literal(self.db) {
+                            Literal::Object(members) => BaseStringificationStep::Complete(
+                                if members
+                                    .iter()
+                                    .any(TypeMember::is_custom_stringification_member)
+                                {
+                                    BaseStringification::Suppress
+                                } else {
+                                    BaseStringification::Report
+                                },
+                            ),
+                            Literal::RegExp(_) => {
+                                BaseStringificationStep::Complete(BaseStringification::Report)
+                            }
+                            _ => BaseStringificationStep::Complete(BaseStringification::Suppress),
+                        },
+                        TypeData::MergedReference(reference) => {
+                            BaseStringificationStep::Children(reference.targets(self.db).collect())
+                        }
+                        TypeData::Object(object) => BaseStringificationStep::Complete(
+                            if object
+                                .members(self.db)
+                                .iter()
+                                .any(TypeMember::is_custom_stringification_member)
+                            {
+                                BaseStringification::Suppress
+                            } else {
+                                BaseStringification::Report
+                            },
+                        ),
+                        TypeData::ObjectKeyword => {
+                            BaseStringificationStep::Complete(BaseStringification::Report)
+                        }
+                        TypeData::TypeofValue(value) => {
+                            BaseStringificationStep::Children(vec![value.ty(self.db)])
+                        }
+                        _ => BaseStringificationStep::Complete(BaseStringification::Unknown),
+                    };
+
+                    match step {
+                        BaseStringificationStep::Complete(result) => {
+                            active.remove(&data);
+                            results.push(result);
+                        }
+                        BaseStringificationStep::Children(children) => {
+                            frames.push(BaseStringificationFrame::Combine {
+                                data,
+                                child_count: children.len(),
+                            });
+                            frames.extend(children.into_iter().rev().map(|data| {
+                                BaseStringificationFrame::Enter {
+                                    data,
+                                    depth: depth + 1,
+                                }
+                            }));
+                        }
+                    }
+                }
+                BaseStringificationFrame::Combine { data, child_count } => {
+                    let first_child = results.len() - child_count;
+                    let result = results[first_child..]
+                        .iter()
+                        .copied()
+                        .fold(BaseStringification::Unknown, BaseStringification::merge);
+                    results.truncate(first_child);
+                    results.push(result);
+                    active.remove(&data);
+                }
+            }
+        }
+
+        results.pop().unwrap_or(BaseStringification::Unknown)
+    }
+}
+
+enum StringificationFrame<'db> {
+    Enter {
+        data: TypeData<'db>,
+        mode: StringificationMode,
+        depth: usize,
+    },
+    Combine {
+        data: TypeData<'db>,
+        combination: StringificationCombination,
+        child_count: usize,
+    },
+}
+
+enum StringificationStep<'db> {
+    Complete(StringificationUsefulness),
+    Children {
+        combination: StringificationCombination,
+        children: Vec<(TypeData<'db>, StringificationMode)>,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum StringificationCombination {
+    Single,
+    Union,
+    Intersection,
+    Tuple,
+}
+
+impl StringificationCombination {
+    fn combine(self, children: &[StringificationUsefulness]) -> StringificationUsefulness {
+        use StringificationUsefulness::{Always, Never, Sometimes};
+
+        match self {
+            Self::Single => children.first().copied().unwrap_or(Always),
+            Self::Union => {
+                let Some(first) = children.first() else {
+                    return Always;
+                };
+                if children.iter().all(|result| result == first) {
+                    *first
+                } else {
+                    Sometimes
+                }
+            }
+            Self::Intersection => {
+                if children.contains(&Always) {
+                    Always
+                } else {
+                    Never
+                }
+            }
+            Self::Tuple => {
+                if children.contains(&Never) {
+                    Never
+                } else if children.contains(&Sometimes) {
+                    Sometimes
+                } else {
+                    Always
+                }
+            }
+        }
+    }
+}
+
+enum BaseStringificationFrame<'db> {
+    Enter {
+        data: TypeData<'db>,
+        depth: usize,
+    },
+    Combine {
+        data: TypeData<'db>,
+        child_count: usize,
+    },
+}
+
+enum BaseStringificationStep<'db> {
+    Complete(BaseStringification),
+    Children(Vec<TypeData<'db>>),
+}
+
+/// Internal result of checking object conversion hooks and inherited types.
+#[derive(Clone, Copy)]
+enum BaseStringification {
+    /// The type definitely uses the base object representation.
+    Report,
+    /// The diagnostic must be suppressed due to a custom hook, cycle, or limit.
+    Suppress,
+    /// The type shape does not determine which representation is used.
+    Unknown,
+}
+
+impl BaseStringification {
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Suppress, _) | (_, Self::Suppress) => Self::Suppress,
+            (Self::Report, _) | (_, Self::Report) => Self::Report,
+            (Self::Unknown, Self::Unknown) => Self::Unknown,
+        }
+    }
+
+    fn into_usefulness(self) -> StringificationUsefulness {
+        match self {
+            Self::Report => StringificationUsefulness::Never,
+            Self::Suppress | Self::Unknown => StringificationUsefulness::Always,
+        }
+    }
+}

--- a/crates/biome_module_graph/benches/type_inference.rs
+++ b/crates/biome_module_graph/benches/type_inference.rs
@@ -3,13 +3,15 @@ use biome_js_parser::JsParserOptions;
 use biome_js_semantic::{SemanticModelOptions, semantic_model};
 use biome_js_syntax::AnyJsRoot;
 use biome_js_type_info::interned_types::{
-    CallArgumentType as InferredCallArgumentType, TypeData as InferredTypeData,
+    CallArgumentType as InferredCallArgumentType, LocalTypeId, TypeData as InferredTypeData,
 };
 use biome_languages::JsFileSource;
 use biome_module_graph::{
-    CallArgumentTypeInput, ModuleDb, ModuleInfo, ModuleInfoKind, NormalizeTypeInput, PathInfoCache,
-    TypeInferenceMode, infer_call_argument_type, infer_module_types, infer_module_types_bottom_up,
-    normalize_type, resolve_js_module_with_inference_mode,
+    BindingTypeInput, CallArgumentTypeInput, ExpressionTypeInput, LocalTypeInput, ModuleDb,
+    ModuleInfo, ModuleInfoKind, NormalizeTypeInput, PathInfoCache, SymbolFromModuleInfo,
+    TypeInferenceMode, infer_binding_type, infer_call_argument_type, infer_export_type,
+    infer_expression_is_promise, infer_expression_type, infer_local_type, infer_module_types,
+    infer_module_types_bottom_up, normalize_type, resolve_js_module_with_inference_mode,
 };
 use biome_project_layout::ProjectLayout;
 use biome_rowan::TextRange;
@@ -180,6 +182,87 @@ fn bench_infer_argument_type_many_overloads(bencher: Bencher) {
         .bench_local_refs(|(db, module, callee_range, callback_range)| {
             let input = overload_benchmark_input(&*db, *module, *callee_range, *callback_range, 31);
             divan::black_box(infer_call_argument_type(&*db, input));
+        });
+}
+
+#[divan::bench(name = "bench_distinct_binding_leaf_queries", sample_size = 1)]
+fn bench_distinct_binding_leaf_queries(bencher: Bencher) {
+    bencher
+        .with_inputs(|| {
+            let (db, module) = build_source_db("bindings.ts", &declaration_heavy_source(128));
+            let ModuleInfoKind::Js(info) = module.kind(&db) else {
+                panic!("module must contain JavaScript information");
+            };
+            let ranges = info.raw_binding_types.keys().copied().collect::<Vec<_>>();
+            (db, module, ranges)
+        })
+        .bench_local_refs(|(db, module, ranges)| {
+            for range in ranges {
+                let input = BindingTypeInput::new(&*db, *module, *range);
+                divan::black_box(infer_binding_type(&*db, input));
+            }
+        });
+}
+
+#[divan::bench(name = "bench_distinct_local_type_leaf_queries", sample_size = 1)]
+fn bench_distinct_local_type_leaf_queries(bencher: Bencher) {
+    bencher
+        .with_inputs(|| {
+            let (db, module) = build_source_db("local_types.ts", &declaration_heavy_source(128));
+            let ModuleInfoKind::Js(info) = module.kind(&db) else {
+                panic!("module must contain JavaScript information");
+            };
+            let type_count = info.raw_types.len();
+            (db, module, type_count)
+        })
+        .bench_local_refs(|(db, module, type_count)| {
+            for index in 0..*type_count {
+                let input = LocalTypeInput::new(&*db, *module, LocalTypeId::new(index));
+                divan::black_box(infer_local_type(&*db, input));
+            }
+        });
+}
+
+#[divan::bench(name = "bench_distinct_export_leaf_queries", sample_size = 1)]
+fn bench_distinct_export_leaf_queries(bencher: Bencher) {
+    bencher
+        .with_inputs(|| {
+            let (db, module) = build_source_db("exports.ts", &declaration_heavy_source(128));
+            let ModuleInfoKind::Js(info) = module.kind(&db) else {
+                panic!("module must contain JavaScript information");
+            };
+            let names = info.exports.keys().cloned().collect::<Vec<_>>();
+            (db, module, names)
+        })
+        .bench_local_refs(|(db, module, names)| {
+            for name in names {
+                let input = SymbolFromModuleInfo::new(&*db, name.to_string(), *module);
+                divan::black_box(infer_export_type(&*db, input));
+            }
+        });
+}
+
+#[divan::bench(name = "bench_distinct_expression_leaf_queries", sample_size = 1)]
+fn bench_distinct_expression_leaf_queries(bencher: Bencher) {
+    bencher
+        .with_inputs(|| expression_query_inputs(128))
+        .bench_local_refs(|(db, module, ranges)| {
+            for range in ranges {
+                let input = ExpressionTypeInput::new(&*db, *module, *range);
+                divan::black_box(infer_expression_type(&*db, input));
+            }
+        });
+}
+
+#[divan::bench(name = "bench_distinct_selective_promise_queries", sample_size = 1)]
+fn bench_distinct_selective_promise_queries(bencher: Bencher) {
+    bencher
+        .with_inputs(|| expression_query_inputs(128))
+        .bench_local_refs(|(db, module, ranges)| {
+            for range in ranges {
+                let input = ExpressionTypeInput::new(&*db, *module, *range);
+                divan::black_box(infer_expression_is_promise(&*db, input));
+            }
         });
 }
 
@@ -464,6 +547,30 @@ fn overloaded_function_source(overload_count: usize) -> String {
     }
     source.push_str("export const callback = () => {};\n");
     source
+}
+
+fn declaration_heavy_source(declaration_count: usize) -> String {
+    let mut source = String::new();
+    for index in 0..declaration_count {
+        source.push_str(&format!(
+            "export interface Value{index} {{ field: number; }}\n\
+             export const value{index}: Value{index} = {{ field: {index} }};\n"
+        ));
+    }
+    source
+}
+
+fn expression_query_inputs(count: usize) -> (WorkspaceDb, ModuleInfo, Vec<TextRange>) {
+    let mut source = String::new();
+    for index in 0..count {
+        source.push_str(&format!("Promise.resolve({index});\n"));
+    }
+    let (db, module) = build_source_db("promises.ts", &source);
+    let ModuleInfoKind::Js(info) = module.kind(&db) else {
+        panic!("module must contain JavaScript information");
+    };
+    let ranges = info.raw_expressions.keys().copied().collect();
+    (db, module, ranges)
 }
 
 fn build_inferred_db(name: &str) -> (WorkspaceDb, ModuleInfo, ModuleInfoKind) {

--- a/crates/biome_module_graph/src/db/queries.rs
+++ b/crates/biome_module_graph/src/db/queries.rs
@@ -176,10 +176,10 @@ pub fn find_jsdoc_for_exported_symbol<'db>(
 /// Generic symbol used by queries to track a generic "symbol", which can represent everything (variable name, class name, etc.)
 pub struct SymbolFromModuleInfo {
     #[returns(clone)]
-    name: String,
+    pub(crate) name: String,
 
     #[returns(ref)]
-    module: ModuleInfo,
+    pub(crate) module: ModuleInfo,
 }
 
 // #endregion

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -23,7 +23,7 @@ use crate::module_for_key;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
 use crate::{JsExport, JsOwnExport, ModuleDb, ResolvedPath};
 use biome_js_type_info::{
-    RawTypeData, TypeReference, TypeResolverLevel,
+    RawTypeData, TypeReference, TypeResolverLevel, global_types,
     interned_types::{
         CallArgumentType as InferredCallArgumentType,
         FunctionParameter as InferredFunctionParameter, InternedConstructor as InferredConstructor,
@@ -233,7 +233,11 @@ pub fn infer_constructor_argument_type<'db>(
 ) -> Option<InferredTypeData<'db>> {
     let (args, argument_index) =
         resolved_call_arguments(db, input.args(db), input.argument_index(db));
-    infer_constructor_argument_type_inner(db, input.callee(db), &args, argument_index)
+    let ty = infer_constructor_argument_type_inner(db, input.callee(db), &args, argument_index)?;
+    Some(match ty {
+        InferredTypeData::GlobalType(id) => global_types(db).get(id),
+        ty => ty,
+    })
 }
 
 /// Resolves local handles and simplifies structural wrappers in `input`.
@@ -715,6 +719,9 @@ fn infer_argument_type<'db>(
 
         match item {
             ArgumentTypeItem::Type(callee) => match callee {
+                InferredTypeData::GlobalType(id) => {
+                    pending.push(ArgumentTypeItem::Type(global_types(db).get(id)));
+                }
                 InferredTypeData::InstanceOf(instance) => {
                     let target = resolve_local_type(db, instance.ty(db));
                     let substitutions =

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -1,29 +1,40 @@
-//! Salsa-backed queries for module-level type inference.
+//! Salsa-backed queries for JavaScript type inference.
 //!
-//! Tracked functions cache their results and record the modules and types they
-//! inspect. Salsa reruns a query when one of those dependencies changes. Query
-//! inputs with several fields use interned structs, which give equal input
-//! values one shared database identity; interning the input is separate from
-//! caching the query result.
+//! Expression, binding, and local-type queries resolve one entry from the raw
+//! tables stored in [`ModuleInfo`]. These are the primary query units for
+//! consumers that do not need every inferred type in a module.
 //!
-//! [`infer_module_types_bottom_up`] is the entry point for callers outside a
-//! database query. It prepares imported modules iteratively so long import
-//! chains do not consume the Rust call stack. Queries that run while module
-//! inference is already active call [`infer_module_types`] directly.
+//! Export discovery is tracked separately from type resolution. Origin and
+//! namespace-name queries inspect only module graph inputs, so their results
+//! can be shared by importers without caching provisional inferred types.
+//!
+//! [`infer_module_types`] materializes the complete set of resolved tables for
+//! compatibility with bulk consumers. [`infer_module_types_bottom_up`] prepares
+//! its dependencies iteratively so long import chains do not consume the Rust
+//! call stack.
+//!
+//! Tracked functions record the inputs and queries they inspect. Salsa reruns a
+//! query when one of those dependencies changes. Inputs with several fields use
+//! interned structs so equal values share one database identity; interning an
+//! input is separate from caching the query result.
 //!
 //! Call and constructor inference is best effort. Unsupported or unresolved
 //! shapes produce `Unknown` or `None` instead of a TypeScript diagnostic.
 
 use crate::db::type_inference::{
-    ImportResolution, apply_substitutions_to_root_body, collected_type_result,
+    ExportOriginResult, ImportResolution, ResolutionCtx, apply_substitutions_to_root_body,
+    collect_namespace_export_names, collected_type_result, find_export_origin,
+    find_member_type_on_demand as find_member_type_impl,
+    find_value_member_type_on_demand as find_value_member_type_impl,
     infer_module_types_cycle_result, normalize_structural_type, normalize_type_cycle_result,
-    resolve_raw_types, substitutions_for_instance,
+    resolve_export_type_on_demand, resolve_local_type_on_demand, resolve_raw_types,
+    substitutions_for_instance,
 };
 use crate::module_for_key;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
-use crate::{JsExport, JsOwnExport, ModuleDb, ResolvedPath};
+use crate::{JsExport, JsOwnExport, ModuleDb, ResolvedPath, SymbolFromModuleInfo};
 use biome_js_type_info::{
-    RawTypeData, TypeReference, TypeResolverLevel, global_types,
+    RawTypeData, TypeId, TypeReference, TypeResolverLevel, global_types,
     interned_types::{
         CallArgumentType as InferredCallArgumentType,
         FunctionParameter as InferredFunctionParameter, InternedConstructor as InferredConstructor,
@@ -36,6 +47,7 @@ use biome_js_type_info::{
         TypeTransformResult,
     },
 };
+use biome_rowan::{Text, TextRange};
 use rustc_hash::FxHashSet;
 
 /// Inferred type tables for one JavaScript or TypeScript module.
@@ -46,14 +58,42 @@ const MAX_ARGUMENT_SEQUENCE_STEPS: usize = 4096;
 const MAX_ARGUMENT_TYPE_STEPS: usize = 1024;
 const MAX_LOCAL_EXTENDS_STEPS: usize = 1024;
 
-// #region EXPORTED TRACKED QUERIES
+// #region EXPORT DISCOVERY QUERIES
 
-/// Infers and caches the types collected for a module.
+/// Finds the module and local name that own an exported symbol.
+///
+/// This query reads only module graph inputs and never resolves inferred types.
+/// Keeping export discovery independent of inference prevents it from joining
+/// an inference cycle. The caller resolves the type stored at the returned
+/// origin.
+#[salsa::tracked(returns(ref))]
+pub(crate) fn resolved_export_origin<'db>(
+    db: &'db dyn ModuleDb,
+    symbol: SymbolFromModuleInfo<'db>,
+) -> ExportOriginResult {
+    find_export_origin(db, *symbol.module(db), Text::from(symbol.name(db)))
+}
+
+/// Collects the export names visible through a module namespace.
+///
+/// This query reads only module graph inputs. An unresolved blanket re-export,
+/// unsupported module, disabled inference, or exhausted traversal budget makes
+/// the namespace indeterminate.
+#[salsa::tracked(returns(ref))]
+pub(crate) fn namespace_export_names(db: &dyn ModuleDb, module: ModuleInfo) -> Option<Box<[Text]>> {
+    collect_namespace_export_names(db, module)
+}
+
+// #endregion
+
+// #region LEAF AND MODULE QUERIES
+
+/// Materializes all inferred type tables for a module.
 ///
 /// The query returns `None` for non-JavaScript modules, modules whose type
 /// inference is disabled, and dependency cycles that Salsa cannot recover.
-/// Imported module results are query dependencies, so changing an import
-/// invalidates affected importers.
+/// Prefer the expression, binding, or local-type query when only one entry is
+/// required.
 ///
 /// Callers outside another database query should use
 /// [`infer_module_types_bottom_up`] to prepare imports first.
@@ -69,14 +109,6 @@ pub fn infer_module_types<'db>(
         return None;
     }
 
-    for import_path in js_info.static_import_paths.values() {
-        if let Some(path) = import_path.as_path()
-            && let Some(target) = db.module_for_path(path)
-        {
-            let _ = infer_module_types(db, target);
-        }
-    }
-
     Some(resolve_raw_types(
         db,
         module,
@@ -85,7 +117,171 @@ pub fn infer_module_types<'db>(
     ))
 }
 
-// NOTE: this is the only exception to the rule, it's a public query and not tracked. Keep it here.
+/// Infers the type collected for one expression.
+///
+/// Returns `None` when the module does not support inference or the expression
+/// was not collected. An inference cycle returns `Unknown`.
+///
+/// Requesting the `promise` expression in the expression statement infers
+/// `Promise<number>`.
+///
+/// ```ts
+/// const promise = Promise.resolve(1);
+/// promise;
+/// ```
+#[salsa::tracked(cycle_result=infer_expression_type_cycle_result)]
+pub fn infer_expression_type<'db>(
+    db: &'db dyn ModuleDb,
+    input: ExpressionTypeInput<'db>,
+) -> Option<InferredTypeData<'db>> {
+    let module = input.module(db);
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    if !js_info.infer_types {
+        return None;
+    }
+
+    let reference = js_info.raw_expressions.get(&input.expression(db))?.clone();
+    let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::Full);
+    Some(ctx.resolve(&reference))
+}
+
+/// Infers the type collected for one binding range.
+///
+/// Returns `None` when the module does not support inference or the range has
+/// no collected binding. An inference cycle returns `Unknown`.
+///
+/// Requesting the declaration binding for `value` infers the numeric literal
+/// type `1`.
+///
+/// ```ts
+/// const value = 1;
+/// ```
+#[salsa::tracked(cycle_result=infer_binding_type_cycle_result)]
+pub fn infer_binding_type<'db>(
+    db: &'db dyn ModuleDb,
+    input: BindingTypeInput<'db>,
+) -> Option<InferredTypeData<'db>> {
+    let module = input.module(db);
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    if !js_info.infer_types {
+        return None;
+    }
+
+    let reference = js_info.raw_binding_types.get(&input.range(db))?.clone();
+    let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::Full);
+    Some(ctx.resolve(&reference))
+}
+
+/// Infers one entry from a module's local type table.
+///
+/// Returns `None` when the module does not support inference or the ID is out
+/// of bounds. An inference cycle returns `Unknown`.
+///
+/// Requesting the local type for `Value` infers an interface with a `field`
+/// member of type `string`.
+///
+/// ```ts
+/// interface Value {
+///     field: string;
+/// }
+/// ```
+#[salsa::tracked(cycle_result=infer_local_type_cycle_result)]
+pub fn infer_local_type<'db>(
+    db: &'db dyn ModuleDb,
+    input: LocalTypeInput<'db>,
+) -> Option<InferredTypeData<'db>> {
+    let module = input.module(db);
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    let type_id = input.type_id(db);
+    if !js_info.infer_types || type_id.index() >= js_info.raw_types.len() {
+        return None;
+    }
+
+    let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::Full);
+    Some(ctx.resolve_raw_type_id(TypeId::new(type_id.index())))
+}
+
+/// Infers the type exported under the requested symbol name.
+///
+/// Returns `None` when the module does not support inference. Missing,
+/// ambiguous, indeterminate, or cyclic exports resolve to `Unknown`.
+///
+/// Requesting the export named `value` infers the numeric literal type `1`.
+///
+/// ```ts
+/// export const value = 1;
+/// ```
+#[salsa::tracked(cycle_result=infer_export_type_cycle_result)]
+pub fn infer_export_type<'db>(
+    db: &'db dyn ModuleDb,
+    symbol: SymbolFromModuleInfo<'db>,
+) -> Option<InferredTypeData<'db>> {
+    resolve_export_type_on_demand(db, *symbol.module(db), &symbol.name(db))
+}
+
+fn infer_expression_type_cycle_result<'db>(
+    _db: &'db dyn ModuleDb,
+    _id: salsa::Id,
+    _input: ExpressionTypeInput<'db>,
+) -> Option<InferredTypeData<'db>> {
+    Some(InferredTypeData::Unknown)
+}
+
+fn infer_binding_type_cycle_result<'db>(
+    _db: &'db dyn ModuleDb,
+    _id: salsa::Id,
+    _input: BindingTypeInput<'db>,
+) -> Option<InferredTypeData<'db>> {
+    Some(InferredTypeData::Unknown)
+}
+
+fn infer_local_type_cycle_result<'db>(
+    _db: &'db dyn ModuleDb,
+    _id: salsa::Id,
+    _input: LocalTypeInput<'db>,
+) -> Option<InferredTypeData<'db>> {
+    Some(InferredTypeData::Unknown)
+}
+
+fn infer_export_type_cycle_result<'db>(
+    _db: &'db dyn ModuleDb,
+    _id: salsa::Id,
+    _symbol: SymbolFromModuleInfo<'db>,
+) -> Option<InferredTypeData<'db>> {
+    Some(InferredTypeData::Unknown)
+}
+
+/// Finds a named member while resolving local types through leaf queries.
+pub fn find_member_type<'db>(
+    db: &'db dyn ModuleDb,
+    ty: InferredTypeData<'db>,
+    name: &str,
+) -> Option<InferredTypeData<'db>> {
+    find_member_type_impl(db, ty, name)
+}
+
+/// Finds a named member available on a value while resolving local types
+/// through leaf queries.
+pub fn find_value_member_type<'db>(
+    db: &'db dyn ModuleDb,
+    ty: InferredTypeData<'db>,
+    name: &str,
+) -> Option<InferredTypeData<'db>> {
+    find_value_member_type_impl(db, ty, name)
+}
+
+// #endregion
+
+// #region EXTERNAL INFERENCE ENTRY POINTS
+
+// The scheduler remains untracked because `infer_module_types` caches each
+// module result while this explicit work list prevents recursive stack growth.
 /// Infers a module after preparing every module it imports or re-exports.
 ///
 /// This is the entry point for work initiated outside a database query, such
@@ -131,8 +327,8 @@ pub fn infer_module_types_bottom_up<'db>(
         let ModuleInfoKind::Js(js_info) = current.kind(db) else {
             continue;
         };
-        for import_path in js_info.static_import_paths.values() {
-            push_inference_dependency(db, &visited, &mut stack, &import_path.resolved_path);
+        for import in js_info.static_imports.values() {
+            push_inference_dependency(db, &visited, &mut stack, &import.resolved_path);
         }
         for reexport in js_info.blanket_reexports.iter() {
             push_inference_dependency(db, &visited, &mut stack, &reexport.import.resolved_path);
@@ -163,6 +359,10 @@ pub fn infer_module_types_bottom_up<'db>(
 
     None
 }
+
+// #endregion
+
+// #region CALL AND NORMALIZATION QUERIES
 
 /// Infers the return type of a call expression.
 ///
@@ -242,24 +442,18 @@ pub fn infer_constructor_argument_type<'db>(
 
 /// Resolves local handles and simplifies structural wrappers in `input`.
 ///
-/// If module inference is unavailable, the original type is returned. A cycle,
-/// invalid structural rebuild, or exhausted normalization budget returns
-/// [`InferredTypeData::Unknown`].
+/// A cycle, invalid structural rebuild, or exhausted normalization budget
+/// returns [`InferredTypeData::Unknown`].
 #[salsa::tracked(cycle_result=normalize_type_cycle_result)]
 pub fn normalize_type<'db>(
     db: &'db dyn ModuleDb,
     input: NormalizeTypeInput<'db>,
 ) -> InferredTypeData<'db> {
-    let module = input.module(db);
     let ty = input.ty(db);
     if !needs_type_normalization(ty) {
         return ty;
     }
-    let Some(inferred) = infer_module_types(db, module) else {
-        return ty;
-    };
-
-    normalize_structural_type(db, ty, |ty| inferred.resolve_type(db, ty))
+    normalize_structural_type(db, ty, |ty| resolve_local_type_on_demand(db, ty))
         .unwrap_or(InferredTypeData::Unknown)
 }
 
@@ -451,7 +645,7 @@ fn resolve_tuple_instance<'db>(
         }
         *remaining_steps -= 1;
 
-        let target = resolve_local_type(db, instance.ty(db));
+        let target = resolve_local_type_on_demand(db, instance.ty(db));
         let substitutions =
             substitutions_for_instance(db, target, instance.type_parameters(db), &[]);
         ty = apply_substitutions_to_root_body(db, target, &substitutions);
@@ -723,7 +917,7 @@ fn infer_argument_type<'db>(
                     pending.push(ArgumentTypeItem::Type(global_types(db).get(id)));
                 }
                 InferredTypeData::InstanceOf(instance) => {
-                    let target = resolve_local_type(db, instance.ty(db));
+                    let target = resolve_local_type_on_demand(db, instance.ty(db));
                     let substitutions =
                         substitutions_for_instance(db, target, instance.type_parameters(db), &[]);
                     pending.push(ArgumentTypeItem::Type(apply_substitutions_to_root_body(
@@ -756,22 +950,6 @@ fn infer_argument_type<'db>(
     }
 
     None
-}
-
-fn resolve_local_type<'db>(
-    db: &'db dyn ModuleDb,
-    ty: InferredTypeData<'db>,
-) -> InferredTypeData<'db> {
-    let InferredTypeData::Local(local) = ty else {
-        return ty;
-    };
-    let Some(module) = module_for_key(db, local.module(db)) else {
-        return ty;
-    };
-    let Some(inferred) = infer_module_types(db, module) else {
-        return ty;
-    };
-    inferred.resolve_type(db, ty)
 }
 
 fn select_constructor_argument_type<'db>(
@@ -2089,6 +2267,36 @@ impl<'db> ArgumentMatchAction<'db> {
 // #endregion
 
 // #region INTERNED TYPES
+
+/// Interned input for [`infer_expression_type`].
+#[salsa::interned]
+#[derive(Debug)]
+pub struct ExpressionTypeInput<'db> {
+    /// Module containing the expression.
+    pub module: ModuleInfo,
+    /// Source location that identifies the expression in the module's raw table.
+    pub expression: TextRange,
+}
+
+/// Interned input for [`infer_binding_type`].
+#[salsa::interned]
+#[derive(Debug)]
+pub struct BindingTypeInput<'db> {
+    /// Module containing the binding.
+    pub module: ModuleInfo,
+    /// Source range used to identify the binding.
+    pub range: TextRange,
+}
+
+/// Interned input for [`infer_local_type`].
+#[salsa::interned]
+#[derive(Debug)]
+pub struct LocalTypeInput<'db> {
+    /// Module owning the local type table.
+    pub module: ModuleInfo,
+    /// Index of the requested local type.
+    pub type_id: InferredLocalTypeId,
+}
 
 /// Interned input for [`infer_call_expression_type`].
 #[salsa::interned]

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -416,6 +416,15 @@ pub fn function_returns_promise<'db>(
     })
 }
 
+/// Resolves only the wrappers needed to reach one unambiguous callable type.
+pub fn resolve_callable_type<'db>(
+    db: &'db dyn ModuleDb,
+    ty: InferredTypeData<'db>,
+) -> Option<InferredTypeData<'db>> {
+    InferredType::new(db, ty)
+        .callable_type_with(|ty| resolve_local_type_on_demand(db, ty).expand_structural_global(db))
+}
+
 // #endregion
 
 // #region EXTERNAL INFERENCE ENTRY POINTS
@@ -1643,7 +1652,6 @@ impl<'db> ArgumentTypeCompatibility<'db> {
             ) => ArgumentMatchAction::Mismatch,
             (
                 InferredTypeData::Conditional
-                | InferredTypeData::Divergent(_)
                 | InferredTypeData::Global
                 | InferredTypeData::GlobalType(_)
                 | InferredTypeData::Literal(_)
@@ -1655,7 +1663,6 @@ impl<'db> ArgumentTypeCompatibility<'db> {
             | (
                 _,
                 InferredTypeData::Conditional
-                | InferredTypeData::Divergent(_)
                 | InferredTypeData::Global
                 | InferredTypeData::GlobalType(_)
                 | InferredTypeData::Literal(_)

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -22,7 +22,9 @@
 //! shapes produce `Unknown` or `None` instead of a TypeScript diagnostic.
 
 use crate::db::type_inference::{
-    ExportOriginResult, ImportResolution, ResolutionCtx, apply_substitutions_to_root_body,
+    ExportOriginResult, ImportResolution, PromiseClassification, ResolutionCtx,
+    apply_substitutions_to_root_body, classify_expression_array_promise,
+    classify_expression_function_return, classify_expression_promise,
     collect_namespace_export_names, collected_type_result, find_export_origin,
     find_member_type_on_demand as find_member_type_impl,
     find_value_member_type_on_demand as find_value_member_type_impl,
@@ -34,7 +36,7 @@ use crate::module_for_key;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
 use crate::{JsExport, JsOwnExport, ModuleDb, ResolvedPath, SymbolFromModuleInfo};
 use biome_js_type_info::{
-    RawTypeData, TypeId, TypeReference, TypeResolverLevel, global_types,
+    InferredType, RawTypeData, TypeId, TypeReference, TypeResolverLevel, global_types,
     interned_types::{
         CallArgumentType as InferredCallArgumentType,
         FunctionParameter as InferredFunctionParameter, InternedConstructor as InferredConstructor,
@@ -113,7 +115,7 @@ pub fn infer_module_types<'db>(
         db,
         module,
         &js_info,
-        ImportResolution::Full,
+        ImportResolution::OnDemand,
     ))
 }
 
@@ -143,8 +145,93 @@ pub fn infer_expression_type<'db>(
     }
 
     let reference = js_info.raw_expressions.get(&input.expression(db))?.clone();
-    let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::Full);
+    let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::OnDemand);
     Some(ctx.resolve(&reference))
+}
+
+/// Classifies whether an expression is a Promise without resolving unrelated members.
+///
+/// Returns `Some(true)` for `Promise` and `PromiseLike` instances and
+/// `Some(false)` for conclusive non-matches. Missing expressions, disabled
+/// inference, unsupported or ambiguous type shapes, dependency cycles, and
+/// exhausted traversal budgets return `None`.
+#[salsa::tracked(cycle_result=infer_expression_is_promise_cycle_result)]
+pub fn infer_expression_is_promise<'db>(
+    db: &'db dyn ModuleDb,
+    input: ExpressionTypeInput<'db>,
+) -> Option<bool> {
+    let module = input.module(db);
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    if !js_info.infer_types {
+        return None;
+    }
+
+    let reference = js_info.raw_expressions.get(&input.expression(db))?;
+    match classify_expression_promise(db, module, reference.clone()) {
+        PromiseClassification::ReturnsPromise => Some(true),
+        PromiseClassification::DoesNotReturnPromise => Some(false),
+        PromiseClassification::Indeterminate => None,
+    }
+}
+
+/// Classifies whether an expression is an array of Promise-like values without
+/// resolving unrelated members.
+#[salsa::tracked(cycle_result=infer_expression_is_array_of_promises_cycle_result)]
+pub fn infer_expression_is_array_of_promises<'db>(
+    db: &'db dyn ModuleDb,
+    input: ExpressionTypeInput<'db>,
+) -> Option<bool> {
+    let module = input.module(db);
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    if !js_info.infer_types {
+        return None;
+    }
+
+    let reference = js_info.raw_expressions.get(&input.expression(db))?;
+    match classify_expression_array_promise(db, module, reference.clone()) {
+        PromiseClassification::ReturnsPromise => Some(true),
+        PromiseClassification::DoesNotReturnPromise => Some(false),
+        PromiseClassification::Indeterminate => None,
+    }
+}
+
+/// Classifies whether an expression is a function that returns a Promise.
+///
+/// Returns `Some(true)` for a supported function whose return type is a
+/// `Promise` or `PromiseLike`, and `Some(false)` when the selected expression is
+/// conclusively not such a function. `None` represents missing expressions,
+/// disabled inference, unsupported or ambiguous type shapes, dependency
+/// cycles, and exhausted traversal budgets.
+///
+/// Requesting `callbacks.callback` returns `Some(true)` without resolving `other`:
+///
+/// ```ts
+/// const callbacks = { callback: async () => {}, other: unknown };
+/// callbacks.callback;
+/// ```
+#[salsa::tracked(cycle_result=infer_expression_function_returns_promise_cycle_result)]
+pub fn infer_expression_function_returns_promise<'db>(
+    db: &'db dyn ModuleDb,
+    input: ExpressionTypeInput<'db>,
+) -> Option<bool> {
+    let module = input.module(db);
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    if !js_info.infer_types {
+        return None;
+    }
+
+    let reference = js_info.raw_expressions.get(&input.expression(db))?;
+    match classify_expression_function_return(db, module, reference.clone()) {
+        PromiseClassification::ReturnsPromise => Some(true),
+        PromiseClassification::DoesNotReturnPromise => Some(false),
+        PromiseClassification::Indeterminate => None,
+    }
 }
 
 /// Infers the type collected for one binding range.
@@ -172,7 +259,7 @@ pub fn infer_binding_type<'db>(
     }
 
     let reference = js_info.raw_binding_types.get(&input.range(db))?.clone();
-    let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::Full);
+    let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::OnDemand);
     Some(ctx.resolve(&reference))
 }
 
@@ -203,7 +290,7 @@ pub fn infer_local_type<'db>(
         return None;
     }
 
-    let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::Full);
+    let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::OnDemand);
     Some(ctx.resolve_raw_type_id(TypeId::new(type_id.index())))
 }
 
@@ -231,6 +318,30 @@ fn infer_expression_type_cycle_result<'db>(
     _input: ExpressionTypeInput<'db>,
 ) -> Option<InferredTypeData<'db>> {
     Some(InferredTypeData::Unknown)
+}
+
+fn infer_expression_is_promise_cycle_result<'db>(
+    _db: &'db dyn ModuleDb,
+    _id: salsa::Id,
+    _input: ExpressionTypeInput<'db>,
+) -> Option<bool> {
+    None
+}
+
+fn infer_expression_is_array_of_promises_cycle_result<'db>(
+    _db: &'db dyn ModuleDb,
+    _id: salsa::Id,
+    _input: ExpressionTypeInput<'db>,
+) -> Option<bool> {
+    None
+}
+
+fn infer_expression_function_returns_promise_cycle_result<'db>(
+    _db: &'db dyn ModuleDb,
+    _id: salsa::Id,
+    _input: ExpressionTypeInput<'db>,
+) -> Option<bool> {
+    None
 }
 
 fn infer_binding_type_cycle_result<'db>(
@@ -274,6 +385,35 @@ pub fn find_value_member_type<'db>(
     name: &str,
 ) -> Option<InferredTypeData<'db>> {
     find_value_member_type_impl(db, ty, name)
+}
+
+/// Returns whether `ty` is a Promise without resolving unrelated nested types.
+pub fn is_promise_type<'db>(db: &'db dyn ModuleDb, ty: InferredTypeData<'db>) -> Option<bool> {
+    InferredType::new(db, ty).is_promise_instance_with(|ty| {
+        resolve_local_type_on_demand(db, ty).expand_structural_global(db)
+    })
+}
+
+/// Returns whether `ty` is an array of Promises without resolving unrelated
+/// nested types.
+pub fn is_array_of_promise_type<'db>(
+    db: &'db dyn ModuleDb,
+    ty: InferredTypeData<'db>,
+) -> Option<bool> {
+    InferredType::new(db, ty).is_array_of_promise_with(|ty| {
+        resolve_local_type_on_demand(db, ty).expand_structural_global(db)
+    })
+}
+
+/// Returns whether `ty` is callable and returns a Promise without resolving
+/// callable parameters or unrelated nested types.
+pub fn function_returns_promise<'db>(
+    db: &'db dyn ModuleDb,
+    ty: InferredTypeData<'db>,
+) -> Option<bool> {
+    InferredType::new(db, ty).function_returns_promise_with(|ty| {
+        resolve_local_type_on_demand(db, ty).expand_structural_global(db)
+    })
 }
 
 // #endregion
@@ -925,6 +1065,13 @@ fn infer_argument_type<'db>(
                         target,
                         &substitutions,
                     )));
+                }
+                InferredTypeData::Local(_) => {
+                    let resolved = resolve_local_type_on_demand(db, callee);
+                    if resolved == callee {
+                        return None;
+                    }
+                    pending.push(ArgumentTypeItem::Type(resolved));
                 }
                 InferredTypeData::Union(union) => {
                     let types = union.types(db);
@@ -2268,7 +2415,7 @@ impl<'db> ArgumentMatchAction<'db> {
 
 // #region INTERNED TYPES
 
-/// Interned input for [`infer_expression_type`].
+/// Interned input for queries that project information from one expression.
 #[salsa::interned]
 #[derive(Debug)]
 pub struct ExpressionTypeInput<'db> {

--- a/crates/biome_module_graph/src/db/type_inference/expressions.rs
+++ b/crates/biome_module_graph/src/db/type_inference/expressions.rs
@@ -435,7 +435,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 }
             }
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -562,7 +561,6 @@ impl<'db> ResolutionCtx<'db, '_> {
             }
             InferredTypeData::Tuple(tuple) => self.push_tuple_spread_arguments(tuple, args),
             ty @ (InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -637,7 +635,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 )
             }
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -684,7 +681,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                     Some(constructor)
                 }
                 InferredTypeData::Unknown
-                | InferredTypeData::Divergent(_)
                 | InferredTypeData::Global
                 | InferredTypeData::GlobalType(_)
                 | InferredTypeData::BigInt
@@ -899,7 +895,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 interface.name(self.db).text() == "PromiseLike"
             }
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -944,7 +939,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                     InferredTypeData::instance_of(self.db, extends, Box::default())
                 }),
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -1043,8 +1037,7 @@ impl<'db> ResolutionCtx<'db, '_> {
                     match self.resolve_inferred_type(*ty) {
                         InferredTypeData::Undefined => {}
                         InferredTypeData::Unknown => types.push(InferredTypeData::Unknown),
-                        ty @ (InferredTypeData::Divergent(_)
-                        | InferredTypeData::Global
+                        ty @ (InferredTypeData::Global
                         | InferredTypeData::GlobalType(_)
                         | InferredTypeData::BigInt
                         | InferredTypeData::Boolean
@@ -1114,7 +1107,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 .map(|ty| apply_substitutions(self.db, ty, &substitutions))
             }
             ty @ (InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
             | InferredTypeData::Boolean
@@ -1491,7 +1483,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                     .map(|ty| self.optional_element_type(*ty, true))
             }
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -1560,7 +1551,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 Some(InferredTypeData::array_instance(self.db, type_parameters))
             }
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -1621,7 +1611,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 self.rest_object_from_type(target, excluded_names)
             }
             subject @ (InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -1735,7 +1724,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                     }
                 }
                 InferredTypeData::Unknown
-                | InferredTypeData::Divergent(_)
                 | InferredTypeData::Global
                 | InferredTypeData::GlobalType(_)
                 | InferredTypeData::BigInt
@@ -1853,8 +1841,7 @@ impl<'db> ResolutionCtx<'db, '_> {
                 | InferredLiteral::Template(_) => Some(InferredTypeData::String),
             },
             InferredTypeData::Unknown => Some(InferredTypeData::Unknown),
-            InferredTypeData::Divergent(_)
-            | InferredTypeData::Global
+            InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::Symbol
             | InferredTypeData::Conditional
@@ -1886,7 +1873,6 @@ impl<'db> ResolutionCtx<'db, '_> {
         match self.resolve_inferred_type(argument) {
             InferredTypeData::BigInt => InferredTypeData::BigInt,
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::Boolean
@@ -1952,7 +1938,6 @@ impl<'db> ResolutionCtx<'db, '_> {
             InferredTypeData::Symbol => self.typeof_string_literal("symbol"),
             InferredTypeData::Undefined => self.typeof_string_literal("undefined"),
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::Conditional
@@ -2033,7 +2018,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                     InferredTypeData::TypeofType(ty) => pending.push(ty.ty(self.db)),
                     InferredTypeData::TypeofValue(value) => pending.push(value.ty(self.db)),
                     InferredTypeData::Unknown
-                    | InferredTypeData::Divergent(_)
                     | InferredTypeData::Global
                     | InferredTypeData::GlobalType(_)
                     | InferredTypeData::BigInt
@@ -2112,7 +2096,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                     InferredTypeData::TypeofType(ty) => pending.push(ty.ty(self.db)),
                     InferredTypeData::TypeofValue(value) => pending.push(value.ty(self.db)),
                     InferredTypeData::Unknown
-                    | InferredTypeData::Divergent(_)
                     | InferredTypeData::Global
                     | InferredTypeData::GlobalType(_)
                     | InferredTypeData::BigInt
@@ -2163,7 +2146,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 InferredTypeData::Number => FilterAction::Mapped(self.number_literal("0")),
                 InferredTypeData::String => FilterAction::Mapped(self.string_literal("")),
                 InferredTypeData::Unknown
-                | InferredTypeData::Divergent(_)
                 | InferredTypeData::Global
                 | InferredTypeData::GlobalType(_)
                 | InferredTypeData::Null
@@ -2208,7 +2190,6 @@ impl<'db> ResolutionCtx<'db, '_> {
             ConditionalSubset::Truthy => match ty {
                 InferredTypeData::Boolean => FilterAction::Mapped(self.boolean_literal(true)),
                 InferredTypeData::Unknown
-                | InferredTypeData::Divergent(_)
                 | InferredTypeData::Global
                 | InferredTypeData::GlobalType(_)
                 | InferredTypeData::BigInt

--- a/crates/biome_module_graph/src/db/type_inference/expressions.rs
+++ b/crates/biome_module_graph/src/db/type_inference/expressions.rs
@@ -811,7 +811,7 @@ impl<'db> ResolutionCtx<'db, '_> {
         Some(inferred_parameters.into_boxed_slice())
     }
 
-    fn resolve_await_expression(
+    pub(in crate::db::type_inference) fn resolve_await_expression(
         &mut self,
         argument: InferredTypeData<'db>,
     ) -> Option<InferredTypeData<'db>> {

--- a/crates/biome_module_graph/src/db/type_inference/imports.rs
+++ b/crates/biome_module_graph/src/db/type_inference/imports.rs
@@ -1,4 +1,13 @@
-use super::{InferredModuleTypes, globals::global_type, resolver::ResolutionCtx};
+use super::{
+    InferredModuleTypes,
+    globals::global_type,
+    named_type_ids,
+    resolver::{MAX_RAW_TYPE_RESOLUTION_DEPTH, ResolutionCtx},
+};
+use crate::db::queries::{
+    BindingTypeInput, LocalTypeInput, SymbolFromModuleInfo, infer_binding_type, infer_local_type,
+    infer_module_types_bottom_up, namespace_export_names, resolved_export_origin,
+};
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
 use crate::{JsExport, JsImport, JsOwnExport, ModuleDb, ResolvedPath};
 use biome_js_type_info::{
@@ -12,12 +21,73 @@ use biome_js_type_info::{
 use biome_rowan::Text;
 use rustc_hash::FxHashSet;
 use salsa::plumbing::AsId;
+use std::cell::Cell;
 
 const MAX_EXPORT_RESOLUTION_STEPS: usize = 1024;
+const MAX_ON_DEMAND_IMPORT_DEPTH: usize = 128;
+
+thread_local! {
+    static ON_DEMAND_IMPORT_DEPTH: Cell<usize> = const { Cell::new(0) };
+    static ITERATIVE_IMPORT_FALLBACK: Cell<bool> = const { Cell::new(false) };
+}
+
+struct OnDemandImportGuard;
+
+impl OnDemandImportGuard {
+    fn enter() -> Option<Self> {
+        ON_DEMAND_IMPORT_DEPTH.with(|depth| {
+            let current = depth.get();
+            if current >= MAX_ON_DEMAND_IMPORT_DEPTH {
+                None
+            } else {
+                depth.set(current + 1);
+                Some(Self)
+            }
+        })
+    }
+}
+
+impl Drop for OnDemandImportGuard {
+    fn drop(&mut self) {
+        ON_DEMAND_IMPORT_DEPTH.with(|depth| depth.set(depth.get() - 1));
+    }
+}
+
+struct IterativeImportFallbackGuard;
+
+impl IterativeImportFallbackGuard {
+    fn enter() -> Self {
+        ITERATIVE_IMPORT_FALLBACK.with(|active| active.set(true));
+        Self
+    }
+
+    fn is_active() -> bool {
+        ITERATIVE_IMPORT_FALLBACK.with(Cell::get)
+    }
+}
+
+impl Drop for IterativeImportFallbackGuard {
+    fn drop(&mut self) {
+        ITERATIVE_IMPORT_FALLBACK.with(|active| active.set(false));
+    }
+}
+
+/// Result of following a named export through its re-export chain.
+#[derive(Clone, Debug, Eq, PartialEq, salsa::Update)]
+pub(crate) enum ExportOriginResult {
+    /// No reachable module owns the requested export.
+    Missing,
+    /// The module and local name of the declaration that owns the export.
+    Found { module: ModuleInfo, name: Text },
+    /// Distinct declarations export the same name through blanket re-exports.
+    Ambiguous,
+    /// The traversal stopped before it could determine an origin.
+    Indeterminate,
+}
 
 struct NamespaceExportCollection {
     names: Vec<Text>,
-    seen_names: FxHashSet<String>,
+    seen_names: FxHashSet<Text>,
     seen_modules: FxHashSet<ModuleKey>,
     stack: Vec<(ModuleInfo, bool)>,
     remaining_steps: usize,
@@ -46,6 +116,12 @@ struct ResolvedExport<'db> {
     ty: InferredTypeData<'db>,
 }
 
+struct ExportOrigin {
+    identity: ExportIdentity,
+    module: ModuleInfo,
+    name: Text,
+}
+
 enum ExportResolution<'db> {
     Missing,
     Resolved(ResolvedExport<'db>),
@@ -58,6 +134,196 @@ enum ExportResolutionStep<'db> {
     Resolved(ResolvedExport<'db>),
 }
 
+enum ExportOriginStep {
+    Continue,
+    Found(ExportOrigin),
+}
+
+/// Follows re-export metadata without resolving any inferred types.
+pub(in crate::db) fn find_export_origin(
+    db: &dyn ModuleDb,
+    root_module: ModuleInfo,
+    root_name: Text,
+) -> ExportOriginResult {
+    let mut stack = Vec::new();
+    let mut seen = FxHashSet::default();
+    let mut resolved = None;
+    let mut remaining_steps = MAX_EXPORT_RESOLUTION_STEPS;
+
+    seen.insert((ModuleKey::new(root_module.as_id()), root_name.clone()));
+    match find_export_origin_in_module(db, root_module, &root_name, &mut stack) {
+        ExportOriginStep::Continue => {}
+        ExportOriginStep::Found(candidate) => resolved = Some(candidate),
+    }
+
+    while let Some((module, name)) = stack.pop() {
+        if !seen.insert((ModuleKey::new(module.as_id()), name.clone())) {
+            continue;
+        }
+        if remaining_steps == 0 {
+            return ExportOriginResult::Indeterminate;
+        }
+        remaining_steps -= 1;
+
+        match find_export_origin_in_module(db, module, &name, &mut stack) {
+            ExportOriginStep::Continue => {}
+            ExportOriginStep::Found(candidate) => {
+                if let Some(previous) = &resolved {
+                    if previous.identity != candidate.identity {
+                        return ExportOriginResult::Ambiguous;
+                    }
+                } else {
+                    resolved = Some(candidate);
+                }
+            }
+        }
+    }
+
+    resolved.map_or(ExportOriginResult::Missing, |origin| {
+        ExportOriginResult::Found {
+            module: origin.module,
+            name: origin.name,
+        }
+    })
+}
+
+/// Collects namespace export names without resolving their inferred types.
+pub(in crate::db) fn collect_namespace_export_names(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+) -> Option<Box<[Text]>> {
+    let mut collection = NamespaceExportCollection::new();
+
+    collection
+        .seen_modules
+        .insert(ModuleKey::new(module.as_id()));
+    if !collect_namespace_names_in_module(db, module, true, &mut collection) {
+        return None;
+    }
+
+    while let Some((module, include_default)) = collection.stack.pop() {
+        let module_key = ModuleKey::new(module.as_id());
+        if collection.seen_modules.contains(&module_key) {
+            continue;
+        }
+        if collection.remaining_steps == 0 {
+            return None;
+        }
+        collection.remaining_steps -= 1;
+        collection.seen_modules.insert(module_key);
+
+        if !collect_namespace_names_in_module(db, module, include_default, &mut collection) {
+            return None;
+        }
+    }
+
+    Some(collection.names.into_boxed_slice())
+}
+
+fn collect_namespace_names_in_module(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    include_default: bool,
+    collection: &mut NamespaceExportCollection,
+) -> bool {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return false;
+    };
+    if !js_info.infer_types {
+        return false;
+    }
+
+    for (name, _) in js_info.raw_exports.iter() {
+        if !include_default && name.text() == "default" {
+            continue;
+        }
+        if collection.seen_names.insert(name.clone()) {
+            collection.names.push(name.clone());
+        }
+    }
+
+    for reexport in js_info.blanket_reexports.iter().rev() {
+        let Some(path) = reexport.import.resolved_path.as_path() else {
+            return false;
+        };
+        let Some(module) = db.module_for_path(path) else {
+            return false;
+        };
+        collection.stack.push((module, false));
+    }
+
+    true
+}
+
+fn find_export_origin_in_module(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    name: &Text,
+    stack: &mut Vec<(ModuleInfo, Text)>,
+) -> ExportOriginStep {
+    let module_key = ModuleKey::new(module.as_id());
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return ExportOriginStep::Continue;
+    };
+    if !js_info.infer_types {
+        return ExportOriginStep::Continue;
+    }
+
+    match js_info.raw_exports.get(name.text()) {
+        Some(JsExport::Own(own_export) | JsExport::OwnType(own_export)) => {
+            ExportOriginStep::Found(ExportOrigin {
+                identity: ExportIdentity {
+                    module: module_key,
+                    own_export: own_export.clone(),
+                },
+                module,
+                name: name.clone(),
+            })
+        }
+        Some(JsExport::Reexport(reexport) | JsExport::ReexportType(reexport)) => {
+            if let Some(path) = reexport.import.resolved_path.as_path()
+                && let Some(module) = db.module_for_path(path)
+            {
+                let name = match &reexport.import.symbol {
+                    ImportSymbol::All => name.clone(),
+                    ImportSymbol::Default => Text::from("default"),
+                    ImportSymbol::Named(name) => name.clone(),
+                };
+                stack.push((module, name));
+            }
+            ExportOriginStep::Continue
+        }
+        None => {
+            for reexport in js_info.blanket_reexports.iter().rev() {
+                let Some(path) = reexport.import.resolved_path.as_path() else {
+                    continue;
+                };
+                if let Some(module) = db.module_for_path(path) {
+                    stack.push((module, name.clone()));
+                }
+            }
+            ExportOriginStep::Continue
+        }
+    }
+}
+
+/// Resolves one exported type through export-discovery and leaf queries.
+pub(in crate::db) fn resolve_export_type_on_demand<'db>(
+    db: &'db dyn ModuleDb,
+    module: ModuleInfo,
+    name: &str,
+) -> Option<InferredTypeData<'db>> {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    if !js_info.infer_types {
+        return None;
+    }
+
+    let ctx = ResolutionCtx::new(db, module, &js_info, super::ImportResolution::Full);
+    Some(ctx.resolve_export_name_on_demand(module, name))
+}
+
 impl<'db> ResolutionCtx<'db, '_> {
     pub(in crate::db::type_inference) fn resolve_import(
         &mut self,
@@ -67,10 +333,7 @@ impl<'db> ResolutionCtx<'db, '_> {
             return InferredTypeData::Unknown;
         };
 
-        self.infer_imported_module(module)
-            .map_or(InferredTypeData::Unknown, |types| {
-                self.resolve_import_symbol(module, types, &qualifier.symbol)
-            })
+        self.resolve_import_symbol(module, &qualifier.symbol)
     }
 
     fn module_for_resolved_path(&self, resolved_path: &ResolvedPath) -> Option<ModuleInfo> {
@@ -78,31 +341,173 @@ impl<'db> ResolutionCtx<'db, '_> {
         self.db.module_for_path(path)
     }
 
-    fn resolve_import_symbol(
+    /// Resolves an import from tables produced by whole-module inference.
+    ///
+    /// Cycle fallback uses this path because its blocked strongly connected
+    /// component is local to the active module query and cannot be cached by
+    /// the on-demand leaf queries.
+    fn resolve_import_symbol_from_tables(
         &self,
         module: ModuleInfo,
         inferred_types: &InferredModuleTypes<'db>,
         symbol: &ImportSymbol,
     ) -> InferredTypeData<'db> {
         match symbol {
-            ImportSymbol::All => self.namespace_for_module(module, inferred_types),
-            ImportSymbol::Default => self.resolve_export_name(module, inferred_types, "default"),
+            ImportSymbol::All => self.namespace_for_module_from_tables(module, inferred_types),
+            ImportSymbol::Default => {
+                self.resolve_export_name_from_tables(module, inferred_types, "default")
+            }
             ImportSymbol::Named(name) => {
-                self.resolve_export_name(module, inferred_types, name.text())
+                self.resolve_export_name_from_tables(module, inferred_types, name.text())
             }
         }
     }
 
-    fn resolve_js_import(&self, import: &JsImport) -> InferredTypeData<'db> {
-        self.module_for_resolved_path(&import.resolved_path)
-            .and_then(|module| {
-                self.infer_imported_module(module)
-                    .map(|types| self.resolve_import_symbol(module, types, &import.symbol))
-            })
-            .unwrap_or(InferredTypeData::Unknown)
+    /// Resolves only the requested import through export-discovery and leaf queries.
+    ///
+    /// Unlike [`Self::resolve_import_symbol_from_tables`], this path does not
+    /// materialize the imported module's complete inferred tables. Import
+    /// chains that exceed the recursion budget switch to iterative table
+    /// materialization to remain stack-safe.
+    fn resolve_import_symbol_on_demand(
+        &self,
+        module: ModuleInfo,
+        symbol: &ImportSymbol,
+    ) -> InferredTypeData<'db> {
+        match symbol {
+            ImportSymbol::All => self.namespace_for_module_on_demand(module),
+            ImportSymbol::Default => self.resolve_export_name_on_demand(module, "default"),
+            ImportSymbol::Named(name) => self.resolve_export_name_on_demand(module, name.text()),
+        }
     }
 
-    fn namespace_for_module(
+    fn resolve_import_symbol(
+        &self,
+        module: ModuleInfo,
+        symbol: &ImportSymbol,
+    ) -> InferredTypeData<'db> {
+        if matches!(
+            self.import_resolution,
+            super::ImportResolution::CycleFallback(_)
+        ) || IterativeImportFallbackGuard::is_active()
+        {
+            return self
+                .infer_imported_module(module)
+                .map_or(InferredTypeData::Unknown, |types| {
+                    self.resolve_import_symbol_from_tables(module, types, symbol)
+                });
+        }
+
+        let Some(_depth_guard) = OnDemandImportGuard::enter() else {
+            // Whole-module inference has an explicit dependency work list. It
+            // bounds the Rust stack for import chains too deep for leaf-query
+            // recursion while retaining leaf queries for ordinary chains.
+            let _fallback_guard = IterativeImportFallbackGuard::enter();
+            return infer_module_types_bottom_up(self.db, module)
+                .map_or(InferredTypeData::Unknown, |types| {
+                    self.resolve_import_symbol_from_tables(module, types, symbol)
+                });
+        };
+
+        self.resolve_import_symbol_on_demand(module, symbol)
+    }
+
+    fn resolve_js_import(&self, import: &JsImport) -> InferredTypeData<'db> {
+        let resolution_depth = self.resolution_depth.get();
+        if resolution_depth >= MAX_RAW_TYPE_RESOLUTION_DEPTH {
+            return InferredTypeData::Unknown;
+        }
+        self.resolution_depth.set(resolution_depth + 1);
+        let result = self
+            .module_for_resolved_path(&import.resolved_path)
+            .map_or(InferredTypeData::Unknown, |module| {
+                self.resolve_import_symbol(module, &import.symbol)
+            });
+        self.resolution_depth.set(resolution_depth);
+        result
+    }
+
+    /// Builds a namespace by resolving each discovered export through leaf queries.
+    fn namespace_for_module_on_demand(&self, module: ModuleInfo) -> InferredTypeData<'db> {
+        let Some(names) = namespace_export_names(self.db, module) else {
+            return InferredTypeData::Unknown;
+        };
+        let mut members = Vec::with_capacity(names.len());
+        for name in names {
+            match self.resolve_export_name_result_on_demand(module, name.text()) {
+                ExportResolution::Resolved(resolved) => members.push(InferredTypeMember {
+                    kind: InferredTypeMemberKind::Named(name.clone()),
+                    ty: resolved.ty,
+                }),
+                ExportResolution::Missing | ExportResolution::Ambiguous => {}
+                ExportResolution::Indeterminate => return InferredTypeData::Unknown,
+            };
+        }
+
+        InferredTypeData::Namespace(InferredNamespace::new(
+            self.db,
+            members.into_boxed_slice(),
+            Path::from(Text::from(module.path(self.db).to_string())),
+        ))
+    }
+
+    /// Resolves one exported name without materializing an inferred module table.
+    pub(in crate::db) fn resolve_export_name_on_demand(
+        &self,
+        module: ModuleInfo,
+        name: &str,
+    ) -> InferredTypeData<'db> {
+        match self.resolve_export_name_result_on_demand(module, name) {
+            ExportResolution::Resolved(resolved) => resolved.ty,
+            ExportResolution::Missing
+            | ExportResolution::Ambiguous
+            | ExportResolution::Indeterminate => InferredTypeData::Unknown,
+        }
+    }
+
+    /// Resolves an export origin, then requests only its binding or local type.
+    fn resolve_export_name_result_on_demand(
+        &self,
+        module: ModuleInfo,
+        name: &str,
+    ) -> ExportResolution<'db> {
+        let symbol = SymbolFromModuleInfo::new(self.db, name.to_string(), module);
+        let (module, name) = match resolved_export_origin(self.db, symbol) {
+            ExportOriginResult::Found { module, name } => (module, name),
+            ExportOriginResult::Missing => return ExportResolution::Missing,
+            ExportOriginResult::Ambiguous => return ExportResolution::Ambiguous,
+            ExportOriginResult::Indeterminate => return ExportResolution::Indeterminate,
+        };
+        let ModuleInfoKind::Js(js_info) = module.kind(self.db) else {
+            return ExportResolution::Missing;
+        };
+        let Some(JsExport::Own(own_export) | JsExport::OwnType(own_export)) =
+            js_info.raw_exports.get(name.text())
+        else {
+            return ExportResolution::Missing;
+        };
+
+        let ty = match own_export {
+            JsOwnExport::Binding(range) => {
+                let input = BindingTypeInput::new(self.db, *module, *range);
+                infer_binding_type(self.db, input).unwrap_or(InferredTypeData::Unknown)
+            }
+            JsOwnExport::Type(resolved_id) => {
+                inferred_type_from_resolved_id_on_demand(self.db, *module, &js_info, *resolved_id)
+            }
+            JsOwnExport::Namespace(reexport) => self.resolve_js_import(&reexport.import),
+        };
+        ExportResolution::Resolved(ResolvedExport {
+            identity: ExportIdentity {
+                module: ModuleKey::new(module.as_id()),
+                own_export: own_export.clone(),
+            },
+            ty,
+        })
+    }
+
+    /// Builds a namespace from whole-module tables during cycle fallback.
+    fn namespace_for_module_from_tables(
         &self,
         module: ModuleInfo,
         inferred_types: &InferredModuleTypes<'db>,
@@ -136,9 +541,20 @@ impl<'db> ResolutionCtx<'db, '_> {
             }
         }
 
-        let mut members = Vec::with_capacity(collection.names.len());
-        for name in collection.names {
-            match self.resolve_export_name_result(module, inferred_types, name.text()) {
+        self.namespace_from_table_names(module, inferred_types, collection.names)
+    }
+
+    fn namespace_from_table_names(
+        &self,
+        module: ModuleInfo,
+        inferred_types: &InferredModuleTypes<'db>,
+        names: impl IntoIterator<Item = Text>,
+    ) -> InferredTypeData<'db> {
+        let names = names.into_iter();
+        let (min_size, _) = names.size_hint();
+        let mut members = Vec::with_capacity(min_size);
+        for name in names {
+            match self.resolve_export_name_result_from_tables(module, inferred_types, name.text()) {
                 ExportResolution::Resolved(resolved) => members.push(InferredTypeMember {
                     kind: InferredTypeMemberKind::Named(name),
                     ty: resolved.ty,
@@ -170,7 +586,7 @@ impl<'db> ResolutionCtx<'db, '_> {
                 continue;
             }
 
-            if !collection.seen_names.insert(name.text().to_string()) {
+            if !collection.seen_names.insert(name.clone()) {
                 continue;
             }
 
@@ -187,13 +603,13 @@ impl<'db> ResolutionCtx<'db, '_> {
         true
     }
 
-    fn resolve_export_name(
+    fn resolve_export_name_from_tables(
         &self,
         module: ModuleInfo,
         inferred_types: &InferredModuleTypes<'db>,
         name: &str,
     ) -> InferredTypeData<'db> {
-        match self.resolve_export_name_result(module, inferred_types, name) {
+        match self.resolve_export_name_result_from_tables(module, inferred_types, name) {
             ExportResolution::Resolved(resolved) => resolved.ty,
             ExportResolution::Missing
             | ExportResolution::Ambiguous
@@ -201,7 +617,8 @@ impl<'db> ResolutionCtx<'db, '_> {
         }
     }
 
-    fn resolve_export_name_result(
+    /// Follows exports while reading types from tables prepared for cycle fallback.
+    fn resolve_export_name_result_from_tables(
         &self,
         module: ModuleInfo,
         inferred_types: &InferredModuleTypes<'db>,
@@ -213,7 +630,12 @@ impl<'db> ResolutionCtx<'db, '_> {
         let mut remaining_steps = MAX_EXPORT_RESOLUTION_STEPS;
 
         seen.insert((ModuleKey::new(module.as_id()), name.to_string()));
-        match self.resolve_export_name_in_module(module, inferred_types, name, &mut stack) {
+        match self.resolve_export_name_in_module_from_tables(
+            module,
+            inferred_types,
+            name,
+            &mut stack,
+        ) {
             ExportResolutionStep::Continue => {}
             ExportResolutionStep::Resolved(candidate) => resolved = Some(candidate),
         }
@@ -231,7 +653,12 @@ impl<'db> ResolutionCtx<'db, '_> {
                 continue;
             };
 
-            match self.resolve_export_name_in_module(module, inferred_types, &name, &mut stack) {
+            match self.resolve_export_name_in_module_from_tables(
+                module,
+                inferred_types,
+                &name,
+                &mut stack,
+            ) {
                 ExportResolutionStep::Continue => {}
                 ExportResolutionStep::Resolved(candidate) => {
                     if let Some(previous) = &resolved {
@@ -248,7 +675,7 @@ impl<'db> ResolutionCtx<'db, '_> {
         resolved.map_or(ExportResolution::Missing, ExportResolution::Resolved)
     }
 
-    fn resolve_export_name_in_module(
+    fn resolve_export_name_in_module_from_tables(
         &self,
         module: ModuleInfo,
         inferred_types: &InferredModuleTypes<'db>,
@@ -267,7 +694,7 @@ impl<'db> ResolutionCtx<'db, '_> {
                         module: module_key,
                         own_export: own_export.clone(),
                     },
-                    ty: self.resolve_own_export(inferred_types, own_export),
+                    ty: self.resolve_own_export_from_tables(inferred_types, own_export),
                 })
             }
             Some(JsExport::Reexport(reexport) | JsExport::ReexportType(reexport)) => {
@@ -306,7 +733,7 @@ impl<'db> ResolutionCtx<'db, '_> {
         }
     }
 
-    fn resolve_own_export(
+    fn resolve_own_export_from_tables(
         &self,
         inferred_types: &InferredModuleTypes<'db>,
         own_export: &JsOwnExport,
@@ -317,14 +744,15 @@ impl<'db> ResolutionCtx<'db, '_> {
                 .get(range)
                 .map_or(InferredTypeData::Unknown, |data| data.ty),
             JsOwnExport::Type(resolved_id) => {
-                inferred_type_from_resolved_id(self.db, inferred_types, *resolved_id)
+                inferred_type_from_resolved_id_from_tables(self.db, inferred_types, *resolved_id)
             }
             JsOwnExport::Namespace(reexport) => self.resolve_js_import(&reexport.import),
         }
     }
 }
 
-fn inferred_type_from_resolved_id<'db>(
+/// Resolves an exported type ID from an already materialized module table.
+fn inferred_type_from_resolved_id_from_tables<'db>(
     db: &'db dyn ModuleDb,
     inferred_types: &InferredModuleTypes<'db>,
     resolved_id: ResolvedTypeId,
@@ -344,6 +772,37 @@ fn inferred_type_from_resolved_id<'db>(
                     .get(resolved_id.index())
                     .copied()
                     .unwrap_or(InferredTypeData::Unknown)
+            }
+        }
+        TypeResolverLevel::Global => GlobalTypeId::try_from_type_id(resolved_id.id())
+            .map_or(InferredTypeData::Unknown, |id| global_type(db, id)),
+        TypeResolverLevel::Full | TypeResolverLevel::Import => InferredTypeData::Unknown,
+    }
+}
+
+/// Resolves an exported type ID without materializing its module table.
+///
+/// Named declarations remain symbolic local handles so recursive types retain
+/// their module identity. Other local types are requested through the leaf
+/// query.
+fn inferred_type_from_resolved_id_on_demand<'db>(
+    db: &'db dyn ModuleDb,
+    module: ModuleInfo,
+    js_info: &crate::JsModuleInfo,
+    resolved_id: ResolvedTypeId,
+) -> InferredTypeData<'db> {
+    match resolved_id.level() {
+        TypeResolverLevel::Thin => {
+            let local_type_id = LocalTypeId::new(resolved_id.index());
+            if named_type_ids(js_info).contains(&resolved_id.id()) {
+                InferredTypeData::Local(LocalTypeHandle::new(
+                    db,
+                    ModuleKey::new(module.as_id()),
+                    local_type_id,
+                ))
+            } else {
+                let input = LocalTypeInput::new(db, module, local_type_id);
+                infer_local_type(db, input).unwrap_or(InferredTypeData::Unknown)
             }
         }
         TypeResolverLevel::Global => GlobalTypeId::try_from_type_id(resolved_id.id())

--- a/crates/biome_module_graph/src/db/type_inference/imports.rs
+++ b/crates/biome_module_graph/src/db/type_inference/imports.rs
@@ -1,7 +1,6 @@
 use super::{
     InferredModuleTypes,
     globals::global_type,
-    named_type_ids,
     resolver::{MAX_RAW_TYPE_RESOLUTION_DEPTH, ResolutionCtx},
 };
 use crate::db::queries::{
@@ -11,14 +10,15 @@ use crate::db::queries::{
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
 use crate::{JsExport, JsImport, JsOwnExport, ModuleDb, ResolvedPath};
 use biome_js_type_info::{
-    GlobalTypeId, ImportSymbol, Path, ResolvedTypeId, TypeImportQualifier, TypeResolverLevel,
+    GlobalTypeId, ImportSymbol, Path, ResolvedTypeId, TypeImportQualifier, TypeReference,
+    TypeResolverLevel,
     interned_types::{
         InternedNamespace as InferredNamespace, LocalTypeHandle, LocalTypeId, ModuleKey,
         TypeData as InferredTypeData, TypeMember as InferredTypeMember,
         TypeMemberKind as InferredTypeMemberKind,
     },
 };
-use biome_rowan::Text;
+use biome_rowan::{Text, TextRange};
 use rustc_hash::FxHashSet;
 use salsa::plumbing::AsId;
 use std::cell::Cell;
@@ -489,8 +489,7 @@ impl<'db> ResolutionCtx<'db, '_> {
 
         let ty = match own_export {
             JsOwnExport::Binding(range) => {
-                let input = BindingTypeInput::new(self.db, *module, *range);
-                infer_binding_type(self.db, input).unwrap_or(InferredTypeData::Unknown)
+                inferred_type_from_binding_on_demand(self.db, *module, &js_info, *range)
             }
             JsOwnExport::Type(resolved_id) => {
                 inferred_type_from_resolved_id_on_demand(self.db, *module, &js_info, *resolved_id)
@@ -751,6 +750,27 @@ impl<'db> ResolutionCtx<'db, '_> {
     }
 }
 
+fn inferred_type_from_binding_on_demand<'db>(
+    db: &'db dyn ModuleDb,
+    module: ModuleInfo,
+    js_info: &crate::JsModuleInfo,
+    range: TextRange,
+) -> InferredTypeData<'db> {
+    if let Some(TypeReference::Resolved(resolved_id)) = js_info.raw_binding_types.get(&range)
+        && resolved_id.level() == TypeResolverLevel::Thin
+        && js_info.is_named_type(resolved_id.id())
+    {
+        return InferredTypeData::Local(LocalTypeHandle::new(
+            db,
+            ModuleKey::new(module.as_id()),
+            LocalTypeId::new(resolved_id.index()),
+        ));
+    }
+
+    let input = BindingTypeInput::new(db, module, range);
+    infer_binding_type(db, input).unwrap_or(InferredTypeData::Unknown)
+}
+
 /// Resolves an exported type ID from an already materialized module table.
 fn inferred_type_from_resolved_id_from_tables<'db>(
     db: &'db dyn ModuleDb,
@@ -760,7 +780,11 @@ fn inferred_type_from_resolved_id_from_tables<'db>(
     match resolved_id.level() {
         TypeResolverLevel::Thin => {
             let local_type_id = LocalTypeId::new(resolved_id.index());
-            if inferred_types.named_type_ids.contains(&local_type_id) {
+            if inferred_types
+                .named_type_ids
+                .binary_search(&local_type_id)
+                .is_ok()
+            {
                 InferredTypeData::Local(LocalTypeHandle::new(
                     db,
                     inferred_types.module_key,
@@ -794,7 +818,7 @@ fn inferred_type_from_resolved_id_on_demand<'db>(
     match resolved_id.level() {
         TypeResolverLevel::Thin => {
             let local_type_id = LocalTypeId::new(resolved_id.index());
-            if named_type_ids(js_info).contains(&resolved_id.id()) {
+            if js_info.is_named_type(resolved_id.id()) {
                 InferredTypeData::Local(LocalTypeHandle::new(
                     db,
                     ModuleKey::new(module.as_id()),

--- a/crates/biome_module_graph/src/db/type_inference/imports.rs
+++ b/crates/biome_module_graph/src/db/type_inference/imports.rs
@@ -320,7 +320,7 @@ pub(in crate::db) fn resolve_export_type_on_demand<'db>(
         return None;
     }
 
-    let ctx = ResolutionCtx::new(db, module, &js_info, super::ImportResolution::Full);
+    let ctx = ResolutionCtx::new(db, module, &js_info, super::ImportResolution::OnDemand);
     Some(ctx.resolve_export_name_on_demand(module, name))
 }
 

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -1,15 +1,13 @@
 use super::{InferredModuleTypes, collected_type_result};
-use crate::ModuleDb;
 use crate::db::queries::{LocalTypeInput, infer_local_type, infer_module_types};
-use crate::module_graph::ModuleInfo;
+use crate::{ModuleDb, module_for_key};
 use biome_js_type_info::interned_types::{
-    Literal as InferredLiteral, LocalTypeHandle, ModuleKey, ReturnType as InferredReturnType,
+    Literal as InferredLiteral, LocalTypeHandle, ReturnType as InferredReturnType,
     TypeData as InferredTypeData, TypeMember as InferredTypeMember,
     TypeMemberKind as InferredTypeMemberKind, TypeSubstitution as InferredTypeSubstitution,
     TypeTransformResult,
 };
 use rustc_hash::FxHashSet;
-use salsa::plumbing::{AsId, FromId};
 
 const MAX_LOCAL_TYPE_RESOLUTION_STEPS: usize = 1024;
 const MAX_MEMBER_LOOKUP_STEPS: usize = 1024;
@@ -400,7 +398,6 @@ pub(in crate::db::type_inference) fn find_member_type_with_resolver<'db>(
                 );
             }
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -478,7 +475,6 @@ fn declared_type_parameters<'db>(
         InferredTypeData::InstanceOf(instance) => Some(instance.type_parameters(db)),
         InferredTypeData::Interface(interface) => Some(interface.type_parameters(db)),
         InferredTypeData::Unknown
-        | InferredTypeData::Divergent(_)
         | InferredTypeData::Global
         | InferredTypeData::GlobalType(_)
         | InferredTypeData::BigInt
@@ -548,7 +544,6 @@ fn class_side_type<'db>(db: &'db dyn ModuleDb, ty: InferredTypeData<'db>) -> Inf
     match ty {
         InferredTypeData::InstanceOf(instance) => instance.ty(db),
         ty @ (InferredTypeData::Unknown
-        | InferredTypeData::Divergent(_)
         | InferredTypeData::Global
         | InferredTypeData::GlobalType(_)
         | InferredTypeData::BigInt
@@ -584,15 +579,6 @@ fn class_side_type<'db>(db: &'db dyn ModuleDb, ty: InferredTypeData<'db>) -> Inf
         | InferredTypeData::UnknownKeyword
         | InferredTypeData::VoidKeyword) => ty,
     }
-}
-
-pub(in crate::db::type_inference) fn module_for_key(
-    db: &dyn ModuleDb,
-    module_key: ModuleKey,
-) -> Option<ModuleInfo> {
-    let module = ModuleInfo::from_id(module_key.as_id());
-    let current = db.module_for_path(module.path(db))?;
-    (ModuleKey::new(current.as_id()) == module_key).then_some(current)
 }
 
 /// Finds a member defined directly on `ty` without traversing related types.
@@ -667,7 +653,6 @@ fn find_own_member_type<'db>(
             find(object.members(db), mode, mode.allows_index_signature())
         }
         InferredTypeData::Unknown
-        | InferredTypeData::Divergent(_)
         | InferredTypeData::Global
         | InferredTypeData::GlobalType(_)
         | InferredTypeData::BigInt

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -1,6 +1,6 @@
 use super::{InferredModuleTypes, collected_type_result};
 use crate::ModuleDb;
-use crate::db::queries::infer_module_types;
+use crate::db::queries::{LocalTypeInput, infer_local_type, infer_module_types};
 use crate::module_graph::ModuleInfo;
 use biome_js_type_info::interned_types::{
     Literal as InferredLiteral, LocalTypeHandle, ModuleKey, ReturnType as InferredReturnType,
@@ -13,6 +13,64 @@ use salsa::plumbing::{AsId, FromId};
 
 const MAX_LOCAL_TYPE_RESOLUTION_STEPS: usize = 1024;
 const MAX_MEMBER_LOOKUP_STEPS: usize = 1024;
+
+/// Resolves local handles through leaf queries until reaching a concrete type.
+///
+/// Repeated handles remain symbolic. Missing modules or local types resolve to
+/// `Unknown`.
+pub(in crate::db) fn resolve_local_type_on_demand<'db>(
+    db: &'db dyn ModuleDb,
+    mut ty: InferredTypeData<'db>,
+) -> InferredTypeData<'db> {
+    let mut seen = FxHashSet::default();
+
+    for _ in 0..MAX_LOCAL_TYPE_RESOLUTION_STEPS {
+        let InferredTypeData::Local(local) = ty else {
+            return ty;
+        };
+        let key = (local.module(db), local.type_id(db));
+        if !seen.insert(key) {
+            return ty;
+        }
+        let Some(module) = module_for_key(db, key.0) else {
+            return InferredTypeData::Unknown;
+        };
+        let input = LocalTypeInput::new(db, module, key.1);
+        ty = infer_local_type(db, input).unwrap_or(InferredTypeData::Unknown);
+    }
+
+    ty
+}
+
+/// Finds a member while resolving local handles through leaf queries.
+pub(in crate::db) fn find_member_type_on_demand<'db>(
+    db: &'db dyn ModuleDb,
+    ty: InferredTypeData<'db>,
+    name: &str,
+) -> Option<InferredTypeData<'db>> {
+    find_member_type_with_resolver(
+        db,
+        &mut OnDemandMemberLookupResolver,
+        ty,
+        name,
+        MemberLookupMode::Any,
+    )
+}
+
+/// Finds a value member while resolving local handles through leaf queries.
+pub(in crate::db) fn find_value_member_type_on_demand<'db>(
+    db: &'db dyn ModuleDb,
+    ty: InferredTypeData<'db>,
+    name: &str,
+) -> Option<InferredTypeData<'db>> {
+    find_member_type_with_resolver(
+        db,
+        &mut OnDemandMemberLookupResolver,
+        ty,
+        name,
+        MemberLookupMode::Value,
+    )
+}
 
 impl<'db> InferredModuleTypes<'db> {
     pub(in crate::db::type_inference) fn resolve_type_iterative(
@@ -141,6 +199,29 @@ impl<'db> MemberLookupResolver<'db> for &InferredModuleTypes<'db> {
         ty: InferredTypeData<'db>,
     ) -> InferredTypeData<'db> {
         self.resolve_type_iterative(db, ty)
+    }
+
+    fn finalize_member_type(
+        &mut self,
+        db: &'db dyn ModuleDb,
+        ty: InferredTypeData<'db>,
+        _is_optional: bool,
+        substitutions: &[InferredTypeSubstitution<'db>],
+        _crossed_instance: bool,
+    ) -> InferredTypeData<'db> {
+        apply_substitutions(db, ty, substitutions)
+    }
+}
+
+struct OnDemandMemberLookupResolver;
+
+impl<'db> MemberLookupResolver<'db> for OnDemandMemberLookupResolver {
+    fn resolve_type(
+        &mut self,
+        db: &'db dyn ModuleDb,
+        ty: InferredTypeData<'db>,
+    ) -> InferredTypeData<'db> {
+        resolve_local_type_on_demand(db, ty)
     }
 
     fn finalize_member_type(

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -15,8 +15,17 @@ mod lookup;
 mod qualifiers;
 mod resolver;
 
-pub(in crate::db) use lookup::{apply_substitutions_to_root_body, substitutions_for_instance};
-pub(in crate::db) use resolver::{ImportResolution, resolve_raw_types};
+pub(in crate::db) use imports::{
+    ExportOriginResult, collect_namespace_export_names, find_export_origin,
+    resolve_export_type_on_demand,
+};
+pub(in crate::db) use lookup::{
+    apply_substitutions_to_root_body, find_member_type_on_demand, find_value_member_type_on_demand,
+    resolve_local_type_on_demand, substitutions_for_instance,
+};
+pub(in crate::db) use resolver::{
+    ImportResolution, ResolutionCtx, named_type_ids, resolve_raw_types,
+};
 
 /// Type information attached to one binding declaration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, salsa::Update)]

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -12,6 +12,7 @@ mod expressions;
 mod globals;
 mod imports;
 mod lookup;
+mod promise_classification;
 mod qualifiers;
 mod resolver;
 
@@ -22,6 +23,10 @@ pub(in crate::db) use imports::{
 pub(in crate::db) use lookup::{
     apply_substitutions_to_root_body, find_member_type_on_demand, find_value_member_type_on_demand,
     resolve_local_type_on_demand, substitutions_for_instance,
+};
+pub(in crate::db) use promise_classification::{
+    PromiseClassification, classify_expression_array_promise, classify_expression_function_return,
+    classify_expression_promise,
 };
 pub(in crate::db) use resolver::{
     ImportResolution, ResolutionCtx, named_type_ids, resolve_raw_types,

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -28,9 +28,7 @@ pub(in crate::db) use promise_classification::{
     PromiseClassification, classify_expression_array_promise, classify_expression_function_return,
     classify_expression_promise,
 };
-pub(in crate::db) use resolver::{
-    ImportResolution, ResolutionCtx, named_type_ids, resolve_raw_types,
-};
+pub(in crate::db) use resolver::{ImportResolution, ResolutionCtx, resolve_raw_types};
 
 /// Type information attached to one binding declaration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, salsa::Update)]

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -257,7 +257,9 @@ fn classify_expression(
                         if let Some((binding_id, binding)) = binding {
                             if matches!(
                                 state.projection,
-                                Projection::FunctionReturn | Projection::ArrayFunctionReturn
+                                Projection::FunctionReturn
+                                    | Projection::ArrayFunctionReturn
+                                    | Projection::AwaitedArrayFunctionReturn
                             ) && scope
                                 .overload_sets()
                                 .iter()
@@ -420,10 +422,10 @@ fn classify_expression(
                             return DoesNotReturnPromise;
                         }
                         if function.is_async {
-                            return match state.projection {
-                                Projection::FunctionReturn => ReturnsPromise,
-                                Projection::ArrayFunctionReturn => DoesNotReturnPromise,
-                                Projection::AwaitedArrayFunctionReturn => DoesNotReturnPromise,
+                            match state.projection {
+                                Projection::FunctionReturn => return ReturnsPromise,
+                                Projection::ArrayFunctionReturn => return DoesNotReturnPromise,
+                                Projection::AwaitedArrayFunctionReturn => {}
                                 Projection::Promise
                                 | Projection::PromiseTarget
                                 | Projection::ArrayPromise
@@ -506,7 +508,10 @@ fn classify_expression(
                             return DoesNotReturnPromise;
                         }
                         TypeofExpression::Await(expression)
-                            if matches!(state.projection, Projection::ArrayPromise) =>
+                            if matches!(
+                                state.projection,
+                                Projection::ArrayPromise | Projection::AwaitedArrayPromise
+                            ) =>
                         {
                             ClassificationState {
                                 module: state.module,
@@ -762,21 +767,62 @@ fn classify_expression(
                         };
                     }
                     RawTypeData::Interface(interface) => {
-                        let Some((name, remaining)) = state.members.split_first() else {
-                            return Indeterminate;
-                        };
-                        let Some(member) = find_own_member(&interface.members, name, None) else {
-                            return Indeterminate;
-                        };
-                        if member.is_getter() {
-                            return Indeterminate;
-                        }
-                        ClassificationState {
-                            module: state.module,
-                            target: ClassificationTarget::Reference(member.ty.clone()),
-                            mode: MemberLookupMode::Value,
-                            members: remaining.into(),
-                            projection: state.projection,
+                        if state.members.is_empty()
+                            && matches!(
+                                state.projection,
+                                Projection::FunctionReturn
+                                    | Projection::ArrayFunctionReturn
+                                    | Projection::AwaitedArrayFunctionReturn
+                            )
+                        {
+                            let mut call_signatures = interface
+                                .members
+                                .iter()
+                                .filter(|member| member.kind.is_call_signature());
+                            if let Some(call_signature) = call_signatures.next() {
+                                if call_signatures.next().is_some() {
+                                    return Indeterminate;
+                                }
+                                ClassificationState {
+                                    module: state.module,
+                                    target: ClassificationTarget::Reference(
+                                        call_signature.ty.clone(),
+                                    ),
+                                    mode: MemberLookupMode::Value,
+                                    members: Box::default(),
+                                    projection: state.projection,
+                                }
+                            } else {
+                                match interface.extends.as_ref() {
+                                    [extends] => ClassificationState {
+                                        module: state.module,
+                                        target: ClassificationTarget::Reference(extends.clone()),
+                                        mode: state.mode,
+                                        members: Box::default(),
+                                        projection: state.projection,
+                                    },
+                                    [] => return DoesNotReturnPromise,
+                                    [_, ..] => return Indeterminate,
+                                }
+                            }
+                        } else {
+                            let Some((name, remaining)) = state.members.split_first() else {
+                                return Indeterminate;
+                            };
+                            let Some(member) = find_own_member(&interface.members, name, None)
+                            else {
+                                return Indeterminate;
+                            };
+                            if member.is_getter() {
+                                return Indeterminate;
+                            }
+                            ClassificationState {
+                                module: state.module,
+                                target: ClassificationTarget::Reference(member.ty.clone()),
+                                mode: MemberLookupMode::Value,
+                                members: remaining.into(),
+                                projection: state.projection,
+                            }
                         }
                     }
                 }

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -49,25 +49,40 @@ enum MemberLookupMode {
     Instance,
 }
 
+/// The Promise-related property requested from the current target.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum Projection {
+    /// Whether an expression evaluates to a Promise-like value.
     Promise,
+    /// Whether an instance target represents `Promise` or `PromiseLike`.
     PromiseTarget,
+    /// Whether a callable returns a Promise-like value.
     FunctionReturn,
+    /// Whether an expression evaluates to an array of Promise-like values.
     ArrayPromise,
+    /// Whether a callable returns an array of Promise-like values.
     ArrayFunctionReturn,
+    /// Whether awaiting an expression produces an array of Promise-like values.
     AwaitedArrayPromise,
+    /// Whether awaiting a callable's return produces an array of Promise-like values.
     AwaitedArrayFunctionReturn,
 }
 
+/// A location in the raw type graph that has not yet been classified.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 enum ClassificationTarget {
+    /// A raw type reference owned by the state's current module.
     Reference(TypeReference),
+    /// An entry in the current module's raw local type table.
     Local(TypeId),
+    /// A symbol imported from another resolved module path.
     Import {
+        /// Path used to locate the imported module in the module graph.
         resolved_path: ResolvedPath,
+        /// Export selected from the imported module.
         symbol: ImportSymbol,
     },
+    /// An export name owned by the state's current module.
     Export(Text),
 }
 
@@ -502,7 +517,7 @@ fn classify_expression(
                             members: state.members,
                             projection: state.projection,
                         },
-                        TypeofExpression::Await(expression)
+                        TypeofExpression::Await(_)
                             if matches!(state.projection, Projection::Promise) =>
                         {
                             return DoesNotReturnPromise;
@@ -665,21 +680,44 @@ fn classify_expression(
                         if matches!(state.projection, Projection::PromiseTarget) {
                             return DoesNotReturnPromise;
                         }
-                        let Some((name, remaining)) = state.members.split_first() else {
-                            return DoesNotReturnPromise;
-                        };
-                        let Some(member) = find_own_member(&object.members, name, None) else {
-                            return Indeterminate;
-                        };
-                        if member.is_getter() {
-                            return Indeterminate;
-                        }
-                        ClassificationState {
-                            module: state.module,
-                            target: ClassificationTarget::Reference(member.ty.clone()),
-                            mode: MemberLookupMode::Value,
-                            members: remaining.into(),
-                            projection: state.projection,
+                        if state.members.is_empty()
+                            && matches!(
+                                state.projection,
+                                Projection::FunctionReturn
+                                    | Projection::ArrayFunctionReturn
+                                    | Projection::AwaitedArrayFunctionReturn
+                            )
+                        {
+                            match sole_call_signature(&object.members) {
+                                Ok(Some(call_signature)) => ClassificationState {
+                                    module: state.module,
+                                    target: ClassificationTarget::Reference(
+                                        call_signature.ty.clone(),
+                                    ),
+                                    mode: MemberLookupMode::Value,
+                                    members: Box::default(),
+                                    projection: state.projection,
+                                },
+                                Ok(None) => return DoesNotReturnPromise,
+                                Err(()) => return Indeterminate,
+                            }
+                        } else {
+                            let Some((name, remaining)) = state.members.split_first() else {
+                                return DoesNotReturnPromise;
+                            };
+                            let Some(member) = find_own_member(&object.members, name, None) else {
+                                return Indeterminate;
+                            };
+                            if member.is_getter() {
+                                return Indeterminate;
+                            }
+                            ClassificationState {
+                                module: state.module,
+                                target: ClassificationTarget::Reference(member.ty.clone()),
+                                mode: MemberLookupMode::Value,
+                                members: remaining.into(),
+                                projection: state.projection,
+                            }
                         }
                     }
                     RawTypeData::Literal(literal) => match literal.as_ref() {
@@ -775,15 +813,8 @@ fn classify_expression(
                                     | Projection::AwaitedArrayFunctionReturn
                             )
                         {
-                            let mut call_signatures = interface
-                                .members
-                                .iter()
-                                .filter(|member| member.kind.is_call_signature());
-                            if let Some(call_signature) = call_signatures.next() {
-                                if call_signatures.next().is_some() {
-                                    return Indeterminate;
-                                }
-                                ClassificationState {
+                            match sole_call_signature(&interface.members) {
+                                Ok(Some(call_signature)) => ClassificationState {
                                     module: state.module,
                                     target: ClassificationTarget::Reference(
                                         call_signature.ty.clone(),
@@ -791,9 +822,8 @@ fn classify_expression(
                                     mode: MemberLookupMode::Value,
                                     members: Box::default(),
                                     projection: state.projection,
-                                }
-                            } else {
-                                match interface.extends.as_ref() {
+                                },
+                                Ok(None) => match interface.extends.as_ref() {
                                     [extends] => ClassificationState {
                                         module: state.module,
                                         target: ClassificationTarget::Reference(extends.clone()),
@@ -803,7 +833,8 @@ fn classify_expression(
                                     },
                                     [] => return DoesNotReturnPromise,
                                     [_, ..] => return Indeterminate,
-                                }
+                                },
+                                Err(()) => return Indeterminate,
                             }
                         } else {
                             let Some((name, remaining)) = state.members.split_first() else {
@@ -926,4 +957,16 @@ fn find_own_member<'a>(
                 MemberLookupMode::Instance => !member.is_static(),
             })
     })
+}
+
+fn sole_call_signature(members: &[TypeMember]) -> Result<Option<&TypeMember>, ()> {
+    let mut call_signatures = members
+        .iter()
+        .filter(|member| member.kind.is_call_signature());
+    let call_signature = call_signatures.next();
+    if call_signatures.next().is_some() {
+        Err(())
+    } else {
+        Ok(call_signature)
+    }
 }

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -1,0 +1,883 @@
+//! Selective Promise classification for raw expression types.
+//!
+//! Expression inference normally converts complete raw types into their
+//! interned representation. Promise classification needs less information: the
+//! references and selected members between an expression and its relevant outer
+//! type. Function-return classification additionally follows the selected
+//! function's return type. Keeping these projections in the raw type graph
+//! avoids resolving sibling object members and function parameters.
+//!
+//! A classification state identifies the module that owns a raw reference, the
+//! value or instance side used for member lookup, and the unconsumed member
+//! path. The traversal is linear and iterative. Unsupported expression forms,
+//! inherited members, accessors, ambiguous exports, cycles, and exhausted work
+//! budgets are indeterminate.
+
+use super::{ImportResolution, ResolutionCtx, find_value_member_type_on_demand};
+use crate::db::queries::{
+    function_returns_promise, is_array_of_promise_type, is_promise_type, resolved_export_origin,
+};
+use crate::js_module_info::TsBindingReferenceExt;
+use crate::module_graph::{ModuleInfo, ModuleInfoKind};
+use crate::{JsExport, JsOwnExport, ModuleDb, ResolvedPath, SymbolFromModuleInfo};
+use biome_js_type_info::{
+    GlobalTypeId, ImportSymbol, Literal, RawTypeData, ScopeId, TypeId, TypeMember, TypeReference,
+    TypeReferenceQualifier, TypeResolverLevel, TypeofExpression, global_types,
+    interned_types::{ReturnType, TypeData as InferredTypeData},
+};
+use biome_rowan::Text;
+use rustc_hash::FxHashSet;
+
+const MAX_PROMISE_CLASSIFICATION_STATES: usize = 1024;
+
+/// Result of testing a projected expression value or function return for a Promise shape.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::db) enum PromiseClassification {
+    /// The selected value is a `Promise` or `PromiseLike` instance.
+    ReturnsPromise,
+    /// The selected value is conclusively not Promise-like.
+    DoesNotReturnPromise,
+    /// The projection cannot classify the expression without broader inference.
+    Indeterminate,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum MemberLookupMode {
+    /// Selects static members when the target is a class value.
+    Value,
+    /// Selects instance members when the target is a class.
+    Instance,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum Projection {
+    Promise,
+    PromiseTarget,
+    FunctionReturn,
+    ArrayPromise,
+    ArrayFunctionReturn,
+    AwaitedArrayPromise,
+    AwaitedArrayFunctionReturn,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum ClassificationTarget {
+    Reference(TypeReference),
+    Local(TypeId),
+    Import {
+        resolved_path: ResolvedPath,
+        symbol: ImportSymbol,
+    },
+    Export(Text),
+}
+
+/// One position in the raw projection.
+///
+/// `members` stores the property names still to consume, in access order. An
+/// empty path applies the current projection directly to `target`.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ClassificationState {
+    module: ModuleInfo,
+    target: ClassificationTarget,
+    mode: MemberLookupMode,
+    members: Box<[Text]>,
+    projection: Projection,
+}
+
+/// Classifies a raw expression's Promise shape without materializing its enclosing type.
+///
+/// The projection follows lexical bindings, imports, exports, aliases, `this`,
+/// calls, and own named members. Unsupported expression forms remain
+/// indeterminate instead of entering complete expression inference.
+pub(in crate::db) fn classify_expression_promise(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    reference: TypeReference,
+) -> PromiseClassification {
+    classify_expression(db, module, reference, Projection::Promise)
+}
+
+/// Classifies whether a raw expression is an array of Promise-like values.
+pub(in crate::db) fn classify_expression_array_promise(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    reference: TypeReference,
+) -> PromiseClassification {
+    classify_expression(db, module, reference, Projection::ArrayPromise)
+}
+
+/// Classifies a raw expression's function return without materializing its enclosing type.
+///
+/// The projection follows lexical bindings, imports, exports, aliases, `this`,
+/// and own named members. Only the selected function's return reference enters
+/// regular inferred-type resolution. Sibling members and function parameters
+/// are not resolved.
+pub(in crate::db) fn classify_expression_function_return(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    reference: TypeReference,
+) -> PromiseClassification {
+    classify_expression(db, module, reference, Projection::FunctionReturn)
+}
+
+fn classify_expression(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    reference: TypeReference,
+    projection: Projection,
+) -> PromiseClassification {
+    use PromiseClassification::{DoesNotReturnPromise, Indeterminate, ReturnsPromise};
+
+    let mut state = ClassificationState {
+        module,
+        target: ClassificationTarget::Reference(reference),
+        mode: MemberLookupMode::Value,
+        members: Box::default(),
+        projection,
+    };
+    let mut seen = FxHashSet::default();
+
+    for _ in 0..MAX_PROMISE_CLASSIFICATION_STATES {
+        if !seen.insert(state.clone()) {
+            return Indeterminate;
+        }
+        db.unwind_if_revision_cancelled();
+
+        state = match state.target {
+            ClassificationTarget::Reference(reference) => match reference {
+                TypeReference::Resolved(resolved) => match resolved.level() {
+                    TypeResolverLevel::Thin => ClassificationState {
+                        target: ClassificationTarget::Local(resolved.id()),
+                        ..state
+                    },
+                    TypeResolverLevel::Global if state.members.is_empty() => {
+                        let Some(id) = GlobalTypeId::try_from_type_id(resolved.id()) else {
+                            return Indeterminate;
+                        };
+                        let ty = match state.projection {
+                            Projection::Promise => global_types(db).get(id),
+                            Projection::PromiseTarget => {
+                                let target = global_types(db).get(id);
+                                InferredTypeData::instance_of(db, target, Box::default())
+                            }
+                            Projection::FunctionReturn => {
+                                let ty = global_types(db).get(id);
+                                let Some(function) = ty.callable_function(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                let ReturnType::Type(return_ty) = function.return_type(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                *return_ty
+                            }
+                            Projection::ArrayPromise => global_types(db).get(id),
+                            Projection::ArrayFunctionReturn => {
+                                let ty = global_types(db).get(id);
+                                let Some(function) = ty.callable_function(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                let ReturnType::Type(return_ty) = function.return_type(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                *return_ty
+                            }
+                            Projection::AwaitedArrayPromise => global_types(db).get(id),
+                            Projection::AwaitedArrayFunctionReturn => {
+                                let ty = global_types(db).get(id);
+                                let Some(function) = ty.callable_function(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                let ReturnType::Type(return_ty) = function.return_type(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                let ModuleInfoKind::Js(js_info) = state.module.kind(db) else {
+                                    return Indeterminate;
+                                };
+                                let mut ctx = ResolutionCtx::new(
+                                    db,
+                                    state.module,
+                                    &js_info,
+                                    ImportResolution::OnDemand,
+                                );
+                                let Some(awaited) = ctx.resolve_await_expression(*return_ty) else {
+                                    return Indeterminate;
+                                };
+                                return match is_array_of_promise_type(db, awaited) {
+                                    Some(true) => ReturnsPromise,
+                                    Some(false) => DoesNotReturnPromise,
+                                    None => Indeterminate,
+                                };
+                            }
+                        };
+                        let result = match state.projection {
+                            Projection::Promise
+                            | Projection::PromiseTarget
+                            | Projection::FunctionReturn => is_promise_type(db, ty),
+                            Projection::ArrayPromise
+                            | Projection::ArrayFunctionReturn
+                            | Projection::AwaitedArrayPromise => is_array_of_promise_type(db, ty),
+                            Projection::AwaitedArrayFunctionReturn => unreachable!(),
+                        };
+                        return match result {
+                            Some(true) => ReturnsPromise,
+                            Some(false) => DoesNotReturnPromise,
+                            None => Indeterminate,
+                        };
+                    }
+                    TypeResolverLevel::Global
+                    | TypeResolverLevel::Full
+                    | TypeResolverLevel::Import => return Indeterminate,
+                },
+                TypeReference::Qualifier(qualifier) => {
+                    let mut qualifier_path = qualifier.path.iter();
+                    let Some(identifier) = qualifier_path.next() else {
+                        return Indeterminate;
+                    };
+                    let members: Box<[Text]> = qualifier_path
+                        .cloned()
+                        .chain(state.members.iter().cloned())
+                        .collect();
+                    let ModuleInfoKind::Js(js_info) = state.module.kind(db) else {
+                        return Indeterminate;
+                    };
+                    let mut scope = js_info.semantic_model.scope_from_id(qualifier.scope_id);
+
+                    loop {
+                        let binding = scope
+                            .get_binding_reference(identifier.text())
+                            .and_then(|reference| {
+                                reference.get_binding_id_for_qualifier(&qualifier)
+                            })
+                            .and_then(|id| {
+                                js_info
+                                    .semantic_model
+                                    .binding_by_id(id)
+                                    .map(|binding| (id, binding))
+                            });
+                        if let Some((binding_id, binding)) = binding {
+                            if matches!(
+                                state.projection,
+                                Projection::FunctionReturn | Projection::ArrayFunctionReturn
+                            ) && scope
+                                .overload_sets()
+                                .iter()
+                                .any(|set| set.contains(&binding_id))
+                            {
+                                return Indeterminate;
+                            }
+                            if binding.is_imported() {
+                                let Some(import) = js_info.static_imports.get(identifier.text())
+                                else {
+                                    return Indeterminate;
+                                };
+                                break ClassificationState {
+                                    module: state.module,
+                                    target: ClassificationTarget::Import {
+                                        resolved_path: import.resolved_path.clone(),
+                                        symbol: import.symbol.clone(),
+                                    },
+                                    mode: state.mode,
+                                    members: members.clone(),
+                                    projection: state.projection,
+                                };
+                            }
+                            let Some(reference) = js_info
+                                .raw_binding_types
+                                .get(&binding.syntax().text_trimmed_range())
+                            else {
+                                return Indeterminate;
+                            };
+                            break ClassificationState {
+                                module: state.module,
+                                target: ClassificationTarget::Reference(reference.clone()),
+                                mode: state.mode,
+                                members: members.clone(),
+                                projection: state.projection,
+                            };
+                        }
+                        if let Some(parent) = scope.parent() {
+                            scope = parent;
+                            continue;
+                        }
+
+                        let mut ctx = ResolutionCtx::new(
+                            db,
+                            state.module,
+                            &js_info,
+                            ImportResolution::OnDemand,
+                        );
+                        let mut ty = ctx.resolve_qualifier(&qualifier);
+                        for member in &members {
+                            let Some(member_ty) =
+                                find_value_member_type_on_demand(db, ty, member.text())
+                            else {
+                                return Indeterminate;
+                            };
+                            ty = member_ty;
+                        }
+                        return match state.projection {
+                            Projection::Promise => match is_promise_type(db, ty) {
+                                Some(true) => ReturnsPromise,
+                                Some(false) => DoesNotReturnPromise,
+                                None => Indeterminate,
+                            },
+                            Projection::FunctionReturn => {
+                                if let InferredTypeData::GlobalType(id) = ty {
+                                    ty = global_types(db).get(id);
+                                }
+                                let result = function_returns_promise(db, ty);
+                                match result {
+                                    Some(true) => ReturnsPromise,
+                                    Some(false) => DoesNotReturnPromise,
+                                    None => Indeterminate,
+                                }
+                            }
+                            Projection::ArrayPromise => match is_array_of_promise_type(db, ty) {
+                                Some(true) => ReturnsPromise,
+                                Some(false) => DoesNotReturnPromise,
+                                None => Indeterminate,
+                            },
+                            Projection::ArrayFunctionReturn => {
+                                if let InferredTypeData::GlobalType(id) = ty {
+                                    ty = global_types(db).get(id);
+                                }
+                                let Some(function) = ty.callable_function(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                let ReturnType::Type(return_ty) = function.return_type(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                match is_array_of_promise_type(db, *return_ty) {
+                                    Some(true) => ReturnsPromise,
+                                    Some(false) => DoesNotReturnPromise,
+                                    None => Indeterminate,
+                                }
+                            }
+                            Projection::AwaitedArrayPromise => {
+                                let Some(awaited) = ctx.resolve_await_expression(ty) else {
+                                    return Indeterminate;
+                                };
+                                match is_array_of_promise_type(db, awaited) {
+                                    Some(true) => ReturnsPromise,
+                                    Some(false) => DoesNotReturnPromise,
+                                    None => Indeterminate,
+                                }
+                            }
+                            Projection::AwaitedArrayFunctionReturn => {
+                                if let InferredTypeData::GlobalType(id) = ty {
+                                    ty = global_types(db).get(id);
+                                }
+                                let Some(function) = ty.callable_function(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                let ReturnType::Type(return_ty) = function.return_type(db) else {
+                                    return DoesNotReturnPromise;
+                                };
+                                let Some(awaited) = ctx.resolve_await_expression(*return_ty) else {
+                                    return Indeterminate;
+                                };
+                                match is_array_of_promise_type(db, awaited) {
+                                    Some(true) => ReturnsPromise,
+                                    Some(false) => DoesNotReturnPromise,
+                                    None => Indeterminate,
+                                }
+                            }
+                            Projection::PromiseTarget => Indeterminate,
+                        };
+                    }
+                }
+                TypeReference::Import(import) => ClassificationState {
+                    module: state.module,
+                    target: ClassificationTarget::Import {
+                        resolved_path: import.resolved_path.clone(),
+                        symbol: import.symbol.clone(),
+                    },
+                    mode: state.mode,
+                    members: state.members,
+                    projection: state.projection,
+                },
+            },
+            ClassificationTarget::Local(type_id) => {
+                let ModuleInfoKind::Js(js_info) = state.module.kind(db) else {
+                    return Indeterminate;
+                };
+                let Some(raw) = js_info.raw_types.get(type_id.index()) else {
+                    return Indeterminate;
+                };
+
+                match raw {
+                    RawTypeData::Function(function) => {
+                        if !state.members.is_empty() {
+                            return Indeterminate;
+                        }
+                        if matches!(
+                            state.projection,
+                            Projection::Promise
+                                | Projection::PromiseTarget
+                                | Projection::ArrayPromise
+                                | Projection::AwaitedArrayPromise
+                        ) {
+                            return DoesNotReturnPromise;
+                        }
+                        if function.is_async {
+                            return match state.projection {
+                                Projection::FunctionReturn => ReturnsPromise,
+                                Projection::ArrayFunctionReturn => DoesNotReturnPromise,
+                                Projection::AwaitedArrayFunctionReturn => DoesNotReturnPromise,
+                                Projection::Promise
+                                | Projection::PromiseTarget
+                                | Projection::ArrayPromise
+                                | Projection::AwaitedArrayPromise => unreachable!(),
+                            };
+                        }
+                        let Some(return_ty) = function.return_type.as_type() else {
+                            return DoesNotReturnPromise;
+                        };
+                        let mut ctx = ResolutionCtx::new(
+                            db,
+                            state.module,
+                            &js_info,
+                            ImportResolution::OnDemand,
+                        );
+                        let ty = ctx.resolve(return_ty);
+                        let result = match state.projection {
+                            Projection::FunctionReturn => is_promise_type(db, ty),
+                            Projection::ArrayFunctionReturn => is_array_of_promise_type(db, ty),
+                            Projection::AwaitedArrayFunctionReturn => {
+                                let Some(awaited) = ctx.resolve_await_expression(ty) else {
+                                    return Indeterminate;
+                                };
+                                is_array_of_promise_type(db, awaited)
+                            }
+                            Projection::Promise
+                            | Projection::PromiseTarget
+                            | Projection::ArrayPromise
+                            | Projection::AwaitedArrayPromise => unreachable!(),
+                        };
+                        return match result {
+                            Some(true) => ReturnsPromise,
+                            Some(false) => DoesNotReturnPromise,
+                            None => Indeterminate,
+                        };
+                    }
+                    RawTypeData::Reference(reference) => ClassificationState {
+                        target: ClassificationTarget::Reference(reference.clone()),
+                        ..state
+                    },
+                    RawTypeData::TypeofType(reference) => ClassificationState {
+                        target: ClassificationTarget::Reference((**reference).clone()),
+                        ..state
+                    },
+                    RawTypeData::TypeofValue(value) => {
+                        let reference = if value.ty.is_unknown() {
+                            TypeReferenceQualifier::from_path(
+                                value.scope_id.unwrap_or(ScopeId::GLOBAL),
+                                value.identifier.clone(),
+                            )
+                            .into()
+                        } else {
+                            value.ty.clone()
+                        };
+                        ClassificationState {
+                            target: ClassificationTarget::Reference(reference),
+                            ..state
+                        }
+                    }
+                    RawTypeData::TypeofExpression(expression) => match expression.as_ref() {
+                        TypeofExpression::StaticMember(expression) => ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(expression.object.clone()),
+                            mode: MemberLookupMode::Value,
+                            members: std::iter::once(expression.member.clone())
+                                .chain(state.members.iter().cloned())
+                                .collect(),
+                            projection: state.projection,
+                        },
+                        TypeofExpression::This(expression) => ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(expression.parent.clone()),
+                            mode: MemberLookupMode::Instance,
+                            members: state.members,
+                            projection: state.projection,
+                        },
+                        TypeofExpression::Await(expression)
+                            if matches!(state.projection, Projection::Promise) =>
+                        {
+                            return DoesNotReturnPromise;
+                        }
+                        TypeofExpression::Await(expression)
+                            if matches!(state.projection, Projection::ArrayPromise) =>
+                        {
+                            ClassificationState {
+                                module: state.module,
+                                target: ClassificationTarget::Reference(
+                                    expression.argument.clone(),
+                                ),
+                                mode: MemberLookupMode::Value,
+                                members: Box::default(),
+                                projection: Projection::AwaitedArrayPromise,
+                            }
+                        }
+                        TypeofExpression::Call(expression)
+                            if state.members.is_empty()
+                                && matches!(
+                                    state.projection,
+                                    Projection::Promise
+                                        | Projection::ArrayPromise
+                                        | Projection::AwaitedArrayPromise
+                                ) =>
+                        {
+                            ClassificationState {
+                                module: state.module,
+                                target: ClassificationTarget::Reference(expression.callee.clone()),
+                                mode: MemberLookupMode::Value,
+                                members: Box::default(),
+                                projection: match state.projection {
+                                    Projection::Promise => Projection::FunctionReturn,
+                                    Projection::ArrayPromise => Projection::ArrayFunctionReturn,
+                                    Projection::AwaitedArrayPromise => {
+                                        Projection::AwaitedArrayFunctionReturn
+                                    }
+                                    Projection::PromiseTarget
+                                    | Projection::FunctionReturn
+                                    | Projection::ArrayFunctionReturn
+                                    | Projection::AwaitedArrayFunctionReturn => unreachable!(),
+                                },
+                            }
+                        }
+                        TypeofExpression::Addition(_)
+                        | TypeofExpression::Await(_)
+                        | TypeofExpression::BitwiseNot(_)
+                        | TypeofExpression::Call(_)
+                        | TypeofExpression::Conditional(_)
+                        | TypeofExpression::Destructure(_)
+                        | TypeofExpression::Index(_)
+                        | TypeofExpression::IterableValueOf(_)
+                        | TypeofExpression::LogicalAnd(_)
+                        | TypeofExpression::LogicalOr(_)
+                        | TypeofExpression::New(_)
+                        | TypeofExpression::NullishCoalescing(_)
+                        | TypeofExpression::Super(_)
+                        | TypeofExpression::Typeof(_)
+                        | TypeofExpression::UnaryMinus(_) => return Indeterminate,
+                    },
+                    RawTypeData::InstanceOf(instance) => match state.projection {
+                        Projection::FunctionReturn
+                        | Projection::ArrayFunctionReturn
+                        | Projection::AwaitedArrayFunctionReturn => ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(instance.ty.clone()),
+                            mode: MemberLookupMode::Instance,
+                            members: state.members,
+                            projection: state.projection,
+                        },
+                        Projection::Promise if state.members.is_empty() => ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(instance.ty.clone()),
+                            mode: MemberLookupMode::Instance,
+                            members: Box::default(),
+                            projection: Projection::PromiseTarget,
+                        },
+                        Projection::Promise => ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(instance.ty.clone()),
+                            mode: MemberLookupMode::Instance,
+                            members: state.members,
+                            projection: Projection::Promise,
+                        },
+                        Projection::PromiseTarget => return DoesNotReturnPromise,
+                        Projection::ArrayPromise if state.members.is_empty() => {
+                            let mut ctx = ResolutionCtx::new(
+                                db,
+                                state.module,
+                                &js_info,
+                                ImportResolution::OnDemand,
+                            );
+                            return match is_array_of_promise_type(
+                                db,
+                                ctx.resolve_raw_type_id(type_id),
+                            ) {
+                                Some(true) => ReturnsPromise,
+                                Some(false) => DoesNotReturnPromise,
+                                None => Indeterminate,
+                            };
+                        }
+                        Projection::ArrayPromise => ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(instance.ty.clone()),
+                            mode: MemberLookupMode::Instance,
+                            members: state.members,
+                            projection: state.projection,
+                        },
+                        Projection::AwaitedArrayPromise if state.members.is_empty() => {
+                            let mut ctx = ResolutionCtx::new(
+                                db,
+                                state.module,
+                                &js_info,
+                                ImportResolution::OnDemand,
+                            );
+                            let ty = ctx.resolve_raw_type_id(type_id);
+                            let Some(awaited) = ctx.resolve_await_expression(ty) else {
+                                return Indeterminate;
+                            };
+                            return match is_array_of_promise_type(db, awaited) {
+                                Some(true) => ReturnsPromise,
+                                Some(false) => DoesNotReturnPromise,
+                                None => Indeterminate,
+                            };
+                        }
+                        Projection::AwaitedArrayPromise => ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(instance.ty.clone()),
+                            mode: MemberLookupMode::Instance,
+                            members: state.members,
+                            projection: state.projection,
+                        },
+                    },
+                    RawTypeData::Class(class) => {
+                        if matches!(state.projection, Projection::PromiseTarget) {
+                            return DoesNotReturnPromise;
+                        }
+                        let Some((name, remaining)) = state.members.split_first() else {
+                            return DoesNotReturnPromise;
+                        };
+                        let Some(member) = find_own_member(&class.members, name, Some(state.mode))
+                        else {
+                            return Indeterminate;
+                        };
+                        if member.is_getter() {
+                            return Indeterminate;
+                        }
+                        ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(member.ty.clone()),
+                            mode: MemberLookupMode::Value,
+                            members: remaining.into(),
+                            projection: state.projection,
+                        }
+                    }
+                    RawTypeData::Object(object) => {
+                        if matches!(state.projection, Projection::PromiseTarget) {
+                            return DoesNotReturnPromise;
+                        }
+                        let Some((name, remaining)) = state.members.split_first() else {
+                            return DoesNotReturnPromise;
+                        };
+                        let Some(member) = find_own_member(&object.members, name, None) else {
+                            return Indeterminate;
+                        };
+                        if member.is_getter() {
+                            return Indeterminate;
+                        }
+                        ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(member.ty.clone()),
+                            mode: MemberLookupMode::Value,
+                            members: remaining.into(),
+                            projection: state.projection,
+                        }
+                    }
+                    RawTypeData::Literal(literal) => match literal.as_ref() {
+                        Literal::Object(object) => {
+                            let Some((name, remaining)) = state.members.split_first() else {
+                                return DoesNotReturnPromise;
+                            };
+                            let Some(member) = find_own_member(object.members(), name, None) else {
+                                return Indeterminate;
+                            };
+                            if member.is_getter() {
+                                return Indeterminate;
+                            }
+                            ClassificationState {
+                                module: state.module,
+                                target: ClassificationTarget::Reference(member.ty.clone()),
+                                mode: MemberLookupMode::Value,
+                                members: remaining.into(),
+                                projection: state.projection,
+                            }
+                        }
+                        Literal::BigInt(_)
+                        | Literal::Boolean(_)
+                        | Literal::Number(_)
+                        | Literal::RegExp(_)
+                        | Literal::String(_)
+                        | Literal::Template(_) => {
+                            return if state.members.is_empty() {
+                                DoesNotReturnPromise
+                            } else {
+                                Indeterminate
+                            };
+                        }
+                    },
+                    RawTypeData::Global
+                    | RawTypeData::BigInt
+                    | RawTypeData::Boolean
+                    | RawTypeData::Null
+                    | RawTypeData::Number
+                    | RawTypeData::String
+                    | RawTypeData::Symbol
+                    | RawTypeData::Undefined
+                    | RawTypeData::Conditional
+                    | RawTypeData::Constructor(_)
+                    | RawTypeData::Tuple(_)
+                    | RawTypeData::ThisKeyword
+                    | RawTypeData::NeverKeyword
+                    | RawTypeData::ObjectKeyword
+                    | RawTypeData::VoidKeyword => {
+                        return if state.members.is_empty() {
+                            DoesNotReturnPromise
+                        } else {
+                            Indeterminate
+                        };
+                    }
+                    RawTypeData::Unknown
+                    | RawTypeData::ImportNamespace(_)
+                    | RawTypeData::Module(_)
+                    | RawTypeData::Namespace(_)
+                    | RawTypeData::Generic(_)
+                    | RawTypeData::Intersection(_)
+                    | RawTypeData::Union(_)
+                    | RawTypeData::TypeOperator(_)
+                    | RawTypeData::MergedReference(_)
+                    | RawTypeData::AnyKeyword
+                    | RawTypeData::UnknownKeyword => return Indeterminate,
+                    RawTypeData::Interface(interface)
+                        if matches!(state.projection, Projection::PromiseTarget) =>
+                    {
+                        if interface.name.text() != "PromiseLike" {
+                            return DoesNotReturnPromise;
+                        }
+                        let mut ctx = ResolutionCtx::new(
+                            db,
+                            state.module,
+                            &js_info,
+                            ImportResolution::OnDemand,
+                        );
+                        let target = ctx.resolve_raw_type_id(type_id);
+                        let instance = InferredTypeData::instance_of(db, target, Box::default());
+                        return match is_promise_type(db, instance) {
+                            Some(true) => ReturnsPromise,
+                            Some(false) => DoesNotReturnPromise,
+                            None => Indeterminate,
+                        };
+                    }
+                    RawTypeData::Interface(interface) => {
+                        let Some((name, remaining)) = state.members.split_first() else {
+                            return Indeterminate;
+                        };
+                        let Some(member) = find_own_member(&interface.members, name, None) else {
+                            return Indeterminate;
+                        };
+                        if member.is_getter() {
+                            return Indeterminate;
+                        }
+                        ClassificationState {
+                            module: state.module,
+                            target: ClassificationTarget::Reference(member.ty.clone()),
+                            mode: MemberLookupMode::Value,
+                            members: remaining.into(),
+                            projection: state.projection,
+                        }
+                    }
+                }
+            }
+            ClassificationTarget::Import {
+                resolved_path,
+                symbol,
+            } => {
+                let Some(path) = resolved_path.as_path() else {
+                    return DoesNotReturnPromise;
+                };
+                let Some(module) = db.module_for_path(path) else {
+                    return DoesNotReturnPromise;
+                };
+                let (name, members) = match symbol {
+                    ImportSymbol::All => {
+                        let Some((name, remaining)) = state.members.split_first() else {
+                            return Indeterminate;
+                        };
+                        (name.clone(), remaining.into())
+                    }
+                    ImportSymbol::Default => (Text::new_static("default"), state.members),
+                    ImportSymbol::Named(name) => (name, state.members),
+                };
+                ClassificationState {
+                    module,
+                    target: ClassificationTarget::Export(name),
+                    mode: state.mode,
+                    members,
+                    projection: state.projection,
+                }
+            }
+            ClassificationTarget::Export(name) => {
+                let symbol = SymbolFromModuleInfo::new(db, name.text().to_string(), state.module);
+                let (module, name) = match resolved_export_origin(db, symbol) {
+                    super::ExportOriginResult::Found { module, name } => (*module, name.clone()),
+                    super::ExportOriginResult::Missing
+                    | super::ExportOriginResult::Ambiguous
+                    | super::ExportOriginResult::Indeterminate => return Indeterminate,
+                };
+                let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+                    return Indeterminate;
+                };
+                let Some(JsExport::Own(own_export) | JsExport::OwnType(own_export)) =
+                    js_info.raw_exports.get(name.text())
+                else {
+                    return Indeterminate;
+                };
+
+                match own_export {
+                    JsOwnExport::Binding(range) => {
+                        let Some(reference) = js_info.raw_binding_types.get(range) else {
+                            return Indeterminate;
+                        };
+                        ClassificationState {
+                            module,
+                            target: ClassificationTarget::Reference(reference.clone()),
+                            mode: state.mode,
+                            members: state.members,
+                            projection: state.projection,
+                        }
+                    }
+                    JsOwnExport::Type(resolved) => ClassificationState {
+                        module,
+                        target: ClassificationTarget::Reference(TypeReference::Resolved(*resolved)),
+                        mode: state.mode,
+                        members: state.members,
+                        projection: state.projection,
+                    },
+                    JsOwnExport::Namespace(reexport) => ClassificationState {
+                        module,
+                        target: ClassificationTarget::Import {
+                            resolved_path: reexport.import.resolved_path.clone(),
+                            symbol: reexport.import.symbol.clone(),
+                        },
+                        mode: state.mode,
+                        members: state.members,
+                        projection: state.projection,
+                    },
+                }
+            }
+        };
+    }
+
+    Indeterminate
+}
+
+/// Finds an own named member visible through the requested side of a class.
+///
+/// `mode` is omitted for object types, whose members are always selected as
+/// instance properties. Accessor dereferencing remains the caller's concern.
+fn find_own_member<'a>(
+    members: &'a [TypeMember],
+    name: &Text,
+    mode: Option<MemberLookupMode>,
+) -> Option<&'a TypeMember> {
+    members.iter().find(|member| {
+        member.has_name(name.text())
+            && mode.is_none_or(|mode| match mode {
+                MemberLookupMode::Value => member.is_static(),
+                MemberLookupMode::Instance => !member.is_static(),
+            })
+    })
+}

--- a/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
+++ b/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
@@ -299,7 +299,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 Some(interface.type_parameters(self.db).to_vec().into())
             }
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -403,7 +402,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 }
                 InferredTypeData::Object(object) => return Some(object.members(self.db).to_vec()),
                 InferredTypeData::Unknown
-                | InferredTypeData::Divergent(_)
                 | InferredTypeData::Global
                 | InferredTypeData::GlobalType(_)
                 | InferredTypeData::BigInt
@@ -458,7 +456,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                     .collect(),
             ),
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt
@@ -507,7 +504,6 @@ impl<'db> ResolutionCtx<'db, '_> {
                 | InferredLiteral::Template(_) => None,
             },
             InferredTypeData::Unknown
-            | InferredTypeData::Divergent(_)
             | InferredTypeData::Global
             | InferredTypeData::GlobalType(_)
             | InferredTypeData::BigInt

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -23,9 +23,17 @@ pub(super) const MAX_RAW_TYPE_RESOLUTION_DEPTH: usize = 64;
 const MAX_INFERRED_EXPRESSION_WRAPPER_STEPS: usize = 64;
 const MAX_LOCAL_TYPE_RESOLUTION_STEPS: usize = 1024;
 
+/// Selects how a resolution context follows references into imported modules.
+///
+/// Regular queries resolve only the requested imported symbol. Salsa cycle
+/// recovery cannot recursively request members of the strongly connected
+/// component that caused the cycle, so it uses materialized module tables and
+/// treats that component as unavailable instead.
 #[derive(Clone, Copy)]
 pub(in crate::db) enum ImportResolution<'a> {
-    Full,
+    /// Resolves imported symbols through export discovery and leaf queries.
+    OnDemand,
+    /// Reads imports from module tables while blocking the active cyclic component.
     CycleFallback(&'a FxHashSet<ModuleInfo>),
 }
 
@@ -145,7 +153,7 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
         module: ModuleInfo,
     ) -> Option<&'db InferredModuleTypes<'db>> {
         match self.import_resolution {
-            ImportResolution::Full => infer_module_types(self.db, module),
+            ImportResolution::OnDemand => infer_module_types(self.db, module),
             ImportResolution::CycleFallback(blocked) => {
                 if blocked.contains(&module) {
                     None

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -1,5 +1,5 @@
 use super::{BindingTypeData, InferredModuleTypes, globals::global_type, lookup::module_for_key};
-use crate::db::queries::infer_module_types;
+use crate::db::queries::{LocalTypeInput, infer_local_type, infer_module_types};
 use crate::module_graph::ModuleInfo;
 use crate::{JsModuleInfo, ModuleDb};
 use biome_js_semantic::JsDeclarationKind;
@@ -12,13 +12,14 @@ use biome_js_type_info::{
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::plumbing::AsId;
+use std::cell::Cell;
 
 /// Unlike the other limits, this one guards actual stack recursion: each level
 /// of `ResolutionCtx::resolve` clones a raw type and runs the conversion walk,
 /// so the frames are heavy. Named declarations already short-circuit to
 /// `TypeData::Local` handles, which leaves only structural nesting within a
 /// single declaration on the stack -- real-world code stays well below this.
-const MAX_RAW_TYPE_RESOLUTION_DEPTH: usize = 64;
+pub(super) const MAX_RAW_TYPE_RESOLUTION_DEPTH: usize = 64;
 const MAX_INFERRED_EXPRESSION_WRAPPER_STEPS: usize = 64;
 const MAX_LOCAL_TYPE_RESOLUTION_STEPS: usize = 1024;
 
@@ -28,7 +29,7 @@ pub(in crate::db) enum ImportResolution<'a> {
     CycleFallback(&'a FxHashSet<ModuleInfo>),
 }
 
-pub(in crate::db::type_inference) struct ResolutionCtx<'db, 'a> {
+pub(in crate::db) struct ResolutionCtx<'db, 'a> {
     pub(in crate::db::type_inference) db: &'db dyn ModuleDb,
     pub(in crate::db::type_inference) module_key: ModuleKey,
     pub(in crate::db::type_inference) js_info: &'a JsModuleInfo,
@@ -36,7 +37,7 @@ pub(in crate::db::type_inference) struct ResolutionCtx<'db, 'a> {
     pub(in crate::db::type_inference) named_type_ids: FxHashSet<TypeId>,
     pub(in crate::db::type_inference) resolved: FxHashMap<TypeId, InferredTypeData<'db>>,
     pub(in crate::db::type_inference) in_progress: FxHashSet<TypeId>,
-    pub(in crate::db::type_inference) resolution_depth: usize,
+    pub(in crate::db::type_inference) resolution_depth: Cell<usize>,
 }
 
 pub(in crate::db) fn resolve_raw_types<'db>(
@@ -45,18 +46,7 @@ pub(in crate::db) fn resolve_raw_types<'db>(
     js_info: &JsModuleInfo,
     import_resolution: ImportResolution<'_>,
 ) -> InferredModuleTypes<'db> {
-    let module_key = ModuleKey::new(module.as_id());
-    let named_type_ids = named_type_ids(js_info);
-    let mut ctx = ResolutionCtx {
-        db,
-        module_key,
-        js_info,
-        import_resolution,
-        named_type_ids,
-        resolved: FxHashMap::default(),
-        in_progress: FxHashSet::default(),
-        resolution_depth: 0,
-    };
+    let mut ctx = ResolutionCtx::new(db, module, js_info, import_resolution);
 
     let mut named_type_ids = ctx
         .named_type_ids
@@ -89,7 +79,7 @@ pub(in crate::db) fn resolve_raw_types<'db>(
         .collect();
 
     InferredModuleTypes {
-        module_key,
+        module_key: ctx.module_key,
         named_type_ids: named_type_ids.into_boxed_slice(),
         types,
         expressions,
@@ -97,7 +87,7 @@ pub(in crate::db) fn resolve_raw_types<'db>(
     }
 }
 
-fn named_type_ids(js_info: &JsModuleInfo) -> FxHashSet<TypeId> {
+pub(in crate::db) fn named_type_ids(js_info: &JsModuleInfo) -> FxHashSet<TypeId> {
     js_info
         .raw_binding_types
         .iter()
@@ -126,7 +116,25 @@ fn is_named_type_declaration(declaration_kind: JsDeclarationKind) -> bool {
     )
 }
 
-impl<'db> ResolutionCtx<'db, '_> {
+impl<'db, 'a> ResolutionCtx<'db, 'a> {
+    pub(in crate::db) fn new(
+        db: &'db dyn ModuleDb,
+        module: ModuleInfo,
+        js_info: &'a JsModuleInfo,
+        import_resolution: ImportResolution<'a>,
+    ) -> Self {
+        Self {
+            db,
+            module_key: ModuleKey::new(module.as_id()),
+            js_info,
+            import_resolution,
+            named_type_ids: named_type_ids(js_info),
+            resolved: FxHashMap::default(),
+            in_progress: FxHashSet::default(),
+            resolution_depth: Cell::new(0),
+        }
+    }
+
     /// Infers `module` as a dependency of the module currently being resolved.
     ///
     /// The tracked query records the imported result as a dependency of the
@@ -148,21 +156,19 @@ impl<'db> ResolutionCtx<'db, '_> {
         }
     }
 
-    pub(in crate::db::type_inference) fn resolve(
-        &mut self,
-        reference: &TypeReference,
-    ) -> InferredTypeData<'db> {
-        if self.resolution_depth >= MAX_RAW_TYPE_RESOLUTION_DEPTH {
+    pub(in crate::db) fn resolve(&mut self, reference: &TypeReference) -> InferredTypeData<'db> {
+        let resolution_depth = self.resolution_depth.get();
+        if resolution_depth >= MAX_RAW_TYPE_RESOLUTION_DEPTH {
             return InferredTypeData::Unknown;
         }
 
-        self.resolution_depth += 1;
+        self.resolution_depth.set(resolution_depth + 1);
         let resolved = match reference {
             TypeReference::Resolved(resolved_id) => self.resolve_resolved_id(*resolved_id),
             TypeReference::Qualifier(qualifier) => self.resolve_qualifier(qualifier),
             TypeReference::Import(import) => self.resolve_import(import),
         };
-        self.resolution_depth -= 1;
+        self.resolution_depth.set(resolution_depth);
         resolved
     }
 
@@ -194,7 +200,7 @@ impl<'db> ResolutionCtx<'db, '_> {
         ))
     }
 
-    fn resolve_raw_type_id(&mut self, type_id: TypeId) -> InferredTypeData<'db> {
+    pub(in crate::db) fn resolve_raw_type_id(&mut self, type_id: TypeId) -> InferredTypeData<'db> {
         if let Some(ty) = self.resolved.get(&type_id) {
             return *ty;
         }
@@ -342,8 +348,10 @@ impl<'db> ResolutionCtx<'db, '_> {
                 self.resolve_raw_type_id(TypeId::new(local_type_id.index()))
             } else {
                 module_for_key(self.db, module_key)
-                    .and_then(|module| self.infer_imported_module(module))
-                    .and_then(|types| types.types.get(local_type_id.index()).copied())
+                    .and_then(|module| {
+                        let input = LocalTypeInput::new(self.db, module, local_type_id);
+                        infer_local_type(self.db, input)
+                    })
                     .unwrap_or(InferredTypeData::Unknown)
             };
         }

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -1,8 +1,7 @@
-use super::{BindingTypeData, InferredModuleTypes, globals::global_type, lookup::module_for_key};
+use super::{BindingTypeData, InferredModuleTypes, globals::global_type};
 use crate::db::queries::{LocalTypeInput, infer_local_type, infer_module_types};
 use crate::module_graph::ModuleInfo;
-use crate::{JsModuleInfo, ModuleDb};
-use biome_js_semantic::JsDeclarationKind;
+use crate::{JsModuleInfo, ModuleDb, module_for_key};
 use biome_js_type_info::{
     GlobalTypeId, RawTypeData, ResolvedTypeId, ScopeId, TypeId, TypeReference,
     TypeReferenceQualifier, TypeResolverLevel,
@@ -42,7 +41,6 @@ pub(in crate::db) struct ResolutionCtx<'db, 'a> {
     pub(in crate::db::type_inference) module_key: ModuleKey,
     pub(in crate::db::type_inference) js_info: &'a JsModuleInfo,
     pub(in crate::db::type_inference) import_resolution: ImportResolution<'a>,
-    pub(in crate::db::type_inference) named_type_ids: FxHashSet<TypeId>,
     pub(in crate::db::type_inference) resolved: FxHashMap<TypeId, InferredTypeData<'db>>,
     pub(in crate::db::type_inference) in_progress: FxHashSet<TypeId>,
     pub(in crate::db::type_inference) resolution_depth: Cell<usize>,
@@ -55,13 +53,6 @@ pub(in crate::db) fn resolve_raw_types<'db>(
     import_resolution: ImportResolution<'_>,
 ) -> InferredModuleTypes<'db> {
     let mut ctx = ResolutionCtx::new(db, module, js_info, import_resolution);
-
-    let mut named_type_ids = ctx
-        .named_type_ids
-        .iter()
-        .map(|type_id| LocalTypeId::new(type_id.index()))
-        .collect::<Vec<_>>();
-    named_type_ids.sort_unstable();
 
     let types = (0..js_info.raw_types.len())
         .map(|index| ctx.resolve_raw_type_id(TypeId::new(index)))
@@ -88,40 +79,11 @@ pub(in crate::db) fn resolve_raw_types<'db>(
 
     InferredModuleTypes {
         module_key: ctx.module_key,
-        named_type_ids: named_type_ids.into_boxed_slice(),
+        named_type_ids: js_info.named_type_ids.clone(),
         types,
         expressions,
         binding_type_data,
     }
-}
-
-pub(in crate::db) fn named_type_ids(js_info: &JsModuleInfo) -> FxHashSet<TypeId> {
-    js_info
-        .raw_binding_types
-        .iter()
-        .filter_map(|(range, reference)| {
-            let binding = js_info.semantic_model.as_binding_by_range(*range)?;
-            if !is_named_type_declaration(binding.declaration_kind()) {
-                return None;
-            }
-            let TypeReference::Resolved(resolved_id) = reference else {
-                return None;
-            };
-            (resolved_id.level() == TypeResolverLevel::Thin).then(|| resolved_id.id())
-        })
-        .collect()
-}
-
-fn is_named_type_declaration(declaration_kind: JsDeclarationKind) -> bool {
-    matches!(
-        declaration_kind,
-        JsDeclarationKind::Class
-            | JsDeclarationKind::Enum
-            | JsDeclarationKind::Interface
-            | JsDeclarationKind::Module
-            | JsDeclarationKind::Namespace
-            | JsDeclarationKind::Type
-    )
 }
 
 impl<'db, 'a> ResolutionCtx<'db, 'a> {
@@ -136,7 +98,6 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
             module_key: ModuleKey::new(module.as_id()),
             js_info,
             import_resolution,
-            named_type_ids: named_type_ids(js_info),
             resolved: FxHashMap::default(),
             in_progress: FxHashSet::default(),
             resolution_depth: Cell::new(0),
@@ -193,7 +154,7 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
     }
 
     fn resolve_raw_type_reference(&mut self, type_id: TypeId) -> InferredTypeData<'db> {
-        if self.named_type_ids.contains(&type_id) {
+        if self.js_info.is_named_type(type_id) {
             return self.local_type(type_id);
         }
 
@@ -295,7 +256,6 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
                     }
                 }
                 InferredTypeData::Unknown
-                | InferredTypeData::Divergent(_)
                 | InferredTypeData::Global
                 | InferredTypeData::GlobalType(_)
                 | InferredTypeData::BigInt

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -11,7 +11,7 @@ use crate::css_module_info::CssClassReference;
 use biome_js_semantic::{JsDeclarationKind, ScopeId};
 use biome_js_syntax::AnyJsImportLike;
 use biome_js_type_info::{
-    FormatTypeContext, ImportSymbol, RawTypeData, ResolvedTypeId, TypeData, TypeReference,
+    FormatTypeContext, ImportSymbol, RawTypeData, ResolvedTypeId, TypeData, TypeId, TypeReference,
     TypeResolverLevel, interned_types::LocalTypeId,
 };
 use biome_resolver::ResolvedPath;
@@ -164,6 +164,10 @@ impl JsModuleInfo {
     }
 
     pub fn local_type_name(&self, type_id: LocalTypeId) -> Option<Text> {
+        if self.named_type_ids.binary_search(&type_id).is_err() {
+            return None;
+        }
+
         self.raw_binding_types
             .iter()
             .find_map(|(range, reference)| {
@@ -184,9 +188,15 @@ impl JsModuleInfo {
                 Some(binding.syntax().text_trimmed().into_text())
             })
     }
+
+    pub(crate) fn is_named_type(&self, type_id: TypeId) -> bool {
+        self.named_type_ids
+            .binary_search(&LocalTypeId::new(type_id.index()))
+            .is_ok()
+    }
 }
 
-fn is_named_type_declaration(declaration_kind: JsDeclarationKind) -> bool {
+pub(super) fn is_named_type_declaration(declaration_kind: JsDeclarationKind) -> bool {
     matches!(
         declaration_kind,
         JsDeclarationKind::Class
@@ -274,6 +284,9 @@ pub struct JsModuleInfoInner {
 
     /// Raw binding references collected before module-level resolution and flattening.
     pub raw_binding_types: FxHashMap<TextRange, TypeReference>,
+
+    /// Sorted local IDs for declarations that retain their symbolic identity.
+    pub(crate) named_type_ids: Box<[LocalTypeId]>,
 
     /// Parsed expressions, mapped from their range to their type ID.
     pub(crate) expressions: FxHashMap<TextRange, ResolvedTypeId>,

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -11,7 +11,7 @@ use biome_js_type_info::{
     FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, GenericTypeParameter, MAX_FLATTEN_DEPTH,
     Module, Namespace, RawTypeData, Resolvable, ResolvedTypeData, ResolvedTypeId, TypeData, TypeId,
     TypeImportQualifier, TypeMember, TypeMemberKind, TypeReference, TypeReferenceQualifier,
-    TypeResolver, TypeResolverLevel, TypeStore, UnionCollector,
+    TypeResolver, TypeResolverLevel, TypeStore, UnionCollector, interned_types::LocalTypeId,
 };
 use biome_rowan::{AstNode, Text, TextRange, TokenText};
 use indexmap::IndexMap;
@@ -20,6 +20,7 @@ use rustc_hash::FxHashMap;
 use super::{
     Exports, ImportSymbol, Imports, JsExport, JsImport, JsModuleInfo, JsModuleInfoDiagnostic,
     JsModuleInfoInner, JsOwnExport, JsReexport, ResolvedPath, binding::JsBindingData,
+    is_named_type_declaration,
 };
 use crate::js_module_info::{scope::TsBindingReferenceExt, utils::reached_too_many_types};
 use crate::{BindingTypeData, JsImportPath, JsImportPhase};
@@ -1195,6 +1196,23 @@ impl JsModuleInfo {
     ) -> Self {
         collector.inference_mode = inference_mode;
         let finalised = collector.finalise(&semantic_model);
+        let mut named_type_ids = finalised
+            .raw_binding_types
+            .iter()
+            .filter_map(|(range, reference)| {
+                let binding = semantic_model.as_binding_by_range(*range)?;
+                if !is_named_type_declaration(binding.declaration_kind()) {
+                    return None;
+                }
+                let TypeReference::Resolved(resolved_id) = reference else {
+                    return None;
+                };
+                (resolved_id.level() == TypeResolverLevel::Thin)
+                    .then(|| LocalTypeId::new(resolved_id.index()))
+            })
+            .collect::<Vec<_>>();
+        named_type_ids.sort_unstable();
+        named_type_ids.dedup();
 
         Self(Arc::new(JsModuleInfoInner {
             static_imports: Imports(collector.static_imports),
@@ -1208,6 +1226,7 @@ impl JsModuleInfo {
             raw_types: finalised.raw_types,
             raw_expressions: finalised.raw_expressions,
             raw_binding_types: finalised.raw_binding_types,
+            named_type_ids: named_type_ids.into_boxed_slice(),
             expressions: collector.parsed_expressions,
             types: collector.types.into(),
             diagnostics: collector.diagnostics.into_iter().map(Into::into).collect(),

--- a/crates/biome_module_graph/src/module_graph.rs
+++ b/crates/biome_module_graph/src/module_graph.rs
@@ -48,7 +48,7 @@ pub fn resolve_js_module(
     enable_type_inference: bool,
 ) -> (JsModuleInfo, ModuleDependencies, Vec<ModuleDiagnostic>) {
     let inference_mode = if enable_type_inference {
-        TypeInferenceMode::Complete
+        TypeInferenceMode::RawTypesOnly
     } else {
         TypeInferenceMode::Disabled
     };

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -26,9 +26,10 @@ use biome_module_graph::{
     HtmlEmbeddedContent, ImportSymbol, JsExport, JsExportedSymbolLookup, JsImport, JsImportPath,
     JsImportPhase, JsModuleInfoDiagnostic, JsOwnExport, JsReexport, ModuleDb, ModuleDiagnostic,
     ModuleInfo, ModuleInfoKind, ModuleResolver, PathInfoCache, ResolvedPath, SymbolFromModuleInfo,
-    find_js_exported_symbol, is_class_referenced_by_importers, resolve_css_module,
-    resolve_html_module, resolve_js_module, transitive_importers_of,
-    traverse_import_tree_for_classes, traverse_import_tree_for_html_classes,
+    TypeInferenceMode, find_js_exported_symbol, is_class_referenced_by_importers,
+    resolve_css_module, resolve_html_module, resolve_js_module_with_inference_mode,
+    transitive_importers_of, traverse_import_tree_for_classes,
+    traverse_import_tree_for_html_classes,
 };
 use biome_package::{Dependencies, PackageJson};
 use biome_project_layout::ProjectLayout;
@@ -52,14 +53,19 @@ fn build_js_db(
     let db = WorkspaceDb::default();
     let path_info_cache = PathInfoCache::default();
     for (path, root, semantic_model) in added_paths {
-        let (module_info, _, _) = resolve_js_module(
+        let inference_mode = if infer_types {
+            TypeInferenceMode::Complete
+        } else {
+            TypeInferenceMode::Disabled
+        };
+        let (module_info, _, _) = resolve_js_module_with_inference_mode(
             root.clone(),
             path,
             fs,
             layout,
             semantic_model.clone(),
             &path_info_cache,
-            infer_types,
+            inference_mode,
         );
         let md = ModuleInfo::new(
             &db,
@@ -110,14 +116,19 @@ fn add_js_modules(
 ) {
     let path_info_cache = PathInfoCache::default();
     for (path, root, semantic_model) in added_paths {
-        let (module_info, _, _) = resolve_js_module(
+        let inference_mode = if infer_types {
+            TypeInferenceMode::Complete
+        } else {
+            TypeInferenceMode::Disabled
+        };
+        let (module_info, _, _) = resolve_js_module_with_inference_mode(
             root.clone(),
             path,
             fs,
             layout,
             semantic_model.clone(),
             &path_info_cache,
-            infer_types,
+            inference_mode,
         );
         let md = ModuleInfo::new(
             db,

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -86,6 +86,61 @@ fn test_module_keys_reject_stale_handles() {
 }
 
 #[test]
+fn test_named_type_ids_are_sorted_and_deduplicated() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            class ClassType {}
+            enum EnumType { Value }
+            interface InterfaceType { first: string }
+            interface InterfaceType { second: number }
+            module ModuleType {}
+            namespace NamespaceType {}
+            type AliasType = string;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+
+    assert!(
+        inferred
+            .named_type_ids
+            .windows(2)
+            .all(|ids| ids[0] < ids[1]),
+        "named type IDs must be sorted and deduplicated"
+    );
+
+    let ModuleInfoKind::Js(info) = module.kind(&db) else {
+        panic!("module must contain JavaScript information");
+    };
+    let mut names = inferred
+        .named_type_ids
+        .iter()
+        .map(|id| {
+            info.local_type_name(*id)
+                .expect("named type must have a name")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    assert_eq!(
+        names,
+        [
+            "ClassType",
+            "InterfaceType",
+            "InterfaceType",
+            "ModuleType",
+            "NamespaceType",
+        ]
+    );
+}
+
+#[test]
 fn test_infer_module_types_poison_unresolved_union_variants() {
     let fs = MemoryFileSystem::default();
     fs.insert(

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -52,6 +52,8 @@ mod intersections;
 mod normalization;
 #[path = "spec_tests_v2/promises.test.rs"]
 mod promises;
+#[path = "spec_tests_v2/queries.test.rs"]
+mod queries;
 #[path = "spec_tests_v2/substitutions.test.rs"]
 mod substitutions;
 
@@ -210,11 +212,11 @@ impl TestModuleDb {
         }
     }
 
-    fn take_salsa_events(&mut self) -> Vec<salsa::Event> {
+    fn take_salsa_events(&self) -> Vec<salsa::Event> {
         std::mem::take(&mut *self.events.0.lock().unwrap())
     }
 
-    fn clear_salsa_events(&mut self) {
+    fn clear_salsa_events(&self) {
         self.take_salsa_events();
     }
 }
@@ -855,6 +857,24 @@ fn build_js_test_module_db_with_layout(
     db
 }
 
+fn binding_range_by_name(db: &dyn ModuleDb, module: ModuleInfo, name: &str) -> TextRange {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        panic!("module must contain JavaScript information");
+    };
+    js_info
+        .semantic_model
+        .all_bindings()
+        .find(|binding| {
+            binding
+                .tree()
+                .name_token()
+                .is_ok_and(|token| token.text_trimmed() == name)
+        })
+        .unwrap_or_else(|| panic!("{name} binding must exist"))
+        .syntax()
+        .text_trimmed_range()
+}
+
 #[test]
 fn test_infer_module_types_resolves_record_index_signature_on_build() {
     let fs = MemoryFileSystem::default();
@@ -1218,8 +1238,7 @@ fn test_infer_module_types_bottom_up_warms_blanket_reexports() {
         "#,
     );
 
-    let mut db =
-        build_js_test_module_db(&fs, &["/src/leaf.ts", "/src/mid.ts", "/src/index.ts"], true);
+    let db = build_js_test_module_db(&fs, &["/src/leaf.ts", "/src/mid.ts", "/src/index.ts"], true);
     let leaf_module = db
         .module_for_path(Utf8Path::new("/src/leaf.ts"))
         .expect("leaf module must exist");
@@ -4751,7 +4770,7 @@ fn test_infer_module_types_is_memoized() {
         "#,
     );
 
-    let mut db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
     let index_module = db
         .module_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");

--- a/crates/biome_module_graph/tests/spec_tests_v2/cycles.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/cycles.test.rs
@@ -14,6 +14,93 @@ fn unwrap_typeof_values<'db>(
     ty
 }
 
+fn insert_import_chain(fs: &MemoryFileSystem, import_count: usize) -> Vec<String> {
+    let paths = (0..=import_count)
+        .map(|index| format!("/src/chain{index}.ts"))
+        .collect::<Vec<_>>();
+
+    for (index, path) in paths.iter().enumerate() {
+        let source = if index == import_count {
+            "export const value = 1;".to_string()
+        } else {
+            format!(
+                "import {{ value as next }} from \"./chain{}.ts\"; export const value = next;",
+                index + 1
+            )
+        };
+        fs.insert(path.into(), source);
+    }
+
+    paths
+}
+
+#[test]
+fn test_import_chains_preserve_terminal_export_across_on_demand_depth_boundary() {
+    for import_count in [127, 128, 129] {
+        let fs = MemoryFileSystem::default();
+        let paths = insert_import_chain(&fs, import_count);
+        let path_refs = paths.iter().map(String::as_str).collect::<Vec<_>>();
+        let db = build_js_test_module_db(&fs, &path_refs, true);
+        let root = db
+            .module_for_path(Utf8Path::new(&paths[0]))
+            .expect("root module must exist");
+
+        let inferred = infer_module_types(&db, root).expect("types must be inferred");
+        let value = inferred_binding_ty_by_name(&db, root, inferred, "value")
+            .expect("terminal export type must be inferred");
+        assert!(
+            is_inferred_number(&db, unwrap_typeof_values(&db, value)),
+            "terminal export must remain numeric across {import_count} imports, got {value:?}"
+        );
+    }
+}
+
+#[test]
+fn test_deep_import_cycle_preserves_neighboring_acyclic_export() {
+    const CYCLE_LENGTH: usize = 129;
+
+    let fs = MemoryFileSystem::default();
+    let mut paths = (0..CYCLE_LENGTH)
+        .map(|index| format!("/src/cycle{index}.ts"))
+        .collect::<Vec<_>>();
+    for (index, path) in paths.iter().enumerate() {
+        let next = (index + 1) % CYCLE_LENGTH;
+        let (stable_import, stable_export) = if index == 0 {
+            (
+                "import { stable } from \"./stable.ts\";",
+                "export const acyclic = stable;",
+            )
+        } else {
+            ("", "")
+        };
+        fs.insert(
+            path.into(),
+            format!(
+                "{stable_import} import {{ cyclic as next }} from \"./cycle{next}.ts\"; export const cyclic = next; {stable_export}"
+            ),
+        );
+    }
+    fs.insert("/src/stable.ts".into(), "export const stable = 1;");
+    paths.push("/src/stable.ts".to_string());
+
+    let path_refs = paths.iter().map(String::as_str).collect::<Vec<_>>();
+    let db = build_js_test_module_db(&fs, &path_refs, true);
+    let root = db
+        .module_for_path(Utf8Path::new(&paths[0]))
+        .expect("root module must exist");
+
+    let inferred = infer_module_types(&db, root).expect("types must be inferred");
+    let cyclic = inferred_binding_ty_by_name(&db, root, inferred, "cyclic")
+        .expect("cyclic binding type must be inferred");
+    assert_eq!(unwrap_typeof_values(&db, cyclic), InferredTypeData::Unknown);
+    let acyclic = inferred_binding_ty_by_name(&db, root, inferred, "acyclic")
+        .expect("acyclic binding type must be inferred");
+    assert!(
+        is_inferred_number(&db, unwrap_typeof_values(&db, acyclic)),
+        "neighboring acyclic export must remain numeric, got {acyclic:?}"
+    );
+}
+
 #[test]
 fn test_infer_module_types_bottom_up_handles_import_cycles() {
     let fs = MemoryFileSystem::default();

--- a/crates/biome_module_graph/tests/spec_tests_v2/cycles.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/cycles.test.rs
@@ -1,4 +1,18 @@
 use super::*;
+use biome_module_graph::{BindingTypeInput, find_member_type, infer_binding_type};
+
+fn unwrap_typeof_values<'db>(
+    db: &'db dyn ModuleDb,
+    mut ty: InferredTypeData<'db>,
+) -> InferredTypeData<'db> {
+    for _ in 0..16 {
+        let InferredTypeData::TypeofValue(value) = ty else {
+            return ty;
+        };
+        ty = value.ty(db);
+    }
+    ty
+}
 
 #[test]
 fn test_infer_module_types_bottom_up_handles_import_cycles() {
@@ -41,4 +55,142 @@ fn test_infer_module_types_bottom_up_handles_import_cycles() {
     let b_ty = inferred_binding_ty_by_name(&db, b_module, b_types, "b")
         .expect("b binding type must be inferred");
     assert_eq!(b_ty, InferredTypeData::Unknown);
+}
+
+#[test]
+fn test_infer_module_types_preserves_acyclic_exports_next_to_reexport_cycles() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            export { value } from "./b.ts";
+            export { stable } from "./stable.ts";
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            export { value } from "./a.ts";
+        "#,
+    );
+    fs.insert("/src/stable.ts".into(), "export const stable = 1;");
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import { stable, value } from "./a.ts";
+            export const cyclic = value;
+            export const acyclic = stable;
+        "#,
+    );
+
+    let db = build_js_test_module_db(
+        &fs,
+        &["/src/a.ts", "/src/b.ts", "/src/stable.ts", "/src/index.ts"],
+        true,
+    );
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+
+    let inferred = infer_module_types_bottom_up(&db, index_module).expect("types must be inferred");
+    let cyclic_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "cyclic")
+        .expect("cyclic binding type must be inferred");
+    assert_eq!(cyclic_ty, InferredTypeData::Unknown);
+    let acyclic_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "acyclic")
+        .expect("acyclic binding type must be inferred");
+    assert!(is_inferred_number(&db, acyclic_ty));
+}
+
+#[test]
+fn test_infer_module_types_bounds_mutual_namespace_reexports() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            export * as b from "./b.ts";
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            export * as a from "./a.ts";
+        "#,
+    );
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import { b } from "./a.ts";
+            export const cyclic = b;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts", "/src/index.ts"], true);
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+
+    let inferred = infer_module_types_bottom_up(&db, index_module).expect("types must be inferred");
+    let mut ty = inferred_binding_ty_by_name(&db, index_module, inferred, "cyclic")
+        .expect("cyclic binding type must be inferred");
+    let mut reached_unknown = false;
+    for name in ["a", "b"].into_iter().cycle().take(128) {
+        let Some(member_ty) = inferred.find_member_type(&db, ty, name) else {
+            break;
+        };
+        if member_ty == InferredTypeData::Unknown {
+            reached_unknown = true;
+            break;
+        }
+        ty = member_ty;
+    }
+    assert!(reached_unknown, "cyclic namespaces must resolve to Unknown");
+}
+
+#[test]
+fn test_binding_query_preserves_acyclic_data_next_to_an_import_cycle() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            import { b } from "./b.ts";
+            export const stable = 1;
+            export const a = b;
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { a, stable } from "./a.ts";
+            export const b = { a, stable };
+        "#,
+    );
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import { a, stable } from "./a.ts";
+            export const result = { a, stable };
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts", "/src/index.ts"], true);
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+    let input = BindingTypeInput::new(
+        &db,
+        index_module,
+        binding_range_by_name(&db, index_module, "result"),
+    );
+
+    let result = infer_binding_type(&db, input).expect("result type must be inferred");
+    let cyclic = find_member_type(&db, result, "a").expect("cyclic member must be present");
+    let cyclic = unwrap_typeof_values(&db, cyclic);
+    assert_eq!(cyclic, InferredTypeData::Unknown);
+
+    let stable = find_member_type(&db, result, "stable").expect("stable member must be inferred");
+    let stable = unwrap_typeof_values(&db, stable);
+    assert!(
+        is_inferred_number(&db, stable),
+        "stable member must be numeric, got {stable:?}"
+    );
 }

--- a/crates/biome_module_graph/tests/spec_tests_v2/imports.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/imports.test.rs
@@ -1,6 +1,68 @@
 use super::*;
 
 #[test]
+fn test_infer_module_types_bottom_up_skips_side_effect_imports() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/side_effect.ts".into(), "export const unused = 1;");
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import "./side_effect.ts";
+            export const value = 1;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/side_effect.ts", "/src/index.ts"], true);
+    let side_effect_module = db
+        .module_for_path(Utf8Path::new("/src/side_effect.ts"))
+        .expect("side-effect module must exist");
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+
+    db.clear_salsa_events();
+    let inferred = infer_module_types_bottom_up(&db, index_module).expect("types must be inferred");
+    let value_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "value")
+        .expect("value binding type must be inferred");
+    assert!(is_inferred_number(&db, value_ty));
+
+    let events = db.take_salsa_events();
+    assert_function_query_was_run(&db, infer_module_types, index_module, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, side_effect_module, &events);
+}
+
+#[test]
+fn test_infer_module_types_bottom_up_prepares_named_imports() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/source.ts".into(), "export const value = 1;");
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import { value } from "./source.ts";
+            export const result = value;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/source.ts", "/src/index.ts"], true);
+    let source_module = db
+        .module_for_path(Utf8Path::new("/src/source.ts"))
+        .expect("source module must exist");
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+
+    db.clear_salsa_events();
+    let inferred = infer_module_types_bottom_up(&db, index_module).expect("types must be inferred");
+    let result_ty = inferred_binding_ty_by_name(&db, index_module, inferred, "result")
+        .expect("result binding type must be inferred");
+    assert!(is_inferred_number(&db, result_ty));
+
+    let events = db.take_salsa_events();
+    assert_function_query_was_run(&db, infer_module_types, source_module, &events);
+    assert_function_query_was_run(&db, infer_module_types, index_module, &events);
+}
+
+#[test]
 fn test_infer_module_types_resolves_react_export_equals_namespace() {
     let fs = MemoryFileSystem::default();
     fs.insert(

--- a/crates/biome_module_graph/tests/spec_tests_v2/promises.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/promises.test.rs
@@ -1,4 +1,230 @@
 use super::*;
+use biome_module_graph::{ExpressionTypeInput, infer_expression_function_returns_promise};
+
+fn expression_function_returns_promise(
+    db: &TestModuleDb,
+    module: ModuleInfo,
+    source: &str,
+    expression: &str,
+) -> Option<bool> {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        panic!("module must contain JavaScript information");
+    };
+    let range = js_info
+        .raw_expressions
+        .keys()
+        .find(|range| source_snippet(source, **range) == expression)
+        .copied()
+        .unwrap_or_else(|| panic!("{expression} expression must exist"));
+    infer_expression_function_returns_promise(db, ExpressionTypeInput::new(db, module, range))
+}
+
+#[test]
+fn test_expression_function_return_classifies_selected_object_members() {
+    const SOURCE: &str = r#"
+        declare function consume(value: unknown): void;
+        const callbacks = {
+            selected: async () => {},
+            cacheDir: "/tmp",
+        };
+        consume(callbacks.selected);
+        consume(callbacks.cacheDir);
+        consume({ selected: async () => {}, cacheDir: "/tmp" });
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    assert_eq!(
+        expression_function_returns_promise(&db, module, SOURCE, "callbacks.selected"),
+        Some(true)
+    );
+    assert_eq!(
+        expression_function_returns_promise(&db, module, SOURCE, "callbacks.cacheDir"),
+        Some(false)
+    );
+    assert_eq!(
+        expression_function_returns_promise(
+            &db,
+            module,
+            SOURCE,
+            r#"{ selected: async () => {}, cacheDir: "/tmp" }"#,
+        ),
+        Some(false)
+    );
+}
+
+#[test]
+fn test_expression_function_return_classifies_local_aliases_and_static_members() {
+    const SOURCE: &str = r#"
+        declare function consume(value: unknown): void;
+        const callback = async () => {};
+        const alias = callback;
+        class Callbacks {
+            static selected = alias;
+        }
+        consume(alias);
+        consume(Callbacks.selected);
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    assert_eq!(
+        expression_function_returns_promise(&db, module, SOURCE, "alias"),
+        Some(true)
+    );
+    assert_eq!(
+        expression_function_returns_promise(&db, module, SOURCE, "Callbacks.selected"),
+        Some(true)
+    );
+}
+
+#[test]
+fn test_expression_function_return_classifies_promise_like_returns() {
+    const SOURCE: &str = r#"
+        interface PromiseLike<T> {
+            then(resolve: (value: T) => void): void;
+        }
+        declare function callback(): PromiseLike<void>;
+        declare function consume(value: unknown): void;
+        consume(callback);
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    assert_eq!(
+        expression_function_returns_promise(&db, module, SOURCE, "callback"),
+        Some(true)
+    );
+}
+
+#[test]
+fn test_expression_function_return_classifies_this_member_chains() {
+    const SOURCE: &str = r#"
+        declare function consume(value: unknown): void;
+        class Runner {
+            #settings = {
+                config: {
+                    callback: async () => {},
+                    cacheDir: "/tmp",
+                },
+            };
+
+            run() {
+                consume(this.#settings.config.callback);
+                consume(this.#settings.config.cacheDir);
+            }
+        }
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    assert_eq!(
+        expression_function_returns_promise(&db, module, SOURCE, "this.#settings.config.callback",),
+        Some(true)
+    );
+    assert_eq!(
+        expression_function_returns_promise(&db, module, SOURCE, "this.#settings.config.cacheDir",),
+        Some(false)
+    );
+}
+
+#[test]
+fn test_expression_function_return_classifies_imported_named_aliases() {
+    const SOURCE: &str = r#"
+        export const callback = async () => {};
+        export const callbacks = { selected: callback };
+    "#;
+    const INDEX: &str = r#"
+        import { callback as importedCallback, callbacks as importedCallbacks } from "./source.ts";
+        declare function consume(value: unknown): void;
+        consume(importedCallback);
+        consume(importedCallbacks.selected);
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/source.ts".into(), SOURCE);
+    fs.insert("/src/index.ts".into(), INDEX);
+    let db = build_js_test_module_db(&fs, &["/src/source.ts", "/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    assert_eq!(
+        expression_function_returns_promise(&db, module, INDEX, "importedCallback"),
+        Some(true)
+    );
+    assert_eq!(
+        expression_function_returns_promise(&db, module, INDEX, "importedCallbacks.selected"),
+        Some(true)
+    );
+}
+
+#[test]
+fn test_expression_function_return_keeps_member_path_in_cycle_identity() {
+    const SOURCE: &str = r#"
+        type Recursive = {
+            next: Recursive;
+            callback: () => Promise<void>;
+        };
+        declare const root: Recursive;
+        declare function consume(value: unknown): void;
+        consume(root.next.callback);
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    assert_eq!(
+        expression_function_returns_promise(&db, module, SOURCE, "root.next.callback"),
+        Some(true)
+    );
+}
+
+#[test]
+fn test_expression_function_return_leaves_interface_and_union_indeterminate() {
+    const SOURCE: &str = r#"
+        interface Callable {
+            (): Promise<void>;
+        }
+        declare const interfaceCallback: Callable;
+        declare const unionCallback: (() => Promise<void>) | (() => Promise<number>);
+        declare function consume(value: unknown): void;
+        consume(interfaceCallback);
+        consume(unionCallback);
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    for expression in ["interfaceCallback", "unionCallback"] {
+        assert_eq!(
+            expression_function_returns_promise(&db, module, SOURCE, expression),
+            None,
+            "{expression}"
+        );
+    }
+}
 
 fn inferred_promise_value_type<'db>(
     db: &'db dyn ModuleDb,

--- a/crates/biome_module_graph/tests/spec_tests_v2/promises.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/promises.test.rs
@@ -199,15 +199,40 @@ fn test_expression_function_return_keeps_member_path_in_cycle_identity() {
 }
 
 #[test]
-fn test_expression_function_return_leaves_interface_and_union_indeterminate() {
+fn test_expression_function_return_classifies_callable_interfaces_conservatively() {
     const SOURCE: &str = r#"
-        interface Callable {
+        interface AsyncCallable {
             (): Promise<void>;
         }
-        declare const interfaceCallback: Callable;
+        interface SyncCallable {
+            (): void;
+        }
+        interface InheritedAsyncCallable extends AsyncCallable {}
+        interface OverloadedCallable {
+            (): Promise<void>;
+            (value: string): Promise<void>;
+        }
+        interface MixedCallable {
+            (): void;
+            (value: string): Promise<void>;
+        }
+        interface CyclicCallable extends CyclicCallable {
+            (): Promise<void>;
+        }
+        declare const asyncCallback: AsyncCallable;
+        declare const syncCallback: SyncCallable;
+        declare const inheritedAsyncCallback: InheritedAsyncCallable;
+        declare const overloadedCallback: OverloadedCallable;
+        declare const mixedCallback: MixedCallable;
+        declare const cyclicCallback: CyclicCallable;
         declare const unionCallback: (() => Promise<void>) | (() => Promise<number>);
         declare function consume(value: unknown): void;
-        consume(interfaceCallback);
+        consume(asyncCallback);
+        consume(syncCallback);
+        consume(inheritedAsyncCallback);
+        consume(overloadedCallback);
+        consume(mixedCallback);
+        consume(cyclicCallback);
         consume(unionCallback);
     "#;
     let fs = MemoryFileSystem::default();
@@ -217,10 +242,18 @@ fn test_expression_function_return_leaves_interface_and_union_indeterminate() {
         .module_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
 
-    for expression in ["interfaceCallback", "unionCallback"] {
+    for (expression, expected) in [
+        ("asyncCallback", Some(true)),
+        ("syncCallback", Some(false)),
+        ("inheritedAsyncCallback", Some(true)),
+        ("overloadedCallback", None),
+        ("mixedCallback", None),
+        ("cyclicCallback", Some(true)),
+        ("unionCallback", None),
+    ] {
         assert_eq!(
             expression_function_returns_promise(&db, module, SOURCE, expression),
-            None,
+            expected,
             "{expression}"
         );
     }

--- a/crates/biome_module_graph/tests/spec_tests_v2/promises.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/promises.test.rs
@@ -219,12 +219,30 @@ fn test_expression_function_return_classifies_callable_interfaces_conservatively
         interface CyclicCallable extends CyclicCallable {
             (): Promise<void>;
         }
+        type AsyncObject = {
+            (): Promise<void>;
+        };
+        type SyncObject = {
+            (): void;
+        };
+        type OverloadedObject = {
+            (): Promise<void>;
+            (value: string): Promise<void>;
+        };
+        type MixedObject = {
+            (): void;
+            (value: string): Promise<void>;
+        };
         declare const asyncCallback: AsyncCallable;
         declare const syncCallback: SyncCallable;
         declare const inheritedAsyncCallback: InheritedAsyncCallable;
         declare const overloadedCallback: OverloadedCallable;
         declare const mixedCallback: MixedCallable;
         declare const cyclicCallback: CyclicCallable;
+        declare const asyncObject: AsyncObject;
+        declare const syncObject: SyncObject;
+        declare const overloadedObject: OverloadedObject;
+        declare const mixedObject: MixedObject;
         declare const unionCallback: (() => Promise<void>) | (() => Promise<number>);
         declare function consume(value: unknown): void;
         consume(asyncCallback);
@@ -233,6 +251,10 @@ fn test_expression_function_return_classifies_callable_interfaces_conservatively
         consume(overloadedCallback);
         consume(mixedCallback);
         consume(cyclicCallback);
+        consume(asyncObject);
+        consume(syncObject);
+        consume(overloadedObject);
+        consume(mixedObject);
         consume(unionCallback);
     "#;
     let fs = MemoryFileSystem::default();
@@ -249,6 +271,10 @@ fn test_expression_function_return_classifies_callable_interfaces_conservatively
         ("overloadedCallback", None),
         ("mixedCallback", None),
         ("cyclicCallback", Some(true)),
+        ("asyncObject", Some(true)),
+        ("syncObject", Some(false)),
+        ("overloadedObject", None),
+        ("mixedObject", None),
         ("unionCallback", None),
     ] {
         assert_eq!(

--- a/crates/biome_module_graph/tests/spec_tests_v2/queries.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/queries.test.rs
@@ -4,7 +4,7 @@ use biome_module_graph::{
     function_returns_promise, infer_binding_type, infer_export_type,
     infer_expression_function_returns_promise, infer_expression_is_array_of_promises,
     infer_expression_is_promise, infer_expression_type, infer_local_type, is_array_of_promise_type,
-    is_promise_type,
+    is_promise_type, resolve_callable_type,
 };
 
 fn local_type_id_by_name(db: &dyn ModuleDb, module: ModuleInfo, name: &str) -> InferredLocalTypeId {
@@ -91,6 +91,53 @@ fn test_binding_query_resolves_imports_without_materializing_modules() {
 }
 
 #[test]
+fn test_namespace_query_keeps_named_exports_symbolic() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/source.ts".into(), "export class Value { field = 1; }");
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import * as source from "./source.ts";
+            export { source };
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/source.ts", "/src/index.ts"], true);
+    let source_module = db
+        .module_for_path(Utf8Path::new("/src/source.ts"))
+        .expect("source module must exist");
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+    let source_binding = BindingTypeInput::new(
+        &db,
+        index_module,
+        binding_range_by_name(&db, index_module, "source"),
+    );
+    let value_binding = BindingTypeInput::new(
+        &db,
+        source_module,
+        binding_range_by_name(&db, source_module, "Value"),
+    );
+
+    db.clear_salsa_events();
+    let namespace = infer_binding_type(&db, source_binding).expect("namespace must be inferred");
+    let InferredTypeData::Namespace(namespace) = namespace else {
+        panic!("namespace import must infer a namespace");
+    };
+    let value = namespace
+        .members(&db)
+        .iter()
+        .find(|member| member.kind.has_name("Value"))
+        .expect("namespace must contain Value");
+    assert!(matches!(value.ty, InferredTypeData::Local(_)));
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_binding_type, value_binding, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, source_module, &events);
+}
+
+#[test]
 fn test_member_lookup_resolves_local_types_without_materializing_the_module() {
     let fs = MemoryFileSystem::default();
     fs.insert(
@@ -117,6 +164,65 @@ fn test_member_lookup_resolves_local_types_without_materializing_the_module() {
     let events = db.take_salsa_events();
 
     assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+}
+
+#[test]
+fn test_callable_type_resolution_skips_interface_parameters_and_siblings() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            interface Noise {
+                nested: string;
+            }
+            interface Handler {
+                (value: Noise): void;
+                unrelated: Noise;
+            }
+            declare const handler: Handler;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let handler_input =
+        BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "handler"));
+    let handler = infer_binding_type(&db, handler_input).expect("handler type must be inferred");
+    let noise = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Noise"));
+
+    db.clear_salsa_events();
+    let callable = resolve_callable_type(&db, handler).expect("Handler must be callable");
+    assert!(InferredType::new(&db, callable).function_returns_void());
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+}
+
+#[test]
+fn test_member_lookup_rejects_stale_local_handles_after_module_replacement() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        "export interface Value { field: string; }",
+    );
+
+    let mut db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let path = Utf8PathBuf::from("/src/index.ts");
+    let original = db.module_for_path(&path).expect("module must exist");
+    let original_key = InferredModuleKey::new(original.as_id());
+    let type_id = local_type_id_by_name(&db, original, "Value");
+    let replacement = ModuleInfo::new(&db, path.clone(), original.kind(&db).clone());
+    db.modules.insert(path, replacement);
+    let stale = InferredTypeData::Local(biome_js_type_info::interned_types::LocalTypeHandle::new(
+        &db,
+        original_key,
+        type_id,
+    ));
+
+    assert!(find_member_type(&db, stale, "field").is_none());
 }
 
 #[test]
@@ -270,6 +376,47 @@ fn test_expression_function_return_query_skips_expression_and_sibling_type_queri
 }
 
 #[test]
+fn test_expression_function_return_query_follows_only_interface_call_signature() {
+    const SOURCE: &str = r#"
+        interface Noise {
+            nested: string;
+        }
+        type Result = Promise<void>;
+        interface AsyncHandler {
+            (value: Noise): Result;
+            unrelated: Noise;
+        }
+        declare const callback: AsyncHandler;
+        declare function consume(value: unknown): void;
+        consume(callback);
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "callback"),
+    );
+    let noise = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Noise"));
+
+    db.clear_salsa_events();
+    assert_eq!(
+        infer_expression_function_returns_promise(&db, expression),
+        Some(true)
+    );
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_expression_type, expression, &events);
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+}
+
+#[test]
 fn test_expression_array_promise_query_skips_sibling_type_queries() {
     const SOURCE: &str = r#"
         interface Noise {
@@ -304,6 +451,75 @@ fn test_expression_array_promise_query_skips_sibling_type_queries() {
 
     assert_function_query_was_not_run(&db, infer_expression_type, expression, &events);
     assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+}
+
+#[test]
+fn test_expression_array_promise_query_unwraps_awaited_function_returns_selectively() {
+    const SOURCE: &str = r#"
+        interface Noise {
+            nested: string;
+        }
+        async function asyncValues(value: Noise): Promise<Array<Promise<void>>> {
+            return [];
+        }
+        function syncValues(value: Noise): Promise<Array<Promise<void>>> {
+            return Promise.resolve([]);
+        }
+        declare const directValues: Promise<Array<Promise<void>>>;
+        declare const uncertain: unknown;
+        declare function overloaded(): Promise<Array<Promise<void>>>;
+        declare function overloaded(value: string): Promise<Array<Promise<void>>>;
+
+        await asyncValues(null as never);
+        await syncValues(null as never);
+        await directValues;
+        await await asyncValues(null as never);
+        await uncertain;
+        await overloaded();
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inputs = [
+        ("await asyncValues(null as never)", Some(true)),
+        ("await syncValues(null as never)", Some(true)),
+        ("await directValues", Some(true)),
+        ("await await asyncValues(null as never)", Some(true)),
+        ("await uncertain", Some(false)),
+        ("await overloaded()", None),
+    ]
+    .map(|(source, expected)| {
+        (
+            source,
+            ExpressionTypeInput::new(
+                &db,
+                module,
+                expression_range_by_source(&db, module, SOURCE, source),
+            ),
+            expected,
+        )
+    });
+    let noise = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Noise"));
+
+    db.clear_salsa_events();
+    for (source, input, expected) in inputs {
+        assert_eq!(
+            infer_expression_is_array_of_promises(&db, input),
+            expected,
+            "{source}"
+        );
+    }
+    let events = db.take_salsa_events();
+
+    for (_, input, _) in inputs {
+        assert_function_query_was_not_run(&db, infer_expression_type, input, &events);
+    }
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, module, &events);
 }
 
 #[test]

--- a/crates/biome_module_graph/tests/spec_tests_v2/queries.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/queries.test.rs
@@ -1,8 +1,42 @@
 use super::*;
 use biome_module_graph::{
     BindingTypeInput, ExpressionTypeInput, LocalTypeInput, SymbolFromModuleInfo, find_member_type,
-    infer_binding_type, infer_export_type, infer_expression_type, infer_local_type,
+    function_returns_promise, infer_binding_type, infer_export_type,
+    infer_expression_function_returns_promise, infer_expression_is_array_of_promises,
+    infer_expression_is_promise, infer_expression_type, infer_local_type, is_array_of_promise_type,
+    is_promise_type,
 };
+
+fn local_type_id_by_name(db: &dyn ModuleDb, module: ModuleInfo, name: &str) -> InferredLocalTypeId {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        panic!("module must contain JavaScript information");
+    };
+    (0..js_info.raw_types.len())
+        .map(InferredLocalTypeId::new)
+        .find(|type_id| {
+            js_info
+                .local_type_name(*type_id)
+                .is_some_and(|type_name| type_name.text() == name)
+        })
+        .unwrap_or_else(|| panic!("{name} local type must exist"))
+}
+
+fn expression_range_by_source(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    source: &str,
+    expected: &str,
+) -> TextRange {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        panic!("module must contain JavaScript information");
+    };
+    js_info
+        .raw_expressions
+        .keys()
+        .find(|range| source_snippet(source, **range) == expected)
+        .copied()
+        .unwrap_or_else(|| panic!("{expected} expression must exist"))
+}
 
 #[test]
 fn test_binding_query_does_not_materialize_the_module() {
@@ -83,6 +117,285 @@ fn test_member_lookup_resolves_local_types_without_materializing_the_module() {
     let events = db.take_salsa_events();
 
     assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+}
+
+#[test]
+fn test_promise_classification_query_skips_instance_type_arguments() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            interface Noise {
+                nested: string;
+            }
+            declare const values: Array<Noise>;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let binding = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "values"));
+    let values = infer_binding_type(&db, binding).expect("values type must be inferred");
+    let noise = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Noise"));
+
+    db.clear_salsa_events();
+    assert_eq!(is_promise_type(&db, values), Some(false));
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+}
+
+#[test]
+fn test_array_promise_classification_query_skips_promise_type_arguments() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            interface Noise {
+                nested: string;
+            }
+            declare const values: Array<Promise<Noise>>;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let binding = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "values"));
+    let values = infer_binding_type(&db, binding).expect("values type must be inferred");
+    let noise = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Noise"));
+
+    db.clear_salsa_events();
+    assert_eq!(is_array_of_promise_type(&db, values), Some(true));
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+}
+
+#[test]
+fn test_promise_return_classification_query_resolves_return_but_skips_parameters() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            interface Noise {
+                nested: string;
+            }
+            type Result = Promise<void>;
+            type Callback = (value: Noise) => Result;
+            declare const callback: Callback;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let binding =
+        BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "callback"));
+    let callback = infer_binding_type(&db, binding).expect("callback type must be inferred");
+    let callback_input =
+        LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Callback"));
+    let result = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Result"));
+    let noise = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Noise"));
+
+    db.clear_salsa_events();
+    assert_eq!(function_returns_promise(&db, callback), Some(true));
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_run(&db, infer_local_type, callback_input, &events);
+    assert_function_query_was_run(&db, infer_local_type, result, &events);
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+}
+
+#[test]
+fn test_expression_function_return_query_skips_expression_and_sibling_type_queries() {
+    const SOURCE: &str = r#"
+        interface Noise {
+            nested: string;
+        }
+        declare function consume(value: unknown): void;
+        class Runner {
+            #settings = {
+                config: { cacheDir: "/tmp", unrelated: null as unknown as Noise }
+            };
+
+            run() {
+                consume({ image: "", syntaxHighlight: async () => {}, unrelated: null as unknown as Noise });
+                consume(this.#settings.config.cacheDir);
+            }
+        }
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let object = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(
+            &db,
+            module,
+            SOURCE,
+            r#"{ image: "", syntaxHighlight: async () => {}, unrelated: null as unknown as Noise }"#,
+        ),
+    );
+    let cache_dir = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "this.#settings.config.cacheDir"),
+    );
+    let noise = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Noise"));
+
+    db.clear_salsa_events();
+    assert_eq!(
+        infer_expression_function_returns_promise(&db, object),
+        Some(false)
+    );
+    assert_eq!(
+        infer_expression_function_returns_promise(&db, cache_dir),
+        Some(false)
+    );
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_expression_type, object, &events);
+    assert_function_query_was_not_run(&db, infer_expression_type, cache_dir, &events);
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+}
+
+#[test]
+fn test_expression_array_promise_query_skips_sibling_type_queries() {
+    const SOURCE: &str = r#"
+        interface Noise {
+            nested: string;
+        }
+        const callbacks = {
+            promises: (): Array<Promise<void>> => [],
+            unrelated: null as unknown as Noise,
+        };
+        callbacks.promises();
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "callbacks.promises()"),
+    );
+    let noise = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Noise"));
+
+    db.clear_salsa_events();
+    assert_eq!(
+        infer_expression_is_array_of_promises(&db, expression),
+        Some(true)
+    );
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_expression_type, expression, &events);
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+}
+
+#[test]
+fn test_expression_promise_queries_follow_imported_interface_members() {
+    const SOURCE: &str = r#"
+        import type { LoaderContext } from "./types";
+        declare const context: LoaderContext;
+        context.store.set({ id: "entry" });
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/types.ts".into(),
+        r#"
+            interface Noise {
+                nested: string;
+            }
+            interface DataStore {
+                set(value: { id: string }): void;
+            }
+            export interface LoaderContext {
+                store: DataStore;
+                unrelated: Noise;
+            }
+        "#,
+    );
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/types.ts", "/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let types_module = db
+        .module_for_path(Utf8Path::new("/src/types.ts"))
+        .expect("types module must exist");
+    let expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "context.store.set({ id: \"entry\" })"),
+    );
+    let noise = LocalTypeInput::new(
+        &db,
+        types_module,
+        local_type_id_by_name(&db, types_module, "Noise"),
+    );
+
+    db.clear_salsa_events();
+    assert_eq!(infer_expression_is_promise(&db, expression), Some(false));
+    assert_eq!(
+        infer_expression_is_array_of_promises(&db, expression),
+        Some(false)
+    );
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_expression_type, expression, &events);
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+}
+
+#[test]
+fn test_expression_promise_queries_match_unknown_node_builtin_imports() {
+    const SOURCE: &str = r#"
+        import fs from "node:fs/promises";
+        async function createDirectory() {
+            await fs.mkdir("/tmp/example", { recursive: true });
+        }
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(
+            &db,
+            module,
+            SOURCE,
+            "await fs.mkdir(\"/tmp/example\", { recursive: true })",
+        ),
+    );
+
+    db.clear_salsa_events();
+    assert_eq!(infer_expression_is_promise(&db, expression), Some(false));
+    assert_eq!(
+        infer_expression_is_array_of_promises(&db, expression),
+        Some(false)
+    );
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_expression_type, expression, &events);
 }
 
 #[test]

--- a/crates/biome_module_graph/tests/spec_tests_v2/queries.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/queries.test.rs
@@ -386,9 +386,15 @@ fn test_expression_function_return_query_follows_only_interface_call_signature()
             (value: Noise): Result;
             unrelated: Noise;
         }
+        type AsyncObject = {
+            (value: Noise): Result;
+            unrelated: Noise;
+        };
         declare const callback: AsyncHandler;
+        declare const objectCallback: AsyncObject;
         declare function consume(value: unknown): void;
         consume(callback);
+        consume(objectCallback);
     "#;
     let fs = MemoryFileSystem::default();
     fs.insert("/src/index.ts".into(), SOURCE);
@@ -402,6 +408,11 @@ fn test_expression_function_return_query_follows_only_interface_call_signature()
         module,
         expression_range_by_source(&db, module, SOURCE, "callback"),
     );
+    let object_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "objectCallback"),
+    );
     let noise = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Noise"));
 
     db.clear_salsa_events();
@@ -409,9 +420,14 @@ fn test_expression_function_return_query_follows_only_interface_call_signature()
         infer_expression_function_returns_promise(&db, expression),
         Some(true)
     );
+    assert_eq!(
+        infer_expression_function_returns_promise(&db, object_expression),
+        Some(true)
+    );
     let events = db.take_salsa_events();
 
     assert_function_query_was_not_run(&db, infer_expression_type, expression, &events);
+    assert_function_query_was_not_run(&db, infer_expression_type, object_expression, &events);
     assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
     assert_function_query_was_not_run(&db, infer_module_types, module, &events);
 }

--- a/crates/biome_module_graph/tests/spec_tests_v2/queries.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/queries.test.rs
@@ -1,0 +1,260 @@
+use super::*;
+use biome_module_graph::{
+    BindingTypeInput, ExpressionTypeInput, LocalTypeInput, SymbolFromModuleInfo, find_member_type,
+    infer_binding_type, infer_export_type, infer_expression_type, infer_local_type,
+};
+
+#[test]
+fn test_binding_query_does_not_materialize_the_module() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), "export const value = 1;");
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let range = binding_range_by_name(&db, module, "value");
+    let input = BindingTypeInput::new(&db, module, range);
+
+    db.clear_salsa_events();
+    let ty = infer_binding_type(&db, input).expect("value type must be inferred");
+    assert!(is_inferred_number(&db, ty));
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_run(&db, infer_binding_type, input, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+}
+
+#[test]
+fn test_binding_query_resolves_imports_without_materializing_modules() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/source.ts".into(), "export const value = 1;");
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import { value } from "./source.ts";
+            export const result = value;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/source.ts", "/src/index.ts"], true);
+    let source_module = db
+        .module_for_path(Utf8Path::new("/src/source.ts"))
+        .expect("source module must exist");
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+    let range = binding_range_by_name(&db, index_module, "result");
+    let input = BindingTypeInput::new(&db, index_module, range);
+
+    db.clear_salsa_events();
+    let ty = infer_binding_type(&db, input).expect("result type must be inferred");
+    assert!(is_inferred_number(&db, ty));
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_module_types, index_module, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, source_module, &events);
+}
+
+#[test]
+fn test_member_lookup_resolves_local_types_without_materializing_the_module() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            interface Value {
+                field: string;
+            }
+            export const value: Value = { field: "value" };
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let range = binding_range_by_name(&db, module, "value");
+    let input = BindingTypeInput::new(&db, module, range);
+    let value_ty = infer_binding_type(&db, input).expect("value type must be inferred");
+
+    db.clear_salsa_events();
+    let field_ty = find_member_type(&db, value_ty, "field").expect("field type must be inferred");
+    assert!(is_inferred_string(&db, field_ty));
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+}
+
+#[test]
+fn test_export_query_does_not_materialize_the_module() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), "export const value = 1;");
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let symbol = SymbolFromModuleInfo::new(&db, "value", module);
+
+    db.clear_salsa_events();
+    let ty = infer_export_type(&db, symbol).expect("export type must be inferred");
+    assert!(is_inferred_number(&db, ty));
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+}
+
+#[test]
+fn test_granular_type_queries_match_module_inference_and_are_memoized() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            interface Value {
+                field: string;
+            }
+
+            const value: Value = { field: "value" };
+            export const result = value.field;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, module).expect("types must be inferred");
+
+    let mut expression_input = None;
+    for (range, expected) in &inferred.expressions {
+        let input = ExpressionTypeInput::new(&db, module, *range);
+        assert_eq!(infer_expression_type(&db, input), Some(*expected));
+        expression_input.get_or_insert(input);
+    }
+
+    let mut binding_input = None;
+    for (range, expected) in &inferred.binding_type_data {
+        let input = BindingTypeInput::new(&db, module, *range);
+        assert_eq!(infer_binding_type(&db, input), Some(expected.ty));
+        binding_input.get_or_insert(input);
+    }
+
+    let mut local_input = None;
+    for (index, expected) in inferred.types.iter().enumerate() {
+        let input = LocalTypeInput::new(&db, module, InferredLocalTypeId::new(index));
+        assert_eq!(infer_local_type(&db, input), Some(*expected));
+        local_input.get_or_insert(input);
+    }
+
+    let expression_input = expression_input.expect("module must contain an expression type");
+    let binding_input = binding_input.expect("module must contain a binding type");
+    let local_input = local_input.expect("module must contain a local type");
+    db.clear_salsa_events();
+    let _ = infer_expression_type(&db, expression_input);
+    let _ = infer_binding_type(&db, binding_input);
+    let _ = infer_local_type(&db, local_input);
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_expression_type, expression_input, &events);
+    assert_function_query_was_not_run(&db, infer_binding_type, binding_input, &events);
+    assert_function_query_was_not_run(&db, infer_local_type, local_input, &events);
+}
+
+#[test]
+fn test_binding_query_is_invalidated_when_its_module_changes() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), "export const value = 1;");
+
+    let mut db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let range = binding_range_by_name(&db, module, "value");
+    {
+        let input = BindingTypeInput::new(&db, module, range);
+        let ty = infer_binding_type(&db, input).expect("value type must be inferred");
+        assert!(is_inferred_number(&db, ty));
+    }
+
+    fs.insert("/src/index.ts".into(), "export const value = 'changed';");
+    let module_kind = resolve_js_module_kind_for_test(&fs, "/src/index.ts", true);
+    salsa::Setter::to(module.set_kind(&mut db), module_kind);
+
+    db.clear_salsa_events();
+    let input = BindingTypeInput::new(&db, module, range);
+    let ty = infer_binding_type(&db, input).expect("changed value type must be inferred");
+    assert!(is_inferred_string(&db, ty));
+    let events = db.take_salsa_events();
+    assert_function_query_was_run(&db, infer_binding_type, input, &events);
+}
+
+#[test]
+fn test_binding_query_is_invalidated_when_an_import_changes() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/source.ts".into(), "export const value = 1;");
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            import { value } from "./source.ts";
+            export const result = value;
+        "#,
+    );
+
+    let mut db = build_js_test_module_db(&fs, &["/src/source.ts", "/src/index.ts"], true);
+    let source_module = db
+        .module_for_path(Utf8Path::new("/src/source.ts"))
+        .expect("source module must exist");
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+    let range = binding_range_by_name(&db, index_module, "result");
+    {
+        let input = BindingTypeInput::new(&db, index_module, range);
+        let ty = infer_binding_type(&db, input).expect("result type must be inferred");
+        assert!(is_inferred_number(&db, ty));
+    }
+
+    fs.insert("/src/source.ts".into(), "export const value = 'changed';");
+    let module_kind = resolve_js_module_kind_for_test(&fs, "/src/source.ts", true);
+    salsa::Setter::to(source_module.set_kind(&mut db), module_kind);
+
+    db.clear_salsa_events();
+    let input = BindingTypeInput::new(&db, index_module, range);
+    let ty = infer_binding_type(&db, input).expect("changed result type must be inferred");
+    assert!(is_inferred_string(&db, ty));
+    let events = db.take_salsa_events();
+    assert_function_query_was_run(&db, infer_binding_type, input, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, index_module, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, source_module, &events);
+}
+
+#[test]
+fn test_binding_query_handles_long_import_chains() {
+    const MODULE_COUNT: usize = 1024;
+
+    let fs = MemoryFileSystem::default();
+    let paths = (0..MODULE_COUNT)
+        .map(|index| format!("/src/module{index}.ts"))
+        .collect::<Vec<_>>();
+    fs.insert(paths[0].clone().into(), "export const value = 1;");
+    for (index, path) in paths.iter().enumerate().skip(1) {
+        fs.insert(
+            path.clone().into(),
+            format!(
+                "import {{ value as previous }} from './module{}.ts'; export const value = previous;",
+                index - 1
+            ),
+        );
+    }
+    let path_refs = paths.iter().map(String::as_str).collect::<Vec<_>>();
+
+    let db = build_js_test_module_db(&fs, &path_refs, true);
+    let module = db
+        .module_for_path(Utf8Path::new(&paths[MODULE_COUNT - 1]))
+        .expect("last module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "value"));
+
+    db.clear_salsa_events();
+    let ty = infer_binding_type(&db, input).expect("value type must be inferred");
+    assert!(is_inferred_number(&db, ty));
+}


### PR DESCRIPTION
## Summary

Switches production module collection and typed analyzer services to Salsa-backed inferred types. Type-aware rules can now detect floating Promises returned through aliased callbacks and async array mapping.

Includes `.changeset/light-carrots-throw.md`.

## Test Plan

Added analyzer coverage for the affected Promise cases and passed type-info, module-graph, and analyzer tests plus all-target clippy.

## Docs

N/A

> This PR was created with AI assistance (OpenCode).