### PR TITLE
feat(fmt/md): prose-wrap formatting for markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "biome_json_formatter",
  "biome_json_parser",
  "biome_json_syntax",
+ "biome_markdown_formatter",
  "biome_plugin_loader",
  "biome_resolver",
  "biome_rowan",
@@ -1422,6 +1423,8 @@ name = "biome_markdown_formatter"
 version = "0.0.1"
 dependencies = [
  "biome_configuration",
+ "biome_deserialize",
+ "biome_deserialize_macros",
  "biome_formatter",
  "biome_formatter_test",
  "biome_fs",

--- a/crates/biome_configuration/Cargo.toml
+++ b/crates/biome_configuration/Cargo.toml
@@ -35,6 +35,7 @@ biome_html_syntax          = { workspace = true, optional = true }
 biome_js_formatter         = { workspace = true, features = ["serde"], optional = true }
 biome_json_formatter       = { workspace = true, features = ["serde"], optional = true }
 biome_json_syntax          = { workspace = true, optional = true }
+biome_markdown_formatter   = { workspace = true, features = ["serde"], optional = true }
 biome_plugin_loader        = { workspace = true, optional = true }
 biome_resolver             = { workspace = true }
 biome_rowan                = { workspace = true, features = ["serde"] }
@@ -66,7 +67,7 @@ lang_graphql = ["biome_configuration_macros/lang_graphql"]
 lang_html    = ["biome_configuration_macros/lang_html", "dep:biome_html_formatter", "dep:biome_html_syntax"]
 lang_js      = ["biome_configuration_macros/lang_js", "dep:biome_js_formatter"]
 lang_json    = ["biome_configuration_macros/lang_json", "dep:biome_json_formatter"]
-lang_md      = []
+lang_md      = ["dep:biome_markdown_formatter"]
 lang_yaml    = ["dep:biome_yaml_syntax"]
 plugins      = ["dep:biome_plugin_loader"]
 schema       = [
@@ -77,6 +78,7 @@ schema       = [
   "biome_js_formatter/schema",
   "biome_json_formatter/schema",
   "biome_json_syntax/schema",
+  "biome_markdown_formatter/schema",
   "biome_plugin_loader/schema",
   "biome_rule_options/schema",
   "biome_yaml_syntax/schema",

--- a/crates/biome_configuration/src/markdown.rs
+++ b/crates/biome_configuration/src/markdown.rs
@@ -1,6 +1,7 @@
 use crate::bool::Bool;
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::{IndentStyle, IndentWidth, LineEnding, LineWidth, TrailingNewline};
+use biome_markdown_formatter::context::ProseWrap;
 #[cfg(feature = "cli")]
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
@@ -68,4 +69,12 @@ pub struct MarkdownFormatterConfiguration {
     #[cfg_attr(all(feature = "cli", feature = "lang_md"), bpaf(hide))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_ending: Option<LineEnding>,
+
+    /// Controls whether Biome keeps, adds, or removes line breaks in Markdown paragraphs.
+    ///
+    /// Manual line breaks are always kept. In Markdown, a manual line break is created by ending a
+    /// line with two spaces or a backslash.
+    #[cfg_attr(all(feature = "cli", feature = "lang_md"), bpaf(hide))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prose_wrap: Option<ProseWrap>,
 }

--- a/crates/biome_markdown_formatter/Cargo.toml
+++ b/crates/biome_markdown_formatter/Cargo.toml
@@ -11,12 +11,14 @@ categories.workspace = true
 include              = ["src/**/*"]
 
 [dependencies]
-biome_formatter        = { workspace = true }
-biome_markdown_factory = { workspace = true }
-biome_markdown_syntax  = { workspace = true }
-biome_rowan            = { workspace = true }
-schemars               = { workspace = true, optional = true }
-serde                  = { workspace = true, features = ["derive"], optional = true }
+biome_deserialize        = { workspace = true }
+biome_deserialize_macros = { workspace = true }
+biome_formatter          = { workspace = true }
+biome_markdown_factory   = { workspace = true }
+biome_markdown_syntax    = { workspace = true }
+biome_rowan              = { workspace = true }
+schemars                 = { workspace = true, optional = true }
+serde                    = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 biome_configuration   = { path = "../biome_configuration" }

--- a/crates/biome_markdown_formatter/src/context.rs
+++ b/crates/biome_markdown_formatter/src/context.rs
@@ -1,12 +1,11 @@
-use std::{fmt, rc::Rc};
-
+use crate::comments::{FormatMarkdownLeadingComment, MarkdownCommentStyle};
+use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::{
     CstFormatContext, FormatContext, FormatOptions, IndentStyle, IndentWidth, LineEnding,
     LineWidth, TrailingNewline, TransformSourceMap, comments::Comments, printer::PrinterOptions,
 };
 use biome_markdown_syntax::MarkdownLanguage;
-
-use crate::comments::{FormatMarkdownLeadingComment, MarkdownCommentStyle};
+use std::{fmt, rc::Rc, str::FromStr};
 
 pub type MarkdownComments = Comments<MarkdownLanguage>;
 
@@ -24,6 +23,51 @@ pub struct MdFormatOptions {
     line_ending: LineEnding,
     line_width: LineWidth,
     trailing_newline: TrailingNewline,
+    prose_wrap: ProseWrap,
+}
+
+/// Controls whether Biome keeps, adds, or removes line breaks in Markdown paragraphs.
+///
+/// Manual line breaks are always kept. In Markdown, a manual line break is created by ending a
+/// line with two spaces or a backslash.
+#[derive(Debug, Default, Clone, Copy, Deserializable, Eq, Hash, Merge, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ProseWrap {
+    /// Keep line breaks as written in the source file. This is the default.
+    #[default]
+    Preserve,
+    /// Wrap paragraphs to fit the configured `lineWidth`.
+    Always,
+    /// Remove line breaks from paragraphs so that each paragraph is on one line.
+    Never,
+}
+
+impl fmt::Display for ProseWrap {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ProseWrap::Preserve => write!(f, "preserve"),
+            ProseWrap::Always => write!(f, "always"),
+            ProseWrap::Never => write!(f, "never"),
+        }
+    }
+}
+
+impl FromStr for ProseWrap {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "preserve" => Ok(Self::Preserve),
+            "always" => Ok(Self::Always),
+            "never" => Ok(Self::Never),
+            _ => Err("Unsupported value for this option"),
+        }
+    }
 }
 
 impl CstFormatContext for MarkdownFormatContext {
@@ -70,6 +114,7 @@ impl MdFormatOptions {
             line_ending: LineEnding::default(),
             line_width: LineWidth::default(),
             trailing_newline: TrailingNewline::default(),
+            prose_wrap: ProseWrap::default(),
         }
     }
 
@@ -96,6 +141,15 @@ impl MdFormatOptions {
     pub fn with_trailing_newline(mut self, trailing_newline: TrailingNewline) -> Self {
         self.trailing_newline = trailing_newline;
         self
+    }
+
+    pub fn with_prose_wrap(mut self, prose_wrap: ProseWrap) -> Self {
+        self.prose_wrap = prose_wrap;
+        self
+    }
+
+    pub fn prose_wrap(&self) -> ProseWrap {
+        self.prose_wrap
     }
 }
 
@@ -136,6 +190,7 @@ impl fmt::Display for MdFormatOptions {
         writeln!(f, "Indent width: {}", self.indent_width.value())?;
         writeln!(f, "Line ending: {}", self.line_ending)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
-        writeln!(f, "Trailing newline: {}", self.trailing_newline.value())
+        writeln!(f, "Trailing newline: {}", self.trailing_newline.value())?;
+        writeln!(f, "Prose Wrap: {}", self.prose_wrap)
     }
 }

--- a/crates/biome_markdown_formatter/src/context.rs
+++ b/crates/biome_markdown_formatter/src/context.rs
@@ -191,6 +191,6 @@ impl fmt::Display for MdFormatOptions {
         writeln!(f, "Line ending: {}", self.line_ending)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
         writeln!(f, "Trailing newline: {}", self.trailing_newline.value())?;
-        writeln!(f, "Prose Wrap: {}", self.prose_wrap)
+        writeln!(f, "Prose wrap: {}", self.prose_wrap)
     }
 }

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/inline_code.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/inline_code.rs
@@ -1,3 +1,4 @@
+use crate::context::ProseWrap;
 use crate::prelude::*;
 use biome_formatter::write;
 use biome_markdown_syntax::{
@@ -239,6 +240,29 @@ impl CodeSpanNormalization {
             0
         }
     }
