### PR TITLE
fix(css_formatter): preserve escaped attribute newlines without breaking parent groups

### DIFF
--- a/crates/biome_css_formatter/src/utils/string_utils.rs
+++ b/crates/biome_css_formatter/src/utils/string_utils.rs
@@ -67,6 +67,10 @@ impl<'token> FormatLiteralStringToken<'token> {
         CleanedStringLiteralText {
             text: content,
             token,
+            literal_line_breaks: matches!(
+                self.parent_kind,
+                StringLiteralParentKind::AttributeMatcherValue
+            ),
         }
     }
 }
@@ -74,44 +78,29 @@ impl<'token> FormatLiteralStringToken<'token> {
 pub(crate) struct CleanedStringLiteralText<'a> {
     token: &'a CssSyntaxToken,
     text: Cow<'a, str>,
+    literal_line_breaks: bool,
 }
 
 impl CleanedStringLiteralText<'_> {
-    fn is_multiline(&self) -> bool {
-        self.text.bytes().any(|byte| matches!(byte, b'\n' | b'\r'))
-    }
-}
+    fn fmt(self, f: &mut Formatter<CssFormatContext>) -> FormatResult<()> {
+        let Self {
+            token,
+            text,
+            literal_line_breaks,
+        } = self;
+        let text = syntax_token_cow_slice(text, token, token.text_trimmed_range().start());
 
-impl Format<CssFormatContext> for CleanedStringLiteralText<'_> {
-    fn fmt(&self, f: &mut Formatter<CssFormatContext>) -> FormatResult<()> {
-        format_replaced(
-            self.token,
-            &syntax_token_cow_slice(
-                self.text.clone(),
-                self.token,
-                self.token.text_trimmed_range().start(),
-            ),
-        )
-        .fmt(f)
+        if literal_line_breaks {
+            format_replaced(token, &text.with_literal_line_breaks()).fmt(f)
+        } else {
+            format_replaced(token, &text).fmt(f)
+        }
     }
 }
 
 impl Format<CssFormatContext> for FormatLiteralStringToken<'_> {
     fn fmt(&self, f: &mut CssFormatter) -> FormatResult<()> {
-        let cleaned = self.clean_text(f.options());
-
-        if matches!(
-            self.parent_kind,
-            StringLiteralParentKind::AttributeMatcherValue
-        ) && cleaned.is_multiline()
-        {
-            // TODO: Replace the duplicated variants with a literal-line
-            // primitive that doesn't expand the surrounding selector group.
-            let cleaned = cleaned.memoized();
-            best_fitting!(cleaned, cleaned).fmt(f)
-        } else {
-            cleaned.fmt(f)
-        }
+        self.clean_text(f.options()).fmt(f)
     }
 }
 

--- a/crates/biome_css_formatter/src/utils/string_utils.rs
+++ b/crates/biome_css_formatter/src/utils/string_utils.rs
@@ -78,6 +78,10 @@ impl<'token> FormatLiteralStringToken<'token> {
 pub(crate) struct CleanedStringLiteralText<'a> {
     token: &'a CssSyntaxToken,
     text: Cow<'a, str>,
+    /// Whether embedded LF characters use non-propagating literal lines.
+    ///
+    /// Attribute matcher values enable this to preserve escaped newlines
+    /// without expanding the surrounding selector group.
     literal_line_breaks: bool,
 }
 

--- a/crates/biome_css_formatter/tests/specs/css/range/escaped_attribute_newline/escaped_attribute_newline.css
+++ b/crates/biome_css_formatter/tests/specs/css/range/escaped_attribute_newline/escaped_attribute_newline.css
@@ -1,0 +1,4 @@
+.root {
+    <<<ROME_RANGE_START>>>div   span[foo='bar short\
+short']<<<ROME_RANGE_END>>>{color:red}
+}

