### PR TITLE
fix(parse/html): accept mixed case doctype declarations

### DIFF
--- a/.changeset/parse-mixed-case-html-doctype.md
+++ b/.changeset/parse-mixed-case-html-doctype.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+The HTML parser now accepts mixed-case `doctype` declarations.

--- a/crates/biome_html_formatter/tests/specs/html/directive/mixed-case.html
+++ b/crates/biome_html_formatter/tests/specs/html/directive/mixed-case.html
@@ -1,0 +1,1 @@
+<!DoCtYpE hTmL>

--- a/crates/biome_html_formatter/tests/specs/html/directive/mixed-case.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/directive/mixed-case.html.snap
@@ -1,0 +1,19 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: directive/mixed-case.html
+---
+
+# Input
+
+```html
+<!DoCtYpE hTmL>
+
+```
+
+
+# Formatted
+
+```html
+<!DoCtYpE html>
+
+```

--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -1002,8 +1002,16 @@ impl<'src> HtmlLexer<'src> {
         self.assert_current_char_boundary();
 
         const BUFFER_SIZE: usize = 14;
+        let lowercase_buffer = matches!(
+            &context,
+            IdentifierContext::Doctype | IdentifierContext::None
+        );
         let mut buffer = [0u8; BUFFER_SIZE];
-        buffer[0] = first;
+        buffer[0] = if lowercase_buffer {
+            first.to_ascii_lowercase()
+        } else {
+            first
+        };
         let mut len = 1;
 
         self.advance_byte_or_char(first);
@@ -1013,7 +1021,7 @@ impl<'src> HtmlLexer<'src> {
                 IdentifierContext::Doctype | IdentifierContext::None => {
                     if is_attribute_name_byte(byte) {
                         if len < BUFFER_SIZE {
-                            buffer[len] = byte;
+                            buffer[len] = byte.to_ascii_lowercase();
                             len += 1;
                         }
 
@@ -1099,8 +1107,8 @@ impl<'src> HtmlLexer<'src> {
         }
 
         match &buffer[..len] {
-            b"doctype" | b"DOCTYPE" => DOCTYPE_KW,
-            b"html" | b"HTML" if context.is_doctype() => HTML_KW,
+            b"doctype" => DOCTYPE_KW,
+            b"html" if context.is_doctype() => HTML_KW,
             b"client" if context.is_astro() && self.current_byte() == Some(b':') => CLIENT_KW,
             b"set" if context.is_astro() && self.current_byte() == Some(b':') => SET_KW,
             b"class" if context.is_astro() && self.current_byte() == Some(b':') => CLASS_KW,

--- a/crates/biome_html_parser/tests/html_specs/ok/mixed-case-doctype.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/mixed-case-doctype.html
@@ -1,0 +1,2 @@
+<!DoCtYpE hTmL>
+<html></html>

--- a/crates/biome_html_parser/tests/html_specs/ok/mixed-case-doctype.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/mixed-case-doctype.html.snap
@@ -1,0 +1,88 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+<!DoCtYpE hTmL>
+<html></html>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: HtmlDirective {
+        l_angle_token: L_ANGLE@0..1 "<" [] [],
+        excl_token: BANG@1..2 "!" [] [],
+        doctype_token: DOCTYPE_KW@2..10 "DoCtYpE" [] [Whitespace(" ")],
+        html_token: HTML_KW@10..14 "hTmL" [] [],
+        quirk_token: missing (optional),
+        public_id_token: missing (optional),
+        system_id_token: missing (optional),
+        r_angle_token: R_ANGLE@14..15 ">" [] [],
+    },
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@15..17 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_KW@17..21 "html" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@21..22 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@22..23 "<" [] [],
+                slash_token: SLASH@23..24 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_KW@24..28 "html" [] [],
+                },
+                r_angle_token: R_ANGLE@28..29 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@29..30 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..30
+  0: (empty)
+  1: (empty)
+  2: HTML_DIRECTIVE@0..15
+    0: L_ANGLE@0..1 "<" [] []
+    1: BANG@1..2 "!" [] []
+    2: DOCTYPE_KW@2..10 "DoCtYpE" [] [Whitespace(" ")]
+    3: HTML_KW@10..14 "hTmL" [] []
+    4: (empty)
+    5: (empty)
+    6: (empty)
+    7: R_ANGLE@14..15 ">" [] []
+  3: HTML_ELEMENT_LIST@15..29
+    0: HTML_ELEMENT@15..29
+      0: HTML_OPENING_ELEMENT@15..22
+        0: L_ANGLE@15..17 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@17..21
+          0: HTML_KW@17..21 "html" [] []
+        2: HTML_ATTRIBUTE_LIST@21..21
+        3: R_ANGLE@21..22 ">" [] []
+      1: HTML_ELEMENT_LIST@22..22
+      2: HTML_CLOSING_ELEMENT@22..29
+        0: L_ANGLE@22..23 "<" [] []
+        1: SLASH@23..24 "/" [] []
+        2: HTML_TAG_NAME@24..28
+          0: HTML_KW@24..28 "html" [] []
+        3: R_ANGLE@28..29 ">" [] []
+  4: EOF@29..30 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
    Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
    Please provide enough information so that others can review your PR.
    Once created, your PR will be automatically labeled according to changed files.
    Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Previously, we weren't accepting mixed case doctype declarations. Now we do.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>