### PR TITLE
fix(cli): create the log directory before starting the file appender

### DIFF
--- a/.changeset/daemon-log-dir-stderr.md
+++ b/.changeset/daemon-log-dir-stderr.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a spurious `Error reading the log directory/files: No such file or directory` message printed to stderr the first time the daemon starts. The log directory is now created before the rolling file appender inspects it, so editors no longer surface an error when they connect to the LSP for the first time.

--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -212,6 +212,13 @@ pub(crate) fn read_most_recent_log_file(
 /// `biome-logs/server.log.yyyy-MM-dd-HH` files inside the system temporary
 /// directory)
 fn setup_tracing_subscriber(log_path: Utf8PathBuf, log_file_name_prefix: String) {
+    // `max_log_files` makes the appender enumerate the log directory as it is built. On a
+    // first run that directory doesn't exist yet, and tracing-appender reports the failed
+    // read straight to stderr, which LSP clients surface as an error even though the daemon
+    // starts fine. Creating it up front keeps startup quiet; if it cannot be created,
+    // `build()` below still fails with a clearer message.
+    let _ = fs::create_dir_all(&log_path);
+
     let appender_builder = tracing_appender::rolling::RollingFileAppender::builder();
     let file_appender = appender_builder
         .filename_prefix(log_file_name_prefix)


### PR DESCRIPTION
## Summary

Closes #11025.

`setup_tracing_subscriber` builds the appender with `max_log_files(7)`, which makes
`tracing-appender` list the log directory. The directory doesn't exist on a first run, so the failed
read is printed straight to stderr and editors report it as an error even though the daemon starts
just fine.

Fix: create the directory before building the appender. Doing it in `setup_tracing_subscriber` also
covers a custom `BIOME_LOG_PATH`, and the result is ignored because `build()` below still
`expect()`s on failure.

> This PR was created with AI assistance (Claude Code).

## Test Plan

- `rm -rf ~/.cache/biome/biome-logs && target/debug/biome __run_server`: the error is printed before
  the fix, nothing after, and `server.log.<date>-<hour>` is still written
- No automated test: `setup_tracing_subscriber` installs a global subscriber and the `biome_cli`
  tests use an in-memory filesystem