--- a/crates/biome_css_formatter/tests/specs/css/range/escaped_attribute_newline/escaped_attribute_newline.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/range/escaped_attribute_newline/escaped_attribute_newline.css.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/range/escaped_attribute_newline/escaped_attribute_newline.css
+---
+
+# Input
+
+```css
+.root {
+    div   span[foo='bar short\
+short']{color:red}
+}
+
+```
+
+
+# Options
+
+```json
+{
+    "$schema": "../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+    "formatter": {
+        "indentStyle": "space",
+        "indentWidth": 4
+    }
+}
+```
+
+# Formatted
+
+```css
+.root {
+    div span[foo="bar short\
+short"] {
+        color: red;
+    }
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/css/range/escaped_attribute_newline/options.json
+++ b/crates/biome_css_formatter/tests/specs/css/range/escaped_attribute_newline/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+    "formatter": {
+        "indentStyle": "space",
+        "indentWidth": 4
+    }
+}

--- a/crates/biome_formatter/src/buffer.rs
+++ b/crates/biome_formatter/src/buffer.rs
@@ -459,6 +459,7 @@ where
 ///                 soft_line_break_or_space(),
 ///                 token("and the line here"),
 ///                 soft_line_break(),
+///                 literal_line_break_without_parent(),
 ///                 token("is removed entirely.")
 ///             ]
 ///         )
@@ -471,6 +472,7 @@ where
 ///         FormatElement::Token { text: "The next soft line or space gets replaced by a space" },
 ///         FormatElement::Space,
 ///         FormatElement::Token { text: "and the line here" },
+///         FormatElement::Line(LineMode::Literal),
 ///         FormatElement::Token { text: "is removed entirely." }
 ///     ]
 /// );

--- a/crates/biome_formatter/src/buffer.rs
+++ b/crates/biome_formatter/src/buffer.rs
@@ -466,15 +466,23 @@ where
 ///     })]
 /// )?;
 ///
+/// let document = formatted.document().as_ref();
+/// assert_eq!(document.len(), 5);
 /// assert_eq!(
-///     formatted.document().as_ref(),
+///     &document[..3],
 ///     &[
 ///         FormatElement::Token { text: "The next soft line or space gets replaced by a space" },
 ///         FormatElement::Space,
 ///         FormatElement::Token { text: "and the line here" },
-///         FormatElement::Line(LineMode::Literal),
-///         FormatElement::Token { text: "is removed entirely." }
 ///     ]
+/// );
+/// assert!(matches!(
+///     document[3],
+///     FormatElement::Line(LineMode::Literal { .. })
+/// ));
+/// assert_eq!(
+///     document[4],
+///     FormatElement::Token { text: "is removed entirely." }
 /// );
 ///
 /// # Ok(())

--- a/crates/biome_formatter/src/builders.rs
+++ b/crates/biome_formatter/src/builders.rs
@@ -108,7 +108,18 @@ pub const fn hard_line_break() -> Line {
 /// group must also expand.
 #[inline]
 pub const fn literal_line_break_without_parent() -> Line {
-    Line::new(LineMode::Literal)
+    Line::new(LineMode::Literal {
+        source_position: None,
+    })
+}
+
+#[inline]
+pub(crate) const fn source_mapped_literal_line_break_without_parent(
+    source_position: TextSize,
+) -> Line {
+    Line::new(LineMode::Literal {
+        source_position: Some(source_position),
+    })
 }
 
 /// A forced empty line. An empty line inserts enough line breaks in the output for
@@ -406,16 +417,37 @@ pub struct SyntaxTokenCowSlice<'a, L: Language> {
     start: TextSize,
 }
 
-impl<L: Language, Context> Format<Context> for SyntaxTokenCowSlice<'_, L>
-where
-    Context: FormatContext,
-{
-    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
+impl<'a, L: Language> SyntaxTokenCowSlice<'a, L> {
+    /// Splits embedded LF characters into non-propagating literal lines.
+    ///
+    /// For `before\nafter`, this emits text for `before`, one literal line, and
+    /// text for `after`. Printing at zero indentation produces:
+    ///
+    /// ```text
+    /// before
+    /// after
+    /// ```
+    ///
+    /// Every literal line resets indentation to the document root.
+    /// Text without newlines keeps the existing single-element representation.
+    pub fn with_literal_line_breaks(self) -> SyntaxTokenCowSliceWithLiteralLineBreaks<'a, L> {
+        SyntaxTokenCowSliceWithLiteralLineBreaks { slice: self }
+    }
+
+    fn fmt_segment<Context>(
+        &self,
+        text: &str,
+        start: TextSize,
+        f: &mut Formatter<Context>,
+    ) -> FormatResult<()>
+    where
+        Context: FormatContext,
+    {
         match &self.text {
-            Cow::Borrowed(text) => {
-                let range = TextRange::at(self.start, text.text_len());
+            Cow::Borrowed(_) => {
+                let range = TextRange::at(start, text.text_len());
                 debug_assert_eq!(
-                    *text,
+                    text,
                     &self.token.text()[range - self.token.text_range().start()],
                     "The borrowed string doesn't match the specified token substring. Does the borrowed string belong to this token and range?"
                 );
@@ -426,7 +458,7 @@ where
                 if f.source_map_generation().is_enabled() {
                     f.write_element(FormatElement::MappedLocatedTokenText {
                         slice,
-                        source_position: self.start,
+                        source_position: start,
                     })
                 } else {
                     f.write_element(FormatElement::LocatedTokenText {
@@ -435,15 +467,15 @@ where
                     })
                 }
             }
-            Cow::Owned(text) => {
+            Cow::Owned(_) => {
                 if f.source_map_generation().is_enabled() {
                     f.write_element(FormatElement::MappedText {
-                        text: text.clone().into_boxed_str(),
-                        source_position: self.start,
+                        text: text.to_string().into_boxed_str(),
+                        source_position: start,
                     })
                 } else {
                     f.write_element(FormatElement::Text {
-                        text: text.clone().into_boxed_str(),
+                        text: text.to_string().into_boxed_str(),
                         text_width: TextWidth::from_text(text, f.options().indent_width()),
                     })
                 }
@@ -452,9 +484,83 @@ where
     }
 }
 
+impl<L: Language, Context> Format<Context> for SyntaxTokenCowSlice<'_, L>
+where
+    Context: FormatContext,
+{
+    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
+        self.fmt_segment(self.text.as_ref(), self.start, f)
+    }
+}
+
 impl<L: Language> std::fmt::Debug for SyntaxTokenCowSlice<'_, L> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::write!(f, "SyntaxTokenCowSlice({})", self.text)
+    }
+}
+
+/// Formatter returned by [`SyntaxTokenCowSlice::with_literal_line_breaks`].
+pub struct SyntaxTokenCowSliceWithLiteralLineBreaks<'a, L: Language> {
+    slice: SyntaxTokenCowSlice<'a, L>,
+}
+
+impl<L: Language> std::fmt::Debug for SyntaxTokenCowSliceWithLiteralLineBreaks<'_, L> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SyntaxTokenCowSliceWithLiteralLineBreaks")
+            .field(&self.slice)
+            .finish()
+    }
+}
+
+impl<L: Language, Context> Format<Context> for SyntaxTokenCowSliceWithLiteralLineBreaks<'_, L>
+where
+    Context: FormatContext,
+{
+    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
+        let text = self.slice.text.as_ref();
+        let Some((first, rest)) = text.split_once('\n') else {
+            return self.slice.fmt(f);
+        };
+
+        let mut source_position = self.slice.start;
+        if !first.is_empty() {
+            self.slice.fmt_segment(first, source_position, f)?;
+        }
+        source_position += first.text_len();
+        self.fmt_literal_line_break(source_position, f)?;
+        source_position += "\n".text_len();
+
+        let mut segments = rest.split('\n').peekable();
+        while let Some(segment) = segments.next() {
+            if !segment.is_empty() {
+                self.slice.fmt_segment(segment, source_position, f)?;
+            }
+            source_position += segment.text_len();
+
+            if segments.peek().is_some() {
+                self.fmt_literal_line_break(source_position, f)?;
+                source_position += "\n".text_len();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<L: Language> SyntaxTokenCowSliceWithLiteralLineBreaks<'_, L> {
+    fn fmt_literal_line_break<Context>(
+        &self,
+        source_position: TextSize,
+        f: &mut Formatter<Context>,
+    ) -> FormatResult<()>
+    where
+        Context: FormatContext,
+    {
+        if f.source_map_generation().is_enabled() {
+            source_mapped_literal_line_break_without_parent(source_position).fmt(f)
+        } else {
+            literal_line_break_without_parent().fmt(f)
+        }
     }
 }
 

--- a/crates/biome_formatter/src/builders.rs
+++ b/crates/biome_formatter/src/builders.rs
@@ -101,6 +101,16 @@ pub const fn hard_line_break() -> Line {
     Line::new(LineMode::Hard)
 }
 
+/// A forced line break that doesn't expand enclosing groups.
+///
+/// The printer always emits the configured line ending and resets indentation
+/// to the document root. Compose it with [`expand_parent`] when the enclosing
+/// group must also expand.
+#[inline]
+pub const fn literal_line_break_without_parent() -> Line {
+    Line::new(LineMode::Literal)
+}
+
 /// A forced empty line. An empty line inserts enough line breaks in the output for
 /// the previous and next element to be separated by an empty line.
 ///

--- a/crates/biome_formatter/src/builders.rs
+++ b/crates/biome_formatter/src/builders.rs
@@ -361,7 +361,7 @@ where
 
 /// Creates a text from a dynamic string and a range of the input source
 pub fn text(text: &str, position: Option<TextSize>) -> Text<'_> {
-    debug_assert_no_newlines(text);
+    debug_assert_normalized_newlines(text);
 
     Text { text, position }
 }
@@ -406,7 +406,7 @@ pub fn syntax_token_cow_slice<'a, L: Language>(
     token: &'a SyntaxToken<L>,
     start: TextSize,
 ) -> SyntaxTokenCowSlice<'a, L> {
