### PR TITLE
chore: trim published crate sizes with cargo diet

### DIFF
--- a/crates/biome_analyze/Cargo.toml
+++ b/crates/biome_analyze/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_analyze/Cargo.toml
+++ b/crates/biome_analyze/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_aria_metadata/Cargo.toml
+++ b/crates/biome_aria_metadata/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["build.rs", "src/lib.rs"]
 publish              = true
-include = ["src/lib.rs", "build.rs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_aria_metadata/Cargo.toml
+++ b/crates/biome_aria_metadata/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/lib.rs", "build.rs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_console/Cargo.toml
+++ b/crates/biome_console/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE", "README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_console/Cargo.toml
+++ b/crates/biome_console/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_css_analyze/Cargo.toml
+++ b/crates/biome_css_analyze/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["build.rs", "src/**/*"]
 publish              = true
-include = ["src/**/*", "build.rs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_css_analyze/Cargo.toml
+++ b/crates/biome_css_analyze/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "build.rs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_css_formatter/Cargo.toml
+++ b/crates/biome_css_formatter/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["!**/*_test.*", "README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "README.md", "!**/*_test.*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_css_formatter/Cargo.toml
+++ b/crates/biome_css_formatter/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "README.md", "!**/*_test.*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_css_parser/Cargo.toml
+++ b/crates/biome_css_parser/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE", "README.md"]
 
 [[bench]]
 harness = false

--- a/crates/biome_css_parser/Cargo.toml
+++ b/crates/biome_css_parser/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE", "README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE", "README.md"]
 
 [[bench]]
 harness = false

--- a/crates/biome_css_semantic/Cargo.toml
+++ b/crates/biome_css_semantic/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["!**/tests/**/*", "src/**/*"]
 publish              = true
-include = ["src/**/*", "!**/tests/**/*"]
 
 [dependencies]
 biome_css_syntax  = { workspace = true }

--- a/crates/biome_css_semantic/Cargo.toml
+++ b/crates/biome_css_semantic/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "!**/tests/**/*"]
 
 [dependencies]
 biome_css_syntax  = { workspace = true }

--- a/crates/biome_diagnostics/Cargo.toml
+++ b/crates/biome_diagnostics/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE", "README.md"]
 
 [[example]]
 name = "cli"

--- a/crates/biome_diagnostics/Cargo.toml
+++ b/crates/biome_diagnostics/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE", "README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE", "README.md"]
 
 [[example]]
 name = "cli"

--- a/crates/biome_formatter/Cargo.toml
+++ b/crates/biome_formatter/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE", "README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_formatter/Cargo.toml
+++ b/crates/biome_formatter/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_graphql_analyze/Cargo.toml
+++ b/crates/biome_graphql_analyze/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "build.rs"]
 
 [dependencies]
 biome_analyze            = { workspace = true }

--- a/crates/biome_graphql_analyze/Cargo.toml
+++ b/crates/biome_graphql_analyze/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["build.rs", "src/**/*"]
 publish              = true
-include = ["src/**/*", "build.rs"]
 
 [dependencies]
 biome_analyze            = { workspace = true }

--- a/crates/biome_graphql_formatter/Cargo.toml
+++ b/crates/biome_graphql_formatter/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_graphql_formatter/Cargo.toml
+++ b/crates/biome_graphql_formatter/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_graphql_parser/Cargo.toml
+++ b/crates/biome_graphql_parser/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_graphql_parser/Cargo.toml
+++ b/crates/biome_graphql_parser/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_graphql_semantic/Cargo.toml
+++ b/crates/biome_graphql_semantic/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "!**/tests/**/*"]
 
 [dependencies]
 biome_graphql_syntax = { workspace = true }

--- a/crates/biome_graphql_semantic/Cargo.toml
+++ b/crates/biome_graphql_semantic/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["!**/tests/**/*", "src/**/*"]
 publish              = true
-include = ["src/**/*", "!**/tests/**/*"]
 
 [dependencies]
 biome_graphql_syntax = { workspace = true }

--- a/crates/biome_grit_formatter/Cargo.toml
+++ b/crates/biome_grit_formatter/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_grit_formatter/Cargo.toml
+++ b/crates/biome_grit_formatter/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_grit_parser/Cargo.toml
+++ b/crates/biome_grit_parser/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 # cargo-workspaces metadata
 [package.metadata.workspaces]

--- a/crates/biome_grit_parser/Cargo.toml
+++ b/crates/biome_grit_parser/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 # cargo-workspaces metadata
 [package.metadata.workspaces]

