### PR TITLE
feat(useSortedClasses): order same-utility values in sort_v4

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
@@ -47,15 +47,119 @@ pub fn sort_class_list(root: &TwRoot) -> String {
     result
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum SortKey {
     Unknown,
     Known {
         property_idx: u16,
         property_count: u8,
         registration_idx: u16,
+        value: ValueKey,
         important: bool,
     },
+}
+
+/// The value and modifier text of a candidate — `red-500` + `50` for
+/// `bg-red-500/50`, `[13px]` + `` for `w-[13px]`, `1` + `2` for the
+/// fraction `w-1/2`. Candidates with an identical
+/// (property, registration) placement order by natural comparison of
+/// these texts, mirroring how Tailwind orders same-utility candidates
+/// in generated CSS.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct ValueKey {
+    value: String,
+    modifier: String,
+}
+
+impl ValueKey {
+    fn from_candidate(candidate: &AnyTwCandidate) -> Self {
+        match candidate {
+            AnyTwCandidate::TwArbitraryCandidate(arbitrary) => Self {
+                value: arbitrary.value().syntax().text_trimmed().to_string(),
+                modifier: modifier_text(arbitrary.modifier().as_ref()),
+            },
+            AnyTwCandidate::TwFunctionalCandidate(functional) => Self {
+                value: functional
+                    .value()
+                    .map(|value| value.syntax().text_trimmed().to_string())
+                    .unwrap_or_default(),
+                modifier: modifier_text(functional.modifier().as_ref()),
+            },
+            // Static candidates have no value; ties between distinct
+            // static utilities are broken by `registration_idx`.
+            AnyTwCandidate::TwStaticCandidate(_) | AnyTwCandidate::TwBogusCandidate(_) => {
+                Self::default()
+            }
+        }
+    }
+
+    fn compare(&self, other: &Self) -> Ordering {
+        natural_cmp(&self.value, &other.value)
+            .then_with(|| natural_cmp(&self.modifier, &other.modifier))
+    }
+}
+
+fn modifier_text(modifier: Option<&AnyTwModifier>) -> String {
+    match modifier {
+        Some(AnyTwModifier::TwModifier(modifier)) => modifier
+            .value()
+            .map(|value| value.syntax().text_trimmed().to_string())
+            .unwrap_or_default(),
+        Some(AnyTwModifier::TwBogusModifier(bogus)) => bogus.syntax().text_trimmed().to_string(),
+        None => String::new(),
+    }
+}
+
+/// Byte-wise comparison with numeric digit runs: when both strings hold
+/// a digit at the first point of divergence, the full runs containing
+/// them compare as integers (`75` < `700`, `red-50` < `red-100`);
+/// everywhere else plain byte order applies, which places digits before
+/// `[` and `[` before letters (`4` < `[1px]` < `auto`) — matching the
+/// order Tailwind emits same-utility candidates in.
+fn natural_cmp(a: &str, b: &str) -> Ordering {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    let (mut i, mut j) = (0, 0);
+    while let (Some(&byte_a), Some(&byte_b)) = (a.get(i), b.get(j)) {
+        if byte_a.is_ascii_digit() && byte_b.is_ascii_digit() {
+            let (run_a, next_i) = digit_run(a, i);
+            let (run_b, next_j) = digit_run(b, j);
+            match compare_digit_runs(run_a, run_b) {
+                Ordering::Equal => (i, j) = (next_i, next_j),
+                ordering => return ordering,
+            }
+        } else if byte_a == byte_b {
+            i += 1;
+            j += 1;
+        } else {
+            return byte_a.cmp(&byte_b);
+        }
+    }
+    // One string is a prefix of the other; the shorter sorts first
+    // (`in` < `in-out`, and a bare value precedes any longer one).
+    (a.len() - i).cmp(&(b.len() - j))
+}
+
+/// The maximal ASCII digit run starting at `start`, and the index just
+/// past it.
+fn digit_run(bytes: &[u8], start: usize) -> (&[u8], usize) {
+    let mut end = start;
+    while bytes.get(end).is_some_and(|byte| byte.is_ascii_digit()) {
+        end += 1;
+    }
+    (&bytes[start..end], end)
+}
+
+/// Compare digit runs as integers without parsing: strip leading zeros,
+/// then longer runs are larger, then byte order decides.
+fn compare_digit_runs(a: &[u8], b: &[u8]) -> Ordering {
+    let a = trim_leading_zeros(a);
+    let b = trim_leading_zeros(b);
+    a.len().cmp(&b.len()).then_with(|| a.cmp(b))
+}
+
+fn trim_leading_zeros(run: &[u8]) -> &[u8] {
+    let first_nonzero = run.iter().position(|&byte| byte != b'0').unwrap_or(run.len());
+    &run[first_nonzero..]
 }
 
 impl SortKey {
@@ -80,6 +184,7 @@ impl SortKey {
         let Ok(inner) = node.candidate() else {
             return Self::Unknown;
         };
+        let value = ValueKey::from_candidate(&inner);
         let base = match inner {
             AnyTwCandidate::TwArbitraryCandidate(a) => {
                 let Ok(property_token) = a.property_token() else {
@@ -93,6 +198,7 @@ impl SortKey {
                     property_idx,
                     property_count: 1,
                     registration_idx: 0,
+                    value: ValueKey::default(),
                     important: false,
                 }
             }
@@ -117,6 +223,7 @@ impl SortKey {
                     property_idx: entry.property_idx,
                     property_count: entry.property_count,
                     registration_idx,
+                    value: ValueKey::default(),
                     important: false,
                 }
             }
@@ -182,6 +289,7 @@ impl SortKey {
                 property_idx,
                 property_count,
                 registration_idx,
+                value,
                 important: is_important,
             },
         }
@@ -189,7 +297,7 @@ impl SortKey {
 }
 
 fn compare(a: &SortKey, b: &SortKey) -> Ordering {
-    match (*a, *b) {
+    match (a, b) {
         // Unknowns float to the front; relative order between unknowns is
         // preserved by the stable sort.
         (SortKey::Unknown, SortKey::Unknown) => Ordering::Equal,
@@ -200,23 +308,29 @@ fn compare(a: &SortKey, b: &SortKey) -> Ordering {
                 property_idx: p1,
                 property_count: c1,
                 registration_idx: r1,
+                value: v1,
                 important: i1,
             },
             SortKey::Known {
                 property_idx: p2,
                 property_count: c2,
                 registration_idx: r2,
+                value: v2,
                 important: i2,
             },
         ) => p1
-            .cmp(&p2)
+            .cmp(p2)
             // Wider utilities (e.g. `sr-only` setting 9 properties) win
             // their property bucket so they sort before single-property
             // utilities in the same bucket.
-            .then_with(|| c2.cmp(&c1))
-            .then_with(|| r1.cmp(&r2))
+            .then_with(|| c2.cmp(c1))
+            .then_with(|| r1.cmp(r2))
+            // Same-utility candidates order by their value (`p-2 p-4
+            // p-10`, `bg-red-50 bg-red-100`), then modifier
+            // (`bg-red-500/25 bg-red-500/50`).
+            .then_with(|| v1.compare(v2))
             // A plain utility precedes its important twin (`flex flex!`).
-            .then_with(|| i1.cmp(&i2)),
+            .then_with(|| i1.cmp(i2)),
     }
 }
 
@@ -286,7 +400,7 @@ fn named_value_type_matches(
 }
 
 /// Walk a basename's named branch list and return the first matching
-/// branch as a `SortKey::Known` (importance is stamped by
+/// branch as a `SortKey::Known` (value and importance are stamped by
 /// `SortKey::from_candidate`). Branch order in the preset
 /// already reflects the resolution precedence we want
 /// (Keyword → Theme → Typed).
@@ -341,6 +455,7 @@ fn resolve_named_branch(
             property_idx,
             property_count,
             registration_idx,
+            value: ValueKey::default(),
             important: false,
         });
     }