-    debug_assert_no_newlines(&text);
+    debug_assert_normalized_newlines(&text);
 
     SyntaxTokenCowSlice { text, token, start }
 }
@@ -419,6 +419,11 @@ pub struct SyntaxTokenCowSlice<'a, L: Language> {
 
 impl<'a, L: Language> SyntaxTokenCowSlice<'a, L> {
     /// Splits embedded LF characters into non-propagating literal lines.
+    ///
+    /// The slice must use LF as its only line terminator. Callers normalize
+    /// source line endings before constructing it, for example with
+    /// [`crate::normalize_newlines`]. The printer converts each logical LF to
+    /// the configured output line ending.
     ///
     /// For `before\nafter`, this emits text for `before`, one literal line, and
     /// text for `after`. Printing at zero indentation produces:
@@ -572,7 +577,7 @@ pub fn located_token_text<L: Language>(
     let relative_range = range - token.text_range().start();
     let slice = token.token_text().slice(relative_range);
 
-    debug_assert_no_newlines(&slice);
+    debug_assert_normalized_newlines(&slice);
 
     LocatedTokenText {
         text: slice,
@@ -610,10 +615,10 @@ impl std::fmt::Debug for LocatedTokenText {
     }
 }
 
-fn debug_assert_no_newlines(text: &str) {
+fn debug_assert_normalized_newlines(text: &str) {
     debug_assert!(
         !text.contains('\r'),
-        "The content '{text}' contains an unsupported '\\r' line terminator character but text must only use line feeds '\\n' as line separator. Use '\\n' instead of '\\r' and '\\r\\n' to insert a line break in strings."
+        "The content '{text}' contains a carriage return, but formatter text must use LF line endings. Normalize source text with `normalize_newlines` before constructing formatter text."
     );
 }
 

--- a/crates/biome_formatter/src/format_element.rs
+++ b/crates/biome_formatter/src/format_element.rs
@@ -139,12 +139,28 @@ pub enum LineMode {
     /// See [crate::builders::empty_line] for documentation.
     Empty,
     /// See [crate::builders::literal_line_break_without_parent] for documentation.
-    Literal,
+    Literal {
+        /// Source offset of the represented LF when source maps are enabled.
+        source_position: Option<TextSize>,
+    },
 }
 
 impl LineMode {
     pub const fn is_hard(&self) -> bool {
         matches!(self, Self::Hard)
+    }
+
+    pub(crate) const fn is_literal(&self) -> bool {
+        matches!(self, Self::Literal { .. })
+    }
+
+    pub(crate) const fn literal_source_position(&self) -> Option<TextSize> {
+        match self {
+            Self::Literal {
+                source_position, ..
+            } => *source_position,
+            _ => None,
+        }
     }
 }
 
@@ -295,7 +311,7 @@ impl FormatElements for FormatElement {
             Self::Tag(Tag::StartGroup(group)) => !group.mode().is_flat(),
             Self::Line(line_mode) => matches!(
                 line_mode,
-                LineMode::Hard | LineMode::Empty | LineMode::Literal
+                LineMode::Hard | LineMode::Empty | LineMode::Literal { .. }
             ),
 
             Self::Text { text_width, .. } | Self::LocatedTokenText { text_width, .. } => {

--- a/crates/biome_formatter/src/format_element.rs
+++ b/crates/biome_formatter/src/format_element.rs
@@ -23,7 +23,9 @@ pub enum FormatElement {
     /// A space token, see [crate::builders::space] for documentation.
     Space,
     HardSpace,
-    /// A new line, see [crate::builders::soft_line_break], [crate::builders::hard_line_break], and [crate::builders::soft_line_break_or_space] for documentation.
+    /// A new line, see [crate::builders::soft_line_break], [crate::builders::hard_line_break],
+    /// [crate::builders::literal_line_break_without_parent], and
+    /// [crate::builders::soft_line_break_or_space] for documentation.
     Line(LineMode),
 
     /// Forces the parent group to print in expanded mode.
@@ -136,6 +138,8 @@ pub enum LineMode {
     Hard,
     /// See [crate::builders::empty_line] for documentation.
     Empty,
+    /// See [crate::builders::literal_line_break_without_parent] for documentation.
+    Literal,
 }
 
 impl LineMode {
@@ -289,7 +293,10 @@ impl FormatElements for FormatElement {
         match self {
             Self::ExpandParent => true,
             Self::Tag(Tag::StartGroup(group)) => !group.mode().is_flat(),
-            Self::Line(line_mode) => matches!(line_mode, LineMode::Hard | LineMode::Empty),
+            Self::Line(line_mode) => matches!(
+                line_mode,
+                LineMode::Hard | LineMode::Empty | LineMode::Literal
+            ),
 
             Self::Text { text_width, .. } | Self::LocatedTokenText { text_width, .. } => {
                 text_width.is_multiline()
@@ -531,7 +538,8 @@ impl FusedIterator for BestFittingVariantsIter<'_> {}
 pub trait FormatElements {
     /// Returns true if this [FormatElement] is guaranteed to break across multiple lines by the printer.
     /// This is the case if this format element recursively contains a:
-    /// * [crate::builders::empty_line] or [crate::builders::hard_line_break]
+    /// * [crate::builders::empty_line], [crate::builders::hard_line_break], or
+    ///   [crate::builders::literal_line_break_without_parent]
     /// * A token containing '\n'
     ///
     /// Use this with caution, this is only a heuristic and the printer may print the element over multiple

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -447,7 +447,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                     LineMode::Empty => {
                         write!(f, [token("empty_line")])?;
                     }
-                    LineMode::Literal => {
+                    LineMode::Literal { .. } => {
                         write!(f, [token("literal_line_break_without_parent")])?;
                     }
                 },
@@ -883,11 +883,18 @@ mod tests {
         let group = tag::Group::new();
         let mut document = Document::from(vec![
             FormatElement::Tag(StartGroup(group.clone())),
-            FormatElement::Line(LineMode::Literal),
+            FormatElement::Line(LineMode::Literal {
+                source_position: None,
+            }),
             FormatElement::Tag(EndGroup),
         ]);
 
-        assert!(!LineMode::Literal.is_hard());
+        assert!(
+            !LineMode::Literal {
+                source_position: None
+            }
+            .is_hard()
+        );
         assert!(document.as_elements().will_break());
 
         document.propagate_expand();
@@ -897,7 +904,9 @@ mod tests {
 
     #[test]
     fn display_literal_line_break() {
-        let document = Document::from(vec![FormatElement::Line(LineMode::Literal)]);
+        let document = Document::from(vec![FormatElement::Line(LineMode::Literal {
+            source_position: None,
+        })]);
 
         assert_eq!(
             &std::format!("{document}"),

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -26,8 +26,10 @@ impl Document {
 
     /// Sets [`expand`](tag::Group::expand) to [`GroupMode::Propagated`] if the group contains any of:
     /// * a group with [`expand`](tag::Group::expand) set to [GroupMode::Propagated] or [GroupMode::Expand].
-    /// * a non-soft [line break](FormatElement::Line) with mode [LineMode::Hard], [LineMode::Empty], or [LineMode::Literal].
+    /// * a [line break](FormatElement::Line) with mode [LineMode::Hard] or [LineMode::Empty].
     /// * a [FormatElement::ExpandParent]
+    ///
+    /// [LineMode::Literal] forces a break without propagating expansion.
     ///
     /// [`BestFitting`] elements act as expand boundaries, meaning that the fact that a
     /// [`BestFitting`]'s content expands is not propagated past the [`BestFitting`] element.
@@ -444,6 +446,9 @@ impl Format<IrFormatContext> for &[FormatElement] {
                     }
                     LineMode::Empty => {
                         write!(f, [token("empty_line")])?;
+                    }
+                    LineMode::Literal => {
+                        write!(f, [token("literal_line_break_without_parent")])?;
                     }
                 },
                 FormatElement::ExpandParent => {
@@ -866,9 +871,39 @@ mod tests {
     use biome_js_syntax::JsSyntaxToken;
 
     use crate::prelude::document::IrFormatOptions;
+    use crate::prelude::tag::GroupMode;
     use crate::prelude::*;
     use crate::{FormatOptions, SimpleFormatContext};
     use crate::{format, format_args, write};
+
+    #[test]
+    fn literal_line_break_is_forced_without_propagating_expand() {
+        use Tag::*;
+
+        let group = tag::Group::new();
+        let mut document = Document::from(vec![
+            FormatElement::Tag(StartGroup(group.clone())),
+            FormatElement::Line(LineMode::Literal),
+            FormatElement::Tag(EndGroup),
+        ]);
+
+        assert!(!LineMode::Literal.is_hard());
+        assert!(document.as_elements().will_break());
+
+        document.propagate_expand();
+
+        assert_eq!(group.mode(), GroupMode::Flat);
+    }
+
+    #[test]
+    fn display_literal_line_break() {
+        let document = Document::from(vec![FormatElement::Line(LineMode::Literal)]);
+
+        assert_eq!(
+            &std::format!("{document}"),
+            "[literal_line_break_without_parent]"
+        );
+    }
 
     #[test]
     fn display_elements() {

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -2460,14 +2460,457 @@ pub struct FormatStateSnapshot {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::{
-        FormatElement, FormatState, LineWidth, SimpleFormatContext, SourceMapGeneration, VecBuffer,
+        Document, FormatElement, FormatState, Formatted, LineEnding, LineMode, LineWidth, Printed,
+        SimpleFormatContext, SimpleFormatOptions, SourceMapGeneration, SourceMarker, VecBuffer,
     };
     use crate::prelude::*;
     use biome_deserialize::json::deserialize_from_json_str;
     use biome_deserialize_macros::Deserializable;
     use biome_diagnostics::Error;
+    use biome_js_parser::{JsParserOptions, parse_module};
+    use biome_js_syntax::{JsSyntaxKind, JsSyntaxToken};
     use biome_rowan::TextSize;
+
+    fn print_literal_token_slice<'a>(
+        syntax_token: &'a JsSyntaxToken,
+        text: Cow<'a, str>,
+        start: TextSize,
+    ) -> Printed {
+        let formatted = crate::format!(
+            SimpleFormatContext::default(),
+            [syntax_token_cow_slice(text, syntax_token, start).with_literal_line_breaks()]
+        )
+        .unwrap();
+
+        formatted
+            .print_with_indent(0, SourceMapGeneration::Enabled)
+            .unwrap()
+    }
+
+    fn print_literal_token_slice_followed_by_generated<'a>(
+        syntax_token: &'a JsSyntaxToken,
+        text: Cow<'a, str>,
+        start: TextSize,
+        context: SimpleFormatContext,
+        source_map_generation: SourceMapGeneration,
+    ) -> Printed {
+        let formatted = crate::format!(
+            context,
+            [
+                syntax_token_cow_slice(text, syntax_token, start).with_literal_line_breaks(),
+                token(";")
+            ]
+        )
+        .unwrap();
+
+        formatted
+            .print_with_indent(0, source_map_generation)
+            .unwrap()
+    }
+
+    #[test]
+    fn borrowed_syntax_token_slice_preserves_literal_lines_and_source_markers() {
+        let token = JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, "ab\ncd", [], []);
+        let printed =
+            print_literal_token_slice(&token, Cow::Borrowed(token.text()), TextSize::from(0));
+
+        assert_eq!(printed.as_code(), "ab\ncd");
+        assert_eq!(
+            printed.sourcemap(),
+            [
+                SourceMarker {
+                    source: TextSize::from(0),
+                    dest: TextSize::from(0)
+                },
+                SourceMarker {
+                    source: TextSize::from(2),
+                    dest: TextSize::from(2)
+                },
+                SourceMarker {
+                    source: TextSize::from(3),
+                    dest: TextSize::from(3)
+                },
+                SourceMarker {
+                    source: TextSize::from(5),
+                    dest: TextSize::from(5)
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn syntax_token_slice_preserves_boundary_literal_lines() {
+        let token =
+            JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, "\nab\n\n", [], []);
+        let printed =
+            print_literal_token_slice(&token, Cow::Borrowed(token.text()), TextSize::from(0));
+
+        assert_eq!(printed.as_code(), "\nab\n\n");
+    }
+
+    #[test]
+    fn owned_syntax_token_slice_preserves_literal_line_source_markers() {
+        let token = JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, "xxxxxxx", [], []);
+        let printed =
+            print_literal_token_slice(&token, Cow::Owned("AB\nCD".to_string()), TextSize::from(1));
+
+        assert_eq!(printed.as_code(), "AB\nCD");
+        assert_eq!(
+            printed.sourcemap(),
+            [
+                SourceMarker {
+                    source: TextSize::from(1),
+                    dest: TextSize::from(0)
+                },
+                SourceMarker {
+                    source: TextSize::from(3),
+                    dest: TextSize::from(2)
+                },
+                SourceMarker {
+                    source: TextSize::from(4),
+                    dest: TextSize::from(3)
+                },
+                SourceMarker {
+                    source: TextSize::from(6),
+                    dest: TextSize::from(5)
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn syntax_token_slice_without_newlines_keeps_one_text_element() {
+        let token = JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, "plain", [], []);
+        let formatted = crate::format!(
+            SimpleFormatContext::default(),
+            [
+                syntax_token_cow_slice(Cow::Borrowed(token.text()), &token, TextSize::from(0),)
+                    .with_literal_line_breaks()
+            ]
+        )
+        .unwrap();
+
+        assert_eq!(formatted.document().as_ref().len(), 1);
+        assert!(matches!(
+            formatted.document().as_ref()[0],
+            FormatElement::MappedLocatedTokenText { .. }
+        ));
+    }
+
+    #[test]
+    fn syntax_token_slice_trailing_literal_lines_advance_source_for_generated_text() {
+        let cases: &[(&str, u32, &[SourceMarker])] = &[
+            (
+                "a\n",
+                0,
+                &[
+                    SourceMarker {
+                        source: TextSize::from(0),
+                        dest: TextSize::from(0),
+                    },
+                    SourceMarker {
+                        source: TextSize::from(1),
+                        dest: TextSize::from(1),
+                    },
+                    SourceMarker {
+                        source: TextSize::from(2),
+                        dest: TextSize::from(2),
+                    },
+                    SourceMarker {
+                        source: TextSize::from(2),
+                        dest: TextSize::from(3),
+                    },
+                ],
+            ),
+            (
+                "\n",
+                10,
+                &[
+                    SourceMarker {
+                        source: TextSize::from(10),
+                        dest: TextSize::from(0),
+                    },
+                    SourceMarker {
+                        source: TextSize::from(11),
+                        dest: TextSize::from(1),
+                    },
+                    SourceMarker {
+                        source: TextSize::from(11),
+                        dest: TextSize::from(2),
+                    },
+                ],
+            ),
+            (
+                "a\n\n",
+                0,
+                &[
+                    SourceMarker {
+                        source: TextSize::from(0),
+                        dest: TextSize::from(0),
+                    },
+                    SourceMarker {
+                        source: TextSize::from(1),
+                        dest: TextSize::from(1),
+                    },
+                    SourceMarker {
+                        source: TextSize::from(2),
+                        dest: TextSize::from(2),
+                    },
+                    SourceMarker {
+                        source: TextSize::from(3),
+                        dest: TextSize::from(3),
+                    },
+                    SourceMarker {
+                        source: TextSize::from(3),
+                        dest: TextSize::from(4),
+                    },
+                ],
+            ),
+        ];
+
+        for &(text, start, expected_markers) in cases {
+            let syntax_token =
+                JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, text, [], []);
+            let printed = print_literal_token_slice_followed_by_generated(
+                &syntax_token,
+                Cow::Borrowed(syntax_token.text()),
+                TextSize::from(start),
+                SimpleFormatContext::default(),
+                SourceMapGeneration::Enabled,
+            );
+
+            assert_eq!(printed.as_code(), std::format!("{text};"));
+            assert_eq!(printed.sourcemap(), expected_markers);
+        }
+    }
+
+    #[test]
+    fn syntax_token_slice_literal_line_mapping_uses_configured_line_ending() {
+        let syntax_token =
+            JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, "a\n", [], []);
+        let printed = print_literal_token_slice_followed_by_generated(
+            &syntax_token,
+            Cow::Borrowed(syntax_token.text()),
+            TextSize::from(0),
+            SimpleFormatContext::new(SimpleFormatOptions {
+                line_ending: LineEnding::Crlf,
+                ..SimpleFormatOptions::default()
+            }),
+            SourceMapGeneration::Enabled,
+        );
+
+        assert_eq!(printed.as_code(), "a\r\n;");
+        assert_eq!(
+            printed.sourcemap(),
+            [
+                SourceMarker {
+                    source: TextSize::from(0),
+                    dest: TextSize::from(0),
+                },
+                SourceMarker {
+                    source: TextSize::from(1),
+                    dest: TextSize::from(1),
+                },
+                SourceMarker {
+                    source: TextSize::from(2),
+                    dest: TextSize::from(3),
+                },
+                SourceMarker {
+                    source: TextSize::from(2),
+                    dest: TextSize::from(4),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn syntax_token_slice_literal_lines_without_source_map_keep_output() {
+        let syntax_token =
+            JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, "a\n\n", [], []);
+        let mut state = FormatState::new_with_source_map_generation(
+            SimpleFormatContext::default(),
+            SourceMapGeneration::Disabled,
+        );
+        let mut buffer = VecBuffer::new(&mut state);
+        crate::write!(
+            buffer,
+            [
+                syntax_token_cow_slice(
+                    Cow::Borrowed(syntax_token.text()),
+                    &syntax_token,
+                    TextSize::from(0),
+                )
+                .with_literal_line_breaks(),
+                token(";")
+            ]
+        )
+        .unwrap();
+        let elements = buffer.into_vec();
+        assert_eq!(
+            elements
+                .iter()
+                .filter(|element| {
+                    matches!(
+                        element,
+                        FormatElement::Line(LineMode::Literal {
+                            source_position: None,
+                            ..
+                        })
+                    )
+                })
+                .count(),
+            2
+        );
+        assert!(elements.iter().all(|element| !matches!(
+            element,
+            FormatElement::Line(LineMode::Literal {
+                source_position: Some(_),
+                ..
+            })
+        )));
+
+        let formatted = Formatted::new(Document::from(elements), state.into_context());
+        let printed = formatted
+            .print_with_indent(0, SourceMapGeneration::Disabled)
+            .unwrap();
+
+        assert_eq!(printed.as_code(), "a\n\n;");
+        assert!(printed.sourcemap().is_empty());
+    }
+
+    #[test]
+    fn syntax_token_slice_literal_line_supersedes_pending_source_position() {
+        let syntax_token =
+            JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, "\n", [], []);
+        let formatted = crate::format!(
+            SimpleFormatContext::default(),
+            [
+                source_position(TextSize::from(0)),
+                syntax_token_cow_slice(
+                    Cow::Borrowed(syntax_token.text()),
+                    &syntax_token,
+                    TextSize::from(0),
+                )
+                .with_literal_line_breaks(),
+                token(";")
+            ]
+        )
+        .unwrap();
+        let printed = formatted
+            .print_with_indent(0, SourceMapGeneration::Enabled)
+            .unwrap();
+
+        assert_eq!(printed.as_code(), "\n;");
+        assert_eq!(
+            printed.sourcemap(),
+            [
+                SourceMarker {
+                    source: TextSize::from(0),
+                    dest: TextSize::from(0),
+                },
+                SourceMarker {
+                    source: TextSize::from(1),
+                    dest: TextSize::from(1),
+                },
+                SourceMarker {
+                    source: TextSize::from(1),
+                    dest: TextSize::from(2),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn source_mapped_literal_line_break_survives_line_suffix_flush() {
+        let syntax_token =
+            JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, "a", [], []);
+        let formatted = crate::format!(
+            SimpleFormatContext::default(),
+            [
+                syntax_token_cow_slice(
+                    Cow::Borrowed(syntax_token.text()),
+                    &syntax_token,
+                    TextSize::from(0),
+                ),
+                line_suffix(&crate::format_args![token("!")]),
+                crate::builders::source_mapped_literal_line_break_without_parent(TextSize::from(1)),
+                token(";")
+            ]
+        )
+        .unwrap();
+        let printed = formatted
+            .print_with_indent(0, SourceMapGeneration::Enabled)
+            .unwrap();
+
+        assert_eq!(printed.as_code(), "a!\n;");
+        assert_eq!(
+            printed.sourcemap(),
+            [
+                SourceMarker {
+                    source: TextSize::from(0),
+                    dest: TextSize::from(0),
+                },
+                SourceMarker {
+                    source: TextSize::from(1),
+                    dest: TextSize::from(1),
+                },
+                SourceMarker {
+                    source: TextSize::from(1),
+                    dest: TextSize::from(2),
+                },
+                SourceMarker {
+                    source: TextSize::from(2),
+                    dest: TextSize::from(3),
+                },
+                SourceMarker {
+                    source: TextSize::from(2),
+                    dest: TextSize::from(4),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn borrowed_utf8_syntax_token_slice_uses_absolute_source_positions() {
+        let parse = parse_module("`aé\nbc`", JsParserOptions::default());
+        assert!(parse.diagnostics().is_empty());
+        let root = parse.syntax();
+        let syntax_token = std::iter::successors(root.first_token(), JsSyntaxToken::next_token)
+            .find(|token| token.kind() == JsSyntaxKind::TEMPLATE_CHUNK)
+            .unwrap();
+        assert_eq!(syntax_token.text_range().start(), TextSize::from(1));
+
+        let text = &syntax_token.text()[1..];
+        assert_eq!(text, "é\nbc");
+        let printed =
+            print_literal_token_slice(&syntax_token, Cow::Borrowed(text), TextSize::from(2));
+
+        assert_eq!(printed.as_code(), "é\nbc");
+        assert_eq!(
+            printed.sourcemap(),
+            [
+                SourceMarker {
+                    source: TextSize::from(2),
+                    dest: TextSize::from(0),
+                },
+                SourceMarker {
+                    source: TextSize::from(4),
+                    dest: TextSize::from(2),
+                },
+                SourceMarker {
+                    source: TextSize::from(5),
+                    dest: TextSize::from(3),
+                },
+                SourceMarker {
+                    source: TextSize::from(7),
+                    dest: TextSize::from(5),
+                },
+            ]
+        );
+    }
 
     #[test]
     fn test_out_of_range_line_width() {

--- a/crates/biome_formatter/src/printer/mod.rs
+++ b/crates/biome_formatter/src/printer/mod.rs
@@ -134,7 +134,7 @@ impl<'a> Printer<'a> {
                             }
                             return Ok(());
                         }
-                        LineMode::Hard | LineMode::Empty | LineMode::Literal => {
+                        LineMode::Hard | LineMode::Empty | LineMode::Literal { .. } => {
                             self.state.measured_group_fits = false;
                         }
                     }
@@ -145,9 +145,13 @@ impl<'a> Printer<'a> {
                     return Ok(());
                 }
 
-                // Only print a newline if the current line isn't already empty, except literal
-                // lines preserve every occurrence.
-                if line_mode == &LineMode::Literal || self.state.line_width > 0 {
+                let is_literal = line_mode.is_literal();
+
+                if let Some(source_position) = line_mode.literal_source_position() {
+                    self.print_mapped_literal_line_break(source_position);
+                } else if is_literal || self.state.line_width > 0 {
+                    // Literal lines preserve every occurrence, including leading
+                    // and consecutive lines.
                     self.print_char('\n');
                 }
 
@@ -158,7 +162,7 @@ impl<'a> Printer<'a> {
                 }
 
                 self.state.pending_space = false;
-                self.state.pending_indent = if line_mode == &LineMode::Literal {
+                self.state.pending_indent = if is_literal {
                     Indention::default()
                 } else {
                     indent_stack.indention()
@@ -449,6 +453,29 @@ impl<'a> Printer<'a> {
             self.state.source_position += text_str.text_len();
         }
 
+        self.push_marker(SourceMarker {
+            source: self.state.source_position,
+            dest: self.state.buffer.text_len(),
+        });
+    }
+
+    /// Prints one source LF and maps both boundaries to the configured output
+    /// line ending.
+    ///
+    /// Leading, trailing, and consecutive literal lines may have no adjacent
+    /// text element to provide either marker. The marker after the line also
+    /// maps one source byte to a multi-byte output line ending such as CRLF.
+    fn print_mapped_literal_line_break(&mut self, source_position: TextSize) {
+        self.state.pending_source_position = None;
+        self.state.source_position = source_position;
+        self.push_marker(SourceMarker {
+            source: self.state.source_position,
+            dest: self.state.buffer.text_len(),
+        });
+
+        self.print_char('\n');
+
+        self.state.source_position += "\n".text_len();
         self.push_marker(SourceMarker {
             source: self.state.source_position,
             dest: self.state.buffer.text_len(),
@@ -1206,7 +1233,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                             self.state.pending_space = true;
                         }
                         LineMode::Soft => {}
-                        LineMode::Literal => {
+                        LineMode::Literal { .. } => {
                             // Literal is a forced fit boundary without parent propagation.
                             return Ok(Fits::Yes);
                         }

--- a/crates/biome_formatter/src/printer/mod.rs
+++ b/crates/biome_formatter/src/printer/mod.rs
@@ -134,7 +134,7 @@ impl<'a> Printer<'a> {
                             }
                             return Ok(());
                         }
-                        LineMode::Hard | LineMode::Empty => {
+                        LineMode::Hard | LineMode::Empty | LineMode::Literal => {
                             self.state.measured_group_fits = false;
                         }
                     }
@@ -145,8 +145,9 @@ impl<'a> Printer<'a> {
                     return Ok(());
                 }
 
-                // Only print a newline if the current line isn't already empty
-                if self.state.line_width > 0 {
+                // Only print a newline if the current line isn't already empty, except literal
+                // lines preserve every occurrence.
+                if line_mode == &LineMode::Literal || self.state.line_width > 0 {
                     self.print_char('\n');
                 }
 
@@ -157,7 +158,11 @@ impl<'a> Printer<'a> {
                 }
 
                 self.state.pending_space = false;
-                self.state.pending_indent = indent_stack.indention();
+                self.state.pending_indent = if line_mode == &LineMode::Literal {
+                    Indention::default()
+                } else {
+                    indent_stack.indention()
+                };
             }
 
             FormatElement::ExpandParent => {
@@ -1201,6 +1206,10 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                             self.state.pending_space = true;
                         }
                         LineMode::Soft => {}
+                        LineMode::Literal => {
+                            // Literal is a forced fit boundary without parent propagation.
+                            return Ok(Fits::Yes);
+                        }
                         LineMode::Hard | LineMode::Empty => {
                             // Even in flat mode, content that _directly_ contains a hard or empty
                             // line is considered to fit when a hard break is reached, since that
@@ -1858,6 +1867,151 @@ two lines`,
         ]);
 
         assert_eq!("a\n\nb", result.as_code())
+    }
+
+    #[test]
+    fn literal_line_break_keeps_the_parent_group_flat() {
+        let result = format(&group(&format_args![
+            token("a"),
+            soft_line_break_or_space(),
+            token("b"),
+            literal_line_break_without_parent(),
+            token("c"),
+        ]));
+        assert_eq!(result.as_code(), "a b\nc");
+    }
+
+    #[test]
+    fn literal_line_break_preserves_leading_consecutive_and_trailing_lines() {
+        let result = format(&format_args![
+            literal_line_break_without_parent(),
+            token("a"),
+            literal_line_break_without_parent(),
+            literal_line_break_without_parent(),
+            token("b"),
+            literal_line_break_without_parent(),
+        ]);
+        assert_eq!(result.as_code(), "\na\n\nb\n");
+    }
+
+    #[test]
+    fn literal_line_break_resets_to_root_indentation() {
+        let options = PrinterOptions {
+            indent_style: IndentStyle::Space,
+            indent_width: 2.try_into().unwrap(),
+            line_ending: LineEnding::Lf,
+            ..PrinterOptions::default()
+        };
+        let result = format_with_options_and_indentation(
+            &format_args![
+                token("{"),
+                block_indent(&format_args![
+                    token("a"),
+                    literal_line_break_without_parent(),
+                    token("b"),
+                ]),
+                token("}"),
+            ],
+            options,
+            1,
+        );
+        assert_eq!(result.as_code(), "  {\n    a\nb\n  }");
+    }
+
+    #[test]
+    fn literal_line_break_at_end_of_align_resets_to_root_indentation() {
+        let options = PrinterOptions {
+            indent_style: IndentStyle::Space,
+            indent_width: 2.try_into().unwrap(),
+            line_ending: LineEnding::Lf,
+            ..PrinterOptions::default()
+        };
+        let result = format_with_options_and_indentation(
+            &format_args![
+                indent(&align(
+                    "  ",
+                    &format_args![token("a"), literal_line_break_without_parent(),],
+                )),
+                token("b"),
+            ],
+            options,
+            1,
+        );
+        assert_eq!(result.as_code(), "  a\nb");
+    }
+
+    #[test]
+    fn hard_line_break_in_nested_dedents_resyncs_at_end_of_align() {
+        let options = PrinterOptions {
+            indent_style: IndentStyle::Space,
+            indent_width: 2.try_into().unwrap(),
+            line_ending: LineEnding::Lf,
+            ..PrinterOptions::default()
+        };
+        let result = format_with_options_and_indentation(
+            &format_args![
+                indent(&align(
+                    "  ",
+                    &format_args![token("a"), dedent(&dedent(&hard_line_break())),],
+                )),
+                token("b"),
+            ],
+            options,
+            1,
+        );
+        assert_eq!(result.as_code(), "  a\n    b");
+    }
+
+    #[test]
+    fn literal_line_break_root_indentation_is_preserved_during_fit_measurement() {
+        let options = PrinterOptions {
+            indent_style: IndentStyle::Space,
+            indent_width: 2.try_into().unwrap(),
+            line_ending: LineEnding::Lf,
+            print_width: PrintWidth::new(5),
+            ..PrinterOptions::default()
+        };
+        let result = format_with_options_and_indentation(
+            &indent(&format_args![
+                align(
+                    "  ",
+                    &format_args![
+                        token("a"),
+                        literal_line_break_without_parent(),
+                        group(&soft_line_break()),
+                    ],
+                ),
+                token("bb"),
+            ]),
+            options,
+            1,
+        );
+        assert_eq!(result.as_code(), "  a\nbb");
+    }
+
+    #[test]
+    fn literal_line_break_uses_the_configured_line_ending() {
+        for (line_ending, expected) in [(LineEnding::Crlf, "a\r\nb"), (LineEnding::Cr, "a\rb")] {
+            let result = format_with_options(
+                &format_args![token("a"), literal_line_break_without_parent(), token("b"),],
+                PrinterOptions {
+                    line_ending,
+                    ..PrinterOptions::default()
+                },
+            );
+            assert_eq!(result.as_code(), expected);
+        }
+    }
+
+    #[test]
+    fn literal_line_break_flushes_line_suffixes() {
+        let result = format(&format_args![
+            token("a"),
+            line_suffix(&format_args![space(), token("// suffix")]),
+            literal_line_break_without_parent(),
+            token("b"),
+        ]);
+        assert_eq!(result.as_code(), "a // suffix\nb");
     }
 
     #[test]


### PR DESCRIPTION
> This PR was created with AI assistance (OpenAI Codex).

## Summary

Adds a [non-propagating literal-line primitive](https://github.com/prettier/prettier/blob/0512f04f32c7421a2175efca52f1bafa9f2a6f44/src/document/builders/line.js#L29-L33) and syntax-token slice support for embedded newlines.

The CSS formatter uses it for escaped newlines in attribute-selector values, preserving literal-line formatting without forcing the surrounding selector group to break. This matches Prettier’s [`literallineWithoutBreakParent` handling](https://github.com/prettier/prettier/blob/0512f04f32c7421a2175efca52f1bafa9f2a6f44/src/language-css/printer-postcss.js#L412-L427).

## Test Plan

- `cargo test -p biome_formatter -p biome_css_formatter`