--- a/crates/biome_html_analyze/Cargo.toml
+++ b/crates/biome_html_analyze/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include = ["src/**/*", "build.rs", "!**/*_tests.*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_html_analyze/Cargo.toml
+++ b/crates/biome_html_analyze/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
-include = ["src/**/*", "build.rs", "!**/*_tests.*"]
+include              = ["!**/*_tests.*", "build.rs", "src/**/*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_html_formatter/Cargo.toml
+++ b/crates/biome_html_formatter/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_html_formatter/Cargo.toml
+++ b/crates/biome_html_formatter/Cargo.toml
@@ -8,8 +8,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_html_parser/Cargo.toml
+++ b/crates/biome_html_parser/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_html_parser/Cargo.toml
+++ b/crates/biome_html_parser/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "build.rs", "!**/*_test.*", "!**/*_tests.*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["!**/*_test.*", "!**/*_tests.*", "build.rs", "src/**/*"]
 publish              = true
-include = ["src/**/*", "build.rs", "!**/*_test.*", "!**/*_tests.*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_js_formatter/Cargo.toml
+++ b/crates/biome_js_formatter/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE", "README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_js_formatter/Cargo.toml
+++ b/crates/biome_js_formatter/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE", "README.md"]
 
 # cargo-workspaces metadata
 [package.metadata.workspaces]

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE", "README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE", "README.md"]
 
 # cargo-workspaces metadata
 [package.metadata.workspaces]

--- a/crates/biome_js_semantic/Cargo.toml
+++ b/crates/biome_js_semantic/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["!**/tests/**/*", "LICENSE", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE", "!**/tests/**/*"]
 
 [dependencies]
 biome_db            = { workspace = true }

--- a/crates/biome_js_semantic/Cargo.toml
+++ b/crates/biome_js_semantic/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE", "!**/tests/**/*"]
 
 [dependencies]
 biome_db            = { workspace = true }

--- a/crates/biome_js_syntax/Cargo.toml
+++ b/crates/biome_js_syntax/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 biome_aria          = { workspace = true }

--- a/crates/biome_js_syntax/Cargo.toml
+++ b/crates/biome_js_syntax/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 biome_aria          = { workspace = true }

--- a/crates/biome_js_type_info/Cargo.toml
+++ b/crates/biome_js_type_info/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 [dependencies]
 biome_db                  = { workspace = true }

--- a/crates/biome_js_type_info/Cargo.toml
+++ b/crates/biome_js_type_info/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 [dependencies]
 biome_db                  = { workspace = true }

--- a/crates/biome_json_analyze/Cargo.toml
+++ b/crates/biome_json_analyze/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["build.rs", "src/**/*"]
 publish              = true
-include = ["src/**/*", "build.rs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_json_analyze/Cargo.toml
+++ b/crates/biome_json_analyze/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "build.rs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_json_formatter/Cargo.toml
+++ b/crates/biome_json_formatter/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE", "README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_json_formatter/Cargo.toml
+++ b/crates/biome_json_formatter/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_json_parser/Cargo.toml
+++ b/crates/biome_json_parser/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "README.md"]
 
 # cargo-workspaces metadata
 [package.metadata.workspaces]

--- a/crates/biome_json_parser/Cargo.toml
+++ b/crates/biome_json_parser/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "README.md"]
 
 # cargo-workspaces metadata
 [package.metadata.workspaces]

--- a/crates/biome_markdown_formatter/Cargo.toml
+++ b/crates/biome_markdown_formatter/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
-include = ["src/**/*"]
+include              = ["src/**/*"]
 
 [dependencies]
 biome_formatter        = { workspace = true }

--- a/crates/biome_markdown_formatter/Cargo.toml
+++ b/crates/biome_markdown_formatter/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include = ["src/**/*"]
 
 [dependencies]
 biome_formatter        = { workspace = true }

--- a/crates/biome_module_graph/Cargo.toml
+++ b/crates/biome_module_graph/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "README.md"]
 
 [[bench]]
 harness = false

--- a/crates/biome_module_graph/Cargo.toml
+++ b/crates/biome_module_graph/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["README.md", "src/**/*"]
 publish              = true
-include = ["src/**/*", "README.md"]
 
 [[bench]]
 harness = false

--- a/crates/biome_package/Cargo.toml
+++ b/crates/biome_package/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_package/Cargo.toml
+++ b/crates/biome_package/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_rowan/Cargo.toml
+++ b/crates/biome_rowan/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE-*", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE-*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_rowan/Cargo.toml
+++ b/crates/biome_rowan/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE-*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_rule_options/Cargo.toml
+++ b/crates/biome_rule_options/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "!**/*_test.*", "!**/*_tests.*"]
 
 [dependencies]
 biome_console            = { workspace = true }

--- a/crates/biome_rule_options/Cargo.toml
+++ b/crates/biome_rule_options/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["!**/*_test.*", "!**/*_tests.*", "src/**/*"]
 publish              = true
-include = ["src/**/*", "!**/*_test.*", "!**/*_tests.*"]
 
 [dependencies]
 biome_console            = { workspace = true }

--- a/crates/biome_tailwind_parser/Cargo.toml
+++ b/crates/biome_tailwind_parser/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_tailwind_parser/Cargo.toml
+++ b/crates/biome_tailwind_parser/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 [[bench]]
 harness = false

--- a/crates/biome_text_size/Cargo.toml
+++ b/crates/biome_text_size/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*", "LICENSE-*"]
 
 [[test]]
 name              = "serde"

--- a/crates/biome_text_size/Cargo.toml
+++ b/crates/biome_text_size/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["LICENSE-*", "src/**/*"]
 publish              = true
-include = ["src/**/*", "LICENSE-*"]
 
 [[test]]
 name              = "serde"

--- a/crates/biome_yaml_formatter/Cargo.toml
+++ b/crates/biome_yaml_formatter/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
 publish              = true
+include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_yaml_formatter/Cargo.toml
+++ b/crates/biome_yaml_formatter/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
+include              = ["src/**/*"]
 publish              = true
-include = ["src/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

follows up on [the Discord thread](https://discord.com/channels/1132231889290285117/1132602492987908166/1531475810396016650) about slimming down the published crates. as part of an e18e effort to diet Rust crates across the ecosystem, several Biome packages currently ship test suites, snapshots, and benchmark fixtures to crates.io that aren't needed by consumers.

this PR ran `cargo diet --workspace` to add `include` directives to 35 workspace crates, restricting published packages to source and manifest files only. total package payload drops from ~115 MB to ~21 MB (**~82% smaller, ~19,900 files removed**), with most of the savings coming from the parser and analyzer test suites.

since Biome isn't actively publishing to `crates.io` right now, there's no urgency here. the goal is just that if publishing resumes, the crates will already be lean. `include` only affects packaging, so builds, tests, and local development are unchanged.

total package payload drops from ~115 MB to ~21 MB (~82%, ~19,900 files), mostly test/snapshot suites shipped by the parsers and analyzers.

<details>
<summary>Per-crate savings</summary>

| Crate | Saved | % of crate | Files removed | Size before |
|---|---:|---:|---:|---:|
| biome_js_parser | 34.1 MB | 98% | 1,417 | 34.9 MB |
| biome_css_parser | 23.2 MB | 96% | 936 | 24.1 MB |
| biome_js_analyze | 10.9 MB | 68% | 5,169 | 15.9 MB |
| biome_html_parser | 5.3 MB | 95% | 752 | 5.6 MB |
| biome_html_analyze | 4.9 MB | 92% | 989 | 5.3 MB |
| biome_html_formatter | 3.1 MB | 85% | 949 | 3.6 MB |
| biome_js_formatter | 2.6 MB | 60% | 3,579 | 4.4 MB |
| biome_json_parser | 2.5 MB | 97% | 602 | 2.6 MB |
| biome_module_graph | 2.2 MB | 74% | 156 | 2.9 MB |
| biome_css_formatter | 1.5 MB | 52% | 1,053 | 3.0 MB |
| biome_graphql_parser | 968.5 kB | 89% | 88 | 1.1 MB |
| biome_markdown_formatter | 527.5 kB | 61% | 1,890 | 860.9 kB |
| biome_css_analyze | 481.5 kB | 39% | 304 | 1.2 MB |
| biome_tailwind_parser | 417.8 kB | 84% | 139 | 496.2 kB |
| biome_grit_parser | 304.3 kB | 72% | 116 | 422.2 kB |
| biome_json_analyze | 126.2 kB | 38% | 176 | 334.0 kB |
| biome_yaml_formatter | 125.2 kB | 36% | 856 | 348.4 kB |
| biome_grit_formatter | 112.8 kB | 27% | 73 | 416.6 kB |
| biome_json_formatter | 110.5 kB | 58% | 175 | 191.3 kB |
| biome_graphql_analyze | 99.8 kB | 48% | 152 | 208.6 kB |
| biome_js_type_info | 97.4 kB | 10% | 45 | 963.0 kB |
| biome_graphql_formatter | 81.7 kB | 26% | 168 | 311.7 kB |
| biome_analyze | 63.0 kB | 16% | 1 | 388.5 kB |
| biome_js_semantic | 57.3 kB | 22% | 9 | 266.2 kB |
| biome_css_semantic | 39.8 kB | 29% | 4 | 139.4 kB |
| biome_diagnostics | 34.8 kB | 14% | 45 | 257.4 kB |
| biome_graphql_semantic | 25.4 kB | 37% | 9 | 68.8 kB |
| biome_package | 24.3 kB | 5% | 19 | 481.0 kB |
| biome_console | 17.2 kB | 24% | 36 | 71.4 kB |
| biome_formatter | 14.5 kB | 2% | 3 | 709.3 kB |
| biome_text_size | 5.1 kB | 12% | 5 | 42.4 kB |
| biome_rowan | 2.0 kB | 0% | 1 | 439.9 kB |
| biome_rule_options | 1.4 kB | 0% | 4 | 431.0 kB |
| biome_js_syntax | 1.1 kB | 0% | 1 | 2.3 MB |
| biome_aria_metadata | 243 B | 1% | 1 | 38.6 kB |
| **Total (35 crates)** | **~94 MB** | **~82%** | **~19,900** | **~115 MB** |

</details>

## Test Plan

`cargo package --no-verify -p <crate>` on the largest crates confirms they still package `include` only affects publishing, not builds or tests.
<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A
<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
