### PR TITLE
chore(xtask): migrate Array global types

### DIFF
--- a/crates/biome_js_type_info/src/generated/global_types.rs
+++ b/crates/biome_js_type_info/src/generated/global_types.rs
@@ -4,6 +4,10 @@
 
 /// Predefined global IDs whose `TypeData` is supplied by this generated module.
 pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
+    crate::globals::ARRAY_ID_GLOBAL_TYPE_ID,
+    crate::globals::ARRAY_FILTER_ID_GLOBAL_TYPE_ID,
+    crate::globals::ARRAY_FOREACH_ID_GLOBAL_TYPE_ID,
+    crate::globals::ARRAY_MAP_ID_GLOBAL_TYPE_ID,
     crate::globals::REGEXP_ID_GLOBAL_TYPE_ID,
     crate::globals::REGEXP_EXEC_ID_GLOBAL_TYPE_ID,
     crate::globals::SYMBOL_ID_GLOBAL_TYPE_ID,
@@ -26,6 +30,76 @@ pub(crate) const MIGRATED_PREDEFINED_IDS: &[crate::globals::GlobalTypeId] = &[
 pub(crate) fn set_generated_global_type_data(
     builder: &mut crate::globals_builder::GlobalsResolverBuilder,
 ) {
+    let data = crate::TypeData::Class(Box::new(crate::Class {
+        name: Some(biome_rowan::Text::new_static("Array")),
+        type_parameters: Box::new([crate::globals::GLOBAL_T_ID.into()]),
+        extends: None,
+        implements: Box::default(),
+        members: Box::new([
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::Named(biome_rowan::Text::new_static("filter")),
+                ty: crate::globals::GLOBAL_ARRAY_FILTER_ID.into(),
+            },
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::Named(biome_rowan::Text::new_static("forEach")),
+                ty: crate::globals::GLOBAL_ARRAY_FOREACH_ID.into(),
+            },
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::Named(biome_rowan::Text::new_static("map")),
+                ty: crate::globals::GLOBAL_ARRAY_MAP_ID.into(),
+            },
+            crate::TypeMember {
+                kind: crate::TypeMemberKind::Named(biome_rowan::Text::new_static("length")),
+                ty: crate::globals::GLOBAL_NUMBER_ID.into(),
+            },
+        ]),
+    }));
+    builder.set_type_data(crate::globals::ARRAY_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Function(Box::new(crate::Function {
+        is_async: false,
+        type_parameters: Box::default(),
+        name: Some(biome_rowan::Text::new_static("Array.prototype.filter")),
+        parameters: Box::new([crate::FunctionParameter::Pattern(
+            crate::PatternFunctionParameter {
+                bindings: Box::default(),
+                ty: crate::globals::GLOBAL_CONDITIONAL_CALLBACK_ID.into(),
+                is_optional: false,
+                is_rest: false,
+            },
+        )]),
+        return_type: crate::ReturnType::Type(crate::globals::GLOBAL_INSTANCEOF_ARRAY_T_ID.into()),
+    }));
+    builder.set_type_data(crate::globals::ARRAY_FILTER_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Function(Box::new(crate::Function {
+        is_async: false,
+        type_parameters: Box::default(),
+        name: Some(biome_rowan::Text::new_static("Array.prototype.forEach")),
+        parameters: Box::new([crate::FunctionParameter::Pattern(
+            crate::PatternFunctionParameter {
+                bindings: Box::default(),
+                ty: crate::globals::GLOBAL_VOID_CALLBACK_ID.into(),
+                is_optional: false,
+                is_rest: false,
+            },
+        )]),
+        return_type: crate::ReturnType::Type(crate::globals::GLOBAL_VOID_ID.into()),
+    }));
+    builder.set_type_data(crate::globals::ARRAY_FOREACH_ID_GLOBAL_TYPE_ID, data);
+    let data = crate::TypeData::Function(Box::new(crate::Function {
+        is_async: false,
+        type_parameters: Box::new([crate::globals::GLOBAL_U_ID.into()]),
+        name: Some(biome_rowan::Text::new_static("Array.prototype.map")),
+        parameters: Box::new([crate::FunctionParameter::Pattern(
+            crate::PatternFunctionParameter {
+                bindings: Box::default(),
+                ty: crate::globals::GLOBAL_MAP_CALLBACK_ID.into(),
+                is_optional: false,
+                is_rest: false,
+            },
+        )]),
+        return_type: crate::ReturnType::Type(crate::globals::GLOBAL_INSTANCEOF_ARRAY_U_ID.into()),
+    }));
+    builder.set_type_data(crate::globals::ARRAY_MAP_ID_GLOBAL_TYPE_ID, data);
     let data = crate::TypeData::Class(Box::new(crate::Class {
         name: Some(biome_rowan::Text::new_static("RegExp")),
         type_parameters: Box::default(),

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -64,29 +64,6 @@ impl Default for RawGlobalTypes {
             }))
         };
 
-        // Builds a one-argument `Array.prototype` method named after `id`.
-        let array_method_definition =
-            |id: TypeId,
-             param_type_id: TypeId,
-             return_type_id: TypeId,
-             type_parameters: Box<[TypeReference]>| {
-                TypeData::from(Function {
-                    is_async: false,
-                    type_parameters,
-                    name: Some(Text::new_static(global_type_name(id).unwrap_or("unknown"))),
-                    parameters: [FunctionParameter::Pattern(PatternFunctionParameter {
-                        bindings: Default::default(),
-                        is_optional: false,
-                        is_rest: false,
-                        ty: ResolvedTypeId::new(TypeResolverLevel::Global, param_type_id).into(),
-                    })]
-                    .into(),
-                    return_type: ReturnType::Type(
-                        ResolvedTypeId::new(TypeResolverLevel::Global, return_type_id).into(),
-                    ),
-                })
-            };
-
         // Builds a zero-argument `Promise` method named after `id` that returns
         // an instance of `Promise`.
         let promise_method_definition = |id: TypeId| {
@@ -124,47 +101,6 @@ impl Default for RawGlobalTypes {
                 ty: TypeReference::from(GLOBAL_ARRAY_ID),
                 type_parameters: [GLOBAL_U_ID.into()].into(),
             })
-        });
-        builder.set_manual_type_data(ARRAY_ID_GLOBAL_TYPE_ID, || {
-            TypeData::Class(Box::new(Class {
-                name: Some(Text::new_static("Array")),
-                type_parameters: Box::new([TypeReference::from(GLOBAL_T_ID)]),
-                extends: None,
-                implements: Box::default(),
-                members: Box::new([
-                    member("filter", ARRAY_FILTER_ID),
-                    member("forEach", ARRAY_FOREACH_ID),
-                    member("map", ARRAY_MAP_ID),
-                    TypeMember {
-                        kind: TypeMemberKind::Named(Text::new_static("length")),
-                        ty: GLOBAL_NUMBER_ID.into(),
-                    },
-                ]),
-            }))
-        });
-        builder.set_manual_type_data(ARRAY_FILTER_ID_GLOBAL_TYPE_ID, || {
-            array_method_definition(
-                ARRAY_FILTER_ID,
-                CONDITIONAL_CALLBACK_ID,
-                INSTANCEOF_ARRAY_T_ID,
-                Default::default(),
-            )
-        });
-        builder.set_manual_type_data(ARRAY_FOREACH_ID_GLOBAL_TYPE_ID, || {
-            array_method_definition(
-                ARRAY_FOREACH_ID,
-                VOID_CALLBACK_ID,
-                VOID_ID,
-                Default::default(),
-            )
-        });
-        builder.set_manual_type_data(ARRAY_MAP_ID_GLOBAL_TYPE_ID, || {
-            array_method_definition(
-                ARRAY_MAP_ID,
-                MAP_CALLBACK_ID,
-                INSTANCEOF_ARRAY_U_ID,
-                [GLOBAL_U_ID.into()].into(),
-            )
         });
         builder.set_manual_type_data(GLOBAL_ID_GLOBAL_TYPE_ID, || TypeData::Global);
         builder.set_manual_type_data(INSTANCEOF_PROMISE_ID_GLOBAL_TYPE_ID, || {

--- a/crates/biome_js_type_info/src/globals_ids.rs
+++ b/crates/biome_js_type_info/src/globals_ids.rs
@@ -476,6 +476,10 @@ mod tests {
         assert_eq!(
             migrated,
             &[
+                ARRAY_ID_GLOBAL_TYPE_ID,
+                ARRAY_FILTER_ID_GLOBAL_TYPE_ID,
+                ARRAY_FOREACH_ID_GLOBAL_TYPE_ID,
+                ARRAY_MAP_ID_GLOBAL_TYPE_ID,
                 REGEXP_ID_GLOBAL_TYPE_ID,
                 REGEXP_EXEC_ID_GLOBAL_TYPE_ID,
                 SYMBOL_ID_GLOBAL_TYPE_ID,

--- a/xtask/codegen/src/generate_global_types/compare.rs
+++ b/xtask/codegen/src/generate_global_types/compare.rs
@@ -4,11 +4,18 @@ use anyhow::{Result, bail};
 
 use super::lower::{
     LoweredClass, LoweredConstructor, LoweredFunction, LoweredFunctionParameter,
-    LoweredGlobalTypes, LoweredInterface, LoweredMemberKind, LoweredTypeData, LoweredTypeReference,
+    LoweredFunctionParameterBinding, LoweredGlobalTypes, LoweredInterface, LoweredMemberKind,
+    LoweredTypeData, LoweredTypeReference,
 };
 
 /// Number of `Error` class members expected in generated output.
 const ERROR_MEMBER_COUNT: usize = 6;
+const ARRAY_MEMBER_COUNT: usize = 4;
+const ARRAY_TYPE_PARAMETERS: &[LoweredTypeReference] =
+    &[LoweredTypeReference::Predefined("GLOBAL_T_ID")];
+const ARRAY_MAP_TYPE_PARAMETERS: &[LoweredTypeReference] =
+    &[LoweredTypeReference::Predefined("GLOBAL_U_ID")];
+const NO_TYPE_PARAMETERS: &[LoweredTypeReference] = &[];
 const SYMBOL_MEMBER_COUNT: usize = 2;
 const MAP_TYPE_PARAMETERS: &[LoweredTypeReference] = &[
     LoweredTypeReference::Predefined("GLOBAL_T_ID"),
@@ -123,7 +130,122 @@ pub fn compare_lowered_globals(lowered: &LoweredGlobalTypes) -> Result<()> {
             return_type_id: "GLOBAL_INSTANCEOF_PROMISE_ID",
         },
     )?;
+    assert_array_shape(lowered)?;
 
+    Ok(())
+}
+
+/// Rejects output that differs from the predefined `Array` projection used by the resolver.
+fn assert_array_shape(lowered: &LoweredGlobalTypes) -> Result<()> {
+    let Some(array) = lowered.global("Array") else {
+        bail!("generated globals are missing the Array global");
+    };
+    if array.id_constant() != "ARRAY_ID_GLOBAL_TYPE_ID" {
+        bail!(
+            "generated Array global targets {}, expected ARRAY_ID_GLOBAL_TYPE_ID",
+            array.id_constant()
+        );
+    }
+    let LoweredTypeData::Class(class) = array.data() else {
+        bail!("generated Array global is not a class");
+    };
+    if class.name() != "Array" {
+        bail!(
+            "generated Array class has name {}, expected Array",
+            class.name()
+        );
+    }
+    if class.type_parameters() != ARRAY_TYPE_PARAMETERS {
+        bail!("generated Array global has unexpected type parameters");
+    }
+    if class.members().len() != ARRAY_MEMBER_COUNT {
+        bail!(
+            "generated Array global has {} members, expected {ARRAY_MEMBER_COUNT}",
+            class.members().len()
+        );
+    }
+
+    assert_array_member(class, "filter", "GLOBAL_ARRAY_FILTER_ID")?;
+    assert_array_member(class, "forEach", "GLOBAL_ARRAY_FOREACH_ID")?;
+    assert_array_member(class, "map", "GLOBAL_ARRAY_MAP_ID")?;
+    assert_array_member(class, "length", "GLOBAL_NUMBER_ID")?;
+
+    assert_array_method(
+        lowered,
+        "Array.prototype.filter",
+        "ARRAY_FILTER_ID_GLOBAL_TYPE_ID",
+        NO_TYPE_PARAMETERS,
+        "GLOBAL_CONDITIONAL_CALLBACK_ID",
+        "GLOBAL_INSTANCEOF_ARRAY_T_ID",
+    )?;
+    assert_array_method(
+        lowered,
+        "Array.prototype.forEach",
+        "ARRAY_FOREACH_ID_GLOBAL_TYPE_ID",
+        NO_TYPE_PARAMETERS,
+        "GLOBAL_VOID_CALLBACK_ID",
+        "GLOBAL_VOID_ID",
+    )?;
+    assert_array_method(
+        lowered,
+        "Array.prototype.map",
+        "ARRAY_MAP_ID_GLOBAL_TYPE_ID",
+        ARRAY_MAP_TYPE_PARAMETERS,
+        "GLOBAL_MAP_CALLBACK_ID",
+        "GLOBAL_INSTANCEOF_ARRAY_U_ID",
+    )?;
+
+    Ok(())
+}
+
+/// Requires a named, non-optional Array member with the expected predefined type.
+fn assert_array_member(class: &LoweredClass, name: &str, type_id: &'static str) -> Result<()> {
+    let Some(member) = class.member(name) else {
+        bail!("generated Array global is missing {name}");
+    };
+    if member.kind() != &(LoweredMemberKind::Named { optional: false }) {
+        bail!("generated Array.{name} has unexpected kind");
+    }
+    if member.type_reference() != &LoweredTypeReference::Predefined(type_id) {
+        bail!("generated Array.{name} has unexpected type");
+    }
+    Ok(())
+}
+
+/// Checks an Array helper's identity, type parameters, callback slot, and return type.
+fn assert_array_method(
+    lowered: &LoweredGlobalTypes,
+    name: &str,
+    id_constant: &str,
+    type_parameters: &[LoweredTypeReference],
+    parameter_type_id: &'static str,
+    return_type_id: &'static str,
+) -> Result<()> {
+    let function = generated_function(lowered, name, id_constant)?;
+    if function.is_async() {
+        bail!("generated {name} helper must not be async");
+    }
+    if function.type_parameters() != type_parameters {
+        bail!("generated {name} helper has unexpected type parameters");
+    }
+    if function.name() != Some(name) {
+        bail!("generated {name} helper has unexpected function name");
+    }
+    let [parameter] = function.parameters() else {
+        bail!("generated {name} helper must have one parameter");
+    };
+    if parameter.binding() != &LoweredFunctionParameterBinding::Pattern {
+        bail!("generated {name} helper must have a pattern parameter");
+    }
+    if parameter.type_reference() != &LoweredTypeReference::Predefined(parameter_type_id) {
+        bail!("generated {name} helper has unexpected parameter type");
+    }
+    if parameter.is_optional() || parameter.is_rest() {
+        bail!("generated {name} helper parameter must be required and non-rest");
+    }
+    if function.return_type() != &LoweredTypeReference::Predefined(return_type_id) {
+        bail!("generated {name} helper has unexpected return type");
+    }
     Ok(())
 }
 
@@ -167,6 +289,9 @@ fn assert_regexp_shape(lowered: &LoweredGlobalTypes) -> Result<()> {
     let exec = generated_function(lowered, "RegExp.exec", "REGEXP_EXEC_ID_GLOBAL_TYPE_ID")?;
     if exec.is_async() {
         bail!("generated RegExp.exec helper must not be async");
+    }
+    if !exec.type_parameters().is_empty() {
+        bail!("generated RegExp.exec helper must not have type parameters");
     }
     if exec.name() != Some("RegExp.exec") {
         bail!("generated RegExp.exec helper has unexpected function name");
@@ -407,6 +532,12 @@ fn assert_disposable_shape(lowered: &LoweredGlobalTypes, shape: DisposableShape)
             shape.helper_name
         );
     }
+    if !helper.type_parameters().is_empty() {
+        bail!(
+            "generated {} helper should not have type parameters",
+            shape.helper_name
+        );
+    }
     if helper.name().is_some() {
         bail!("generated {} helper should be anonymous", shape.helper_name);
     }
@@ -528,6 +659,9 @@ fn assert_error_call_shape(call: &LoweredFunction) -> Result<()> {
     if call.is_async() {
         bail!("generated Error call helper should not be async");
     }
+    if !call.type_parameters().is_empty() {
+        bail!("generated Error call helper should not have type parameters");
+    }
     if call.name() != Some("Error") {
         bail!("generated Error call helper has unexpected function name");
     }
@@ -549,8 +683,11 @@ fn assert_single_optional_message_parameter(
             parameters.len()
         );
     };
-    if parameter.name() != "message" {
-        bail!("{owner} has unexpected parameter name {}", parameter.name());
+    let LoweredFunctionParameterBinding::Named(name) = parameter.binding() else {
+        bail!("{owner} message parameter must be named");
+    };
+    if name.text() != "message" {
+        bail!("{owner} has unexpected parameter name {}", name.text());
     }
     if parameter.type_reference() != &LoweredTypeReference::Predefined("GLOBAL_STRING_ID") {
         bail!("{owner} message parameter has unexpected type");

--- a/xtask/codegen/src/generate_global_types/emit.rs
+++ b/xtask/codegen/src/generate_global_types/emit.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 use anyhow::{Result, bail};
 
 use super::lower::{
-    LoweredClass, LoweredConstructor, LoweredFunction, LoweredFunctionParameter, LoweredGlobal,
-    LoweredGlobalTypes, LoweredInterface, LoweredMemberKind, LoweredTypeData, LoweredTypeMember,
-    LoweredTypeReference,
+    LoweredClass, LoweredConstructor, LoweredFunction, LoweredFunctionParameter,
+    LoweredFunctionParameterBinding, LoweredGlobal, LoweredGlobalTypes, LoweredInterface,
+    LoweredMemberKind, LoweredTypeData, LoweredTypeMember, LoweredTypeReference,
 };
 
 /// Relative path of the generated global types module from the workspace root.
@@ -16,6 +16,10 @@ const OUTPUT_RELATIVE_PATH: &str = "crates/biome_js_type_info/src/generated/glob
 /// The index is the row position in `PREDEFINED_ID_ROWS`. This keeps
 /// `MIGRATED_PREDEFINED_IDS` sorted for the runtime `binary_search`.
 const GLOBAL_ID_EMIT_ORDER: &[&str] = &[
+    "ARRAY_ID_GLOBAL_TYPE_ID",
+    "ARRAY_FILTER_ID_GLOBAL_TYPE_ID",
+    "ARRAY_FOREACH_ID_GLOBAL_TYPE_ID",
+    "ARRAY_MAP_ID_GLOBAL_TYPE_ID",
     "REGEXP_ID_GLOBAL_TYPE_ID",
     "REGEXP_EXEC_ID_GLOBAL_TYPE_ID",
     "SYMBOL_ID_GLOBAL_TYPE_ID",
@@ -183,12 +187,13 @@ fn render_function(function: &LoweredFunction) -> String {
     format!(
         "crate::TypeData::Function(Box::new(crate::Function {{
             is_async: {is_async},
-            type_parameters: Box::default(),
+            type_parameters: {type_parameters},
             name: {name},
             parameters: Box::new([{parameters}]),
             return_type: crate::ReturnType::Type({return_type}),
         }}))",
         is_async = function.is_async(),
+        type_parameters = render_type_references(function.type_parameters()),
         parameters = render_function_parameters(function.parameters()),
         return_type = render_type_reference(function.return_type()),
     )
@@ -269,20 +274,37 @@ fn render_function_parameters(parameters: &[LoweredFunctionParameter]) -> String
     rendered
 }
 
-/// Builds one named parameter expression.
+/// Preserves named bindings and uses pattern parameters for synthetic callback slots.
 fn render_function_parameter(parameter: &LoweredFunctionParameter) -> String {
-    format!(
-        "crate::FunctionParameter::Named(crate::NamedFunctionParameter {{
-            name: biome_rowan::Text::new_static({name}),
-            ty: {type_reference},
-            is_optional: {is_optional},
-            is_rest: {is_rest},
-        }})",
-        name = rust_string_literal(parameter.name()),
-        type_reference = render_type_reference(parameter.type_reference()),
-        is_optional = parameter.is_optional(),
-        is_rest = parameter.is_rest(),
-    )
+    match parameter.binding() {
+        LoweredFunctionParameterBinding::Named(name) => {
+            format!(
+                "crate::FunctionParameter::Named(crate::NamedFunctionParameter {{
+                    name: biome_rowan::Text::new_static({name}),
+                    ty: {type_reference},
+                    is_optional: {is_optional},
+                    is_rest: {is_rest},
+                }})",
+                name = rust_string_literal(name.text()),
+                type_reference = render_type_reference(parameter.type_reference()),
+                is_optional = parameter.is_optional(),
+                is_rest = parameter.is_rest(),
+            )
+        }
+        LoweredFunctionParameterBinding::Pattern => {
+            format!(
+                "crate::FunctionParameter::Pattern(crate::PatternFunctionParameter {{
+                    bindings: Box::default(),
+                    ty: {type_reference},
+                    is_optional: {is_optional},
+                    is_rest: {is_rest},
+                }})",
+                type_reference = render_type_reference(parameter.type_reference()),
+                is_optional = parameter.is_optional(),
+                is_rest = parameter.is_rest(),
+            )
+        }
+    }
 }
 
 /// Builds a generated `TypeReference` expression.

