### PR TITLE
fix(lint): detect deprecated ambient imports

### DIFF
--- a/.changeset/warm-ads-shave.md
+++ b/.changeset/warm-ads-shave.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7635](https://github.com/biomejs/biome/issues/7635): [`noDeprecatedImports`](https://biomejs.dev/linter/rules/no-deprecated-imports/) now detects deprecated ambient declarations that are exported separately.

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/ambientDeclarations.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/ambientDeclarations.ts
@@ -1,0 +1,7 @@
+/** @deprecated Use Grid2. */
+declare const Grid: unknown;
+export { Grid };
+
+/** @deprecated Use generateText. */
+declare function generateObject(): void;
+export { generateObject };

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/ambientDeclarations.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/ambientDeclarations.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ambientDeclarations.ts
+---
+# Input
+```ts
+/** @deprecated Use Grid2. */
+declare const Grid: unknown;
+export { Grid };
+
+/** @deprecated Use generateText. */
+declare function generateObject(): void;
+export { generateObject };
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/invalidAmbientDeclarations.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/invalidAmbientDeclarations.ts
@@ -1,0 +1,2 @@
+/* should generate diagnostics */
+import { Grid, generateObject } from "./ambientDeclarations";

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/invalidAmbientDeclarations.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDeprecatedImports/invalidAmbientDeclarations.ts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidAmbientDeclarations.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+import { Grid, generateObject } from "./ambientDeclarations";
+
+```
+
+# Diagnostics
+```
+invalidAmbientDeclarations.ts:2:10 lint/suspicious/noDeprecatedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Deprecated import: Use Grid2.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ import { Grid, generateObject } from "./ambientDeclarations";
+      │          ^^^^
+    3 │ 
+  
+  i An @deprecated annotation indicates the author doesn't want you to rely on this import anymore.
+  
+  i You should probably import a different symbol instead.
+  
+
+```
+
+```
+invalidAmbientDeclarations.ts:2:16 lint/suspicious/noDeprecatedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Deprecated import: Use generateText.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ import { Grid, generateObject } from "./ambientDeclarations";
+      │                ^^^^^^^^^^^^^^
+    3 │ 
+  
+  i An @deprecated annotation indicates the author doesn't want you to rely on this import anymore.
+  
+  i You should probably import a different symbol instead.
+  
+
+```

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -1,7 +1,7 @@
 use super::*;
 use biome_js_syntax::{
     AnyJsDeclaration, AnyJsRoot, JsExport, JsIdentifierAssignment, JsSyntaxNode, TextRange,
-    TsConditionalType, TsTypeParameterName,
+    TsConditionalType, TsDeclareStatement, TsTypeParameterName,
 };
 use biome_jsdoc_comment::JsdocComment;
 use biome_rowan::SyntaxNodePtr;
@@ -485,6 +485,8 @@ fn find_jsdoc(node: &JsSyntaxNode) -> Option<JsdocComment> {
     node.ancestors().find_map(|ancestor| {
         if let Some(export) = JsExport::cast_ref(&ancestor) {
             JsdocComment::try_from(export.syntax()).ok()
+        } else if let Some(decl) = TsDeclareStatement::cast_ref(&ancestor) {
+            JsdocComment::try_from(decl.syntax()).ok()
         } else if let Some(decl) = AnyJsDeclaration::cast(ancestor) {
             JsdocComment::try_from(decl.syntax()).ok()
         } else {

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -49,6 +49,8 @@ mod globals;
 mod imports;
 #[path = "spec_tests_v2/intersections.test.rs"]
 mod intersections;
+#[path = "spec_tests_v2/js_doc.test.rs"]
+mod js_doc;
 #[path = "spec_tests_v2/normalization.test.rs"]
 mod normalization;
 #[path = "spec_tests_v2/promises.test.rs"]

--- a/crates/biome_module_graph/tests/spec_tests_v2/js_doc.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/js_doc.test.rs
@@ -1,0 +1,35 @@
+use super::*;
+use biome_module_graph::{SymbolFromModuleInfo, find_jsdoc_for_exported_symbol};
+
+#[test]
+fn finds_jsdoc_for_separately_exported_ambient_declarations() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            /** @deprecated Use Grid2. */
+            declare const Grid: unknown;
+            export { Grid };
+
+            /** @deprecated Use generateText. */
+            declare function generateObject(): void;
+            export { generateObject };
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], false);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    for (name, expected) in [
+        ("Grid", "@deprecated Use Grid2."),
+        ("generateObject", "@deprecated Use generateText."),
+    ] {
+        let symbol = SymbolFromModuleInfo::new(&db, name, module);
+        let jsdoc = find_jsdoc_for_exported_symbol(&db, symbol)
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name} must have JSDoc"));
+        assert_eq!(jsdoc.as_ref(), expected);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7635

Associate JSDoc on standalone ambient declarations with their semantic bindings so `noDeprecatedImports` detects symbols exported separately. Includes a patch changeset.

## Test Plan

Added new tests in module graph and the list rule

## Docs

N/A

> This PR was created with AI assistance (OpenCode).