### PR TITLE
chore(xtask): migrate Symbol global types

### DIFF
--- a/crates/biome_js_type_info/src/generated/global_types.rs
+++ b/crates/biome_js_type_info/src/generated/global_types.rs
@@ -4,6 +4,9 @@
 
 /// Predefined global IDs whose `TypeData` is supplied by this generated module.
 pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
+    crate::globals::SYMBOL_ID_GLOBAL_TYPE_ID,
+    crate::globals::SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID,
+    crate::globals::SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID,
     crate::globals::DISPOSABLE_ID_GLOBAL_TYPE_ID,
     crate::globals::DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID,
     crate::globals::ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID,
@@ -17,6 +20,29 @@ pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
 pub(crate) fn set_generated_global_type_data(
     builder: &mut crate::globals_builder::GlobalsResolverBuilder,
 ) {
+    let data = crate::TypeData::Class(Box::new(crate::Class {
+        name: Some(biome_rowan::Text::new_static("Symbol")),
+        type_parameters: Box::default(),
+        extends: None,
+        implements: Box::default(),
+        members: Box::new([
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::NamedStatic(biome_rowan::Text::new_static("dispose")),
+                ty: crate::globals::GLOBAL_SYMBOL_DISPOSE_ID.into(),
+            },
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::NamedStatic(biome_rowan::Text::new_static(
+                    "asyncDispose",
+                )),
+                ty: crate::globals::GLOBAL_SYMBOL_ASYNC_DISPOSE_ID.into(),
+            },
+        ]),
+    }));
+    builder.set_type_data(crate::globals::SYMBOL_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Symbol;
+    builder.set_type_data(crate::globals::SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Symbol;
+    builder.set_type_data(crate::globals::SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID, data);
     let data = crate::TypeData::Interface(Box::new(crate::Interface {
         name: biome_rowan::Text::new_static("Disposable"),
         type_parameters: Box::default(),

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -398,24 +398,6 @@ impl Default for RawGlobalTypes {
         builder.set_manual_type_data(INSTANCEOF_SYMBOL_ID_GLOBAL_TYPE_ID, || {
             TypeData::instance_of(TypeReference::from(GLOBAL_SYMBOL_ID))
         });
-        builder.set_manual_type_data(SYMBOL_ID_GLOBAL_TYPE_ID, || {
-            TypeData::Class(Box::new(Class {
-                name: Some(Text::new_static(SYMBOL_ID_NAME)),
-                type_parameters: Box::default(),
-                extends: None,
-                implements: Box::default(),
-                members: Box::new([
-                    static_member("dispose", SYMBOL_DISPOSE_ID),
-                    static_member("asyncDispose", SYMBOL_ASYNC_DISPOSE_ID),
-                ]),
-            }))
-        });
-        builder.set_manual_type_data(SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID, || TypeData::Symbol);
-        builder.set_manual_type_data(SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID, || TypeData::Symbol);
-        // `Disposable`, `AsyncDisposable`, and their `[Symbol.(async)Dispose]` helpers are
-        // supplied by the generated global types (see `MIGRATED_PREDEFINED_IDS`), which encode
-        // the members as computed keys instead of the index-signature hack this used to carry.
-
         builder.build()
     }
 }
@@ -716,5 +698,29 @@ mod tests {
             panic!("Promise must be a class");
         };
         assert!(!promise.members(&db).is_empty());
+    }
+
+    #[test]
+    fn generated_symbol_globals_keep_static_members() {
+        let db = TestDb::default();
+        let globals = global_types(&db);
+        let InferredTypeData::Class(symbol) = globals.get(SYMBOL_ID_GLOBAL_TYPE_ID) else {
+            panic!("Symbol must be a class");
+        };
+        let members = symbol.members(&db);
+        assert_eq!(members.len(), 2);
+
+        for (name, global_type_id) in [
+            ("dispose", SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID),
+            ("asyncDispose", SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID),
+        ] {
+            let member = members
+                .iter()
+                .find(|member| member.kind.has_name(name))
+                .unwrap_or_else(|| panic!("Symbol.{name} must exist"));
+            assert!(member.kind.is_static());
+            assert_eq!(member.ty, InferredTypeData::GlobalType(global_type_id));
+            assert_eq!(globals.get(global_type_id), InferredTypeData::Symbol);
+        }
     }
 }

--- a/crates/biome_js_type_info/src/globals_ids.rs
+++ b/crates/biome_js_type_info/src/globals_ids.rs
@@ -471,11 +471,14 @@ mod tests {
     }
 
     #[test]
-    fn error_and_disposable_globals_are_migrated() {
+    fn migrated_predefined_ids_match_expected_order() {
         let migrated = crate::generated::global_types::MIGRATED_PREDEFINED_IDS;
         assert_eq!(
             migrated,
             &[
+                SYMBOL_ID_GLOBAL_TYPE_ID,
+                SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID,
+                SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID,
                 DISPOSABLE_ID_GLOBAL_TYPE_ID,
                 DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID,
                 ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID,

--- a/xtask/codegen/src/generate_global_types/compare.rs
+++ b/xtask/codegen/src/generate_global_types/compare.rs
@@ -9,8 +9,9 @@ use super::lower::{
 
 /// Number of `Error` class members expected in generated output.
 const ERROR_MEMBER_COUNT: usize = 6;
+const SYMBOL_MEMBER_COUNT: usize = 2;
 /// Expected number of lowered generated globals.
-const GENERATED_GLOBAL_COUNT: usize = 7;
+const GENERATED_GLOBAL_COUNT: usize = 10;
 
 /// Expected shape of one lowered disposable pair (interface + dispose helper), checked by
 /// [`assert_disposable_shape`] against the generated model.
@@ -77,6 +78,7 @@ pub fn compare_lowered_globals(lowered: &LoweredGlobalTypes) -> Result<()> {
     let call = generated_function(lowered, "Error.call", "ERROR_CALL_ID_GLOBAL_TYPE_ID")?;
     assert_error_call_shape(call)?;
 
+    assert_symbol_shape(lowered)?;
     assert_disposable_shape(
         lowered,
         DisposableShape {
@@ -106,6 +108,79 @@ pub fn compare_lowered_globals(lowered: &LoweredGlobalTypes) -> Result<()> {
         },
     )?;
 
+    Ok(())
+}
+
+/// Validates the generated `Symbol` class and its two symbol-valued helpers.
+fn assert_symbol_shape(lowered: &LoweredGlobalTypes) -> Result<()> {
+    let Some(symbol) = lowered.global("Symbol") else {
+        bail!("generated globals are missing the Symbol global");
+    };
+    if symbol.id_constant() != "SYMBOL_ID_GLOBAL_TYPE_ID" {
+        bail!(
+            "generated Symbol global targets {}, expected SYMBOL_ID_GLOBAL_TYPE_ID",
+            symbol.id_constant()
+        );
+    }
+    let LoweredTypeData::Class(class) = symbol.data() else {
+        bail!("generated Symbol global is not a class");
+    };
+    if class.name() != "Symbol" {
+        bail!(
+            "generated Symbol class has name {}, expected Symbol",
+            class.name()
+        );
+    }
+    if class.members().len() != SYMBOL_MEMBER_COUNT {
+        bail!(
+            "generated Symbol global has {} members, expected {}",
+            class.members().len(),
+            SYMBOL_MEMBER_COUNT
+        );
+    }
+
+    assert_symbol_member(class, "dispose", "GLOBAL_SYMBOL_DISPOSE_ID")?;
+    assert_symbol_member(class, "asyncDispose", "GLOBAL_SYMBOL_ASYNC_DISPOSE_ID")?;
+    assert_symbol_helper(
+        lowered,
+        "Symbol.dispose",
+        "SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID",
+    )?;
+    assert_symbol_helper(
+        lowered,
+        "Symbol.asyncDispose",
+        "SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",
+    )?;
+
+    Ok(())
+}
+
+fn assert_symbol_member(class: &LoweredClass, name: &str, type_id: &'static str) -> Result<()> {
+    let Some(member) = class.member(name) else {
+        bail!("generated Symbol global is missing {name}");
+    };
+    if member.kind() != &LoweredMemberKind::NamedStatic {
+        bail!("generated Symbol.{name} has unexpected kind");
+    }
+    if member.type_reference() != &LoweredTypeReference::Predefined(type_id) {
+        bail!("generated Symbol.{name} has unexpected type");
+    }
+    Ok(())
+}
+
+fn assert_symbol_helper(lowered: &LoweredGlobalTypes, name: &str, id_constant: &str) -> Result<()> {
+    let Some(helper) = lowered.global(name) else {
+        bail!("generated globals are missing {name}");
+    };
+    if helper.id_constant() != id_constant {
+        bail!(
+            "generated {name} targets {}, expected {id_constant}",
+            helper.id_constant()
+        );
+    }
+    if helper.data() != &LoweredTypeData::Symbol {
+        bail!("generated {name} helper is not symbol data");
+    }
     Ok(())
 }
 

--- a/xtask/codegen/src/generate_global_types/compare.rs
+++ b/xtask/codegen/src/generate_global_types/compare.rs
@@ -10,8 +10,6 @@ use super::lower::{
 /// Number of `Error` class members expected in generated output.
 const ERROR_MEMBER_COUNT: usize = 6;
 const SYMBOL_MEMBER_COUNT: usize = 2;
-/// Expected number of lowered generated globals.
-const GENERATED_GLOBAL_COUNT: usize = 10;
 
 /// Expected shape of one lowered disposable pair (interface + dispose helper), checked by
 /// [`assert_disposable_shape`] against the generated model.
@@ -29,14 +27,6 @@ struct DisposableShape<'a> {
 
 /// Validates lowered generated globals before they are emitted.
 pub fn compare_lowered_globals(lowered: &LoweredGlobalTypes) -> Result<()> {
-    if lowered.globals().len() != GENERATED_GLOBAL_COUNT {
-        bail!(
-            "generated globals contain {} entries, expected {}",
-            lowered.globals().len(),
-            GENERATED_GLOBAL_COUNT
-        );
-    }
-
     let Some(error) = lowered.global("Error") else {
         bail!("generated globals are missing the Error global");
     };

--- a/xtask/codegen/src/generate_global_types/emit.rs
+++ b/xtask/codegen/src/generate_global_types/emit.rs
@@ -15,7 +15,10 @@ const OUTPUT_RELATIVE_PATH: &str = "crates/biome_js_type_info/src/generated/glob
 ///
 /// Must stay ordered by ascending `GlobalTypeId` index so the emitted
 /// `MIGRATED_PREDEFINED_IDS` stays sorted for the runtime `binary_search`.
-const GLOBAL_ID_EMIT_ORDER: [&str; 7] = [
+const GLOBAL_ID_EMIT_ORDER: [&str; 10] = [
+    "SYMBOL_ID_GLOBAL_TYPE_ID",
+    "SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID",
+    "SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",
     "DISPOSABLE_ID_GLOBAL_TYPE_ID",
     "DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID",
     "ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID",
@@ -93,6 +96,7 @@ fn render_type_data(data: &LoweredTypeData) -> String {
         LoweredTypeData::Constructor(constructor) => render_constructor(constructor),
         LoweredTypeData::Function(function) => render_function(function),
         LoweredTypeData::Interface(interface) => render_interface(interface),
+        LoweredTypeData::Symbol => "crate::TypeData::Symbol".to_string(),
     }
 }
 
@@ -287,7 +291,7 @@ fn global_with_id_constant<'a>(
 }
 
 /// Returns generated globals in the sorted predefined-ID order.
-fn sorted_globals(lowered: &LoweredGlobalTypes) -> Result<[&LoweredGlobal; 7]> {
+fn sorted_globals(lowered: &LoweredGlobalTypes) -> Result<[&LoweredGlobal; 10]> {
     for global in lowered.globals() {
         if !GLOBAL_ID_EMIT_ORDER.contains(&global.id_constant()) {
             bail!(
@@ -306,5 +310,8 @@ fn sorted_globals(lowered: &LoweredGlobalTypes) -> Result<[&LoweredGlobal; 7]> {
         global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[4])?,
         global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[5])?,
         global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[6])?,
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[7])?,
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[8])?,
+        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[9])?,
     ])
 }

--- a/xtask/codegen/src/generate_global_types/emit.rs
+++ b/xtask/codegen/src/generate_global_types/emit.rs
@@ -15,7 +15,7 @@ const OUTPUT_RELATIVE_PATH: &str = "crates/biome_js_type_info/src/generated/glob
 ///
 /// Must stay ordered by ascending `GlobalTypeId` index so the emitted
 /// `MIGRATED_PREDEFINED_IDS` stays sorted for the runtime `binary_search`.
-const GLOBAL_ID_EMIT_ORDER: [&str; 10] = [
+const GLOBAL_ID_EMIT_ORDER: &[&str] = &[
     "SYMBOL_ID_GLOBAL_TYPE_ID",
     "SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID",
     "SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",
@@ -67,25 +67,25 @@ pub(crate) fn set_generated_global_type_data(builder: &mut crate::globals_builde
 /// Builds the migrated ID slice body.
 fn render_migrated_ids(lowered: &LoweredGlobalTypes) -> Result<String> {
     let mut ids = String::new();
-    for global in sorted_globals(lowered)? {
+    for_each_global_in_emit_order(lowered, |global| {
         ids.push_str("    crate::globals::");
         ids.push_str(global.id_constant());
         ids.push_str(",\n");
-    }
+    })?;
     Ok(ids)
 }
 
 /// Builds the resolver registration statements.
 fn render_registrations(lowered: &LoweredGlobalTypes) -> Result<String> {
     let mut registrations = String::new();
-    for global in sorted_globals(lowered)? {
+    for_each_global_in_emit_order(lowered, |global| {
         registrations.push_str("    let data = ");
         registrations.push_str(&render_type_data(global.data()));
         registrations.push_str(";\n");
         registrations.push_str("    builder.set_type_data(crate::globals::");
         registrations.push_str(global.id_constant());
         registrations.push_str(", data);\n");
-    }
+    })?;
     Ok(registrations)
 }
 
@@ -290,8 +290,10 @@ fn global_with_id_constant<'a>(
     bail!("generated global output is missing {id_constant}");
 }
 
-/// Returns generated globals in the sorted predefined-ID order.
-fn sorted_globals(lowered: &LoweredGlobalTypes) -> Result<[&LoweredGlobal; 10]> {
+fn for_each_global_in_emit_order(
+    lowered: &LoweredGlobalTypes,
+    mut visit: impl FnMut(&LoweredGlobal),
+) -> Result<()> {
     for global in lowered.globals() {
         if !GLOBAL_ID_EMIT_ORDER.contains(&global.id_constant()) {
             bail!(
@@ -302,16 +304,9 @@ fn sorted_globals(lowered: &LoweredGlobalTypes) -> Result<[&LoweredGlobal; 10]> 
         }
     }
 
-    Ok([
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[0])?,
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[1])?,
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[2])?,
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[3])?,
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[4])?,
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[5])?,
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[6])?,
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[7])?,
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[8])?,
-        global_with_id_constant(lowered, GLOBAL_ID_EMIT_ORDER[9])?,
-    ])
+    for id_constant in GLOBAL_ID_EMIT_ORDER {
+        visit(global_with_id_constant(lowered, id_constant)?);
+    }
+
+    Ok(())
 }

--- a/xtask/codegen/src/generate_global_types/emit.rs
+++ b/xtask/codegen/src/generate_global_types/emit.rs
@@ -11,10 +11,10 @@ use super::lower::{
 /// Relative path of the generated global types module from the workspace root.
 const OUTPUT_RELATIVE_PATH: &str = "crates/biome_js_type_info/src/generated/global_types.rs";
 
-/// Stable generated global emission order for generated globals with fixed IDs.
+/// Generated globals in ascending `GlobalTypeId` index order.
 ///
-/// Must stay ordered by ascending `GlobalTypeId` index so the emitted
-/// `MIGRATED_PREDEFINED_IDS` stays sorted for the runtime `binary_search`.
+/// The index is the row position in `PREDEFINED_ID_ROWS`. This keeps
+/// `MIGRATED_PREDEFINED_IDS` sorted for the runtime `binary_search`.
 const GLOBAL_ID_EMIT_ORDER: &[&str] = &[
     "SYMBOL_ID_GLOBAL_TYPE_ID",
     "SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID",

--- a/xtask/codegen/src/generate_global_types/lower.rs
+++ b/xtask/codegen/src/generate_global_types/lower.rs
@@ -5,7 +5,7 @@ use biome_js_parser::{JsParserOptions, parse};
 use biome_js_syntax::{
     AnyJsBindingPattern, AnyJsExpression, AnyJsFormalParameter, AnyJsName, AnyJsObjectMemberName,
     AnyJsParameter, AnyJsRoot, AnyTsReturnType, AnyTsType, AnyTsTypeMember,
-    AnyTsVariableAnnotation, JsParameters, JsVariableDeclarator, TsCallSignatureTypeMember,
+    AnyTsVariableAnnotation, JsParameters, JsVariableDeclarator, T, TsCallSignatureTypeMember,
     TsConstructSignatureTypeMember, TsDeclarationModule, TsInterfaceDeclaration,
     TsMethodSignatureTypeMember, TsPropertySignatureTypeMember,
 };
@@ -68,6 +68,7 @@ pub enum LoweredTypeData {
     Constructor(LoweredConstructor),
     Function(LoweredFunction),
     Interface(LoweredInterface),
+    Symbol,
 }
 
 /// Lowered class-like global.
@@ -344,6 +345,9 @@ pub fn lower_global_types(
         data: LoweredTypeData::Function(call),
     });
 
+    if let Some(symbol_globals) = lower_symbol_globals(manifest, &mut source_cache)? {
+        globals.extend(symbol_globals);
+    }
     if let Some(disposable_globals) =
         lower_disposable_global(manifest, &mut source_cache, DISPOSABLE_GLOBAL)?
     {
@@ -443,6 +447,264 @@ struct ParsedSource<'a> {
 struct ParsedSourceCache<'a> {
     source_files: &'a [DiscoveredFile],
     parsed: Vec<ParsedSource<'a>>,
+}
+
+#[derive(Clone, Copy)]
+enum SelectedSymbolMember {
+    Dispose,
+    AsyncDispose,
+}
+
+impl SelectedSymbolMember {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Dispose => "dispose",
+            Self::AsyncDispose => "asyncDispose",
+        }
+    }
+}
+
+/// Lowers the predefined `Symbol` projection and its two well-known symbol helpers.
+fn lower_symbol_globals(
+    manifest: &GlobalManifest,
+    source_cache: &mut ParsedSourceCache,
+) -> Result<Option<[LoweredGlobal; 3]>> {
+    let Some(symbol_group) = manifest.global_group("Symbol") else {
+        return Ok(None);
+    };
+    if !symbol_group.has_role(GlobalDeclarationRole::Type) {
+        bail!("Symbol global must have a type-side declaration");
+    }
+    if !symbol_group.has_role(GlobalDeclarationRole::Value) {
+        bail!("Symbol global must have a value-side declaration");
+    }
+
+    validate_symbol_declarations(symbol_group.declarations(), source_cache)?;
+
+    let Some(constructor_group) = manifest.global_group("SymbolConstructor") else {
+        bail!("Symbol global value side references missing SymbolConstructor group");
+    };
+    if !constructor_group.has_role(GlobalDeclarationRole::Type) {
+        bail!("SymbolConstructor must have a type-side declaration");
+    }
+    validate_symbol_constructor_members(constructor_group.declarations(), source_cache)?;
+
+    Ok(Some([
+        LoweredGlobal {
+            name: Text::from("Symbol"),
+            id_constant: "SYMBOL_ID_GLOBAL_TYPE_ID",
+            data: LoweredTypeData::Class(LoweredClass {
+                name: Text::from("Symbol"),
+                members: Box::new([
+                    LoweredTypeMember {
+                        name: Text::from("dispose"),
+                        kind: LoweredMemberKind::NamedStatic,
+                        type_reference: LoweredTypeReference::Predefined(
+                            "GLOBAL_SYMBOL_DISPOSE_ID",
+                        ),
+                    },
+                    LoweredTypeMember {
+                        name: Text::from("asyncDispose"),
+                        kind: LoweredMemberKind::NamedStatic,
+                        type_reference: LoweredTypeReference::Predefined(
+                            "GLOBAL_SYMBOL_ASYNC_DISPOSE_ID",
+                        ),
+                    },
+                ]),
+            }),
+        },
+        LoweredGlobal {
+            name: Text::from("Symbol.dispose"),
+            id_constant: "SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID",
+            data: LoweredTypeData::Symbol,
+        },
+        LoweredGlobal {
+            name: Text::from("Symbol.asyncDispose"),
+            id_constant: "SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",
+            data: LoweredTypeData::Symbol,
+        },
+    ]))
+}
+
+fn validate_symbol_declarations(
+    records: &[DeclarationRecord],
+    source_cache: &mut ParsedSourceCache,
+) -> Result<()> {
+    for record in records {
+        match &record.kind {
+            DeclarationKind::Interface => {}
+            DeclarationKind::VariableDeclarator { .. } => {
+                validate_symbol_constructor_reference(record, source_cache)?;
+            }
+            DeclarationKind::TypeAlias => {
+                bail!("type aliases are not supported in the Symbol global")
+            }
+            DeclarationKind::DeclareFunction | DeclarationKind::ImportEquals => {
+                bail!(
+                    "unsupported value-side Symbol declaration {:?}",
+                    record.kind
+                )
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_symbol_constructor_reference(
+    record: &DeclarationRecord,
+    source_cache: &mut ParsedSourceCache,
+) -> Result<()> {
+    let declarator = source_cache
+        .find_variable_declarator(record)?
+        .with_context(|| {
+            format!(
+                "failed to find variable declaration {} at {:?}",
+                record.declared_name.text(),
+                record.text_range
+            )
+        })?;
+    let Some(annotation) = declarator.variable_annotation() else {
+        bail!("declare var Symbol is missing a type annotation");
+    };
+    let AnyTsVariableAnnotation::TsTypeAnnotation(annotation) = annotation else {
+        bail!("declare var Symbol uses unsupported definite assignment annotation");
+    };
+    let AnyTsType::TsReferenceType(reference) = annotation.ty()? else {
+        bail!("declare var Symbol must reference SymbolConstructor");
+    };
+    if reference.type_arguments().is_some() {
+        bail!("declare var Symbol must reference SymbolConstructor without type arguments");
+    }
+    let biome_js_syntax::AnyTsName::JsReferenceIdentifier(identifier) = reference
+        .name()
+        .context("declare var Symbol is missing a type reference name")?
+    else {
+        bail!("declare var Symbol must reference SymbolConstructor");
+    };
+    if identifier.value_token()?.token_text_trimmed().text() != "SymbolConstructor" {
+        bail!("declare var Symbol must reference SymbolConstructor");
+    }
+
+    Ok(())
+}
+
+/// Validates the two selected `unique symbol` properties across merged constructor interfaces.
+fn validate_symbol_constructor_members(
+    records: &[DeclarationRecord],
+    source_cache: &mut ParsedSourceCache,
+) -> Result<()> {
+    let mut saw_dispose = false;
+    let mut saw_async_dispose = false;
+
+    for record in records {
+        match &record.kind {
+            DeclarationKind::Interface => {}
+            DeclarationKind::TypeAlias => {
+                bail!("type aliases are not supported in SymbolConstructor")
+            }
+            DeclarationKind::DeclareFunction
+            | DeclarationKind::VariableDeclarator { .. }
+            | DeclarationKind::ImportEquals => {
+                bail!("value-side SymbolConstructor declarations are not supported")
+            }
+        }
+
+        let declaration = source_cache
+            .find_interface_declaration(record)?
+            .with_context(|| {
+                format!(
+                    "failed to find interface declaration {} at {:?}",
+                    record.declared_name.text(),
+                    record.text_range
+                )
+            })?;
+        for member in declaration.members() {
+            match member {
+                AnyTsTypeMember::TsPropertySignatureTypeMember(property) => {
+                    if let Some(member) = selected_symbol_member(property.name()?)? {
+                        let saw_member = match member {
+                            SelectedSymbolMember::Dispose => &mut saw_dispose,
+                            SelectedSymbolMember::AsyncDispose => &mut saw_async_dispose,
+                        };
+                        if *saw_member {
+                            bail!(
+                                "SymbolConstructor has multiple {} properties",
+                                member.name()
+                            );
+                        }
+                        validate_unique_symbol_property(&property, member.name())?;
+                        *saw_member = true;
+                    }
+                }
+                AnyTsTypeMember::TsMethodSignatureTypeMember(member) => {
+                    reject_selected_symbol_non_property(member.name()?)?;
+                }
+                AnyTsTypeMember::TsGetterSignatureTypeMember(member) => {
+                    reject_selected_symbol_non_property(member.name()?)?;
+                }
+                AnyTsTypeMember::TsSetterSignatureTypeMember(member) => {
+                    reject_selected_symbol_non_property(member.name()?)?;
+                }
+                AnyTsTypeMember::JsBogusMember(_)
+                | AnyTsTypeMember::TsCallSignatureTypeMember(_)
+                | AnyTsTypeMember::TsConstructSignatureTypeMember(_)
+                | AnyTsTypeMember::TsIndexSignatureTypeMember(_) => {}
+            }
+        }
+    }
+
+    if !saw_dispose {
+        bail!("SymbolConstructor is missing dispose");
+    }
+    if !saw_async_dispose {
+        bail!("SymbolConstructor is missing asyncDispose");
+    }
+
+    Ok(())
+}
+
+fn reject_selected_symbol_non_property(name: AnyJsObjectMemberName) -> Result<()> {
+    if let Some(member) = selected_symbol_member(name)? {
+        bail!("SymbolConstructor.{} must be a property", member.name());
+    }
+    Ok(())
+}
+
+fn selected_symbol_member(name: AnyJsObjectMemberName) -> Result<Option<SelectedSymbolMember>> {
+    let AnyJsObjectMemberName::JsLiteralMemberName(name) = name else {
+        return Ok(None);
+    };
+
+    Ok(match name.name()?.text() {
+        "dispose" => Some(SelectedSymbolMember::Dispose),
+        "asyncDispose" => Some(SelectedSymbolMember::AsyncDispose),
+        _ => None,
+    })
+}
+
+fn validate_unique_symbol_property(
+    property: &TsPropertySignatureTypeMember,
+    name: &str,
+) -> Result<()> {
+    if property.optional_token().is_some() {
+        bail!("SymbolConstructor.{name} must not be optional");
+    }
+    let type_node = property
+        .type_annotation()
+        .with_context(|| format!("SymbolConstructor.{name} is missing a type annotation"))?
+        .ty()
+        .with_context(|| format!("SymbolConstructor.{name} has a malformed type annotation"))?;
+    let AnyTsType::TsTypeOperatorType(operator) = type_node else {
+        bail!("SymbolConstructor.{name} must be unique symbol");
+    };
+    if operator.operator_token()?.kind() != T![unique]
+        || !matches!(operator.ty()?, AnyTsType::TsSymbolType(_))
+    {
+        bail!("SymbolConstructor.{name} must be unique symbol");
+    }
+
+    Ok(())
 }
 
 impl<'a> ParsedSourceCache<'a> {

--- a/xtask/codegen/src/generate_global_types/lower.rs
+++ b/xtask/codegen/src/generate_global_types/lower.rs
@@ -345,19 +345,14 @@ pub fn lower_global_types(
         data: LoweredTypeData::Function(call),
     });
 
-    if let Some(symbol_globals) = lower_symbol_globals(manifest, &mut source_cache)? {
-        globals.extend(symbol_globals);
-    }
-    if let Some(disposable_globals) =
-        lower_disposable_global(manifest, &mut source_cache, DISPOSABLE_GLOBAL)?
-    {
-        globals.extend(disposable_globals);
-    }
-    if let Some(async_disposable_globals) =
-        lower_disposable_global(manifest, &mut source_cache, ASYNC_DISPOSABLE_GLOBAL)?
-    {
-        globals.extend(async_disposable_globals);
-    }
+    lower_symbol_globals(manifest, &mut source_cache, &mut globals)?;
+    lower_disposable_global(manifest, &mut source_cache, &mut globals, DISPOSABLE_GLOBAL)?;
+    lower_disposable_global(
+        manifest,
+        &mut source_cache,
+        &mut globals,
+        ASYNC_DISPOSABLE_GLOBAL,
+    )?;
 
     Ok(LoweredGlobalTypes {
         globals: globals.into_boxed_slice(),
@@ -468,9 +463,10 @@ impl SelectedSymbolMember {
 fn lower_symbol_globals(
     manifest: &GlobalManifest,
     source_cache: &mut ParsedSourceCache,
-) -> Result<Option<[LoweredGlobal; 3]>> {
+    globals: &mut Vec<LoweredGlobal>,
+) -> Result<()> {
     let Some(symbol_group) = manifest.global_group("Symbol") else {
-        return Ok(None);
+        return Ok(());
     };
     if !symbol_group.has_role(GlobalDeclarationRole::Type) {
         bail!("Symbol global must have a type-side declaration");
@@ -489,41 +485,39 @@ fn lower_symbol_globals(
     }
     validate_symbol_constructor_members(constructor_group.declarations(), source_cache)?;
 
-    Ok(Some([
-        LoweredGlobal {
+    globals.push(LoweredGlobal {
+        name: Text::from("Symbol"),
+        id_constant: "SYMBOL_ID_GLOBAL_TYPE_ID",
+        data: LoweredTypeData::Class(LoweredClass {
             name: Text::from("Symbol"),
-            id_constant: "SYMBOL_ID_GLOBAL_TYPE_ID",
-            data: LoweredTypeData::Class(LoweredClass {
-                name: Text::from("Symbol"),
-                members: Box::new([
-                    LoweredTypeMember {
-                        name: Text::from("dispose"),
-                        kind: LoweredMemberKind::NamedStatic,
-                        type_reference: LoweredTypeReference::Predefined(
-                            "GLOBAL_SYMBOL_DISPOSE_ID",
-                        ),
-                    },
-                    LoweredTypeMember {
-                        name: Text::from("asyncDispose"),
-                        kind: LoweredMemberKind::NamedStatic,
-                        type_reference: LoweredTypeReference::Predefined(
-                            "GLOBAL_SYMBOL_ASYNC_DISPOSE_ID",
-                        ),
-                    },
-                ]),
-            }),
-        },
-        LoweredGlobal {
-            name: Text::from("Symbol.dispose"),
-            id_constant: "SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID",
-            data: LoweredTypeData::Symbol,
-        },
-        LoweredGlobal {
-            name: Text::from("Symbol.asyncDispose"),
-            id_constant: "SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",
-            data: LoweredTypeData::Symbol,
-        },
-    ]))
+            members: Box::new([
+                LoweredTypeMember {
+                    name: Text::from("dispose"),
+                    kind: LoweredMemberKind::NamedStatic,
+                    type_reference: LoweredTypeReference::Predefined("GLOBAL_SYMBOL_DISPOSE_ID"),
+                },
+                LoweredTypeMember {
+                    name: Text::from("asyncDispose"),
+                    kind: LoweredMemberKind::NamedStatic,
+                    type_reference: LoweredTypeReference::Predefined(
+                        "GLOBAL_SYMBOL_ASYNC_DISPOSE_ID",
+                    ),
+                },
+            ]),
+        }),
+    });
+    globals.push(LoweredGlobal {
+        name: Text::from("Symbol.dispose"),
+        id_constant: "SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID",
+        data: LoweredTypeData::Symbol,
+    });
+    globals.push(LoweredGlobal {
+        name: Text::from("Symbol.asyncDispose"),
+        id_constant: "SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",
+        data: LoweredTypeData::Symbol,
+    });
+
+    Ok(())
 }
 
 fn validate_symbol_declarations(
@@ -785,14 +779,14 @@ impl<'a> ParsedSourceCache<'a> {
 }
 
 /// Lowers a disposable interface into its interface global plus the dispose helper global.
-/// Returns `None` when the manifest has no group for `spec.interface_name`.
 fn lower_disposable_global(
     manifest: &GlobalManifest,
     source_cache: &mut ParsedSourceCache,
+    globals: &mut Vec<LoweredGlobal>,
     spec: DisposableGlobalSpec,
-) -> Result<Option<[LoweredGlobal; 2]>> {
+) -> Result<()> {
     let Some(group) = manifest.global_group(spec.interface_name) else {
-        return Ok(None);
+        return Ok(());
     };
     if !group.has_role(GlobalDeclarationRole::Type) {
         bail!(
@@ -854,26 +848,26 @@ fn lower_disposable_global(
     let lowered_member = lowered_member
         .with_context(|| format!("{} is missing {}", spec.interface_name, spec.member_name))?;
 
-    Ok(Some([
-        LoweredGlobal {
+    globals.push(LoweredGlobal {
+        name: Text::from(spec.interface_name),
+        id_constant: spec.global_id_constant,
+        data: LoweredTypeData::Interface(LoweredInterface {
             name: Text::from(spec.interface_name),
-            id_constant: spec.global_id_constant,
-            data: LoweredTypeData::Interface(LoweredInterface {
-                name: Text::from(spec.interface_name),
-                members: Box::new([lowered_member]),
-            }),
-        },
-        LoweredGlobal {
-            name: Text::from(spec.helper_name),
-            id_constant: spec.helper_id_constant,
-            data: LoweredTypeData::Function(LoweredFunction {
-                is_async: spec.return_kind.helper_is_async(),
-                name: None,
-                parameters: Box::default(),
-                return_type: LoweredTypeReference::Predefined(spec.return_kind.return_type_id()),
-            }),
-        },
-    ]))
+            members: Box::new([lowered_member]),
+        }),
+    });
+    globals.push(LoweredGlobal {
+        name: Text::from(spec.helper_name),
+        id_constant: spec.helper_id_constant,
+        data: LoweredTypeData::Function(LoweredFunction {
+            is_async: spec.return_kind.helper_is_async(),
+            name: None,
+            parameters: Box::default(),
+            return_type: LoweredTypeReference::Predefined(spec.return_kind.return_type_id()),
+        }),
+    });
+
+    Ok(())
 }
 
 /// Lowers the single member of a disposable interface. Only a computed method signature

--- a/xtask/codegen/tests/fixtures/global-types/manifest.disposables.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.disposables.d.ts
@@ -12,6 +12,20 @@ interface ErrorConstructor {
 
 declare var Error: ErrorConstructor;
 
+interface Symbol {}
+
+interface SymbolConstructor {
+    readonly prototype: Symbol;
+}
+
+interface SymbolConstructor {
+    readonly [Symbol.iterator]: unique symbol;
+    readonly dispose: unique symbol;
+    readonly asyncDispose: unique symbol;
+}
+
+declare var Symbol: SymbolConstructor;
+
 interface Disposable {
     [Symbol.dispose](): void;
 }

--- a/xtask/codegen/tests/fixtures/global-types/manifest.error-missing-message.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.error-missing-message.d.ts
@@ -11,6 +11,15 @@ interface ErrorConstructor {
 
 declare var Error: ErrorConstructor;
 
+interface Symbol {}
+
+interface SymbolConstructor {
+    readonly dispose: unique symbol;
+    readonly asyncDispose: unique symbol;
+}
+
+declare var Symbol: SymbolConstructor;
+
 interface Disposable {
     [Symbol.dispose](): void;
 }

--- a/xtask/codegen/tests/fixtures/global-types/manifest.symbol-missing-async-dispose.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.symbol-missing-async-dispose.d.ts
@@ -1,14 +1,11 @@
 interface Error {
     name: string;
-}
-
-interface Error {
     message: string;
     stack?: string;
 }
 
 interface ErrorConstructor {
-    new(message?: string): void;
+    new(message?: string): Error;
     (message?: string): Error;
     readonly prototype: Error;
 }
@@ -19,15 +16,6 @@ interface Symbol {}
 
 interface SymbolConstructor {
     readonly dispose: unique symbol;
-    readonly asyncDispose: unique symbol;
 }
 
 declare var Symbol: SymbolConstructor;
-
-interface Disposable {
-    [Symbol.dispose](): void;
-}
-
-interface AsyncDisposable {
-    [Symbol.asyncDispose](): PromiseLike<void>;
-}

--- a/xtask/codegen/tests/fixtures/global-types/manifest.symbol-wrong-constructor.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.symbol-wrong-constructor.d.ts
@@ -1,14 +1,11 @@
 interface Error {
     name: string;
-}
-
-interface Error {
     message: string;
     stack?: string;
 }
 
 interface ErrorConstructor {
-    new(message?: string): void;
+    new(message?: string): Error;
     (message?: string): Error;
     readonly prototype: Error;
 }
@@ -22,12 +19,6 @@ interface SymbolConstructor {
     readonly asyncDispose: unique symbol;
 }
 
-declare var Symbol: SymbolConstructor;
+interface OtherSymbolConstructor {}
 
-interface Disposable {
-    [Symbol.dispose](): void;
-}
-
-interface AsyncDisposable {
-    [Symbol.asyncDispose](): PromiseLike<void>;
-}
+declare var Symbol: OtherSymbolConstructor;

--- a/xtask/codegen/tests/fixtures/global-types/manifest.symbol-wrong-type.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.symbol-wrong-type.d.ts
@@ -1,14 +1,11 @@
 interface Error {
     name: string;
-}
-
-interface Error {
     message: string;
     stack?: string;
 }
 
 interface ErrorConstructor {
-    new(message?: string): void;
+    new(message?: string): Error;
     (message?: string): Error;
     readonly prototype: Error;
 }
@@ -18,16 +15,8 @@ declare var Error: ErrorConstructor;
 interface Symbol {}
 
 interface SymbolConstructor {
-    readonly dispose: unique symbol;
+    readonly dispose: symbol;
     readonly asyncDispose: unique symbol;
 }
 
 declare var Symbol: SymbolConstructor;
-
-interface Disposable {
-    [Symbol.dispose](): void;
-}
-
-interface AsyncDisposable {
-    [Symbol.asyncDispose](): PromiseLike<void>;
-}

--- a/xtask/codegen/tests/global_types_codegen.rs
+++ b/xtask/codegen/tests/global_types_codegen.rs
@@ -997,6 +997,9 @@ mod tests {
         assert!(generated.contains("crate::globals::ERROR_ID_GLOBAL_TYPE_ID"));
         assert!(generated.contains("crate::globals::ERROR_CONSTRUCTOR_ID_GLOBAL_TYPE_ID"));
         assert!(generated.contains("crate::globals::ERROR_CALL_ID_GLOBAL_TYPE_ID"));
+        assert!(generated.contains("crate::globals::SYMBOL_ID_GLOBAL_TYPE_ID"));
+        assert!(generated.contains("crate::globals::SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID"));
+        assert!(generated.contains("crate::globals::SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID"));
         assert!(generated.contains("crate::globals::DISPOSABLE_ID_GLOBAL_TYPE_ID"));
         assert!(generated.contains("crate::globals::DISPOSABLE_DISPOSE_ID_GLOBAL_TYPE_ID"));
         assert!(generated.contains("crate::globals::ASYNC_DISPOSABLE_ID_GLOBAL_TYPE_ID"));
@@ -1007,6 +1010,7 @@ mod tests {
         assert!(generated.contains("crate::TypeData::Interface("));
         assert!(generated.contains("crate::TypeData::Constructor("));
         assert!(generated.contains("crate::TypeData::Function("));
+        assert!(generated.contains("crate::TypeData::Symbol"));
         assert!(generated.contains("crate::TypeMemberKind::ComputedValue("));
         // Pin the async flag at the rendered-source level: the `AsyncDisposable` helper must emit
         // `is_async: true` and the synchronous helpers `is_async: false`, so a regression back to a
@@ -1286,6 +1290,82 @@ mod tests {
     }
 
     #[test]
+    fn lowerer_lowers_symbol_globals() -> Result<()> {
+        let lowered = lowered_from_fixture("manifest.disposables.d.ts")?;
+
+        let symbol = lowered.global("Symbol").expect("Symbol should be lowered");
+        assert_eq!(symbol.id_constant(), "SYMBOL_ID_GLOBAL_TYPE_ID");
+        let LoweredTypeData::Class(symbol_class) = symbol.data() else {
+            bail!("Symbol should lower to class data");
+        };
+        assert_eq!(symbol_class.name(), "Symbol");
+        let dispose = symbol_class
+            .member("dispose")
+            .expect("Symbol.dispose should be lowered");
+        assert_eq!(dispose.kind(), &LoweredMemberKind::NamedStatic);
+        assert_eq!(
+            dispose.type_reference(),
+            &LoweredTypeReference::Predefined("GLOBAL_SYMBOL_DISPOSE_ID")
+        );
+        let async_dispose = symbol_class
+            .member("asyncDispose")
+            .expect("Symbol.asyncDispose should be lowered");
+        assert_eq!(async_dispose.kind(), &LoweredMemberKind::NamedStatic);
+        assert_eq!(
+            async_dispose.type_reference(),
+            &LoweredTypeReference::Predefined("GLOBAL_SYMBOL_ASYNC_DISPOSE_ID")
+        );
+        assert_eq!(symbol_class.members().len(), 2);
+
+        let dispose_helper = lowered
+            .global("Symbol.dispose")
+            .expect("Symbol.dispose helper should be lowered");
+        assert_eq!(
+            dispose_helper.id_constant(),
+            "SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID"
+        );
+        assert!(matches!(dispose_helper.data(), LoweredTypeData::Symbol));
+
+        let async_dispose_helper = lowered
+            .global("Symbol.asyncDispose")
+            .expect("Symbol.asyncDispose helper should be lowered");
+        assert_eq!(
+            async_dispose_helper.id_constant(),
+            "SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID"
+        );
+        assert!(matches!(
+            async_dispose_helper.data(),
+            LoweredTypeData::Symbol
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn lowerer_rejects_missing_symbol_member() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.symbol-missing-async-dispose.d.ts"),
+            "SymbolConstructor is missing asyncDispose",
+        )
+    }
+
+    #[test]
+    fn lowerer_rejects_non_unique_symbol_member() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.symbol-wrong-type.d.ts"),
+            "SymbolConstructor.dispose must be unique symbol",
+        )
+    }
+
+    #[test]
+    fn lowerer_rejects_wrong_symbol_constructor_reference() -> Result<()> {
+        expect_error_contains(
+            lowered_from_fixture("manifest.symbol-wrong-constructor.d.ts"),
+            "declare var Symbol must reference SymbolConstructor",
+        )
+    }
+
+    #[test]
     fn lowerer_rejects_error_interface_extends_clause() -> Result<()> {
         expect_error_contains(
             lowered_from_fixture("manifest.error-extends.d.ts"),
@@ -1332,7 +1412,7 @@ mod tests {
 
         expect_error_contains(
             compare_lowered_globals(&lowered),
-            "generated globals contain 3 entries, expected 7",
+            "generated globals contain 3 entries, expected 10",
         )
     }
 

--- a/xtask/codegen/tests/global_types_codegen.rs
+++ b/xtask/codegen/tests/global_types_codegen.rs
@@ -1407,12 +1407,12 @@ mod tests {
     }
 
     #[test]
-    fn comparator_rejects_missing_disposable_globals() -> Result<()> {
+    fn comparator_rejects_missing_symbol_global() -> Result<()> {
         let lowered = lowered_from_fixture("manifest.error.d.ts")?;
 
         expect_error_contains(
             compare_lowered_globals(&lowered),
-            "generated globals contain 3 entries, expected 10",
+            "generated globals are missing the Symbol global",
         )
     }
 


### PR DESCRIPTION
## Summary

Part of #5977.

Migrates `Symbol`, `Symbol.dispose`, and `Symbol.asyncDispose` to generated global types while preserving their existing raw and Salsa-backed shapes. This does not change the inference engine.

> This PR was implemented with AI assistance from Codex.

## Test Plan

- Added lowerer coverage for merged and invalid `Symbol` declarations.
- Added runtime coverage for the generated static members and symbol-valued helpers.
- Verified `just gen-global-types` is idempotent.

## Docs

N/A