--- a/xtask/codegen/src/generate_global_types/lower.rs
+++ b/xtask/codegen/src/generate_global_types/lower.rs
@@ -5,12 +5,13 @@ use biome_js_parser::{JsParserOptions, parse};
 use biome_js_syntax::{
     AnyJsBindingPattern, AnyJsExpression, AnyJsFormalParameter, AnyJsName, AnyJsObjectMemberName,
     AnyJsParameter, AnyJsRoot, AnyTsReturnType, AnyTsType, AnyTsTypeMember,
-    AnyTsVariableAnnotation, JsParameters, JsVariableDeclarator, T, TsCallSignatureTypeMember,
-    TsConstructSignatureTypeMember, TsDeclarationModule, TsInterfaceDeclaration,
-    TsMethodSignatureTypeMember, TsPropertySignatureTypeMember,
+    AnyTsVariableAnnotation, JsFormalParameter, JsParameters, JsVariableDeclarator, T,
+    TsCallSignatureTypeMember, TsConstructSignatureTypeMember, TsDeclarationModule, TsFunctionType,
+    TsInterfaceDeclaration, TsMethodSignatureTypeMember, TsPropertySignatureTypeMember,
+    TsTypeParameters,
 };
 use biome_languages::JsFileSource;
-use biome_rowan::{AstNode, Text};
+use biome_rowan::{AstNode, AstNodeList, SyntaxResult, Text};
 
 use crate::generate_global_types::{
     collect::{DeclarationKind, DeclarationRecord},
@@ -152,6 +153,7 @@ impl LoweredConstructor {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LoweredFunction {
     is_async: bool,
+    type_parameters: Box<[LoweredTypeReference]>,
     name: Option<Text>,
     parameters: Box<[LoweredFunctionParameter]>,
     return_type: LoweredTypeReference,
@@ -161,6 +163,11 @@ impl LoweredFunction {
     /// Returns whether this function is `async`.
     pub fn is_async(&self) -> bool {
         self.is_async
+    }
+
+    /// Function type parameters in declaration order.
+    pub fn type_parameters(&self) -> &[LoweredTypeReference] {
+        &self.type_parameters
     }
 
     /// Function name, if present.
@@ -179,19 +186,19 @@ impl LoweredFunction {
     }
 }
 
-/// Lowered named function parameter.
+/// Parameter data shared by generated functions and constructors.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LoweredFunctionParameter {
-    name: Text,
+    binding: LoweredFunctionParameterBinding,
     type_reference: LoweredTypeReference,
     is_optional: bool,
     is_rest: bool,
 }
 
 impl LoweredFunctionParameter {
-    /// Parameter binding name.
-    pub fn name(&self) -> &str {
-        self.name.text()
+    /// Returns the parameter form used by the emitter.
+    pub fn binding(&self) -> &LoweredFunctionParameterBinding {
+        &self.binding
     }
 
     /// Parameter type.
@@ -208,6 +215,13 @@ impl LoweredFunctionParameter {
     pub fn is_rest(&self) -> bool {
         self.is_rest
     }
+}
+
+/// Selects the emitted `FunctionParameter` variant.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LoweredFunctionParameterBinding {
+    Named(Text),
+    Pattern,
 }
 
 /// Lowered class/interface member.
@@ -259,6 +273,7 @@ pub fn lower_global_types(
     let mut source_cache = ParsedSourceCache::new(source_files);
     let mut globals = Vec::new();
 
+    lower_array_globals(manifest, &mut source_cache, &mut globals)?;
     lower_error_globals(manifest, &mut source_cache, &mut globals)?;
     lower_regexp_globals(manifest, &mut source_cache, &mut globals)?;
     lower_symbol_globals(manifest, &mut source_cache, &mut globals)?;
@@ -485,6 +500,574 @@ const WEAK_MAP_GLOBAL: MemberlessClassSpec = MemberlessClassSpec {
 };
 
 const REGEXP_EXEC_RETURN_TYPE_VARIANT_COUNT: usize = 2;
+
+/// Array members retained in the resolver's reduced projection.
+#[derive(Clone, Copy)]
+enum SelectedArrayMember {
+    Filter,
+    ForEach,
+    Length,
+    Map,
+}
+
+impl SelectedArrayMember {
+    /// Returns the TypeScript spelling used in diagnostics.
+    fn name(self) -> &'static str {
+        match self {
+            Self::Filter => "filter",
+            Self::ForEach => "forEach",
+            Self::Length => "length",
+            Self::Map => "map",
+        }
+    }
+}
+
+/// Return shape required from a selected Array callback declaration.
+#[derive(Clone, Copy)]
+enum ArrayCallbackReturn<'a> {
+    Reference(&'a str),
+    Unknown,
+    Void,
+}
+
+/// Validates selected members across merged declarations and builds the resolver projection.
+fn lower_array_globals(
+    manifest: &GlobalManifest,
+    source_cache: &mut ParsedSourceCache,
+    globals: &mut Vec<LoweredGlobal>,
+) -> Result<()> {
+    let Some(array_group) = manifest.global_group("Array") else {
+        return Ok(());
+    };
+    if !array_group.has_role(GlobalDeclarationRole::Type) {
+        bail!("Array global must have a type-side declaration");
+    }
+
+    let mut saw_interface = false;
+    let mut saw_filter = false;
+    let mut saw_for_each = false;
+    let mut saw_length = false;
+    let mut saw_map = false;
+
+    for record in array_group.declarations() {
+        match &record.kind {
+            DeclarationKind::Interface => {
+                saw_interface = true;
+            }
+            DeclarationKind::TypeAlias => {
+                bail!("type aliases are not supported in the Array global")
+            }
+            DeclarationKind::VariableDeclarator { .. } => continue,
+            DeclarationKind::DeclareFunction | DeclarationKind::ImportEquals => {
+                bail!("unsupported value-side Array declaration")
+            }
+        }
+
+        let declaration = source_cache
+            .find_interface_declaration(record)?
+            .with_context(|| {
+                format!(
+                    "failed to find interface declaration {} at {:?}",
+                    record.declared_name.text(),
+                    record.text_range
+                )
+            })?;
+        let array_type_parameter = validate_array_interface_type_parameter(&declaration)?;
+
+        for member in declaration.members() {
+            match member {
+                AnyTsTypeMember::TsMethodSignatureTypeMember(method) => {
+                    let Some(selected) = selected_array_member(method.name()?)? else {
+                        continue;
+                    };
+                    match selected {
+                        SelectedArrayMember::Filter => {
+                            if method.type_parameters().is_some() {
+                                continue;
+                            }
+                            if saw_filter {
+                                bail!("Array has multiple non-generic filter overloads");
+                            }
+                            validate_array_filter(&method, array_type_parameter.text())?;
+                            saw_filter = true;
+                        }
+                        SelectedArrayMember::ForEach => {
+                            if saw_for_each {
+                                bail!("Array has multiple forEach methods");
+                            }
+                            validate_array_for_each(&method, array_type_parameter.text())?;
+                            saw_for_each = true;
+                        }
+                        SelectedArrayMember::Length => {
+                            bail!("Array.length must be a property")
+                        }
+                        SelectedArrayMember::Map => {
+                            if saw_map {
+                                bail!("Array has multiple map methods");
+                            }
+                            validate_array_map(&method, array_type_parameter.text())?;
+                            saw_map = true;
+                        }
+                    }
+                }
+                AnyTsTypeMember::TsPropertySignatureTypeMember(property) => {
+                    let Some(selected) = selected_array_member(property.name()?)? else {
+                        continue;
+                    };
+                    if !matches!(selected, SelectedArrayMember::Length) {
+                        bail!("Array.{} must be a method", selected.name());
+                    }
+                    if saw_length {
+                        bail!("Array has multiple length properties");
+                    }
+                    validate_array_length(&property)?;
+                    saw_length = true;
+                }
+                AnyTsTypeMember::TsGetterSignatureTypeMember(getter) => {
+                    reject_selected_array_accessor(getter.name()?)?;
+                }
+                AnyTsTypeMember::TsSetterSignatureTypeMember(setter) => {
+                    reject_selected_array_accessor(setter.name()?)?;
+                }
+                AnyTsTypeMember::JsBogusMember(_)
+                | AnyTsTypeMember::TsCallSignatureTypeMember(_)
+                | AnyTsTypeMember::TsConstructSignatureTypeMember(_)
+                | AnyTsTypeMember::TsIndexSignatureTypeMember(_) => {}
+            }
+        }
+    }
+
+    if !saw_interface {
+        bail!("Array global must include an interface declaration");
+    }
+    if !saw_filter {
+        bail!("Array is missing a non-generic filter overload");
+    }
+    if !saw_for_each {
+        bail!("Array is missing forEach");
+    }
+    if !saw_length {
+        bail!("Array is missing length");
+    }
+    if !saw_map {
+        bail!("Array is missing map");
+    }
+
+    globals.push(LoweredGlobal {
+        name: Text::from("Array"),
+        id_constant: "ARRAY_ID_GLOBAL_TYPE_ID",
+        data: LoweredTypeData::Class(LoweredClass {
+            name: Text::from("Array"),
+            type_parameters: Box::new([LoweredTypeReference::Predefined("GLOBAL_T_ID")]),
+            members: Box::new([
+                LoweredTypeMember {
+                    name: Text::from("filter"),
+                    kind: LoweredMemberKind::Named { optional: false },
+                    type_reference: LoweredTypeReference::Predefined("GLOBAL_ARRAY_FILTER_ID"),
+                },
+                LoweredTypeMember {
+                    name: Text::from("forEach"),
+                    kind: LoweredMemberKind::Named { optional: false },
+                    type_reference: LoweredTypeReference::Predefined("GLOBAL_ARRAY_FOREACH_ID"),
+                },
+                LoweredTypeMember {
+                    name: Text::from("map"),
+                    kind: LoweredMemberKind::Named { optional: false },
+                    type_reference: LoweredTypeReference::Predefined("GLOBAL_ARRAY_MAP_ID"),
+                },
+                LoweredTypeMember {
+                    name: Text::from("length"),
+                    kind: LoweredMemberKind::Named { optional: false },
+                    type_reference: LoweredTypeReference::Predefined("GLOBAL_NUMBER_ID"),
+                },
+            ]),
+        }),
+    });
+    globals.push(array_method_global(
+        "Array.prototype.filter",
+        "ARRAY_FILTER_ID_GLOBAL_TYPE_ID",
+        Box::default(),
+        "GLOBAL_CONDITIONAL_CALLBACK_ID",
+        "GLOBAL_INSTANCEOF_ARRAY_T_ID",
+    ));
+    globals.push(array_method_global(
+        "Array.prototype.forEach",
+        "ARRAY_FOREACH_ID_GLOBAL_TYPE_ID",
+        Box::default(),
+        "GLOBAL_VOID_CALLBACK_ID",
+        "GLOBAL_VOID_ID",
+    ));
+    globals.push(array_method_global(
+        "Array.prototype.map",
+        "ARRAY_MAP_ID_GLOBAL_TYPE_ID",
+        Box::new([LoweredTypeReference::Predefined("GLOBAL_U_ID")]),
+        "GLOBAL_MAP_CALLBACK_ID",
+        "GLOBAL_INSTANCEOF_ARRAY_U_ID",
+    ));
+
+    Ok(())
+}
+
+/// Builds the resolver's single-callback shape, omitting the validated `thisArg`.
+fn array_method_global(
+    name: &'static str,
+    id_constant: &'static str,
+    type_parameters: Box<[LoweredTypeReference]>,
+    parameter_type_id: &'static str,
+    return_type_id: &'static str,
+) -> LoweredGlobal {
+    LoweredGlobal {
+        name: Text::from(name),
+        id_constant,
+        data: LoweredTypeData::Function(LoweredFunction {
+            is_async: false,
+            type_parameters,
+            name: Some(Text::from(name)),
+            parameters: Box::new([LoweredFunctionParameter {
+                binding: LoweredFunctionParameterBinding::Pattern,
+                type_reference: LoweredTypeReference::Predefined(parameter_type_id),
+                is_optional: false,
+                is_rest: false,
+            }]),
+            return_type: LoweredTypeReference::Predefined(return_type_id),
+        }),
+    }
+}
+
+/// Requires unextended `Array<T>` with no modifiers, constraint, or default on `T`.
+fn validate_array_interface_type_parameter(declaration: &TsInterfaceDeclaration) -> Result<Text> {
+    if declaration.extends_clause().is_some() {
+        bail!("Array interface extends clauses are not supported");
+    }
+    single_type_parameter_name(declaration.type_parameters(), "Array interface")
+}
+
+/// Recognizes only the Array members represented by the resolver projection.
+fn selected_array_member(name: AnyJsObjectMemberName) -> Result<Option<SelectedArrayMember>> {
+    let AnyJsObjectMemberName::JsLiteralMemberName(name) = name else {
+        return Ok(None);
+    };
+    Ok(match name.name()?.text() {
+        "filter" => Some(SelectedArrayMember::Filter),
+        "forEach" => Some(SelectedArrayMember::ForEach),
+        "length" => Some(SelectedArrayMember::Length),
+        "map" => Some(SelectedArrayMember::Map),
+        _ => None,
+    })
+}
+
+/// Rejects selected members expressed as unsupported getter or setter declarations.
+fn reject_selected_array_accessor(name: AnyJsObjectMemberName) -> Result<()> {
+    if let Some(member) = selected_array_member(name)? {
+        bail!(
+            "Array.{} has an unsupported accessor declaration",
+            member.name()
+        );
+    }
+    Ok(())
+}
+
+/// Requires `length` to be a mutable, required `number` property.
+fn validate_array_length(property: &TsPropertySignatureTypeMember) -> Result<()> {
+    if property.readonly_token().is_some() {
+        bail!("Array.length must not be readonly");
+    }
+    if property.optional_token().is_some() {
+        bail!("Array.length must not be optional");
+    }
+    let type_node = property
+        .type_annotation()
+        .context("Array.length is missing a type annotation")?
+        .ty()
+        .context("Array.length has a malformed type annotation")?;
+    if !matches!(type_node, AnyTsType::TsNumberType(_)) {
+        bail!("Array.length must be number");
+    }
+    Ok(())
+}
+
+/// Validates the selected non-generic `filter` overload that preserves the element type.
+fn validate_array_filter(
+    method: &TsMethodSignatureTypeMember,
+    array_type_parameter: &str,
+) -> Result<()> {
+    validate_array_method_parameters(
+        method,
+        "Array.filter",
+        array_type_parameter,
+        ArrayCallbackReturn::Unknown,
+    )?;
+    validate_array_method_array_return(method, "Array.filter", array_type_parameter)
+}
+
+/// Requires a non-generic `forEach` method and callback that both return `void`.
+fn validate_array_for_each(
+    method: &TsMethodSignatureTypeMember,
+    array_type_parameter: &str,
+) -> Result<()> {
+    if method.type_parameters().is_some() {
+        bail!("Array.forEach must not be generic");
+    }
+    validate_array_method_parameters(
+        method,
+        "Array.forEach",
+        array_type_parameter,
+        ArrayCallbackReturn::Void,
+    )?;
+    validate_array_method_void_return(method, "Array.forEach")
+}
+
+/// Requires `map` to use one type parameter for both callback and array results.
+fn validate_array_map(
+    method: &TsMethodSignatureTypeMember,
+    array_type_parameter: &str,
+) -> Result<()> {
+    let map_type_parameter = single_type_parameter_name(method.type_parameters(), "Array.map")?;
+    validate_array_method_parameters(
+        method,
+        "Array.map",
+        array_type_parameter,
+        ArrayCallbackReturn::Reference(map_type_parameter.text()),
+    )?;
+    validate_array_method_array_return(method, "Array.map", map_type_parameter.text())
+}
+
+/// Requires a callback followed by an optional `any`-typed `thisArg`.
+fn validate_array_method_parameters(
+    method: &TsMethodSignatureTypeMember,
+    owner: &str,
+    array_type_parameter: &str,
+    callback_return: ArrayCallbackReturn,
+) -> Result<()> {
+    if method.optional_token().is_some() {
+        bail!("{owner} must not be optional");
+    }
+
+    let mut parameters = method.parameters()?.items().into_iter();
+    let expected_parameters = "a callback and an optional thisArg parameter";
+    let callback_parameter =
+        required_formal_parameter(parameters.next(), owner, expected_parameters)?;
+    let this_argument_parameter =
+        required_formal_parameter(parameters.next(), owner, expected_parameters)?;
+    if parameters.next().is_some() {
+        bail!("{owner} must have a callback and an optional thisArg parameter");
+    }
+
+    if callback_parameter.question_mark_token().is_some() {
+        bail!("{owner} callback must not be optional");
+    }
+    let callback_type = callback_parameter
+        .type_annotation()
+        .with_context(|| format!("{owner} callback is missing a type annotation"))?
+        .ty()
+        .with_context(|| format!("{owner} callback has a malformed type annotation"))?;
+    let AnyTsType::TsFunctionType(callback) = callback_type else {
+        bail!("{owner} callback must be a function type");
+    };
+    validate_array_callback(&callback, owner, array_type_parameter, callback_return)?;
+
+    if this_argument_parameter.question_mark_token().is_none() {
+        bail!("{owner} thisArg must be optional");
+    }
+    let this_argument_type = this_argument_parameter
+        .type_annotation()
+        .with_context(|| format!("{owner} thisArg is missing a type annotation"))?
+        .ty()
+        .with_context(|| format!("{owner} thisArg has a malformed type annotation"))?;
+    if !matches!(this_argument_type, AnyTsType::TsAnyType(_)) {
+        bail!("{owner} thisArg must be any");
+    }
+
+    Ok(())
+}
+
+/// Extracts a plain formal parameter without decorators or an initializer.
+fn required_formal_parameter(
+    parameter: Option<SyntaxResult<AnyJsParameter>>,
+    owner: &str,
+    expected_parameters: &str,
+) -> Result<JsFormalParameter> {
+    let Some(parameter) = parameter else {
+        bail!("{owner} must have {expected_parameters}");
+    };
+    let AnyJsParameter::AnyJsFormalParameter(AnyJsFormalParameter::JsFormalParameter(parameter)) =
+        parameter.with_context(|| format!("{owner} has a malformed parameter"))?
+    else {
+        bail!("{owner} has an unsupported parameter");
+    };
+    if !parameter.decorators().is_empty() || parameter.initializer().is_some() {
+        bail!("{owner} has an unsupported parameter");
+    }
+    Ok(parameter)
+}
+
+/// Requires a non-generic callback with the selected parameters and return shape.
+fn validate_array_callback(
+    callback: &TsFunctionType,
+    owner: &str,
+    array_type_parameter: &str,
+    callback_return: ArrayCallbackReturn,
+) -> Result<()> {
+    if callback.type_parameters().is_some() {
+        bail!("{owner} callback must not be generic");
+    }
+
+    let mut parameters = callback.parameters()?.items().into_iter();
+    let expected_parameters = "a callback with three required parameters";
+    let value_parameter = required_formal_parameter(parameters.next(), owner, expected_parameters)?;
+    let index_parameter = required_formal_parameter(parameters.next(), owner, expected_parameters)?;
+    let array_parameter = required_formal_parameter(parameters.next(), owner, expected_parameters)?;
+    if parameters.next().is_some() {
+        bail!("{owner} must have a callback with three required parameters");
+    }
+    let value_type = required_array_callback_parameter_type(&value_parameter, owner)?;
+    validate_reference_type(&value_type, array_type_parameter, owner)?;
+    let index_type = required_array_callback_parameter_type(&index_parameter, owner)?;
+    if !matches!(index_type, AnyTsType::TsNumberType(_)) {
+        bail!("{owner} callback index parameter must be number");
+    }
+    let array_type = required_array_callback_parameter_type(&array_parameter, owner)?;
+    validate_array_type(&array_type, array_type_parameter, owner)?;
+
+    let return_type = callback.return_type()?;
+    match callback_return {
+        ArrayCallbackReturn::Reference(type_parameter) => {
+            let return_type = regular_return_type(return_type, owner)?;
+            validate_reference_type(&return_type, type_parameter, owner)?;
+        }
+        ArrayCallbackReturn::Unknown => {
+            let return_type = regular_return_type(return_type, owner)?;
+            if !matches!(return_type, AnyTsType::TsUnknownType(_)) {
+                bail!("{owner} callback must return unknown");
+            }
+        }
+        ArrayCallbackReturn::Void => {
+            let return_type = regular_return_type(return_type, owner)?;
+            if !matches!(return_type, AnyTsType::TsVoidType(_)) {
+                bail!("{owner} callback must return void");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns the type annotation after rejecting an optional callback parameter.
+fn required_array_callback_parameter_type(
+    parameter: &JsFormalParameter,
+    owner: &str,
+) -> Result<AnyTsType> {
+    if parameter.question_mark_token().is_some() {
+        bail!("{owner} callback must have three required parameters");
+    }
+    parameter
+        .type_annotation()
+        .with_context(|| format!("{owner} callback parameter is missing a type annotation"))?
+        .ty()
+        .with_context(|| format!("{owner} callback parameter has a malformed type annotation"))
+}
+
+/// Requires a regular array return whose element matches the selected type parameter.
+fn validate_array_method_array_return(
+    method: &TsMethodSignatureTypeMember,
+    owner: &str,
+    element_type_parameter: &str,
+) -> Result<()> {
+    let return_type = method
+        .return_type_annotation()
+        .with_context(|| format!("{owner} is missing a return type"))?
+        .ty()
+        .with_context(|| format!("{owner} has a malformed return type"))?;
+    let return_type = regular_return_type(return_type, owner)?;
+    validate_array_type(&return_type, element_type_parameter, owner)
+}
+
+/// Requires an ordinary `void` return rather than a predicate or assertion.
+fn validate_array_method_void_return(
+    method: &TsMethodSignatureTypeMember,
+    owner: &str,
+) -> Result<()> {
+    let return_type = method
+        .return_type_annotation()
+        .with_context(|| format!("{owner} is missing a return type"))?
+        .ty()
+        .with_context(|| format!("{owner} has a malformed return type"))?;
+    let return_type = regular_return_type(return_type, owner)?;
+    if !matches!(return_type, AnyTsType::TsVoidType(_)) {
+        bail!("{owner} must return void");
+    }
+    Ok(())
+}
+
+/// Requires array syntax whose element references the expected type parameter.
+fn validate_array_type(
+    type_node: &AnyTsType,
+    element_type_parameter: &str,
+    owner: &str,
+) -> Result<()> {
+    let AnyTsType::TsArrayType(array_type) = type_node else {
+        bail!("{owner} must use an array type");
+    };
+    validate_reference_type(&array_type.element_type()?, element_type_parameter, owner)
+}
+
+/// Requires an unqualified type reference without type arguments.
+fn validate_reference_type(type_node: &AnyTsType, expected_name: &str, owner: &str) -> Result<()> {
+    let AnyTsType::TsReferenceType(reference) = type_node else {
+        bail!("{owner} must reference {expected_name}");
+    };
+    if reference.type_arguments().is_some() {
+        bail!("{owner} must reference {expected_name} without type arguments");
+    }
+    let biome_js_syntax::AnyTsName::JsReferenceIdentifier(identifier) = reference
+        .name()
+        .with_context(|| format!("{owner} has a missing type reference name"))?
+    else {
+        bail!("{owner} must reference {expected_name}");
+    };
+    if identifier.value_token()?.token_text_trimmed().text() != expected_name {
+        bail!("{owner} must reference {expected_name}");
+    }
+    Ok(())
+}
+
+/// Rejects predicate and assertion return types.
+fn regular_return_type(return_type: AnyTsReturnType, owner: &str) -> Result<AnyTsType> {
+    match return_type {
+        AnyTsReturnType::AnyTsType(type_node) => Ok(type_node),
+        AnyTsReturnType::TsAssertsReturnType(_) | AnyTsReturnType::TsPredicateReturnType(_) => {
+            bail!("{owner} must use a regular return type")
+        }
+    }
+}
+
+/// Extracts one unmodified type parameter without a constraint or default.
+fn single_type_parameter_name(
+    type_parameters: Option<TsTypeParameters>,
+    owner: &str,
+) -> Result<Text> {
+    let type_parameters =
+        type_parameters.with_context(|| format!("{owner} must have one type parameter"))?;
+    let mut type_parameters = type_parameters.items().into_iter();
+    let Some(type_parameter) = type_parameters.next() else {
+        bail!("{owner} must have one type parameter");
+    };
+    let type_parameter =
+        type_parameter.with_context(|| format!("{owner} has a malformed type parameter"))?;
+    if type_parameters.next().is_some() {
+        bail!("{owner} must have one type parameter");
+    }
+    if !type_parameter.modifiers().is_empty()
+        || type_parameter.constraint().is_some()
+        || type_parameter.default().is_some()
+    {
+        bail!("{owner} has an unsupported type parameter");
+    }
+
+    Ok(Text::from(
+        type_parameter.name()?.ident_token()?.token_text_trimmed(),
+    ))
+}
 
 struct ParsedSource<'a> {
     repo_relative: &'a str,
@@ -741,6 +1324,7 @@ fn lower_regexp_globals(
         id_constant: "REGEXP_EXEC_ID_GLOBAL_TYPE_ID",
         data: LoweredTypeData::Function(LoweredFunction {
             is_async: false,
+            type_parameters: Box::default(),
             name: Some(Text::from("RegExp.exec")),
             parameters: Box::default(),
             return_type: LoweredTypeReference::Predefined("GLOBAL_INSTANCEOF_REGEXP_ID"),
@@ -1216,6 +1800,7 @@ fn lower_disposable_global(
         id_constant: spec.helper_id_constant,
         data: LoweredTypeData::Function(LoweredFunction {
             is_async: spec.return_kind.helper_is_async(),
+            type_parameters: Box::default(),
             name: None,
             parameters: Box::default(),
             return_type: LoweredTypeReference::Predefined(spec.return_kind.return_type_id()),
@@ -1688,6 +2273,7 @@ fn lower_call_signature(member: &TsCallSignatureTypeMember) -> Result<LoweredFun
 
     Ok(LoweredFunction {
         is_async: false,
+        type_parameters: Box::default(),
         name: Some(Text::from("Error")),
         parameters: lower_parameters(member.parameters()?)?,
         return_type: instance_return_reference(return_type),
@@ -1712,7 +2298,7 @@ fn lower_parameters(parameters: JsParameters) -> Result<Box<[LoweredFunctionPara
                     .context("ErrorConstructor parameter has malformed type annotation")
                     .and_then(|type_node| lower_type_reference(&type_node))?;
                 lowered.push(LoweredFunctionParameter {
-                    name,
+                    binding: LoweredFunctionParameterBinding::Named(name),
                     type_reference,
                     is_optional,
                     is_rest: false,
@@ -1727,7 +2313,7 @@ fn lower_parameters(parameters: JsParameters) -> Result<Box<[LoweredFunctionPara
                     .context("ErrorConstructor rest parameter has malformed type annotation")
                     .and_then(|type_node| lower_type_reference(&type_node))?;
                 lowered.push(LoweredFunctionParameter {
-                    name,
+                    binding: LoweredFunctionParameterBinding::Named(name),
                     type_reference,
                     is_optional: false,
                     is_rest: true,

--- a/xtask/codegen/src/generate_global_types/lower.rs
+++ b/xtask/codegen/src/generate_global_types/lower.rs
@@ -929,20 +929,17 @@ fn validate_array_callback(
     let array_type = required_array_callback_parameter_type(&array_parameter, owner)?;
     validate_array_type(&array_type, array_type_parameter, owner)?;
 
-    let return_type = callback.return_type()?;
+    let return_type = regular_return_type(callback.return_type()?, owner)?;
     match callback_return {
         ArrayCallbackReturn::Reference(type_parameter) => {
-            let return_type = regular_return_type(return_type, owner)?;
             validate_reference_type(&return_type, type_parameter, owner)?;
         }
         ArrayCallbackReturn::Unknown => {
-            let return_type = regular_return_type(return_type, owner)?;
             if !matches!(return_type, AnyTsType::TsUnknownType(_)) {
                 bail!("{owner} callback must return unknown");
             }
         }
         ArrayCallbackReturn::Void => {
-            let return_type = regular_return_type(return_type, owner)?;
             if !matches!(return_type, AnyTsType::TsVoidType(_)) {
                 bail!("{owner} callback must return void");
             }

--- a/xtask/codegen/tests/fixtures/global-types/manifest.disposables.d.ts
+++ b/xtask/codegen/tests/fixtures/global-types/manifest.disposables.d.ts
@@ -34,6 +34,13 @@ interface AsyncDisposable {
     [Symbol.asyncDispose](): PromiseLike<void>;
 }
 
+interface Array<T> {
+    length: number;
+    filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
+    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+}
+
 interface RegExpExecArray {}
 
 interface RegExp {


### PR DESCRIPTION
## Summary

Part of #5977.

Migrates `Array` and its `filter`, `forEach`, and `map` helpers to generated global types while preserving their existing shapes. The selected TypeScript declarations are validated without changing the inference engine.

> This PR was implemented with AI assistance from Codex.

## Test Plan

- Verified `just gen-global-types` is idempotent.
- `cargo test -p biome_js_type_info migrated_predefined_ids_match_expected_order`
- `cargo test -p biome_js_type_info infer_type_of_array`

## Docs

N/A
