### PR TITLE
fix(linter): allow delete on computed process.env members

### DIFF
--- a/.changeset/fix-no-delete-process-env-computed.md
+++ b/.changeset/fix-no-delete-process-env-computed.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11014](https://github.com/biomejs/biome/issues/11014): [`noDelete`](https://biomejs.dev/linter/rules/no-delete/) no longer reports `delete process.env["FOO"]`. The rule already allowed the static form `delete process.env.FOO`, since Node.js documents `delete` as the way to remove environment variables; the computed form is now treated the same.

--- a/crates/biome_js_analyze/src/lint/performance/no_delete.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_delete.rs
@@ -61,6 +61,7 @@ declare_lint_rule! {
     ///
     /// ```js
     /// delete process.env.FOO;
+    /// delete process.env["FOO"];
     ///```
     ///
     pub NoDelete {
@@ -88,11 +89,18 @@ impl Rule for NoDelete {
 
         let should_report = if let Some(computed) = argument.as_js_computed_member_expression() {
             // `delete record[x]` is allowed, but if `x` is a literal value.
-            computed
+            let has_literal_member = computed
                 .member()
                 .ok()?
                 .as_any_js_literal_expression()
-                .is_some()
+                .is_some();
+            // Skip `delete process.env["FOO"]`, like its static counterpart below.
+            has_literal_member
+                && !computed
+                    .object()
+                    .ok()
+                    .and_then(|object| is_process_env(&object))
+                    .unwrap_or_default()
         } else {
             let static_member_expression = argument.as_js_static_member_expression();
             if let Some(static_member_expression) = static_member_expression {
@@ -108,7 +116,12 @@ impl Rule for NoDelete {
                 // Skip `delete process.env.FOO`: Node.js documents `delete` as the way
                 // to remove environment variables.
                 // https://nodejs.org/api/process.html#processenv
-                if is_process_env(static_member_expression).unwrap_or_default() {
+                if static_member_expression
+                    .object()
+                    .ok()
+                    .and_then(|object| is_process_env(&object))
+                    .unwrap_or_default()
+                {
                     return None;
                 }
                 true
@@ -157,10 +170,9 @@ impl Rule for NoDelete {
     }
 }
 
-/// Check if a static member expression targets `process.env.*`.
-fn is_process_env(expr: &biome_js_syntax::JsStaticMemberExpression) -> Option<bool> {
-    let object = expr.object().ok()?;
-    let static_obj = object.as_js_static_member_expression()?;
+/// Check if an expression is exactly `process.env`.
+fn is_process_env(expr: &AnyJsExpression) -> Option<bool> {
+    let static_obj = expr.as_js_static_member_expression()?;
     let member = static_obj.member().ok()?;
     let name = member.as_js_name()?;
     if name

--- a/crates/biome_js_analyze/tests/specs/performance/noDelete/valid.jsonc
+++ b/crates/biome_js_analyze/tests/specs/performance/noDelete/valid.jsonc
@@ -7,5 +7,6 @@
 	"delete f()",
 	"delete el.dataset.something",
 	// `delete process.env.FOO` is the documented way to remove env vars in Node.js
-	"delete process.env.FOO"
+	"delete process.env.FOO",
+	"delete process.env['FOO']"
 ]

--- a/crates/biome_js_analyze/tests/specs/performance/noDelete/valid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/performance/noDelete/valid.jsonc.snap
@@ -36,3 +36,8 @@ delete el.dataset.something
 ```cjs
 delete process.env.FOO
 ```
+
+# Input
+```cjs
+delete process.env['FOO']
+```


### PR DESCRIPTION
## Summary

Fixes #11014.

`noDelete` already skips `delete process.env.FOO`, since Node.js documents `delete` as the way to remove environment variables, but the computed form `delete process.env["FOO"]` was still reported. The computed-member branch only checked whether the member is a literal and never looked at the object.

The fix changes the `is_process_env` helper to take the object expression instead of the whole static member expression, so both the static and computed branches can share the same check. No behavior change for anything other than `process.env` computed accesses with a literal key.

## Test Plan

Added the computed form to the valid fixtures and to the rule's rustdoc valid examples. Full `biome_js_analyze` suite passes.

## Docs

N/A (rustdoc example updated inline).

---

Disclosure: this fix was implemented with Claude Code, including the tests. I read and verified the final diff.