@@ -348,7 +463,7 @@ fn resolve_named_branch(
 }
 
 /// Walk a basename's arbitrary branch list and return the first matching
-/// branch as a `SortKey::Known` (importance is stamped by
+/// branch as a `SortKey::Known` (value and importance are stamped by
 /// `SortKey::from_candidate`). Typed branches precede the
 /// type-blind fallback in generated preset order.
 fn resolve_arbitrary_branch(
@@ -370,6 +485,7 @@ fn resolve_arbitrary_branch(
             property_idx,
             property_count,
             registration_idx,
+            value: ValueKey::default(),
             important: false,
         });
     }
@@ -386,7 +502,15 @@ mod tests {
             property_idx,
             property_count,
             registration_idx,
+            value: ValueKey::default(),
             important: false,
+        }
+    }
+
+    fn value_key(value: &str, modifier: &str) -> ValueKey {
+        ValueKey {
+            value: value.to_string(),
+            modifier: modifier.to_string(),
         }
     }
 
@@ -458,13 +582,79 @@ mod tests {
             property_idx: 5,
             property_count: 1,
             registration_idx: 0,
+            value: ValueKey::default(),
             important: true,
         };
         assert_eq!(compare(&plain, &important), Ordering::Less);
         assert_eq!(compare(&important, &plain), Ordering::Greater);
     }
 
