### PR TITLE
chore(xtask): migrate RegExp global types

### DIFF
--- a/crates/biome_js_type_info/src/generated/global_types.rs
+++ b/crates/biome_js_type_info/src/generated/global_types.rs
@@ -4,6 +4,8 @@
 
 /// Predefined global IDs whose `TypeData` is supplied by this generated module.
 pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
+    crate::globals::REGEXP_ID_GLOBAL_TYPE_ID,
+    crate::globals::REGEXP_EXEC_ID_GLOBAL_TYPE_ID,
     crate::globals::SYMBOL_ID_GLOBAL_TYPE_ID,
     crate::globals::SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID,
     crate::globals::SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID,
@@ -22,6 +24,25 @@ pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
 pub(crate) fn set_generated_global_type_data(
     builder: &mut crate::globals_builder::GlobalsResolverBuilder,
 ) {
+    let data = crate::TypeData::Class(Box::new(crate::Class {
+        name: Some(biome_rowan::Text::new_static("RegExp")),
+        type_parameters: Box::default(),
+        extends: None,
+        implements: Box::default(),
+        members: Box::new([crate::TypeMember {
+            kind: crate::TypeMemberKind::Named(biome_rowan::Text::new_static("exec")),
+            ty: crate::globals::GLOBAL_REGEXP_EXEC_ID.into(),
+        }]),
+    }));
+    builder.set_type_data(crate::globals::REGEXP_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Function(Box::new(crate::Function {
+        is_async: false,
+        type_parameters: Box::default(),
+        name: Some(biome_rowan::Text::new_static("RegExp.exec")),
+        parameters: Box::new([]),
+        return_type: crate::ReturnType::Type(crate::globals::GLOBAL_INSTANCEOF_REGEXP_ID.into()),
+    }));
+    builder.set_type_data(crate::globals::REGEXP_EXEC_ID_GLOBAL_TYPE_ID, data);
     let data = crate::TypeData::Class(Box::new(crate::Class {
         name: Some(biome_rowan::Text::new_static("Symbol")),
         type_parameters: Box::default(),

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -335,24 +335,6 @@ impl Default for RawGlobalTypes {
         builder.set_manual_type_data(INSTANCEOF_REGEXP_ID_GLOBAL_TYPE_ID, || {
             TypeData::instance_of(TypeReference::from(GLOBAL_REGEXP_ID))
         });
-        builder.set_manual_type_data(REGEXP_ID_GLOBAL_TYPE_ID, || {
-            TypeData::Class(Box::new(Class {
-                name: Some(Text::new_static(REGEXP_ID_NAME)),
-                type_parameters: Box::default(),
-                extends: None,
-                implements: Box::default(),
-                members: Box::new([member("exec", REGEXP_EXEC_ID)]),
-            }))
-        });
-        builder.set_manual_type_data(REGEXP_EXEC_ID_GLOBAL_TYPE_ID, || {
-            TypeData::from(Function {
-                is_async: false,
-                type_parameters: Default::default(),
-                name: Some(Text::new_static(REGEXP_EXEC_ID_NAME)),
-                parameters: Default::default(),
-                return_type: ReturnType::Type(GLOBAL_INSTANCEOF_REGEXP_ID.into()),
-            })
-        });
         builder.set_manual_type_data(INSTANCEOF_DATE_ID_GLOBAL_TYPE_ID, || {
             TypeData::instance_of(TypeReference::from(GLOBAL_DATE_ID))
         });

--- a/crates/biome_js_type_info/src/globals_ids.rs
+++ b/crates/biome_js_type_info/src/globals_ids.rs
@@ -476,6 +476,8 @@ mod tests {
         assert_eq!(
             migrated,
             &[
+                REGEXP_ID_GLOBAL_TYPE_ID,
+                REGEXP_EXEC_ID_GLOBAL_TYPE_ID,
                 SYMBOL_ID_GLOBAL_TYPE_ID,
                 SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID,
                 SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID,

--- a/xtask/codegen/src/generate_global_types/compare.rs
+++ b/xtask/codegen/src/generate_global_types/compare.rs
@@ -74,6 +74,7 @@ pub fn compare_lowered_globals(lowered: &LoweredGlobalTypes) -> Result<()> {
     assert_error_call_shape(call)?;
 
     assert_symbol_shape(lowered)?;
+    assert_regexp_shape(lowered)?;
     assert_memberless_class_shape(
         lowered,
         "Date",
@@ -114,6 +115,60 @@ pub fn compare_lowered_globals(lowered: &LoweredGlobalTypes) -> Result<()> {
             return_type_id: "GLOBAL_INSTANCEOF_PROMISE_ID",
         },
     )?;
+
+    Ok(())
+}
+
+/// Rejects output that differs from the predefined `RegExp` projection used by the resolver.
+fn assert_regexp_shape(lowered: &LoweredGlobalTypes) -> Result<()> {
+    let Some(regexp) = lowered.global("RegExp") else {
+        bail!("generated globals are missing the RegExp global");
+    };
+    if regexp.id_constant() != "REGEXP_ID_GLOBAL_TYPE_ID" {
+        bail!(
+            "generated RegExp global targets {}, expected REGEXP_ID_GLOBAL_TYPE_ID",
+            regexp.id_constant()
+        );
+    }
+    let LoweredTypeData::Class(class) = regexp.data() else {
+        bail!("generated RegExp global is not a class");
+    };
+    if class.name() != "RegExp" {
+        bail!(
+            "generated RegExp class has name {}, expected RegExp",
+            class.name()
+        );
+    }
+    if !class.type_parameters().is_empty() {
+        bail!("generated RegExp global must not have type parameters");
+    }
+    let [exec_member] = class.members() else {
+        bail!(
+            "generated RegExp global has {} members, expected one",
+            class.members().len()
+        );
+    };
+    if exec_member.name() != "exec"
+        || exec_member.kind() != &(LoweredMemberKind::Named { optional: false })
+        || exec_member.type_reference()
+            != &LoweredTypeReference::Predefined("GLOBAL_REGEXP_EXEC_ID")
+    {
+        bail!("generated RegExp.exec member has unexpected shape");
+    }
+
+    let exec = generated_function(lowered, "RegExp.exec", "REGEXP_EXEC_ID_GLOBAL_TYPE_ID")?;
+    if exec.is_async() {
+        bail!("generated RegExp.exec helper must not be async");
+    }
+    if exec.name() != Some("RegExp.exec") {
+        bail!("generated RegExp.exec helper has unexpected function name");
+    }
+    if !exec.parameters().is_empty() {
+        bail!("generated RegExp.exec helper must not have parameters");
+    }
+    if exec.return_type() != &LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_REGEXP_ID") {
+        bail!("generated RegExp.exec helper has unexpected return type");
+    }
 
     Ok(())
 }

--- a/xtask/codegen/src/generate_global_types/emit.rs
+++ b/xtask/codegen/src/generate_global_types/emit.rs
@@ -16,6 +16,8 @@ const OUTPUT_RELATIVE_PATH: &str = "crates/biome_js_type_info/src/generated/glob
 /// The index is the row position in `PREDEFINED_ID_ROWS`. This keeps
 /// `MIGRATED_PREDEFINED_IDS` sorted for the runtime `binary_search`.
 const GLOBAL_ID_EMIT_ORDER: &[&str] = &[
+    "REGEXP_ID_GLOBAL_TYPE_ID",
+    "REGEXP_EXEC_ID_GLOBAL_TYPE_ID",
     "SYMBOL_ID_GLOBAL_TYPE_ID",
     "SYMBOL_DISPOSE_ID_GLOBAL_TYPE_ID",
     "SYMBOL_ASYNC_DISPOSE_ID_GLOBAL_TYPE_ID",

--- a/xtask/codegen/src/generate_global_types/lower.rs
+++ b/xtask/codegen/src/generate_global_types/lower.rs
@@ -260,6 +260,7 @@ pub fn lower_global_types(
     let mut globals = Vec::new();
 
     lower_error_globals(manifest, &mut source_cache, &mut globals)?;
+    lower_regexp_globals(manifest, &mut source_cache, &mut globals)?;
     lower_symbol_globals(manifest, &mut source_cache, &mut globals)?;
     lower_disposable_global(manifest, &mut source_cache, &mut globals, DISPOSABLE_GLOBAL)?;
     lower_disposable_global(
@@ -469,6 +470,8 @@ const WEAK_MAP_GLOBAL: MemberlessClassSpec = MemberlessClassSpec {
     type_parameter_ids: &["GLOBAL_T_ID", "GLOBAL_U_ID"],
 };
 
+const REGEXP_EXEC_RETURN_TYPE_VARIANT_COUNT: usize = 2;
+
 struct ParsedSource<'a> {
     repo_relative: &'a str,
     module: TsDeclarationModule,
@@ -614,6 +617,221 @@ fn validate_symbol_constructor_reference(
     };
     if identifier.value_token()?.token_text_trimmed().text() != "SymbolConstructor" {
         bail!("declare var Symbol must reference SymbolConstructor");
+    }
+
+    Ok(())
+}
+
+/// Validates the TypeScript `exec` signature before emitting the predefined `RegExp` projection.
+fn lower_regexp_globals(
+    manifest: &GlobalManifest,
+    source_cache: &mut ParsedSourceCache,
+    globals: &mut Vec<LoweredGlobal>,
+) -> Result<()> {
+    let Some(regexp_group) = manifest.global_group("RegExp") else {
+        return Ok(());
+    };
+    if !regexp_group.has_role(GlobalDeclarationRole::Type) {
+        bail!("RegExp global must have a type-side declaration");
+    }
+
+    let Some(exec_array_group) = manifest.global_group("RegExpExecArray") else {
+        bail!("RegExp.exec references missing RegExpExecArray global");
+    };
+    if !exec_array_group.has_role(GlobalDeclarationRole::Type) {
+        bail!("RegExpExecArray must have a type-side declaration");
+    }
+
+    let mut saw_interface = false;
+    let mut saw_exec = false;
+    for record in regexp_group.declarations() {
+        match &record.kind {
+            DeclarationKind::Interface => {
+                saw_interface = true;
+            }
+            DeclarationKind::TypeAlias => {
+                bail!("type aliases are not supported in the RegExp global")
+            }
+            DeclarationKind::VariableDeclarator { .. } => continue,
+            DeclarationKind::DeclareFunction | DeclarationKind::ImportEquals => {
+                bail!("unsupported value-side RegExp declaration")
+            }
+        }
+
+        let declaration = source_cache
+            .find_interface_declaration(record)?
+            .with_context(|| {
+                format!(
+                    "failed to find interface declaration {} at {:?}",
+                    record.declared_name.text(),
+                    record.text_range
+                )
+            })?;
+        if declaration.extends_clause().is_some() {
+            bail!("RegExp interface extends clauses are not supported");
+        }
+        if declaration.type_parameters().is_some() {
+            bail!("RegExp interface type parameters are not supported");
+        }
+
+        for member in declaration.members() {
+            match member {
+                AnyTsTypeMember::TsMethodSignatureTypeMember(method) => {
+                    if is_regexp_exec_member(method.name()?)? {
+                        if saw_exec {
+                            bail!("RegExp has multiple exec methods");
+                        }
+                        validate_regexp_exec_method(&method)?;
+                        saw_exec = true;
+                    }
+                }
+                AnyTsTypeMember::TsPropertySignatureTypeMember(property) => {
+                    reject_regexp_exec_non_method(property.name()?)?;
+                }
+                AnyTsTypeMember::TsGetterSignatureTypeMember(getter) => {
+                    reject_regexp_exec_non_method(getter.name()?)?;
+                }
+                AnyTsTypeMember::TsSetterSignatureTypeMember(setter) => {
+                    reject_regexp_exec_non_method(setter.name()?)?;
+                }
+                AnyTsTypeMember::JsBogusMember(_)
+                | AnyTsTypeMember::TsCallSignatureTypeMember(_)
+                | AnyTsTypeMember::TsConstructSignatureTypeMember(_)
+                | AnyTsTypeMember::TsIndexSignatureTypeMember(_) => {}
+            }
+        }
+    }
+
+    if !saw_interface {
+        bail!("RegExp global must include an interface declaration");
+    }
+    if !saw_exec {
+        bail!("RegExp is missing exec");
+    }
+
+    globals.push(LoweredGlobal {
+        name: Text::from("RegExp"),
+        id_constant: "REGEXP_ID_GLOBAL_TYPE_ID",
+        data: LoweredTypeData::Class(LoweredClass {
+            name: Text::from("RegExp"),
+            type_parameters: Box::default(),
+            members: Box::new([LoweredTypeMember {
+                name: Text::from("exec"),
+                kind: LoweredMemberKind::Named { optional: false },
+                type_reference: LoweredTypeReference::Predefined("GLOBAL_REGEXP_EXEC_ID"),
+            }]),
+        }),
+    });
+    globals.push(LoweredGlobal {
+        name: Text::from("RegExp.exec"),
+        id_constant: "REGEXP_EXEC_ID_GLOBAL_TYPE_ID",
+        data: LoweredTypeData::Function(LoweredFunction {
+            is_async: false,
+            name: Some(Text::from("RegExp.exec")),
+            parameters: Box::default(),
+            return_type: LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_REGEXP_ID"),
+        }),
+    });
+
+    Ok(())
+}
+
+/// Computed names are excluded from the selected `exec` declaration.
+fn is_regexp_exec_member(name: AnyJsObjectMemberName) -> Result<bool> {
+    let AnyJsObjectMemberName::JsLiteralMemberName(name) = name else {
+        return Ok(false);
+    };
+    Ok(name.name()?.text() == "exec")
+}
+
+/// Prevents a property or accessor named `exec` from being silently ignored.
+fn reject_regexp_exec_non_method(name: AnyJsObjectMemberName) -> Result<()> {
+    if is_regexp_exec_member(name)? {
+        bail!("RegExp.exec must be a method");
+    }
+    Ok(())
+}
+
+/// Accepts a required, non-generic `exec(string): RegExpExecArray | null` declaration.
+fn validate_regexp_exec_method(method: &TsMethodSignatureTypeMember) -> Result<()> {
+    if method.optional_token().is_some() {
+        bail!("RegExp.exec must not be optional");
+    }
+    if method.type_parameters().is_some() {
+        bail!("RegExp.exec must not be generic");
+    }
+    validate_regexp_exec_parameter(method.parameters()?)?;
+
+    let return_type = method
+        .return_type_annotation()
+        .context("RegExp.exec is missing a return type")?
+        .ty()
+        .context("RegExp.exec has a malformed return type")?;
+    let AnyTsReturnType::AnyTsType(AnyTsType::TsUnionType(union)) = return_type else {
+        bail!("RegExp.exec must return RegExpExecArray | null");
+    };
+
+    let mut saw_exec_array = false;
+    let mut saw_null = false;
+    let mut return_type_variant_count = 0;
+    for variant in union.types() {
+        let variant = variant.context("RegExp.exec has a malformed return type variant")?;
+        return_type_variant_count += 1;
+        match variant {
+            AnyTsType::TsNullLiteralType(_) => saw_null = true,
+            AnyTsType::TsReferenceType(reference) => {
+                if reference.type_arguments().is_some() {
+                    bail!("RegExp.exec must return RegExpExecArray | null");
+                }
+                let biome_js_syntax::AnyTsName::JsReferenceIdentifier(identifier) = reference
+                    .name()
+                    .context("RegExp.exec return type is missing a reference name")?
+                else {
+                    bail!("RegExp.exec must return RegExpExecArray | null");
+                };
+                if identifier.value_token()?.token_text_trimmed().text() != "RegExpExecArray" {
+                    bail!("RegExp.exec must return RegExpExecArray | null");
+                }
+                saw_exec_array = true;
+            }
+            _ => bail!("RegExp.exec must return RegExpExecArray | null"),
+        }
+    }
+    if return_type_variant_count != REGEXP_EXEC_RETURN_TYPE_VARIANT_COUNT
+        || !saw_exec_array
+        || !saw_null
+    {
+        bail!("RegExp.exec must return RegExpExecArray | null");
+    }
+
+    Ok(())
+}
+
+/// Requires exactly one non-optional `string` parameter.
+fn validate_regexp_exec_parameter(parameters: JsParameters) -> Result<()> {
+    let mut parameters = parameters.items().into_iter();
+    let Some(parameter) = parameters.next() else {
+        bail!("RegExp.exec must have one required string parameter");
+    };
+    if parameters.next().is_some() {
+        bail!("RegExp.exec must have one required string parameter");
+    }
+
+    let AnyJsParameter::AnyJsFormalParameter(AnyJsFormalParameter::JsFormalParameter(parameter)) =
+        parameter.context("RegExp.exec has a malformed parameter")?
+    else {
+        bail!("RegExp.exec must have one required string parameter");
+    };
+    if parameter.question_mark_token().is_some() {
+        bail!("RegExp.exec must have one required string parameter");
+    }
+    let type_node = parameter
+        .type_annotation()
+        .context("RegExp.exec parameter is missing a type annotation")?
+        .ty()
+        .context("RegExp.exec parameter has a malformed type annotation")?;
+    if !matches!(type_node, AnyTsType::TsStringType(_)) {
+        bail!("RegExp.exec must have one required string parameter");
     }
 
     Ok(())

--- a/xtask/codegen/tests/fixtures/global-types/manifest.disposables.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.disposables.d.ts
@@ -34,6 +34,12 @@ interface AsyncDisposable {
     [Symbol.asyncDispose](): PromiseLike<void>;
 }
 
+interface RegExpExecArray {}
+
+interface RegExp {
+    exec(string: string): RegExpExecArray | null;
+}
+
 interface Date {
     toString(): string;
 }


### PR DESCRIPTION
## Summary

Part of #5977.

Migrates `RegExp` and `RegExp.exec` to generated global types while preserving their existing shapes. The TypeScript `exec` signature is validated without changing the inference engine.

> This PR was implemented with AI assistance from Codex.

## Test Plan

- Verified `just gen-global-types` is idempotent.

## Docs

N/A
