### PR TITLE
feat(css_syntax): allow SCSS variables in rule lists

### DIFF
--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -5382,7 +5382,7 @@ where
 }
 pub fn css_rule_list<I>(items: I) -> CssRuleList
 where
-    I: IntoIterator<Item = AnyCssRule>,
+    I: IntoIterator<Item = AnyCssRuleListItem>,
     I::IntoIter: ExactSizeIterator,
 {
     CssRuleList::unwrap_cast(SyntaxNode::new_detached(

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -9642,7 +9642,9 @@ impl SyntaxFactory for CssSyntaxFactory {
             CSS_ROOT_ITEM_LIST => {
                 Self::make_node_list_syntax(kind, children, AnyCssRootItem::can_cast)
             }
-            CSS_RULE_LIST => Self::make_node_list_syntax(kind, children, AnyCssRule::can_cast),
+            CSS_RULE_LIST => {
+                Self::make_node_list_syntax(kind, children, AnyCssRuleListItem::can_cast)
+            }
             CSS_SELECTOR_LIST => Self::make_separated_list_syntax(
                 kind,
                 children,

--- a/crates/biome_css_formatter/src/css/any/mod.rs
+++ b/crates/biome_css_formatter/src/css/any/mod.rs
@@ -95,6 +95,7 @@ pub(crate) mod root;
 pub(crate) mod root_item;
 pub(crate) mod rule;
 pub(crate) mod rule_block;
+pub(crate) mod rule_list_item;
 pub(crate) mod scope_range;
 pub(crate) mod selector;
 pub(crate) mod selector_custom_identifier;

--- a/crates/biome_css_formatter/src/css/any/rule_list_item.rs
+++ b/crates/biome_css_formatter/src/css/any/rule_list_item.rs
@@ -1,0 +1,15 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
+
+use crate::prelude::*;
+use biome_css_syntax::AnyCssRuleListItem;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatAnyCssRuleListItem;
+impl FormatRule<AnyCssRuleListItem> for FormatAnyCssRuleListItem {
+    type Context = CssFormatContext;
+    fn fmt(&self, node: &AnyCssRuleListItem, f: &mut CssFormatter) -> FormatResult<()> {
+        match node {
+            AnyCssRuleListItem::AnyCssRule(node) => node.format().fmt(f),
+            AnyCssRuleListItem::ScssVariableDeclaration(node) => node.format().fmt(f),
+        }
+    }
+}

--- a/crates/biome_css_formatter/src/css/lists/rule_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/rule_list.rs
@@ -9,8 +9,8 @@ impl FormatRule<CssRuleList> for FormatCssRuleList {
         // lines from the input, so we can use `join_nodes_with_hardline`.
         let mut join = f.join_nodes_with_hardline();
 
-        for rule in node {
-            join.entry(rule.syntax(), &format_or_verbatim(rule.format()));
+        for item in node {
+            join.entry(item.syntax(), &format_or_verbatim(item.format()));
         }
 
         join.finish()

--- a/crates/biome_css_formatter/src/generated.rs
+++ b/crates/biome_css_formatter/src/generated.rs
@@ -15247,6 +15247,31 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssRuleBlock {
         )
     }
 }
+impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssRuleListItem {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_css_syntax::AnyCssRuleListItem,
+        crate::css::any::rule_list_item::FormatAnyCssRuleListItem,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::css::any::rule_list_item::FormatAnyCssRuleListItem::default(),
+        )
+    }
+}
+impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssRuleListItem {
+    type Format = FormatOwnedWithRule<
+        biome_css_syntax::AnyCssRuleListItem,
+        crate::css::any::rule_list_item::FormatAnyCssRuleListItem,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::css::any::rule_list_item::FormatAnyCssRuleListItem::default(),
+        )
+    }
+}
 impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssScopeRange {
     type Format<'a> = FormatRefWithRule<
         'a,

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/conditional-block-variables.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/conditional-block-variables.scss
@@ -1,0 +1,4 @@
+@media(width >= 40rem){$gap:2rem;.before{margin:$gap}$columns:3;a:hover{margin:$gap}@supports(display:grid){$display:grid;.grid{display:$display}}}
+@supports(display:grid){.before{display:block}$display:grid;.after{display:$display}}
+.card{@media(width >= 60rem){$color:red;color:$color}}
+@document regexp(".*"){$theme:dark;.document{color:$theme}}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/conditional-block-variables.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/conditional-block-variables.scss.snap
@@ -1,0 +1,58 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/at-rule/conditional-block-variables.scss
+---
+
+# Input
+
+```scss
+@media(width >= 40rem){$gap:2rem;.before{margin:$gap}$columns:3;a:hover{margin:$gap}@supports(display:grid){$display:grid;.grid{display:$display}}}
+@supports(display:grid){.before{display:block}$display:grid;.after{display:$display}}
+.card{@media(width >= 60rem){$color:red;color:$color}}
+@document regexp(".*"){$theme:dark;.document{color:$theme}}
+
+```
+
+
+# Formatted
+
+```scss
+@media (width >= 40rem) {
+	$gap: 2rem;
+	.before {
+		margin: $gap;
+	}
+	$columns: 3;
+	a:hover {
+		margin: $gap;
+	}
+	@supports (display: grid) {
+		$display: grid;
+		.grid {
+			display: $display;
+		}
+	}
+}
+@supports (display: grid) {
+	.before {
+		display: block;
+	}
+	$display: grid;
+	.after {
+		display: $display;
+	}
+}
+.card {
+	@media (width >= 60rem) {
+		$color: red;
+		color: $color;
+	}
+}
+@document regexp(".*") {
+	$theme: dark;
+	.document {
+		color: $theme;
+	}
+}
+
+```

--- a/crates/biome_css_parser/src/syntax/block/conditional_block.rs
+++ b/crates/biome_css_parser/src/syntax/block/conditional_block.rs
@@ -14,6 +14,17 @@ use crate::syntax::block::{parse_declaration_or_rule_list_block, parse_rule_bloc
 /// In addition to nested style rules, this specification allows nested group rules inside of style rules:
 /// any at-rule whose body contains style rules can be nested inside of a style rule as well.
 ///
+/// Top-level SCSS conditional blocks also accept variable declarations:
+///
+/// ```scss
+/// @supports (display: grid) {
+///   $display: grid;
+///   .grid {
+///     display: $display;
+///   }
+/// }
+/// ```
+///
 /// For more detailed information refer to the
 /// [CSS Nesting Module](https://drafts.csswg.org/css-nesting-1/#conditionals)
 ///

--- a/crates/biome_css_parser/src/syntax/block/rule_block.rs
+++ b/crates/biome_css_parser/src/syntax/block/rule_block.rs
@@ -11,6 +11,7 @@ use crate::syntax::block::ParseBlockBody;
 pub(crate) fn parse_rule_block(p: &mut CssParser) -> CompletedMarker {
     RuleBlock.parse_block_body(p)
 }
+
 struct RuleBlock;
 
 impl ParseBlockBody for RuleBlock {

--- a/crates/biome_css_parser/src/syntax/mod.rs
+++ b/crates/biome_css_parser/src/syntax/mod.rs
@@ -14,7 +14,7 @@ use crate::parser::CssParser;
 use crate::syntax::at_rule::{is_at_at_rule, parse_at_rule};
 use crate::syntax::block::{DeclarationOrRuleList, parse_declaration_or_rule_list_block};
 use crate::syntax::parse_error::{
-    expected_any_rule, expected_non_css_wide_keyword_identifier,
+    expected_any_rule, expected_any_rule_list_item, expected_non_css_wide_keyword_identifier,
     inconsistent_scss_bracketed_list_separators, scss_only_syntax_error, tailwind_disabled,
 };
 use crate::syntax::property::color::{is_at_color, parse_color};
@@ -164,7 +164,7 @@ impl RuleList {
 
 #[inline]
 pub(crate) fn is_at_rule_list_element(p: &mut CssParser) -> bool {
-    is_at_at_rule(p) || is_at_qualified_rule(p)
+    is_at_at_rule(p) || is_at_scss_variable_declaration(p) || is_at_qualified_rule(p)
 }
 
 struct RuleListParseRecovery {
@@ -195,6 +195,14 @@ impl ParseNodeList for RuleList {
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
         if is_at_at_rule(p) {
             parse_at_rule(p)
+        } else if is_at_scss_variable_declaration(p) {
+            CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+                p,
+                parse_scss_variable_declaration,
+                |p, marker| {
+                    scss_only_syntax_error(p, "SCSS variable declarations", marker.range(p))
+                },
+            )
         } else if is_at_qualified_rule(p) {
             parse_qualified_rule(p)
         } else {
@@ -214,7 +222,7 @@ impl ParseNodeList for RuleList {
         parsed_element.or_recover(
             p,
             &RuleListParseRecovery::new(self.end_kind),
-            expected_any_rule,
+            expected_any_rule_list_item,
         )
     }
 }

--- a/crates/biome_css_parser/src/syntax/parse_error.rs
+++ b/crates/biome_css_parser/src/syntax/parse_error.rs
@@ -63,6 +63,18 @@ pub(crate) fn expected_any_rule(p: &CssParser, range: TextRange) -> ParseDiagnos
     expected_any(&["qualified rule", "at rule"], range, p)
 }
 
+pub(crate) fn expected_any_rule_list_item(p: &CssParser, range: TextRange) -> ParseDiagnostic {
+    if p.source_type.is_scss() {
+        expected_any(
+            &["qualified rule", "at rule", "SCSS variable declaration"],
+            range,
+            p,
+        )
+    } else {
+        expected_any_rule(p, range)
+    }
+}
+
 pub(crate) fn expected_any_declaration_or_at_rule(
     p: &CssParser,
     range: TextRange,

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/conditional_block_variables.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/conditional_block_variables.css
@@ -1,0 +1,7 @@
+@media (width >= 40rem) {
+  $gap: 2rem;
+
+  .card {
+    margin: 2rem;
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/conditional_block_variables.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/conditional_block_variables.css.snap
@@ -1,0 +1,214 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@media (width >= 40rem) {
+  $gap: 2rem;
+
+  .card {
+    margin: 2rem;
+  }
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1..7 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaFeatureInParens {
+                                l_paren_token: L_PAREN@7..8 "(" [] [],
+                                feature: CssQueryFeatureRange {
+                                    left: CssIdentifier {
+                                        value_token: IDENT@8..14 "width" [] [Whitespace(" ")],
+                                    },
+                                    comparison: CssQueryFeatureRangeComparison {
+                                        operator: GTEQ@14..17 ">=" [] [Whitespace(" ")],
+                                    },
+                                    right: CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@17..19 "40" [] [],
+                                        unit_token: IDENT@19..22 "rem" [] [],
+                                    },
+                                },
+                                r_paren_token: R_PAREN@22..24 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+                block: CssBogusBlock {
+                    items: [
+                        L_CURLY@24..25 "{" [] [],
+                        CssBogus {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        ScssVariable {
+                                            dollar_token: DOLLAR@25..29 "$" [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssIdentifier {
+                                                value_token: IDENT@29..32 "gap" [] [],
+                                            },
+                                        },
+                                        COLON@32..34 ":" [] [Whitespace(" ")],
+                                        ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssRegularDimension {
+                                                    value_token: CSS_NUMBER_LITERAL@34..35 "2" [] [],
+                                                    unit_token: IDENT@35..38 "rem" [] [],
+                                                },
+                                            ],
+                                        },
+                                        ScssVariableModifierList [],
+                                        SEMICOLON@38..39 ";" [] [],
+                                    ],
+                                },
+                                CssQualifiedRule {
+                                    prelude: CssSelectorList [
+                                        CssCompoundSelector {
+                                            nesting_selectors: CssNestedSelectorList [],
+                                            simple_selector: missing (optional),
+                                            sub_selectors: CssSubSelectorList [
+                                                CssClassSelector {
+                                                    dot_token: DOT@39..44 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                                    name: CssCustomIdentifier {
+                                                        value_token: IDENT@44..49 "card" [] [Whitespace(" ")],
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                    block: CssDeclarationOrRuleBlock {
+                                        l_curly_token: L_CURLY@49..50 "{" [] [],
+                                        items: CssDeclarationOrRuleList [
+                                            CssDeclarationWithSemicolon {
+                                                declaration: CssDeclaration {
+                                                    property: CssGenericProperty {
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@50..61 "margin" [Newline("\n"), Whitespace("    ")] [],
+                                                        },
+                                                        colon_token: COLON@61..63 ":" [] [Whitespace(" ")],
+                                                        value: CssGenericComponentValueList [
+                                                            CssRegularDimension {
+                                                                value_token: CSS_NUMBER_LITERAL@63..64 "2" [] [],
+                                                                unit_token: IDENT@64..67 "rem" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    important: missing (optional),
+                                                },
+                                                semicolon_token: SEMICOLON@67..68 ";" [] [],
+                                            },
+                                        ],
+                                        r_curly_token: R_CURLY@68..72 "}" [Newline("\n"), Whitespace("  ")] [],
+                                    },
+                                },
+                            ],
+                        },
+                        R_CURLY@72..74 "}" [Newline("\n")] [],
+                    ],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@74..75 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..75
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..74
+    0: CSS_AT_RULE@0..74
+      0: AT@0..1 "@" [] []
+      1: CSS_MEDIA_AT_RULE@1..74
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1..24
+          0: MEDIA_KW@1..7 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@7..24
+            0: CSS_MEDIA_CONDITION_QUERY@7..24
+              0: CSS_MEDIA_FEATURE_IN_PARENS@7..24
+                0: L_PAREN@7..8 "(" [] []
+                1: CSS_QUERY_FEATURE_RANGE@8..22
+                  0: CSS_IDENTIFIER@8..14
+                    0: IDENT@8..14 "width" [] [Whitespace(" ")]
+                  1: CSS_QUERY_FEATURE_RANGE_COMPARISON@14..17
+                    0: GTEQ@14..17 ">=" [] [Whitespace(" ")]
+                  2: CSS_REGULAR_DIMENSION@17..22
+                    0: CSS_NUMBER_LITERAL@17..19 "40" [] []
+                    1: IDENT@19..22 "rem" [] []
+                2: R_PAREN@22..24 ")" [] [Whitespace(" ")]
+        1: CSS_BOGUS_BLOCK@24..74
+          0: L_CURLY@24..25 "{" [] []
+          1: CSS_BOGUS@25..72
+            0: CSS_BOGUS@25..39
+              0: SCSS_VARIABLE@25..32
+                0: DOLLAR@25..29 "$" [Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@29..32
+                  0: IDENT@29..32 "gap" [] []
+              1: COLON@32..34 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@34..38
+                0: SCSS_EXPRESSION_ITEM_LIST@34..38
+                  0: CSS_REGULAR_DIMENSION@34..38
+                    0: CSS_NUMBER_LITERAL@34..35 "2" [] []
+                    1: IDENT@35..38 "rem" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@38..38
+              4: SEMICOLON@38..39 ";" [] []
+            1: CSS_QUALIFIED_RULE@39..72
+              0: CSS_SELECTOR_LIST@39..49
+                0: CSS_COMPOUND_SELECTOR@39..49
+                  0: CSS_NESTED_SELECTOR_LIST@39..39
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@39..49
+                    0: CSS_CLASS_SELECTOR@39..49
+                      0: DOT@39..44 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@44..49
+                        0: IDENT@44..49 "card" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@49..72
+                0: L_CURLY@49..50 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@50..68
+                  0: CSS_DECLARATION_WITH_SEMICOLON@50..68
+                    0: CSS_DECLARATION@50..67
+                      0: CSS_GENERIC_PROPERTY@50..67
+                        0: CSS_IDENTIFIER@50..61
+                          0: IDENT@50..61 "margin" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@61..63 ":" [] [Whitespace(" ")]
+                        2: CSS_GENERIC_COMPONENT_VALUE_LIST@63..67
+                          0: CSS_REGULAR_DIMENSION@63..67
+                            0: CSS_NUMBER_LITERAL@63..64 "2" [] []
+                            1: IDENT@64..67 "rem" [] []
+                      1: (empty)
+                    1: SEMICOLON@67..68 ";" [] []
+                2: R_CURLY@68..72 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@72..74 "}" [Newline("\n")] []
+  2: EOF@74..75 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+conditional_block_variables.css:2:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS variable declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    1 │ @media (width >= 40rem) {
+  > 2 │   $gap: 2rem;
+      │   ^^^^^^^^^^^
+    3 │ 
+    4 │   .card {
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/conditional_block_variables_supports.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/conditional_block_variables_supports.css
@@ -1,0 +1,3 @@
+@supports (display: grid) {
+  $display: grid;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/conditional_block_variables_supports.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/conditional_block_variables_supports.css.snap
@@ -1,0 +1,139 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@supports (display: grid) {
+  $display: grid;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@1..10 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@10..11 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@11..18 "display" [] [],
+                                },
+                                colon_token: COLON@18..20 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssIdentifier {
+                                        value_token: IDENT@20..24 "grid" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssBogusBlock {
+                    items: [
+                        L_CURLY@26..27 "{" [] [],
+                        CssBogus {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        ScssVariable {
+                                            dollar_token: DOLLAR@27..31 "$" [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssIdentifier {
+                                                value_token: IDENT@31..38 "display" [] [],
+                                            },
+                                        },
+                                        COLON@38..40 ":" [] [Whitespace(" ")],
+                                        ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@40..44 "grid" [] [],
+                                                },
+                                            ],
+                                        },
+                                        ScssVariableModifierList [],
+                                        SEMICOLON@44..45 ";" [] [],
+                                    ],
+                                },
+                            ],
+                        },
+                        R_CURLY@45..47 "}" [Newline("\n")] [],
+                    ],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@47..48 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..48
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..47
+    0: CSS_AT_RULE@0..47
+      0: AT@0..1 "@" [] []
+      1: CSS_SUPPORTS_AT_RULE@1..47
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@1..26
+          0: SUPPORTS_KW@1..10 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@10..26
+            0: L_PAREN@10..11 "(" [] []
+            1: CSS_DECLARATION@11..24
+              0: CSS_GENERIC_PROPERTY@11..24
+                0: CSS_IDENTIFIER@11..18
+                  0: IDENT@11..18 "display" [] []
+                1: COLON@18..20 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@20..24
+                  0: CSS_IDENTIFIER@20..24
+                    0: IDENT@20..24 "grid" [] []
+              1: (empty)
+            2: R_PAREN@24..26 ")" [] [Whitespace(" ")]
+        1: CSS_BOGUS_BLOCK@26..47
+          0: L_CURLY@26..27 "{" [] []
+          1: CSS_BOGUS@27..45
+            0: CSS_BOGUS@27..45
+              0: SCSS_VARIABLE@27..38
+                0: DOLLAR@27..31 "$" [Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@31..38
+                  0: IDENT@31..38 "display" [] []
+              1: COLON@38..40 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@40..44
+                0: SCSS_EXPRESSION_ITEM_LIST@40..44
+                  0: CSS_IDENTIFIER@40..44
+                    0: IDENT@40..44 "grid" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@44..44
+              4: SEMICOLON@44..45 ";" [] []
+          2: R_CURLY@45..47 "}" [Newline("\n")] []
+  2: EOF@47..48 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+conditional_block_variables_supports.css:2:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS variable declarations are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    1 │ @supports (display: grid) {
+  > 2 │   $display: grid;
+      │   ^^^^^^^^^^^^^^^
+    3 │ }
+    4 │ 
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/conditional-block-variables.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/conditional-block-variables.scss
@@ -1,0 +1,7 @@
+@media (width >= 40rem) {
+  $gap:;
+
+  .after {
+    margin: 0;
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/conditional-block-variables.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/conditional-block-variables.scss.snap
@@ -1,0 +1,206 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@media (width >= 40rem) {
+  $gap:;
+
+  .after {
+    margin: 0;
+  }
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1..7 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaFeatureInParens {
+                                l_paren_token: L_PAREN@7..8 "(" [] [],
+                                feature: CssQueryFeatureRange {
+                                    left: CssIdentifier {
+                                        value_token: IDENT@8..14 "width" [] [Whitespace(" ")],
+                                    },
+                                    comparison: CssQueryFeatureRangeComparison {
+                                        operator: GTEQ@14..17 ">=" [] [Whitespace(" ")],
+                                    },
+                                    right: CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@17..19 "40" [] [],
+                                        unit_token: IDENT@19..22 "rem" [] [],
+                                    },
+                                },
+                                r_paren_token: R_PAREN@22..24 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@24..25 "{" [] [],
+                    rules: CssRuleList [
+                        ScssVariableDeclaration {
+                            name: ScssVariable {
+                                dollar_token: DOLLAR@25..29 "$" [Newline("\n"), Whitespace("  ")] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@29..32 "gap" [] [],
+                                },
+                            },
+                            colon_token: COLON@32..33 ":" [] [],
+                            value: missing (required),
+                            modifiers: ScssVariableModifierList [],
+                            semicolon_token: SEMICOLON@33..34 ";" [] [],
+                        },
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@34..39 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@39..45 "after" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@45..46 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@46..57 "margin" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@57..59 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssNumber {
+                                                            value_token: CSS_NUMBER_LITERAL@59..60 "0" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@60..61 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@61..65 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@65..67 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@67..68 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..68
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..67
+    0: CSS_AT_RULE@0..67
+      0: AT@0..1 "@" [] []
+      1: CSS_MEDIA_AT_RULE@1..67
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1..24
+          0: MEDIA_KW@1..7 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@7..24
+            0: CSS_MEDIA_CONDITION_QUERY@7..24
+              0: CSS_MEDIA_FEATURE_IN_PARENS@7..24
+                0: L_PAREN@7..8 "(" [] []
+                1: CSS_QUERY_FEATURE_RANGE@8..22
+                  0: CSS_IDENTIFIER@8..14
+                    0: IDENT@8..14 "width" [] [Whitespace(" ")]
+                  1: CSS_QUERY_FEATURE_RANGE_COMPARISON@14..17
+                    0: GTEQ@14..17 ">=" [] [Whitespace(" ")]
+                  2: CSS_REGULAR_DIMENSION@17..22
+                    0: CSS_NUMBER_LITERAL@17..19 "40" [] []
+                    1: IDENT@19..22 "rem" [] []
+                2: R_PAREN@22..24 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@24..67
+          0: L_CURLY@24..25 "{" [] []
+          1: CSS_RULE_LIST@25..65
+            0: SCSS_VARIABLE_DECLARATION@25..34
+              0: SCSS_VARIABLE@25..32
+                0: DOLLAR@25..29 "$" [Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@29..32
+                  0: IDENT@29..32 "gap" [] []
+              1: COLON@32..33 ":" [] []
+              2: (empty)
+              3: SCSS_VARIABLE_MODIFIER_LIST@33..33
+              4: SEMICOLON@33..34 ";" [] []
+            1: CSS_QUALIFIED_RULE@34..65
+              0: CSS_SELECTOR_LIST@34..45
+                0: CSS_COMPOUND_SELECTOR@34..45
+                  0: CSS_NESTED_SELECTOR_LIST@34..34
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@34..45
+                    0: CSS_CLASS_SELECTOR@34..45
+                      0: DOT@34..39 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@39..45
+                        0: IDENT@39..45 "after" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@45..65
+                0: L_CURLY@45..46 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@46..61
+                  0: CSS_DECLARATION_WITH_SEMICOLON@46..61
+                    0: CSS_DECLARATION@46..60
+                      0: CSS_GENERIC_PROPERTY@46..60
+                        0: CSS_IDENTIFIER@46..57
+                          0: IDENT@46..57 "margin" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@57..59 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@59..60
+                          0: SCSS_EXPRESSION_ITEM_LIST@59..60
+                            0: CSS_NUMBER@59..60
+                              0: CSS_NUMBER_LITERAL@59..60 "0" [] []
+                      1: (empty)
+                    1: SEMICOLON@60..61 ";" [] []
+                2: R_CURLY@61..65 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@65..67 "}" [Newline("\n")] []
+  2: EOF@67..68 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+conditional-block-variables.scss:2:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a SCSS expression but instead found ';'.
+  
+    1 │ @media (width >= 40rem) {
+  > 2 │   $gap:;
+      │        ^
+    3 │ 
+    4 │   .after {
+  
+  i Expected a SCSS expression here.
+  
+    1 │ @media (width >= 40rem) {
+  > 2 │   $gap:;
+      │        ^
+    3 │ 
+    4 │   .after {
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/conditional-block-variable-rule-list.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/conditional-block-variable-rule-list.scss
@@ -1,0 +1,7 @@
+@media (width >= 40rem) {
+  $gap: 2rem;
+
+  .card {
+    gap: $gap;
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/conditional-block-variable-rule-list.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/conditional-block-variable-rule-list.scss.snap
@@ -1,0 +1,199 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@media (width >= 40rem) {
+  $gap: 2rem;
+
+  .card {
+    gap: $gap;
+  }
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1..7 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaFeatureInParens {
+                                l_paren_token: L_PAREN@7..8 "(" [] [],
+                                feature: CssQueryFeatureRange {
+                                    left: CssIdentifier {
+                                        value_token: IDENT@8..14 "width" [] [Whitespace(" ")],
+                                    },
+                                    comparison: CssQueryFeatureRangeComparison {
+                                        operator: GTEQ@14..17 ">=" [] [Whitespace(" ")],
+                                    },
+                                    right: CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@17..19 "40" [] [],
+                                        unit_token: IDENT@19..22 "rem" [] [],
+                                    },
+                                },
+                                r_paren_token: R_PAREN@22..24 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@24..25 "{" [] [],
+                    rules: CssRuleList [
+                        ScssVariableDeclaration {
+                            name: ScssVariable {
+                                dollar_token: DOLLAR@25..29 "$" [Newline("\n"), Whitespace("  ")] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@29..32 "gap" [] [],
+                                },
+                            },
+                            colon_token: COLON@32..34 ":" [] [Whitespace(" ")],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@34..35 "2" [] [],
+                                        unit_token: IDENT@35..38 "rem" [] [],
+                                    },
+                                ],
+                            },
+                            modifiers: ScssVariableModifierList [],
+                            semicolon_token: SEMICOLON@38..39 ";" [] [],
+                        },
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@39..44 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@44..49 "card" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@49..50 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@50..58 "gap" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@58..60 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@60..61 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@61..64 "gap" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@64..65 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@65..69 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@69..71 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@71..72 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..72
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..71
+    0: CSS_AT_RULE@0..71
+      0: AT@0..1 "@" [] []
+      1: CSS_MEDIA_AT_RULE@1..71
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1..24
+          0: MEDIA_KW@1..7 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@7..24
+            0: CSS_MEDIA_CONDITION_QUERY@7..24
+              0: CSS_MEDIA_FEATURE_IN_PARENS@7..24
+                0: L_PAREN@7..8 "(" [] []
+                1: CSS_QUERY_FEATURE_RANGE@8..22
+                  0: CSS_IDENTIFIER@8..14
+                    0: IDENT@8..14 "width" [] [Whitespace(" ")]
+                  1: CSS_QUERY_FEATURE_RANGE_COMPARISON@14..17
+                    0: GTEQ@14..17 ">=" [] [Whitespace(" ")]
+                  2: CSS_REGULAR_DIMENSION@17..22
+                    0: CSS_NUMBER_LITERAL@17..19 "40" [] []
+                    1: IDENT@19..22 "rem" [] []
+                2: R_PAREN@22..24 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@24..71
+          0: L_CURLY@24..25 "{" [] []
+          1: CSS_RULE_LIST@25..69
+            0: SCSS_VARIABLE_DECLARATION@25..39
+              0: SCSS_VARIABLE@25..32
+                0: DOLLAR@25..29 "$" [Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@29..32
+                  0: IDENT@29..32 "gap" [] []
+              1: COLON@32..34 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@34..38
+                0: SCSS_EXPRESSION_ITEM_LIST@34..38
+                  0: CSS_REGULAR_DIMENSION@34..38
+                    0: CSS_NUMBER_LITERAL@34..35 "2" [] []
+                    1: IDENT@35..38 "rem" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@38..38
+              4: SEMICOLON@38..39 ";" [] []
+            1: CSS_QUALIFIED_RULE@39..69
+              0: CSS_SELECTOR_LIST@39..49
+                0: CSS_COMPOUND_SELECTOR@39..49
+                  0: CSS_NESTED_SELECTOR_LIST@39..39
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@39..49
+                    0: CSS_CLASS_SELECTOR@39..49
+                      0: DOT@39..44 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@44..49
+                        0: IDENT@44..49 "card" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@49..69
+                0: L_CURLY@49..50 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@50..65
+                  0: CSS_DECLARATION_WITH_SEMICOLON@50..65
+                    0: CSS_DECLARATION@50..64
+                      0: CSS_GENERIC_PROPERTY@50..64
+                        0: CSS_IDENTIFIER@50..58
+                          0: IDENT@50..58 "gap" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@58..60 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@60..64
+                          0: SCSS_EXPRESSION_ITEM_LIST@60..64
+                            0: SCSS_VARIABLE@60..64
+                              0: DOLLAR@60..61 "$" [] []
+                              1: CSS_IDENTIFIER@61..64
+                                0: IDENT@61..64 "gap" [] []
+                      1: (empty)
+                    1: SEMICOLON@64..65 ";" [] []
+                2: R_CURLY@65..69 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@69..71 "}" [Newline("\n")] []
+  2: EOF@71..72 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/conditional-block-variables.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/conditional-block-variables.scss
@@ -1,0 +1,69 @@
+@media (width >= 40rem) {
+  $gap: 2rem;
+
+  .before {
+    margin: $gap;
+  }
+
+  $columns: 3;
+
+  a:hover {
+    margin: $gap;
+  }
+
+  @supports (display: grid) {
+    $display: grid;
+
+    .grid {
+      display: $display;
+    }
+  }
+}
+
+@supports (display: grid) {
+  .before {
+    display: block;
+  }
+
+  $display: grid;
+
+  .after {
+    display: $display;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motion {
+    transition: none;
+  }
+}
+
+@supports (display: grid) {
+  .shell {
+    @media (width >= 60rem) {
+      $nested-gap: 2rem;
+      gap: $nested-gap;
+    }
+  }
+}
+
+.card {
+  @media (width >= 60rem) {
+    $color: red;
+    color: $color;
+  }
+}
+
+@document regexp(".*") {
+  $theme: dark;
+
+  .document {
+    color: $theme;
+  }
+}
+
+@media (width >= 40rem) {
+  [data-value$="suffix"] {
+    color: red;
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/conditional-block-variables.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/conditional-block-variables.scss.snap
@@ -1,0 +1,1538 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@media (width >= 40rem) {
+  $gap: 2rem;
+
+  .before {
+    margin: $gap;
+  }
+
+  $columns: 3;
+
+  a:hover {
+    margin: $gap;
+  }
+
+  @supports (display: grid) {
+    $display: grid;
+
+    .grid {
+      display: $display;
+    }
+  }
+}
+
+@supports (display: grid) {
+  .before {
+    display: block;
+  }
+
+  $display: grid;
+
+  .after {
+    display: $display;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motion {
+    transition: none;
+  }
+}
+
+@supports (display: grid) {
+  .shell {
+    @media (width >= 60rem) {
+      $nested-gap: 2rem;
+      gap: $nested-gap;
+    }
+  }
+}
+
+.card {
+  @media (width >= 60rem) {
+    $color: red;
+    color: $color;
+  }
+}
+
+@document regexp(".*") {
+  $theme: dark;
+
+  .document {
+    color: $theme;
+  }
+}
+
+@media (width >= 40rem) {
+  [data-value$="suffix"] {
+    color: red;
+  }
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1..7 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaFeatureInParens {
+                                l_paren_token: L_PAREN@7..8 "(" [] [],
+                                feature: CssQueryFeatureRange {
+                                    left: CssIdentifier {
+                                        value_token: IDENT@8..14 "width" [] [Whitespace(" ")],
+                                    },
+                                    comparison: CssQueryFeatureRangeComparison {
+                                        operator: GTEQ@14..17 ">=" [] [Whitespace(" ")],
+                                    },
+                                    right: CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@17..19 "40" [] [],
+                                        unit_token: IDENT@19..22 "rem" [] [],
+                                    },
+                                },
+                                r_paren_token: R_PAREN@22..24 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@24..25 "{" [] [],
+                    rules: CssRuleList [
+                        ScssVariableDeclaration {
+                            name: ScssVariable {
+                                dollar_token: DOLLAR@25..29 "$" [Newline("\n"), Whitespace("  ")] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@29..32 "gap" [] [],
+                                },
+                            },
+                            colon_token: COLON@32..34 ":" [] [Whitespace(" ")],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@34..35 "2" [] [],
+                                        unit_token: IDENT@35..38 "rem" [] [],
+                                    },
+                                ],
+                            },
+                            modifiers: ScssVariableModifierList [],
+                            semicolon_token: SEMICOLON@38..39 ";" [] [],
+                        },
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@39..44 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@44..51 "before" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@51..52 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@52..63 "margin" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@63..65 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@65..66 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@66..69 "gap" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@69..70 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@70..74 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                        ScssVariableDeclaration {
+                            name: ScssVariable {
+                                dollar_token: DOLLAR@74..79 "$" [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@79..86 "columns" [] [],
+                                },
+                            },
+                            colon_token: COLON@86..88 ":" [] [Whitespace(" ")],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    CssNumber {
+                                        value_token: CSS_NUMBER_LITERAL@88..89 "3" [] [],
+                                    },
+                                ],
+                            },
+                            modifiers: ScssVariableModifierList [],
+                            semicolon_token: SEMICOLON@89..90 ";" [] [],
+                        },
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@90..95 "a" [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [
+                                        CssPseudoClassSelector {
+                                            colon_token: COLON@95..96 ":" [] [],
+                                            class: CssPseudoClassIdentifier {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@96..102 "hover" [] [Whitespace(" ")],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@102..103 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@103..114 "margin" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@114..116 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@116..117 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@117..120 "gap" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@120..121 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@121..125 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                        CssAtRule {
+                            at_token: AT@125..130 "@" [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                            rule: CssSupportsAtRule {
+                                declarator: CssSupportsAtRuleDeclarator {
+                                    supports_token: SUPPORTS_KW@130..139 "supports" [] [Whitespace(" ")],
+                                    condition: CssSupportsFeatureDeclaration {
+                                        l_paren_token: L_PAREN@139..140 "(" [] [],
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@140..147 "display" [] [],
+                                                },
+                                                colon_token: COLON@147..149 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@149..153 "grid" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        r_paren_token: R_PAREN@153..155 ")" [] [Whitespace(" ")],
+                                    },
+                                },
+                                block: CssDeclarationOrRuleBlock {
+                                    l_curly_token: L_CURLY@155..156 "{" [] [],
+                                    items: CssDeclarationOrRuleList [
+                                        ScssVariableDeclaration {
+                                            name: ScssVariable {
+                                                dollar_token: DOLLAR@156..162 "$" [Newline("\n"), Whitespace("    ")] [],
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@162..169 "display" [] [],
+                                                },
+                                            },
+                                            colon_token: COLON@169..171 ":" [] [Whitespace(" ")],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    CssIdentifier {
+                                                        value_token: IDENT@171..175 "grid" [] [],
+                                                    },
+                                                ],
+                                            },
+                                            modifiers: ScssVariableModifierList [],
+                                            semicolon_token: SEMICOLON@175..176 ";" [] [],
+                                        },
+                                        CssNestedQualifiedRule {
+                                            prelude: CssRelativeSelectorList [
+                                                CssRelativeSelector {
+                                                    combinator: missing (optional),
+                                                    selector: CssCompoundSelector {
+                                                        nesting_selectors: CssNestedSelectorList [],
+                                                        simple_selector: missing (optional),
+                                                        sub_selectors: CssSubSelectorList [
+                                                            CssClassSelector {
+                                                                dot_token: DOT@176..183 "." [Newline("\n"), Newline("\n"), Whitespace("    ")] [],
+                                                                name: CssCustomIdentifier {
+                                                                    value_token: IDENT@183..188 "grid" [] [Whitespace(" ")],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                },
+                                            ],
+                                            block: CssDeclarationOrRuleBlock {
+                                                l_curly_token: L_CURLY@188..189 "{" [] [],
+                                                items: CssDeclarationOrRuleList [
+                                                    CssDeclarationWithSemicolon {
+                                                        declaration: CssDeclaration {
+                                                            property: CssGenericProperty {
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@189..203 "display" [Newline("\n"), Whitespace("      ")] [],
+                                                                },
+                                                                colon_token: COLON@203..205 ":" [] [Whitespace(" ")],
+                                                                value: ScssExpression {
+                                                                    items: ScssExpressionItemList [
+                                                                        ScssVariable {
+                                                                            dollar_token: DOLLAR@205..206 "$" [] [],
+                                                                            name: CssIdentifier {
+                                                                                value_token: IDENT@206..213 "display" [] [],
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                },
+                                                            },
+                                                            important: missing (optional),
+                                                        },
+                                                        semicolon_token: SEMICOLON@213..214 ";" [] [],
+                                                    },
+                                                ],
+                                                r_curly_token: R_CURLY@214..220 "}" [Newline("\n"), Whitespace("    ")] [],
+                                            },
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@220..224 "}" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@224..226 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@226..229 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@229..238 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@238..239 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@239..246 "display" [] [],
+                                },
+                                colon_token: COLON@246..248 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssIdentifier {
+                                            value_token: IDENT@248..252 "grid" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@252..254 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@254..255 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@255..259 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@259..266 "before" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@266..267 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@267..279 "display" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@279..281 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@281..286 "block" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@286..287 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@287..291 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                        ScssVariableDeclaration {
+                            name: ScssVariable {
+                                dollar_token: DOLLAR@291..296 "$" [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@296..303 "display" [] [],
+                                },
+                            },
+                            colon_token: COLON@303..305 ":" [] [Whitespace(" ")],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    CssIdentifier {
+                                        value_token: IDENT@305..309 "grid" [] [],
+                                    },
+                                ],
+                            },
+                            modifiers: ScssVariableModifierList [],
+                            semicolon_token: SEMICOLON@309..310 ";" [] [],
+                        },
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@310..315 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@315..321 "after" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@321..322 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@322..334 "display" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@334..336 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@336..337 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@337..344 "display" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@344..345 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@345..349 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@349..351 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@351..354 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@354..360 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaFeatureInParens {
+                                l_paren_token: L_PAREN@360..361 "(" [] [],
+                                feature: CssQueryFeaturePlain {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@361..383 "prefers-reduced-motion" [] [],
+                                    },
+                                    colon_token: COLON@383..385 ":" [] [Whitespace(" ")],
+                                    value: CssIdentifier {
+                                        value_token: IDENT@385..391 "reduce" [] [],
+                                    },
+                                },
+                                r_paren_token: R_PAREN@391..393 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@393..394 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@394..398 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@398..405 "motion" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@405..406 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@406..421 "transition" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@421..423 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@423..427 "none" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@427..428 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@428..432 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@432..434 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@434..437 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssSupportsAtRule {
+                declarator: CssSupportsAtRuleDeclarator {
+                    supports_token: SUPPORTS_KW@437..446 "supports" [] [Whitespace(" ")],
+                    condition: CssSupportsFeatureDeclaration {
+                        l_paren_token: L_PAREN@446..447 "(" [] [],
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@447..454 "display" [] [],
+                                },
+                                colon_token: COLON@454..456 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssIdentifier {
+                                            value_token: IDENT@456..460 "grid" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        r_paren_token: R_PAREN@460..462 ")" [] [Whitespace(" ")],
+                    },
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@462..463 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@463..467 "." [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@467..473 "shell" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@473..474 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssAtRule {
+                                        at_token: AT@474..480 "@" [Newline("\n"), Whitespace("    ")] [],
+                                        rule: CssMediaAtRule {
+                                            declarator: CssMediaAtRuleDeclarator {
+                                                media_token: MEDIA_KW@480..486 "media" [] [Whitespace(" ")],
+                                                queries: CssMediaQueryList [
+                                                    CssMediaConditionQuery {
+                                                        condition: CssMediaFeatureInParens {
+                                                            l_paren_token: L_PAREN@486..487 "(" [] [],
+                                                            feature: CssQueryFeatureRange {
+                                                                left: CssIdentifier {
+                                                                    value_token: IDENT@487..493 "width" [] [Whitespace(" ")],
+                                                                },
+                                                                comparison: CssQueryFeatureRangeComparison {
+                                                                    operator: GTEQ@493..496 ">=" [] [Whitespace(" ")],
+                                                                },
+                                                                right: CssRegularDimension {
+                                                                    value_token: CSS_NUMBER_LITERAL@496..498 "60" [] [],
+                                                                    unit_token: IDENT@498..501 "rem" [] [],
+                                                                },
+                                                            },
+                                                            r_paren_token: R_PAREN@501..503 ")" [] [Whitespace(" ")],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            block: CssDeclarationOrRuleBlock {
+                                                l_curly_token: L_CURLY@503..504 "{" [] [],
+                                                items: CssDeclarationOrRuleList [
+                                                    ScssVariableDeclaration {
+                                                        name: ScssVariable {
+                                                            dollar_token: DOLLAR@504..512 "$" [Newline("\n"), Whitespace("      ")] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@512..522 "nested-gap" [] [],
+                                                            },
+                                                        },
+                                                        colon_token: COLON@522..524 ":" [] [Whitespace(" ")],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssRegularDimension {
+                                                                    value_token: CSS_NUMBER_LITERAL@524..525 "2" [] [],
+                                                                    unit_token: IDENT@525..528 "rem" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        modifiers: ScssVariableModifierList [],
+                                                        semicolon_token: SEMICOLON@528..529 ";" [] [],
+                                                    },
+                                                    CssDeclarationWithSemicolon {
+                                                        declaration: CssDeclaration {
+                                                            property: CssGenericProperty {
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@529..539 "gap" [Newline("\n"), Whitespace("      ")] [],
+                                                                },
+                                                                colon_token: COLON@539..541 ":" [] [Whitespace(" ")],
+                                                                value: ScssExpression {
+                                                                    items: ScssExpressionItemList [
+                                                                        ScssVariable {
+                                                                            dollar_token: DOLLAR@541..542 "$" [] [],
+                                                                            name: CssIdentifier {
+                                                                                value_token: IDENT@542..552 "nested-gap" [] [],
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                },
+                                                            },
+                                                            important: missing (optional),
+                                                        },
+                                                        semicolon_token: SEMICOLON@552..553 ";" [] [],
+                                                    },
+                                                ],
+                                                r_curly_token: R_CURLY@553..559 "}" [Newline("\n"), Whitespace("    ")] [],
+                                            },
+                                        },
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@559..563 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@563..565 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@565..568 "." [Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@568..573 "card" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@573..574 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssAtRule {
+                        at_token: AT@574..578 "@" [Newline("\n"), Whitespace("  ")] [],
+                        rule: CssMediaAtRule {
+                            declarator: CssMediaAtRuleDeclarator {
+                                media_token: MEDIA_KW@578..584 "media" [] [Whitespace(" ")],
+                                queries: CssMediaQueryList [
+                                    CssMediaConditionQuery {
+                                        condition: CssMediaFeatureInParens {
+                                            l_paren_token: L_PAREN@584..585 "(" [] [],
+                                            feature: CssQueryFeatureRange {
+                                                left: CssIdentifier {
+                                                    value_token: IDENT@585..591 "width" [] [Whitespace(" ")],
+                                                },
+                                                comparison: CssQueryFeatureRangeComparison {
+                                                    operator: GTEQ@591..594 ">=" [] [Whitespace(" ")],
+                                                },
+                                                right: CssRegularDimension {
+                                                    value_token: CSS_NUMBER_LITERAL@594..596 "60" [] [],
+                                                    unit_token: IDENT@596..599 "rem" [] [],
+                                                },
+                                            },
+                                            r_paren_token: R_PAREN@599..601 ")" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                ],
+                            },
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@601..602 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    ScssVariableDeclaration {
+                                        name: ScssVariable {
+                                            dollar_token: DOLLAR@602..608 "$" [Newline("\n"), Whitespace("    ")] [],
+                                            name: CssIdentifier {
+                                                value_token: IDENT@608..613 "color" [] [],
+                                            },
+                                        },
+                                        colon_token: COLON@613..615 ":" [] [Whitespace(" ")],
+                                        value: ScssExpression {
+                                            items: ScssExpressionItemList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@615..618 "red" [] [],
+                                                },
+                                            ],
+                                        },
+                                        modifiers: ScssVariableModifierList [],
+                                        semicolon_token: SEMICOLON@618..619 ";" [] [],
+                                    },
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@619..629 "color" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@629..631 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@631..632 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@632..637 "color" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@637..638 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@638..642 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@642..644 "}" [Newline("\n")] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@644..647 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssDocumentAtRule {
+                document_token: DOCUMENT_KW@647..656 "document" [] [Whitespace(" ")],
+                matchers: CssDocumentMatcherList [
+                    CssDocumentCustomMatcher {
+                        name: REGEXP_KW@656..662 "regexp" [] [],
+                        l_paren_token: L_PAREN@662..663 "(" [] [],
+                        value: CssString {
+                            value_token: CSS_STRING_LITERAL@663..667 "\".*\"" [] [],
+                        },
+                        r_paren_token: R_PAREN@667..669 ")" [] [Whitespace(" ")],
+                    },
+                ],
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@669..670 "{" [] [],
+                    rules: CssRuleList [
+                        ScssVariableDeclaration {
+                            name: ScssVariable {
+                                dollar_token: DOLLAR@670..674 "$" [Newline("\n"), Whitespace("  ")] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@674..679 "theme" [] [],
+                                },
+                            },
+                            colon_token: COLON@679..681 ":" [] [Whitespace(" ")],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    CssIdentifier {
+                                        value_token: IDENT@681..685 "dark" [] [],
+                                    },
+                                ],
+                            },
+                            modifiers: ScssVariableModifierList [],
+                            semicolon_token: SEMICOLON@685..686 ";" [] [],
+                        },
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssClassSelector {
+                                            dot_token: DOT@686..691 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                            name: CssCustomIdentifier {
+                                                value_token: IDENT@691..700 "document" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@700..701 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@701..711 "color" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@711..713 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@713..714 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@714..719 "theme" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@719..720 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@720..724 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@724..726 "}" [Newline("\n")] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@726..729 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@729..735 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaFeatureInParens {
+                                l_paren_token: L_PAREN@735..736 "(" [] [],
+                                feature: CssQueryFeatureRange {
+                                    left: CssIdentifier {
+                                        value_token: IDENT@736..742 "width" [] [Whitespace(" ")],
+                                    },
+                                    comparison: CssQueryFeatureRangeComparison {
+                                        operator: GTEQ@742..745 ">=" [] [Whitespace(" ")],
+                                    },
+                                    right: CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@745..747 "40" [] [],
+                                        unit_token: IDENT@747..750 "rem" [] [],
+                                    },
+                                },
+                                r_paren_token: R_PAREN@750..752 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@752..753 "{" [] [],
+                    rules: CssRuleList [
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssAttributeSelector {
+                                            l_brack_token: L_BRACK@753..757 "[" [Newline("\n"), Whitespace("  ")] [],
+                                            name: CssAttributeName {
+                                                namespace: missing (optional),
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@757..767 "data-value" [] [],
+                                                },
+                                            },
+                                            matcher: CssAttributeMatcher {
+                                                operator: DOLLAR_EQ@767..769 "$=" [] [],
+                                                value: CssAttributeMatcherValue {
+                                                    name: CssString {
+                                                        value_token: CSS_STRING_LITERAL@769..777 "\"suffix\"" [] [],
+                                                    },
+                                                },
+                                                modifier: missing (optional),
+                                            },
+                                            r_brack_token: R_BRACK@777..779 "]" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@779..780 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@780..790 "color" [Newline("\n"), Whitespace("    ")] [],
+                                                },
+                                                colon_token: COLON@790..792 ":" [] [Whitespace(" ")],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssIdentifier {
+                                                            value_token: IDENT@792..795 "red" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@795..796 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@796..800 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@800..802 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@802..803 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..803
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..802
+    0: CSS_AT_RULE@0..226
+      0: AT@0..1 "@" [] []
+      1: CSS_MEDIA_AT_RULE@1..226
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1..24
+          0: MEDIA_KW@1..7 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@7..24
+            0: CSS_MEDIA_CONDITION_QUERY@7..24
+              0: CSS_MEDIA_FEATURE_IN_PARENS@7..24
+                0: L_PAREN@7..8 "(" [] []
+                1: CSS_QUERY_FEATURE_RANGE@8..22
+                  0: CSS_IDENTIFIER@8..14
+                    0: IDENT@8..14 "width" [] [Whitespace(" ")]
+                  1: CSS_QUERY_FEATURE_RANGE_COMPARISON@14..17
+                    0: GTEQ@14..17 ">=" [] [Whitespace(" ")]
+                  2: CSS_REGULAR_DIMENSION@17..22
+                    0: CSS_NUMBER_LITERAL@17..19 "40" [] []
+                    1: IDENT@19..22 "rem" [] []
+                2: R_PAREN@22..24 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@24..226
+          0: L_CURLY@24..25 "{" [] []
+          1: CSS_RULE_LIST@25..224
+            0: SCSS_VARIABLE_DECLARATION@25..39
+              0: SCSS_VARIABLE@25..32
+                0: DOLLAR@25..29 "$" [Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@29..32
+                  0: IDENT@29..32 "gap" [] []
+              1: COLON@32..34 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@34..38
+                0: SCSS_EXPRESSION_ITEM_LIST@34..38
+                  0: CSS_REGULAR_DIMENSION@34..38
+                    0: CSS_NUMBER_LITERAL@34..35 "2" [] []
+                    1: IDENT@35..38 "rem" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@38..38
+              4: SEMICOLON@38..39 ";" [] []
+            1: CSS_QUALIFIED_RULE@39..74
+              0: CSS_SELECTOR_LIST@39..51
+                0: CSS_COMPOUND_SELECTOR@39..51
+                  0: CSS_NESTED_SELECTOR_LIST@39..39
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@39..51
+                    0: CSS_CLASS_SELECTOR@39..51
+                      0: DOT@39..44 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@44..51
+                        0: IDENT@44..51 "before" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@51..74
+                0: L_CURLY@51..52 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@52..70
+                  0: CSS_DECLARATION_WITH_SEMICOLON@52..70
+                    0: CSS_DECLARATION@52..69
+                      0: CSS_GENERIC_PROPERTY@52..69
+                        0: CSS_IDENTIFIER@52..63
+                          0: IDENT@52..63 "margin" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@63..65 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@65..69
+                          0: SCSS_EXPRESSION_ITEM_LIST@65..69
+                            0: SCSS_VARIABLE@65..69
+                              0: DOLLAR@65..66 "$" [] []
+                              1: CSS_IDENTIFIER@66..69
+                                0: IDENT@66..69 "gap" [] []
+                      1: (empty)
+                    1: SEMICOLON@69..70 ";" [] []
+                2: R_CURLY@70..74 "}" [Newline("\n"), Whitespace("  ")] []
+            2: SCSS_VARIABLE_DECLARATION@74..90
+              0: SCSS_VARIABLE@74..86
+                0: DOLLAR@74..79 "$" [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@79..86
+                  0: IDENT@79..86 "columns" [] []
+              1: COLON@86..88 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@88..89
+                0: SCSS_EXPRESSION_ITEM_LIST@88..89
+                  0: CSS_NUMBER@88..89
+                    0: CSS_NUMBER_LITERAL@88..89 "3" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@89..89
+              4: SEMICOLON@89..90 ";" [] []
+            3: CSS_QUALIFIED_RULE@90..125
+              0: CSS_SELECTOR_LIST@90..102
+                0: CSS_COMPOUND_SELECTOR@90..102
+                  0: CSS_NESTED_SELECTOR_LIST@90..90
+                  1: CSS_TYPE_SELECTOR@90..95
+                    0: (empty)
+                    1: CSS_IDENTIFIER@90..95
+                      0: IDENT@90..95 "a" [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                  2: CSS_SUB_SELECTOR_LIST@95..102
+                    0: CSS_PSEUDO_CLASS_SELECTOR@95..102
+                      0: COLON@95..96 ":" [] []
+                      1: CSS_PSEUDO_CLASS_IDENTIFIER@96..102
+                        0: CSS_IDENTIFIER@96..102
+                          0: IDENT@96..102 "hover" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@102..125
+                0: L_CURLY@102..103 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@103..121
+                  0: CSS_DECLARATION_WITH_SEMICOLON@103..121
+                    0: CSS_DECLARATION@103..120
+                      0: CSS_GENERIC_PROPERTY@103..120
+                        0: CSS_IDENTIFIER@103..114
+                          0: IDENT@103..114 "margin" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@114..116 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@116..120
+                          0: SCSS_EXPRESSION_ITEM_LIST@116..120
+                            0: SCSS_VARIABLE@116..120
+                              0: DOLLAR@116..117 "$" [] []
+                              1: CSS_IDENTIFIER@117..120
+                                0: IDENT@117..120 "gap" [] []
+                      1: (empty)
+                    1: SEMICOLON@120..121 ";" [] []
+                2: R_CURLY@121..125 "}" [Newline("\n"), Whitespace("  ")] []
+            4: CSS_AT_RULE@125..224
+              0: AT@125..130 "@" [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+              1: CSS_SUPPORTS_AT_RULE@130..224
+                0: CSS_SUPPORTS_AT_RULE_DECLARATOR@130..155
+                  0: SUPPORTS_KW@130..139 "supports" [] [Whitespace(" ")]
+                  1: CSS_SUPPORTS_FEATURE_DECLARATION@139..155
+                    0: L_PAREN@139..140 "(" [] []
+                    1: CSS_DECLARATION@140..153
+                      0: CSS_GENERIC_PROPERTY@140..153
+                        0: CSS_IDENTIFIER@140..147
+                          0: IDENT@140..147 "display" [] []
+                        1: COLON@147..149 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@149..153
+                          0: SCSS_EXPRESSION_ITEM_LIST@149..153
+                            0: CSS_IDENTIFIER@149..153
+                              0: IDENT@149..153 "grid" [] []
+                      1: (empty)
+                    2: R_PAREN@153..155 ")" [] [Whitespace(" ")]
+                1: CSS_DECLARATION_OR_RULE_BLOCK@155..224
+                  0: L_CURLY@155..156 "{" [] []
+                  1: CSS_DECLARATION_OR_RULE_LIST@156..220
+                    0: SCSS_VARIABLE_DECLARATION@156..176
+                      0: SCSS_VARIABLE@156..169
+                        0: DOLLAR@156..162 "$" [Newline("\n"), Whitespace("    ")] []
+                        1: CSS_IDENTIFIER@162..169
+                          0: IDENT@162..169 "display" [] []
+                      1: COLON@169..171 ":" [] [Whitespace(" ")]
+                      2: SCSS_EXPRESSION@171..175
+                        0: SCSS_EXPRESSION_ITEM_LIST@171..175
+                          0: CSS_IDENTIFIER@171..175
+                            0: IDENT@171..175 "grid" [] []
+                      3: SCSS_VARIABLE_MODIFIER_LIST@175..175
+                      4: SEMICOLON@175..176 ";" [] []
+                    1: CSS_NESTED_QUALIFIED_RULE@176..220
+                      0: CSS_RELATIVE_SELECTOR_LIST@176..188
+                        0: CSS_RELATIVE_SELECTOR@176..188
+                          0: (empty)
+                          1: CSS_COMPOUND_SELECTOR@176..188
+                            0: CSS_NESTED_SELECTOR_LIST@176..176
+                            1: (empty)
+                            2: CSS_SUB_SELECTOR_LIST@176..188
+                              0: CSS_CLASS_SELECTOR@176..188
+                                0: DOT@176..183 "." [Newline("\n"), Newline("\n"), Whitespace("    ")] []
+                                1: CSS_CUSTOM_IDENTIFIER@183..188
+                                  0: IDENT@183..188 "grid" [] [Whitespace(" ")]
+                      1: CSS_DECLARATION_OR_RULE_BLOCK@188..220
+                        0: L_CURLY@188..189 "{" [] []
+                        1: CSS_DECLARATION_OR_RULE_LIST@189..214
+                          0: CSS_DECLARATION_WITH_SEMICOLON@189..214
+                            0: CSS_DECLARATION@189..213
+                              0: CSS_GENERIC_PROPERTY@189..213
+                                0: CSS_IDENTIFIER@189..203
+                                  0: IDENT@189..203 "display" [Newline("\n"), Whitespace("      ")] []
+                                1: COLON@203..205 ":" [] [Whitespace(" ")]
+                                2: SCSS_EXPRESSION@205..213
+                                  0: SCSS_EXPRESSION_ITEM_LIST@205..213
+                                    0: SCSS_VARIABLE@205..213
+                                      0: DOLLAR@205..206 "$" [] []
+                                      1: CSS_IDENTIFIER@206..213
+                                        0: IDENT@206..213 "display" [] []
+                              1: (empty)
+                            1: SEMICOLON@213..214 ";" [] []
+                        2: R_CURLY@214..220 "}" [Newline("\n"), Whitespace("    ")] []
+                  2: R_CURLY@220..224 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@224..226 "}" [Newline("\n")] []
+    1: CSS_AT_RULE@226..351
+      0: AT@226..229 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@229..351
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@229..254
+          0: SUPPORTS_KW@229..238 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@238..254
+            0: L_PAREN@238..239 "(" [] []
+            1: CSS_DECLARATION@239..252
+              0: CSS_GENERIC_PROPERTY@239..252
+                0: CSS_IDENTIFIER@239..246
+                  0: IDENT@239..246 "display" [] []
+                1: COLON@246..248 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@248..252
+                  0: SCSS_EXPRESSION_ITEM_LIST@248..252
+                    0: CSS_IDENTIFIER@248..252
+                      0: IDENT@248..252 "grid" [] []
+              1: (empty)
+            2: R_PAREN@252..254 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@254..351
+          0: L_CURLY@254..255 "{" [] []
+          1: CSS_RULE_LIST@255..349
+            0: CSS_QUALIFIED_RULE@255..291
+              0: CSS_SELECTOR_LIST@255..266
+                0: CSS_COMPOUND_SELECTOR@255..266
+                  0: CSS_NESTED_SELECTOR_LIST@255..255
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@255..266
+                    0: CSS_CLASS_SELECTOR@255..266
+                      0: DOT@255..259 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@259..266
+                        0: IDENT@259..266 "before" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@266..291
+                0: L_CURLY@266..267 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@267..287
+                  0: CSS_DECLARATION_WITH_SEMICOLON@267..287
+                    0: CSS_DECLARATION@267..286
+                      0: CSS_GENERIC_PROPERTY@267..286
+                        0: CSS_IDENTIFIER@267..279
+                          0: IDENT@267..279 "display" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@279..281 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@281..286
+                          0: SCSS_EXPRESSION_ITEM_LIST@281..286
+                            0: CSS_IDENTIFIER@281..286
+                              0: IDENT@281..286 "block" [] []
+                      1: (empty)
+                    1: SEMICOLON@286..287 ";" [] []
+                2: R_CURLY@287..291 "}" [Newline("\n"), Whitespace("  ")] []
+            1: SCSS_VARIABLE_DECLARATION@291..310
+              0: SCSS_VARIABLE@291..303
+                0: DOLLAR@291..296 "$" [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@296..303
+                  0: IDENT@296..303 "display" [] []
+              1: COLON@303..305 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@305..309
+                0: SCSS_EXPRESSION_ITEM_LIST@305..309
+                  0: CSS_IDENTIFIER@305..309
+                    0: IDENT@305..309 "grid" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@309..309
+              4: SEMICOLON@309..310 ";" [] []
+            2: CSS_QUALIFIED_RULE@310..349
+              0: CSS_SELECTOR_LIST@310..321
+                0: CSS_COMPOUND_SELECTOR@310..321
+                  0: CSS_NESTED_SELECTOR_LIST@310..310
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@310..321
+                    0: CSS_CLASS_SELECTOR@310..321
+                      0: DOT@310..315 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@315..321
+                        0: IDENT@315..321 "after" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@321..349
+                0: L_CURLY@321..322 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@322..345
+                  0: CSS_DECLARATION_WITH_SEMICOLON@322..345
+                    0: CSS_DECLARATION@322..344
+                      0: CSS_GENERIC_PROPERTY@322..344
+                        0: CSS_IDENTIFIER@322..334
+                          0: IDENT@322..334 "display" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@334..336 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@336..344
+                          0: SCSS_EXPRESSION_ITEM_LIST@336..344
+                            0: SCSS_VARIABLE@336..344
+                              0: DOLLAR@336..337 "$" [] []
+                              1: CSS_IDENTIFIER@337..344
+                                0: IDENT@337..344 "display" [] []
+                      1: (empty)
+                    1: SEMICOLON@344..345 ";" [] []
+                2: R_CURLY@345..349 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@349..351 "}" [Newline("\n")] []
+    2: CSS_AT_RULE@351..434
+      0: AT@351..354 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@354..434
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@354..393
+          0: MEDIA_KW@354..360 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@360..393
+            0: CSS_MEDIA_CONDITION_QUERY@360..393
+              0: CSS_MEDIA_FEATURE_IN_PARENS@360..393
+                0: L_PAREN@360..361 "(" [] []
+                1: CSS_QUERY_FEATURE_PLAIN@361..391
+                  0: CSS_IDENTIFIER@361..383
+                    0: IDENT@361..383 "prefers-reduced-motion" [] []
+                  1: COLON@383..385 ":" [] [Whitespace(" ")]
+                  2: CSS_IDENTIFIER@385..391
+                    0: IDENT@385..391 "reduce" [] []
+                2: R_PAREN@391..393 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@393..434
+          0: L_CURLY@393..394 "{" [] []
+          1: CSS_RULE_LIST@394..432
+            0: CSS_QUALIFIED_RULE@394..432
+              0: CSS_SELECTOR_LIST@394..405
+                0: CSS_COMPOUND_SELECTOR@394..405
+                  0: CSS_NESTED_SELECTOR_LIST@394..394
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@394..405
+                    0: CSS_CLASS_SELECTOR@394..405
+                      0: DOT@394..398 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@398..405
+                        0: IDENT@398..405 "motion" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@405..432
+                0: L_CURLY@405..406 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@406..428
+                  0: CSS_DECLARATION_WITH_SEMICOLON@406..428
+                    0: CSS_DECLARATION@406..427
+                      0: CSS_GENERIC_PROPERTY@406..427
+                        0: CSS_IDENTIFIER@406..421
+                          0: IDENT@406..421 "transition" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@421..423 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@423..427
+                          0: SCSS_EXPRESSION_ITEM_LIST@423..427
+                            0: CSS_IDENTIFIER@423..427
+                              0: IDENT@423..427 "none" [] []
+                      1: (empty)
+                    1: SEMICOLON@427..428 ";" [] []
+                2: R_CURLY@428..432 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@432..434 "}" [Newline("\n")] []
+    3: CSS_AT_RULE@434..565
+      0: AT@434..437 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_SUPPORTS_AT_RULE@437..565
+        0: CSS_SUPPORTS_AT_RULE_DECLARATOR@437..462
+          0: SUPPORTS_KW@437..446 "supports" [] [Whitespace(" ")]
+          1: CSS_SUPPORTS_FEATURE_DECLARATION@446..462
+            0: L_PAREN@446..447 "(" [] []
+            1: CSS_DECLARATION@447..460
+              0: CSS_GENERIC_PROPERTY@447..460
+                0: CSS_IDENTIFIER@447..454
+                  0: IDENT@447..454 "display" [] []
+                1: COLON@454..456 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@456..460
+                  0: SCSS_EXPRESSION_ITEM_LIST@456..460
+                    0: CSS_IDENTIFIER@456..460
+                      0: IDENT@456..460 "grid" [] []
+              1: (empty)
+            2: R_PAREN@460..462 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@462..565
+          0: L_CURLY@462..463 "{" [] []
+          1: CSS_RULE_LIST@463..563
+            0: CSS_QUALIFIED_RULE@463..563
+              0: CSS_SELECTOR_LIST@463..473
+                0: CSS_COMPOUND_SELECTOR@463..473
+                  0: CSS_NESTED_SELECTOR_LIST@463..463
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@463..473
+                    0: CSS_CLASS_SELECTOR@463..473
+                      0: DOT@463..467 "." [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@467..473
+                        0: IDENT@467..473 "shell" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@473..563
+                0: L_CURLY@473..474 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@474..559
+                  0: CSS_AT_RULE@474..559
+                    0: AT@474..480 "@" [Newline("\n"), Whitespace("    ")] []
+                    1: CSS_MEDIA_AT_RULE@480..559
+                      0: CSS_MEDIA_AT_RULE_DECLARATOR@480..503
+                        0: MEDIA_KW@480..486 "media" [] [Whitespace(" ")]
+                        1: CSS_MEDIA_QUERY_LIST@486..503
+                          0: CSS_MEDIA_CONDITION_QUERY@486..503
+                            0: CSS_MEDIA_FEATURE_IN_PARENS@486..503
+                              0: L_PAREN@486..487 "(" [] []
+                              1: CSS_QUERY_FEATURE_RANGE@487..501
+                                0: CSS_IDENTIFIER@487..493
+                                  0: IDENT@487..493 "width" [] [Whitespace(" ")]
+                                1: CSS_QUERY_FEATURE_RANGE_COMPARISON@493..496
+                                  0: GTEQ@493..496 ">=" [] [Whitespace(" ")]
+                                2: CSS_REGULAR_DIMENSION@496..501
+                                  0: CSS_NUMBER_LITERAL@496..498 "60" [] []
+                                  1: IDENT@498..501 "rem" [] []
+                              2: R_PAREN@501..503 ")" [] [Whitespace(" ")]
+                      1: CSS_DECLARATION_OR_RULE_BLOCK@503..559
+                        0: L_CURLY@503..504 "{" [] []
+                        1: CSS_DECLARATION_OR_RULE_LIST@504..553
+                          0: SCSS_VARIABLE_DECLARATION@504..529
+                            0: SCSS_VARIABLE@504..522
+                              0: DOLLAR@504..512 "$" [Newline("\n"), Whitespace("      ")] []
+                              1: CSS_IDENTIFIER@512..522
+                                0: IDENT@512..522 "nested-gap" [] []
+                            1: COLON@522..524 ":" [] [Whitespace(" ")]
+                            2: SCSS_EXPRESSION@524..528
+                              0: SCSS_EXPRESSION_ITEM_LIST@524..528
+                                0: CSS_REGULAR_DIMENSION@524..528
+                                  0: CSS_NUMBER_LITERAL@524..525 "2" [] []
+                                  1: IDENT@525..528 "rem" [] []
+                            3: SCSS_VARIABLE_MODIFIER_LIST@528..528
+                            4: SEMICOLON@528..529 ";" [] []
+                          1: CSS_DECLARATION_WITH_SEMICOLON@529..553
+                            0: CSS_DECLARATION@529..552
+                              0: CSS_GENERIC_PROPERTY@529..552
+                                0: CSS_IDENTIFIER@529..539
+                                  0: IDENT@529..539 "gap" [Newline("\n"), Whitespace("      ")] []
+                                1: COLON@539..541 ":" [] [Whitespace(" ")]
+                                2: SCSS_EXPRESSION@541..552
+                                  0: SCSS_EXPRESSION_ITEM_LIST@541..552
+                                    0: SCSS_VARIABLE@541..552
+                                      0: DOLLAR@541..542 "$" [] []
+                                      1: CSS_IDENTIFIER@542..552
+                                        0: IDENT@542..552 "nested-gap" [] []
+                              1: (empty)
+                            1: SEMICOLON@552..553 ";" [] []
+                        2: R_CURLY@553..559 "}" [Newline("\n"), Whitespace("    ")] []
+                2: R_CURLY@559..563 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@563..565 "}" [Newline("\n")] []
+    4: CSS_QUALIFIED_RULE@565..644
+      0: CSS_SELECTOR_LIST@565..573
+        0: CSS_COMPOUND_SELECTOR@565..573
+          0: CSS_NESTED_SELECTOR_LIST@565..565
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@565..573
+            0: CSS_CLASS_SELECTOR@565..573
+              0: DOT@565..568 "." [Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@568..573
+                0: IDENT@568..573 "card" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@573..644
+        0: L_CURLY@573..574 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@574..642
+          0: CSS_AT_RULE@574..642
+            0: AT@574..578 "@" [Newline("\n"), Whitespace("  ")] []
+            1: CSS_MEDIA_AT_RULE@578..642
+              0: CSS_MEDIA_AT_RULE_DECLARATOR@578..601
+                0: MEDIA_KW@578..584 "media" [] [Whitespace(" ")]
+                1: CSS_MEDIA_QUERY_LIST@584..601
+                  0: CSS_MEDIA_CONDITION_QUERY@584..601
+                    0: CSS_MEDIA_FEATURE_IN_PARENS@584..601
+                      0: L_PAREN@584..585 "(" [] []
+                      1: CSS_QUERY_FEATURE_RANGE@585..599
+                        0: CSS_IDENTIFIER@585..591
+                          0: IDENT@585..591 "width" [] [Whitespace(" ")]
+                        1: CSS_QUERY_FEATURE_RANGE_COMPARISON@591..594
+                          0: GTEQ@591..594 ">=" [] [Whitespace(" ")]
+                        2: CSS_REGULAR_DIMENSION@594..599
+                          0: CSS_NUMBER_LITERAL@594..596 "60" [] []
+                          1: IDENT@596..599 "rem" [] []
+                      2: R_PAREN@599..601 ")" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@601..642
+                0: L_CURLY@601..602 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@602..638
+                  0: SCSS_VARIABLE_DECLARATION@602..619
+                    0: SCSS_VARIABLE@602..613
+                      0: DOLLAR@602..608 "$" [Newline("\n"), Whitespace("    ")] []
+                      1: CSS_IDENTIFIER@608..613
+                        0: IDENT@608..613 "color" [] []
+                    1: COLON@613..615 ":" [] [Whitespace(" ")]
+                    2: SCSS_EXPRESSION@615..618
+                      0: SCSS_EXPRESSION_ITEM_LIST@615..618
+                        0: CSS_IDENTIFIER@615..618
+                          0: IDENT@615..618 "red" [] []
+                    3: SCSS_VARIABLE_MODIFIER_LIST@618..618
+                    4: SEMICOLON@618..619 ";" [] []
+                  1: CSS_DECLARATION_WITH_SEMICOLON@619..638
+                    0: CSS_DECLARATION@619..637
+                      0: CSS_GENERIC_PROPERTY@619..637
+                        0: CSS_IDENTIFIER@619..629
+                          0: IDENT@619..629 "color" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@629..631 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@631..637
+                          0: SCSS_EXPRESSION_ITEM_LIST@631..637
+                            0: SCSS_VARIABLE@631..637
+                              0: DOLLAR@631..632 "$" [] []
+                              1: CSS_IDENTIFIER@632..637
+                                0: IDENT@632..637 "color" [] []
+                      1: (empty)
+                    1: SEMICOLON@637..638 ";" [] []
+                2: R_CURLY@638..642 "}" [Newline("\n"), Whitespace("  ")] []
+        2: R_CURLY@642..644 "}" [Newline("\n")] []
+    5: CSS_AT_RULE@644..726
+      0: AT@644..647 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_DOCUMENT_AT_RULE@647..726
+        0: DOCUMENT_KW@647..656 "document" [] [Whitespace(" ")]
+        1: CSS_DOCUMENT_MATCHER_LIST@656..669
+          0: CSS_DOCUMENT_CUSTOM_MATCHER@656..669
+            0: REGEXP_KW@656..662 "regexp" [] []
+            1: L_PAREN@662..663 "(" [] []
+            2: CSS_STRING@663..667
+              0: CSS_STRING_LITERAL@663..667 "\".*\"" [] []
+            3: R_PAREN@667..669 ")" [] [Whitespace(" ")]
+        2: CSS_RULE_BLOCK@669..726
+          0: L_CURLY@669..670 "{" [] []
+          1: CSS_RULE_LIST@670..724
+            0: SCSS_VARIABLE_DECLARATION@670..686
+              0: SCSS_VARIABLE@670..679
+                0: DOLLAR@670..674 "$" [Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@674..679
+                  0: IDENT@674..679 "theme" [] []
+              1: COLON@679..681 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@681..685
+                0: SCSS_EXPRESSION_ITEM_LIST@681..685
+                  0: CSS_IDENTIFIER@681..685
+                    0: IDENT@681..685 "dark" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@685..685
+              4: SEMICOLON@685..686 ";" [] []
+            1: CSS_QUALIFIED_RULE@686..724
+              0: CSS_SELECTOR_LIST@686..700
+                0: CSS_COMPOUND_SELECTOR@686..700
+                  0: CSS_NESTED_SELECTOR_LIST@686..686
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@686..700
+                    0: CSS_CLASS_SELECTOR@686..700
+                      0: DOT@686..691 "." [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                      1: CSS_CUSTOM_IDENTIFIER@691..700
+                        0: IDENT@691..700 "document" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@700..724
+                0: L_CURLY@700..701 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@701..720
+                  0: CSS_DECLARATION_WITH_SEMICOLON@701..720
+                    0: CSS_DECLARATION@701..719
+                      0: CSS_GENERIC_PROPERTY@701..719
+                        0: CSS_IDENTIFIER@701..711
+                          0: IDENT@701..711 "color" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@711..713 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@713..719
+                          0: SCSS_EXPRESSION_ITEM_LIST@713..719
+                            0: SCSS_VARIABLE@713..719
+                              0: DOLLAR@713..714 "$" [] []
+                              1: CSS_IDENTIFIER@714..719
+                                0: IDENT@714..719 "theme" [] []
+                      1: (empty)
+                    1: SEMICOLON@719..720 ";" [] []
+                2: R_CURLY@720..724 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@724..726 "}" [Newline("\n")] []
+    6: CSS_AT_RULE@726..802
+      0: AT@726..729 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@729..802
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@729..752
+          0: MEDIA_KW@729..735 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@735..752
+            0: CSS_MEDIA_CONDITION_QUERY@735..752
+              0: CSS_MEDIA_FEATURE_IN_PARENS@735..752
+                0: L_PAREN@735..736 "(" [] []
+                1: CSS_QUERY_FEATURE_RANGE@736..750
+                  0: CSS_IDENTIFIER@736..742
+                    0: IDENT@736..742 "width" [] [Whitespace(" ")]
+                  1: CSS_QUERY_FEATURE_RANGE_COMPARISON@742..745
+                    0: GTEQ@742..745 ">=" [] [Whitespace(" ")]
+                  2: CSS_REGULAR_DIMENSION@745..750
+                    0: CSS_NUMBER_LITERAL@745..747 "40" [] []
+                    1: IDENT@747..750 "rem" [] []
+                2: R_PAREN@750..752 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@752..802
+          0: L_CURLY@752..753 "{" [] []
+          1: CSS_RULE_LIST@753..800
+            0: CSS_QUALIFIED_RULE@753..800
+              0: CSS_SELECTOR_LIST@753..779
+                0: CSS_COMPOUND_SELECTOR@753..779
+                  0: CSS_NESTED_SELECTOR_LIST@753..753
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@753..779
+                    0: CSS_ATTRIBUTE_SELECTOR@753..779
+                      0: L_BRACK@753..757 "[" [Newline("\n"), Whitespace("  ")] []
+                      1: CSS_ATTRIBUTE_NAME@757..767
+                        0: (empty)
+                        1: CSS_IDENTIFIER@757..767
+                          0: IDENT@757..767 "data-value" [] []
+                      2: CSS_ATTRIBUTE_MATCHER@767..777
+                        0: DOLLAR_EQ@767..769 "$=" [] []
+                        1: CSS_ATTRIBUTE_MATCHER_VALUE@769..777
+                          0: CSS_STRING@769..777
+                            0: CSS_STRING_LITERAL@769..777 "\"suffix\"" [] []
+                        2: (empty)
+                      3: R_BRACK@777..779 "]" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@779..800
+                0: L_CURLY@779..780 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@780..796
+                  0: CSS_DECLARATION_WITH_SEMICOLON@780..796
+                    0: CSS_DECLARATION@780..795
+                      0: CSS_GENERIC_PROPERTY@780..795
+                        0: CSS_IDENTIFIER@780..790
+                          0: IDENT@780..790 "color" [Newline("\n"), Whitespace("    ")] []
+                        1: COLON@790..792 ":" [] [Whitespace(" ")]
+                        2: SCSS_EXPRESSION@792..795
+                          0: SCSS_EXPRESSION_ITEM_LIST@792..795
+                            0: CSS_IDENTIFIER@792..795
+                              0: IDENT@792..795 "red" [] []
+                      1: (empty)
+                    1: SEMICOLON@795..796 ";" [] []
+                2: R_CURLY@796..800 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@800..802 "}" [Newline("\n")] []
+  2: EOF@802..803 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/rule-list-variable.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/rule-list-variable.scss
@@ -1,0 +1,7 @@
+@custom-variant theme {
+  $selector: ".theme";
+
+  &:where(.theme *) {
+    @slot;
+  }
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/rule-list-variable.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/custom-variants/rule-list-variable.scss.snap
@@ -1,0 +1,197 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@custom-variant theme {
+  $selector: ".theme";
+
+  &:where(.theme *) {
+    @slot;
+  }
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: TwCustomVariantAtRule {
+                custom_variant_token: CUSTOM_VARIANT_KW@1..16 "custom-variant" [] [Whitespace(" ")],
+                name: CssIdentifier {
+                    value_token: IDENT@16..22 "theme" [] [Whitespace(" ")],
+                },
+                selector: CssRuleBlock {
+                    l_curly_token: L_CURLY@22..23 "{" [] [],
+                    rules: CssRuleList [
+                        ScssVariableDeclaration {
+                            name: ScssVariable {
+                                dollar_token: DOLLAR@23..27 "$" [Newline("\n"), Whitespace("  ")] [],
+                                name: CssIdentifier {
+                                    value_token: IDENT@27..35 "selector" [] [],
+                                },
+                            },
+                            colon_token: COLON@35..37 ":" [] [Whitespace(" ")],
+                            value: ScssExpression {
+                                items: ScssExpressionItemList [
+                                    CssString {
+                                        value_token: CSS_STRING_LITERAL@37..45 "\".theme\"" [] [],
+                                    },
+                                ],
+                            },
+                            modifiers: ScssVariableModifierList [],
+                            semicolon_token: SEMICOLON@45..46 ";" [] [],
+                        },
+                        CssQualifiedRule {
+                            prelude: CssSelectorList [
+                                CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [
+                                        CssNestedSelector {
+                                            amp_token: AMP@46..51 "&" [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                        },
+                                    ],
+                                    simple_selector: missing (optional),
+                                    sub_selectors: CssSubSelectorList [
+                                        CssPseudoClassSelector {
+                                            colon_token: COLON@51..52 ":" [] [],
+                                            class: CssPseudoClassFunctionSelectorList {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@52..57 "where" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@57..58 "(" [] [],
+                                                selectors: CssSelectorList [
+                                                    CssComplexSelector {
+                                                        left: CssCompoundSelector {
+                                                            nesting_selectors: CssNestedSelectorList [],
+                                                            simple_selector: missing (optional),
+                                                            sub_selectors: CssSubSelectorList [
+                                                                CssClassSelector {
+                                                                    dot_token: DOT@58..59 "." [] [],
+                                                                    name: CssCustomIdentifier {
+                                                                        value_token: IDENT@59..64 "theme" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        combinator: CSS_SPACE_LITERAL@64..65 " " [] [],
+                                                        right: CssCompoundSelector {
+                                                            nesting_selectors: CssNestedSelectorList [],
+                                                            simple_selector: CssUniversalSelector {
+                                                                namespace: missing (optional),
+                                                                star_token: STAR@65..66 "*" [] [],
+                                                            },
+                                                            sub_selectors: CssSubSelectorList [],
+                                                        },
+                                                    },
+                                                ],
+                                                r_paren_token: R_PAREN@66..68 ")" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@68..69 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssAtRule {
+                                        at_token: AT@69..75 "@" [Newline("\n"), Whitespace("    ")] [],
+                                        rule: TwSlotAtRule {
+                                            slot_token: SLOT_KW@75..79 "slot" [] [],
+                                            semicolon_token: SEMICOLON@79..80 ";" [] [],
+                                        },
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@80..84 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@84..86 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@86..87 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..87
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..86
+    0: CSS_AT_RULE@0..86
+      0: AT@0..1 "@" [] []
+      1: TW_CUSTOM_VARIANT_AT_RULE@1..86
+        0: CUSTOM_VARIANT_KW@1..16 "custom-variant" [] [Whitespace(" ")]
+        1: CSS_IDENTIFIER@16..22
+          0: IDENT@16..22 "theme" [] [Whitespace(" ")]
+        2: CSS_RULE_BLOCK@22..86
+          0: L_CURLY@22..23 "{" [] []
+          1: CSS_RULE_LIST@23..84
+            0: SCSS_VARIABLE_DECLARATION@23..46
+              0: SCSS_VARIABLE@23..35
+                0: DOLLAR@23..27 "$" [Newline("\n"), Whitespace("  ")] []
+                1: CSS_IDENTIFIER@27..35
+                  0: IDENT@27..35 "selector" [] []
+              1: COLON@35..37 ":" [] [Whitespace(" ")]
+              2: SCSS_EXPRESSION@37..45
+                0: SCSS_EXPRESSION_ITEM_LIST@37..45
+                  0: CSS_STRING@37..45
+                    0: CSS_STRING_LITERAL@37..45 "\".theme\"" [] []
+              3: SCSS_VARIABLE_MODIFIER_LIST@45..45
+              4: SEMICOLON@45..46 ";" [] []
+            1: CSS_QUALIFIED_RULE@46..84
+              0: CSS_SELECTOR_LIST@46..68
+                0: CSS_COMPOUND_SELECTOR@46..68
+                  0: CSS_NESTED_SELECTOR_LIST@46..51
+                    0: CSS_NESTED_SELECTOR@46..51
+                      0: AMP@46..51 "&" [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                  1: (empty)
+                  2: CSS_SUB_SELECTOR_LIST@51..68
+                    0: CSS_PSEUDO_CLASS_SELECTOR@51..68
+                      0: COLON@51..52 ":" [] []
+                      1: CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST@52..68
+                        0: CSS_IDENTIFIER@52..57
+                          0: IDENT@52..57 "where" [] []
+                        1: L_PAREN@57..58 "(" [] []
+                        2: CSS_SELECTOR_LIST@58..66
+                          0: CSS_COMPLEX_SELECTOR@58..66
+                            0: CSS_COMPOUND_SELECTOR@58..64
+                              0: CSS_NESTED_SELECTOR_LIST@58..58
+                              1: (empty)
+                              2: CSS_SUB_SELECTOR_LIST@58..64
+                                0: CSS_CLASS_SELECTOR@58..64
+                                  0: DOT@58..59 "." [] []
+                                  1: CSS_CUSTOM_IDENTIFIER@59..64
+                                    0: IDENT@59..64 "theme" [] []
+                            1: CSS_SPACE_LITERAL@64..65 " " [] []
+                            2: CSS_COMPOUND_SELECTOR@65..66
+                              0: CSS_NESTED_SELECTOR_LIST@65..65
+                              1: CSS_UNIVERSAL_SELECTOR@65..66
+                                0: (empty)
+                                1: STAR@65..66 "*" [] []
+                              2: CSS_SUB_SELECTOR_LIST@66..66
+                        3: R_PAREN@66..68 ")" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@68..84
+                0: L_CURLY@68..69 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@69..80
+                  0: CSS_AT_RULE@69..80
+                    0: AT@69..75 "@" [Newline("\n"), Whitespace("    ")] []
+                    1: TW_SLOT_AT_RULE@75..80
+                      0: SLOT_KW@75..79 "slot" [] []
+                      1: SEMICOLON@79..80 ";" [] []
+                2: R_CURLY@80..84 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@84..86 "}" [Newline("\n")] []
+  2: EOF@86..87 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -16504,6 +16504,25 @@ impl AnyCssRuleBlock {
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, Serialize)]
+pub enum AnyCssRuleListItem {
+    AnyCssRule(AnyCssRule),
+    ScssVariableDeclaration(ScssVariableDeclaration),
+}
+impl AnyCssRuleListItem {
+    pub fn as_any_css_rule(&self) -> Option<&AnyCssRule> {
+        match &self {
+            Self::AnyCssRule(item) => Some(item),
+            _ => None,
+        }
+    }
+    pub fn as_scss_variable_declaration(&self) -> Option<&ScssVariableDeclaration> {
+        match &self {
+            Self::ScssVariableDeclaration(item) => Some(item),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum AnyCssScopeRange {
     CssBogusScopeRange(CssBogusScopeRange),
     CssScopeRangeEnd(CssScopeRangeEnd),
@@ -42495,6 +42514,71 @@ impl From<AnyCssRuleBlock> for SyntaxElement {
         node.into()
     }
 }
+impl From<ScssVariableDeclaration> for AnyCssRuleListItem {
+    fn from(node: ScssVariableDeclaration) -> Self {
+        Self::ScssVariableDeclaration(node)
+    }
+}
+impl AstNode for AnyCssRuleListItem {
+    type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        AnyCssRule::KIND_SET.union(ScssVariableDeclaration::KIND_SET);
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SCSS_VARIABLE_DECLARATION => true,
+            k if AnyCssRule::can_cast(k) => true,
+            _ => false,
+        }
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        let res = match syntax.kind() {
+            SCSS_VARIABLE_DECLARATION => {
+                Self::ScssVariableDeclaration(ScssVariableDeclaration { syntax })
+            }
+            _ => {
+                if let Some(any_css_rule) = AnyCssRule::cast(syntax) {
+                    return Some(Self::AnyCssRule(any_css_rule));
+                }
+                return None;
+            }
+        };
+        Some(res)
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        match self {
+            Self::ScssVariableDeclaration(it) => it.syntax(),
+            Self::AnyCssRule(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            Self::ScssVariableDeclaration(it) => it.into_syntax(),
+            Self::AnyCssRule(it) => it.into_syntax(),
+        }
+    }
+}
+impl std::fmt::Debug for AnyCssRuleListItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AnyCssRule(it) => std::fmt::Debug::fmt(it, f),
+            Self::ScssVariableDeclaration(it) => std::fmt::Debug::fmt(it, f),
+        }
+    }
+}
+impl From<AnyCssRuleListItem> for SyntaxNode {
+    fn from(n: AnyCssRuleListItem) -> Self {
+        match n {
+            AnyCssRuleListItem::AnyCssRule(it) => it.into_syntax(),
+            AnyCssRuleListItem::ScssVariableDeclaration(it) => it.into_syntax(),
+        }
+    }
+}
+impl From<AnyCssRuleListItem> for SyntaxElement {
+    fn from(n: AnyCssRuleListItem) -> Self {
+        let node: SyntaxNode = n.into();
+        node.into()
+    }
+}
 impl From<CssBogusScopeRange> for AnyCssScopeRange {
     fn from(node: CssBogusScopeRange) -> Self {
         Self::CssBogusScopeRange(node)
@@ -46837,6 +46921,11 @@ impl std::fmt::Display for AnyCssRule {
     }
 }
 impl std::fmt::Display for AnyCssRuleBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for AnyCssRuleListItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }
@@ -53181,7 +53270,7 @@ impl Serialize for CssRuleList {
 }
 impl AstNodeList for CssRuleList {
     type Language = Language;
-    type Node = AnyCssRule;
+    type Node = AnyCssRuleListItem;
     fn syntax_list(&self) -> &SyntaxList {
         &self.syntax_list
     }
@@ -53196,15 +53285,15 @@ impl Debug for CssRuleList {
     }
 }
 impl IntoIterator for &CssRuleList {
-    type Item = AnyCssRule;
-    type IntoIter = AstNodeListIterator<Language, AnyCssRule>;
+    type Item = AnyCssRuleListItem;
+    type IntoIter = AstNodeListIterator<Language, AnyCssRuleListItem>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 impl IntoIterator for CssRuleList {
-    type Item = AnyCssRule;
-    type IntoIter = AstNodeListIterator<Language, AnyCssRule>;
+    type Item = AnyCssRuleListItem;
+    type IntoIter = AstNodeListIterator<Language, AnyCssRuleListItem>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -88,7 +88,11 @@ AnyCssRootItem =
 	| ScssVariableDeclaration
 	| CssBogus
 
-CssRuleList = AnyCssRule*
+CssRuleList = AnyCssRuleListItem*
+
+AnyCssRuleListItem =
+	AnyCssRule
+	| ScssVariableDeclaration
 
 AnyCssRule =
 	CssQualifiedRule


### PR DESCRIPTION
> This PR was created with AI assistance (OpenAI Codex).

## Summary

Allows SCSS variable declarations directly inside rule-list blocks such as `@media` and `@supports`.

```scss
@media (width >= 40rem) {
  $gap: 2rem;

  .card {
    gap: $gap;
  }
}
```


## Test Plan

- `cargo test -p biome_css_parser -p biome_css_formatter`