+
+    fn replace_line_endings_with_spaces(text: &str) -> Cow<'_, str> {
+        if !text.contains(['\r', '\n']) {
+            return Cow::Borrowed(text);
+        }
+
+        let mut normalized = String::with_capacity(text.len());
+        let mut chars = text.chars().peekable();
+        while let Some(char) = chars.next() {
+            match char {
+                '\r' => {
+                    if chars.peek() == Some(&'\n') {
+                        chars.next();
+                    }
+                    normalized.push(' ');
+                }
+                '\n' => normalized.push(' '),
+                char => normalized.push(char),
+            }
+        }
+
+        Cow::Owned(normalized)
+    }
 }
 
 impl Format<MarkdownFormatContext> for CodeSpanNormalization {
@@ -248,21 +272,24 @@ impl Format<MarkdownFormatContext> for CodeSpanNormalization {
         }
 
         let last_index = self.textuals.len().saturating_sub(1);
+        let prose_wrap = f.options().prose_wrap();
 
         for (index, textual) in self.textuals.iter().enumerate() {
-            if !self.trim_boundaries || (index != 0 && index != last_index) {
+            if prose_wrap == ProseWrap::Preserve
+                && (!self.trim_boundaries || (index != 0 && index != last_index))
+            {
                 write!(f, [textual.format()])?;
                 continue;
             }
 
             let value_token = textual.value_token()?;
             let token_text = value_token.text();
-            let start = if index == 0 {
+            let start = if self.trim_boundaries && index == 0 {
                 Self::leading_space_or_line_ending_len(token_text)
             } else {
                 0
             };
-            let end = if index == last_index {
+            let end = if self.trim_boundaries && index == last_index {
                 token_text.len() - Self::trailing_space_or_line_ending_len(token_text)
             } else {
                 token_text.len()
@@ -274,8 +301,14 @@ impl Format<MarkdownFormatContext> for CodeSpanNormalization {
             if start == end {
                 format_removed(&value_token).fmt(f)?;
             } else {
+                let content = &token_text[start..end];
+                let content = if prose_wrap == ProseWrap::Preserve {
+                    Cow::Borrowed(content)
+                } else {
+                    Self::replace_line_endings_with_spaces(content)
+                };
                 let replacement = syntax_token_cow_slice(
-                    Cow::Borrowed(&token_text[start..end]),
+                    content,
                     &value_token,
                     value_token.text_range().start() + TextSize::from(start as u32),
                 )

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/link_reference_definition.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/link_reference_definition.rs
@@ -1,4 +1,8 @@
 use crate::prelude::*;
+use crate::{
+    context::ProseWrap,
+    markdown::auxiliary::link_title::{FormatMdLinkTitleOptions, is_empty_link_title},
+};
 use biome_formatter::write;
 use biome_markdown_syntax::{MdLinkReferenceDefinition, MdLinkReferenceDefinitionFields};
 #[derive(Debug, Clone, Default)]
@@ -10,7 +14,7 @@ impl FormatNodeRule<MdLinkReferenceDefinition> for FormatMdLinkReferenceDefiniti
         f: &mut MarkdownFormatter,
     ) -> FormatResult<()> {
         let MdLinkReferenceDefinitionFields {
-            indent,
+            indent: indent_tokens,
             l_brack_token,
             label,
             r_brack_token,
@@ -19,23 +23,58 @@ impl FormatNodeRule<MdLinkReferenceDefinition> for FormatMdLinkReferenceDefiniti
             title,
         } = node.as_fields();
 
+        if f.options().prose_wrap() == ProseWrap::Always {
+            let formatted_title = format_with(|f| {
+                if let Some(title) = &title
+                    && !is_empty_link_title(title)
+                {
+                    write!(
+                        f,
+                        [
+                            soft_line_break_or_space(),
+                            title.format().with_options(FormatMdLinkTitleOptions {
+                                leading_space: false,
+                            })
+                        ]
+                    )?;
+                }
+                Ok(())
+            });
+            return write!(
+                f,
+                [group(&biome_formatter::format_args![
+                    indent_tokens.format(),
+                    l_brack_token.format(),
+                    label.format(),
+                    r_brack_token.format(),
+                    colon_token.format(),
+                    indent(&biome_formatter::format_args![
+                        soft_line_break_or_space(),
+                        destination.format(),
+                        formatted_title
+                    ])
+                ])]
+            );
+        }
+
+        let formatted_title = format_with(|f| {
+            if let Some(title) = &title {
+                write!(f, [title.format()])?;
+            }
+            Ok(())
+        });
         write!(
             f,
             [
-                indent.format(),
+                indent_tokens.format(),
                 l_brack_token.format(),
                 label.format(),
                 r_brack_token.format(),
                 colon_token.format(),
                 space(),
                 destination.format(),
+                formatted_title,
             ]
-        )?;
-
-        if let Some(title) = title {
-            write!(f, [title.format()])?;
-        }
-
-        Ok(())
+        )
     }
 }

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/link_title.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/link_title.rs
@@ -2,40 +2,64 @@ use crate::markdown::auxiliary::textual::FormatMdTextualOptions;
 use crate::markdown::lists::inline_item_list::FormatMdFormatInlineItemListOptions;
 use crate::prelude::*;
 use crate::shared::{TextContext, TextPrintMode};
-use biome_formatter::write;
+use biome_formatter::{FormatRuleWithOptions, write};
 use biome_markdown_syntax::{
     AnyMdInline, MarkdownLanguage, MarkdownSyntaxToken, MdLinkTitle, MdLinkTitleFields, MdTextual,
 };
 use biome_rowan::{AstNode, AstNodeListIterator, TextRange, TextSize};
 use std::borrow::Cow;
 
-#[derive(Debug, Clone, Default)]
-pub(crate) struct FormatMdLinkTitle;
+#[derive(Debug, Clone)]
+pub(crate) struct FormatMdLinkTitle {
+    leading_space: bool,
+}
+
+impl Default for FormatMdLinkTitle {
+    fn default() -> Self {
+        Self {
+            leading_space: true,
+        }
+    }
+}
 impl FormatNodeRule<MdLinkTitle> for FormatMdLinkTitle {
     fn fmt_fields(&self, node: &MdLinkTitle, f: &mut MarkdownFormatter) -> FormatResult<()> {
         let MdLinkTitleFields { content } = node.as_fields();
 
         let Some(normalization) = LinkTitleNormalization::from_node(node) else {
-            return write!(
-                f,
-                [
-                    space(),
-                    content
-                        .format()
-                        .with_options(FormatMdFormatInlineItemListOptions {
-                            print_mode: TextPrintMode::trim_all(),
-                            keep_fences_in_italics: false,
-                            text_context: TextContext::Neutral,
-                        })
-                ]
-            );
+            let content = content
+                .format()
+                .with_options(FormatMdFormatInlineItemListOptions {
+                    print_mode: TextPrintMode::trim_all(),
+                    keep_fences_in_italics: false,
+                    text_context: TextContext::Neutral,
+                });
+            return if self.leading_space {
+                write!(f, [space(), content])
+            } else {
+                write!(f, [content])
+            };
         };
 
         if normalization.is_empty() {
             write!(f, [normalization])
-        } else {
+        } else if self.leading_space {
             write!(f, [space(), normalization])
+        } else {
+            write!(f, [normalization])
         }
+    }
+}
+
+pub(crate) struct FormatMdLinkTitleOptions {
+    pub(crate) leading_space: bool,
+}
+
+impl FormatRuleWithOptions<MdLinkTitle> for FormatMdLinkTitle {
+    type Options = FormatMdLinkTitleOptions;
+
+    fn with_options(mut self, options: Self::Options) -> Self {
+        self.leading_space = options.leading_space;
+        self
     }
 }
 
@@ -131,6 +155,10 @@ impl<'a> LinkTitleNormalization<'a> {
     fn is_empty(&self) -> bool {
         self.analysis.is_empty
     }
+}
+
+pub(crate) fn is_empty_link_title(title: &MdLinkTitle) -> bool {
+    LinkTitleNormalization::from_node(title).is_some_and(|normalization| normalization.is_empty())
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/quote.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/quote.rs
@@ -1,3 +1,4 @@
+use crate::context::ProseWrap;
 use crate::markdown::auxiliary::quote_prefix::FormatMdQuotePrefixOptions;
 use crate::markdown::lists::block_list::{
     FormatMdBlockListOptions, QuoteBoundaryTrim, quote_boundary_trim_range,
@@ -11,7 +12,8 @@ use biome_markdown_syntax::{MdQuote, MdQuoteFields};
 pub(crate) struct FormatMdQuote;
 impl FormatNodeRule<MdQuote> for FormatMdQuote {
     fn fmt_fields(&self, node: &MdQuote, f: &mut MarkdownFormatter) -> FormatResult<()> {
-        if should_format_quote_structurally(node)? {
+        let prose_wrap = f.options().prose_wrap();
+        if prose_wrap == ProseWrap::Preserve && should_format_quote_structurally(node)? {
             return Quote::new(node.clone()).fmt(f);
         }
 
@@ -40,11 +42,13 @@ impl FormatNodeRule<MdQuote> for FormatMdQuote {
             write!(f, [prefix.format()])?;
         }
 
-        write!(
-            f,
-            [content.format().with_options(FormatMdBlockListOptions {
-                quote_boundary_trim,
-            })]
-        )
+        let content = content.format().with_options(FormatMdBlockListOptions {
+            quote_boundary_trim,
+        });
+        if prose_wrap == ProseWrap::Preserve {
+            write!(f, [content])
+        } else {
+            write!(f, [align("> ", &content)])
+        }
     }
 }

--- a/crates/biome_markdown_formatter/src/markdown/auxiliary/setext_header.rs
+++ b/crates/biome_markdown_formatter/src/markdown/auxiliary/setext_header.rs
@@ -4,6 +4,8 @@ use crate::shared::{TextContext, TextPrintMode};
 use biome_formatter::write;
 use biome_markdown_syntax::{MdSetextHeader, MdSetextHeaderFields};
 
+use crate::context::ProseWrap;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatMdSetextHeader;
 impl FormatNodeRule<MdSetextHeader> for FormatMdSetextHeader {
@@ -15,7 +17,10 @@ impl FormatNodeRule<MdSetextHeader> for FormatMdSetextHeader {
 
         let underline_token = underline_token?;
 
-        if content.will_break() {
+        let prose_wrap = f.options().prose_wrap();
+        if prose_wrap == ProseWrap::Always
+            || prose_wrap == ProseWrap::Preserve && content.will_break()
+        {
             write!(
                 f,
                 [

--- a/crates/biome_markdown_formatter/src/markdown/lists/block_list.rs
+++ b/crates/biome_markdown_formatter/src/markdown/lists/block_list.rs
@@ -1,6 +1,8 @@
 use crate::bullet_list::FmtAnyList;
+use crate::context::ProseWrap;
 use crate::markdown::auxiliary::newline::FormatMdNewlineOptions;
 use crate::markdown::auxiliary::paragraph::FormatMdParagraphOptions;
+use crate::markdown::auxiliary::quote_prefix::FormatMdQuotePrefixOptions;
 use crate::prelude::*;
 use crate::shared::{TextContext, TextPrintMode, format_removed_quote_boundary};
 use biome_formatter::FormatRuleWithOptions;
@@ -18,6 +20,7 @@ pub(crate) struct FormatMdBlockList {
 impl FormatRule<MdBlockList> for FormatMdBlockList {
     type Context = MarkdownFormatContext;
     fn fmt(&self, node: &MdBlockList, f: &mut MarkdownFormatter) -> FormatResult<()> {
+        let prose_wrap = f.options().prose_wrap();
         let mut joiner = f.join();
 
         let text_context = if node
@@ -50,7 +53,11 @@ impl FormatRule<MdBlockList> for FormatMdBlockList {
                     AnyMdBlock::AnyMdLeafBlock(AnyMdLeafBlock::MdParagraph(paragraph)) => {
                         prev_content = PrevContentBlock::Paragraph;
                         joiner.entry(&paragraph.format().with_options(FormatMdParagraphOptions {
-                            trim_mode: TextPrintMode::Pristine,
+                            trim_mode: if prose_wrap == ProseWrap::Preserve {
+                                TextPrintMode::Pristine
+                            } else {
+                                TextPrintMode::fill()
+                            },
                             text_context,
                         }));
                     }
@@ -71,6 +78,12 @@ impl FormatRule<MdBlockList> for FormatMdBlockList {
                             joiner.entry(&node.format());
                         }
                         prev_content = PrevContentBlock::Other;
+                    }
+
+                    AnyMdBlock::MdQuotePrefix(prefix) if prose_wrap != ProseWrap::Preserve => {
+                        joiner.entry(&prefix.format().with_options(FormatMdQuotePrefixOptions {
+                            should_remove: true,
+                        }));
                     }
 
                     AnyMdBlock::MdQuotePrefix(prefix)

--- a/crates/biome_markdown_formatter/src/markdown/lists/inline_item_list.rs
+++ b/crates/biome_markdown_formatter/src/markdown/lists/inline_item_list.rs
@@ -980,16 +980,24 @@ impl FormatMdInlineItemList {
     }
 
     fn format_fill_segment(items: &[ProseItem], f: &mut MarkdownFormatter) -> FormatResult<()> {
+        let no_separator = format_with(|_| Ok(()));
         let mut fill = f.fill();
+        let mut has_separator = false;
 
         for item in items {
-            let ProseItem::WordGroup(group) = item else {
-                continue;
-            };
-            if group.starts_with_block_marker() {
-                fill.entry(&space(), group);
-            } else {
-                fill.entry(&soft_line_break_or_space(), group);
+            match item {
+                ProseItem::Space | ProseItem::SoftBreak => has_separator = true,
+                ProseItem::WordGroup(group) => {
+                    if group.starts_with_block_marker() {
+                        fill.entry(&space(), group);
+                    } else if has_separator {
+                        fill.entry(&soft_line_break_or_space(), group);
+                    } else {
+                        fill.entry(&no_separator, group);
+                    }
+                    has_separator = false;
+                }
+                ProseItem::HardBreak(_) | ProseItem::OutdentedLineStart => {}
             }
         }
 

--- a/crates/biome_markdown_formatter/src/markdown/lists/inline_item_list.rs
+++ b/crates/biome_markdown_formatter/src/markdown/lists/inline_item_list.rs
@@ -1,14 +1,14 @@
+use crate::context::ProseWrap;
 use crate::markdown::auxiliary::hard_line::FormatMdFormatHardLineOptions;
 use crate::markdown::auxiliary::inline_italic::FormatMdInlineItalicOptions;
 use crate::markdown::auxiliary::textual::FormatMdTextualOptions;
 use crate::prelude::*;
 use crate::shared::{TextContext, TextPrintMode, TrimMode};
-use crate::words::{FormatWordGroup, ProseItem, WordStreamResult, build_word_stream_flat};
+use crate::words::{ProseItem, ProseItemList};
 use biome_formatter::Format;
 use biome_markdown_syntax::MdBullet;
 
-/// Formats a sequence of prose items as a single line — word groups joined by spaces.
-/// SoftBreak and HardBreak are treated as space separators if encountered.
+/// Formats Markdown text on one line, replacing whitespace and line breaks with spaces.
 struct FormatSourceLine<'a>(&'a [ProseItem]);
 
 impl Format<MarkdownFormatContext> for FormatSourceLine<'_> {
@@ -16,15 +16,11 @@ impl Format<MarkdownFormatContext> for FormatSourceLine<'_> {
         let mut needs_space = false;
         for item in self.0 {
             match item {
-                ProseItem::WordGroup { atoms, escape } => {
+                ProseItem::WordGroup(group) => {
                     if needs_space {
                         write!(f, [space()])?;
                     }
-                    FormatWordGroup {
-                        atoms,
-                        escape: *escape,
-                    }
-                    .fmt(f)?;
+                    group.fmt(f)?;
                     needs_space = true;
                 }
                 ProseItem::Space | ProseItem::SoftBreak | ProseItem::HardBreak(_) => {
@@ -36,33 +32,6 @@ impl Format<MarkdownFormatContext> for FormatSourceLine<'_> {
         Ok(())
     }
 }
-/// Removes leading `Space` items after every `SoftBreak` in the word stream.
-///
-/// When the parser doesn't recognize continuation-line whitespace as
-/// `MdIndentToken` (e.g. because the source list marker had leading spaces
-/// that shift the expected indent), those spaces end up as `MdTextual " "`
-/// tokens → `Space` items in the stream. The structural `align()` in the IR
-/// already provides the correct indentation, so these spaces are artifacts.
-fn strip_spaces_after_soft_breaks(stream: &mut Vec<ProseItem>) {
-    let mut i = 0;
-    while i < stream.len() {
-        if matches!(stream[i], ProseItem::SoftBreak) {
-            let mut start = i + 1;
-            while start < stream.len() && matches!(stream[start], ProseItem::OutdentedLineStart) {
-                start += 1;
-            }
-            let mut end = start;
-            while end < stream.len() && matches!(stream[end], ProseItem::Space) {
-                end += 1;
-            }
-            if end > start {
-                stream.drain(start..end);
-            }
-        }
-        i += 1;
-    }
-}
-
 fn outdented_list_marker_lines(
     node: &MdInlineItemList,
     content_indent: usize,
@@ -850,23 +819,40 @@ impl FormatMdInlineItemList {
         write!(f, [hard_line_break()])
     }
 
-    /// Formats prose with `proseWrap: "preserve"` semantics.
-    ///
-    /// Each source line is emitted as-is with `hard_line_break` between them.
-    /// Hard breaks (`  \n` or `\\\n`) are formatted using their original node.
-    ///
-    /// TODO: for `proseWrap: "always"`, replace sequential writes with `f.fill()`
-    /// using `soft_line_break_or_space()` separators between word-level entries.
-    /// The word stream from `build_word_stream_flat` already provides the
-    /// granularity needed — just change the emission strategy.
     fn fmt_fill(
         &self,
         node: &MdInlineItemList,
         f: &mut MarkdownFormatter,
         text_context: TextContext,
     ) -> FormatResult<()> {
-        let WordStreamResult { mut stream } = build_word_stream_flat(node, f)?;
+        let mut items = ProseItemList::from_inline_item_list(node, f)?;
         let inside_list = text_context.is_list();
+
+        if inside_list {
+            items.remove_spaces_after_soft_breaks();
+        }
+        let items = items.as_slice();
+
+        match f.options().prose_wrap() {
+            ProseWrap::Preserve => self.fmt_prose_preserve(node, items, f, inside_list)?,
+            ProseWrap::Always => self.fmt_prose_always(items, f)?,
+            ProseWrap::Never => self.fmt_prose_never(items, f)?,
+        }
+
+        if !inside_list {
+            write!(f, [hard_line_break()])?;
+        }
+
+        Ok(())
+    }
+
+    fn fmt_prose_preserve(
+        &self,
+        node: &MdInlineItemList,
+        items: &[ProseItem],
+        f: &mut MarkdownFormatter,
+        inside_list: bool,
+    ) -> FormatResult<()> {
         let (outdented_lines, indented_outdented_lines) = if inside_list {
             enclosing_list_content_indent(node)
                 .map(|content_indent| outdented_list_marker_lines(node, content_indent))
@@ -876,18 +862,14 @@ impl FormatMdInlineItemList {
             (Vec::new(), Vec::new())
         };
 
-        if inside_list {
-            strip_spaces_after_soft_breaks(&mut stream);
-        }
-
         let mut is_first_line = true;
         let mut line_index = 0;
         let mut line_start = 0;
 
-        for (i, item) in stream.iter().enumerate() {
+        for (i, item) in items.iter().enumerate() {
             match item {
                 ProseItem::HardBreak(hard_break) => {
-                    let line_items = &stream[line_start..i];
+                    let line_items = &items[line_start..i];
                     if !line_items.is_empty() {
                         format_source_line(
                             line_items,
@@ -911,7 +893,7 @@ impl FormatMdInlineItemList {
                     line_index += 1;
                 }
                 ProseItem::SoftBreak => {
-                    let line_items = &stream[line_start..i];
+                    let line_items = &items[line_start..i];
                     if !line_items.is_empty() {
                         let next_line_is_outdented_list_marker =
                             indented_outdented_lines.contains(&(line_index + 1));
@@ -936,7 +918,7 @@ impl FormatMdInlineItemList {
                 _ => {}
             }
         }
-        let remaining = &stream[line_start..];
+        let remaining = &items[line_start..];
         if !remaining.is_empty() {
             format_source_line(
                 remaining,
@@ -948,12 +930,74 @@ impl FormatMdInlineItemList {
             )?;
         }
 
-        if !inside_list {
-            write!(f, [hard_line_break()])?;
-        }
-
         Ok(())
     }
+
+    fn fmt_prose_never(&self, items: &[ProseItem], f: &mut MarkdownFormatter) -> FormatResult<()> {
+        let mut segment_start = 0;
+
+        for (index, item) in items.iter().enumerate() {
+            let ProseItem::HardBreak(hard_break) = item else {
+                continue;
+            };
+
+            FormatSourceLine(&items[segment_start..index]).fmt(f)?;
+            write!(
+                f,
+                [hard_break
+                    .format()
+                    .with_options(FormatMdFormatHardLineOptions {
+                        print_mode: TextPrintMode::fill(),
+                    })]
+            )?;
+            segment_start = index + 1;
+        }
+
+        FormatSourceLine(&items[segment_start..]).fmt(f)
+    }
+
+    fn fmt_prose_always(&self, items: &[ProseItem], f: &mut MarkdownFormatter) -> FormatResult<()> {
+        let mut segment_start = 0;
+
+        for (index, item) in items.iter().enumerate() {
+            let ProseItem::HardBreak(hard_break) = item else {
+                continue;
+            };
+
+            format_fill_segment(&items[segment_start..index], f)?;
+            write!(
+                f,
+                [hard_break
+                    .format()
+                    .with_options(FormatMdFormatHardLineOptions {
+                        print_mode: TextPrintMode::fill(),
+                    })]
+            )?;
+            segment_start = index + 1;
+        }
+
+        format_fill_segment(&items[segment_start..], f)
+    }
+}
+
+fn format_fill_segment(items: &[ProseItem], f: &mut MarkdownFormatter) -> FormatResult<()> {
+    let wrap_separator = soft_line_break_or_space();
+    let marker_separator = space();
+    let mut fill = f.fill();
+
+    for item in items {
+        let ProseItem::WordGroup(group) = item else {
+            continue;
+        };
+        let separator = if group.starts_with_block_marker() {
+            &marker_separator as &dyn Format<MarkdownFormatContext>
+        } else {
+            &wrap_separator
+        };
+        fill.entry(separator, group);
+    }
+
+    fill.finish()
 }
 
 /// Business-level items for fenced code content inside lists.

--- a/crates/biome_markdown_formatter/src/markdown/lists/inline_item_list.rs
+++ b/crates/biome_markdown_formatter/src/markdown/lists/inline_item_list.rs
@@ -986,11 +986,11 @@ impl FormatMdInlineItemList {
             let ProseItem::WordGroup(group) = item else {
                 continue;
             };
-            let separator = if group.starts_with_block_marker() {
+            if group.starts_with_block_marker() {
                 fill.entry(&space(), group);
             } else {
                 fill.entry(&soft_line_break_or_space(), group);
-            };
+            }
         }
 
         fill.finish()

--- a/crates/biome_markdown_formatter/src/markdown/lists/inline_item_list.rs
+++ b/crates/biome_markdown_formatter/src/markdown/lists/inline_item_list.rs
@@ -964,7 +964,7 @@ impl FormatMdInlineItemList {
                 continue;
             };
 
-            format_fill_segment(&items[segment_start..index], f)?;
+            Self::format_fill_segment(&items[segment_start..index], f)?;
             write!(
                 f,
                 [hard_break
@@ -976,28 +976,25 @@ impl FormatMdInlineItemList {
             segment_start = index + 1;
         }
 
-        format_fill_segment(&items[segment_start..], f)
-    }
-}
-
-fn format_fill_segment(items: &[ProseItem], f: &mut MarkdownFormatter) -> FormatResult<()> {
-    let wrap_separator = soft_line_break_or_space();
-    let marker_separator = space();
-    let mut fill = f.fill();
-
-    for item in items {
-        let ProseItem::WordGroup(group) = item else {
-            continue;
-        };
-        let separator = if group.starts_with_block_marker() {
-            &marker_separator as &dyn Format<MarkdownFormatContext>
-        } else {
-            &wrap_separator
-        };
-        fill.entry(separator, group);
+        Self::format_fill_segment(&items[segment_start..], f)
     }
 
-    fill.finish()
+    fn format_fill_segment(items: &[ProseItem], f: &mut MarkdownFormatter) -> FormatResult<()> {
+        let mut fill = f.fill();
+
+        for item in items {
+            let ProseItem::WordGroup(group) = item else {
+                continue;
+            };
+            let separator = if group.starts_with_block_marker() {
+                fill.entry(&space(), group);
+            } else {
+                fill.entry(&soft_line_break_or_space(), group);
+            };
+        }
+
+        fill.finish()
+    }
 }
 
 /// Business-level items for fenced code content inside lists.

--- a/crates/biome_markdown_formatter/src/quote.rs
+++ b/crates/biome_markdown_formatter/src/quote.rs
@@ -1,4 +1,5 @@
 use crate::bullet_list::FmtAnyList;
+use crate::context::ProseWrap;
 use crate::markdown::auxiliary::hard_line::FormatMdFormatHardLineOptions;
 use crate::markdown::auxiliary::inline_italic::FormatMdInlineItalicOptions;
 use crate::markdown::auxiliary::paragraph::FormatMdParagraphOptions;
@@ -101,6 +102,7 @@ impl Format<MarkdownFormatContext> for QuoteBlockList {
         f.context().comments().is_suppressed(self.content.syntax());
 
         let quote_trim_range = quote_boundary_trim_range(&self.content, self.quote_boundary_trim);
+        let prose_wrap = f.options().prose_wrap();
         let mut prev_content = PrevContentBlock::None;
         let mut iter = self.content.iter().enumerate().peekable();
         let mut joiner = f.join();
@@ -118,7 +120,11 @@ impl Format<MarkdownFormatContext> for QuoteBlockList {
                         joiner.entry(&QuoteParagraph { paragraph });
                     } else {
                         joiner.entry(&paragraph.format().with_options(FormatMdParagraphOptions {
-                            trim_mode: TextPrintMode::Pristine,
+                            trim_mode: if prose_wrap == ProseWrap::Preserve {
+                                TextPrintMode::Pristine
+                            } else {
+                                TextPrintMode::fill()
+                            },
                             text_context: TextContext::Neutral,
                         }));
                     }

--- a/crates/biome_markdown_formatter/src/words.rs
+++ b/crates/biome_markdown_formatter/src/words.rs
@@ -23,6 +23,14 @@ impl MdWord {
             source_position,
         }
     }
+
+    fn is_single_underscore(&self) -> bool {
+        self.text.text() == "_"
+    }
+
+    fn fmt_escaped(&self, f: &mut Formatter<MarkdownFormatContext>) -> FormatResult<()> {
+        write!(f, [token("\\"), self])
+    }
 }
 
 impl Format<MarkdownFormatContext> for MdWord {
@@ -43,23 +51,66 @@ impl Format<MarkdownFormatContext> for MdWord {
 
 /// A single atom within a word group.
 #[derive(Debug, Clone)]
-pub(crate) enum ProseAtom {
+enum ProseAtom {
     /// A plain text word slice from an MdTextual token.
     Word(MdWord),
     /// An atomic inline element: emphasis, code, link, image, autolink, etc.
     InlineElement(AnyMdInline),
 }
 
-/// An item in the flattened word stream.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+enum WordGroupEscape {
+    /// Print the word group normally.
+    #[default]
+    None,
+    /// Prefix each marker atom with a backslash.
+    EscapeEachMarker,
+    /// Prefix the first marker in the word group with a backslash.
+    EscapeLeadingMarker,
+    /// Print a five-marker sequence as strong emphasis around an escaped marker.
+    EmptyStrongWithEscapedMarker,
+}
+
+/// Adjacent prose atoms that cannot be separated by whitespace or a line break.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct WordGroup {
+    atoms: Vec<ProseAtom>,
+    escape: WordGroupEscape,
+}
+
+impl WordGroup {
+    fn push(&mut self, atom: ProseAtom) {
+        self.atoms.push(atom);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.atoms.is_empty()
+    }
+
+    pub(crate) fn starts_with_block_marker(&self) -> bool {
+        let Some(ProseAtom::Word(word)) = self.atoms.first() else {
+            return false;
+        };
+        let text = word.text.text();
+
+        if text.starts_with('>')
+            || matches!(text, "*" | "+" | "-")
+            || matches!(text, "#" | "##" | "###" | "####" | "#####" | "######")
+        {
+            return true;
+        }
+
+        text.strip_suffix(['.', ')']).is_some_and(|number| {
+            !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit())
+        })
+    }
+}
+
+/// An item in a flattened prose list.
 #[derive(Debug, Clone)]
 pub(crate) enum ProseItem {
     /// One or more adjacent atoms with no whitespace between them (a single "word").
-    WordGroup {
-        /// Adjacent text slices and inline elements printed without separators.
-        atoms: Vec<ProseAtom>,
-        /// Special printing mode for emphasis delimiter runs that must not be emitted raw.
-        escape: WordGroupEscape,
-    },
+    WordGroup(WordGroup),
     /// Whitespace between words — becomes the fill separator.
     Space,
     /// Source line break (\n) — behavior depends on proseWrap mode.
@@ -71,475 +122,660 @@ pub(crate) enum ProseItem {
     OutdentedLineStart,
 }
 
-/// Result of building the word stream.
-pub(crate) struct WordStreamResult {
-    /// Flat stream of prose items — may contain `HardBreak` items inline.
-    pub stream: Vec<ProseItem>,
-}
+/// Prose items collected from an inline item list.
+pub(crate) struct ProseItemList(Vec<ProseItem>);
 
-/// Build a flat word stream from an `MdInlineItemList`.
-///
-/// Returns the stream plus metadata about trailing breaks.
-pub(crate) fn build_word_stream_flat(
-    node: &MdInlineItemList,
-    f: &mut MarkdownFormatter,
-) -> SyntaxResult<WordStreamResult> {
-    let (mut stream, current_word_group) = build_word_stream(node, f)?;
+impl ProseItemList {
+    /// Collects prose as word groups separated by spaces and line breaks.
+    pub(crate) fn from_inline_item_list(
+        node: &MdInlineItemList,
+        f: &mut MarkdownFormatter,
+    ) -> SyntaxResult<Self> {
+        let mut items = Self(Vec::new());
+        let mut current_word_group = WordGroup::default();
 
-    // Flush any remaining word group
-    if !current_word_group.is_empty() {
-        stream.push(ProseItem::WordGroup {
-            atoms: current_word_group,
-            escape: WordGroupEscape::None,
-        });
-    }
+        for item in node.iter() {
+            match &item {
+                AnyMdInline::MdTextual(text) => {
+                    let token = text.value_token()?;
+                    let token_text_str = token.text();
 
-    mark_words_that_need_escaping(&mut stream);
-    mark_outdented_setext_markers(&mut stream);
+                    f.context().comments().is_suppressed(text.syntax());
 
-    Ok(WordStreamResult { stream })
-}
+                    if text.is_newline()? {
+                        items.finish_word_group(&mut current_word_group);
+                        items.0.push(ProseItem::SoftBreak);
+                        f.state_mut().track_token(&token);
+                        continue;
+                    }
 
-fn flush_word_group(stream: &mut Vec<ProseItem>, current: &mut Vec<ProseAtom>) {
-    if !current.is_empty() {
-        stream.push(ProseItem::WordGroup {
-            atoms: std::mem::take(current),
-            escape: WordGroupEscape::None,
-        });
-    }
-}
-
-/// Walk an `MdInlineItemList` and flatten its tokens into a linear word stream.
-///
-/// The stream captures the paragraph's content as a sequence of word groups,
-/// spaces, soft breaks, and hard breaks — stripping away whitespace-only
-/// structural tokens (indents, quote prefixes) and performing token tracking
-/// so the formatter's source-map stays accurate.
-///
-/// Word grouping rule: consecutive non-whitespace atoms (plain text slices and
-/// inline elements like code spans or links) accumulate into the same
-/// `WordGroup` until a whitespace boundary (Space, SoftBreak, HardBreak) is
-/// encountered. This means an inline element adjacent to text without
-/// intervening whitespace (e.g. `word[link](url)`) stays in one group and
-/// won't be separated by a line break.
-///
-/// - Whitespace splits plain text slices from 'MdTextual' tokens into
-///   individual `Word` atoms.
-/// - Inline elements (emphasis, code, links, images, etc.) become single
-///   `InlineElement` atoms — kept opaque so their own formatters handle
-///   internal layout and fence normalization.
-/// - Any run of whitespace inside an `MdTextual` token collapses into a
-///   single `Space`, ending the current group.
-/// - A newline `MdTextual` token emits a `SoftBreak`, ending the current
-///   group. (The token is tracked but not removed — it's already a no-op
-///   in the output since it has no visible content.)
-/// - `MdHardLine` emits a `HardBreak`, ending the current group.
-/// - `MdIndentToken` tokens are removed from the output (`format_removed`)
-///   and produce no stream items — indentation is handled structurally
-///   by the formatter.
-fn build_word_stream(
-    node: &MdInlineItemList,
-    f: &mut MarkdownFormatter,
-) -> SyntaxResult<(Vec<ProseItem>, Vec<ProseAtom>)> {
-    let mut stream = Vec::new();
-    let mut current_word_group = Vec::new();
-
-    for item in node.iter() {
-        match &item {
-            AnyMdInline::MdTextual(text) => {
-                let token = text.value_token()?;
-                let token_text_str = token.text();
-
-                f.context().comments().is_suppressed(text.syntax());
-
-                if text.is_newline()? {
-                    flush_word_group(&mut stream, &mut current_word_group);
-                    stream.push(ProseItem::SoftBreak);
                     f.state_mut().track_token(&token);
-                    continue;
-                }
+                    let token_start = token.text_range().start();
 
-                f.state_mut().track_token(&token);
-                let token_start = token.text_range().start();
+                    let bytes = token_text_str.as_bytes();
+                    let len = bytes.len();
+                    let mut pos = 0usize;
 
-                let bytes = token_text_str.as_bytes();
-                let len = bytes.len();
-                let mut pos = 0usize;
+                    while pos < len {
+                        let white_space_start = pos;
+                        while pos < len && bytes[pos].is_ascii_whitespace() {
+                            pos += 1;
+                        }
+                        if pos > white_space_start {
+                            items.finish_word_group(&mut current_word_group);
+                            items.0.push(ProseItem::Space);
+                        }
 
-                // Split token text into words at ASCII whitespace boundaries.
-                while pos < len {
-                    let white_space_start = pos;
-                    while pos < len && bytes[pos].is_ascii_whitespace() {
-                        pos += 1;
-                    }
-                    // Flush consecutive whitespaces into a single Space.
-                    if pos > white_space_start {
-                        flush_word_group(&mut stream, &mut current_word_group);
-                        stream.push(ProseItem::Space);
-                    }
-
-                    let word_start = pos;
-                    while pos < len && !bytes[pos].is_ascii_whitespace() {
-                        pos += 1;
-                    }
-                    if pos > word_start {
-                        let start = TextSize::from(word_start as u32);
-                        let end = TextSize::from(pos as u32);
-                        let text_slice = token.token_text().slice(TextRange::new(start, end));
-                        let source_position = token_start + start;
-                        current_word_group
-                            .push(ProseAtom::Word(MdWord::new(text_slice, source_position)));
+                        let word_start = pos;
+                        while pos < len && !bytes[pos].is_ascii_whitespace() {
+                            pos += 1;
+                        }
+                        if pos > word_start {
+                            let start = TextSize::from(word_start as u32);
+                            let end = TextSize::from(pos as u32);
+                            let text_slice = token.token_text().slice(TextRange::new(start, end));
+                            current_word_group.push(ProseAtom::Word(MdWord::new(
+                                text_slice,
+                                token_start + start,
+                            )));
+                        }
                     }
                 }
-            }
 
-            AnyMdInline::MdHardLine(hard_line) => {
-                // Don't format_removed here — the node will be formatted in Phase 2
-                // using its own formatter which handles token tracking internally.
-                flush_word_group(&mut stream, &mut current_word_group);
-                stream.push(ProseItem::HardBreak(hard_line.clone()));
-            }
+                AnyMdInline::MdHardLine(hard_line) => {
+                    items.finish_word_group(&mut current_word_group);
+                    items.0.push(ProseItem::HardBreak(hard_line.clone()));
+                }
 
-            // Atomic inline elements — never broken internally.
-            // Emphasis/italic are kept atomic to preserve their fence
-            // normalization logic (e.g. _ → *) which lives in their formatters.
-            AnyMdInline::MdInlineItalic(_)
-            | AnyMdInline::MdInlineEmphasis(_)
-            | AnyMdInline::MdInlineCode(_)
-            | AnyMdInline::MdInlineLink(_)
-            | AnyMdInline::MdInlineImage(_)
-            | AnyMdInline::MdAutolink(_)
-            | AnyMdInline::MdReferenceLink(_)
-            | AnyMdInline::MdReferenceImage(_)
-            | AnyMdInline::MdInlineHtml(_)
-            | AnyMdInline::MdEntityReference(_) => {
-                current_word_group.push(ProseAtom::InlineElement(item));
-            }
+                AnyMdInline::MdInlineItalic(_)
+                | AnyMdInline::MdInlineEmphasis(_)
+                | AnyMdInline::MdInlineCode(_)
+                | AnyMdInline::MdInlineLink(_)
+                | AnyMdInline::MdInlineImage(_)
+                | AnyMdInline::MdAutolink(_)
+                | AnyMdInline::MdReferenceLink(_)
+                | AnyMdInline::MdReferenceImage(_)
+                | AnyMdInline::MdInlineHtml(_)
+                | AnyMdInline::MdEntityReference(_) => {
+                    current_word_group.push(ProseAtom::InlineElement(item));
+                }
 
-            AnyMdInline::MdIndentToken(indent) => {
-                f.context().comments().is_suppressed(indent.syntax());
-                let token = indent.md_indent_char_token()?;
-                format_removed(&token).fmt(f).ok();
-                if current_word_group.is_empty()
-                    && matches!(stream.last(), Some(ProseItem::SoftBreak))
+                AnyMdInline::MdIndentToken(indent) => {
+                    f.context().comments().is_suppressed(indent.syntax());
+                    let token = indent.md_indent_char_token()?;
+                    format_removed(&token).fmt(f).ok();
+                    if current_word_group.is_empty()
+                        && matches!(items.0.last(), Some(ProseItem::SoftBreak))
+                    {
+                        items.0.push(ProseItem::OutdentedLineStart);
+                    }
+                }
+
+                AnyMdInline::MdHtmlBlock(html_block) => {
+                    f.context().comments().is_suppressed(html_block.syntax());
+                    items.finish_word_group(&mut current_word_group);
+                    current_word_group.push(ProseAtom::InlineElement(item));
+                    items.finish_word_group(&mut current_word_group);
+                }
+
+                AnyMdInline::MdCodeContent(code) => {
+                    f.context().comments().is_suppressed(code.syntax());
+                    items.finish_word_group(&mut current_word_group);
+                    current_word_group.push(ProseAtom::InlineElement(item));
+                    items.finish_word_group(&mut current_word_group);
+                }
+                AnyMdInline::MdQuotePrefix(prefix) => {
+                    prefix
+                        .format()
+                        .with_options(FormatMdQuotePrefixOptions {
+                            should_remove: true,
+                        })
+                        .fmt(f)
+                        .ok();
+                }
+            }
+        }
+
+        items.finish_word_group(&mut current_word_group);
+        items.mark_word_groups_for_escaping();
+        items.mark_outdented_setext_markers();
+
+        Ok(items)
+    }
+
+    fn finish_word_group(&mut self, current: &mut WordGroup) {
+        if !current.is_empty() {
+            self.0.push(ProseItem::WordGroup(std::mem::take(current)));
+        }
+    }
+
+    pub(crate) fn as_slice(&self) -> &[ProseItem] {
+        &self.0
+    }
+
+    pub(crate) fn remove_spaces_after_soft_breaks(&mut self) {
+        let mut index = 0;
+        while index < self.0.len() {
+            if matches!(self.0[index], ProseItem::SoftBreak) {
+                let mut start = index + 1;
+                while start < self.0.len() && matches!(self.0[start], ProseItem::OutdentedLineStart)
                 {
-                    stream.push(ProseItem::OutdentedLineStart);
+                    start += 1;
+                }
+                let mut end = start;
+                while end < self.0.len() && matches!(self.0[end], ProseItem::Space) {
+                    end += 1;
+                }
+                if end > start {
+                    self.0.drain(start..end);
                 }
             }
+            index += 1;
+        }
+    }
 
-            AnyMdInline::MdHtmlBlock(html_block) => {
-                f.context().comments().is_suppressed(html_block.syntax());
-                flush_word_group(&mut stream, &mut current_word_group);
-                current_word_group.push(ProseAtom::InlineElement(item));
-                flush_word_group(&mut stream, &mut current_word_group);
-            }
-
-            // Document-level fenced code content never appears in prose;
-            // handled defensively as an atomic element printed verbatim by
-            // its own formatter.
-            AnyMdInline::MdCodeContent(code) => {
-                f.context().comments().is_suppressed(code.syntax());
-                flush_word_group(&mut stream, &mut current_word_group);
-                current_word_group.push(ProseAtom::InlineElement(item));
-                flush_word_group(&mut stream, &mut current_word_group);
-            }
-            AnyMdInline::MdQuotePrefix(prefix) => {
-                prefix
-                    .format()
-                    .with_options(FormatMdQuotePrefixOptions {
-                        should_remove: true,
-                    })
-                    .fmt(f)
-                    .ok();
+    fn mark_word_groups_for_escaping(&mut self) {
+        for index in 0..self.0.len() {
+            let escape = WordGroupEscape::from(self, index);
+            if let ProseItem::WordGroup(group) = &mut self.0[index] {
+                group.escape = escape;
             }
         }
     }
-    Ok((stream, current_word_group))
-}
 
-/// Format a single word group (all atoms concatenated without separators).
-pub(crate) struct FormatWordGroup<'a> {
-    pub(crate) atoms: &'a [ProseAtom],
-    pub(crate) escape: WordGroupEscape,
-}
+    fn mark_outdented_setext_markers(&mut self) {
+        let mut line_start = 0;
 
-impl Format<MarkdownFormatContext> for FormatWordGroup<'_> {
-    fn fmt(&self, f: &mut Formatter<MarkdownFormatContext>) -> FormatResult<()> {
-        if self.escape == WordGroupEscape::EscapeEachMarker {
-            for atom in self.atoms {
-                match atom {
-                    ProseAtom::Word(word) => write!(f, [token("\\"), word])?,
-                    ProseAtom::InlineElement(elem) => elem.format().fmt(f)?,
-                }
+        for line_end in 0..=self.0.len() {
+            let is_line_end = line_end == self.0.len()
+                || matches!(
+                    self.0[line_end],
+                    ProseItem::SoftBreak | ProseItem::HardBreak(_)
+                );
+            if !is_line_end {
+                continue;
             }
-            return Ok(());
+
+            if let Some(relative_index) =
+                Self::outdented_setext_word_group(&self.0[line_start..line_end])
+            {
+                let ProseItem::WordGroup(group) = &mut self.0[line_start + relative_index] else {
+                    unreachable!();
+                };
+                group.escape = WordGroupEscape::EscapeLeadingMarker;
+            }
+
+            line_start = line_end + 1;
+        }
+    }
+
+    fn outdented_setext_word_group(line: &[ProseItem]) -> Option<usize> {
+        let mut has_removed_indent = false;
+        let mut first_word_group = None;
+        let mut delimiter = None;
+
+        for (index, item) in line.iter().enumerate() {
+            match item {
+                ProseItem::OutdentedLineStart if first_word_group.is_none() => {
+                    has_removed_indent = true;
+                }
+                ProseItem::Space => {}
+                ProseItem::WordGroup(group) if has_removed_indent => {
+                    if first_word_group.is_some() && delimiter == Some(b'=') {
+                        return None;
+                    }
+                    first_word_group.get_or_insert(index);
+                    for atom in &group.atoms {
+                        let ProseAtom::Word(word) = atom else {
+                            return None;
+                        };
+                        for byte in word.text.text().bytes() {
+                            if !matches!(byte, b'=' | b'-') {
+                                return None;
+                            }
+                            if delimiter.is_some_and(|delimiter| delimiter != byte) {
+                                return None;
+                            }
+                            delimiter = Some(byte);
+                        }
+                    }
+                }
+                _ => return None,
+            }
         }
 
-        if self.escape == WordGroupEscape::EscapeLeadingMarker {
-            write!(f, [token("\\")])?;
+        delimiter.and(first_word_group)
+    }
+
+    fn has_matching_marker_boundary(
+        &self,
+        index: usize,
+        marker_sequence: EmphasisMarkerSequence,
+    ) -> bool {
+        self.0[..index].iter().any(|item| match item {
+            ProseItem::WordGroup(group) => marker_sequence.matches_start_of(group),
+            _ => false,
+        }) || self.0[index + 1..].iter().any(|item| match item {
+            ProseItem::WordGroup(group) => marker_sequence.matches_end_of(group),
+            _ => false,
+        })
+    }
+}
+
+enum WordGroupLayout<'a> {
+    /// Prints every atom without additional escaping.
+    ///
+    /// ```text
+    /// word -> word
+    /// ```
+    Default,
+    /// Escapes every marker in a delimiter-only word group.
+    ///
+    /// ```text
+    /// __ -> \_\_
+    /// ```
+    EscapeEachMarker,
+    /// Escapes the first marker in an outdented Setext-like sequence.
+    ///
+    /// ```text
+    /// --- -> \---
+    /// ```
+    EscapeLeadingMarker,
+    /// Prints five markers as strong emphasis containing one escaped marker.
+    ///
+    /// ```text
+    /// _____ -> **\_**
+    /// ```
+    EmptyStrongSequence {
+        delimiter: u8,
+        positions: [TextSize; 5],
+    },
+    /// Escapes an underscore that follows literal punctuation.
+    ///
+    /// ```text
+    /// !_1_2 -> !\_1_2
+    /// ```
+    LiteralLeadingUnderscore {
+        leading: &'a MdWord,
+        trailing: &'a MdWord,
+    },
+    /// Escapes unmatched underscores adjacent to parsed italic or strong emphasis.
+    ///
+    /// ```text
+    /// __foo_ -> \__foo_
+    /// ```
+    UnmatchedUnderscore(UnmatchedUnderscoreLayout<'a>),
+}
+
+enum UnmatchedUnderscoreLayout<'a> {
+    /// Escapes a literal underscore before underscore-delimited italic text.
+    ///
+    /// ```text
+    /// __foo_ -> \__foo_
+    /// ```
+    LeadingWithItalic {
+        leading: &'a MdWord,
+        italic: &'a MdInlineItalic,
+    },
+    /// Escapes an underscore-delimited italic span and its trailing literal underscore.
+    ///
+    /// ```text
+    /// _foo__ -> \_foo\_\_
+    /// ```
+    ItalicWithTrailing {
+        italic: &'a MdInlineItalic,
+        trailing: &'a MdWord,
+    },
+    /// Escapes the unmatched markers around italic text in a four-underscore sequence.
+    ///
+    /// ```text
+    /// ____foo_ -> \__\_\_foo_
+    /// ```
+    LeadingSequenceWithItalic {
+        first: &'a MdWord,
+        second: &'a MdWord,
+        third: &'a MdWord,
+        italic: &'a MdInlineItalic,
+    },
+    /// Moves a leading literal underscore inside normalized strong emphasis.
+    ///
+    /// ```text
+    /// ___foo__ -> **\_foo**
+    /// ```
+    LeadingWithEmphasis {
+        leading: &'a MdWord,
+        emphasis: &'a MdInlineEmphasis,
+    },
+    /// Moves a trailing literal underscore inside normalized strong emphasis.
+    ///
+    /// ```text
+    /// __foo___ -> **foo\_**
+    /// ```
+    EmphasisWithTrailing {
+        emphasis: &'a MdInlineEmphasis,
+        trailing: &'a MdWord,
+    },
+}
+
+impl Format<MarkdownFormatContext> for UnmatchedUnderscoreLayout<'_> {
+    fn fmt(&self, f: &mut Formatter<MarkdownFormatContext>) -> FormatResult<()> {
+        match self {
+            Self::LeadingWithItalic { leading, italic } => {
+                write!(
+                    f,
+                    [format_with(|f| leading.fmt_escaped(f)), italic.format()]
+                )
+            }
+            Self::ItalicWithTrailing { italic, trailing } => {
+                let l_fence = italic.l_fence()?;
+                let r_fence = italic.r_fence()?;
+                f.context().comments().is_suppressed(italic.syntax());
+
+                write!(
+                    f,
+                    [
+                        format_replaced(&l_fence, &text("\\_", Some(l_fence.text_range().start()))),
+                        italic.content().format(),
+                        format_replaced(&r_fence, &text("\\_", Some(r_fence.text_range().start()))),
+                        format_with(|f| trailing.fmt_escaped(f)),
+                    ]
+                )
+            }
+            Self::LeadingSequenceWithItalic {
+                first,
+                second,
+                third,
+                italic,
+            } => {
+                let l_fence = italic.l_fence()?;
+                let r_fence = italic.r_fence()?;
+                f.context().comments().is_suppressed(italic.syntax());
+
+                write!(
+                    f,
+                    [
+                        format_with(|f| first.fmt_escaped(f)),
+                        second,
+                        format_with(|f| third.fmt_escaped(f)),
+                        format_replaced(&l_fence, &text("\\_", Some(l_fence.text_range().start()))),
+                        italic.content().format(),
+                        r_fence.format(),
+                    ]
+                )
+            }
+            Self::LeadingWithEmphasis { leading, emphasis } => {
+                let l_fence = emphasis.l_fence()?;
+                let r_fence = emphasis.r_fence()?;
+                f.context().comments().is_suppressed(emphasis.syntax());
+
+                write!(
+                    f,
+                    [
+                        format_replaced(&l_fence, &text("**", Some(l_fence.text_range().start()))),
+                        format_with(|f| leading.fmt_escaped(f)),
+                        emphasis.content().format(),
+                        format_replaced(&r_fence, &text("**", Some(r_fence.text_range().start()))),
+                    ]
+                )
+            }
+            Self::EmphasisWithTrailing { emphasis, trailing } => {
+                let l_fence = emphasis.l_fence()?;
+                let r_fence = emphasis.r_fence()?;
+                f.context().comments().is_suppressed(emphasis.syntax());
+
+                write!(
+                    f,
+                    [
+                        format_replaced(&l_fence, &text("**", Some(l_fence.text_range().start()))),
+                        emphasis.content().format(),
+                        format_with(|f| trailing.fmt_escaped(f)),
+                        format_replaced(&r_fence, &text("**", Some(r_fence.text_range().start()))),
+                    ]
+                )
+            }
+        }
+    }
+}
+
+impl WordGroup {
+    fn layout(&self) -> SyntaxResult<WordGroupLayout<'_>> {
+        Ok(match self.escape {
+            WordGroupEscape::EscapeEachMarker => WordGroupLayout::EscapeEachMarker,
+            WordGroupEscape::EscapeLeadingMarker => WordGroupLayout::EscapeLeadingMarker,
+            WordGroupEscape::EmptyStrongWithEscapedMarker => self.empty_strong_sequence_layout(),
+            WordGroupEscape::None => self
+                .literal_leading_underscore_layout()
+                .or(self
+                    .unmatched_underscore_layout()?
+                    .map(WordGroupLayout::UnmatchedUnderscore))
+                .unwrap_or(WordGroupLayout::Default),
+        })
+    }
+
+    fn empty_strong_sequence_layout(&self) -> WordGroupLayout<'_> {
+        let Some(marker_sequence) = self.emphasis_marker_sequence() else {
+            return WordGroupLayout::Default;
+        };
+
+        debug_assert_eq!(
+            marker_sequence.len, 5,
+            "empty strong formatting is selected only for five-marker sequences"
+        );
+
+        let mut positions = Vec::with_capacity(marker_sequence.len);
+        for atom in &self.atoms {
+            let ProseAtom::Word(word) = atom else {
+                return WordGroupLayout::Default;
+            };
+            positions.extend(
+                (0..word.text.text().len())
+                    .map(|index| word.source_position + TextSize::from(index as u32)),
+            );
         }
 
-        if self.escape == WordGroupEscape::EmptyStrongWithEscapedMarker {
-            return fmt_empty_strong_delimiter(self.atoms, f);
+        let Ok(positions) = positions.try_into() else {
+            return WordGroupLayout::Default;
+        };
+
+        WordGroupLayout::EmptyStrongSequence {
+            delimiter: marker_sequence.delimiter,
+            positions,
+        }
+    }
+
+    fn literal_leading_underscore_layout(&self) -> Option<WordGroupLayout<'_>> {
+        let [ProseAtom::Word(leading), ProseAtom::Word(trailing)] = self.atoms.as_slice() else {
+            return None;
+        };
+        let trailing_text = trailing.text.text();
+        let remainder = trailing_text.strip_prefix('_')?;
+        if !remainder.contains('_')
+            || !leading.text.text().chars().next_back().is_some_and(|char| {
+                !char.is_alphanumeric() && !char.is_whitespace() && !matches!(char, '*' | '_')
+            })
+        {
+            return None;
         }
 
-        if fmt_literal_leading_underscore(self.atoms, f)? {
-            return Ok(());
+        Some(WordGroupLayout::LiteralLeadingUnderscore { leading, trailing })
+    }
+
+    fn unmatched_underscore_layout(&self) -> SyntaxResult<Option<UnmatchedUnderscoreLayout<'_>>> {
+        let layout = match self.atoms.as_slice() {
+            [
+                ProseAtom::Word(leading),
+                ProseAtom::InlineElement(AnyMdInline::MdInlineItalic(italic)),
+            ] if leading.is_single_underscore() && italic.fence()? == MdItalicFence::Underscore => {
+                Some(UnmatchedUnderscoreLayout::LeadingWithItalic { leading, italic })
+            }
+            [
+                ProseAtom::InlineElement(AnyMdInline::MdInlineItalic(italic)),
+                ProseAtom::Word(trailing),
+            ] if trailing.is_single_underscore()
+                && italic.fence()? == MdItalicFence::Underscore =>
+            {
+                Some(UnmatchedUnderscoreLayout::ItalicWithTrailing { italic, trailing })
+            }
+            [
+                ProseAtom::Word(first),
+                ProseAtom::Word(second),
+                ProseAtom::Word(third),
+                ProseAtom::InlineElement(AnyMdInline::MdInlineItalic(italic)),
+            ] if first.is_single_underscore()
+                && second.is_single_underscore()
+                && third.is_single_underscore()
+                && italic.fence()? == MdItalicFence::Underscore =>
+            {
+                Some(UnmatchedUnderscoreLayout::LeadingSequenceWithItalic {
+                    first,
+                    second,
+                    third,
+                    italic,
+                })
+            }
+            [
+                ProseAtom::Word(leading),
+                ProseAtom::InlineElement(AnyMdInline::MdInlineEmphasis(emphasis)),
+            ] if leading.is_single_underscore()
+                && emphasis.fence()? == MdEmphasisFence::DoubleUnderscore =>
+            {
+                Some(UnmatchedUnderscoreLayout::LeadingWithEmphasis { leading, emphasis })
+            }
+            [
+                ProseAtom::InlineElement(AnyMdInline::MdInlineEmphasis(emphasis)),
+                ProseAtom::Word(trailing),
+            ] if trailing.is_single_underscore()
+                && emphasis.fence()? == MdEmphasisFence::DoubleUnderscore =>
+            {
+                Some(UnmatchedUnderscoreLayout::EmphasisWithTrailing { emphasis, trailing })
+            }
+            _ => None,
+        };
+
+        Ok(layout)
+    }
+
+    fn emphasis_marker_sequence(&self) -> Option<EmphasisMarkerSequence> {
+        let mut delimiter = None;
+        let mut len = 0usize;
+
+        for atom in &self.atoms {
+            let ProseAtom::Word(word) = atom else {
+                return None;
+            };
+
+            for byte in word.text.text().bytes() {
+                if !matches!(byte, b'*' | b'_') {
+                    return None;
+                }
+
+                if let Some(delimiter) = delimiter {
+                    if delimiter != byte {
+                        return None;
+                    }
+                } else {
+                    delimiter = Some(byte);
+                }
+
+                len += 1;
+            }
         }
 
-        if fmt_unmatched_underscore_delimiter(self.atoms, f)? {
-            return Ok(());
-        }
+        delimiter.map(|delimiter| EmphasisMarkerSequence { delimiter, len })
+    }
 
-        for atom in self.atoms {
+    fn fmt_default(&self, f: &mut Formatter<MarkdownFormatContext>) -> FormatResult<()> {
+        for atom in &self.atoms {
             match atom {
                 ProseAtom::Word(word) => word.fmt(f)?,
-                ProseAtom::InlineElement(elem) => {
-                    elem.format().fmt(f)?;
-                }
+                ProseAtom::InlineElement(elem) => elem.format().fmt(f)?,
             }
         }
         Ok(())
     }
-}
 
-fn fmt_literal_leading_underscore(
-    atoms: &[ProseAtom],
-    f: &mut Formatter<MarkdownFormatContext>,
-) -> FormatResult<bool> {
-    let [ProseAtom::Word(leading), ProseAtom::Word(trailing)] = atoms else {
-        return Ok(false);
-    };
-    let trailing_text = trailing.text.text();
-    let Some(remainder) = trailing_text.strip_prefix('_') else {
-        return Ok(false);
-    };
-    if !remainder.contains('_')
-        || !leading.text.text().chars().next_back().is_some_and(|char| {
-            !char.is_alphanumeric() && !char.is_whitespace() && !matches!(char, '*' | '_')
-        })
-    {
-        return Ok(false);
-    }
-
-    write!(f, [leading, token("\\"), trailing])?;
-    Ok(true)
-}
-
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
-pub(crate) enum WordGroupEscape {
-    /// Print the word group normally.
-    #[default]
-    None,
-    /// Prefix each marker atom with a backslash.
-    EscapeEachMarker,
-    /// Prefix the first marker in the word group with a backslash.
-    EscapeLeadingMarker,
-    /// Print a five-marker delimiter run as strong emphasis around an escaped marker.
-    EmptyStrongWithEscapedMarker,
-}
-
-fn fmt_unmatched_underscore_delimiter(
-    atoms: &[ProseAtom],
-    f: &mut Formatter<MarkdownFormatContext>,
-) -> FormatResult<bool> {
-    match atoms {
-        [
-            ProseAtom::Word(leading),
-            ProseAtom::InlineElement(AnyMdInline::MdInlineItalic(italic)),
-        ] if is_single_underscore_word(leading) => {
-            fmt_leading_underscore_with_italic(leading, italic, f)
+    fn fmt_each_marker(&self, f: &mut Formatter<MarkdownFormatContext>) -> FormatResult<()> {
+        for atom in &self.atoms {
+            match atom {
+                ProseAtom::Word(word) => write!(f, [token("\\"), word])?,
+                ProseAtom::InlineElement(elem) => elem.format().fmt(f)?,
+            }
         }
-        [
-            ProseAtom::InlineElement(AnyMdInline::MdInlineItalic(italic)),
-            ProseAtom::Word(trailing),
-        ] if is_single_underscore_word(trailing) => {
-            fmt_italic_with_trailing_underscore(italic, trailing, f)
+        Ok(())
+    }
+
+    fn fmt_empty_strong_sequence(
+        &self,
+        delimiter: u8,
+        positions: [TextSize; 5],
+        f: &mut Formatter<MarkdownFormatContext>,
+    ) -> FormatResult<()> {
+        let escaped_marker = if delimiter == b'*' { "\\*" } else { "\\_" };
+        write!(
+            f,
+            [
+                text("**", Some(positions[0])),
+                text(escaped_marker, Some(positions[2])),
+                text("**", Some(positions[3])),
+            ]
+        )
+    }
+
+    fn fmt_literal_leading_underscore(
+        &self,
+        leading: &MdWord,
+        trailing: &MdWord,
+        f: &mut Formatter<MarkdownFormatContext>,
+    ) -> FormatResult<()> {
+        write!(f, [leading, token("\\"), trailing])
+    }
+}
+
+impl Format<MarkdownFormatContext> for WordGroup {
+    fn fmt(&self, f: &mut Formatter<MarkdownFormatContext>) -> FormatResult<()> {
+        let layout = self.layout()?;
+
+        match layout {
+            WordGroupLayout::Default => self.fmt_default(f),
+            WordGroupLayout::EscapeEachMarker => self.fmt_each_marker(f),
+            WordGroupLayout::EscapeLeadingMarker => {
+                write!(f, [token("\\")])?;
+                self.fmt_default(f)
+            }
+            WordGroupLayout::EmptyStrongSequence {
+                delimiter,
+                positions,
+            } => self.fmt_empty_strong_sequence(delimiter, positions, f),
+            WordGroupLayout::LiteralLeadingUnderscore { leading, trailing } => {
+                self.fmt_literal_leading_underscore(leading, trailing, f)
+            }
+            WordGroupLayout::UnmatchedUnderscore(layout) => layout.fmt(f),
         }
-        [
-            ProseAtom::Word(first),
-            ProseAtom::Word(second),
-            ProseAtom::Word(third),
-            ProseAtom::InlineElement(AnyMdInline::MdInlineItalic(italic)),
-        ] if is_single_underscore_word(first)
-            && is_single_underscore_word(second)
-            && is_single_underscore_word(third) =>
-        {
-            fmt_leading_underscore_run_with_italic(first, second, third, italic, f)
-        }
-        [
-            ProseAtom::Word(leading),
-            ProseAtom::InlineElement(AnyMdInline::MdInlineEmphasis(emphasis)),
-        ] if is_single_underscore_word(leading) => {
-            fmt_leading_underscore_with_emphasis(leading, emphasis, f)
-        }
-        [
-            ProseAtom::InlineElement(AnyMdInline::MdInlineEmphasis(emphasis)),
-            ProseAtom::Word(trailing),
-        ] if is_single_underscore_word(trailing) => {
-            fmt_emphasis_with_trailing_underscore(emphasis, trailing, f)
-        }
-        _ => Ok(false),
     }
-}
-
-fn is_single_underscore_word(word: &MdWord) -> bool {
-    word.text.text() == "_"
-}
-
-fn fmt_escaped_underscore_word(
-    word: &MdWord,
-    f: &mut Formatter<MarkdownFormatContext>,
-) -> FormatResult<()> {
-    write!(f, [token("\\"), word])
-}
-
-fn fmt_leading_underscore_with_italic(
-    leading: &MdWord,
-    italic: &MdInlineItalic,
-    f: &mut Formatter<MarkdownFormatContext>,
-) -> FormatResult<bool> {
-    if italic.fence()? != MdItalicFence::Underscore {
-        return Ok(false);
-    }
-
-    write!(
-        f,
-        [
-            format_with(|f| fmt_escaped_underscore_word(leading, f)),
-            italic.format()
-        ]
-    )?;
-
-    Ok(true)
-}
-
-fn fmt_italic_with_trailing_underscore(
-    italic: &MdInlineItalic,
-    trailing: &MdWord,
-    f: &mut Formatter<MarkdownFormatContext>,
-) -> FormatResult<bool> {
-    let l_fence = italic.l_fence()?;
-    let r_fence = italic.r_fence()?;
-    if italic.fence()? != MdItalicFence::Underscore {
-        return Ok(false);
-    }
-    f.context().comments().is_suppressed(italic.syntax());
-
-    write!(
-        f,
-        [
-            format_replaced(&l_fence, &text("\\_", Some(l_fence.text_range().start()))),
-            italic.content().format(),
-            format_replaced(&r_fence, &text("\\_", Some(r_fence.text_range().start()))),
-            format_with(|f| fmt_escaped_underscore_word(trailing, f)),
-        ]
-    )?;
-
-    Ok(true)
-}
-
-fn fmt_leading_underscore_run_with_italic(
-    first: &MdWord,
-    second: &MdWord,
-    third: &MdWord,
-    italic: &MdInlineItalic,
-    f: &mut Formatter<MarkdownFormatContext>,
-) -> FormatResult<bool> {
-    let l_fence = italic.l_fence()?;
-    let r_fence = italic.r_fence()?;
-    if italic.fence()? != MdItalicFence::Underscore {
-        return Ok(false);
-    }
-    f.context().comments().is_suppressed(italic.syntax());
-
-    write!(
-        f,
-        [
-            format_with(|f| fmt_escaped_underscore_word(first, f)),
-            second,
-            format_with(|f| fmt_escaped_underscore_word(third, f)),
-            format_replaced(&l_fence, &text("\\_", Some(l_fence.text_range().start()))),
-            italic.content().format(),
-            r_fence.format(),
-        ]
-    )?;
-
-    Ok(true)
-}
-
-fn fmt_leading_underscore_with_emphasis(
-    leading: &MdWord,
-    emphasis: &MdInlineEmphasis,
-    f: &mut Formatter<MarkdownFormatContext>,
-) -> FormatResult<bool> {
-    let l_fence = emphasis.l_fence()?;
-    let r_fence = emphasis.r_fence()?;
-    if emphasis.fence()? != MdEmphasisFence::DoubleUnderscore {
-        return Ok(false);
-    }
-    f.context().comments().is_suppressed(emphasis.syntax());
-
-    write!(
-        f,
-        [
-            format_replaced(&l_fence, &text("**", Some(l_fence.text_range().start()))),
-            format_with(|f| fmt_escaped_underscore_word(leading, f)),
-            emphasis.content().format(),
-            format_replaced(&r_fence, &text("**", Some(r_fence.text_range().start()))),
-        ]
-    )?;
-
-    Ok(true)
-}
-
-fn fmt_emphasis_with_trailing_underscore(
-    emphasis: &MdInlineEmphasis,
-    trailing: &MdWord,
-    f: &mut Formatter<MarkdownFormatContext>,
-) -> FormatResult<bool> {
-    let l_fence = emphasis.l_fence()?;
-    let r_fence = emphasis.r_fence()?;
-    if emphasis.fence()? != MdEmphasisFence::DoubleUnderscore {
-        return Ok(false);
-    }
-    f.context().comments().is_suppressed(emphasis.syntax());
-
-    write!(
-        f,
-        [
-            format_replaced(&l_fence, &text("**", Some(l_fence.text_range().start()))),
-            emphasis.content().format(),
-            format_with(|f| fmt_escaped_underscore_word(trailing, f)),
-            format_replaced(&r_fence, &text("**", Some(r_fence.text_range().start()))),
-        ]
-    )?;
-
-    Ok(true)
 }
 
 #[derive(Debug, Clone, Copy)]
-struct EmptyEmphasisDelimiterRun {
+struct EmphasisMarkerSequence {
     delimiter: u8,
     len: usize,
 }
 
-impl EmptyEmphasisDelimiterRun {
-    fn matches_start_of_word_group(self, atoms: &[ProseAtom]) -> bool {
-        self.matches_word_group_boundary(atoms.iter().map(|atom| match atom {
+impl EmphasisMarkerSequence {
+    fn matches_start_of(self, group: &WordGroup) -> bool {
+        self.matches_boundary(group.atoms.iter().map(|atom| match atom {
             ProseAtom::Word(word) => Some(word.text.text().bytes()),
             ProseAtom::InlineElement(_) => None,
         }))
     }
 
-    fn matches_end_of_word_group(self, atoms: &[ProseAtom]) -> bool {
-        self.matches_word_group_boundary(atoms.iter().rev().map(|atom| match atom {
+    fn matches_end_of(self, group: &WordGroup) -> bool {
+        self.matches_boundary(group.atoms.iter().rev().map(|atom| match atom {
             ProseAtom::Word(word) => Some(word.text.text().bytes().rev()),
             ProseAtom::InlineElement(_) => None,
         }))
     }
 
-    fn matches_word_group_boundary<I, B>(self, words: I) -> bool
+    fn matches_boundary<I, B>(self, words: I) -> bool
     where
         I: IntoIterator<Item = Option<B>>,
         B: IntoIterator<Item = u8>,
@@ -567,234 +803,28 @@ impl EmptyEmphasisDelimiterRun {
     }
 }
 
-fn mark_words_that_need_escaping(stream: &mut [ProseItem]) {
-    for index in 0..stream.len() {
-        let escape = word_group_escape(stream, index);
-        if let ProseItem::WordGroup {
-            escape: word_group_escape,
-            ..
-        } = &mut stream[index]
-        {
-            *word_group_escape = escape;
-        }
-    }
-}
-
-fn mark_outdented_setext_markers(stream: &mut [ProseItem]) {
-    let mut line_start = 0;
-
-    for line_end in 0..=stream.len() {
-        let is_line_end = line_end == stream.len()
-            || matches!(
-                stream[line_end],
-                ProseItem::SoftBreak | ProseItem::HardBreak(_)
-            );
-        if !is_line_end {
-            continue;
-        }
-
-        if let Some(relative_index) = outdented_setext_word_group(&stream[line_start..line_end]) {
-            let ProseItem::WordGroup { escape, .. } = &mut stream[line_start + relative_index]
-            else {
-                unreachable!();
-            };
-            *escape = WordGroupEscape::EscapeLeadingMarker;
-        }
-
-        line_start = line_end + 1;
-    }
-}
-
-fn outdented_setext_word_group(line: &[ProseItem]) -> Option<usize> {
-    let mut has_removed_indent = false;
-    let mut first_word_group = None;
-    let mut delimiter = None;
-
-    for (index, item) in line.iter().enumerate() {
-        match item {
-            ProseItem::OutdentedLineStart if first_word_group.is_none() => {
-                has_removed_indent = true;
-            }
-            ProseItem::Space => {}
-            ProseItem::WordGroup { atoms, .. } if has_removed_indent => {
-                // Space-separated dashes can form a thematic break, but
-                // space-separated equals signs cannot form block syntax.
-                if first_word_group.is_some() && delimiter == Some(b'=') {
-                    return None;
-                }
-                first_word_group.get_or_insert(index);
-                for atom in atoms {
-                    let ProseAtom::Word(word) = atom else {
-                        return None;
-                    };
-                    for byte in word.text.text().bytes() {
-                        if !matches!(byte, b'=' | b'-') {
-                            return None;
-                        }
-                        if delimiter.is_some_and(|delimiter| delimiter != byte) {
-                            return None;
-                        }
-                        delimiter = Some(byte);
-                    }
-                }
-            }
-            _ => return None,
-        }
-    }
-
-    delimiter.and(first_word_group)
-}
-
-/// Returns how a word group should print marker-only text.
-///
-/// A word group needs special escaping when every atom is plain text, the whole
-/// group looks like an empty emphasis delimiter run, and the run is not paired
-/// with a matching marker boundary elsewhere in the paragraph:
-///
-/// - `**` or `__`, which looks like empty emphasis.
-/// - `***` or `___`, which looks like an empty combined emphasis/strong run.
-/// - `****` or `____`, which looks like empty strong emphasis.
-/// - `*****` or `_____`, which is printed as strong emphasis containing an
-///   escaped literal marker.
-///
-/// The Markdown parser keeps these marker runs as plain `MdTextual` words.
-/// Although they parse as literal text, printing them raw makes them look like
-/// emphasis delimiters, so the formatter prints an escaped form.
-///
-/// If another word in the paragraph starts or ends with the same marker run,
-/// the run is treated as part of that larger emphasis-like boundary and left
-/// unchanged. This preserves cases such as `** foo bar**`, `**foo bar **`, and
-/// their `_` equivalents.
-///
-/// Inline atoms are excluded because emphasis, links, code spans, and other
-/// structured inline nodes already own their delimiters and escaping rules.
-/// Single markers and runs longer than five are left unchanged because they are
-/// outside this empty-emphasis compatibility case.
-fn word_group_escape(stream: &[ProseItem], index: usize) -> WordGroupEscape {
-    let Some(ProseItem::WordGroup { atoms, .. }) = stream.get(index) else {
-        return WordGroupEscape::None;
-    };
-
-    let Some(delimiter_run) = empty_emphasis_delimiter_run(atoms) else {
-        return WordGroupEscape::None;
-    };
-
-    if has_matching_marker_boundary_before(stream, index, delimiter_run)
-        || has_matching_marker_boundary_after(stream, index, delimiter_run)
-    {
-        return WordGroupEscape::None;
-    }
-
-    match delimiter_run.len {
-        2..=4 => WordGroupEscape::EscapeEachMarker,
-        5 => WordGroupEscape::EmptyStrongWithEscapedMarker,
-        _ => WordGroupEscape::None,
-    }
-}
-
-fn fmt_empty_strong_delimiter(
-    atoms: &[ProseAtom],
-    f: &mut Formatter<MarkdownFormatContext>,
-) -> FormatResult<()> {
-    let Some(delimiter_run) = empty_emphasis_delimiter_run(atoms) else {
-        return Ok(());
-    };
-
-    debug_assert_eq!(
-        delimiter_run.len, 5,
-        "empty strong delimiter formatting is selected only for five-marker runs"
-    );
-
-    let mut positions = Vec::with_capacity(delimiter_run.len);
-    for atom in atoms {
-        let ProseAtom::Word(word) = atom else {
-            return Ok(());
+impl WordGroupEscape {
+    /// Returns how a word group should print marker-only text.
+    ///
+    /// Marker sequences containing two to five identical emphasis markers need
+    /// escaping unless another group forms a matching boundary in the paragraph.
+    fn from(items: &ProseItemList, index: usize) -> Self {
+        let Some(ProseItem::WordGroup(group)) = items.0.get(index) else {
+            return Self::None;
         };
 
-        for index in 0..word.text.text().len() {
-            positions.push(word.source_position + TextSize::from(index as u32));
-        }
-    }
-
-    let escaped_marker = if delimiter_run.delimiter == b'*' {
-        "\\*"
-    } else {
-        "\\_"
-    };
-
-    if positions.len() != 5 {
-        for atom in atoms {
-            if let ProseAtom::Word(word) = atom {
-                word.fmt(f)?;
-            }
-        }
-        return Ok(());
-    }
-
-    // Five marker runs are printed as strong emphasis around an escaped marker:
-    // the first two markers become the opening `**`, the middle marker is
-    // escaped, and the last two markers become the closing `**`.
-    let first = positions[0];
-    let middle = positions[2];
-    let last_start = positions[3];
-
-    write!(
-        f,
-        [
-            text("**", Some(first)),
-            text(escaped_marker, Some(middle)),
-            text("**", Some(last_start)),
-        ]
-    )
-}
-
-fn empty_emphasis_delimiter_run(atoms: &[ProseAtom]) -> Option<EmptyEmphasisDelimiterRun> {
-    let mut delimiter = None;
-    let mut len = 0usize;
-
-    for atom in atoms {
-        let ProseAtom::Word(word) = atom else {
-            return None;
+        let Some(marker_sequence) = group.emphasis_marker_sequence() else {
+            return Self::None;
         };
 
-        for byte in word.text.text().bytes() {
-            if !matches!(byte, b'*' | b'_') {
-                return None;
-            }
+        if items.has_matching_marker_boundary(index, marker_sequence) {
+            return Self::None;
+        }
 
-            if let Some(delimiter) = delimiter {
-                if delimiter != byte {
-                    return None;
-                }
-            } else {
-                delimiter = Some(byte);
-            }
-
-            len += 1;
+        match marker_sequence.len {
+            2..=4 => Self::EscapeEachMarker,
+            5 => Self::EmptyStrongWithEscapedMarker,
+            _ => Self::None,
         }
     }
-
-    delimiter.map(|delimiter| EmptyEmphasisDelimiterRun { delimiter, len })
-}
-
-fn has_matching_marker_boundary_before(
-    stream: &[ProseItem],
-    index: usize,
-    delimiter_run: EmptyEmphasisDelimiterRun,
-) -> bool {
-    stream[..index].iter().any(|item| match item {
-        ProseItem::WordGroup { atoms, .. } => delimiter_run.matches_start_of_word_group(atoms),
-        _ => false,
-    })
-}
-
-fn has_matching_marker_boundary_after(
-    stream: &[ProseItem],
-    index: usize,
-    delimiter_run: EmptyEmphasisDelimiterRun,
-) -> bool {
-    stream[index + 1..].iter().any(|item| match item {
-        ProseItem::WordGroup { atoms, .. } => delimiter_run.matches_end_of_word_group(atoms),
-        _ => false,
-    })
 }

--- a/crates/biome_markdown_formatter/tests/specs/markdown/proseAlways/options.json
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/proseAlways/options.json
@@ -1,0 +1,9 @@
+{
+  "markdown": {
+    "formatter": {
+      "proseWrap": "always",
+      "lineWidth": 40,
+      "indentStyle": "space"
+    }
+  }
+}

--- a/crates/biome_markdown_formatter/tests/specs/markdown/proseAlways/prose.md
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/proseAlways/prose.md
@@ -1,0 +1,30 @@
+This is a long paragraph with enough words to exceed the configured line width and require wrapping.
+
+This paragraph starts on one source line
+and continues on another source line.
+
+Text next to **strong emphasis**, `inline code`, and a [link](https://example.com) remains available for wrapping.
+
+Text with ``inline
+code spanning source lines`` remains one code span.
+
+This paragraph has an explicit hard break here.  
+The next line remains separate from the first.
+
+- This list item contains enough prose to wrap across multiple lines at the configured width.
+
+> This block quote contains enough prose to wrap across multiple lines at the configured width.
+
+This paragraph contains enough words before - this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before > this marker remains prose instead of becoming a quote.
+
+This paragraph contains enough words before 1. this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before ### this marker remains prose instead of becoming a heading.
+
+A long setext heading starts on this line
+and continues with enough words to wrap
+===
+
+[a-long-reference-label]: https://example.com/a/long/destination "A long reference title"

--- a/crates/biome_markdown_formatter/tests/specs/markdown/proseAlways/prose.md.snap
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/proseAlways/prose.md.snap
@@ -1,0 +1,114 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: markdown/proseAlways/prose.md
+---
+
+# Input
+
+```md
+This is a long paragraph with enough words to exceed the configured line width and require wrapping.
+
+This paragraph starts on one source line
+and continues on another source line.
+
+Text next to **strong emphasis**, `inline code`, and a [link](https://example.com) remains available for wrapping.
+
+Text with ``inline
+code spanning source lines`` remains one code span.
+
+This paragraph has an explicit hard break here.  
+The next line remains separate from the first.
+
+- This list item contains enough prose to wrap across multiple lines at the configured width.
+
+> This block quote contains enough prose to wrap across multiple lines at the configured width.
+
+This paragraph contains enough words before - this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before > this marker remains prose instead of becoming a quote.
+
+This paragraph contains enough words before 1. this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before ### this marker remains prose instead of becoming a heading.
+
+A long setext heading starts on this line
+and continues with enough words to wrap
+===
+
+[a-long-reference-label]: https://example.com/a/long/destination "A long reference title"
+
+```
+
+
+# Options
+
+```json
+{
+  "markdown": {
+    "formatter": {
+      "proseWrap": "always",
+      "lineWidth": 40,
+      "indentStyle": "space"
+    }
+  }
+}
+```
+
+# Formatted
+
+```md
+This is a long paragraph with enough
+words to exceed the configured line
+width and require wrapping.
+
+This paragraph starts on one source line
+and continues on another source line.
+
+Text next to **strong emphasis**,
+`inline code`, and a
+[link](https://example.com) remains
+available for wrapping.
+
+Text with
+`inline code spanning source lines`
+remains one code span.
+
+This paragraph has an explicit hard
+break here.  
+The next line remains separate from the
+first.
+
+- This list item contains enough prose
+  to wrap across multiple lines at the
+  configured width.
+
+> This block quote contains enough prose
+> to wrap across multiple lines at the
+> configured width.
+
+This paragraph contains enough words
+before - this marker remains prose
+instead of becoming a list.
+
+This paragraph contains enough words
+before > this marker remains prose
+instead of becoming a quote.
+
+This paragraph contains enough words
+before 1. this marker remains prose
+instead of becoming a list.
+
+This paragraph contains enough words
+before ### this marker remains prose
+instead of becoming a heading.
+
+A long setext heading starts on this
+line and continues with enough words to
+wrap
+===
+
+[a-long-reference-label]:
+  https://example.com/a/long/destination
+  "A long reference title"
+
+```

--- a/crates/biome_markdown_formatter/tests/specs/markdown/proseNever/options.json
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/proseNever/options.json
@@ -1,0 +1,9 @@
+{
+  "markdown": {
+    "formatter": {
+      "proseWrap": "never",
+      "lineWidth": 40,
+      "indentStyle": "space"
+    }
+  }
+}

--- a/crates/biome_markdown_formatter/tests/specs/markdown/proseNever/prose.md
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/proseNever/prose.md
@@ -1,0 +1,30 @@
+This is a long paragraph with enough words to exceed the configured line width and require wrapping.
+
+This paragraph starts on one source line
+and continues on another source line.
+
+Text next to **strong emphasis**, `inline code`, and a [link](https://example.com) remains available for wrapping.
+
+Text with ``inline
+code spanning source lines`` remains one code span.
+
+This paragraph has an explicit hard break here.  
+The next line remains separate from the first.
+
+- This list item contains enough prose to wrap across multiple lines at the configured width.
+
+> This block quote contains enough prose to wrap across multiple lines at the configured width.
+
+This paragraph contains enough words before - this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before > this marker remains prose instead of becoming a quote.
+
+This paragraph contains enough words before 1. this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before ### this marker remains prose instead of becoming a heading.
+
+A long setext heading starts on this line
+and continues with enough words to wrap
+===
+
+[a-long-reference-label]: https://example.com/a/long/destination "A long reference title"

--- a/crates/biome_markdown_formatter/tests/specs/markdown/proseNever/prose.md.snap
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/proseNever/prose.md.snap
@@ -1,0 +1,101 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: markdown/proseNever/prose.md
+---
+
+# Input
+
+```md
+This is a long paragraph with enough words to exceed the configured line width and require wrapping.
+
+This paragraph starts on one source line
+and continues on another source line.
+
+Text next to **strong emphasis**, `inline code`, and a [link](https://example.com) remains available for wrapping.
+
+Text with ``inline
+code spanning source lines`` remains one code span.
+
+This paragraph has an explicit hard break here.  
+The next line remains separate from the first.
+
+- This list item contains enough prose to wrap across multiple lines at the configured width.
+
+> This block quote contains enough prose to wrap across multiple lines at the configured width.
+
+This paragraph contains enough words before - this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before > this marker remains prose instead of becoming a quote.
+
+This paragraph contains enough words before 1. this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before ### this marker remains prose instead of becoming a heading.
+
+A long setext heading starts on this line
+and continues with enough words to wrap
+===
+
+[a-long-reference-label]: https://example.com/a/long/destination "A long reference title"
+
+```
+
+
+# Options
+
+```json
+{
+  "markdown": {
+    "formatter": {
+      "proseWrap": "never",
+      "lineWidth": 40,
+      "indentStyle": "space"
+    }
+  }
+}
+```
+
+# Formatted
+
+```md
+This is a long paragraph with enough words to exceed the configured line width and require wrapping.
+
+This paragraph starts on one source line and continues on another source line.
+
+Text next to **strong emphasis**, `inline code`, and a [link](https://example.com) remains available for wrapping.
+
+Text with `inline code spanning source lines` remains one code span.
+
+This paragraph has an explicit hard break here.  
+The next line remains separate from the first.
+
+- This list item contains enough prose to wrap across multiple lines at the configured width.
+
+> This block quote contains enough prose to wrap across multiple lines at the configured width.
+
+This paragraph contains enough words before - this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before > this marker remains prose instead of becoming a quote.
+
+This paragraph contains enough words before 1. this marker remains prose instead of becoming a list.
+
+This paragraph contains enough words before ### this marker remains prose instead of becoming a heading.
+
+# A long setext heading starts on this line and continues with enough words to wrap
+
+[a-long-reference-label]: https://example.com/a/long/destination "A long reference title"
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    1: This is a long paragraph with enough words to exceed the configured line width and require wrapping.
+    5: Text next to **strong emphasis**, `inline code`, and a [link](https://example.com) remains available for wrapping.
+   12: - This list item contains enough prose to wrap across multiple lines at the configured width.
+   14: > This block quote contains enough prose to wrap across multiple lines at the configured width.
+   16: This paragraph contains enough words before - this marker remains prose instead of becoming a list.
+   18: This paragraph contains enough words before > this marker remains prose instead of becoming a quote.
+   20: This paragraph contains enough words before 1. this marker remains prose instead of becoming a list.
+   22: This paragraph contains enough words before ### this marker remains prose instead of becoming a heading.
+   24: # A long setext heading starts on this line and continues with enough words to wrap
+   26: [a-long-reference-label]: https://example.com/a/long/destination "A long reference title"
+```

--- a/crates/biome_service/src/file_handlers/md.rs
+++ b/crates/biome_service/src/file_handlers/md.rs
@@ -15,7 +15,7 @@ use biome_configuration::markdown::{MarkdownFormatterConfiguration, MarkdownForm
 use biome_db::AnyParsedSource;
 use biome_formatter::{IndentStyle, IndentWidth, LineEnding, LineWidth, Printed, TrailingNewline};
 use biome_fs::BiomePath;
-use biome_markdown_formatter::context::MdFormatOptions;
+use biome_markdown_formatter::context::{MdFormatOptions, ProseWrap};
 use biome_markdown_formatter::format_node;
 use biome_markdown_parser::{MarkdownParserOptions, parse_markdown_with_cache};
 use biome_markdown_syntax::{MarkdownLanguage, MarkdownSyntaxNode, MdDocument};
@@ -34,6 +34,7 @@ pub struct MarkdownFormatterSettings {
     pub indent_style: Option<IndentStyle>,
     pub trailing_newline: Option<TrailingNewline>,
     pub enabled: Option<MarkdownFormatterEnabled>,
+    pub prose_wrap: Option<ProseWrap>,
 }
 
 impl From<MarkdownFormatterConfiguration> for MarkdownFormatterSettings {
@@ -45,6 +46,7 @@ impl From<MarkdownFormatterConfiguration> for MarkdownFormatterSettings {
             indent_style: configuration.indent_style,
             enabled: configuration.enabled,
             trailing_newline: configuration.trailing_newline,
+            prose_wrap: configuration.prose_wrap,
         }
     }
 }
@@ -117,12 +119,14 @@ impl ServiceLanguage for MarkdownLanguage {
             .trailing_newline
             .or(global.trailing_newline)
             .unwrap_or_default();
+        let prose_wrap = language.prose_wrap.unwrap_or_default();
         MdFormatOptions::new()
             .with_indent_style(indent_style)
             .with_indent_width(indent_width)
             .with_line_width(line_width)
             .with_line_ending(line_ending)
             .with_trailing_newline(trailing_newline)
+            .with_prose_wrap(prose_wrap)
     }
 
     fn resolve_analyzer_options(


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

> [!NOTE]
> Implemented with a coding agent

## Summary

This PR adds `proseWrap` option to `markdown.formatter`. It keeps the same semantics as Prettier. It's safe to add it on `main` because the whole `markdown` configuration is still hidden via Rust gates.

The real implementation is mostly confined in `inline_item_list.rs`. The other changes are mostly refactor because I didn't like how some parts of the code have become.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

I will open a PR when we enable markdown formatter 

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
