### PR TITLE
fix(html): stop duplicating leading comments before Svelte  {@const}/{@debug} blocks

### DIFF
--- a/.changeset/fix-svelte-const-block-leading-comment-duplication.md
+++ b/.changeset/fix-svelte-const-block-leading-comment-duplication.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed an issue where the HTML formatter would duplicate a comment placed directly before a Svelte `{@const ...}` or `{@debug ...}` block. The duplication compounded on every subsequent `--write`, causing the file to grow exponentially.

--- a/crates/biome_html_formatter/src/svelte/auxiliary/const_block.rs
+++ b/crates/biome_html_formatter/src/svelte/auxiliary/const_block.rs
@@ -23,4 +23,13 @@ impl FormatNodeRule<SvelteConstBlock> for FormatSvelteConstBlock {
             ]
         )
     }
+
+    fn fmt_leading_comments(
+        &self,
+        _node: &SvelteConstBlock,
+        _f: &mut HtmlFormatter,
+    ) -> FormatResult<()> {
+        // handled by element list formatter
+        Ok(())
+    }
 }

--- a/crates/biome_html_formatter/src/svelte/auxiliary/debug_block.rs
+++ b/crates/biome_html_formatter/src/svelte/auxiliary/debug_block.rs
@@ -24,4 +24,13 @@ impl FormatNodeRule<SvelteDebugBlock> for FormatSvelteDebugBlock {
 
         write!(f, [r_curly_token.format()])
     }
+
+    fn fmt_leading_comments(
+        &self,
+        _node: &SvelteDebugBlock,
+        _f: &mut HtmlFormatter,
+    ) -> FormatResult<()> {
+        // handled by element list formatter
+        Ok(())
+    }
 }

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments/debug_leading_comment.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments/debug_leading_comment.svelte
@@ -1,0 +1,5 @@
+{#if x}
+	<!-- a comment right before @debug -->
+	{@debug x}
+	<div>{x}</div>
+{/if}

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments/debug_leading_comment.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments/debug_leading_comment.svelte.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/comments/debug_leading_comment.svelte
+---
+
+# Input
+
+```svelte
+{#if x}
+	<!-- a comment right before @debug -->
+	{@debug x}
+	<div>{x}</div>
+{/if}
+
+```
+
+
+# Formatted
+
+```svelte
+{#if x}
+	<!-- a comment right before @debug -->
+	{@debug x}
+	<div>{x}</div>
+{/if}
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments/snippet_const_repro.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments/snippet_const_repro.svelte
@@ -1,0 +1,5 @@
+{#snippet thing(x: number)}
+	<!-- a doc comment sitting between the snippet's opening tag and its first {@const} -->
+	{@const doubled = x * 2}
+	<div>{doubled}</div>
+{/snippet}

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments/snippet_const_repro.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments/snippet_const_repro.svelte.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/comments/snippet_const_repro.svelte
+---
+
+# Input
+
+```svelte
+{#snippet thing(x: number)}
+	<!-- a doc comment sitting between the snippet's opening tag and its first {@const} -->
+	{@const doubled = x * 2}
+	<div>{doubled}</div>
+{/snippet}
+
+```
+
+
+# Formatted
+
+```svelte
+{#snippet thing(x: number)}
+	<!-- a doc comment sitting between the snippet's opening tag and its first {@const} -->
+	{@const doubled = x * 2}
+	<div>{doubled}</div>
+{/snippet}
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    2: 	<!-- a doc comment sitting between the snippet's opening tag and its first {@const} -->
+```


### PR DESCRIPTION
## Summary

`SvelteConstBlock` (`{@const ...}`) and `SvelteDebugBlock` (`{@debug ...}`) were missing the `fmt_leading_comments` no-op override that every other Svelte block formatter (`if`/`each`/`key`/`html`/`snippet`/`render`/`await`) already has.

Without it, a comment placed directly before one of these blocks was printed twice: once by the HTML element list formatter (which owns comment placement for Svelte block children), and again by the default `fmt_leading_comments` impl when formatting the block node itself.

Because the duplicate is written back to disk, every subsequent `biome check --write` re-duplicated the already-duplicated comments, roughly quadrupling the affected region's size on each run — completely silent, since `biome check` without `--write` doesn't flag anything wrong with the (already duplicated) output.

Fix: add the same `fmt_leading_comments` no-op override (`// handled by element list formatter`) to `const_block.rs` and `debug_block.rs`, matching the existing pattern.

> This PR was created with AI assistance (Claude Code).

## Test Plan

Added two HTML formatter snapshot tests, which automatically assert re-formatting idempotency:
- `tests/specs/html/svelte/comments/snippet_const_repro.svelte` — comment directly before `{@const}` inside a `{#snippet}`
- `tests/specs/html/svelte/comments/debug_leading_comment.svelte` — comment directly before `{@debug}`

Both failed with `Formatter is not idempotent: re-formatting produced different output` before the fix, and pass after.
