### PR TITLE
feat(html): support .htm files

### DIFF
--- a/.changeset/support-htm-files.md
+++ b/.changeset/support-htm-files.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Biome now recognizes files with the `.htm` extension as HTML.

--- a/crates/biome_cli/tests/cases/html.rs
+++ b/crates/biome_cli/tests/cases/html.rs
@@ -1,5 +1,5 @@
 use crate::run_cli;
-use crate::snap_test::{SnapshotPayload, assert_cli_snapshot};
+use crate::snap_test::{SnapshotPayload, assert_cli_snapshot, assert_file_contents};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
 use bpaf::Args;
@@ -566,6 +566,41 @@ fn should_lint_a_html_file() {
         console,
         result,
     ));
+}
+
+#[test]
+fn should_handle_htm_file() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let htm_file = Utf8Path::new("index.htm");
+    fs.insert(
+        htm_file.into(),
+        r#"<main><h1>Hello</h1></main>
+"#
+        .as_bytes(),
+    );
+
+    fs.insert(
+        Utf8Path::new("biome.json").into(),
+        r#"{
+    "html": {
+        "formatter": {
+            "enabled": true
+        }
+    }
+}"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--write", htm_file.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+    assert_file_contents(&fs, htm_file, "<main><h1>Hello</h1></main>\n");
 }
 
 #[test]

--- a/crates/biome_cli/tests/cases/html.rs
+++ b/crates/biome_cli/tests/cases/html.rs
@@ -576,7 +576,7 @@ fn should_handle_htm_file() {
     let htm_file = Utf8Path::new("index.htm");
     fs.insert(
         htm_file.into(),
-        r#"<main class = "content"><h1>Hello</h1></main>
+        r#"<div scope = "col"></div>
 "#
         .as_bytes(),
     );
@@ -586,6 +586,9 @@ fn should_handle_htm_file() {
         r#"{
     "html": {
         "formatter": {
+            "enabled": true
+        },
+        "linter": {
             "enabled": true
         }
     }

--- a/crates/biome_cli/tests/cases/html.rs
+++ b/crates/biome_cli/tests/cases/html.rs
@@ -1,5 +1,5 @@
 use crate::run_cli;
-use crate::snap_test::{SnapshotPayload, assert_cli_snapshot, assert_file_contents};
+use crate::snap_test::{SnapshotPayload, assert_cli_snapshot};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
 use bpaf::Args;
@@ -576,7 +576,7 @@ fn should_handle_htm_file() {
     let htm_file = Utf8Path::new("index.htm");
     fs.insert(
         htm_file.into(),
-        r#"<main><h1>Hello</h1></main>
+        r#"<main class = "content"><h1>Hello</h1></main>
 "#
         .as_bytes(),
     );
@@ -596,11 +596,18 @@ fn should_handle_htm_file() {
     let (fs, result) = run_cli(
         fs,
         &mut console,
-        Args::from(["format", "--write", htm_file.as_str()].as_slice()),
+        Args::from(["check", htm_file.as_str()].as_slice()),
     );
 
-    assert!(result.is_ok(), "run_cli returned {result:?}");
-    assert_file_contents(&fs, htm_file, "<main><h1>Hello</h1></main>\n");
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_handle_htm_file",
+        fs,
+        console,
+        result,
+    ));
 }
 
 #[test]

--- a/crates/biome_cli/tests/snapshots/main_cases_html/should_handle_htm_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_html/should_handle_htm_file.snap
@@ -10,6 +10,9 @@ expression: redactor(content)
   "html": {
     "formatter": {
       "enabled": true
+    },
+    "linter": {
+      "enabled": true
     }
   }
 }
@@ -18,7 +21,7 @@ expression: redactor(content)
 ## `index.htm`
 
 ```htm
-<main class = "content"><h1>Hello</h1></main>
+<div scope = "col"></div>
 
 ```
 
@@ -36,16 +39,39 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
+index.htm:1:6 lint/a11y/noHeaderScope  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Avoid using the scope attribute on elements other than th elements.
+  
+  > 1 │ <div scope = "col"></div>
+      │      ^^^^^^^^^^^^^
+    2 │ 
+  
+  i The scope attribute is used to associate a data cell with its corresponding header cell in a data table,
+                so it should be placed on th elements to provide accessibility to screen readers.
+  
+  i Follow the links for more information,
+                WCAG 1.3.1
+                WCAG 4.1.1
+  
+  i Unsafe fix: Remove the scope attribute.
+  
+    1 │ <div·scope·=·"col"></div>
+      │      -------------       
+
+```
+
+```block
 index.htm format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Formatter would have printed the following content:
   
-    1 │ <main·class·=·"content"><h1>Hello</h1></main>
-      │            - -                               
+    1 │ <div·scope·=·"col"></div>
+      │           - -            
 
 ```
 
 ```block
 Checked 1 file in <TIME>. No fixes applied.
