### PR TITLE
fix(lint): remove double space in noUselessTernary quick fix

### DIFF
--- a/.changeset/fix-no-useless-ternary-double-space.md
+++ b/.changeset/fix-no-useless-ternary-double-space.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11092](https://github.com/biomejs/biome/issues/11092): The [`noUselessTernary`](https://biomejs.dev/linter/rules/no-useless-ternary/) quick fix no longer produces a double space before the operator when simplifying ternary expressions like `x > -1 ? true : false`.

--- a/.changeset/fix-no-useless-ternary-double-space.md
+++ b/.changeset/fix-no-useless-ternary-double-space.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#11092](https://github.com/biomejs/biome/issues/11092): The [`noUselessTernary`](https://biomejs.dev/linter/rules/no-useless-ternary/) quick fix no longer produces a double space before the operator when simplifying ternary expressions like `x > -1 ? true : false`.
+Fixed [#11092](https://github.com/biomejs/biome/issues/11092): The [`noUselessTernary`](https://biomejs.dev/linter/rules/no-useless-ternary/) quick fix now preserves operator spacing when simplifying or inverting boolean ternary expressions.

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
@@ -144,51 +144,32 @@ impl Rule for NoUselessTernary {
         } else if is_boolean_expression(&node.test().ok()?)? {
             match node_expression_kind {
                 JsSyntaxKind::JS_BINARY_EXPRESSION => {
-                    let left = node.test().ok()?.as_js_binary_expression()?.left().ok()?;
-                    let right = node.test().ok()?.as_js_binary_expression()?.right().ok()?;
-                    let operator = node
-                        .test()
-                        .ok()?
-                        .as_js_binary_expression()?
-                        .operator_token()
-                        .ok()?
-                        .kind();
+                    let binary = node.test().ok()?.as_js_binary_expression()?.clone();
+                    let left = binary.left().ok()?;
+                    let operator_token = binary.operator_token().ok()?;
+                    let right = binary.right().ok()?;
 
                     new_node = AnyJsExpression::from(make::js_binary_expression(
                         left,
-                        make::token_decorated_with_space(operator),
+                        operator_token,
                         right,
                     ));
                 }
                 JsSyntaxKind::JS_INSTANCEOF_EXPRESSION => {
-                    let left = node
-                        .test()
-                        .ok()?
-                        .as_js_instanceof_expression()?
-                        .left()
-                        .ok()?;
-                    let right = node
-                        .test()
-                        .ok()?
-                        .as_js_instanceof_expression()?
-                        .right()
-                        .ok()?;
-                    new_node = make::js_instanceof_expression(
-                        left,
-                        make::token_decorated_with_space(T![instanceof]),
-                        right,
-                    )
-                    .into();
+                    let instanceof = node.test().ok()?.as_js_instanceof_expression()?.clone();
+                    let left = instanceof.left().ok()?;
+                    let instanceof_token = instanceof.instanceof_token().ok()?;
+                    let right = instanceof.right().ok()?;
+
+                    new_node = make::js_instanceof_expression(left, instanceof_token, right).into();
                 }
                 JsSyntaxKind::JS_IN_EXPRESSION => {
-                    let property = node.test().ok()?.as_js_in_expression()?.property().ok()?;
-                    let object = node.test().ok()?.as_js_in_expression()?.object().ok()?;
-                    new_node = make::js_in_expression(
-                        property,
-                        make::token_decorated_with_space(T![in]),
-                        object,
-                    )
-                    .into();
+                    let in_expr = node.test().ok()?.as_js_in_expression()?.clone();
+                    let property = in_expr.property().ok()?;
+                    let in_token = in_expr.in_token().ok()?;
+                    let object = in_expr.object().ok()?;
+
+                    new_node = make::js_in_expression(property, in_token, object).into();
                 }
                 JsSyntaxKind::JS_UNARY_EXPRESSION => {
                     let argument = node

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
@@ -244,12 +244,15 @@ fn invert_expression(expression: &AnyJsExpression) -> Option<AnyJsExpression> {
             _ => None,
         };
 
-        if let Some(operator) = suggested_operator {
+        if let Some(suggested_operator) = suggested_operator {
             let left = expression.as_js_binary_expression()?.left().ok()?;
             let right = expression.as_js_binary_expression()?.right().ok()?;
+            let suggested_operator = make::token(suggested_operator)
+                .with_leading_trivia_pieces(operator.leading_trivia().pieces())
+                .with_trailing_trivia_pieces(operator.trailing_trivia().pieces());
             let new_node = AnyJsExpression::from(make::js_binary_expression(
                 left,
-                make::token(operator),
+                suggested_operator,
                 right,
             ));
 

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js
@@ -18,6 +18,4 @@ var a = x instanceof foo ? true : false;
 
 var a = 'make' in car ? true : false;
 var a = 'make' in car ? false : true;
-
-// Regression test: no double space before operator (biome#11092)
 const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js
@@ -18,3 +18,6 @@ var a = x instanceof foo ? true : false;
 
 var a = 'make' in car ? true : false;
 var a = 'make' in car ? false : true;
+
+// Regression test: no double space before operator (biome#11092)
+const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js.snap
@@ -24,6 +24,9 @@ var a = x instanceof foo ? true : false;
 
 var a = 'make' in car ? true : false;
 var a = 'make' in car ? false : true;
+
+// Regression test: no double space before operator (biome#11092)
+const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;
 ```
 
 # Diagnostics
@@ -263,13 +266,8 @@ invalid.js:11:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
   
   i Unsafe fix: Remove the conditional expression with
   
-     9  9 │   var a = foo() ? true : false;
-    10 10 │   var a = foo ? true : false;
-    11    │ - var·a·=·foo·===·1·?·true·:·false;
-       11 │ + var·a·=·foo··===·1;
-    12 12 │   var a = foo + 1 ? true : false;
-    13 13 │   
-  
+    11 │ var·a·=·foo·===·1·?·true·:·false;
+       │                  --------------- 
 
 ```
 
@@ -373,13 +371,8 @@ invalid.js:17:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
   
   i Unsafe fix: Remove the conditional expression with
   
-    15 15 │   
-    16 16 │   var a = x instanceof foo ? false : true;
-    17    │ - var·a·=·x·instanceof·foo·?·true·:·false;
-       17 │ + var·a·=·x··instanceof·foo;
-    18 18 │   
-    19 19 │   var a = 'make' in car ? true : false;
-  
+    17 │ var·a·=·x·instanceof·foo·?·true·:·false;
+       │                         --------------- 
 
 ```
 
@@ -393,6 +386,7 @@ invalid.js:19:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
   > 19 │ var a = 'make' in car ? true : false;
        │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     20 │ var a = 'make' in car ? false : true;
+    21 │ 
   
   i Simplify your code by directly assigning the result without using a ternary operator.
   
@@ -401,12 +395,8 @@ invalid.js:19:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
   
   i Unsafe fix: Remove the conditional expression with
   
-    17 17 │   var a = x instanceof foo ? true : false;
-    18 18 │   
-    19    │ - var·a·=·'make'·in·car·?·true·:·false;
-       19 │ + var·a·=·'make'··in·car;
-    20 20 │   var a = 'make' in car ? false : true;
-  
+    19 │ var·a·=·'make'·in·car·?·true·:·false;
+       │                      --------------- 
 
 ```
 
@@ -418,6 +408,8 @@ invalid.js:20:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
     19 │ var a = 'make' in car ? true : false;
   > 20 │ var a = 'make' in car ? false : true;
        │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
+    22 │ // Regression test: no double space before operator (biome#11092)
   
   i Simplify your code by directly assigning the result without using a ternary operator.
   
@@ -430,6 +422,29 @@ invalid.js:20:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
     19 19 │   var a = 'make' in car ? true : false;
     20    │ - var·a·=·'make'·in·car·?·false·:·true;
        20 │ + var·a·=·!('make'·in·car·);
+    21 21 │   
+    22 22 │   // Regression test: no double space before operator (biome#11092)
   
+
+```
+
+```
+invalid.js:23:24 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unnecessary use of boolean literals in conditional expression.
+  
+    22 │ // Regression test: no double space before operator (biome#11092)
+  > 23 │ const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;
+       │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i Simplify your code by directly assigning the result without using a ternary operator.
+  
+  i If your goal is negation, you may use the logical NOT (!) or double NOT (!!) operator for clearer and concise code.
+     Check for more details about NOT operator.
+  
+  i Unsafe fix: Remove the conditional expression with
+  
+    23 │ const·pauseEventLane·=·document.cookie.indexOf('cid_debug=false')·>·-1·?·true·:·false;
+       │                                                                       --------------- 
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid.js.snap
@@ -24,8 +24,6 @@ var a = x instanceof foo ? true : false;
 
 var a = 'make' in car ? true : false;
 var a = 'make' in car ? false : true;
-
-// Regression test: no double space before operator (biome#11092)
 const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;
 ```
 
@@ -154,7 +152,7 @@ invalid.js:6:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━�
      4  4 │   var a = foo() ? false : true;
      5  5 │   var a = foo ? false : true;
      6    │ - var·a·=·foo·===·1·?·false·:·true;
-        6 │ + var·a·=·foo·!==1;
+        6 │ + var·a·=·foo·!==·1;
      7  7 │   var a = foo + 1 ? false : true;
      8  8 │   
   
@@ -386,7 +384,7 @@ invalid.js:19:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
   > 19 │ var a = 'make' in car ? true : false;
        │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     20 │ var a = 'make' in car ? false : true;
-    21 │ 
+    21 │ const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;
   
   i Simplify your code by directly assigning the result without using a ternary operator.
   
@@ -408,8 +406,7 @@ invalid.js:20:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
     19 │ var a = 'make' in car ? true : false;
   > 20 │ var a = 'make' in car ? false : true;
        │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    21 │ 
-    22 │ // Regression test: no double space before operator (biome#11092)
+    21 │ const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;
   
   i Simplify your code by directly assigning the result without using a ternary operator.
   
@@ -422,19 +419,19 @@ invalid.js:20:9 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━
     19 19 │   var a = 'make' in car ? true : false;
     20    │ - var·a·=·'make'·in·car·?·false·:·true;
        20 │ + var·a·=·!('make'·in·car·);
-    21 21 │   
-    22 22 │   // Regression test: no double space before operator (biome#11092)
+    21 21 │   const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;
   
 
 ```
 
 ```
-invalid.js:23:24 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:21:24 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Unnecessary use of boolean literals in conditional expression.
   
-    22 │ // Regression test: no double space before operator (biome#11092)
-  > 23 │ const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;
+    19 │ var a = 'make' in car ? true : false;
+    20 │ var a = 'make' in car ? false : true;
+  > 21 │ const pauseEventLane = document.cookie.indexOf('cid_debug=false') > -1 ? true : false;
        │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
   i Simplify your code by directly assigning the result without using a ternary operator.
@@ -444,7 +441,7 @@ invalid.js:23:24 lint/complexity/noUselessTernary  FIXABLE  ━━━━━━�
   
   i Unsafe fix: Remove the conditional expression with
   
-    23 │ const·pauseEventLane·=·document.cookie.indexOf('cid_debug=false')·>·-1·?·true·:·false;
+    21 │ const·pauseEventLane·=·document.cookie.indexOf('cid_debug=false')·>·-1·?·true·:·false;
        │                                                                       --------------- 
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid_without_trivia.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessTernary/invalid_without_trivia.js.snap
@@ -264,13 +264,8 @@ invalid_without_trivia.js:11:9 lint/complexity/noUselessTernary  FIXABLE  ━━
   
   i Unsafe fix: Remove the conditional expression with
   
-     9  9 │   var a = foo()?true:false;
-    10 10 │   var a = foo?true:false;
-    11    │ - var·a·=·foo===1?true:false;
-       11 │ + var·a·=·foo·===·1;
-    12 12 │   var a = foo+1?true:false;
-    13 13 │   
-  
+    11 │ var·a·=·foo===1?true:false;
+       │                ----------- 
 
 ```
 


### PR DESCRIPTION
> This PR was authored with assistance from Claude Code (AI). I reviewed, understood, and validated all changes.

## Summary

Fixes #11092.

Preserves original operator trivia when simplifying boolean ternaries. This removes doubled spacing for direct comparisons and preserves spacing when equality operators are inverted.

## Test Plan

- Added the reported regression case in `invalid.js`
- Updated snapshots, including `foo === 1 ? false : true` becoming `foo !== 1`
- `cargo test -p biome_js_analyze -- no_useless_ternary`
- `cargo fmt --all --check`
- `just l`

## Docs

No documentation changes needed; this corrects an existing quick fix.