### PR TITLE
fix(noUselessTernary): keep operator spacing intact in the fix 🤖🤖🤖

### DIFF
--- a/.changeset/fix-useless-ternary-operator-spacing.md
+++ b/.changeset/fix-useless-ternary-operator-spacing.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11092](https://github.com/biomejs/biome/issues/11092): the [`noUselessTernary`](https://biomejs.dev/linter/rules/no-useless-ternary/) fix no longer doubles the whitespace around the operator when the ternary test is a binary, `instanceof`, or `in` expression, and no longer drops the whitespace when it inverts a comparison.

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
@@ -154,10 +154,13 @@ impl Rule for NoUselessTernary {
                         .ok()?
                         .kind();
 
+                    // The operator carries a space on each side, so the
+                    // operands must not keep the whitespace that surrounded
+                    // the original operator or it ends up doubled.
                     new_node = AnyJsExpression::from(make::js_binary_expression(
-                        left,
+                        left.trim_trailing_trivia()?,
                         make::token_decorated_with_space(operator),
-                        right,
+                        right.trim_leading_trivia()?,
                     ));
                 }
                 JsSyntaxKind::JS_INSTANCEOF_EXPRESSION => {
@@ -174,9 +177,9 @@ impl Rule for NoUselessTernary {
                         .right()
                         .ok()?;
                     new_node = make::js_instanceof_expression(
-                        left,
+                        left.trim_trailing_trivia()?,
                         make::token_decorated_with_space(T![instanceof]),
-                        right,
+                        right.trim_leading_trivia()?,
                     )
                     .into();
                 }
@@ -184,9 +187,9 @@ impl Rule for NoUselessTernary {
                     let property = node.test().ok()?.as_js_in_expression()?.property().ok()?;
                     let object = node.test().ok()?.as_js_in_expression()?.object().ok()?;
                     new_node = make::js_in_expression(
-                        property,
+                        property.trim_trailing_trivia()?,
                         make::token_decorated_with_space(T![in]),
-                        object,
+                        object.trim_leading_trivia()?,
                     )
                     .into();
                 }
@@ -266,10 +269,12 @@ fn invert_expression(expression: &AnyJsExpression) -> Option<AnyJsExpression> {
         if let Some(operator) = suggested_operator {
             let left = expression.as_js_binary_expression()?.left().ok()?;
             let right = expression.as_js_binary_expression()?.right().ok()?;
+            // Same as above: the replacement operator brings its own spacing,
+            // so the operands must not carry the original operator's.
             let new_node = AnyJsExpression::from(make::js_binary_expression(
-                left,
-                make::token(operator),
-                right,
+                left.trim_trailing_trivia()?,
+                make::token_decorated_with_space(operator),
+                right.trim_leading_trivia()?,
             ));
 
             return Some(new_node);

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js
@@ -18,3 +18,6 @@ var a = x instanceof foo ? true : false;
 
 var a = 'make' in car ? true : false;
 var a = 'make' in car ? false : true;
+var a = x.indexOf('y') > -1 ? true : false;
+var b = obj.prop instanceof Foo ? true : false;
+var c = 'key' in someObject ? true : false;

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js.snap
@@ -24,6 +24,10 @@ var a = x instanceof foo ? true : false;
 
 var a = 'make' in car ? true : false;
 var a = 'make' in car ? false : true;
+var a = x.indexOf('y') > -1 ? true : false;
+var b = obj.prop instanceof Foo ? true : false;
+var c = 'key' in someObject ? true : false;
+
 ```
 
 # Diagnostics
@@ -151,7 +155,7 @@ invalid.js:6:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━�
      4  4 │   var a = foo() ? false : true;
      5  5 │   var a = foo ? false : true;
      6    │ - var·a·=·foo·===·1·?·false·:·true;
-        6 │ + var·a·=·foo·!==1;
+        6 │ + var·a·=·foo·!==·1;
      7  7 │   var a = foo + 1 ? false : true;
      8  8 │   
   
@@ -263,13 +267,8 @@ invalid.js:11:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
   
   i Unsafe fix: Remove the conditional expression with
   
-     9  9 │   var a = foo() ? true : false;
-    10 10 │   var a = foo ? true : false;
-    11    │ - var·a·=·foo·===·1·?·true·:·false;
-       11 │ + var·a·=·foo··===·1;
-    12 12 │   var a = foo + 1 ? true : false;
-    13 13 │   
-  
+    11 │ var·a·=·foo·===·1·?·true·:·false;
+       │                  --------------- 
 
 ```
 
@@ -373,13 +372,8 @@ invalid.js:17:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
   
   i Unsafe fix: Remove the conditional expression with
   
-    15 15 │   
-    16 16 │   var a = x instanceof foo ? false : true;
-    17    │ - var·a·=·x·instanceof·foo·?·true·:·false;
-       17 │ + var·a·=·x··instanceof·foo;
-    18 18 │   
-    19 19 │   var a = 'make' in car ? true : false;
-  
+    17 │ var·a·=·x·instanceof·foo·?·true·:·false;
+       │                         --------------- 
 
 ```
 
@@ -393,6 +387,7 @@ invalid.js:19:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
   > 19 │ var a = 'make' in car ? true : false;
        │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     20 │ var a = 'make' in car ? false : true;
+    21 │ var a = x.indexOf('y') > -1 ? true : false;
   
   i Simplify your code by directly assigning the result without using a ternary operator.
   
@@ -401,12 +396,8 @@ invalid.js:19:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
   
   i Unsafe fix: Remove the conditional expression with
   
-    17 17 │   var a = x instanceof foo ? true : false;
-    18 18 │   
-    19    │ - var·a·=·'make'·in·car·?·true·:·false;
-       19 │ + var·a·=·'make'··in·car;
-    20 20 │   var a = 'make' in car ? false : true;
-  
+    19 │ var·a·=·'make'·in·car·?·true·:·false;
+       │                      --------------- 
 
 ```
 
@@ -418,6 +409,8 @@ invalid.js:20:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
     19 │ var a = 'make' in car ? true : false;
   > 20 │ var a = 'make' in car ? false : true;
        │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ var a = x.indexOf('y') > -1 ? true : false;
+    22 │ var b = obj.prop instanceof Foo ? true : false;
   
   i Simplify your code by directly assigning the result without using a ternary operator.
   
@@ -430,6 +423,79 @@ invalid.js:20:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
     19 19 │   var a = 'make' in car ? true : false;
     20    │ - var·a·=·'make'·in·car·?·false·:·true;
        20 │ + var·a·=·!('make'·in·car·);
+    21 21 │   var a = x.indexOf('y') > -1 ? true : false;
+    22 22 │   var b = obj.prop instanceof Foo ? true : false;
   
+
+```
+
+```
+invalid.js:21:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unnecessary use of boolean literals in conditional expression.
+  
+    19 │ var a = 'make' in car ? true : false;
+    20 │ var a = 'make' in car ? false : true;
+  > 21 │ var a = x.indexOf('y') > -1 ? true : false;
+       │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    22 │ var b = obj.prop instanceof Foo ? true : false;
+    23 │ var c = 'key' in someObject ? true : false;
+  
+  i Simplify your code by directly assigning the result without using a ternary operator.
+  
+  i If your goal is negation, you may use the logical NOT (!) or double NOT (!!) operator for clearer and concise code.
+     Check for more details about NOT operator.
+  
+  i Unsafe fix: Remove the conditional expression with
+  
+    21 │ var·a·=·x.indexOf('y')·>·-1·?·true·:·false;
+       │                            --------------- 
+
+```
+
+```
+invalid.js:22:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unnecessary use of boolean literals in conditional expression.
+  
+    20 │ var a = 'make' in car ? false : true;
+    21 │ var a = x.indexOf('y') > -1 ? true : false;
+  > 22 │ var b = obj.prop instanceof Foo ? true : false;
+       │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    23 │ var c = 'key' in someObject ? true : false;
+    24 │ 
+  
+  i Simplify your code by directly assigning the result without using a ternary operator.
+  
+  i If your goal is negation, you may use the logical NOT (!) or double NOT (!!) operator for clearer and concise code.
+     Check for more details about NOT operator.
+  
+  i Unsafe fix: Remove the conditional expression with
+  
+    22 │ var·b·=·obj.prop·instanceof·Foo·?·true·:·false;
+       │                                --------------- 
+
+```
+
+```
+invalid.js:23:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unnecessary use of boolean literals in conditional expression.
+  
+    21 │ var a = x.indexOf('y') > -1 ? true : false;
+    22 │ var b = obj.prop instanceof Foo ? true : false;
+  > 23 │ var c = 'key' in someObject ? true : false;
+       │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │ 
+  
+  i Simplify your code by directly assigning the result without using a ternary operator.
+  
+  i If your goal is negation, you may use the logical NOT (!) or double NOT (!!) operator for clearer and concise code.
+     Check for more details about NOT operator.
+  
+  i Unsafe fix: Remove the conditional expression with
+  
+    23 │ var·c·=·'key'·in·someObject·?·true·:·false;
+       │                            --------------- 
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid_without_trivia.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid_without_trivia.js.snap
@@ -152,7 +152,7 @@ invalid_without_trivia.js:6:9 lint/complexity/noUselessTernary  FIXABLE  ━━�
      4  4 │   var a = foo()?false:true;
      5  5 │   var a = foo?false:true;
      6    │ - var·a·=·foo===1?false:true;
-        6 │ + var·a·=·foo!==1;
+        6 │ + var·a·=·foo·!==·1;
      7  7 │   var a = foo+1?false:true;
      8  8 │   
   


### PR DESCRIPTION
## Summary

Fixes #11092

`token_decorated_with_space` puts a space on each side of the operator, but the operands still carried the whitespace that surrounded the original one, so the fix doubled it. `foo === 1 ? true : false` became `foo  === 1`.

While adding a test I hit the mirror bug in `invert_expression`: it builds the inverted comparison with `make::token`, which has no spacing, so the left operand's trailing space survived and the right side lost its leading one. `foo === 1 ? false : true` became `foo !==1`. That one was already visible in the committed snapshot.

Both are fixed by trimming the trivia the replacement operator supplies itself. Applied to binary, `instanceof` and `in` tests, since all three build the operator the same way.

## Test Plan

Added the reported case plus `instanceof` and `in` variants to `invalid.js`. The snapshot diff shows `foo  === 1` becoming `foo === 1` and `foo !==1` becoming `foo !== 1`.

`cargo test -p biome_js_analyze --test spec_tests` passes, 2735 tests.

## Docs

Not applicable, no rule behaviour or option changed.

---

This PR was written primarily by Claude Code (Claude Sonnet 5), including the root cause analysis and the tests. I reviewed the diff and the test output before submitting.