+    #[test]
+    fn compare_breaks_registration_tie_by_value_before_importance() {
+        // `p-2! p-4`: the value decides, the important suffix does not
+        // pull `p-4` ahead of `p-2!`.
+        let important_two = SortKey::Known {
+            property_idx: 5,
+            property_count: 1,
+            registration_idx: 0,
+            value: value_key("2", ""),
+            important: true,
+        };
+        let plain_four = SortKey::Known {
+            property_idx: 5,
+            property_count: 1,
+            registration_idx: 0,
+            value: value_key("4", ""),
+            important: false,
+        };
+        assert_eq!(compare(&important_two, &plain_four), Ordering::Less);
+    }
+
+    #[test]
+    fn compare_breaks_value_tie_by_modifier() {
+        let base = |modifier: &str| SortKey::Known {
+            property_idx: 5,
+            property_count: 1,
+            registration_idx: 0,
+            value: value_key("red-500", modifier),
+            important: false,
+        };
+        assert_eq!(compare(&base("25"), &base("50")), Ordering::Less);
+        assert_eq!(compare(&base("50"), &base("50")), Ordering::Equal);
+    }
+
     // endregion: compare
+
+    // region: natural comparison
+
+    #[test]
+    fn natural_cmp_compares_digit_runs_numerically() {
+        assert_eq!(natural_cmp("2", "10"), Ordering::Less);
+        assert_eq!(natural_cmp("red-50", "red-100"), Ordering::Less);
+        // The run is compared from its start, not from the point of
+        // divergence: `75` < `700` even though `5` > `0`.
+        assert_eq!(natural_cmp("75", "700"), Ordering::Less);
+        assert_eq!(natural_cmp("[2px]", "[10rem]"), Ordering::Less);
+    }
+
+    #[test]
+    fn natural_cmp_uses_byte_order_outside_digit_runs() {
+        // Digits precede `[`, and `[` precedes letters.
+        assert_eq!(natural_cmp("4", "[1px]"), Ordering::Less);
+        assert_eq!(natural_cmp("[13px]", "auto"), Ordering::Less);
+        assert_eq!(natural_cmp("2xl", "base"), Ordering::Less);
+        assert_eq!(natural_cmp("bold", "light"), Ordering::Less);
+    }
+
+    #[test]
+    fn natural_cmp_puts_prefixes_first() {
+        assert_eq!(natural_cmp("", "sm"), Ordering::Less);
+        assert_eq!(natural_cmp("in", "in-out"), Ordering::Less);
+        assert_eq!(natural_cmp("1", "1.5"), Ordering::Less);
+        assert_eq!(natural_cmp("sm", "sm"), Ordering::Equal);
+    }
+
+    // endregion: natural comparison
 
     // region: branch resolution
 
@@ -603,7 +793,16 @@ mod tests {
         let parsed = parse_tailwind("[display:block]");
         let full = parsed.tree().candidates().iter().next().unwrap();
         let display_idx = *PROPERTY_INDEX.get("display").unwrap();
-        assert_eq!(SortKey::from_candidate(&full), known(display_idx, 1, 0));
+        assert_eq!(
+            SortKey::from_candidate(&full),
+            SortKey::Known {
+                property_idx: display_idx,
+                property_count: 1,
+                registration_idx: 0,
+                value: value_key("block", ""),
+                important: false,
+            }
+        );
     }
 
     #[test]
@@ -612,6 +811,7 @@ mod tests {
             property_idx,
             property_count,
             registration_idx,
+            value,
             important: false,
         } = classify("flex")
         else {
@@ -623,6 +823,7 @@ mod tests {
                 property_idx,
                 property_count,
                 registration_idx,
+                value,
                 important: true,
             }
         );
