### PR TITLE
fix(cli): populate severity in rdjson reporter output

### DIFF
--- a/.changeset/rdjson-reporter-severity.md
+++ b/.changeset/rdjson-reporter-severity.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+The `rdjson` reporter now populates the [severity](https://github.com/reviewdog/reviewdog/blob/master/proto/rdf/reviewdog.proto) field of each diagnostic (`ERROR`, `WARNING`, or `INFO`), so tools consuming Reviewdog Diagnostic Format output no longer need to assume a default severity.

--- a/crates/biome_cli/src/reporter/rdjson.rs
+++ b/crates/biome_cli/src/reporter/rdjson.rs
@@ -3,7 +3,7 @@ use crate::runner::execution::Execution;
 use crate::{DiagnosticsPayload, TraversalSummary};
 use biome_console::markup;
 use biome_diagnostics::display::SourceFile;
-use biome_diagnostics::{Error, Location, PrintDescription, Visit};
+use biome_diagnostics::{Error, Location, PrintDescription, Severity, Visit};
 use biome_rowan::{TextRange, TextSize};
 use biome_text_edit::{CompressedOp, DiffOp, TextEdit};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -108,6 +108,7 @@ fn diagnostic_to_rdjson<'a>(diagnostic: &'a Error) -> Option<RdJsonDiagnostic<'a
         code,
         location,
         message,
+        severity: diagnostic.severity().into(),
         suggestions,
     })
 }
@@ -305,8 +306,30 @@ struct RdJsonDiagnostic<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     location: Option<RdJsonLocation>,
     message: String,
+    severity: RdJsonSeverity,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     suggestions: Vec<RdJsonSuggestion>,
+}
+
+/// Severity of a [Reviewdog Diagnostic](https://github.com/reviewdog/reviewdog/blob/master/proto/rdf/reviewdog.proto).
+#[derive(Serialize)]
+enum RdJsonSeverity {
+    #[serde(rename = "ERROR")]
+    Error,
+    #[serde(rename = "WARNING")]
+    Warning,
+    #[serde(rename = "INFO")]
+    Info,
+}
+
+impl From<Severity> for RdJsonSeverity {
+    fn from(severity: Severity) -> Self {
+        match severity {
+            Severity::Fatal | Severity::Error => Self::Error,
+            Severity::Warning => Self::Warning,
+            Severity::Information | Severity::Hint => Self::Info,
+        }
+    }
 }
 
 #[derive(Serialize)]

--- a/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/first_file_then_reporter_name.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/first_file_then_reporter_name.snap
@@ -30,6 +30,7 @@ expression: redactor(content)
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -50,7 +51,8 @@ expression: redactor(content)
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     }
   ]
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/one_report_to_console_one_to_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/one_report_to_console_one_to_file.snap
@@ -30,6 +30,7 @@ expression: redactor(content)
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -50,7 +51,8 @@ expression: redactor(content)
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     }
   ]
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/two_report_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/two_report_files.snap
@@ -30,6 +30,7 @@ expression: redactor(content)
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -50,7 +51,8 @@ expression: redactor(content)
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     }
   ]
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/two_report_to_console.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_multiple_reporters/two_report_to_console.snap
@@ -47,6 +47,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -67,7 +68,8 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     }
   ]
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_code_suggestions_rdjson_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_code_suggestions_rdjson_check_command.snap
@@ -49,6 +49,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This let declares a variable that is only assigned once.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command.snap
@@ -69,6 +69,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This import is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -104,6 +105,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Several of these imports are unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -139,6 +141,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -174,6 +177,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -209,6 +213,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This import is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -244,6 +249,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Several of these imports are unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -279,6 +285,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -314,6 +321,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -349,6 +357,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Sort these imports.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -384,6 +393,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Using == may be unsafe if you are relying on type coercion.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -419,6 +429,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -453,7 +464,8 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -473,7 +485,8 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -493,7 +506,8 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'z' is redeclared in the same scope."
+      "message": "'z' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -513,13 +527,15 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'f' is redeclared in the same scope."
+      "message": "'f' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -540,6 +556,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Sort these imports.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -575,6 +592,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Using == may be unsafe if you are relying on type coercion.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -610,6 +628,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -644,7 +663,8 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -664,7 +684,8 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -684,7 +705,8 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'z' is redeclared in the same scope."
+      "message": "'z' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -704,13 +726,15 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'f' is redeclared in the same scope."
+      "message": "'f' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     }
   ]
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_check_command_file.snap
@@ -30,6 +30,7 @@ expression: redactor(content)
         }
       },
       "message": "This import is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -65,6 +66,7 @@ expression: redactor(content)
         }
       },
       "message": "Several of these imports are unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -100,6 +102,7 @@ expression: redactor(content)
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -135,6 +138,7 @@ expression: redactor(content)
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -170,6 +174,7 @@ expression: redactor(content)
         }
       },
       "message": "This import is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -205,6 +210,7 @@ expression: redactor(content)
         }
       },
       "message": "Several of these imports are unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -240,6 +246,7 @@ expression: redactor(content)
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -275,6 +282,7 @@ expression: redactor(content)
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -310,6 +318,7 @@ expression: redactor(content)
         }
       },
       "message": "Sort these imports.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -345,6 +354,7 @@ expression: redactor(content)
         }
       },
       "message": "Using == may be unsafe if you are relying on type coercion.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -380,6 +390,7 @@ expression: redactor(content)
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -414,7 +425,8 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -434,7 +446,8 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -454,7 +467,8 @@ expression: redactor(content)
           }
         }
       },
