### PR TITLE
fix(cli): create log directory before initializing tracing appender

### DIFF
--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -212,9 +212,7 @@ pub(crate) fn read_most_recent_log_file(
 /// `biome-logs/server.log.yyyy-MM-dd-HH` files inside the system temporary
 /// directory)
 fn setup_tracing_subscriber(log_path: Utf8PathBuf, log_file_name_prefix: String) {
-    if let Err(err) = std::fs::create_dir_all(&log_path) {
-        eprintln!("Failed to create log directory: {err}");
-    }
+    fs::create_dir_all(&log_path).expect("Failed to create log directory for the daemon.");
 
     let appender_builder = tracing_appender::rolling::RollingFileAppender::builder();
     let file_appender = appender_builder

--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -212,6 +212,10 @@ pub(crate) fn read_most_recent_log_file(
 /// `biome-logs/server.log.yyyy-MM-dd-HH` files inside the system temporary
 /// directory)
 fn setup_tracing_subscriber(log_path: Utf8PathBuf, log_file_name_prefix: String) {
+    if let Err(err) = std::fs::create_dir_all(&log_path) {
+        eprintln!("Failed to create log directory: {err}");
+    }
+
     let appender_builder = tracing_appender::rolling::RollingFileAppender::builder();
     let file_appender = appender_builder
         .filename_prefix(log_file_name_prefix)


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

Fixes: #11025 

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Fixes an issue where starting Biome for the first time (or with a non-existent log directory) causes `tracing-appender` to output a spurious warning/error to `stderr`:
`Error reading the log directory/files: No such file or directory (os error 2)`

## Cause

When .max_log_files(7) is set on RollingFileAppender, tracing-appender attempts to scan and clean up old log files upon .build(log_path). If log_path does not exist yet, fs::read_dir() fails internally inside tracing-appender and prints an error to stderr before creating the directory.

## Solution

Ensures `std::fs::create_dir_all(&log_path)` is called prior to building `RollingFileAppender` in `setup_tracing_subscriber`.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

1. Remove existing log directory: `rm -rf ~/.cache/biome/biome-logs`
2. Run `cargo build --bin biome`
3. Test daemon startup: `./target/debug/biome start`
4. Verify that stderr is clean and no Error reading the log directory/files error is emitted.
5. Ran CLI unit tests: `cargo test -p biome_cli commands::daemon`

All 57 CLI tests passed.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