-Found 1 error.
+Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_html/should_handle_htm_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_html/should_handle_htm_file.snap
@@ -1,0 +1,51 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 577
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": {
+    "formatter": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## `index.htm`
+
+```htm
+<main class = "content"><h1>Hello</h1></main>
+
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+index.htm format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 │ <main·class·=·"content"><h1>Hello</h1></main>
+      │            - -                               
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_languages/src/html.rs
+++ b/crates/biome_languages/src/html.rs
@@ -132,7 +132,7 @@ impl HtmlFileSource {
     pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
         // We assume the file extension is normalized to lowercase
         match extension {
-            "html" | "svg" => Ok(Self::html()),
+            "htm" | "html" | "svg" => Ok(Self::html()),
             "astro" => Ok(Self::astro()),
             "vue" => Ok(Self::vue()),
             "svelte" => Ok(Self::svelte()),

--- a/crates/biome_languages/src/html.rs
+++ b/crates/biome_languages/src/html.rs
@@ -48,8 +48,7 @@ impl HtmlFileSource {
         }
     }
 
-    /// Returns `true` if the current file is `.html` and doesn't support
-    /// any text expression capability
+    /// Returns `true` for standard HTML sources without text-expression support.
     pub const fn is_html(&self) -> bool {
         matches!(self.variant, HtmlVariant::Standard(_))
     }

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1765,7 +1765,7 @@ async fn pull_diagnostics_for_htm_files() -> Result<()> {
     let fs = MemoryFileSystem::default();
     let config = r#"{
         "html": {
-            "formatter": { "enabled": true }
+            "linter": { "enabled": true }
         }
     }"#;
 
@@ -1785,9 +1785,10 @@ async fn pull_diagnostics_for_htm_files() -> Result<()> {
 
     server.load_configuration().await?;
 
-    let incorrect_config = r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red" /></svg>"#;
+    let invalid_html = r#"<div scope="col"></div>"#;
     server
-        .open_named_document(incorrect_config, uri!("document.htm"), "html")
+        // VS Code assigns the `html` language identifier to `.htm` files.
+        .open_named_document(invalid_html, uri!("document.htm"), "html")
         .await?;
 
     let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
@@ -1802,22 +1803,24 @@ async fn pull_diagnostics_for_htm_files() -> Result<()> {
                     range: Range {
                         start: Position {
                             line: 0,
-                            character: 0,
+                            character: 5,
                         },
                         end: Position {
                             line: 0,
-                            character: 112,
+                            character: 16,
                         },
                     },
                     severity: Some(DiagnosticSeverity::ERROR),
                     code: Some(NumberOrString::String(String::from(
-                        "lint/a11y/noSvgWithoutTitle"
+                        "lint/a11y/noHeaderScope"
                     ))),
                     code_description: Some(CodeDescription {
-                        href: "https://biomejs.dev/linter/rules/no-svg-without-title".parse()?
+                        href: "https://biomejs.dev/linter/rules/no-header-scope".parse()?
                     }),
                     source: Some(String::from("biome")),
-                    message: String::from("Alternative text title element cannot be empty",),
+                    message: String::from(
+                        "Avoid using the scope attribute on elements other than th elements.",
+                    ),
                     related_information: None,
                     tags: None,
                     data: None,

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1761,6 +1761,80 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
 }
 
 #[tokio::test]
+async fn pull_diagnostics_for_htm_files() -> Result<()> {
+    let fs = MemoryFileSystem::default();
+    let config = r#"{
+        "html": {
+            "formatter": { "enabled": true }
+        }
+    }"#;
+
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), config);
+
+    let factory = ServerFactory::new_with_fs(Arc::new(fs));
+    let (service, client) = factory.create().into_inner();
+
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server.load_configuration().await?;
+
+    let incorrect_config = r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red" /></svg>"#;
+    server
+        .open_named_document(incorrect_config, uri!("document.htm"), "html")
+        .await?;
+
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+
+    assert_eq!(
+        notification,
+        Some(ServerNotification::PublishDiagnostics(
+            PublishDiagnosticsParams {
+                uri: uri!("document.htm"),
+                version: Some(0),
+                diagnostics: vec![Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: 0,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 0,
+                            character: 112,
+                        },
+                    },
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: Some(NumberOrString::String(String::from(
+                        "lint/a11y/noSvgWithoutTitle"
+                    ))),
+                    code_description: Some(CodeDescription {
+                        href: "https://biomejs.dev/linter/rules/no-svg-without-title".parse()?
+                    }),
+                    source: Some(String::from("biome")),
+                    message: String::from("Alternative text title element cannot be empty",),
+                    related_information: None,
+                    tags: None,
+                    data: None,
+                }],
+            }
+        ))
+    );
+
+    server.close_document().await?;
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn pull_diagnostics_for_svg_files() -> Result<()> {
     let fs = MemoryFileSystem::default();
     let config = r#"{


### PR DESCRIPTION
## Summary
- add support for `.htm` files alongside `.html`
- recognize `.htm` as an HTML file wherever Biome determines the language from the file extension
- keep the existing behavior for `.html` unchanged
- Closes #11112

## Test Plan
- added test covering .htm file detection
- verified that .htm files are parsed as HTML

## Docs
- biomejs/website#4403

## AI Discolsure
I used an AI assistant just to write the dedicated test