-      "message": "'z' is redeclared in the same scope."
+      "message": "'z' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -474,13 +488,15 @@ expression: redactor(content)
           }
         }
       },
-      "message": "'f' is redeclared in the same scope."
+      "message": "'f' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -501,6 +517,7 @@ expression: redactor(content)
         }
       },
       "message": "Sort these imports.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -536,6 +553,7 @@ expression: redactor(content)
         }
       },
       "message": "Using == may be unsafe if you are relying on type coercion.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -571,6 +589,7 @@ expression: redactor(content)
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -605,7 +624,8 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -625,7 +645,8 @@ expression: redactor(content)
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -645,7 +666,8 @@ expression: redactor(content)
           }
         }
       },
-      "message": "'z' is redeclared in the same scope."
+      "message": "'z' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -665,13 +687,15 @@ expression: redactor(content)
           }
         }
       },
-      "message": "'f' is redeclared in the same scope."
+      "message": "'f' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     }
   ]
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_ci_command.snap
@@ -69,6 +69,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This import is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -104,6 +105,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Several of these imports are unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -139,6 +141,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -174,6 +177,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -209,6 +213,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This import is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -244,6 +249,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Several of these imports are unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -279,6 +285,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -314,6 +321,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -349,6 +357,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Sort these imports.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -384,6 +393,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Using == may be unsafe if you are relying on type coercion.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -419,6 +429,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -453,7 +464,8 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -473,7 +485,8 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -493,7 +506,8 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'z' is redeclared in the same scope."
+      "message": "'z' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -513,13 +527,15 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'f' is redeclared in the same scope."
+      "message": "'f' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
         "value": "format"
       },
-      "message": "File content differs from formatting output"
+      "message": "File content differs from formatting output",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -540,6 +556,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Sort these imports.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -575,6 +592,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "Using == may be unsafe if you are relying on type coercion.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -610,6 +628,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -644,7 +663,8 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -664,7 +684,8 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -684,7 +705,8 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'z' is redeclared in the same scope."
+      "message": "'z' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -704,13 +726,15 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
           }
         }
       },
-      "message": "'f' is redeclared in the same scope."
+      "message": "'f' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
         "value": "format"
       },
-      "message": "File content differs from formatting output"
+      "message": "File content differs from formatting output",
+      "severity": "ERROR"
     }
   ]
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_format_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_format_command.snap
@@ -54,13 +54,15 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     },
     {
       "code": {
         "value": "format"
       },
-      "message": "Formatter would have printed the following content:"
+      "message": "Formatter would have printed the following content:",
+      "severity": "ERROR"
     }
   ]
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_lint_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_rdjson/reports_diagnostics_rdjson_lint_command.snap
@@ -69,6 +69,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "This import is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -104,6 +105,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "Several of these imports are unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -139,6 +141,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -174,6 +177,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -209,6 +213,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "This import is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -244,6 +249,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "Several of these imports are unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -279,6 +285,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -314,6 +321,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "This variable f is unused.",
+      "severity": "WARNING",
       "suggestions": [
         {
           "range": {
@@ -349,6 +357,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "Using == may be unsafe if you are relying on type coercion.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -384,6 +393,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -418,7 +428,8 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -438,7 +449,8 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -458,7 +470,8 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "'z' is redeclared in the same scope."
+      "message": "'z' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -478,7 +491,8 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "'f' is redeclared in the same scope."
+      "message": "'f' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -499,6 +513,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "Using == may be unsafe if you are relying on type coercion.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -534,6 +549,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
         }
       },
       "message": "This is an unexpected use of the debugger statement.",
+      "severity": "ERROR",
       "suggestions": [
         {
           "range": {
@@ -568,7 +584,8 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -588,7 +605,8 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "This variable implicitly has the any type."
+      "message": "This variable implicitly has the any type.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -608,7 +626,8 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "'z' is redeclared in the same scope."
+      "message": "'z' is redeclared in the same scope.",
+      "severity": "ERROR"
     },
     {
       "code": {
@@ -628,7 +647,8 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
           }
         }
       },
-      "message": "'f' is redeclared in the same scope."
+      "message": "'f' is redeclared in the same scope.",
+      "severity": "ERROR"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The `rdjson` reporter leaves the [Reviewdog Diagnostic Format](https://github.com/reviewdog/reviewdog/blob/master/proto/rdf/reviewdog.proto)'s optional `severity` field unset, so consumers of `--reporter=rdjson` output fall back to `UNKNOWN_SEVERITY` and have to assume a severity for every diagnostic, even though Biome knows it.

This populates `severity` on each diagnostic, mapped from Biome's severity: `Fatal`/`Error` → `ERROR`, `Warning` → `WARNING`, `Information`/`Hint` → `INFO`.

Notes on the mapping:
- rdformat has nothing below `INFO`, so `Hint` collapses into `INFO`.
- The field is always emitted (never null) since every Biome diagnostic carries a severity.

A changeset is included (`patch`, on the reasoning that this completes the reporter's spec output rather than adding a user API — happy to reclassify and retarget to `next` if you consider it a feature).

## Test Plan

- Updated the `reporter_rdjson` and `multiple_reporters` snapshot tests (`cargo test -p biome_cli reporter_rdjson multiple_reporters` passes).
- Manually verified against a fixture that severities match the `json` reporter's `severity` field for the same diagnostics (e.g. `lint/correctness/noUnusedVariables` → `WARNING`, `lint/style/useEnumInitializers` → `ERROR`).

## Docs

No documentation change; the reporter emits a field defined by the rdformat spec.

---

This PR was written primarily by Claude Code, including tests and the changeset; the output was reviewed, and the mapping verified manually, by a human.