@@ -650,6 +851,24 @@ mod tests {
     fn important_with_variants_is_still_unknown() {
         // Variant weight is the remaining TODO; `!` must not bypass it.
         assert_eq!(classify("hover:flex!"), SortKey::Unknown);
+    }
+
+    #[test]
+    fn classification_captures_value_and_modifier_text() {
+        let value_of = |input: &str| match classify(input) {
+            SortKey::Known { value, .. } => value,
+            SortKey::Unknown => panic!("expected `{input}` to classify as known"),
+        };
+        assert_eq!(value_of("p-4"), value_key("4", ""));
+        // The parser splits a fraction into value and modifier.
+        assert_eq!(value_of("w-1/2"), value_key("1", "2"));
+        assert_eq!(value_of("bg-red-500/50"), value_key("red-500", "50"));
+        // Arbitrary values keep their brackets; arbitrary properties
+        // contribute their value text.
+        assert_eq!(value_of("w-[13px]"), value_key("[13px]", ""));
+        assert_eq!(value_of("[color:red]/50"), value_key("red", "50"));
+        // Static utilities have no value.
+        assert_eq!(value_of("flex"), ValueKey::default());
     }
 
     // endregion: sort key classification

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
@@ -66,6 +66,9 @@ enum SortKey {
 /// tree. Candidates with an identical (property, registration) placement
 /// order by natural comparison of these texts, mirroring how Tailwind
 /// orders same-utility candidates in generated CSS.
+// TODO: the derived equality compares text chunk-wise and cannot
+// short-circuit on syntax kind mismatches; switch to a structural node
+// comparison once a generic `is_node_equal` is available.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct ValueKey {
     value: Option<SyntaxNodeText>,

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 
 use biome_rowan::{AstNode, AstNodeList, AstSeparatedList, SyntaxNodeText, TokenText};
+use biome_string_case::Collator;
 use biome_tailwind_syntax::{
     AnyTwCandidate, AnyTwFullCandidate, AnyTwModifier, AnyTwValue, CssGenericComponentValueList,
     TwRoot,
@@ -60,29 +61,29 @@ enum SortKey {
 }
 
 /// The value and modifier text of a candidate — `red-500` + `50` for
-/// `bg-red-500/50`, `[13px]` + `` for `w-[13px]`, `1` + `2` for the
-/// fraction `w-1/2`. Candidates with an identical
-/// (property, registration) placement order by natural comparison of
-/// these texts, mirroring how Tailwind orders same-utility candidates
-/// in generated CSS.
+/// `bg-red-500/50`, `[13px]` + nothing for `w-[13px]`, `1` + `2` for the
+/// fraction `w-1/2` — held as allocation-free views into the syntax
+/// tree. Candidates with an identical (property, registration) placement
+/// order by natural comparison of these texts, mirroring how Tailwind
+/// orders same-utility candidates in generated CSS.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct ValueKey {
-    value: String,
-    modifier: String,
+    value: Option<SyntaxNodeText>,
+    modifier: Option<SyntaxNodeText>,
 }
 
 impl ValueKey {
     fn from_candidate(candidate: &AnyTwCandidate) -> Self {
         match candidate {
             AnyTwCandidate::TwArbitraryCandidate(arbitrary) => Self {
-                value: arbitrary.value().syntax().text_trimmed().to_string(),
+                value: Some(arbitrary.value().syntax().text_trimmed()),
                 modifier: modifier_text(arbitrary.modifier().as_ref()),
             },
             AnyTwCandidate::TwFunctionalCandidate(functional) => Self {
                 value: functional
                     .value()
-                    .map(|value| value.syntax().text_trimmed().to_string())
-                    .unwrap_or_default(),
+                    .ok()
+                    .map(|value| value.syntax().text_trimmed()),
                 modifier: modifier_text(functional.modifier().as_ref()),
             },
             // Static candidates have no value; ties between distinct
@@ -94,72 +95,50 @@ impl ValueKey {
     }
 
     fn compare(&self, other: &Self) -> Ordering {
-        natural_cmp(&self.value, &other.value)
-            .then_with(|| natural_cmp(&self.modifier, &other.modifier))
+        natural_cmp(self.value.as_ref(), other.value.as_ref())
+            .then_with(|| natural_cmp(self.modifier.as_ref(), other.modifier.as_ref()))
     }
 }
 
-fn modifier_text(modifier: Option<&AnyTwModifier>) -> String {
+fn modifier_text(modifier: Option<&AnyTwModifier>) -> Option<SyntaxNodeText> {
     match modifier {
         Some(AnyTwModifier::TwModifier(modifier)) => modifier
             .value()
-            .map(|value| value.syntax().text_trimmed().to_string())
-            .unwrap_or_default(),
-        Some(AnyTwModifier::TwBogusModifier(bogus)) => bogus.syntax().text_trimmed().to_string(),
-        None => String::new(),
+            .ok()
+            .map(|value| value.syntax().text_trimmed()),
+        Some(AnyTwModifier::TwBogusModifier(bogus)) => Some(bogus.syntax().text_trimmed()),
+        None => None,
     }
 }
 
-/// Byte-wise comparison with numeric digit runs: when both strings hold
-/// a digit at the first point of divergence, the full runs containing
-/// them compare as integers (`75` < `700`, `red-50` < `red-100`);
-/// everywhere else plain byte order applies, which places digits before
-/// `[` and `[` before letters (`4` < `[1px]` < `auto`) — matching the
-/// order Tailwind emits same-utility candidates in.
-fn natural_cmp(a: &str, b: &str) -> Ordering {
-    let (a, b) = (a.as_bytes(), b.as_bytes());
-    let (mut i, mut j) = (0, 0);
-    while let (Some(&byte_a), Some(&byte_b)) = (a.get(i), b.get(j)) {
-        if byte_a.is_ascii_digit() && byte_b.is_ascii_digit() {
-            let (run_a, next_i) = digit_run(a, i);
-            let (run_b, next_j) = digit_run(b, j);
-            match compare_digit_runs(run_a, run_b) {
-                Ordering::Equal => (i, j) = (next_i, next_j),
-                ordering => return ordering,
-            }
-        } else if byte_a == byte_b {
-            i += 1;
-            j += 1;
-        } else {
-            return byte_a.cmp(&byte_b);
-        }
+/// Orders candidate value text the way Tailwind's own `compare()` does:
+/// plain code-point order, except that digit sequences compare as
+/// integers (`75` < `700`, `red-50` < `red-100`). Code-point order
+/// places digits before `[` and `[` before letters
+/// (`4` < `[1px]` < `auto`), matching the order Tailwind emits
+/// same-utility candidates in — which is why this does not reuse
+/// [biome_string_case::CldrAsciiCollator]: CLDR collation places
+/// punctuation before digits and interleaves letter case.
+struct TwValueCollator;
+
+impl Collator for TwValueCollator {
+    type Char = char;
+
+    fn weight(&self, c: &char) -> impl Ord {
+        *c
     }
-    // One string is a prefix of the other; the shorter sorts first
-    // (`in` < `in-out`, and a bare value precedes any longer one).
-    (a.len() - i).cmp(&(b.len() - j))
-}
 
-/// The maximal ASCII digit run starting at `start`, and the index just
-/// past it.
-fn digit_run(bytes: &[u8], start: usize) -> (&[u8], usize) {
-    let mut end = start;
-    while bytes.get(end).is_some_and(|byte| byte.is_ascii_digit()) {
-        end += 1;
+    fn as_digit(&self, c: &char) -> Option<impl Ord> {
+        c.is_ascii_digit().then_some(*c)
     }
-    (&bytes[start..end], end)
 }
 
-/// Compare digit runs as integers without parsing: strip leading zeros,
-/// then longer runs are larger, then byte order decides.
-fn compare_digit_runs(a: &[u8], b: &[u8]) -> Ordering {
-    let a = trim_leading_zeros(a);
-    let b = trim_leading_zeros(b);
-    a.len().cmp(&b.len()).then_with(|| a.cmp(b))
-}
-
-fn trim_leading_zeros(run: &[u8]) -> &[u8] {
-    let first_nonzero = run.iter().position(|&byte| byte != b'0').unwrap_or(run.len());
-    &run[first_nonzero..]
+/// Natural comparison of two optional text views without materializing
+/// either side; a missing text compares as empty, so a bare value
+/// precedes any longer one (`in` < `in-out`).
+fn natural_cmp(a: Option<&SyntaxNodeText>, b: Option<&SyntaxNodeText>) -> Ordering {
+    let chars = |text: Option<&SyntaxNodeText>| text.map(|text| text.chars()).into_iter().flatten();
+    TwValueCollator.cmp(chars(a), chars(b))
 }
 
 impl SortKey {
@@ -507,11 +486,20 @@ mod tests {
         }
     }
 
-    fn value_key(value: &str, modifier: &str) -> ValueKey {
-        ValueKey {
-            value: value.to_string(),
-            modifier: modifier.to_string(),
-        }
+    /// The value and modifier text of a known key, materialized for
+    /// assertion messages; a missing text reads as empty.
+    fn value_texts(key: &SortKey) -> (String, String) {
+        let SortKey::Known { value, .. } = key else {
+            panic!("expected a known key");
+        };
+        let text = |text: Option<&SyntaxNodeText>| {
+            text.map(ToString::to_string).unwrap_or_default()
+        };
+        (text(value.value.as_ref()), text(value.modifier.as_ref()))
+    }
+
+    fn nat_cmp(a: &str, b: &str) -> Ordering {
+        TwValueCollator.cmp(a.chars(), b.chars())
     }
 
     fn classify(input: &str) -> SortKey {
@@ -593,34 +581,17 @@ mod tests {
     fn compare_breaks_registration_tie_by_value_before_importance() {
         // `p-2! p-4`: the value decides, the important suffix does not
         // pull `p-4` ahead of `p-2!`.
-        let important_two = SortKey::Known {
-            property_idx: 5,
-            property_count: 1,
-            registration_idx: 0,
-            value: value_key("2", ""),
-            important: true,
-        };
-        let plain_four = SortKey::Known {
-            property_idx: 5,
-            property_count: 1,
-            registration_idx: 0,
-            value: value_key("4", ""),
-            important: false,
-        };
+        let important_two = classify("p-2!");
+        let plain_four = classify("p-4");
         assert_eq!(compare(&important_two, &plain_four), Ordering::Less);
     }
 
     #[test]
     fn compare_breaks_value_tie_by_modifier() {
-        let base = |modifier: &str| SortKey::Known {
-            property_idx: 5,
-            property_count: 1,
-            registration_idx: 0,
-            value: value_key("red-500", modifier),
-            important: false,
-        };
-        assert_eq!(compare(&base("25"), &base("50")), Ordering::Less);
-        assert_eq!(compare(&base("50"), &base("50")), Ordering::Equal);
+        let twenty_five = classify("bg-red-500/25");
+        let fifty = classify("bg-red-500/50");
+        assert_eq!(compare(&twenty_five, &fifty), Ordering::Less);
+        assert_eq!(compare(&fifty, &fifty), Ordering::Equal);
     }
 
     // endregion: compare
@@ -628,30 +599,30 @@ mod tests {
     // region: natural comparison
 
     #[test]
-    fn natural_cmp_compares_digit_runs_numerically() {
-        assert_eq!(natural_cmp("2", "10"), Ordering::Less);
-        assert_eq!(natural_cmp("red-50", "red-100"), Ordering::Less);
-        // The run is compared from its start, not from the point of
-        // divergence: `75` < `700` even though `5` > `0`.
-        assert_eq!(natural_cmp("75", "700"), Ordering::Less);
-        assert_eq!(natural_cmp("[2px]", "[10rem]"), Ordering::Less);
+    fn collator_compares_digit_sequences_numerically() {
+        assert_eq!(nat_cmp("2", "10"), Ordering::Less);
+        assert_eq!(nat_cmp("red-50", "red-100"), Ordering::Less);
+        // The digit sequence is compared as a whole number, not from the
+        // point of divergence: `75` < `700` even though `5` > `0`.
+        assert_eq!(nat_cmp("75", "700"), Ordering::Less);
+        assert_eq!(nat_cmp("[2px]", "[10rem]"), Ordering::Less);
     }
 
     #[test]
-    fn natural_cmp_uses_byte_order_outside_digit_runs() {
+    fn collator_uses_code_point_order_outside_digit_sequences() {
         // Digits precede `[`, and `[` precedes letters.
-        assert_eq!(natural_cmp("4", "[1px]"), Ordering::Less);
-        assert_eq!(natural_cmp("[13px]", "auto"), Ordering::Less);
-        assert_eq!(natural_cmp("2xl", "base"), Ordering::Less);
-        assert_eq!(natural_cmp("bold", "light"), Ordering::Less);
+        assert_eq!(nat_cmp("4", "[1px]"), Ordering::Less);
+        assert_eq!(nat_cmp("[13px]", "auto"), Ordering::Less);
+        assert_eq!(nat_cmp("2xl", "base"), Ordering::Less);
+        assert_eq!(nat_cmp("bold", "light"), Ordering::Less);
     }
 
     #[test]
-    fn natural_cmp_puts_prefixes_first() {
-        assert_eq!(natural_cmp("", "sm"), Ordering::Less);
-        assert_eq!(natural_cmp("in", "in-out"), Ordering::Less);
-        assert_eq!(natural_cmp("1", "1.5"), Ordering::Less);
-        assert_eq!(natural_cmp("sm", "sm"), Ordering::Equal);
+    fn collator_puts_prefixes_first() {
+        assert_eq!(nat_cmp("", "sm"), Ordering::Less);
+        assert_eq!(nat_cmp("in", "in-out"), Ordering::Less);
+        assert_eq!(nat_cmp("1", "1.5"), Ordering::Less);
+        assert_eq!(nat_cmp("sm", "sm"), Ordering::Equal);
     }
 
     // endregion: natural comparison
@@ -793,16 +764,21 @@ mod tests {
         let parsed = parse_tailwind("[display:block]");
         let full = parsed.tree().candidates().iter().next().unwrap();
         let display_idx = *PROPERTY_INDEX.get("display").unwrap();
-        assert_eq!(
-            SortKey::from_candidate(&full),
-            SortKey::Known {
-                property_idx: display_idx,
-                property_count: 1,
-                registration_idx: 0,
-                value: value_key("block", ""),
-                important: false,
-            }
-        );
+        let key = SortKey::from_candidate(&full);
+        let SortKey::Known {
+            property_idx,
+            property_count,
+            registration_idx,
+            important: false,
+            ..
+        } = &key
+        else {
+            panic!("expected a plain known key");
+        };
+        assert_eq!(*property_idx, display_idx);
+        assert_eq!(*property_count, 1);
+        assert_eq!(*registration_idx, 0);
+        assert_eq!(value_texts(&key), ("block".to_string(), String::new()));
     }
 
     #[test]
@@ -855,20 +831,18 @@ mod tests {
 
     #[test]
     fn classification_captures_value_and_modifier_text() {
-        let value_of = |input: &str| match classify(input) {
-            SortKey::Known { value, .. } => value,
-            SortKey::Unknown => panic!("expected `{input}` to classify as known"),
-        };
-        assert_eq!(value_of("p-4"), value_key("4", ""));
+        let texts_of = |input: &str| value_texts(&classify(input));
+        let pair = |value: &str, modifier: &str| (value.to_string(), modifier.to_string());
+        assert_eq!(texts_of("p-4"), pair("4", ""));
         // The parser splits a fraction into value and modifier.
-        assert_eq!(value_of("w-1/2"), value_key("1", "2"));
-        assert_eq!(value_of("bg-red-500/50"), value_key("red-500", "50"));
+        assert_eq!(texts_of("w-1/2"), pair("1", "2"));
+        assert_eq!(texts_of("bg-red-500/50"), pair("red-500", "50"));
         // Arbitrary values keep their brackets; arbitrary properties
         // contribute their value text.
-        assert_eq!(value_of("w-[13px]"), value_key("[13px]", ""));
-        assert_eq!(value_of("[color:red]/50"), value_key("red", "50"));
+        assert_eq!(texts_of("w-[13px]"), pair("[13px]", ""));
+        assert_eq!(texts_of("[color:red]/50"), pair("red", "50"));
         // Static utilities have no value.
-        assert_eq!(value_of("flex"), ValueKey::default());
+        assert_eq!(texts_of("flex"), pair("", ""));
     }
 
     // endregion: sort key classification

--- a/crates/biome_js_analyze/tests/sort_v4/cases.jsonc
+++ b/crates/biome_js_analyze/tests/sort_v4/cases.jsonc
@@ -16,7 +16,7 @@
 	"bg-red-500 flex p-4",   // ThemeNamespace::Color
 	"p-4 m-2 flex",          // NamedTyped(Number)
 	"text-lg bg-red-500 p-4",
-	"p-4 p-2",               // same basename, stable input order
+	"p-4 p-2",               // same basename, ordered by value (p-2 first)
 	"origin-top flex p-4",   // NamedKeyword pool
 	"flex-1 flex p-4",       // STATIC `flex` wins over functional `flex` basename
 
@@ -30,8 +30,8 @@
 	// NamedTyped(Number) for bare integers, NamedTyped(Ratio) for fractions.
 	"w-10 flex p-4",         // NamedTyped(Number)
 	"w-1/2 flex p-4",        // NamedTyped(Ratio)
-	"w-full flex p-4",       // Named(Spacing) — `--spacing-full` theme key
-	"w-screen w-10 w-full",  // multi-value same basename, stable order
+	"w-full flex p-4",       // `full` is no `--spacing-*` key in the default theme → Unknown
+	"w-screen w-10 w-full",  // full/screen aren't --spacing-* keys → Unknown floats front
 
 	// aspect basename — NamedKeyword pool (auto/square),
 	// Named(Aspect) (theme keys like `video`), NamedTyped(Ratio).
@@ -75,7 +75,7 @@
 
 	"from-50% flex",              // TwPercentageValue → gradient-stop
 	"to-100% via-25% from-50%",   // three gradient stops, stable order within bucket
-	"flex w-1/2 w-1/3",           // two ratios share the same w branch, stable input order
+	"flex w-1/2 w-1/3",           // two ratios share the same w branch, ordered by value text
 	"flex bg-red-500/50",         // color modifier — base named color sort key
 	"flex text-lg/8",             // line-height modifier — base named text-size sort key
 	"flex w-1/foo",               // non-fraction modifier — base number sort key
@@ -112,10 +112,34 @@
 	"p-4 bg-linear-to-r from-blue-500 to-purple-500 m-2",         // linear gradient with surrounding spacing
 	"mask-linear-to-75% mask-linear-from-25%",                    // mask gradient stops
 
+	// ─── value ordering within a utility ───────────────────────────
+	// Candidates sharing a (property, registration) placement order by
+	// natural comparison of their value text (digit runs compare
+	// numerically), then modifier. Expected order cross-checked against
+	// prettier-plugin-tailwindcss 0.8.0.
+
+	"p-10 p-2 p-4",                     // numeric, not lexicographic
+	"p-2.5 p-2 p-10",                   // decimal segments compare piecewise
+	"duration-700 duration-75",         // digit runs compare from their start
+	"bg-red-500 bg-red-50 bg-red-100",  // scale steps within one color
+	"bg-red-500 bg-blue-500",           // colors order by text, not theme order
+	"text-lg text-sm text-2xl text-xs", // digit-led values first, then alphabetical
+	"w-2/5 w-1/2",                      // fractions by text, not numeric value
+	"leading-6 leading-none leading-3", // digits precede letters
+	"-m-4 -m-2 m-1",                    // negatives keep their bucket, values still order
+	"bg-red-500/50 bg-red-500/25",      // modifier breaks a value tie
+	"text-lg/8 text-sm/6",              // value ordering beats the modifier
+	"mt-2 mt-[10px]",                   // concrete number before arbitrary value
+	"w-[1px] w-4",                      // bracket text compares as written
+	"w-[2px] w-[10rem] w-[13px]",       // numeric inside brackets, across units
+	"ease-in ease-out ease-in-out",     // keyword-pool values order by text
+	"[display:flex] [display:block]",   // arbitrary properties compare their values
+	"p-4! p-2",                         // value order dominates the important suffix
+
 	// ─── important suffix ──────────────────────────────────────────
 	// `flex!` sorts exactly where `flex` does; an exact-key tie breaks
 	// plain-first. Expected order cross-checked against
-	// prettier-plugin-tailwindcss.
+	// prettier-plugin-tailwindcss 0.8.0.
 
 	"px-2! flex p-4",               // position-neutral: sorts as px-2
 	"underline flex!",              // jumps ahead with its utility

--- a/crates/biome_js_analyze/tests/sort_v4/cases.snap
+++ b/crates/biome_js_analyze/tests/sort_v4/cases.snap
@@ -29,7 +29,7 @@ input:  text-lg bg-red-500 p-4
 sorted: bg-red-500 p-4 text-lg
 ---
 input:  p-4 p-2
-sorted: p-4 p-2
+sorted: p-2 p-4
 ---
 input:  origin-top flex p-4
 sorted: flex origin-top p-4
@@ -143,7 +143,7 @@ input:  border-[#f00] border-[2px]
 sorted: border-[2px] border-[#f00]
 ---
 input:  text-[#fff] text-[larger] text-[20px]
-sorted: text-[larger] text-[20px] text-[#fff]
+sorted: text-[20px] text-[larger] text-[#fff]
 ---
 input:  bg-[#fff] bg-[COVER] border-[THIN] text-[LARGER] flex
 sorted: flex border-[THIN] bg-[#fff] bg-[COVER] text-[LARGER]
@@ -174,6 +174,57 @@ sorted: m-2 bg-linear-to-r from-blue-500 to-purple-500 p-4
 ---
 input:  mask-linear-to-75% mask-linear-from-25%
 sorted: mask-linear-from-25% mask-linear-to-75%
+---
+input:  p-10 p-2 p-4
+sorted: p-2 p-4 p-10
+---
+input:  p-2.5 p-2 p-10
+sorted: p-2 p-2.5 p-10
+---
+input:  duration-700 duration-75
+sorted: duration-75 duration-700
+---
+input:  bg-red-500 bg-red-50 bg-red-100
+sorted: bg-red-50 bg-red-100 bg-red-500
+---
+input:  bg-red-500 bg-blue-500
+sorted: bg-blue-500 bg-red-500
+---
+input:  text-lg text-sm text-2xl text-xs
+sorted: text-2xl text-lg text-sm text-xs
+---
+input:  w-2/5 w-1/2
+sorted: w-1/2 w-2/5
+---
+input:  leading-6 leading-none leading-3
+sorted: leading-3 leading-6 leading-none
+---
+input:  -m-4 -m-2 m-1
+sorted: -m-2 -m-4 m-1
+---
+input:  bg-red-500/50 bg-red-500/25
+sorted: bg-red-500/25 bg-red-500/50
+---
+input:  text-lg/8 text-sm/6
+sorted: text-lg/8 text-sm/6
+---
+input:  mt-2 mt-[10px]
+sorted: mt-2 mt-[10px]
+---
+input:  w-[1px] w-4
+sorted: w-4 w-[1px]
+---
+input:  w-[2px] w-[10rem] w-[13px]
+sorted: w-[2px] w-[10rem] w-[13px]
+---
+input:  ease-in ease-out ease-in-out
+sorted: ease-in ease-in-out ease-out
+---
+input:  [display:flex] [display:block]
+sorted: [display:block] [display:flex]
+---
+input:  p-4! p-2
+sorted: p-2 p-4!
 ---
 input:  px-2! flex p-4
 sorted: flex p-4 px-2!


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Moves #1274.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

Same-utility candidates previously kept stable input order. They now order by:
1. natural comparison of value text 
2. modifier text, with digit runs comparing as integers. 

ValueKey added to SortKey::Known. v1.compare(v2) sits between `registration_idx` and `important` in the compare chain.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Followup to #10880. AI tools were used to identify the next unclaimed step in useSortedClasses nursery promotion; implementation plans were drafted and considered, with this being the winning candidate for its adherence to repo conventions and inclusion of correct additional tests.

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

No changesets as sort_v4 is not yet wired to user-side behavior.


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- 17 new fixtures in cases.jsonc, each byte-identical to prettier-plugin-tailwindcss 0.8.0 (re-verified against the real plugin today). 
- 2 pre-existing fixtures now use post-sorted values
- 52 use_sorted_classes unit tests
- 15 specs
- full biome_js_analyze suite green; `cargo fmt --all --check` and the full-workspace `clippy --all-features --all-targets --deny warnings` both exit 0.


## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

No docs as no user-visible behavior change yet.

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
